### PR TITLE
Add option to set TCP keep alive

### DIFF
--- a/src/main/com/mongodb/DBPort.java
+++ b/src/main/com/mongodb/DBPort.java
@@ -204,6 +204,7 @@ public class DBPort {
                 
                 _socket.setTcpNoDelay( ! USE_NAGLE );
                 _socket.setSoTimeout( _options.socketTimeout );
+                _socket.setKeepAlive( _options.socketKeepAlive );
                 _in = new BufferedInputStream( _socket.getInputStream() );
                 _out = _socket.getOutputStream();
                 return true;

--- a/src/main/com/mongodb/MongoOptions.java
+++ b/src/main/com/mongodb/MongoOptions.java
@@ -35,6 +35,7 @@ public class MongoOptions {
         maxWaitTime = 1000 * 60 * 2;
         connectTimeout = 0;
         socketTimeout = 0;
+        socketKeepAlive = true;
         autoConnectRetry = false;
         slaveOk = false;
         safe = false;
@@ -93,7 +94,15 @@ public class MongoOptions {
      * 0 is default and infinite
      */
     public int socketTimeout;
-    
+
+    /**
+     * This controls whether or not to have socket keep alive
+     * turned on (SO_KEEPALIVE).
+     *
+     * defaults to true
+     */
+    public boolean socketKeepAlive;
+
     /**
      * This controls whether the system retries automatically
      * on connection errors.  
@@ -150,6 +159,7 @@ public class MongoOptions {
         buf.append( "maxWaitTime: " ).append( maxWaitTime ).append( " " );
         buf.append( "connectTimeout: " ).append( connectTimeout ).append( " " );
         buf.append( "socketTimeout: " ).append( socketTimeout ).append( " " );
+        buf.append( "socketKeepAlive: " ).append( socketKeepAlive ).append( " " );
         buf.append( "autoConnectRetry: " ).append( autoConnectRetry ).append( " " );
         buf.append( "slaveOk: " ).append( slaveOk ).append( " " );
         buf.append( "safe: " ).append( safe ).append( " " );


### PR DESCRIPTION
As mentioned in my ticket (http://jira.mongodb.org/browse/SERVER-2599), it would be helpful to control the TCP keep alive setting in the Java driver.
Setting keep alive to true (by default) makes sense IMO because the pool doesn't free existing connections. This often results in idle connections that remain open for a long time.
