### PR TITLE
Encoding concurrency

### DIFF
--- a/src/main/org/bson/util/ClassAncestry.java
+++ b/src/main/org/bson/util/ClassAncestry.java
@@ -1,0 +1,72 @@
+package org.bson.util;
+
+import static java.util.Collections.unmodifiableList;
+import static org.bson.util.concurrent.CopyOnWriteMap.newHashMap;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+
+class ClassAncestry {
+
+    /**
+     * getAncestry
+     * 
+     * Walks superclass and interface graph, superclasses first, then
+     * interfaces, to compute an ancestry list. Supertypes are visited left to
+     * right. Duplicates are removed such that no Class will appear in the list
+     * before one of its subtypes.
+     * 
+     * Does not need to be synchronized, races are harmless as the Class graph
+     * does not change at runtime.
+     */
+    public static <T> List<Class<?>> getAncestry(Class<T> c) {
+        final ConcurrentMap<Class<?>, List<Class<?>>> cache = getClassAncestryCache();
+        while (true) {
+            List<Class<?>> cachedResult = cache.get(c);
+            if (cachedResult != null) {
+                return cachedResult;
+            }
+            cache.putIfAbsent(c, computeAncestry(c));
+        }
+    }
+
+    /**
+     * computeAncestry, starting with children and going back to parents
+     */
+    private static List<Class<?>> computeAncestry(Class<?> c) {
+        final List<Class<?>> result = new ArrayList<Class<?>>();
+        result.add(Object.class);
+        computeAncestry(c, result);
+        Collections.reverse(result);
+        return unmodifiableList(new ArrayList<Class<?>>(result));
+    }
+
+    private static <T> void computeAncestry(Class<T> c, List<Class<?>> result) {
+        if ((c == null) || (c == Object.class)) {
+            return;
+        }
+
+        // first interfaces (looks backwards but is not)
+        Class<?>[] interfaces = c.getInterfaces();
+        for (int i = interfaces.length - 1; i >= 0; i--) {
+            computeAncestry(interfaces[i], result);
+        }
+
+        // next superclass
+        computeAncestry(c.getSuperclass(), result);
+
+        if (!result.contains(c))
+            result.add(c);
+    }
+
+    /**
+     * classAncestryCache
+     */
+    private static ConcurrentMap<Class<?>, List<Class<?>>> getClassAncestryCache() {
+        return (_ancestryCache);
+    }
+
+    private static final ConcurrentMap<Class<?>, List<Class<?>>> _ancestryCache = newHashMap();
+}

--- a/src/main/org/bson/util/concurrent/ComputingMap.java
+++ b/src/main/org/bson/util/concurrent/ComputingMap.java
@@ -1,0 +1,109 @@
+package org.bson.util.concurrent;
+
+import static org.bson.util.concurrent.Assertions.notNull;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+public final class ComputingMap<K, V> implements Map<K, V>, Function<K, V> {
+
+    public static <K, V> Map<K, V> create(Function<K, V> function) {
+        return new ComputingMap<K, V>(CopyOnWriteMap.<K, V> newHashMap(), function);
+    }
+
+    private final ConcurrentMap<K, V> map;
+    private final Function<K, V> function;
+
+    ComputingMap(ConcurrentMap<K, V> map, Function<K, V> function) {
+        this.map = notNull("map", map);
+        this.function = notNull("function", function);
+    }
+
+    public V get(Object key) {
+        while (true) {
+            V v = map.get(key);
+            if (v != null)
+                return v;
+            @SuppressWarnings("unchecked")
+            K k = (K) key;
+            V value = function.apply(k);
+            if (value == null)
+                return null;
+            map.putIfAbsent(k, value);
+        }
+    }
+
+    public V apply(K k) {
+        return get(k);
+    }
+
+    public V putIfAbsent(K key, V value) {
+        return map.putIfAbsent(key, value);
+    }
+
+    public boolean remove(Object key, Object value) {
+        return map.remove(key, value);
+    }
+
+    public boolean replace(K key, V oldValue, V newValue) {
+        return map.replace(key, oldValue, newValue);
+    }
+
+    public V replace(K key, V value) {
+        return map.replace(key, value);
+    }
+
+    public int size() {
+        return map.size();
+    }
+
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    public V put(K key, V value) {
+        return map.put(key, value);
+    }
+
+    public V remove(Object key) {
+        return map.remove(key);
+    }
+
+    public void putAll(Map<? extends K, ? extends V> m) {
+        map.putAll(m);
+    }
+
+    public void clear() {
+        map.clear();
+    }
+
+    public Set<K> keySet() {
+        return map.keySet();
+    }
+
+    public Collection<V> values() {
+        return map.values();
+    }
+
+    public Set<java.util.Map.Entry<K, V>> entrySet() {
+        return map.entrySet();
+    }
+
+    public boolean equals(Object o) {
+        return map.equals(o);
+    }
+
+    public int hashCode() {
+        return map.hashCode();
+    }
+}

--- a/src/main/org/bson/util/concurrent/Function.java
+++ b/src/main/org/bson/util/concurrent/Function.java
@@ -1,0 +1,5 @@
+package org.bson.util.concurrent;
+
+public interface Function<A, B> {
+    B apply(A a);
+}


### PR DESCRIPTION
Here's an implementation that is threadsafe and performant. It uses the CopyOnWriteMap as the basis for a simple ComputingMap that is then used to implement the original ClassMap functionality. The original population isn't as pretty as it could be, but the parent class finding code at least been separated out into ClassAncestry.
