### PR TITLE
Support Eclipse feature for generating a p2 repository

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -45,6 +45,10 @@ limitations under the License.
         <mkdir dir="build/main" />
         <mkdir dir="build/test" />
         <mkdir dir="build/util" />
+        <mkdir dir="build/feature" />
+        <mkdir dir="build/p2" />
+        <mkdir dir="build/p2/features" />
+        <mkdir dir="build/p2/plugins" />
         <mkdir dir="logs" />
         <mkdir dir="${testdir}" />
     </target>
@@ -144,6 +148,10 @@ limitations under the License.
             <filterset><filter token="VERSION" value="${build.conf.lib.version}"/></filterset>
         </copy>
 
+        <copy file="src/feature/feature.xml" tofile="build/feature/feature.xml" filtering="true">
+            <filterset><filter token="VERSION" value="${build.conf.lib.version}"/></filterset>
+        </copy>
+
         <exec executable="git" output="build/main/git-hash">
             <arg value="log" />
             <arg value="--pretty=format:%H" />
@@ -156,6 +164,8 @@ limitations under the License.
           <fileset dir="build/main"><not><filename name="com/"/></not></fileset>
         </jar>
 
+        <jar jarfile="build/p2/features/mongo.feature.jar"><fileset dir="build/feature" /></jar>
+        <copy file="mongo.jar" tofile="build/p2/plugins/mongo.jar"/>
     </target>
 
     <!-- ******************************************************************* -->

--- a/src/feature/feature.xml
+++ b/src/feature/feature.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="com.mongodb.feature"
+      label="MongoDB Driver"
+      version="@VERSION@"
+      provider-name="MongoDB">
+
+   <description url="http://www.mongodb.org/display/DOCS/Java+Language+Center">
+      Driver for the MongoDB database.
+   </description>
+
+   <license url="http://www.apache.org/licenses/LICENSE-2.0">
+      Copyright 2011 MongoDB
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   </license>
+
+   <plugin
+         id="com.mongodb"
+         download-size="0"
+         install-size="0"
+         version="@VERSION@"
+         unpack="false"/>
+
+</feature>


### PR DESCRIPTION
I've added an Eclipse feature that can be used with the mongo.jar bundle to create a p2 repository. My modifications to the build will set everything up to generate the p2 repository, but does not call the p2 publisher to actually generate the repository. I'm not sure the best way to integrate calling the p2 publisher. The call is of the form:

java -jar /plugins/org.eclipse.equinox.launcher_*.jar
-application org.eclipse.equinox.p2.publisher.FeaturesAndBundlesPublisher
-metadataRepository file://repository
-artifactRepository file://repository
-source //build/p2
-publishArtifacts

My apologies for the bad pull request - I'm still learning Git.  Hopefully this pull request will be better.
