### PR TITLE
Remove host name override for "localhost"

### DIFF
--- a/src/main/com/mongodb/ServerAddress.java
+++ b/src/main/com/mongodb/ServerAddress.java
@@ -216,10 +216,6 @@ public class ServerAddress {
     private static InetAddress[] _getAddress( String host )
         throws UnknownHostException {
 
-        if ( host.toLowerCase().equals("localhost") ){
-            return new InetAddress[] { InetAddress.getLocalHost()};
-        }
-        
         return InetAddress.getAllByName( host );
     }
     


### PR DESCRIPTION
When resolving "localhost", the code was instead calling InetAddress.getLocalHost(),
which determines the host name to resolve by retrieving the name of the host from
the system.

This changes the resolution from localhost (which will result in 127.0.0.1 on most
systems) to the machine's host name (which will result in the machine's external
IP address on most systems).

The new behavior leaves the resolution of "localhost" to the underlying OS as the
user would expect.
