### PR TITLE
Adding MACs to machine-piece

### DIFF
--- a/src/main/org/bson/types/ObjectId.java
+++ b/src/main/org/bson/types/ObjectId.java
@@ -358,6 +358,18 @@ public class ObjectId implements Comparable<ObjectId> , java.io.Serializable {
                     while ( e.hasMoreElements() ){
                         NetworkInterface ni = e.nextElement();
                         sb.append( ni.toString() );
+                        byte[] mac = ni.getHardwareAddress();
+            			if (mac != null) {
+            				// expecting a 6 byte MAC
+            				ByteBuffer bb = ByteBuffer.wrap(mac);
+            				try{
+            					sb.append(bb.getChar());
+            					sb.append(bb.getChar());
+            					sb.append(bb.getChar());
+            				}catch(BufferUnderflowException shortHardwareAddressException){
+            					// mac with less than 6 bytes. continue
+            				}
+            			}
                     }
                     machinePiece = sb.toString().hashCode() << 16;
                 } catch (Throwable e) {


### PR DESCRIPTION
This adds the MACs to the StringBuffer from which the machine-piece is created. Just adding the interface names (lo,eth0...) is probably less unique than intended :)
