### PR TITLE
Fix for BasicBSONObject equals method

### DIFF
--- a/src/main/org/bson/BasicBSONObject.java
+++ b/src/main/org/bson/BasicBSONObject.java
@@ -333,9 +333,15 @@ public class BasicBSONObject extends LinkedHashMap<String,Object> implements BSO
                     return false;
             }
             else if ( a instanceof Number && b instanceof Number ){
-                if ( ((Number)a).doubleValue() !=
-                     ((Number)b).doubleValue() )
+                Number aNumber = (Number) a;
+                Number bNumber = (Number) b;
+                if (aNumber instanceof Double || bNumber instanceof Double) {
+                    if (aNumber.doubleValue() != bNumber.doubleValue()) {
+                        return false;
+                    }
+                } else if (aNumber.longValue() != bNumber.longValue()) {
                     return false;
+                }
             }
             else if ( a instanceof Pattern && b instanceof Pattern ){
                 Pattern p1 = (Pattern) a;

--- a/src/test/org/bson/BSONTest.java
+++ b/src/test/org/bson/BSONTest.java
@@ -18,10 +18,14 @@
 
 package org.bson;
 
+import static org.testng.Assert.assertNotEquals;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Vector;
 import org.bson.io.BasicOutputBuffer;
 import org.bson.io.OutputBuffer;
 import org.bson.types.CodeWScope;
@@ -250,6 +254,21 @@ public class BSONTest extends Assert {
         BSON.removeDecodingHook( Date.class, tf );
         assertFalse( BSON.getDecodingHooks( Date.class ).contains( tf ) );
 
+    }
+    
+    @Test
+    public void testEquals() {
+        assertNotEquals(new BasicBSONObject("a", 1111111111111111111L), new BasicBSONObject("a", 1111111111111111112L),
+                "longs should not be equal");
+
+        assertNotEquals(new BasicBSONObject("a", 100.1D), new BasicBSONObject("a", 100.2D),
+                "doubles should not be equal");
+        
+        assertEquals(new BasicBSONObject("a", 100.1D), new BasicBSONObject("a", 100.1D),
+                "doubles should be equal");
+        
+        assertEquals(new BasicBSONObject("a", 100), new BasicBSONObject("a", 100L),
+                "int and long should be equal");
     }
 
     private class TestDate {


### PR DESCRIPTION
very large Long values were being converted to doubles for comparison
and incorrectly considered equals
