### PR TITLE
Codecs canDecode correctly works for Lists and Arrays

### DIFF
--- a/driver/src/main/org/mongodb/codecs/Codecs.java
+++ b/driver/src/main/org/mongodb/codecs/Codecs.java
@@ -73,7 +73,7 @@ public class Codecs implements Codec<Object> {
             arrayCodec.encode(bsonWriter, object);
         } else if (object instanceof Map) {
             encode(bsonWriter, (Map) object);
-        } else {
+        }  else {
             encoderRegistry.getDefaultEncoder().encode(bsonWriter, object);
         }
     }
@@ -130,9 +130,9 @@ public class Codecs implements Codec<Object> {
     }
 
     public boolean canDecode(final Class<?> theClass) {
-        return theClass.getClass().isArray()
+        return theClass.isArray()
                || primitiveCodecs.canDecode(theClass)
-               || iterableCodec.getEncoderClass().isInstance(theClass)
+               || iterableCodec.getEncoderClass().isAssignableFrom(theClass)
                || mapCodec.getEncoderClass().isAssignableFrom(theClass)
                || dbRefEncoder.getEncoderClass().isInstance(theClass)
                || codeWithScopeCodec.getEncoderClass().isInstance(theClass)


### PR DESCRIPTION
canDecode previously didn't correctly test if a given class could be handled or not. It was failing for Arrays and Lists, because the compared class didn't match.

theClass is already a class, thus invoking getClass will lead to the wrong class
isInstance is wrong to be used as we're checking Class Objects and not some Instance Objects, thus isAssignableFrom is the correct way. I only changed it for the iterableCodec, but I expect the same is true for dbRefEncoder and codeWithScopeCodec.
