### PR TITLE
Update to MongoClientURI javadoc

### DIFF
--- a/src/main/com/mongodb/MongoClientURI.java
+++ b/src/main/com/mongodb/MongoClientURI.java
@@ -37,7 +37,7 @@ import java.util.logging.Logger;
  * be used and options.
  * <p>The format of the URI is:
  * <pre>
- *   mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+ *   mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database[.collection]][?options]]
  * </pre>
  * <ul>
  * <li>{@code mongodb://} is a required prefix to identify that this is a string in the standard connection format.</li>


### PR DESCRIPTION
URI can contain collection name which is not mentioned in javadoc. Fixed.
