### PR TITLE
IntelliJ IDEA .iml files should not be in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,6 @@ TAGS
 src/test/ed/webtests/webtest-local.bash
 
 *.ipr
+*.iml
 *.iws
 atlassian-ide-plugin.xml


### PR DESCRIPTION
As discussed in a [previous pull request](https://github.com/mongodb/mongo-java-driver/pull/92), .iml files should be excluded from version control.
