### PR TITLE
Jira Java-180 - NullPointerException when calling DBTCPCnnector.close()

### DIFF
--- a/src/main/com/mongodb/DBTCPConnector.java
+++ b/src/main/com/mongodb/DBTCPConnector.java
@@ -348,8 +348,10 @@ class DBTCPConnector implements DBConnector {
 
     public void close(){
         _closed = true;
-        _portHolder.close();
-        _rsStatus.close();
+        if ( _portHolder != null )
+        	_portHolder.close();
+        if ( _rsStatus != null )
+        	_rsStatus.close();
     }
 
     final Mongo _mongo;


### PR DESCRIPTION
http://jira.mongodb.org/browse/JAVA-180

In the above issue I documented a case where calling Mongo.close() can result in a NullPointerException being thrown. This problem is new with the 2.2 driver due to code that was added to DBTCPConnecter.close().
