### PR TITLE
Topic/withinbox

### DIFF
--- a/src/main/com/mongodb/QueryBuilder.java
+++ b/src/main/com/mongodb/QueryBuilder.java
@@ -215,6 +215,21 @@ public class QueryBuilder {
                     new Double[]{ x , y , maxDistance } );
         return this;
     }
+    
+    /**
+     * Append a within bounding box search using a two corners to the current QueryBuilder.
+     * 
+     * @param x the x coordinate of the first box corner.
+     * @param y the y coordinate of the first box corner.
+     * @param xx the x coordinate of the second box corner.
+     * @param yy the y coordinate of the second box corner.
+     * @return the current QueryBuilder with an appended within bounding box search.
+     */
+    public QueryBuilder withinBox(double x, double y, double xx, double yy) {
+    	addOperand( "$within" , 
+    	             new BasicDBObject( "$box" , new Object[] { new Double[] { x, y }, new Double[] { xx, yy } } ) );
+    	return this;
+    }
 
 
     public QueryBuilder or( DBObject ... ors ){


### PR DESCRIPTION
We use MongoDB to store POI, and extensively use the within bounding box search.

Writing the code with QueryBuilder 'put' and 'is'  (ie: without a dedicated method) is rather cumbersome  :
https://gist.github.com/980fccd00d1ab7d457a4

So we added a cleaner implementation to the QueryBuilder.

We think it's interesting for anyone doing bounding box search, we know it's not everyone but anyhow... here's our code.

Jean-Laurent
