### PR TITLE
Merge a fix causing a NullPointerException inside fetchMaxBsonObjectSize in logging.

### DIFF
--- a/src/main/com/mongodb/DBTCPConnector.java
+++ b/src/main/com/mongodb/DBTCPConnector.java
@@ -414,7 +414,7 @@ public class DBTCPConnector implements DBConnector {
                 maxBsonObjectSize = Bytes.MAX_OBJECT_SIZE;
             }
         } catch (Exception e) {
-            _logger.log(Level.WARNING, null, e);
+            _logger.log(Level.WARNING, "Exception determining maxBSON size using"+maxBsonObjectSize, e);
         } finally {
             port.getPool().done(port);
         }


### PR DESCRIPTION
Logger in deteremining fetchMaxBsonObjectSize doesn't like null, giving it a string so it doesn't cause a java.lang.NullPointerException
