### PR TITLE
JAVA-734 JSON.parse doesn't handle $timestamp correctly

### DIFF
--- a/src/main/com/mongodb/util/JSONCallback.java
+++ b/src/main/com/mongodb/util/JSONCallback.java
@@ -87,10 +87,15 @@ public class JSONCallback extends BasicBSONCallback {
         } else if (b.containsField("$regex")) {
             o = Pattern.compile((String) b.get("$regex"),
                     BSON.regexFlags((String) b.get("$options")));
-        } else if (b.containsField("$ts")) {
-            Long ts = ((Number) b.get("$ts")).longValue();
-            Long inc = ((Number) b.get("$inc")).longValue();
-            o = new BSONTimestamp(ts.intValue(), inc.intValue());
+        } else if (b.containsField("$ts")) { //Legacy timestamp format
+            Integer ts = ((Number) b.get("$ts")).intValue();
+            Integer inc = ((Number) b.get("$inc")).intValue();
+            o = new BSONTimestamp(ts, inc);
+        } else if (b.containsField("$timestamp")) {
+            BSONObject tsObject = (BSONObject) b.get("$timestamp");
+            Integer ts = ((Number) tsObject.get("t")).intValue();
+            Integer inc = ((Number) tsObject.get("i")).intValue();
+            o = new BSONTimestamp(ts, inc);
         } else if (b.containsField("$code")) {
             if (b.containsField("$scope")) {
                 o = new CodeWScope((String) b.get("$code"), (DBObject) b.get("$scope"));

--- a/src/main/com/mongodb/util/JSONSerializers.java
+++ b/src/main/com/mongodb/util/JSONSerializers.java
@@ -403,8 +403,8 @@ public class JSONSerializers {
         public void serialize(Object obj, StringBuilder buf) {
             BSONTimestamp t = (BSONTimestamp) obj;
             BasicDBObject temp = new BasicDBObject();
-            temp.put("$t", Integer.valueOf(t.getTime()));
-            temp.put("$i", Integer.valueOf(t.getInc()));
+            temp.put("t", Integer.valueOf(t.getTime()));
+            temp.put("i", Integer.valueOf(t.getInc()));
             BasicDBObject timestampObj = new BasicDBObject();
             timestampObj.put("$timestamp", temp);
             serializer.serialize(timestampObj, buf);

--- a/src/test/com/mongodb/util/JSONCallbackTest.java
+++ b/src/test/com/mongodb/util/JSONCallbackTest.java
@@ -1,12 +1,16 @@
 package com.mongodb.util;
 
+import com.mongodb.DBRef;
+import org.bson.types.BSONTimestamp;
 import org.bson.types.Binary;
+import org.bson.types.ObjectId;
 
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.SimpleTimeZone;
+import java.util.regex.Pattern;
 
 public class JSONCallbackTest extends com.mongodb.util.TestCase {
 
@@ -43,5 +47,40 @@ public class JSONCallbackTest extends com.mongodb.util.TestCase {
         org.testng.Assert.assertEquals(parsedBinary.getType(), 0);
         org.testng.Assert.assertEquals(parsedBinary.getData(), new byte[]{97, 98, 99, 100});
     }
+
+    @org.testng.annotations.Test(groups = {"basic"})
+    public void timestampParsing() {
+        BSONTimestamp timestamp = (BSONTimestamp) JSON.parse(("{ \"$timestamp\" : { \"t\": 123, \"i\": 456 } }"));
+        org.testng.Assert.assertEquals(timestamp.getInc(), 456);
+        org.testng.Assert.assertEquals(timestamp.getTime(), 123);
+    }
+
+
+    @org.testng.annotations.Test(groups = {"basic"})
+    public void regexParsing() {
+        Pattern pattern = (Pattern) JSON.parse(("{ \"$regex\" : \".*\",  \"$options\": \"i\" }"));
+        org.testng.Assert.assertEquals(pattern.pattern(), ".*");
+        org.testng.Assert.assertEquals(pattern.flags(), Pattern.CASE_INSENSITIVE);
+    }
+
+    @org.testng.annotations.Test(groups = {"basic"})
+    public void oidParsing() {
+        ObjectId id = (ObjectId) JSON.parse(("{ \"$oid\" : \"01234567890123456789abcd\" }"));
+        org.testng.Assert.assertEquals(id, new ObjectId("01234567890123456789abcd"));
+    }
+
+    @org.testng.annotations.Test(groups = {"basic"})
+    public void refParsing() {
+        DBRef ref = (DBRef) JSON.parse(("{ \"$ref\" : \"friends\", \"$id\" : \"01234567890123456789abcd\" }"));
+        org.testng.Assert.assertEquals(ref.getRef(), "friends");
+        org.testng.Assert.assertEquals(ref.getId(), new ObjectId("01234567890123456789abcd"));
+    }
+
+// No such concept in Java
+//    @org.testng.annotations.Test(groups = {"basic"})
+//    public void undefinedParsing() {
+//        BasicDBObject undef = (BasicDBObject) JSON.parse(("{ \"$undefined\" : true }"));
+//        org.testng.Assert.assertEquals(undef, 123);
+//    }
 
 }

--- a/src/test/com/mongodb/util/JSONSerializersTest.java
+++ b/src/test/com/mongodb/util/JSONSerializersTest.java
@@ -167,8 +167,8 @@ public class JSONSerializersTest extends com.mongodb.util.TestCase {
         
         // test  BSON_TIMESTAMP
         buf = new StringBuilder();
-        serializer.serialize(new BSONTimestamp(), buf);
-        assertEquals(buf.toString(), "{ \"$timestamp\" : { \"$t\" : 0 , \"$i\" : 0}}");
+        serializer.serialize(new BSONTimestamp(123, 456), buf);
+        assertEquals(buf.toString(), "{ \"$timestamp\" : { \"t\" : 123 , \"i\" : 456}}");
         
         // test  BYTE_ARRAY
         buf = new StringBuilder();


### PR DESCRIPTION
Fix for JAVA-734 JSON.parse doesn't handle $timestamp correctly
