### PR TITLE
findAndModify not honoring sort parameter

### DIFF
--- a/src/main/com/mongodb/DBCollection.java
+++ b/src/main/com/mongodb/DBCollection.java
@@ -286,7 +286,7 @@ public abstract class DBCollection {
      * @return the old document
      */
     public DBObject findAndModify( DBObject query , DBObject sort , DBObject update){ 
-    	return findAndModify( query, null, null, false, update, false, false);
+        return findAndModify( query, null, sort, false, update, false, false);
     }
 
     /**


### PR DESCRIPTION
The method findAndModify( DBObject query , DBObject sort , DBObject update) was not passing the sort DBObject into the delegate findAndModify method
