### PR TITLE
Improve the performance of DBCollection.findOne()

### DIFF
--- a/src/main/com/mongodb/DBCollection.java
+++ b/src/main/com/mongodb/DBCollection.java
@@ -779,7 +779,7 @@ public abstract class DBCollection {
             queryOpBuilder.addReadPreference(readPref);
         }
 
-        Iterator<DBObject> i = __find(queryOpBuilder.get(), fields , 0 , -1 , 0, getOptions(), readPref, getDecoder() );
+        Iterator<DBObject> i = __find(queryOpBuilder.get(), fields , 0 , -1 , 1, getOptions(), readPref, getDecoder() );
         
         DBObject obj = (i.hasNext() ? i.next() : null);
         if ( obj != null && ( fields != null && fields.keySet().size() > 0 ) ){


### PR DESCRIPTION
__find() get "limit" for query. We need only one record, I don't know why that value is 0. If 0 given, mongoD may retrieve all record for result then return the cursor, but when 1 given, immediately return the cursor when found at least 1 record. Isn't it?
see db.collection.find().limit(1).explain() vs. db.collection.find().explain()
