### PR TITLE
Make exception message more friendly

### DIFF
--- a/src/main/com/mongodb/DBTCPConnector.java
+++ b/src/main/com/mongodb/DBTCPConnector.java
@@ -245,7 +245,7 @@ public class DBTCPConnector implements DBConnector {
         if ( err != null && err.isNotMasterError() ){
             checkMaster( true , true );
             if ( retries <= 0 ){
-                throw new MongoException( "not talking to master and retries used up" );
+                throw new MongoException( "not talking to master and retries used up,error from server:" + err.getError());
             }
             return call( db , coll , m , hostNeeded , retries -1, readPref, decoder );
         }


### PR DESCRIPTION
I've met  a exception such as "not talking to master and retries used up,error from server",but i don't know why.
At last,i found it that because i query data from secondary mongodb not master,so i have to set slaveOk to be true.

But if the exception message contained server error message,i can fixed it much more easily.So i pull this request to add server error in exception message.Thanks a lot.
