### PR TITLE
JAVA-272 - OSGi Manifest is incorrect

### DIFF
--- a/src/main/META-INF/MANIFEST.MF
+++ b/src/main/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: MongoDB
 Bundle-SymbolicName: com.mongodb
 Bundle-Version: @VERSION@
-Import-Package: javax.management
+Import-Package: javax.management, javax.net
 Export-Package: com.mongodb, com.mongodb.io, com.mongodb.util, com.mongodb.gridfs, org.bson, org.bson.util, org.bson.types, org.bson.io


### PR DESCRIPTION
Fixes JAVA-272. Using org.mongodb classes fails in an OSGi environment because the bundle does not import javax.net. The bundle will become active but it doesn't have all of the necessary classes available.

Here's the first few lines of the stacktrace when this happens.

The activate method has thrown an exception (java.lang.NoClassDefFoundError: javax/net/SocketFactory) java.lang.NoClassDefFoundError: javax/net/SocketFactory
    at com.mongodb.MongoOptions.reset(MongoOptions.java:48)
    at com.mongodb.MongoOptions.<init>(MongoOptions.java:29)
    at com.mongodb.MongoURI.<init>(MongoURI.java:264)

After this patch this behavior stops and the driver works correctly.
