### PR TITLE
Force Javadoc encoding to UTF-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,7 @@ configure(subprojects.findAll { it.name != 'util' }) {
         options.tagletPath project(':util').sourceSets.main.output.classesDir
         options.taglets 'ManualTaglet'
         options.taglets 'ServerReleaseTaglet'
+        options.encoding = "UTF-8"
     }
 
 }


### PR DESCRIPTION
As windows encoding is CP1252, the javadoc can't be generated with this encoding due to an non ascii caracter in this project.
Forcing it to UTF-8 allow to build the javadoc without errors
