### PR TITLE
JAVA-1187: Be less aggressive closing connections on exceptions

### DIFF
--- a/src/main/com/mongodb/DBTCPConnector.java
+++ b/src/main/com/mongodb/DBTCPConnector.java
@@ -217,6 +217,9 @@ public class DBTCPConnector implements DBConnector {
             port.checkAuth( db.getMongo() );
             return operation.execute();
         }
+        catch ( MongoException re ){
+            throw re;
+        }
         catch ( IOException ioe ){
             _myPort.error(port, ioe);
             throw new MongoException.Network("Operation on server " + port.getAddress() + " failed" , ioe );


### PR DESCRIPTION
We should catch the `MongoException` first. Otherwish, any `RuntimeException` (com.mongodb.MongoException$DuplicateKey for example) will cause connection closed.
