### PR TITLE
fix for DuplicateKey Exception without code

### DIFF
--- a/src/main/com/mongodb/CommandResult.java
+++ b/src/main/com/mongodb/CommandResult.java
@@ -70,7 +70,9 @@ public class CommandResult extends BasicDBObject {
         if ( !ok() ) {   // check for command failure
             return new CommandFailureException( this );
         } else if ( hasErr() ) { // check for errors reported by getlasterror command
-            if (getCode() == 11000 || getCode() == 11001 || getCode() == 12582) {
+            String err = getErr();
+            if (getCode() == 11000 || getCode() == 11001 || getCode() == 12582 ||
+                    err.startsWith("E11000") || err.startsWith("E11001")) {
                 return new MongoException.DuplicateKey(this);
             }
             else {
@@ -92,13 +94,17 @@ public class CommandResult extends BasicDBObject {
         return code;
     }
 
+    String getErr() {
+        return (String) get("err");
+    }
+
     /**
      * check the "err" field
      * @return if it has it, and isn't null
      */
     boolean hasErr(){
-        Object o = get( "err" );
-        return (o != null && ( (String) o ).length() > 0 );
+        String o = getErr();
+        return (o != null && !o.isEmpty());
     }
 
     /**

--- a/src/test/com/mongodb/CommandResultTest.java
+++ b/src/test/com/mongodb/CommandResultTest.java
@@ -57,4 +57,21 @@ public class CommandResultTest extends TestCase {
             assertEquals(5000, e.getCode());
         }
     }
+
+    /**
+     * mongoS return an "err" but don't return a "code" for duplicate key errors
+     */
+    @Test
+    public void testCommandDuplicateKeyWithoutCode() throws UnknownHostException {
+        CommandResult commandResult = new CommandResult(new ServerAddress("localhost"));
+        final DBObject result = new BasicDBObject("ok", 1.0).append("err", "E11000 duplicate key error index");
+        commandResult.putAll(result);
+        assertEquals(MongoException.DuplicateKey.class, commandResult.getException().getClass());
+        try {
+            commandResult.throwOnError();
+            fail("Should throw");
+        } catch (MongoException.DuplicateKey e) {
+            assertEquals(commandResult, e.getCommandResult());
+        }
+    }
 }


### PR DESCRIPTION
We have some error handling code that depends on catching a DuplicateKey exception. We started getting a WriteConcernException instead after upgrading to the 2.11.3 version of the driver from 2.9.3

The problem is that mongoS doesn't return a "code" in the response (at least in the version which we're using:  2.2.3).  Previous versions of the driver checked for a string in the "err", but that was removed in 2.11.x.

 Here's an example of a response:

``` json
{
    "err": "E11000 duplicate key error index: foursquare.coll.$_id_  dup key: { : 1 }",
    "errObjects": [
        {
            "code": 11000,
            "connectionId": 1514529,
            "err": "E11000 duplicate key error index: foursquare.coll.$_id_  dup key: { : 1 }",
            "lastOp": {
                "$inc": 9,
                "$ts": 1384877384
            },
            "n": 0,
            "ok": 1.0
        },
        {
            "code": 11000,
            "connectionId": 1866741,
            "err": "E11000 duplicate key error index: foursquare.coll.$_id_  dup key: { : 2 }",
            "lastOp": {
                "$inc": 0,
                "$ts": 0
            },
            "n": 0,
            "ok": 1.0
        }
    ],
    "errs": [
        "E11000 duplicate key error index: foursquare.coll.$_id_  dup key: { : 1 }",
        "E11000 duplicate key error index: foursquare.coll.$_id_  dup key: { : 2 }"
    ],
    "n": 0,
    "ok": 1.0,
    "serverUsed": "/127.0.0.1:27017",
    "shardRawGLE": {
        "shard0/a:27017,b:27017": {
            "code": 11000,
            "connectionId": 1514529,
            "err": "E11000 duplicate key error index: foursquare.coll.$_id_  dup key: { : 1 }",
            "lastOp": {
                "$inc": 9,
                "$ts": 1384877384
            },
            "n": 0,
            "ok": 1.0
        },
        "shard1/c:27017,d:27017": {
            "code": 11000,
            "connectionId": 1866741,
            "err": "E11000 duplicate key error index: foursquare.coll.$_id_  dup key: { : 2 }",
            "lastOp": {
                "$inc": 0,
                "$ts": 0
            },
            "n": 0,
            "ok": 1.0
        }
    },
    "shards": [
        "shard0/a:27017,b:27017",
        "shard1/c:27017,d:27017"
    ]
}
```
