### PR TITLE
Improved covariance of DBCollection.insert

### DIFF
--- a/src/main/com/mongodb/DBCollection.java
+++ b/src/main/com/mongodb/DBCollection.java
@@ -143,7 +143,7 @@ public abstract class DBCollection {
      * @throws MongoException if the operation fails
      * @mongodb.driver.manual tutorial/insert-documents/ Insert
      */
-    public WriteResult insert(List<DBObject> list ){
+    public WriteResult insert(List<? extends DBObject> list ){
         return insert( list, getWriteConcern() );
     }
 
@@ -157,7 +157,7 @@ public abstract class DBCollection {
      * @throws MongoException if the operation fails
      * @mongodb.driver.manual tutorial/insert-documents/ Insert
      */
-    public WriteResult insert(List<DBObject> list, WriteConcern concern ){
+    public WriteResult insert(List<? extends DBObject> list, WriteConcern concern ){
         return insert(list, concern, getDBEncoder() );
     }
 
@@ -172,7 +172,7 @@ public abstract class DBCollection {
      * @throws MongoException if the operation fails
      * @mongodb.driver.manual tutorial/insert-documents/ Insert
      */
-    public abstract WriteResult insert(List<DBObject> list, WriteConcern concern, DBEncoder encoder);
+    public abstract WriteResult insert(List<? extends DBObject> list, WriteConcern concern, DBEncoder encoder);
 
     /**
      * Modify an existing document or documents in collection. By default the method updates a single document. The query parameter employs

--- a/src/main/com/mongodb/DBCollectionImpl.java
+++ b/src/main/com/mongodb/DBCollectionImpl.java
@@ -155,11 +155,11 @@ class DBCollectionImpl extends DBCollection {
         }
     }
 
-    public WriteResult insert(List<DBObject> list, WriteConcern concern, DBEncoder encoder ){
+    public WriteResult insert(List<? extends DBObject> list, WriteConcern concern, DBEncoder encoder ){
         return insert(list, true, concern, encoder);
     }
 
-    protected WriteResult insert(List<DBObject> list, boolean shouldApply , WriteConcern concern, DBEncoder encoder ){
+    protected WriteResult insert(List<? extends DBObject> list, boolean shouldApply , WriteConcern concern, DBEncoder encoder ){
         if (concern == null) {
             throw new IllegalArgumentException("Write concern can not be null");
         }
@@ -363,7 +363,7 @@ class DBCollectionImpl extends DBCollection {
         }
     }
 
-    private BulkWriteResult insertWithCommandProtocol(final List<DBObject> list, final WriteConcern writeConcern,
+    private BulkWriteResult insertWithCommandProtocol(final List<? extends DBObject> list, final WriteConcern writeConcern,
                                                       final DBEncoder encoder,
                                                       final DBPort port, final boolean shouldApply) {
         if ( shouldApply ){
@@ -376,7 +376,7 @@ class DBCollectionImpl extends DBCollection {
         return writeWithCommandProtocol(port, INSERT, message, writeConcern);
     }
 
-    private void applyRulesForInsert(final List<DBObject> list) {
+    private void applyRulesForInsert(final List<? extends DBObject> list) {
         for (DBObject o : list) {
             _checkObject(o, false, false);
             apply(o);
@@ -491,7 +491,7 @@ class DBCollectionImpl extends DBCollection {
     }
 
 
-    private WriteResult insertWithWriteProtocol(final List<DBObject> list, final WriteConcern concern, final DBEncoder encoder,
+    private WriteResult insertWithWriteProtocol(final List<? extends DBObject> list, final WriteConcern concern, final DBEncoder encoder,
                                                 final DBPort port, final boolean shouldApply) {
         if ( shouldApply ){
             applyRulesForInsert(list);

--- a/src/main/com/mongodb/InsertCommandMessage.java
+++ b/src/main/com/mongodb/InsertCommandMessage.java
@@ -21,10 +21,10 @@ import org.bson.io.OutputBuffer;
 import java.util.List;
 
 class InsertCommandMessage extends BaseWriteCommandMessage {
-    private final List<DBObject> documents;
+    private final List<? extends DBObject> documents;
     private final DBEncoder encoder;
 
-    public InsertCommandMessage(final MongoNamespace namespace, final WriteConcern writeConcern, final List<DBObject> documents,
+    public InsertCommandMessage(final MongoNamespace namespace, final WriteConcern writeConcern, final List<? extends DBObject> documents,
                                 final DBEncoder commandEncoder, final DBEncoder encoder, final MessageSettings settings) {
         super(namespace, writeConcern, commandEncoder, settings);
         this.documents = documents;


### PR DESCRIPTION
Changed signature of the insert method from `insert(List<DBOject>)` to `insert(List<? extends DBOject>)`. This is needed to (for example) enable insert to accept a `List<BasicDBObject>`.