### PR TITLE
Fix for throwing duplicate key exception

### DIFF
--- a/src/test/com/mongodb/CommandResultTest.java
+++ b/src/test/com/mongodb/CommandResultTest.java
@@ -129,4 +129,41 @@ public class CommandResultTest extends TestCase {
             assertEquals(5000, e.getCode());
         }
     }
+
+
+    /**
+     * mongoS return an "err" but don't return a "code" for duplicate key errors
+     */
+    @Test
+    public void testCommandDuplicateKeyWithoutCode() throws UnknownHostException {
+        CommandResult commandResult = new CommandResult(new ServerAddress("localhost"));
+        final DBObject result = new BasicDBObject("ok", 1.0).append("err", "E11000 duplicate key error index");
+        commandResult.putAll(result);
+        assertEquals(MongoException.DuplicateKey.class, commandResult.getException().getClass());
+        try {
+            commandResult.throwOnError();
+            fail("Should throw");
+        } catch (MongoException.DuplicateKey e) {
+            assertEquals(commandResult, e.getCommandResult());
+        }
+    }
+
+    /**
+     * mongoS return an "err" but causedBy might be "E11000"
+     */
+    @Test
+    public void testCommandDuplicateKeyInnerException() throws UnknownHostException {
+        CommandResult commandResult = new CommandResult(new ServerAddress("localhost"));
+        final DBObject result = new BasicDBObject("ok", 1.0).append("err", "error inserting 1 documents to shard " +
+            " :: caused by :: " +
+            "E11000 duplicate key error index");
+        commandResult.putAll(result);
+        assertEquals(MongoException.DuplicateKey.class, commandResult.getException().getClass());
+        try {
+            commandResult.throwOnError();
+            fail("Should throw");
+        } catch (MongoException.DuplicateKey e) {
+            assertEquals(commandResult, e.getCommandResult());
+        }
+    }
 }


### PR DESCRIPTION
in sharded clusters sometimes the CommandResult for a duplicate key
error looks like this:

{
    "serverUsed": "localhost:22023",
    "err": "error inserting 1 documents to shard shard0000:hoffrocket.local:22020 at version 2|1||53bc4ba51d95f80dd550b55b :: caused by :: E11000 duplicate key error index: test.t.$_id_  dup key: { : 1 }",
    "code": 16460,
    "n": 0,
    "ok": 1.0
}

this patch handles the case where the error code doesn't agree with the message
