### PR TITLE
C# driver style Query Builder?

### DIFF
--- a/src/main/com/mongodb/Query.java
+++ b/src/main/com/mongodb/Query.java
@@ -1,0 +1,371 @@
+// Query.java
+
+/**
+ *      Copyright (C) 2010 10gen Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.mongodb;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import com.mongodb.QueryOperators;
+
+/**
+ * Utility for creating DBObject queries
+ * @author Wes Freeman
+ *
+ */
+public class Query extends BasicDBObject implements DBObject {
+	
+    public static final long serialVersionUID=98805780708789820L;
+
+    /**
+     * Creates a builder with an empty query
+     */
+    public Query() {
+        super();
+    }
+
+    /**
+     * Creates a builder with an object 
+     */
+    public Query(String key, Object val) {
+        super(key, val);
+    }
+
+    /**
+     * Equivalent to the $gt operator
+     * @param val value to query
+     * @return Returns Query with GT  
+     */
+    public Query GT(Object val) {
+        this.appendToLastKeyValue(QueryOperators.GT, val); 
+        return this;
+    }
+
+    /**
+     * Equivalent to the $gt operator
+     * @param key key to query
+     * @param val value to query
+     * @return Returns Query with GT  
+     */
+    public static Query GT(String key, Object val) {
+        Query q = new Query(key, new Query(QueryOperators.GT,val));
+        return q;
+    }
+
+    /**
+     * Equivalent to the $gte operator
+     * @param val value to query
+     * @return Returns Query with GTE  
+     */
+    public Query GTE(Object val) {
+        this.appendToLastKeyValue(QueryOperators.GTE, val); 
+        return this;
+    }
+
+    /**
+     * Equivalent to the $gte operator
+     * @param key key to query
+     * @param val value to query
+     * @return Returns Query with GTE  
+     */
+    public static Query GTE(String key, Object val) {
+        Query q = new Query(key, new Query(QueryOperators.GTE,val));
+        return q;
+    }
+
+    /**
+     * Equivalent to the $lt operator
+     * @param val value to query
+     * @return Returns Query with LT  
+     */
+    public Query LT(Object val) {
+        this.appendToLastKeyValue(QueryOperators.LT, val); 
+        return this;
+    }
+
+    /**
+     * Equivalent to the $lt operator
+     * @param key key to query
+     * @param val value to query
+     * @return Returns Query with LT  
+     */
+    public static Query LT(String key, Object val) {
+        Query q = new Query(key, new Query(QueryOperators.LT,val));
+        return q;
+    }
+
+    /**
+     * Equivalent to the $lte operator (chainable version)
+     * @param val value to query
+     * @return Returns Query with LTE  
+     */
+    public Query LTE(Object val) {
+        this.appendToLastKeyValue(QueryOperators.LTE, val); 
+        return this;
+    }
+
+    /**
+     * Equivalent to the $lte operator
+     * @param key key to query
+     * @param val value to query
+     * @return Returns query with LTE  
+     */
+    public static Query LTE(String key, Object val) {
+        Query q = new Query(key, new Query(QueryOperators.LTE,val));
+        return q;
+    }
+
+    /**
+     * Equivalent to the is relationship
+     * @param key key to query
+     * @param val value to query
+     * @return Returns query with IS
+     */
+    public static Query EQ(String key, Object val) {
+        Query q = new Query(key,val);
+        return q;
+    } 
+
+    /**
+     * Equivalent to the $ne operator
+     * @param key key to query
+     * @param val value to query
+     * @return Returns query with NE  
+     */
+    public static Query NE(String key, Object val) {
+        Query q = new Query(key, new Query(QueryOperators.NE,val));
+        return q;
+    } 
+
+    /**
+     * Equivalent to the $in operator
+     * @param key key to query
+     * @param val value to query
+     * @return Returns query with IN 
+     */
+    public static Query In(String key, Object val) {
+        Query q = new Query(key, new Query(QueryOperators.IN, val));
+        return q;
+    } 
+
+    /**
+     * Equivalent to the $nin operator
+     * @param key key to query
+     * @param val value to query
+     * @return Returns query with NIN 
+     */
+    public static Query NotIn(String key, Object val) {
+        Query q = new Query(key, new Query(QueryOperators.NIN, val));
+        return q;
+    } 
+
+    /**
+     * Equivalent to the $mod operator
+     * @param key key to query
+     * @param mod value to mod by
+     * @param equals value mod op should equal
+     * @return Returns query with MOD 
+     */
+    public static Query Mod(String key, int mod, int equals) {
+        Query q = new Query(key, new Query(QueryOperators.MOD, Arrays.asList(mod,equals)));
+        return q;
+    } 
+
+    /**
+     * Equivalent to the $all operator
+     * @param key key to query
+     * @param val value to query
+     * @return Returns query with ALL
+     */
+    public static Query All(String key, Object val) {
+        Query q = new Query(key, new Query(QueryOperators.ALL, val));
+        return q;
+    } 
+
+    /**
+     * Equivalent to the $size operator (non-static, chainable version)
+     * @param size size to compare
+     * @return Returns query with SIZE
+     */
+    public Query Size(int size) {
+        this.appendToLastKeyValue(QueryOperators.SIZE, size); 
+        return this;
+    } 
+
+    /**
+     * Equivalent to the $size operator
+     * @param key key to query
+     * @param size size to compare
+     * @return Returns query with SIZE
+     */
+    public static Query Size(String key, int size) {
+        Query q = new Query(key, new Query(QueryOperators.SIZE, size));
+        return q;
+    } 
+
+    /**
+     * Equivalent to the $exists operator
+     * @param key key to query
+     * @param exists boolean exists
+     * @return Returns query with EXISTS
+     */
+    public static Query Exists(String key, boolean exists) {
+        Query q = new Query(key, new Query(QueryOperators.EXISTS, exists));
+        return q;
+    } 
+
+    /**
+     * Equivalent to the $regex operator
+     * @param key key to query
+     * @param regex Pattern regex to match
+     * @return Returns query with REGEX
+     */
+    public static Query Regex(String key, Pattern regex) {
+        Query q = new Query(key, regex);
+        return q;
+    } 
+
+    /**
+     * Equivalent to the $and operator (non-static, chainable version)
+     * @param params array of DBObjects
+     * @return Returns query with AND
+     */
+    public Query and(DBObject... params) {
+        List<DBObject> list = new ArrayList<DBObject>();
+        list.add(this);
+        for(DBObject p : params) {
+           list.add(p);
+	}
+        Query q = new Query(QueryOperators.AND,list);
+        return q;
+    } 
+
+    /**
+     * Equivalent to the $and operator
+     * @param params array of DBObjects
+     * @return Returns query with AND
+     */
+    public static Query And(DBObject... params) {
+        List<DBObject> list = new ArrayList<DBObject>();
+        for(DBObject p : params) {
+           list.add(p);
+	}
+        Query q = new Query(QueryOperators.AND,list);
+        return q;
+    } 
+
+    /**
+     * Equivalent to the $or operator (non-static, chainable version)
+     * @param params array of DBObjects
+     * @return Returns query with OR 
+     */
+    public Query or(DBObject... params) {
+        List<DBObject> list = new ArrayList<DBObject>();
+        list.add(this);
+        for(DBObject p : params) {
+           list.add(p);
+	}
+        Query q = new Query(QueryOperators.OR,list);
+        return q;
+    }
+
+    /**
+     * Equivalent to the $or operator
+     * @param params array of DBObjects
+     * @return Returns query with OR 
+     */
+    public static Query Or(DBObject... params) {
+        List<DBObject> list = new ArrayList<DBObject>();
+        for(DBObject p : params) {
+           list.add(p);
+	}
+        Query q = new Query(QueryOperators.OR,list);
+        return q;
+    }
+
+    /**
+     * Equivalent to the $elemMatch operator
+     * @param params array of DBObjects
+     * @return Returns query with elemMatch 
+     */
+    public static Query ElemMatch(String key, Object val) {
+        Query q = new Query(key, new Query(QueryOperators.ELEMMATCH,val));
+        return q;
+    }
+
+    /**
+     * Equivalent to the $near operator
+     * @param key The key to check
+     * @param x The x coord
+     * @param y The y coord
+     * @param dist The max distance
+     * @param sphere Boolean -- whether to use nearSphere
+     * @return Returns query with Near
+     */
+    public static Query Near(String key, double x, double y, double dist, boolean sphere) {
+        Query q = null;
+        if(sphere) {
+            q = new Query(key, new Query(QueryOperators.NEARSPHERE,Arrays.asList(x, y)).append(QueryOperators.MAXDISTANCE, dist));
+        } else {
+            q = new Query(key, new Query(QueryOperators.NEAR,Arrays.asList(x, y)).append(QueryOperators.MAXDISTANCE, dist));
+        }
+        return q;
+    }
+
+    /**
+     * Equivalent to the $near operator
+     * @param key The key to check
+     * @param x The x coord
+     * @param y The y coord
+     * @param dist The max distance
+     * @return Returns query with Near
+     */
+    public static Query Near(String key, double x, double y, double dist) {
+        Query q = new Query(key, new Query(QueryOperators.NEAR,Arrays.asList(x, y)).append(QueryOperators.MAXDISTANCE, dist));
+        return q;
+    }
+
+    /**
+     * Equivalent to the $near operator
+     * @param key The key to check
+     * @param x The x coord
+     * @param y The y coord
+     * @return Returns query with Near
+     */
+    public static Query Near(String key, double x, double y) {
+        Query q = new Query(key, new Query(QueryOperators.NEAR,Arrays.asList(x,y)));
+        return q;
+    }
+
+    @Override
+    public final String toString() {
+        return super.toString();
+    } 
+
+    /** 
+     * Helper to append another operator and value.
+     * @param k operator to append
+     * @param val value to append
+     */
+    private void appendToLastKeyValue(String k, Object val) {
+        String key = (String)this.toMap().keySet().toArray()[this.toMap().keySet().toArray().length-1];
+        this.put(key, ((BasicDBObject)this.toMap().get(key)).append(k,val));
+    }
+}

--- a/src/main/com/mongodb/QueryOperators.java
+++ b/src/main/com/mongodb/QueryOperators.java
@@ -36,4 +36,9 @@ public class QueryOperators {
 	public static final String EXISTS = "$exists";
 	public static final String WHERE = "$where";
 	public static final String NEAR = "$near";
+	public static final String NEARSPHERE = "$nearSphere";
+	public static final String MAXDISTANCE = "$maxDistance";
+	public static final String AND = "$and";
+	public static final String OR = "$or";
+	public static final String ELEMMATCH = "$elemMatch";
 }

--- a/src/test/com/mongodb/QueryTest.java
+++ b/src/test/com/mongodb/QueryTest.java
@@ -1,0 +1,384 @@
+// QueryTest.java
+
+/**
+ *      Copyright (C) 2010 10gen Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.mongodb;
+
+import java.util.*;
+import java.util.regex.Pattern;
+import org.testng.annotations.*;
+
+import com.mongodb.util.TestCase;
+
+/**
+ * Test for various methods of <code/>Query</code>
+ * @author Wes Freeeman
+ *
+ */
+public class QueryTest extends TestCase {
+    private static TestDB _testDB;
+	
+    @BeforeClass
+    public static void setup() {
+        _testDB = new TestDB("queryTest");
+    }
+	
+    @Test
+    public void greaterThanTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("gt-test");
+        saveTestDocument(collection, key, 0);
+		
+        DBObject queryTrue = Query.GT(key, -1);
+        assertTrue(testQuery(collection, queryTrue));
+		
+        DBObject queryFalse = Query.GT(key,0);
+        assertFalse(testQuery(collection, queryFalse));
+    }
+
+    @Test
+    public void greaterThanEqualsTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("gte-test");
+        saveTestDocument(collection, key, 0);
+		
+        DBObject queryTrue = Query.GTE(key,0);
+        assertTrue(testQuery(collection, queryTrue));
+		
+        DBObject queryTrue2 = Query.GTE(key,-1);
+        assertTrue(testQuery(collection, queryTrue2));
+		
+        DBObject queryFalse = Query.GTE(key,1);
+        assertFalse(testQuery(collection, queryFalse));
+
+    }
+
+    @Test
+    public void lessThanTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("lt-test");
+        saveTestDocument(collection, key, 0);
+		
+        DBObject queryTrue = Query.LT(key,1);
+        assertTrue(testQuery(collection, queryTrue));
+		
+        DBObject queryFalse = Query.LT(key,0);
+        assertFalse(testQuery(collection, queryFalse));
+
+    }
+
+    @Test
+    public void lessThanEqualsTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("lte-test");
+        saveTestDocument(collection, key, 0);
+		
+        DBObject queryTrue = Query.LTE(key,1);
+        assertTrue(testQuery(collection, queryTrue));
+		
+        DBObject queryTrue2 = Query.LTE(key,0);
+        assertTrue(testQuery(collection, queryTrue2));
+		
+        DBObject queryFalse = Query.LTE(key,-1);
+        assertFalse(testQuery(collection, queryFalse));
+    }
+
+    @Test
+    public void equalsTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("is-test");
+        saveTestDocument(collection, key, "test");
+		
+        DBObject queryTrue = Query.EQ(key,"test");
+        assertTrue(testQuery(collection, queryTrue));
+		
+        DBObject queryFalse = Query.EQ(key,"test1");
+        assertFalse(testQuery(collection, queryFalse));
+    }
+
+    @Test
+    public void notEqualsTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("ne-test");
+        saveTestDocument(collection, key, "test");
+		
+        DBObject queryTrue = Query.NE(key,"test1");
+        assertTrue(testQuery(collection, queryTrue));
+		
+        DBObject queryFalse = Query.NE(key,"test");
+        assertFalse(testQuery(collection, queryFalse));
+
+    }
+	
+    @Test    
+    public void inTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("in-test");
+        saveTestDocument(collection, key, 1);
+		
+        DBObject queryTrue = Query.In(key,Arrays.asList(1, 2, 3));
+        assertTrue(testQuery(collection, queryTrue));
+		
+        DBObject queryFalse = Query.In(key,Arrays.asList(2, 3, 4));
+        assertFalse(testQuery(collection, queryFalse));
+    }
+	
+
+    @Test
+    public void notInTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("nin-test");
+        saveTestDocument(collection, key, 1);
+
+        DBObject queryTrue = Query.NotIn(key,Arrays.asList(2, 3, 4));
+        assertTrue(testQuery(collection, queryTrue));
+		
+        DBObject queryFalse = Query.NotIn(key,Arrays.asList(1, 2, 3));
+        assertFalse(testQuery(collection, queryFalse));
+    }
+	
+    @Test
+    public void modTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("mod-test");
+        saveTestDocument(collection, key, 9);
+		
+        DBObject queryTrue = Query.Mod(key, 2, 1);
+        assertTrue(testQuery(collection, queryTrue));
+		
+        DBObject queryFalse = Query.Mod(key, 2, 0);
+        assertFalse(testQuery(collection, queryFalse));
+    }	
+	
+    @Test
+    public void allTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("all-test");
+        saveTestDocument(collection, key, Arrays.asList(1, 2, 3));
+		
+        DBObject query = Query.All(key,Arrays.asList(1, 2, 3));
+        assertTrue(testQuery(collection, query));
+		
+        DBObject queryFalse = Query.All(key,Arrays.asList(2, 3, 4));
+        assertFalse(testQuery(collection, queryFalse));
+    }
+	
+    @Test
+    public void sizeTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("size-test");
+        saveTestDocument(collection, key, Arrays.asList(1, 2, 3));
+		
+        DBObject queryTrue = Query.Size(key,3);
+        assertTrue(testQuery(collection, queryTrue));
+		
+        DBObject queryFalse = Query.Size(key,4);
+        assertFalse(testQuery(collection, queryFalse));
+		
+        DBObject queryFalse2 = Query.Size(key,2);
+        assertFalse(testQuery(collection, queryFalse2));
+    }
+
+    @Test
+    public void existsTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("exists-test");
+        saveTestDocument(collection, key, "test");
+		
+        DBObject queryTrue = Query.Exists(key,true);
+        assertTrue(testQuery(collection, queryTrue));
+		
+        DBObject queryFalse = Query.Exists(key, false);
+        assertFalse(testQuery(collection, queryFalse));
+    }
+
+    @Test
+    public void regexTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("regex-test");
+        saveTestDocument(collection, key, "test");
+		
+        DBObject queryTrue = Query.Regex(key,Pattern.compile("\\w*"));
+        assertTrue(testQuery(collection, queryTrue));
+    }
+	
+    @Test
+    public void rangeChainTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("range-test");
+        saveTestDocument(collection, key, 2);
+		
+        DBObject queryTrue = Query.GT(key,0).LT(3);
+        assertTrue(testQuery(collection, queryTrue));
+
+        DBObject queryTrue2 = Query.LT(key,3).GT(0);
+        assertTrue(testQuery(collection, queryTrue2));
+
+        DBObject queryTrue3 = Query.LT(key,3).GTE(2);
+        assertTrue(testQuery(collection, queryTrue3));
+
+        DBObject queryTrue4 = Query.GT(key,0).LTE(2);
+        assertTrue(testQuery(collection, queryTrue2));
+    }
+	
+    @Test
+    public void compoundChainTest() {
+        String key = "x";
+        String key2 = "y";
+        String value = key;
+        DBCollection collection = _testDB.getCollection("compound-test");
+        DBObject testDocument = new BasicDBObject();
+        testDocument.put(key, value);
+        testDocument.put(key2, 9);
+        collection.save(testDocument);
+		
+        DBObject queryTrue = Query.And(Query.EQ(key,value), Query.Mod(key2,2,1));
+        assertTrue(testQuery(collection, queryTrue));
+    }
+	
+    @Test
+    public void arrayChainTest() {
+        String key = "x";
+        DBCollection collection = _testDB.getCollection("array-test");
+        saveTestDocument(collection, key, Arrays.asList(1, 2, 3));
+		
+        DBObject queryTrue = Query.All(key,Arrays.asList(1,2,3)).Size(3);
+        assertTrue(testQuery(collection, queryTrue));
+    }
+	
+    @Test
+    public void testOr() {
+        DBCollection c = _testDB.getCollection( "or1" );
+        c.drop();
+        c.insert( new BasicDBObject( "a" , 1 ) );
+        c.insert( new BasicDBObject( "b" , 1 ) );
+        
+        DBObject q = Query.Or( Query.EQ( "a" , 1 ) , 
+                               Query.EQ( "b" , 1 ) );
+        assertEquals( 2 , c.find( q ).itcount() );
+        DBObject q2 = Query.EQ( "a" , 1 ).or( Query.EQ( "b" , 1 ) );
+        assertEquals( 2 , c.find( q2 ).itcount() );
+    }
+
+    @Test
+    public void testAnd() {
+        DBCollection c = _testDB.getCollection( "and1" );
+        c.drop();
+        c.insert( new BasicDBObject( "a" , 1 ).append( "b" , 1) );
+        c.insert( new BasicDBObject( "b" , 1 ) );
+        
+        DBObject q = Query.And( Query.EQ( "a" , 1 ) , 
+                                Query.EQ( "b" , 1 ) );
+        assertEquals( 1 , c.find( q ).itcount() );
+        DBObject q2 = Query.EQ( "a" , 1 ).and( Query.EQ( "b" , 1 ) );
+        assertEquals( 1 , c.find( q2 ).itcount() );
+    }
+
+    @Test
+    public void testElemMatch() {
+        DBCollection c = _testDB.getCollection( "elemmatch1" );
+        c.drop();
+        c.insert( new BasicDBObject( "a" , Arrays.asList(new BasicDBObject("b",1).append("c",1), new BasicDBObject("c",1) ) ));
+        c.insert( new BasicDBObject( "a" , 1 ) );
+        
+        DBObject q = Query.ElemMatch( "a", Query.And(Query.EQ("b",1),Query.EQ("c",1) ));
+        assertEquals( 1 , c.find( q ).itcount() );
+    }
+
+    @Test
+    public void testNear() {
+        DBCollection c = _testDB.getCollection( "near" );
+        c.drop();
+        c.ensureIndex(new BasicDBObject("loc","2d"));
+        c.insert( new BasicDBObject( "loc" , Arrays.asList(1.1,2.2) ));
+        
+        DBObject q = Query.Near( "loc", 1.2, 2.3 );
+        assertEquals( 1 , c.find( q ).itcount() );
+    }
+
+    @Test
+    public void testNearMaxDist() {
+        DBCollection c = _testDB.getCollection( "near" );
+        c.drop();
+        c.ensureIndex(new BasicDBObject("loc","2d"));
+        c.insert( new BasicDBObject( "loc" , Arrays.asList(1.1,2.2) ));
+        
+        DBObject q = Query.Near( "loc", 1.2, 2.3, 0.2 );
+        assertEquals( 1 , c.find( q ).itcount() );
+        DBObject q2 = Query.Near( "loc", 1.2, 2.3, 0.1 );
+        assertEquals( 0 , c.find( q2 ).itcount() );
+    }
+
+    @Test
+    public void testNearMaxDistSphere() {
+        DBCollection c = _testDB.getCollection( "near" );
+        c.drop();
+        c.ensureIndex(new BasicDBObject("loc","2d"));
+        c.insert( new BasicDBObject( "loc" , Arrays.asList(1.1,2.2) ));
+        
+        DBObject q = Query.Near( "loc", 1.2, 2.3, 0.2, true );
+        assertEquals( 1 , c.find( q ).itcount() );
+        DBObject q2 = Query.Near( "loc", 1.2, 2.3, 0.001, true );
+        assertEquals( 0 , c.find( q2 ).itcount() );
+    }
+
+    @Test
+    public void testComplex() {
+        DBCollection c = _testDB.getCollection( "complex1" );
+        c.drop();
+        c.insert( new BasicDBObject( "a" , 1 ).append( "b" , 2).append("d",4) );
+        c.insert( new BasicDBObject( "b" , 2 ).append( "e" , 5) );
+        c.insert( new BasicDBObject( "b" , 1 ) );
+        c.insert( new BasicDBObject( "e" , 5 ) );
+        c.insert( new BasicDBObject( "d" , 4 ) );
+        c.insert( new BasicDBObject( "b" , 2 ) );
+        
+        DBObject q = Query.And(
+            Query.Or( Query.EQ( "a" , 1 ) , 
+                 Query.EQ( "b" , 2 ) ,
+                 Query.EQ( "c" , 3 ) ),
+            Query.Or( 
+                     Query.EQ( "d" , 4 ), 
+                     Query.EQ( "e" , 5 ) )
+                );
+        
+        assertEquals( 2 , c.find( q ).itcount() );
+    }
+    
+    @AfterClass
+    public static void tearDown() {
+        _testDB.cleanup();
+    }
+	
+    /**
+     * Convenience method that
+     * creates a new MongoDB Document with a key-value pair and saves it inside the specified collection
+     * @param collection Collection to save the new document to
+     * @param key key of the field to be inserted to the new document
+     * @param value value of the field to be inserted to the new document
+     */
+    private void saveTestDocument(DBCollection collection, String key, Object value) {
+        DBObject testDocument = new BasicDBObject();
+        testDocument.put(key, value);
+        collection.save(testDocument);
+    }
+	
+    private boolean testQuery(DBCollection collection, DBObject query) {
+        DBCursor cursor = collection.find(query);
+        return cursor.hasNext();
+    }
+		
+}

--- a/testng.xml
+++ b/testng.xml
@@ -41,6 +41,7 @@ limitations under the License.
             <class name="com.mongodb.ObjectIdTest"/>
             <class name="com.mongodb.DBRefTest"/>
             <class name="com.mongodb.QueryBuilderTest"/>
+            <class name="com.mongodb.QueryTest"/>
             <class name="com.mongodb.ErrorTest"/>
             <class name="com.mongodb.ThreadingTest"/>
             <class name="com.mongodb.MongoURITest"/>


### PR DESCRIPTION
Using the C# QueryBuilder.cs as loose example, I built Query.java, which has a similar interface. It's more concise than the QueryBuilder.java. Also, as `Query` implements `DBObject`, it can be passed directly to the function needing it, without `.get()`. 

For example: `QueryBuilder.start().or(new BasicDBObject("a",1),new BasicDBObject("b",1)).get();`
Becomes: `Query.Or(Query.EQ("a",1), Query.EQ("b",1));`

And: `QueryBuilder.start(key).is(value).and(key2).mod(Arrays.asList(2,1)).get();`
Becomes: `Query.EQ(key,value).and(Query.Mod(key2,2,1));`
Or: `Query.And(Query.EQ(key,value), Query.Mod(key2,2,1));`

I've included a QueryTest.java, which mimics all of the tests that QueryBuilderTest.java had, and a few extras for good measure. I’ve also implemented $near and $elemMatch, and a few others.

I realize that it's somewhat redundant functionality, but `QueryBuilder` isn't exactly full-featured yet--I thought you guys might be open to having two builders, or migrating to this one. What do you think?
