### PR TITLE
JAVA-378 reallocate buffer when changing chunksize of GridFsInputFile

### DIFF
--- a/src/main/com/mongodb/gridfs/GridFSInputFile.java
+++ b/src/main/com/mongodb/gridfs/GridFSInputFile.java
@@ -144,6 +144,7 @@ public class GridFSInputFile extends GridFSFile {
         if (_outputStream != null || _savedChunks)
             return;
         this._chunkSize = _chunkSize;
+        this._buffer = new byte[(int) _chunkSize];
     }
 
     /**


### PR DESCRIPTION
This pull requests relates to an issue reported 47 weeks ago.
If you change the chunksize of an GridFsInputFile to a size greater than the default you will get an IndexOutOfBounds Exception, because the buffer isn't reallocated to fit the size.

BR lesnail
