### PR TITLE
Add bin directory to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ crap
 hs_err_*
 doc
 docs
+bin
 target
 include/jython/cachedir
 mongo.jar


### PR DESCRIPTION
This directory is used by Eclipse for `.class` files when it is imported as a standard Java project.
