### PR TITLE
DBCursor.next() throws NoSuchElementException

### DIFF
--- a/src/main/com/mongodb/DBApiLayer.java
+++ b/src/main/com/mongodb/DBApiLayer.java
@@ -22,14 +22,7 @@ import com.mongodb.util.JSON;
 import org.bson.BSONObject;
 import org.bson.types.ObjectId;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Level;
@@ -406,7 +399,7 @@ public class DBApiLayer extends DB {
             }
 
             if ( ! _curResult.hasGetMore( _options ) )
-                throw new RuntimeException( "no more" );
+                throw new NoSuchElementException("no more");
 
             _advance();
             return next();

--- a/src/test/com/mongodb/DBCursorTest.java
+++ b/src/test/com/mongodb/DBCursorTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -461,6 +462,15 @@ public class DBCursorTest extends TestCase {
         	assertTrue( val > curmax);
         	curmax = val;
         }
+    }
+
+    @Test(expectedExceptions = NoSuchElementException.class)
+    public void testShouldThrowNoSuchElementException() {
+        DBCollection c = _db.getCollection("emptyCollection");
+
+        DBCursor cursor = c.find();
+
+        cursor.next();
     }
 
     @Test


### PR DESCRIPTION
This pull request includes a fix for https://jira.mongodb.org/browse/JAVA-720. It changes DBCursor.next() to throw the appropriate kind of exception to conform to the contract for java.util.Iterator.

It's a fairly straightforward change, and a unit test is included.

This is bascially the same change as the [previous pull request](https://github.com/mongodb/mongo-java-driver/pull/92), plus changes as suggested by @jyemin.
