### PR TITLE
Use bundlor to create a correct MANIFEST.MF file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0'?>
-<project name="MongoDB Java Driver" default="compile" basedir=".">
+<project name="MongoDB Java Driver" default="compile" basedir="."
+  xmlns:bundlor="antlib:com.springsource.bundlor.ant">
 
   <property name="version" value="2.7.0-pre"/>
   <property name="targetdir" location="target"/>
@@ -89,7 +90,7 @@
       <arg value="-1" />
     </exec>
 
-    <jar jarfile="mongo.jar" manifest="src/main/META-INF/MANIFEST.MF" >
+    <jar jarfile="mongo.jar" manifest="build/main/META-INF/MANIFEST.MF" >
       <fileset dir="build/main" />
     </jar>
 
@@ -259,4 +260,22 @@
     </exec>
   </target>
 
+  <target name="bundlor.init">
+    <taskdef resource="com/springsource/bundlor/ant/antlib.xml"
+      uri="antlib:com.springsource.bundlor.ant">
+      <classpath id="bundlor.classpath">
+        <fileset dir="${bundlor.home}/dist"/>
+        <fileset dir="${bundlor.home}/lib"/>
+      </classpath>
+    </taskdef>
+  </target>
+  
+  <bundlor:bundlor
+    inputPath="${basedir}/build/main"
+    outputPath="${basedir}/build/main"
+    bundleVersion="${version}"
+    manifestTemplatePath="${basedir}/template.mf" >
+    <property name="name" value="${ant.project.name}" />
+    <property name="version" value="${version}" />
+  </bundlor:bundlor>
 </project>

--- a/src/main/META-INF/MANIFEST.MF
+++ b/src/main/META-INF/MANIFEST.MF
@@ -1,7 +1,0 @@
-Manifest-Version: 1.0
-Bundle-ManifestVersion: 2
-Bundle-Name: MongoDB
-Bundle-SymbolicName: com.mongodb
-Bundle-Version: 2.7.0
-Import-Package: javax.management 
-Export-Package: com.mongodb, com.mongodb.io, com.mongodb.util, com.mongodb.gridfs, org.bson, org.bson.util, org.bson.types, org.bson.io

--- a/template.mf
+++ b/template.mf
@@ -1,0 +1,11 @@
+Bundle-Name: ${name}
+Bundle-SymbolicName: com.mongodb
+Bundle-Version: ${version}
+Bundle-ManifestVersion: 2
+Export-Template:  
+ com.mongodb.*;version="${version}",
+ org.bson.*;version="${version}"
+Import-Template: 
+ javax.management.*;version="0"
+Excluded-Imports: 
+ org.testng.*


### PR DESCRIPTION
The OSGi information in the MANIFEST.MF file for the mongo driver was not working out on Virgo.
I patched the build process so that bundlor is used to dynamically generate the MANIFEST.MF file.

To be able to build the driver with bundlor, download bundlor from http://www.springsource.org/bundlor extract the archive and copy the jars from the dist and lib directory into the lib directory of your ant installation.

Tell me if this works for you as well

James
