### PR TITLE
Add support for sharding on individual collections.

### DIFF
--- a/src/main/com/mongodb/DB.java
+++ b/src/main/com/mongodb/DB.java
@@ -83,6 +83,38 @@ public abstract class DB {
     }
 
     /**
+     * Gets a collection with a given name.
+     * If the collection does not exist, a new collection is created, and the specified command is run against it.
+     * @param name the name of the collection to return
+     * @param cmd the command to run against a newly created collection
+     * @return the collection
+     */
+    protected abstract DBCollection doGetCollectionWithDBCommandOnCreation( String name, DBObject cmd );
+
+    /**
+     * Gets a collection with a given name.
+     * If the collection does not exist, a new collection is created, and the specified command is run against it.
+     * @param name the name of the collection to return
+     * @param cmd the command to run against a newly created collection
+     * @return the collection
+     */
+    public final DBCollection getCollectionWithAdminDBCommandOnCreation( String name, DBObject cmd ){
+        DBCollection c = doGetCollectionWithDBCommandOnCreation(name,cmd);
+        return c;
+    }
+
+    public final DBCollection getShardedCollection( String name ){
+        BasicDBObject key = new BasicDBObject("_id", new Integer(1));
+        return getCollectionShardedWithKey(name, key);
+    }
+
+    public DBCollection getCollectionShardedWithKey(String name, BasicDBObject key) {
+        DBObject cmd = new BasicDBObject( "shardcollection", _name + "." + name );
+        cmd.put("key", key);
+        return getCollectionWithAdminDBCommandOnCreation(name, cmd);
+    }
+
+    /**
      * Creates a collection with a given name and options.
      * If the collection does not exist, a new collection is created.
      * Note that if the options parameter is null, the creation will be deferred to when the collection is written to.

--- a/src/main/com/mongodb/DBApiLayer.java
+++ b/src/main/com/mongodb/DBApiLayer.java
@@ -113,13 +113,22 @@ public class DBApiLayer extends DB {
     }
 
     protected MyCollection doGetCollection( String name ){
+        return doGetCollectionWithDBCommandOnCreation(name, null);
+    }
+
+    protected MyCollection doGetCollectionWithDBCommandOnCreation(String name, DBObject cmd) {
         MyCollection c = _collections.get( name );
         if ( c != null )
             return c;
 
         c = new MyCollection( name );
         MyCollection old = _collections.putIfAbsent(name, c);
-        return old != null ? old : c;
+        if (old != null) return old;
+        else {
+            if (cmd != null) getMongo().getDB("admin").command(cmd);
+            return c;
+        }
+
     }
 
     String _removeRoot( String ns ){

--- a/src/main/com/mongodb/Mongo.java
+++ b/src/main/com/mongodb/Mongo.java
@@ -286,12 +286,20 @@ public class Mongo {
     }
 
     /**
-     * gets a database object
+     * gets a database object, creating it if it doesn't exist
      * @param dbname the database name
      * @return
      */
     public DB getDB( String dbname ){
+        return getDBWithAdminCommandOnCreation(dbname, null);
+    }
 
+  /**
+     * gets a database object, creating it and running the specified command if the db doesn't exist
+     * @param dbname the database name
+     * @return
+     */
+    public DB getDBWithAdminCommandOnCreation(String dbname, DBObject cmd){
         DB db = _dbs.get( dbname );
         if ( db != null )
             return db;
@@ -300,7 +308,21 @@ public class Mongo {
         DB temp = _dbs.putIfAbsent( dbname , db );
         if ( temp != null )
             return temp;
+        if ( cmd != null ) {
+            getDB("admin").command(cmd);
+
+        }
         return db;
+    }
+
+  /**
+     * gets a sharded database object, creating it if it doesn't exist
+     * @param dbname the database name
+     * @return
+     */
+    public DB getShardedDB( String dbname){
+        DBObject cmd = new BasicDBObject( "enablesharding", dbname );
+        return getDBWithAdminCommandOnCreation(dbname, cmd);
     }
 
     /**


### PR DESCRIPTION
Change by Miles O'Connor.

This commits a general method to run a command the first time a mongo instance interacts with a db, which is specifically used to enable sharding on individual collections. We'd love to know if there's a better way to do this.
