### PR TITLE
Allow access to setGridFS

### DIFF
--- a/driver-compat/src/main/com/mongodb/gridfs/GridFSFile.java
+++ b/driver-compat/src/main/com/mongodb/gridfs/GridFSFile.java
@@ -283,7 +283,7 @@ public abstract class GridFSFile implements DBObject {
      *
      * @param fs gridFS instance
      */
-    protected void setGridFS(final GridFS fs) {
+    public void setGridFS(GridFS fs) {
         this.fs = fs;
     }
 


### PR DESCRIPTION
Allows for custom implementations of GridFS.  One usecase is to use JodaDateTime for uploaded date, instead of java date.