### PR TITLE
JAVA-1165: ensure array and itcount methods always close server-side cursor

### DIFF
--- a/src/main/com/mongodb/DBCursor.java
+++ b/src/main/com/mongodb/DBCursor.java
@@ -602,8 +602,12 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
 
     void _fill( int n ){
         _checkType( CursorType.ARRAY );
-        while ( n >= _all.size() && _hasNext() )
-            _next();
+        try {
+            while ( n >= _all.size() && _hasNext() )
+                _next();
+        } finally {
+            this.close();
+        }
     }
 
     /**
@@ -649,12 +653,16 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
      * @throws MongoException
      */
     public int itcount(){
-        int n = 0;
-        while ( this.hasNext() ){
-            this.next();
-            n++;
+        try {
+            int n = 0;
+            while ( this.hasNext() ){
+                this.next();
+                n++;
+            }
+            return n;
+        } finally {
+            this.close();
         }
-        return n;
     }
 
     /**

--- a/src/test/com/mongodb/DBCursorTest.java
+++ b/src/test/com/mongodb/DBCursorTest.java
@@ -674,6 +674,20 @@ public class DBCursorTest extends TestCase {
         }
     }
 
+    @Test
+    public void testToArrayCursorClosed() {
+        final DBCollection c = collection;
+
+        // Insert some data.
+        for (int i = 0; i < 4; i++) {
+            c.insert(new BasicDBObject("one", "two"));
+        }
+
+        final DBCursor cursor = c.find().batchSize(3); // ensure under normal conditions the cursor would remain
+        cursor.toArray(3);
+        assertEquals(0L, cursor.getCursorId());
+    }
+
     @Test(expected = MongoException.class)
     public void testSnapshotWithHint() {
         DBCursor cursor = new DBCursor(collection, new BasicDBObject(), new BasicDBObject(), ReadPreference.primary())


### PR DESCRIPTION
Now ensuring server-side cursor is closed on the following methods:
- `itcount()`
- `length()`
- `toArray()`
- `toArray(int)`

While many of this will exhaust the cursor, and therefore effectively have the cursor closed, it wasn't guaranteed in the event of an IO failure. Added test case asserting the toArray(n) behavior.

_Note:_ this change _does_ break a couple potential client code patterns that I could imagine:

1.) clients perform one `toArray(small n)`, search this result for something, and if they did not find it page the cursor using the standard iterator approach, which picked up where `n` left off.
2.) clients repeatedly call `toArray(n)` in a loop, expecting to page this way.

Each of these patterns seem somewhat unintuitive in practice, but I must concede they _could_ exist, and would now be broken.

JIRA: https://jira.mongodb.org/browse/JAVA-1165
CC: @jyemin
