### PR TITLE
Remove .* style imports and replace with explicit imports.

### DIFF
--- a/src/main/com/mongodb/BasicDBList.java
+++ b/src/main/com/mongodb/BasicDBList.java
@@ -18,8 +18,9 @@
 
 package com.mongodb;
 
-import org.bson.types.*;
-import com.mongodb.util.*;
+import org.bson.types.BasicBSONList;
+
+import com.mongodb.util.JSON;
 
 /**
  * a basic implementation of bson list that is mongo specific 

--- a/src/main/com/mongodb/BasicDBObject.java
+++ b/src/main/com/mongodb/BasicDBObject.java
@@ -18,11 +18,11 @@
 
 package com.mongodb;
 
-import java.util.*;
+import java.util.Map;
 
-import org.bson.*;
+import org.bson.BasicBSONObject;
 
-import com.mongodb.util.*;
+import com.mongodb.util.JSON;
 
 /**
  * a basic implementation of bson object that is mongo specific.

--- a/src/main/com/mongodb/BasicDBObjectBuilder.java
+++ b/src/main/com/mongodb/BasicDBObjectBuilder.java
@@ -18,7 +18,9 @@
 
 package com.mongodb;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
 
 /**
  * utility for building complex objects

--- a/src/main/com/mongodb/Bytes.java
+++ b/src/main/com/mongodb/Bytes.java
@@ -18,13 +18,17 @@
 
 package com.mongodb;
 
-import java.nio.*;
+import java.nio.ByteOrder;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.logging.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-import org.bson.*;
-import org.bson.types.*;
+import org.bson.BSON;
+import org.bson.types.BSONTimestamp;
+import org.bson.types.Code;
+import org.bson.types.CodeWScope;
+import org.bson.types.ObjectId;
 
 /**
  * Class that hold definitions of the wire protocol

--- a/src/main/com/mongodb/DB.java
+++ b/src/main/com/mongodb/DB.java
@@ -18,10 +18,17 @@
 
 package com.mongodb;
 
-import java.io.*;
-import java.util.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
-import com.mongodb.util.*;
+import com.mongodb.util.Util;
 
 /**
  * an abstract class that represents a logical database on a server

--- a/src/main/com/mongodb/DBAddress.java
+++ b/src/main/com/mongodb/DBAddress.java
@@ -18,7 +18,8 @@
 
 package com.mongodb;
 
-import java.net.*;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 /**
  * Represents a database address

--- a/src/main/com/mongodb/DBApiLayer.java
+++ b/src/main/com/mongodb/DBApiLayer.java
@@ -18,7 +18,14 @@
 
 package com.mongodb;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/src/main/com/mongodb/DBCallback.java
+++ b/src/main/com/mongodb/DBCallback.java
@@ -19,7 +19,7 @@
 package com.mongodb;
 
 
-import org.bson.*;
+import org.bson.BSONCallback;
 
 /**
  * The DB callback interface.

--- a/src/main/com/mongodb/DBCollection.java
+++ b/src/main/com/mongodb/DBCollection.java
@@ -19,7 +19,14 @@
 package com.mongodb;
 
 // Mongo
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.bson.types.ObjectId;
 

--- a/src/main/com/mongodb/DBCursor.java
+++ b/src/main/com/mongodb/DBCursor.java
@@ -18,7 +18,11 @@
 
 package com.mongodb;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 
 import com.mongodb.DBApiLayer.Result;
 

--- a/src/main/com/mongodb/DBDecoder.java
+++ b/src/main/com/mongodb/DBDecoder.java
@@ -17,6 +17,7 @@ package com.mongodb;
 
 import java.io.IOException;
 import java.io.InputStream;
+
 import org.bson.BSONDecoder;
 
 /**

--- a/src/main/com/mongodb/DBObject.java
+++ b/src/main/com/mongodb/DBObject.java
@@ -18,7 +18,7 @@
 
 package com.mongodb;
 
-import org.bson.*;
+import org.bson.BSONObject;
 
 /**
  * A key-value map that can be saved to the database.

--- a/src/main/com/mongodb/DBPointer.java
+++ b/src/main/com/mongodb/DBPointer.java
@@ -18,7 +18,7 @@
 
 package com.mongodb;
 
-import org.bson.types.*;
+import org.bson.types.ObjectId;
 
 /**
  * @deprecated

--- a/src/main/com/mongodb/DBPort.java
+++ b/src/main/com/mongodb/DBPort.java
@@ -18,12 +18,19 @@
 
 package com.mongodb;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
-import java.util.logging.*;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-import com.mongodb.util.*;
+import com.mongodb.util.ThreadUtil;
 
 /**
  * represents a Port to the database, which is effectively a single connection to a server

--- a/src/main/com/mongodb/DBPortPool.java
+++ b/src/main/com/mongodb/DBPortPool.java
@@ -19,11 +19,18 @@
 package com.mongodb;
 
 import java.lang.management.ManagementFactory;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.logging.Level;
 
-import javax.management.*;
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
 
 import com.mongodb.util.SimplePool;
 

--- a/src/main/com/mongodb/DBRef.java
+++ b/src/main/com/mongodb/DBRef.java
@@ -18,7 +18,7 @@
 
 package com.mongodb;
 
-import org.bson.*;
+import org.bson.BSONObject;
 
 /**
  * overrides DBRefBase to understand a BSONObject representation of a reference.

--- a/src/main/com/mongodb/DBTCPConnector.java
+++ b/src/main/com/mongodb/DBTCPConnector.java
@@ -20,7 +20,9 @@ package com.mongodb;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/src/main/com/mongodb/DefaultDBCallback.java
+++ b/src/main/com/mongodb/DefaultDBCallback.java
@@ -19,12 +19,13 @@
 package com.mongodb;
 
 // Bson
-import org.bson.*;
-import org.bson.types.*;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-// Java
-import java.util.*;
-import java.util.logging.*;
+import org.bson.BSONObject;
+import org.bson.BasicBSONCallback;
+import org.bson.types.ObjectId;
 
 /**
  * This class overrides BasicBSONCallback to implement some extra features specific to the Database.

--- a/src/main/com/mongodb/DefaultDBDecoder.java
+++ b/src/main/com/mongodb/DefaultDBDecoder.java
@@ -17,6 +17,7 @@ package com.mongodb;
 
 import java.io.IOException;
 import java.io.InputStream;
+
 import org.bson.BasicBSONDecoder;
 
 /**

--- a/src/main/com/mongodb/LazyDBDecoder.java
+++ b/src/main/com/mongodb/LazyDBDecoder.java
@@ -17,6 +17,7 @@ package com.mongodb;
 
 import java.io.IOException;
 import java.io.InputStream;
+
 import org.bson.LazyBSONDecoder;
 
 /**

--- a/src/main/com/mongodb/Mongo.java
+++ b/src/main/com/mongodb/Mongo.java
@@ -19,7 +19,10 @@
 package com.mongodb;
 
 import java.net.UnknownHostException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 

--- a/src/main/com/mongodb/MongoException.java
+++ b/src/main/com/mongodb/MongoException.java
@@ -18,7 +18,7 @@
 
 package com.mongodb;
 
-import org.bson.*;
+import org.bson.BSONObject;
 
 /**
  * A general exception raised in Mongo

--- a/src/main/com/mongodb/MongoURI.java
+++ b/src/main/com/mongodb/MongoURI.java
@@ -18,9 +18,11 @@
 
 package com.mongodb;
 
-import java.net.*;
-import java.util.*;
-import java.util.logging.*;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * Represents a URI which can be used to create a Mongo instance.

--- a/src/main/com/mongodb/OutMessage.java
+++ b/src/main/com/mongodb/OutMessage.java
@@ -18,14 +18,18 @@
 
 package com.mongodb;
 
-import java.util.concurrent.atomic.*;
-import java.io.*;
+import static org.bson.BSON.EOO;
+import static org.bson.BSON.OBJECT;
+import static org.bson.BSON.REF;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import org.bson.*;
-import org.bson.io.*;
-import org.bson.types.*;
-import static org.bson.BSON.*;
+import org.bson.BSONEncoder;
+import org.bson.BSONObject;
+import org.bson.io.PoolOutputBuffer;
+import org.bson.types.ObjectId;
 
 class OutMessage extends BSONEncoder {
 

--- a/src/main/com/mongodb/QueryBuilder.java
+++ b/src/main/com/mongodb/QueryBuilder.java
@@ -18,7 +18,8 @@
 
 package com.mongodb;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
 
 /**

--- a/src/main/com/mongodb/RawDBObject.java
+++ b/src/main/com/mongodb/RawDBObject.java
@@ -18,14 +18,39 @@
 
 package com.mongodb;
 
-import java.nio.*;
-import java.util.*;
+import static com.mongodb.util.MyAsserts.assertEquals;
+import static org.bson.BSON.ARRAY;
+import static org.bson.BSON.BINARY;
+import static org.bson.BSON.BOOLEAN;
+import static org.bson.BSON.CODE;
+import static org.bson.BSON.CODE_W_SCOPE;
+import static org.bson.BSON.DATE;
+import static org.bson.BSON.EOO;
+import static org.bson.BSON.MAXKEY;
+import static org.bson.BSON.MINKEY;
+import static org.bson.BSON.NULL;
+import static org.bson.BSON.NUMBER;
+import static org.bson.BSON.NUMBER_INT;
+import static org.bson.BSON.NUMBER_LONG;
+import static org.bson.BSON.OBJECT;
+import static org.bson.BSON.OID;
+import static org.bson.BSON.REF;
+import static org.bson.BSON.REGEX;
+import static org.bson.BSON.STRING;
+import static org.bson.BSON.SYMBOL;
+import static org.bson.BSON.TIMESTAMP;
+import static org.bson.BSON.UNDEFINED;
 
-import org.bson.*;
-import org.bson.types.*;
+import java.nio.ByteBuffer;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
 
-import static com.mongodb.Bytes.*;
-import static com.mongodb.util.MyAsserts.*;
+import org.bson.BSONObject;
+import org.bson.types.ObjectId;
 
 /**
  * This object wraps the binary object format ("BSON") used for the transport of serialized objects to / from the Mongo database.

--- a/src/main/com/mongodb/ReflectionDBObject.java
+++ b/src/main/com/mongodb/ReflectionDBObject.java
@@ -18,10 +18,16 @@
 
 package com.mongodb;
 
-import java.util.*;
-import java.lang.reflect.*;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
-import org.bson.*;
+import org.bson.BSONObject;
 
 /**
  * This class enables to map simple Class fields to a BSON object fields

--- a/src/main/com/mongodb/Response.java
+++ b/src/main/com/mongodb/Response.java
@@ -18,10 +18,15 @@
 
 package com.mongodb;
 
-import java.io.*;
-import java.util.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 
-import org.bson.io.*;
+import org.bson.io.Bits;
 
 class Response {
 

--- a/src/main/com/mongodb/ServerAddress.java
+++ b/src/main/com/mongodb/ServerAddress.java
@@ -18,8 +18,11 @@
 
 package com.mongodb;
 
-import java.net.*;
-import java.util.*;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * mongo server address

--- a/src/main/com/mongodb/ServerError.java
+++ b/src/main/com/mongodb/ServerError.java
@@ -18,7 +18,7 @@
 
 package com.mongodb;
 
-import org.bson.*;
+import org.bson.BSONObject;
 
 /**
  * Represents a server error

--- a/src/main/com/mongodb/WriteConcern.java
+++ b/src/main/com/mongodb/WriteConcern.java
@@ -18,8 +18,10 @@
 
 package com.mongodb;
 
-import java.lang.reflect.*;
-import java.util.*;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * <p>WriteConcern control the write behavior for with various options, as well as exception raising on error conditions.</p>

--- a/src/main/com/mongodb/gridfs/CLI.java
+++ b/src/main/com/mongodb/gridfs/CLI.java
@@ -18,11 +18,13 @@
 
 package com.mongodb.gridfs;
 
-import java.io.*;
-import java.security.*;
+import java.io.File;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
 
-import com.mongodb.*;
-import com.mongodb.util.*;
+import com.mongodb.DBObject;
+import com.mongodb.Mongo;
+import com.mongodb.util.Util;
 
 
 /**

--- a/src/main/com/mongodb/gridfs/GridFS.java
+++ b/src/main/com/mongodb/gridfs/GridFS.java
@@ -18,12 +18,22 @@
 
 package com.mongodb.gridfs;
 
-import java.io.*;
-import java.util.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
-import com.mongodb.*;
+import org.bson.types.ObjectId;
 
-import org.bson.types.*;
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
 
 /**
  *  Implementation of GridFS v1.0

--- a/src/main/com/mongodb/gridfs/GridFSDBFile.java
+++ b/src/main/com/mongodb/gridfs/GridFSDBFile.java
@@ -18,9 +18,16 @@
 
 package com.mongodb.gridfs;
 
-import com.mongodb.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
-import java.io.*;
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBObject;
+import com.mongodb.MongoException;
 
 /**
  * This class enables to retrieve a GridFS file metadata and content.

--- a/src/main/com/mongodb/gridfs/GridFSFile.java
+++ b/src/main/com/mongodb/gridfs/GridFSFile.java
@@ -18,12 +18,20 @@
 
 package com.mongodb.gridfs;
 
-import com.mongodb.*;
-import com.mongodb.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import org.bson.*;
+import org.bson.BSONObject;
 
-import java.util.*;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import com.mongodb.MongoException;
+import com.mongodb.util.JSON;
 
 /**
  * The abstract class representing a GridFS file

--- a/src/main/com/mongodb/gridfs/GridFSInputFile.java
+++ b/src/main/com/mongodb/gridfs/GridFSInputFile.java
@@ -18,14 +18,19 @@
 
 package com.mongodb.gridfs;
 
-import java.io.*;
-import java.security.*;
-import java.util.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.MessageDigest;
+import java.util.Date;
 
-import org.bson.types.*;
+import org.bson.types.ObjectId;
 
-import com.mongodb.*;
-import com.mongodb.util.*;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBObject;
+import com.mongodb.MongoException;
+import com.mongodb.util.SimplePool;
+import com.mongodb.util.Util;
 
 /**
  * This class represents a GridFS file to be written to the database

--- a/src/main/com/mongodb/io/ByteBufferFactory.java
+++ b/src/main/com/mongodb/io/ByteBufferFactory.java
@@ -18,7 +18,7 @@
 
 package com.mongodb.io;
 
-import java.nio.*;
+import java.nio.ByteBuffer;
 
 public interface ByteBufferFactory {
     public ByteBuffer get();

--- a/src/main/com/mongodb/io/ByteBufferHolder.java
+++ b/src/main/com/mongodb/io/ByteBufferHolder.java
@@ -18,8 +18,9 @@
 
 package com.mongodb.io;
 
-import java.util.*;
-import java.nio.*;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ByteBufferHolder {
 

--- a/src/main/com/mongodb/io/ByteBufferInputStream.java
+++ b/src/main/com/mongodb/io/ByteBufferInputStream.java
@@ -18,9 +18,9 @@
 
 package com.mongodb.io;
 
-import java.io.*;
-import java.nio.*;
-import java.util.*;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.List;
 
 public class ByteBufferInputStream extends InputStream {
 

--- a/src/main/com/mongodb/io/ByteBufferOutputStream.java
+++ b/src/main/com/mongodb/io/ByteBufferOutputStream.java
@@ -18,9 +18,10 @@
 
 package com.mongodb.io;
 
-import java.io.*;
-import java.nio.*;
-import java.util.*;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ByteBufferOutputStream extends OutputStream  {
 

--- a/src/main/com/mongodb/io/ByteStream.java
+++ b/src/main/com/mongodb/io/ByteStream.java
@@ -18,7 +18,7 @@
 
 package com.mongodb.io;
 
-import java.nio.*;
+import java.nio.ByteBuffer;
 
 public interface ByteStream {
     

--- a/src/main/com/mongodb/io/StreamUtil.java
+++ b/src/main/com/mongodb/io/StreamUtil.java
@@ -18,7 +18,15 @@
 
 package com.mongodb.io;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
 
 public class StreamUtil {
 

--- a/src/main/com/mongodb/io/ZipUtil.java
+++ b/src/main/com/mongodb/io/ZipUtil.java
@@ -18,10 +18,10 @@
 
 package com.mongodb.io;
 
-import java.io.*;
-import java.nio.*;
-import java.util.*;
-import java.util.zip.*;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
 public class ZipUtil {
     

--- a/src/main/com/mongodb/util/Args.java
+++ b/src/main/com/mongodb/util/Args.java
@@ -18,7 +18,10 @@
 
 package com.mongodb.util;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class Args {
     public Args( String args[] ){

--- a/src/main/com/mongodb/util/FastStack.java
+++ b/src/main/com/mongodb/util/FastStack.java
@@ -18,7 +18,8 @@
 
 package com.mongodb.util;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class FastStack<T>{
 

--- a/src/main/com/mongodb/util/IdentitySet.java
+++ b/src/main/com/mongodb/util/IdentitySet.java
@@ -18,7 +18,9 @@
 
 package com.mongodb.util;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
 
 public class IdentitySet<T> implements Iterable<T> {
 

--- a/src/main/com/mongodb/util/JSON.java
+++ b/src/main/com/mongodb/util/JSON.java
@@ -20,13 +20,27 @@ package com.mongodb.util;
 
 import java.lang.reflect.Array;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Map;
+import java.util.Set;
+import java.util.SimpleTimeZone;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 import org.bson.BSONCallback;
-import org.bson.types.*;
+import org.bson.types.BSONTimestamp;
+import org.bson.types.Binary;
+import org.bson.types.Code;
+import org.bson.types.CodeWScope;
+import org.bson.types.MaxKey;
+import org.bson.types.MinKey;
+import org.bson.types.ObjectId;
 
-import com.mongodb.*;
+import com.mongodb.BasicDBObject;
+import com.mongodb.Bytes;
+import com.mongodb.DBObject;
+import com.mongodb.DBRefBase;
 
 /**
  *   Helper methods for JSON serialization and de-serialization

--- a/src/main/com/mongodb/util/JSONCallback.java
+++ b/src/main/com/mongodb/util/JSONCallback.java
@@ -20,13 +20,25 @@ package com.mongodb.util;
 
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.GregorianCalendar;
+import java.util.SimpleTimeZone;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
-import org.bson.*;
-import org.bson.types.*;
+import org.bson.BSON;
+import org.bson.BSONObject;
+import org.bson.BasicBSONCallback;
+import org.bson.types.BSONTimestamp;
+import org.bson.types.Code;
+import org.bson.types.CodeWScope;
+import org.bson.types.MaxKey;
+import org.bson.types.MinKey;
+import org.bson.types.ObjectId;
 
-import com.mongodb.*;
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import com.mongodb.DBRef;
 
 public class JSONCallback extends BasicBSONCallback {
     

--- a/src/main/com/mongodb/util/MyAsserts.java
+++ b/src/main/com/mongodb/util/MyAsserts.java
@@ -18,7 +18,7 @@
 
 package com.mongodb.util;
 
-import java.util.regex.*;
+import java.util.regex.Pattern;
 
 public class MyAsserts {
 

--- a/src/main/com/mongodb/util/OptionMap.java
+++ b/src/main/com/mongodb/util/OptionMap.java
@@ -18,7 +18,7 @@
 
 package com.mongodb.util;
 
-import java.util.*;
+import java.util.TreeMap;
 
 public class OptionMap extends TreeMap<String,String> {
     

--- a/src/main/com/mongodb/util/SimplePool.java
+++ b/src/main/com/mongodb/util/SimplePool.java
@@ -18,11 +18,20 @@
 
 package com.mongodb.util;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-import javax.management.*;
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.DynamicMBean;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
 
 public abstract class SimplePool<T> implements DynamicMBean {
 

--- a/src/main/com/mongodb/util/TestCase.java
+++ b/src/main/com/mongodb/util/TestCase.java
@@ -18,11 +18,15 @@
 
 package com.mongodb.util;
 
-import java.io.*;
-import java.util.*;
-import java.lang.reflect.*;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 
-import com.mongodb.*;
+import com.mongodb.Mongo;
 
 public class TestCase extends MyAsserts {
     

--- a/src/main/com/mongodb/util/TestNGListener.java
+++ b/src/main/com/mongodb/util/TestNGListener.java
@@ -18,9 +18,13 @@
 
 package com.mongodb.util;
 
-import com.mongodb.*;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
 
-import org.testng.*;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import com.mongodb.Mongo;
 
 public class TestNGListener extends TestListenerAdapter {
 

--- a/src/main/com/mongodb/util/ThreadPool.java
+++ b/src/main/com/mongodb/util/ThreadPool.java
@@ -18,9 +18,11 @@
 
 package com.mongodb.util;
 
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
+import java.util.List;
+import java.util.Vector;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class ThreadPool<T> {
 

--- a/src/main/com/mongodb/util/ThreadUtil.java
+++ b/src/main/com/mongodb/util/ThreadUtil.java
@@ -18,7 +18,9 @@
 
 package com.mongodb.util;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ThreadUtil {
 

--- a/src/main/com/mongodb/util/UniqueList.java
+++ b/src/main/com/mongodb/util/UniqueList.java
@@ -18,7 +18,8 @@
 
 package com.mongodb.util;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class UniqueList<T> extends ArrayList<T> {
 

--- a/src/main/com/mongodb/util/Util.java
+++ b/src/main/com/mongodb/util/Util.java
@@ -16,7 +16,7 @@
  */
 package com.mongodb.util;
 
-import java.nio.*;
+import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 

--- a/src/main/com/mongodb/util/WeakBag.java
+++ b/src/main/com/mongodb/util/WeakBag.java
@@ -18,8 +18,11 @@
 
 package com.mongodb.util;
 
-import java.lang.ref.*;
-import java.util.*;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * if its not obvious what a weak bag should do, then, well...


### PR DESCRIPTION
I performed a Eclipse organize imports on all the com.mongo packages using
the import order file checked in to the repository.

Being explicit with import statements makes class dependencies clearer to
developers new to the code base since they can simply scan the top of a class
file to know what dependencies a class has outside of its package.
