### PR TITLE
critical path in lookup of DBPortPool

### DIFF
--- a/src/main/com/mongodb/DBPortPool.java
+++ b/src/main/com/mongodb/DBPortPool.java
@@ -54,16 +54,11 @@ public class DBPortPool extends SimplePool<DBPort> {
 
         DBPortPool get( ServerAddress addr ){
             
-            DBPortPool p = _pools.get( addr );
-            
-            if (p != null) 
-                return p;
-            
             synchronized (_pools) {
-                p = _pools.get( addr );
-                if (p != null) {
+                DBPortPool p = _pools.get( addr );
+            
+                if (p != null) 
                     return p;
-                }
                 
                 p = new DBPortPool( addr , _options );
                 _pools.put( addr , p);
@@ -85,9 +80,9 @@ public class DBPortPool extends SimplePool<DBPort> {
                     }
                 }
 
+                return p;
             }
             
-            return p;
         }
 
         void close(){
@@ -115,7 +110,7 @@ public class DBPortPool extends SimplePool<DBPort> {
         }
 
         final MongoOptions _options;
-        final Map<ServerAddress,DBPortPool> _pools = Collections.synchronizedMap( new HashMap<ServerAddress,DBPortPool>() );
+        final Map<ServerAddress,DBPortPool> _pools = new HashMap<ServerAddress,DBPortPool>();
         final MBeanServer _server;
     }
 


### PR DESCRIPTION
critical path in lookup of DBPortPool: if 2 threads pass by and find no 
DBPortPool for the same addr, then 2 DBPortPool objects will be created
and returned, but only one of them is actually stored in the _pool map
(side effect is that on close() only one DBPortPool will be closed);
note that this patch will make the _pool object a non synchronized map
to avoid double synchronization
