### PR TITLE
JAVA-1125 Change way remove(query) on gridfs is performed to improve performances (branch 3.0.x)

### DIFF
--- a/driver-compat/src/test/unit/com/mongodb/gridfs/GridFSTest.java
+++ b/driver-compat/src/test/unit/com/mongodb/gridfs/GridFSTest.java
@@ -250,6 +250,46 @@ public class GridFSTest extends DatabaseTestCase {
         }
     }
 
+    @Test
+    public void testRemove() throws Exception {
+        int target = GridFS.DEFAULT_CHUNKSIZE * 3;
+        StringBuilder buf = new StringBuilder(target);
+        while (buf.length() < target) {
+            buf.append("asdasdkjasldkjasldjlasjdlajsdljasldjlasjdlkasjdlaskjdlaskjdlsakjdlaskjdasldjsad");
+        }
+        String s = buf.toString();
+
+        int nbFiles = 100;
+        for (int idx = 0; idx < nbFiles; ++idx) {
+            GridFSInputFile in = gridFS.createFile(s.getBytes(defaultCharset()));
+            in.save();
+        }
+        gridFS.remove(new BasicDBObject());
+        int[] end = getCurrentCollectionCounts();
+        assertEquals(0, end[0]);
+        assertEquals(0, end[1]);
+    }
+
+    @Test
+    public void testBulkRemove() throws Exception {
+        int target = GridFS.DEFAULT_CHUNKSIZE * 3;
+        StringBuilder buf = new StringBuilder(target);
+        while (buf.length() < target) {
+            buf.append("asdasdkjasldkjasldjlasjdlajsdljasldjlasjdlkasjdlaskjdlaskjdlsakjdlaskjdasldjsad");
+        }
+        String s = buf.toString();
+
+        int nbFiles = 100;
+        for (int idx = 0; idx < nbFiles; ++idx) {
+            GridFSInputFile in = gridFS.createFile(s.getBytes(defaultCharset()));
+            in.save();
+        }
+        gridFS.remove(new BasicDBObject(), false);
+        int[] end = getCurrentCollectionCounts();
+        assertEquals(0, end[0]);
+        assertEquals(0, end[1]);
+    }
+
     void testInOut(final String s) throws Exception {
 
         int[] start = getCurrentCollectionCounts();


### PR DESCRIPTION
## Problem
While using a query to remove data in the GridFS (both [bucket].files and [bucket].chunks collections) the current driver first issues a select, and then loops over the results to run 2 removes (files and chunks) on each iteration.
On large resultsets, this behavior can results in thousands of requests x2 (files and chunks).

I can understand that performing files and chunks removal, one after the other, is a way to limit data inconsistency. But there still is a risk. 
Thus, as long as the linked removal between files and chunks isn't managed by the server itself, the client side is responsible for checking whether both files and chunks are consistent. 

## Solution
I updated my previous PR by adding a parameter to keep the legacy behavior but allowing to force the "bulk removal".
A remove(query) = remove(query,true) as the default existing behavior.
A remove(query, false) only issues 3 requests : 
 - one select on "files", 
 - and then a remove using the query on files 
 - and a remove with a $in clause on chunks.
Fields ids are remembered using a list. 
On a single remove this won't be a great improvement, but on large sets of files it'll be worthwhile.

"Legacy" remove(query) = 2 * n requests for remove on gridfs.
"Bulk" remove(query, false) = 3 requests for remove on gridfs.
where n = number of files matched by the query.

[Fixes : https://jira.mongodb.org/browse/JAVA-1125]
[Updates/Improves of PR https://github.com/mongodb/mongo-java-driver/pull/171 against branch 3.0.x]
