### PR TITLE
JAVA-374 - Logging of entry to and exit from calls to server

### DIFF
--- a/src/main/com/mongodb/DBPort.java
+++ b/src/main/com/mongodb/DBPort.java
@@ -126,7 +126,7 @@ public class DBPort {
         
         if ( _out == null )
             throw new IllegalStateException( "_out shouldn't be null" );
-
+        long start = System.currentTimeMillis();
         try {
             msg.prepare();
             _activeState = new ActiveState(msg);
@@ -148,6 +148,10 @@ public class DBPort {
         finally {
             _activeState = null;
             _processingResponse = false;
+            if(DBApiLayer.willTrace()){
+                long timeTaken = System.currentTimeMillis() - start;
+                DBApiLayer.trace(msg.getQueryDetails(timeTaken));
+            }
         }
     }
 

--- a/src/main/com/mongodb/OutMessage.java
+++ b/src/main/com/mongodb/OutMessage.java
@@ -279,6 +279,24 @@ class OutMessage extends BasicBSONEncoder {
         return _numDocuments;
     }
 
+    String getQueryDetails(long timeTaken){
+        String name = "[" +_collection.getName() + "]";
+        if(_opCode == OpCode.OP_QUERY){
+            String prefix = "";
+            if(! "$cmd".equals(_collection.getName())){
+                prefix = "[" +_collection.getName() + "] ";
+            }
+            name = prefix + _query.toString();
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("Request : ")
+                .append("Id: ").append(_id)
+                .append(" (").append(timeTaken).append(" ms) ")
+                .append(_opCode.name())
+                .append(", ").append(name);
+        return sb.toString();
+    }
+
     @Override
     public int putObject(BSONObject o) {
         if (_buffer == null) {

--- a/src/test/com/mongodb/QueryLogTest.java
+++ b/src/test/com/mongodb/QueryLogTest.java
@@ -1,0 +1,89 @@
+package com.mongodb;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import com.mongodb.util.TestCase;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.Test;
+
+public class QueryLogTest extends TestCase {
+
+    public QueryLogTest() {
+        _mongo = cleanupMongo;
+        cleanupDB = "com_mongodb_unittest_QueryLogTest";
+        _db = cleanupMongo.getDB( cleanupDB );
+    }
+
+    @Test
+    public void testQueryLogs() throws Exception{
+        DBCollection test = _db.getCollection("test");
+        setUpLogger();
+        test.save(new BasicDBObject("key1","val1"));
+        test.save(new BasicDBObject("key2","val2"));
+
+        int saveCount = 0;
+        for(LogRecord lr : testHandler.getRecords()){
+            //Check for logMessage with word 'save' as
+            //we save two objects once loggers are enabled
+            if(lr.getMessage().indexOf("save") != -1){
+                saveCount++;
+            }
+        }
+
+        //Should have 2 save records related to save operation
+        assertEquals(2,saveCount);
+    }
+
+    @AfterTest
+    public void cleanup(){
+        DBApiLayer.TRACE_LOGGER.removeHandler(testHandler);
+        DBApiLayer.TRACE_LOGGER.removeHandler(consoleHandler);
+        testHandler.reset();
+    }
+
+    private void setUpLogger() {
+        Logger logger = DBApiLayer.TRACE_LOGGER;
+        logger.addHandler(testHandler);
+        logger.setLevel(Level.FINEST);
+
+        consoleHandler.setLevel(Level.FINEST);
+        logger.addHandler(consoleHandler);
+    }
+
+    final Mongo _mongo;
+    final DB _db;
+    final TestHandler testHandler = new TestHandler();
+    final ConsoleHandler consoleHandler = new ConsoleHandler();
+
+    private static class TestHandler extends Handler {
+        private final List<LogRecord> records = new ArrayList<LogRecord>();
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() throws SecurityException {
+            records.clear();
+        }
+
+        public List<LogRecord> getRecords() {
+            return records;
+        }
+
+        public void reset(){
+            records.clear();
+        }
+    }
+}


### PR DESCRIPTION
Adding support for logging the calls made to Mongo DB along with time taken. The message log consist of following part. The logs can be enabled by set the LogLevel for 'com.mongodb.TRACE' category

```
Request: Id: <sequence number> (<time taken in millis> ms) <operation name>, [<collection name>]
```

For example below are logs obtained while executing a testcase which consisted of two inserts

```
FINEST: save:  com_mongodb_unittest_QueryLogTest.test { "key1" : "val1"}
FINEST: Request : Id: 1 (5 ms) OP_QUERY, { "isMaster" : 1}
FINEST: Request : Id: 2 (0 ms) OP_INSERT, [test]
FINEST: save:  com_mongodb_unittest_QueryLogTest.test { "key2" : "val2"}
FINEST: Request : Id: 3 (0 ms) OP_INSERT, [test]
```
