### PR TITLE
Return fully functional GridFSFile objects from getFileList methods

### DIFF
--- a/src/main/com/mongodb/gridfs/GridFS.java
+++ b/src/main/com/mongodb/gridfs/GridFS.java
@@ -26,14 +26,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.mongodb.*;
 import org.bson.types.ObjectId;
-
-import com.mongodb.BasicDBObject;
-import com.mongodb.BasicDBObjectBuilder;
-import com.mongodb.DB;
-import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
 
 /**
  *  Implementation of GridFS v1.0
@@ -95,6 +89,17 @@ public class GridFS {
     // ------ utils       -------
     // --------------------------
 
+    protected class GridFSCursor extends DBCursor {
+        public GridFSCursor(DBCollection collection , DBObject q , DBObject k, ReadPreference preference ){
+            super(collection, q, k, preference);
+        }
+
+        @Override
+        public DBObject next() throws MongoException {
+            DBObject obj = super.next();
+            return _fix(obj);
+        }
+    }
 
     /**
      * gets the list of files stored in this gridfs, sorted by filename
@@ -102,7 +107,7 @@ public class GridFS {
      * @return cursor of file objects
      */
     public DBCursor getFileList(){
-        return _filesCollection.find().sort(new BasicDBObject("filename",1));
+        return new GridFSCursor(_filesCollection, new BasicDBObject(), null, null).sort(new BasicDBObject("filename", 1));
     }
 
     /**
@@ -112,7 +117,7 @@ public class GridFS {
      * @return cursor of file objects
      */
     public DBCursor getFileList( DBObject query ){
-        return _filesCollection.find( query ).sort(new BasicDBObject("filename",1));
+        return new GridFSCursor(_filesCollection, query, null, null).sort(new BasicDBObject("filename", 1));
     }
 
 


### PR DESCRIPTION
At the moment DBObjects returned by GridFS.getFileList methods can be casted to GridFSFiles, but input/output with them fails as _fs instance variable has not been properly initialized using _fix method in GridFS class.

This effectively prevents one to execute "cursor queries" (with limit, skip etc) and still use the returned objects for input/output. Only way to circumvent this is to use find() instead of getFiles(), but it does not provide any API to e.g. limit the resultset and thus in many cases ends up using unnecessary I/O.

This commit wraps DBCursor returned from getFileList with GridFSCursor that uses _fix to inject GridFS instance into GridFSFiles returned when calling next(). This allows one to cast returned DBObjects into GridFSFiles and make I/O operations with them successfully.

I'm not sure if this kind of approach is an appropriate one and would very much like to hear any better suggestions to solve the same problem!
