### PR TITLE
Made CommandResult generic

### DIFF
--- a/async-driver/src/main/org/mongodb/async/MongoDatabase.java
+++ b/async-driver/src/main/org/mongodb/async/MongoDatabase.java
@@ -75,7 +75,7 @@ public interface MongoDatabase {
      * @param commandDocument the document describing the command to execute.
      * @return a future representation the completion of the command
      */
-    MongoFuture<CommandResult> executeCommand(Document commandDocument);
+    MongoFuture<CommandResult<Document>> executeCommand(Document commandDocument);
 
     /**
      * @return the DatabaseAdministration that provides admin methods that can be performed

--- a/async-driver/src/main/org/mongodb/async/MongoDatabaseImpl.java
+++ b/async-driver/src/main/org/mongodb/async/MongoDatabaseImpl.java
@@ -62,10 +62,11 @@ class MongoDatabaseImpl implements MongoDatabase {
     }
 
     @Override
-    public MongoFuture<CommandResult> executeCommand(final Document commandDocument) {
-        return client.execute(new CommandWriteOperation(name, new BsonDocumentWrapper<Document>(commandDocument,
-                                                                                                options.getDocumentCodec())
-        ));
+    public MongoFuture<CommandResult<Document>> executeCommand(final Document commandDocument) {
+        return client.execute(new CommandWriteOperation<Document>(name,
+                                                                  new BsonDocumentWrapper<Document>(commandDocument,
+                                                                                                    options.getDocumentCodec()),
+                                                                  options.getDocumentCodec()));
     }
 
     @Override

--- a/async-rxjava-driver/src/main/org/mongodb/async/rxjava/MongoDatabase.java
+++ b/async-rxjava-driver/src/main/org/mongodb/async/rxjava/MongoDatabase.java
@@ -77,7 +77,7 @@ public interface MongoDatabase {
      * @return an Observable representing the completion of the command. It will report exactly one event when the command completes
      * successfully.
      */
-    Observable<CommandResult> executeCommand(Document commandDocument);
+    Observable<CommandResult<Document>> executeCommand(Document commandDocument);
 
     /**
      * @return the DatabaseAdministration that provides admin methods that can be performed

--- a/async-rxjava-driver/src/main/org/mongodb/async/rxjava/MongoDatabaseImpl.java
+++ b/async-rxjava-driver/src/main/org/mongodb/async/rxjava/MongoDatabaseImpl.java
@@ -51,13 +51,14 @@ class MongoDatabaseImpl implements MongoDatabase {
     }
 
     @Override
-    public Observable<CommandResult> executeCommand(final Document commandDocument) {
-         return Observable.create(new OnSubscribeAdapter<CommandResult>(new OnSubscribeAdapter.FutureFunction<CommandResult>() {
-             @Override
-             public MongoFuture<CommandResult> apply() {
-                 return wrapped.executeCommand(commandDocument);
-             }
-         }));
+    public Observable<CommandResult<Document>> executeCommand(final Document command) {
+        return Observable.create(new OnSubscribeAdapter<CommandResult<Document>>(
+                new OnSubscribeAdapter.FutureFunction<CommandResult<Document>>() {
+                    @Override
+                    public MongoFuture<CommandResult<Document>> apply() {
+                        return wrapped.executeCommand(command);
+                    }
+                }));
     }
 
     @Override

--- a/driver-compat/src/main/com/mongodb/CommandFailureException.java
+++ b/driver-compat/src/main/com/mongodb/CommandFailureException.java
@@ -43,7 +43,8 @@ public class CommandFailureException extends MongoException {
     }
 
     CommandFailureException(final MongoCommandFailureException e) {
-        this(new CommandResult(e.getCommandResult()), e.getMessage());
+        this(new CommandResult(DBObjects.toDBObject(e.getResponse()), new ServerAddress(e.getServerAddress())),
+             e.getMessage());
     }
 
     /**

--- a/driver-compat/src/main/com/mongodb/CommandResult.java
+++ b/driver-compat/src/main/com/mongodb/CommandResult.java
@@ -16,7 +16,6 @@
 
 package com.mongodb;
 
-import static com.mongodb.DBObjects.toDBObject;
 import static org.mongodb.assertions.Assertions.notNull;
 
 /**
@@ -26,9 +25,9 @@ public class CommandResult extends BasicDBObject {
     private static final long serialVersionUID = 5907909423864204060L;
     private final ServerAddress host;
 
-    CommandResult(final org.mongodb.CommandResult commandResult) {
+    CommandResult(final org.mongodb.CommandResult<DBObject> commandResult) {
         this(new ServerAddress(commandResult.getAddress()));
-        putAll(toDBObject(commandResult.getResponse()));
+        putAll(commandResult.getResponse());
     }
 
     CommandResult(final DBObject response, final ServerAddress serverAddress) {

--- a/driver-compat/src/main/com/mongodb/DB.java
+++ b/driver-compat/src/main/com/mongodb/DB.java
@@ -571,11 +571,11 @@ public class DB {
     }
 
     CommandResult executeCommand(final BsonDocument commandDocument) {
-        return new CommandResult(getMongo().execute(new CommandWriteOperation(getName(), commandDocument)));
+        return new CommandResult(getMongo().execute(new CommandWriteOperation<DBObject>(getName(), commandDocument, DBObjects.codec)));
     }
 
     CommandResult executeCommand(final BsonDocument commandDocument, final ReadPreference readPreference) {
-        return new CommandResult(getMongo().execute(new CommandReadOperation(getName(), commandDocument),
+        return new CommandResult(getMongo().execute(new CommandReadOperation<DBObject>(getName(), commandDocument, DBObjects.codec),
                                                     readPreference));
     }
 

--- a/driver-compat/src/main/com/mongodb/DBCollection.java
+++ b/driver-compat/src/main/com/mongodb/DBCollection.java
@@ -1273,7 +1273,8 @@ public class DBCollection {
      * @mongodb.server.release 2.6
      */
     public CommandResult explainAggregate(final List<DBObject> pipeline, final AggregationOptions options) {
-        return new CommandResult(execute(new AggregateExplainOperation(getNamespace(), preparePipeline(pipeline), options.toNew()),
+        return new CommandResult(execute(new AggregateExplainOperation<DBObject>(getNamespace(), preparePipeline(pipeline),
+                                                                                 options.toNew(), getObjectCodec()),
                                          primaryPreferred()));
     }
 

--- a/driver-compat/src/main/com/mongodb/WriteConcernException.java
+++ b/driver-compat/src/main/com/mongodb/WriteConcernException.java
@@ -41,7 +41,7 @@ public class WriteConcernException extends MongoException {
     }
 
     WriteConcernException(final MongoWriteException e) {
-        this(new CommandResult(DBObjects.toDBObject(e.getCommandResult().getResponse()), new ServerAddress(e.getServerAddress())),
+        this(new CommandResult(DBObjects.toDBObject(e.getResponse()), new ServerAddress(e.getServerAddress())),
              e.getMessage());
     }
 

--- a/driver-compat/src/test/unit/com/mongodb/MongoExceptionsSpecification.groovy
+++ b/driver-compat/src/test/unit/com/mongodb/MongoExceptionsSpecification.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package com.mongodb
 
 import org.bson.BsonDocument
@@ -63,12 +62,15 @@ class MongoExceptionsSpecification extends Specification {
         new org.mongodb.MongoInterruptedException(MESSAGE, new InterruptedException('cause')) | MongoInterruptedException        | -4
         new MongoSocketReadException(MESSAGE, new ServerAddress(), new IOException('cause'))  | MongoSocketException             | -2
         new MongoDuplicateKeyException(ERROR_CODE, MESSAGE,
-                                       commandResultWithErrorCode(ERROR_CODE))                | MongoException.DuplicateKey      |
+                                       responseWithErrorCode(ERROR_CODE),
+                                       new ServerAddress())                                   | MongoException.DuplicateKey      |
         ERROR_CODE
-        new MongoCommandFailureException(commandResultWithErrorCode(ERROR_CODE))              | CommandFailureException          |
+        new MongoCommandFailureException(responseWithErrorCode(ERROR_CODE), ERROR_CODE,
+                                         MESSAGE, new ServerAddress())                        | CommandFailureException          |
         ERROR_CODE
         new org.mongodb.MongoInternalException(MESSAGE)                                       | MongoInternalException           | -4
-        new MongoWriteException(ERROR_CODE, MESSAGE, commandResultWithErrorCode(ERROR_CODE))  | WriteConcernException            |
+        new MongoWriteException(ERROR_CODE, MESSAGE, responseWithErrorCode(ERROR_CODE),
+                                new ServerAddress())                                          | WriteConcernException            |
         ERROR_CODE
         new org.mongodb.connection.MongoTimeoutException(MESSAGE)                             | MongoTimeoutException            | -3
         new org.mongodb.connection.MongoWaitQueueFullException(MESSAGE)                       | MongoWaitQueueFullException      | -3
@@ -115,8 +117,8 @@ class MongoExceptionsSpecification extends Specification {
     }
 
 
-    private static org.mongodb.CommandResult commandResultWithErrorCode(int expectedErrorCode) {
-        new org.mongodb.CommandResult(new ServerAddress(), new BsonDocument('code', new BsonInt32(expectedErrorCode)), 15L)
+    private static BsonDocument responseWithErrorCode(int expectedErrorCode) {
+        new BsonDocument('code', new BsonInt32(expectedErrorCode))
     }
 
 }

--- a/driver/src/main/org/mongodb/MongoCommandFailureException.java
+++ b/driver/src/main/org/mongodb/MongoCommandFailureException.java
@@ -16,6 +16,9 @@
 
 package org.mongodb;
 
+import org.bson.BsonDocument;
+import org.mongodb.connection.ServerAddress;
+
 import static java.lang.String.format;
 
 /**
@@ -24,25 +27,33 @@ import static java.lang.String.format;
 public class MongoCommandFailureException extends MongoServerException {
     private static final long serialVersionUID = -50109343643507362L;
 
-    private final CommandResult commandResult;
+    private final BsonDocument response;
+    private final int errorCode;
+    private final String errorMessage;
 
-    public MongoCommandFailureException(final CommandResult commandResult) {
-        super(format("Command failed with error %s: '%s' on server %s", commandResult.getErrorCode(),
-                     commandResult.getErrorMessage(), commandResult.getAddress()), commandResult.getAddress());
-        this.commandResult = commandResult;
+    public MongoCommandFailureException(final BsonDocument response, final int errorCode, final String errorMessage,
+                                        final ServerAddress serverAddress) {
+        super(format("Command failed with error %s: '%s' on server %s", errorCode, errorMessage, serverAddress), serverAddress);
+        this.response = response;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
     }
 
-    public CommandResult getCommandResult() {
-        return commandResult;
+    public <T> MongoCommandFailureException(final CommandResult<T> commandResult) {
+        this(commandResult.getRawResponse(), commandResult.getErrorCode(), commandResult.getErrorMessage(), commandResult.getAddress());
+    }
+
+    public BsonDocument getResponse() {
+        return response;
     }
 
     @Override
     public int getErrorCode() {
-        return commandResult.getErrorCode();
+        return errorCode;
     }
 
     @Override
     public String getErrorMessage() {
-        return commandResult.getErrorMessage();
+        return errorMessage;
     }
 }

--- a/driver/src/main/org/mongodb/MongoDatabase.java
+++ b/driver/src/main/org/mongodb/MongoDatabase.java
@@ -26,9 +26,9 @@ import org.mongodb.annotations.ThreadSafe;
 public interface MongoDatabase {
     String getName();
 
-    CommandResult executeCommand(Document command);
+    CommandResult<Document> executeCommand(Document command);
 
-    CommandResult executeCommand(final Document command, final ReadPreference readPreference);
+    CommandResult<Document> executeCommand(final Document command, final ReadPreference readPreference);
 
     MongoDatabaseOptions getOptions();
 

--- a/driver/src/main/org/mongodb/MongoDatabaseImpl.java
+++ b/driver/src/main/org/mongodb/MongoDatabaseImpl.java
@@ -72,15 +72,14 @@ class MongoDatabaseImpl implements MongoDatabase {
     }
 
     @Override
-    public CommandResult executeCommand(final Document command) {
-        return client.execute(new CommandWriteOperation(getName(), wrap(command)));
+    public CommandResult<Document> executeCommand(final Document command) {
+        return client.execute(new CommandWriteOperation<Document>(getName(), wrap(command), options.getDocumentCodec()));
     }
 
     @Override
-    public CommandResult executeCommand(final Document command, final ReadPreference readPreference) {
+    public CommandResult<Document> executeCommand(final Document command, final ReadPreference readPreference) {
         notNull("readPreference", readPreference);
-        return client.execute(new CommandReadOperation(getName(), wrap(command)),
-                              readPreference);
+        return client.execute(new CommandReadOperation<Document>(getName(), wrap(command), options.getDocumentCodec()), readPreference);
     }
 
     @Override

--- a/driver/src/main/org/mongodb/MongoDuplicateKeyException.java
+++ b/driver/src/main/org/mongodb/MongoDuplicateKeyException.java
@@ -16,6 +16,9 @@
 
 package org.mongodb;
 
+import org.bson.BsonDocument;
+import org.mongodb.connection.ServerAddress;
+
 /**
  * A duplicate key error.
  *
@@ -24,7 +27,8 @@ package org.mongodb;
 public class MongoDuplicateKeyException extends MongoWriteException {
     private static final long serialVersionUID = 3661905154229799985L;
 
-    public MongoDuplicateKeyException(final int errorCode, final String errorMessage, final CommandResult commandResult) {
-        super(errorCode, errorMessage, commandResult);
+    public MongoDuplicateKeyException(final int errorCode, final String errorMessage, final BsonDocument response,
+                                      final ServerAddress serverAddress) {
+        super(errorCode, errorMessage, response, serverAddress);
     }
 }

--- a/driver/src/main/org/mongodb/MongoWriteException.java
+++ b/driver/src/main/org/mongodb/MongoWriteException.java
@@ -16,6 +16,9 @@
 
 package org.mongodb;
 
+import org.bson.BsonDocument;
+import org.mongodb.connection.ServerAddress;
+
 import static java.lang.String.format;
 
 /**
@@ -26,14 +29,13 @@ public class MongoWriteException extends MongoServerException {
 
     private final int code;
     private final String message;
-    private final CommandResult commandResult;
+    private final BsonDocument response;
 
-    public MongoWriteException(final int code, final String message, final CommandResult commandResult) {
-        super(format("Write failed with error code %d and error message '%s'", code, message),
-              commandResult.getAddress());
+    public <T> MongoWriteException(final int code, final String message, final BsonDocument response, final ServerAddress serverAddress) {
+        super(format("Write failed with error code %d and error message '%s'", code, message), serverAddress);
         this.code = code;
         this.message = message;
-        this.commandResult = commandResult;
+        this.response = response;
     }
 
     @Override
@@ -46,7 +48,7 @@ public class MongoWriteException extends MongoServerException {
         return message;
     }
 
-    public CommandResult getCommandResult() {
-        return commandResult;
+    public BsonDocument getResponse() {
+        return response;
     }
 }

--- a/driver/src/main/org/mongodb/connection/InternalStreamConnection.java
+++ b/driver/src/main/org/mongodb/connection/InternalStreamConnection.java
@@ -20,7 +20,6 @@ import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.ByteBuf;
 import org.bson.io.BasicInputBuffer;
-import org.mongodb.CommandResult;
 import org.mongodb.MongoCommandFailureException;
 import org.mongodb.MongoCredential;
 import org.mongodb.MongoException;
@@ -216,14 +215,13 @@ class InternalStreamConnection implements InternalConnection {
     }
 
     private void initializeConnectionId() {
-        CommandResult result;
+        BsonDocument response;
         try {
-            result = CommandHelper.executeCommand("admin", new BsonDocument("getlasterror", new BsonInt32(1)), this);
-
+            response = CommandHelper.executeCommand("admin", new BsonDocument("getlasterror", new BsonInt32(1)), this).getResponse();
         } catch (MongoCommandFailureException e) {
-            result = e.getCommandResult();
+            response = e.getResponse();
         }
-        BsonInt32 connectionIdFromServer = (BsonInt32) result.getResponse().get("connectionId");
+        BsonInt32 connectionIdFromServer = (BsonInt32) response.get("connectionId");
         id = "conn" + (connectionIdFromServer != null ? connectionIdFromServer.getValue() : "*" + incrementingId.incrementAndGet() + "*");
     }
 

--- a/driver/src/main/org/mongodb/connection/NativeAuthenticator.java
+++ b/driver/src/main/org/mongodb/connection/NativeAuthenticator.java
@@ -33,9 +33,9 @@ class NativeAuthenticator extends Authenticator {
     @Override
     public void authenticate() {
         try {
-            CommandResult nonceResponse = executeCommand(getCredential().getSource(),
-                                                         NativeAuthenticationHelper.getNonceCommand(),
-                                                         getInternalConnection());
+            CommandResult<BsonDocument> nonceResponse = executeCommand(getCredential().getSource(),
+                                                                       NativeAuthenticationHelper.getNonceCommand(),
+                                                                       getInternalConnection());
 
             BsonDocument authCommand = getAuthCommand(getCredential().getUserName(),
                                                       getCredential().getPassword(),

--- a/driver/src/main/org/mongodb/connection/SaslAuthenticator.java
+++ b/driver/src/main/org/mongodb/connection/SaslAuthenticator.java
@@ -39,7 +39,7 @@ abstract class SaslAuthenticator extends Authenticator {
         SaslClient saslClient = createSaslClient();
         try {
             byte[] response = (saslClient.hasInitialResponse() ? saslClient.evaluateChallenge(new byte[0]) : null);
-            CommandResult res = sendSaslStart(response);
+            CommandResult<BsonDocument> res = sendSaslStart(response);
 
             BsonInt32 conversationId = (BsonInt32) res.getResponse().get("conversationId");
 
@@ -66,11 +66,11 @@ abstract class SaslAuthenticator extends Authenticator {
 
     protected abstract SaslClient createSaslClient();
 
-    private CommandResult sendSaslStart(final byte[] outToken) {
+    private CommandResult<BsonDocument> sendSaslStart(final byte[] outToken) {
         return executeCommand(getCredential().getSource(), createSaslStartCommandDocument(outToken), getInternalConnection());
     }
 
-    private CommandResult sendSaslContinue(final BsonInt32 conversationId, final byte[] outToken) {
+    private CommandResult<BsonDocument> sendSaslContinue(final BsonInt32 conversationId, final byte[] outToken) {
         return executeCommand(getCredential().getSource(), createSaslContinueDocument(conversationId, outToken), getInternalConnection());
     }
 

--- a/driver/src/main/org/mongodb/connection/ServerMonitor.java
+++ b/driver/src/main/org/mongodb/connection/ServerMonitor.java
@@ -236,16 +236,17 @@ class ServerMonitor {
 
     private ServerDescription lookupServerDescription(final InternalConnection connection) {
         LOGGER.debug(format("Checking status of %s", serverAddress));
-        CommandResult isMasterResult = executeCommand("admin", new BsonDocument("ismaster", new BsonInt32(1)), connection);
+        CommandResult<BsonDocument> isMasterResult = executeCommand("admin", new BsonDocument("ismaster", new BsonInt32(1)), connection);
         count++;
         roundTripTimeSum += isMasterResult.getElapsedNanoseconds();
 
-        CommandResult buildInfoResult = executeCommand("admin", new BsonDocument("buildinfo", new BsonInt32(1)), connection);
+        CommandResult<BsonDocument> buildInfoResult = executeCommand("admin", new BsonDocument("buildinfo", new BsonInt32(1)), connection);
         return createDescription(isMasterResult, buildInfoResult, roundTripTimeSum / count);
     }
 
     @SuppressWarnings("unchecked")
-    private ServerDescription createDescription(final CommandResult commandResult, final CommandResult buildInfoResult,
+    private ServerDescription createDescription(final CommandResult<BsonDocument> commandResult,
+                                                final CommandResult<BsonDocument> buildInfoResult,
                                                 final long roundTripTime) {
         return ServerDescription.builder()
                                 .state(CONNECTED)
@@ -284,7 +285,7 @@ class ServerMonitor {
     }
 
     @SuppressWarnings("unchecked")
-    private static ServerVersion getVersion(final CommandResult buildInfoResult) {
+    private static ServerVersion getVersion(final CommandResult<BsonDocument> buildInfoResult) {
         List<BsonValue> versionArray = buildInfoResult.getResponse().getArray("versionArray").subList(0, 3);
 
         return new ServerVersion(asList(versionArray.get(0).asInt32().getValue(),

--- a/driver/src/main/org/mongodb/operation/AggregateToCollectionOperation.java
+++ b/driver/src/main/org/mongodb/operation/AggregateToCollectionOperation.java
@@ -17,7 +17,6 @@
 package org.mongodb.operation;
 
 import org.bson.BsonDocument;
-import org.bson.codecs.BsonDocumentCodec;
 import org.mongodb.AggregationOptions;
 import org.mongodb.CommandResult;
 import org.mongodb.MongoFuture;
@@ -66,16 +65,15 @@ public class AggregateToCollectionOperation implements AsyncWriteOperation<Void>
     @SuppressWarnings("unchecked")
     @Override
     public Void execute(final WriteBinding binding) {
-        executeWrappedCommandProtocol(namespace, asCommandDocument(namespace, pipeline, options),
-                                      new BsonDocumentCodec(), binding, new VoidTransformer<CommandResult>());
+        executeWrappedCommandProtocol(namespace.getDatabaseName(), asCommandDocument(namespace, pipeline, options),
+                                      binding, new VoidTransformer<CommandResult<BsonDocument>>());
 
         return null;
     }
 
     @Override
     public MongoFuture<Void> executeAsync(final AsyncWriteBinding binding) {
-        return executeWrappedCommandProtocolAsync(namespace, asCommandDocument(namespace, pipeline, options),
-                                                  new BsonDocumentCodec(), binding,
-                                                  new VoidTransformer<CommandResult>());
+        return executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), asCommandDocument(namespace, pipeline, options),
+                                                  binding, new VoidTransformer<CommandResult<BsonDocument>>());
     }
 }

--- a/driver/src/main/org/mongodb/operation/CommandReadOperation.java
+++ b/driver/src/main/org/mongodb/operation/CommandReadOperation.java
@@ -17,6 +17,7 @@
 package org.mongodb.operation;
 
 import org.bson.BsonDocument;
+import org.bson.codecs.Decoder;
 import org.mongodb.CommandResult;
 import org.mongodb.MongoFuture;
 import org.mongodb.binding.AsyncReadBinding;
@@ -30,22 +31,24 @@ import static org.mongodb.operation.CommandOperationHelper.executeWrappedCommand
  *
  * @since 3.0
  */
-public class CommandReadOperation implements AsyncReadOperation<CommandResult>, ReadOperation<CommandResult> {
+public class CommandReadOperation<T> implements AsyncReadOperation<CommandResult<T>>, ReadOperation<CommandResult<T>> {
     private final String database;
-    private final BsonDocument commandDocument;
+    private final BsonDocument command;
+    private final Decoder<T> decoder;
 
-    public CommandReadOperation(final String database, final BsonDocument command) {
+    public CommandReadOperation(final String database, final BsonDocument command, final Decoder<T> decoder) {
         this.database = database;
-        this.commandDocument = command;
+        this.command = command;
+        this.decoder = decoder;
     }
 
     @Override
-    public CommandResult execute(final ReadBinding binding) {
-        return executeWrappedCommandProtocol(database, commandDocument, binding);
+    public CommandResult<T> execute(final ReadBinding binding) {
+        return executeWrappedCommandProtocol(database, command, decoder, binding);
     }
 
     @Override
-    public MongoFuture<CommandResult> executeAsync(final AsyncReadBinding binding) {
-        return executeWrappedCommandProtocolAsync(database, commandDocument, binding);
+    public MongoFuture<CommandResult<T>> executeAsync(final AsyncReadBinding binding) {
+        return executeWrappedCommandProtocolAsync(database, command, decoder, binding);
     }
 }

--- a/driver/src/main/org/mongodb/operation/CommandWriteOperation.java
+++ b/driver/src/main/org/mongodb/operation/CommandWriteOperation.java
@@ -17,6 +17,7 @@
 package org.mongodb.operation;
 
 import org.bson.BsonDocument;
+import org.bson.codecs.Decoder;
 import org.mongodb.CommandResult;
 import org.mongodb.MongoFuture;
 import org.mongodb.binding.AsyncWriteBinding;
@@ -30,22 +31,24 @@ import static org.mongodb.operation.CommandOperationHelper.executeWrappedCommand
  *
  * @since 3.0
  */
-public class CommandWriteOperation implements AsyncWriteOperation<CommandResult>, WriteOperation<CommandResult> {
+public class CommandWriteOperation<T> implements AsyncWriteOperation<CommandResult<T>>, WriteOperation<CommandResult<T>> {
     private final String database;
-    private final BsonDocument commandDocument;
+    private final BsonDocument command;
+    private final Decoder<T> decoder;
 
-    public CommandWriteOperation(final String database, final BsonDocument command) {
+    public CommandWriteOperation(final String database, final BsonDocument command, final Decoder<T> decoder) {
         this.database = database;
-        this.commandDocument = command;
+        this.command = command;
+        this.decoder = decoder;
     }
 
     @Override
-    public CommandResult execute(final WriteBinding binding) {
-        return executeWrappedCommandProtocol(database, commandDocument, binding);
+    public CommandResult<T> execute(final WriteBinding binding) {
+        return executeWrappedCommandProtocol(database, command, decoder, binding);
     }
 
     @Override
-    public MongoFuture<CommandResult> executeAsync(final AsyncWriteBinding binding) {
-        return executeWrappedCommandProtocolAsync(database, commandDocument, binding);
+    public MongoFuture<CommandResult<T>> executeAsync(final AsyncWriteBinding binding) {
+        return executeWrappedCommandProtocolAsync(database, command, decoder, binding);
     }
 }

--- a/driver/src/main/org/mongodb/operation/CountOperation.java
+++ b/driver/src/main/org/mongodb/operation/CountOperation.java
@@ -18,7 +18,6 @@ package org.mongodb.operation;
 
 import org.bson.BsonDocument;
 import org.bson.BsonString;
-import org.bson.codecs.BsonDocumentCodec;
 import org.mongodb.CommandResult;
 import org.mongodb.Function;
 import org.mongodb.MongoFuture;
@@ -48,20 +47,18 @@ public class CountOperation implements AsyncReadOperation<Long>, ReadOperation<L
 
 
     public Long execute(final ReadBinding binding) {
-        return executeWrappedCommandProtocol(namespace, asCommandDocument(), new BsonDocumentCodec(), binding,
-                                             transformer());
+        return executeWrappedCommandProtocol(namespace.getDatabaseName(), asCommandDocument(), binding, transformer());
     }
 
     @Override
     public MongoFuture<Long> executeAsync(final AsyncReadBinding binding) {
-        return executeWrappedCommandProtocolAsync(namespace, asCommandDocument(), new BsonDocumentCodec(),
-                                                  binding, transformer());
+        return executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), asCommandDocument(), binding, transformer());
     }
 
-    private Function<CommandResult, Long> transformer() {
-        return new Function<CommandResult, Long>() {
+    private Function<CommandResult<BsonDocument>, Long> transformer() {
+        return new Function<CommandResult<BsonDocument>, Long>() {
             @Override
-            public Long apply(final CommandResult result) {
+            public Long apply(final CommandResult<BsonDocument> result) {
                 return (result.getResponse().getNumber("n")).longValue();
             }
         };

--- a/driver/src/main/org/mongodb/operation/CreateIndexesOperation.java
+++ b/driver/src/main/org/mongodb/operation/CreateIndexesOperation.java
@@ -93,10 +93,10 @@ public class CreateIndexesOperation implements AsyncWriteOperation<Void>, WriteO
             public MongoFuture<Void> call(final Connection connection) {
                 final SingleResultFuture<Void> future = new SingleResultFuture<Void>();
                 if (serverIsAtLeastVersionTwoDotSix(connection)) {
-                    executeWrappedCommandProtocolAsync(namespace, getCommand(), connection)
-                    .register(new SingleResultCallback<CommandResult>() {
+                    executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), getCommand(), connection)
+                    .register(new SingleResultCallback<CommandResult<BsonDocument>>() {
                         @Override
-                        public void onResult(final CommandResult result, final MongoException e) {
+                        public void onResult(final CommandResult<BsonDocument> result, final MongoException e) {
                             future.init(null, translateException(e));
                         }
                     });
@@ -168,7 +168,7 @@ public class CreateIndexesOperation implements AsyncWriteOperation<Void>, WriteO
 
     private MongoServerException checkForDuplicateKeyError(final MongoCommandFailureException e) {
         if (DUPLICATE_KEY_ERROR_CODES.contains(e.getErrorCode())) {
-            return new MongoDuplicateKeyException(e.getErrorCode(), e.getErrorMessage(), e.getCommandResult());
+            return new MongoDuplicateKeyException(e.getErrorCode(), e.getErrorMessage(), e.getResponse(), e.getServerAddress());
         } else {
             return e;
         }

--- a/driver/src/main/org/mongodb/operation/CreateUserOperation.java
+++ b/driver/src/main/org/mongodb/operation/CreateUserOperation.java
@@ -76,7 +76,7 @@ public class CreateUserOperation implements AsyncWriteOperation<Void>, WriteOper
             public MongoFuture<Void> call(final Connection connection) {
                 if (serverIsAtLeastVersionTwoDotSix(connection)) {
                     return executeWrappedCommandProtocolAsync(user.getCredential().getSource(), getCommand(), connection,
-                                                              new VoidTransformer<CommandResult>());
+                                                              new VoidTransformer<CommandResult<BsonDocument>>());
                 } else {
                     return executeProtocolAsync(getCollectionBasedProtocol(), connection, new VoidTransformer<WriteResult>());
                 }

--- a/driver/src/main/org/mongodb/operation/DistinctOperation.java
+++ b/driver/src/main/org/mongodb/operation/DistinctOperation.java
@@ -58,29 +58,29 @@ public class DistinctOperation implements AsyncReadOperation<BsonArray>, ReadOpe
 
     @Override
     public BsonArray execute(final ReadBinding binding) {
-        return executeWrappedCommandProtocol(namespace, getCommand(), binding, transformer());
+        return executeWrappedCommandProtocol(namespace.getDatabaseName(), getCommand(), binding, transformer());
     }
 
     @Override
     public MongoFuture<BsonArray> executeAsync(final AsyncReadBinding binding) {
-        return executeWrappedCommandProtocolAsync(namespace, getCommand(), binding, asyncTransformer());
+        return executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), getCommand(), binding, asyncTransformer());
     }
 
     @SuppressWarnings("unchecked")
-    private Function<CommandResult, BsonArray> transformer() {
-        return new Function<CommandResult, BsonArray>() {
+    private Function<CommandResult<BsonDocument>, BsonArray> transformer() {
+        return new Function<CommandResult<BsonDocument>, BsonArray>() {
             @Override
-            public BsonArray apply(final CommandResult result) {
+            public BsonArray apply(final CommandResult<BsonDocument> result) {
                 return result.getResponse().getArray("values");
             }
         };
     }
 
-    private Function<CommandResult, BsonArray> asyncTransformer() {
-        return new Function<CommandResult, BsonArray>() {
+    private Function<CommandResult<BsonDocument>, BsonArray> asyncTransformer() {
+        return new Function<CommandResult<BsonDocument>, BsonArray>() {
             @SuppressWarnings("unchecked")
             @Override
-            public BsonArray apply(final CommandResult result) {
+            public BsonArray apply(final CommandResult<BsonDocument> result) {
                 return result.getResponse().getArray("values");
             }
         };

--- a/driver/src/main/org/mongodb/operation/DropCollectionOperation.java
+++ b/driver/src/main/org/mongodb/operation/DropCollectionOperation.java
@@ -27,7 +27,6 @@ import org.mongodb.binding.WriteBinding;
 import static org.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocol;
 import static org.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocolAsync;
 import static org.mongodb.operation.CommandOperationHelper.ignoreNameSpaceErrors;
-import static org.mongodb.operation.OperationHelper.ignoreResult;
 
 /**
  * Operation to drop a Collection in MongoDB.  The {@code execute} method throws MongoCommandFailureException if something goes wrong, but
@@ -59,8 +58,7 @@ public class DropCollectionOperation implements AsyncWriteOperation<Void>, Write
 
     @Override
     public MongoFuture<Void> executeAsync(final AsyncWriteBinding binding) {
-        return ignoreResult(ignoreNameSpaceErrors(executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), getCommand(),
-                                                                                     binding)));
+        return ignoreNameSpaceErrors(executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), getCommand(), binding));
     }
 
     private BsonDocument getCommand() {

--- a/driver/src/main/org/mongodb/operation/DropDatabaseOperation.java
+++ b/driver/src/main/org/mongodb/operation/DropDatabaseOperation.java
@@ -43,11 +43,11 @@ public class DropDatabaseOperation implements AsyncWriteOperation<Void>, WriteOp
 
     @Override
     public Void execute(final WriteBinding binding) {
-        return executeWrappedCommandProtocol(databaseName, DROP_DATABASE, binding, new VoidTransformer<CommandResult>());
+        return executeWrappedCommandProtocol(databaseName, DROP_DATABASE, binding, new VoidTransformer<CommandResult<BsonDocument>>());
     }
 
     @Override
     public MongoFuture<Void> executeAsync(final AsyncWriteBinding binding) {
-        return executeWrappedCommandProtocolAsync(databaseName, DROP_DATABASE, binding, new VoidTransformer<CommandResult>());
+        return executeWrappedCommandProtocolAsync(databaseName, DROP_DATABASE, binding, new VoidTransformer<CommandResult<BsonDocument>>());
     }
 }

--- a/driver/src/main/org/mongodb/operation/DropIndexOperation.java
+++ b/driver/src/main/org/mongodb/operation/DropIndexOperation.java
@@ -27,7 +27,6 @@ import org.mongodb.binding.WriteBinding;
 import static org.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocol;
 import static org.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocolAsync;
 import static org.mongodb.operation.CommandOperationHelper.ignoreNameSpaceErrors;
-import static org.mongodb.operation.OperationHelper.ignoreResult;
 
 /**
  * An operation that drops an index.
@@ -55,7 +54,7 @@ public class DropIndexOperation implements AsyncWriteOperation<Void>, WriteOpera
 
     @Override
     public MongoFuture<Void> executeAsync(final AsyncWriteBinding binding) {
-        return ignoreResult(ignoreNameSpaceErrors(executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), getCommand(), binding)));
+        return ignoreNameSpaceErrors(executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), getCommand(), binding));
     }
 
     private BsonDocument getCommand() {

--- a/driver/src/main/org/mongodb/operation/DropUserOperation.java
+++ b/driver/src/main/org/mongodb/operation/DropUserOperation.java
@@ -74,7 +74,8 @@ public class DropUserOperation implements AsyncWriteOperation<Void>, WriteOperat
             @Override
             public MongoFuture<Void> call(final Connection connection) {
                 if (serverIsAtLeastVersionTwoDotSix(connection)) {
-                    return executeWrappedCommandProtocolAsync(database, getCommand(), connection, new VoidTransformer<CommandResult>());
+                    return executeWrappedCommandProtocolAsync(database, getCommand(), connection,
+                                                              new VoidTransformer<CommandResult<BsonDocument>>());
                 } else {
                     return executeProtocolAsync(getCollectionBasedProtocol(), connection, new VoidTransformer<WriteResult>());
                 }

--- a/driver/src/main/org/mongodb/operation/FindAndModifyHelper.java
+++ b/driver/src/main/org/mongodb/operation/FindAndModifyHelper.java
@@ -16,16 +16,17 @@
 
 package org.mongodb.operation;
 
+import org.bson.BsonDocument;
 import org.mongodb.CommandResult;
 import org.mongodb.Function;
 
 final class FindAndModifyHelper {
 
-    static <T> Function<CommandResult, T> transformer() {
-        return new Function<CommandResult, T>() {
+    static <T> Function<CommandResult<BsonDocument>, T> transformer() {
+        return new Function<CommandResult<BsonDocument>, T>() {
             @SuppressWarnings("unchecked")
             @Override
-            public T apply(final CommandResult result) {
+            public T apply(final CommandResult<BsonDocument> result) {
                 if (!result.getResponse().isDocument("value")) {
                     return null;
                 }

--- a/driver/src/main/org/mongodb/operation/FindAndRemoveOperation.java
+++ b/driver/src/main/org/mongodb/operation/FindAndRemoveOperation.java
@@ -49,14 +49,14 @@ public class FindAndRemoveOperation<T> implements AsyncWriteOperation<T>, WriteO
 
     @Override
     public T execute(final WriteBinding binding) {
-        return executeWrappedCommandProtocol(namespace, getFindAndRemoveDocument(),
+        return executeWrappedCommandProtocol(namespace.getDatabaseName(), getFindAndRemoveDocument(),
                                              CommandResultDocumentCodec.create(resultDecoder, "value"),
                                              binding, FindAndModifyHelper.<T>transformer());
     }
 
     @Override
     public MongoFuture<T> executeAsync(final AsyncWriteBinding binding) {
-        return executeWrappedCommandProtocolAsync(namespace, getFindAndRemoveDocument(),
+        return executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), getFindAndRemoveDocument(),
                                                   CommandResultDocumentCodec.create(resultDecoder, "value"),
                                                   binding, FindAndModifyHelper.<T>transformer());
     }

--- a/driver/src/main/org/mongodb/operation/FindAndReplaceOperation.java
+++ b/driver/src/main/org/mongodb/operation/FindAndReplaceOperation.java
@@ -58,15 +58,16 @@ public class FindAndReplaceOperation<T> implements AsyncWriteOperation<T>, Write
 
     @Override
     public T execute(final WriteBinding binding) {
-        return executeWrappedCommandProtocol(namespace, getCommand(), getValidator(), CommandResultDocumentCodec.create(codec, "value"),
+        return executeWrappedCommandProtocol(namespace.getDatabaseName(), getCommand(), getValidator(),
+                                             CommandResultDocumentCodec.create(codec, "value"),
                                              binding, FindAndModifyHelper.<T>transformer());
     }
 
     @Override
     public MongoFuture<T> executeAsync(final AsyncWriteBinding binding) {
-        return executeWrappedCommandProtocolAsync(namespace, getCommand(), getValidator(),
-                                                  CommandResultDocumentCodec.create(codec, "value"), binding,
-                                                  FindAndModifyHelper.<T>transformer());
+        return executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), getCommand(), getValidator(),
+                                                  CommandResultDocumentCodec.create(codec, "value"),
+                                                  binding, FindAndModifyHelper.<T>transformer());
     }
 
     private BsonDocument getCommand() {

--- a/driver/src/main/org/mongodb/operation/FindAndUpdateOperation.java
+++ b/driver/src/main/org/mongodb/operation/FindAndUpdateOperation.java
@@ -57,16 +57,16 @@ public class FindAndUpdateOperation<T> implements AsyncWriteOperation<T>, WriteO
 
     @Override
     public T execute(final WriteBinding binding) {
-        return executeWrappedCommandProtocol(namespace, getCommand(), getValidator(),
-                                             CommandResultDocumentCodec.create(decoder, "value"), binding,
-                                             FindAndModifyHelper.<T>transformer());
+        return executeWrappedCommandProtocol(namespace.getDatabaseName(), getCommand(), getValidator(),
+                                             CommandResultDocumentCodec.create(decoder, "value"),
+                                             binding, FindAndModifyHelper.<T>transformer());
     }
 
     @Override
     public MongoFuture<T> executeAsync(final AsyncWriteBinding binding) {
-        return executeWrappedCommandProtocolAsync(namespace, getCommand(), getValidator(),
-                                                  CommandResultDocumentCodec.create(decoder, "value"), binding,
-                                                  FindAndModifyHelper.<T>transformer());
+        return executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), getCommand(), getValidator(),
+                                                  CommandResultDocumentCodec.create(decoder, "value"),
+                                                  binding, FindAndModifyHelper.<T>transformer());
     }
 
     private BsonDocument getCommand() {

--- a/driver/src/main/org/mongodb/operation/GetDatabaseNamesOperation.java
+++ b/driver/src/main/org/mongodb/operation/GetDatabaseNamesOperation.java
@@ -59,11 +59,11 @@ public class GetDatabaseNamesOperation implements AsyncReadOperation<List<String
         return executeWrappedCommandProtocolAsync("admin", getCommand(), binding, transformer());
     }
 
-    private Function<CommandResult, List<String>> transformer() {
-        return new Function<CommandResult, List<String>>() {
+    private Function<CommandResult<BsonDocument>, List<String>> transformer() {
+        return new Function<CommandResult<BsonDocument>, List<String>>() {
             @SuppressWarnings("unchecked")
             @Override
-            public List<String> apply(final CommandResult result) {
+            public List<String> apply(final CommandResult<BsonDocument> result) {
                 BsonArray databases = result.getResponse().getArray("databases");
 
                 List<String> databaseNames = new ArrayList<String>();

--- a/driver/src/main/org/mongodb/operation/GroupOperation.java
+++ b/driver/src/main/org/mongodb/operation/GroupOperation.java
@@ -66,8 +66,8 @@ public class GroupOperation<T> implements AsyncReadOperation<MongoAsyncCursor<T>
     @Override
     @SuppressWarnings("unchecked")
     public MongoCursor<T> execute(final ReadBinding binding) {
-        return executeWrappedCommandProtocol(namespace, getCommand(), CommandResultDocumentCodec.create(decoder, "retval"), binding,
-                                             transformer());
+        return executeWrappedCommandProtocol(namespace.getDatabaseName(), getCommand(),
+                CommandResultDocumentCodec.create(decoder, "retval"), binding, transformer());
     }
 
     /**
@@ -79,31 +79,30 @@ public class GroupOperation<T> implements AsyncReadOperation<MongoAsyncCursor<T>
     @Override
     @SuppressWarnings("unchecked")
     public MongoFuture<MongoAsyncCursor<T>> executeAsync(final AsyncReadBinding binding) {
-        return executeWrappedCommandProtocolAsync(namespace, getCommand(), CommandResultDocumentCodec.create(decoder, "retval"), binding,
-                                                  asyncTransformer());
+        return executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), getCommand(),
+                CommandResultDocumentCodec.create(decoder, "retval"), binding, asyncTransformer());
     }
 
-    private Function<CommandResult, MongoCursor<T>> transformer() {
-        return new Function<CommandResult, MongoCursor<T>>() {
+    private Function<CommandResult<BsonDocument>, MongoCursor<T>> transformer() {
+        return new Function<CommandResult<BsonDocument>, MongoCursor<T>>() {
             @SuppressWarnings("unchecked")
             @Override
-            public MongoCursor<T> apply(final CommandResult result) {
+            public MongoCursor<T> apply(final CommandResult<BsonDocument> result) {
                 return new InlineMongoCursor<T>(result.getAddress(),
                                                 BsonDocumentWrapperHelper.<T>toList(result.getResponse().getArray("retval")));
             }
         };
     }
 
-    private Function<CommandResult, MongoAsyncCursor<T>> asyncTransformer() {
-        return new Function<CommandResult, MongoAsyncCursor<T>>() {
+    private Function<CommandResult<BsonDocument>, MongoAsyncCursor<T>> asyncTransformer() {
+        return new Function<CommandResult<BsonDocument>, MongoAsyncCursor<T>>() {
             @SuppressWarnings("unchecked")
             @Override
-            public MongoAsyncCursor<T> apply(final CommandResult result) {
+            public MongoAsyncCursor<T> apply(final CommandResult<BsonDocument> result) {
                 return new InlineMongoAsyncCursor<T>(BsonDocumentWrapperHelper.<T>toList(result.getResponse().getArray("retval")));
             }
         };
     }
-
 
     private BsonDocument getCommand() {
 

--- a/driver/src/main/org/mongodb/operation/MapReduceHelper.java
+++ b/driver/src/main/org/mongodb/operation/MapReduceHelper.java
@@ -16,29 +16,30 @@
 
 package org.mongodb.operation;
 
+import org.bson.BsonDocument;
 import org.mongodb.CommandResult;
 import org.mongodb.MapReduceStatistics;
 
 final class MapReduceHelper {
 
-    static MapReduceStatistics createStatistics(final CommandResult commandResult) {
+    static MapReduceStatistics createStatistics(final CommandResult<BsonDocument> commandResult) {
         return new MapReduceStatistics(getInputCount(commandResult), getOutputCount(commandResult), getEmitCount(commandResult),
                                        getDuration(commandResult));
     }
 
-    private static int getInputCount(final CommandResult commandResult) {
+    private static int getInputCount(final CommandResult<BsonDocument> commandResult) {
         return commandResult.getResponse().getDocument("counts").getInt32("input").getValue();
     }
 
-    private static int getOutputCount(final CommandResult commandResult) {
+    private static int getOutputCount(final CommandResult<BsonDocument> commandResult) {
         return commandResult.getResponse().getDocument("counts").getInt32("output").getValue();
     }
 
-    private static int getEmitCount(final CommandResult commandResult) {
+    private static int getEmitCount(final CommandResult<BsonDocument> commandResult) {
         return commandResult.getResponse().getDocument("counts").getInt32("emit").getValue();
     }
 
-    private static int getDuration(final CommandResult commandResult) {
+    private static int getDuration(final CommandResult<BsonDocument> commandResult) {
         return commandResult.getResponse().getInt32("timeMillis").getValue();
     }
 

--- a/driver/src/main/org/mongodb/operation/MapReduceToCollectionOperation.java
+++ b/driver/src/main/org/mongodb/operation/MapReduceToCollectionOperation.java
@@ -86,11 +86,11 @@ public class MapReduceToCollectionOperation implements AsyncWriteOperation<MapRe
         return serverUsed;
     }
 
-    private Function<CommandResult, MapReduceStatistics> transformer() {
-        return new Function<CommandResult, MapReduceStatistics>() {
+    private Function<CommandResult<BsonDocument>, MapReduceStatistics> transformer() {
+        return new Function<CommandResult<BsonDocument>, MapReduceStatistics>() {
             @SuppressWarnings("unchecked")
             @Override
-            public MapReduceStatistics apply(final CommandResult result) {
+            public MapReduceStatistics apply(final CommandResult<BsonDocument> result) {
                 serverUsed = result.getAddress();
                 return MapReduceHelper.createStatistics(result);
             }

--- a/driver/src/main/org/mongodb/operation/MapReduceWithInlineResultsOperation.java
+++ b/driver/src/main/org/mongodb/operation/MapReduceWithInlineResultsOperation.java
@@ -75,32 +75,32 @@ public class MapReduceWithInlineResultsOperation<T> implements AsyncReadOperatio
     @Override
     @SuppressWarnings("unchecked")
     public MapReduceCursor<T> execute(final ReadBinding binding) {
-        return executeWrappedCommandProtocol(namespace, getCommand(), CommandResultDocumentCodec.create(decoder, "results"),
-                                             binding, transformer());
+        return executeWrappedCommandProtocol(namespace.getDatabaseName(), getCommand(),
+                                             CommandResultDocumentCodec.create(decoder, "results"), binding, transformer());
     }
 
     @Override
     public MongoFuture<MapReduceAsyncCursor<T>> executeAsync(final AsyncReadBinding binding) {
-        return executeWrappedCommandProtocolAsync(namespace, getCommand(), CommandResultDocumentCodec.create(decoder, "results"),
-                                                  binding, asyncTransformer());
+        return executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), getCommand(),
+                                                  CommandResultDocumentCodec.create(decoder, "results"), binding, asyncTransformer());
     }
 
-    private Function<CommandResult, MapReduceCursor<T>> transformer() {
-        return new Function<CommandResult, MapReduceCursor<T>>() {
+    private Function<CommandResult<BsonDocument>, MapReduceCursor<T>> transformer() {
+        return new Function<CommandResult<BsonDocument>, MapReduceCursor<T>>() {
             @SuppressWarnings("unchecked")
             @Override
-            public MapReduceCursor<T> apply(final CommandResult result) {
+            public MapReduceCursor<T> apply(final CommandResult<BsonDocument> result) {
                 return new MapReduceInlineResultsCursor<T>(BsonDocumentWrapperHelper.<T>toList(result.getResponse().getArray("results")),
                                                            MapReduceHelper.createStatistics(result), result.getAddress());
             }
         };
     }
 
-    private Function<CommandResult, MapReduceAsyncCursor<T>> asyncTransformer() {
-        return new Function<CommandResult, MapReduceAsyncCursor<T>>() {
+    private Function<CommandResult<BsonDocument>, MapReduceAsyncCursor<T>> asyncTransformer() {
+        return new Function<CommandResult<BsonDocument>, MapReduceAsyncCursor<T>>() {
             @SuppressWarnings("unchecked")
             @Override
-            public MapReduceAsyncCursor<T> apply(final CommandResult result) {
+            public MapReduceAsyncCursor<T> apply(final CommandResult<BsonDocument> result) {
                 return new MapReduceInlineResultsAsyncCursor<T>(BsonDocumentWrapperHelper.<T>toList(result.getResponse()
                                                                                                           .getArray("results")),
                                                                 MapReduceHelper.createStatistics(result));

--- a/driver/src/main/org/mongodb/operation/MixedBulkWriteOperation.java
+++ b/driver/src/main/org/mongodb/operation/MixedBulkWriteOperation.java
@@ -509,7 +509,7 @@ public class MixedBulkWriteOperation<T> implements AsyncWriteOperation<BulkWrite
                                 bulkWriteBatchCombiner.addResult(bulkWriteResult, indexMap);
                             }
                         } catch (MongoWriteException writeException) {
-                            if (writeException.getCommandResult().getResponse().get("wtimeout") != null) {
+                            if (writeException.getResponse().get("wtimeout") != null) {
                                 bulkWriteBatchCombiner.addWriteConcernErrorResult(getWriteConcernError(writeException));
                             } else {
                                 bulkWriteBatchCombiner.addWriteErrorResult(getBulkWriteError(writeException), indexMap);
@@ -548,7 +548,7 @@ public class MixedBulkWriteOperation<T> implements AsyncWriteOperation<BulkWrite
                         if (e != null) {
                             if (e instanceof MongoWriteException) {
                                 MongoWriteException writeException = (MongoWriteException) e;
-                                if (writeException.getCommandResult().getResponse().get("wtimeout") != null) {
+                                if (writeException.getResponse().get("wtimeout") != null) {
                                     bulkWriteBatchCombiner.addWriteConcernErrorResult(getWriteConcernError(writeException));
                                 } else {
                                     bulkWriteBatchCombiner.addWriteErrorResult(getBulkWriteError(writeException), indexMap);
@@ -595,8 +595,8 @@ public class MixedBulkWriteOperation<T> implements AsyncWriteOperation<BulkWrite
 
             List<BulkWriteUpsert> getUpsertedItems(final WriteResult writeResult) {
                 return writeResult.getUpsertedId() == null
-                        ? Collections.<BulkWriteUpsert>emptyList()
-                        : asList(new BulkWriteUpsert(0, writeResult.getUpsertedId()));
+                       ? Collections.<BulkWriteUpsert>emptyList()
+                       : asList(new BulkWriteUpsert(0, writeResult.getUpsertedId()));
             }
 
             @SuppressWarnings("unchecked")
@@ -633,13 +633,13 @@ public class MixedBulkWriteOperation<T> implements AsyncWriteOperation<BulkWrite
 
             private BulkWriteError getBulkWriteError(final MongoWriteException writeException) {
                 return new BulkWriteError(writeException.getErrorCode(), writeException.getErrorMessage(),
-                                          translateGetLastErrorResponseToErrInfo(writeException.getCommandResult().getResponse()), 0);
+                                          translateGetLastErrorResponseToErrInfo(writeException.getResponse()), 0);
             }
 
             private WriteConcernError getWriteConcernError(final MongoWriteException writeException) {
                 return new WriteConcernError(writeException.getErrorCode(),
-                                             ((BsonString) writeException.getCommandResult().getResponse().get("err")).getValue(),
-                                             translateGetLastErrorResponseToErrInfo(writeException.getCommandResult().getResponse()));
+                                             ((BsonString) writeException.getResponse().get("err")).getValue(),
+                                             translateGetLastErrorResponseToErrInfo(writeException.getResponse()));
             }
 
             private BsonDocument translateGetLastErrorResponseToErrInfo(final BsonDocument response) {

--- a/driver/src/main/org/mongodb/operation/PingOperation.java
+++ b/driver/src/main/org/mongodb/operation/PingOperation.java
@@ -50,10 +50,10 @@ public class PingOperation implements AsyncReadOperation<Double>, ReadOperation<
     //TODO: it's not clear from the documentation what the return type should be
     //http://docs.mongodb.org/manual/reference/command/ping/
     @SuppressWarnings("unchecked")
-    private Function<CommandResult, Double> transformer() {
-        return new Function<CommandResult, Double>() {
+    private Function<CommandResult<BsonDocument>, Double> transformer() {
+        return new Function<CommandResult<BsonDocument>, Double>() {
             @Override
-            public Double apply(final CommandResult result) {
+            public Double apply(final CommandResult<BsonDocument> result) {
                 return result.getResponse().getDouble("ok").doubleValue();
             }
         };

--- a/driver/src/main/org/mongodb/operation/RenameCollectionOperation.java
+++ b/driver/src/main/org/mongodb/operation/RenameCollectionOperation.java
@@ -66,7 +66,7 @@ public class RenameCollectionOperation implements AsyncWriteOperation<Void>, Wri
      */
     @Override
     public Void execute(final WriteBinding binding) {
-        return executeWrappedCommandProtocol("admin", getCommand(), binding, new VoidTransformer<CommandResult>());
+        return executeWrappedCommandProtocol("admin", getCommand(), binding, new VoidTransformer<CommandResult<BsonDocument>>());
     }
 
     /**
@@ -78,7 +78,7 @@ public class RenameCollectionOperation implements AsyncWriteOperation<Void>, Wri
      */
     @Override
     public MongoFuture<Void> executeAsync(final AsyncWriteBinding binding) {
-        return executeWrappedCommandProtocolAsync("admin", getCommand(), binding, new VoidTransformer<CommandResult>());
+        return executeWrappedCommandProtocolAsync("admin", getCommand(), binding, new VoidTransformer<CommandResult<BsonDocument>>());
     }
 
     private BsonDocument getCommand() {

--- a/driver/src/main/org/mongodb/operation/UpdateUserOperation.java
+++ b/driver/src/main/org/mongodb/operation/UpdateUserOperation.java
@@ -75,7 +75,7 @@ public class UpdateUserOperation implements AsyncWriteOperation<Void>, WriteOper
             public MongoFuture<Void> call(final Connection connection) {
                 if (serverIsAtLeastVersionTwoDotSix(connection)) {
                     return executeWrappedCommandProtocolAsync(user.getCredential().getSource(), getCommand(), connection,
-                                                              new VoidTransformer<CommandResult>());
+                                                              new VoidTransformer<CommandResult<BsonDocument>>());
                 } else {
                     return executeProtocolAsync(getCollectionBasedProtocol(), connection, new VoidTransformer<WriteResult>());
                 }

--- a/driver/src/main/org/mongodb/operation/UserExistsOperation.java
+++ b/driver/src/main/org/mongodb/operation/UserExistsOperation.java
@@ -62,8 +62,8 @@ public class UserExistsOperation implements AsyncReadOperation<Boolean>, ReadOpe
             @Override
             public Boolean call(final Connection connection) {
                 if (serverIsAtLeastVersionTwoDotSix(connection)) {
-                    return executeWrappedCommandProtocol(database, getCommand(), connection, binding.getReadPreference(),
-                                                         transformCommandResult());
+                    return executeWrappedCommandProtocol(database, getCommand(), new BsonDocumentCodec(), connection,
+                                                         binding.getReadPreference(), transformCommandResult());
                 } else {
                     return executeProtocol(getCollectionBasedProtocol(), connection, transformQueryResult());
                 }
@@ -77,7 +77,8 @@ public class UserExistsOperation implements AsyncReadOperation<Boolean>, ReadOpe
             @Override
             public MongoFuture<Boolean> call(final Connection connection) {
                 if (serverIsAtLeastVersionTwoDotSix(connection)) {
-                    return executeWrappedCommandProtocolAsync(database, getCommand(), connection, transformCommandResult());
+                    return executeWrappedCommandProtocolAsync(database, getCommand(), new BsonDocumentCodec(), connection,
+                                                              binding.getReadPreference(), transformCommandResult());
                 } else {
                     return executeProtocolAsync(getCollectionBasedProtocol(), connection, transformQueryResult());
                 }
@@ -85,10 +86,10 @@ public class UserExistsOperation implements AsyncReadOperation<Boolean>, ReadOpe
         });
     }
 
-    private Function<CommandResult, Boolean> transformCommandResult() {
-        return new Function<CommandResult, Boolean>() {
+    private Function<CommandResult<BsonDocument>, Boolean> transformCommandResult() {
+        return new Function<CommandResult<BsonDocument>, Boolean>() {
             @Override
-            public Boolean apply(final CommandResult result) {
+            public Boolean apply(final CommandResult<BsonDocument> result) {
                 return result.getResponse().get("users").isArray() && !result.getResponse().getArray("users").isEmpty();
             }
         };

--- a/driver/src/main/org/mongodb/protocol/CommandResultCallback.java
+++ b/driver/src/main/org/mongodb/protocol/CommandResultCallback.java
@@ -25,19 +25,19 @@ import org.mongodb.connection.SingleResultCallback;
 import org.mongodb.diagnostics.Loggers;
 import org.mongodb.diagnostics.logging.Logger;
 
-class CommandResultCallback extends CommandResultBaseCallback {
+class CommandResultCallback<T> extends CommandResultBaseCallback<T> {
     public static final Logger LOGGER = Loggers.getLogger("protocol.command");
 
-    private final SingleResultCallback<CommandResult> callback;
+    private final SingleResultCallback<CommandResult<T>> callback;
 
-    public CommandResultCallback(final SingleResultCallback<CommandResult> callback, final Decoder<BsonDocument> decoder,
-                                 final long requestId, final ServerAddress serverAddress) {
-        super(decoder, requestId, serverAddress);
+    public CommandResultCallback(final SingleResultCallback<CommandResult<T>> callback, final Decoder<T> decoder,
+                                 final Decoder<BsonDocument> rawDecoder, final long requestId, final ServerAddress serverAddress) {
+        super(decoder, rawDecoder, requestId, serverAddress);
         this.callback = callback;
     }
 
     @Override
-    protected boolean callCallback(final CommandResult commandResult, final MongoException e) {
+    protected boolean callCallback(final CommandResult<T> commandResult, final MongoException e) {
         if (e != null) {
             callback.onResult(null, e);
         } else {

--- a/driver/src/main/org/mongodb/protocol/WriteProtocol.java
+++ b/driver/src/main/org/mongodb/protocol/WriteProtocol.java
@@ -77,14 +77,16 @@ public abstract class WriteProtocol implements Protocol<WriteResult> {
                                                                              buffer,
                                                                              getLastErrorMessage.getId(),
                                                                              retVal,
-                                                                             new WriteResultCallback(retVal,
-                                                                                                     new BsonDocumentCodec(),
-                                                                                                     getNamespace(),
-                                                                                                     nextMessage,
-                                                                                                     ordered,
-                                                                                                     writeConcern,
-                                                                                                     getLastErrorMessage.getId(),
-                                                                                                     connection)
+                                                                             new WriteResultCallback<BsonDocument>(retVal,
+                                                                                                                   new BsonDocumentCodec(),
+                                                                                                                   new BsonDocumentCodec(),
+                                                                                                                   getNamespace(),
+                                                                                                                   nextMessage,
+                                                                                                                   ordered,
+                                                                                                                   writeConcern,
+                                                                                                                   getLastErrorMessage
+                                                                                                                       .getId(),
+                                                                                                                   connection)
                                         )
                                        );
         } else {
@@ -143,9 +145,11 @@ public abstract class WriteProtocol implements Protocol<WriteResult> {
         ResponseBuffers responseBuffers = connection.receiveMessage(requestMessage.getId());
         try {
             ReplyMessage<BsonDocument> replyMessage = new ReplyMessage<BsonDocument>(responseBuffers, new BsonDocumentCodec(),
-                                                                                     requestMessage.getId());
-            return ProtocolHelper.getWriteResult(new CommandResult(connection.getServerAddress(), replyMessage.getDocuments().get(0),
-                                                                   replyMessage.getElapsedNanoseconds()));
+                                                                          requestMessage.getId());
+            return ProtocolHelper.getWriteResult(new CommandResult<BsonDocument>(connection.getServerAddress(),
+                                                                                 replyMessage.getDocuments().get(0),
+                                                                                 replyMessage.getElapsedNanoseconds(),
+                                                                                 new BsonDocumentCodec()));
         } finally {
             responseBuffers.close();
         }

--- a/driver/src/main/org/mongodb/protocol/WriteResultCallback.java
+++ b/driver/src/main/org/mongodb/protocol/WriteResultCallback.java
@@ -29,7 +29,7 @@ import org.mongodb.operation.SingleResultFuture;
 import org.mongodb.operation.SingleResultFutureCallback;
 import org.mongodb.protocol.message.RequestMessage;
 
-class WriteResultCallback extends CommandResultBaseCallback {
+class WriteResultCallback<T> extends CommandResultBaseCallback<T> {
     private final SingleResultFuture<WriteResult> future;
     private final MongoNamespace namespace;
     private final RequestMessage nextMessage; // only used for batch inserts that need to be split into multiple messages
@@ -38,12 +38,12 @@ class WriteResultCallback extends CommandResultBaseCallback {
     private final Connection connection;
 
     // CHECKSTYLE:OFF
-    public WriteResultCallback(final SingleResultFuture<WriteResult> future, final Decoder<BsonDocument> decoder,
-                               final MongoNamespace namespace, final RequestMessage nextMessage,
-                               final boolean ordered, final WriteConcern writeConcern, final long requestId,
-                               final Connection connection) {
+    public WriteResultCallback(final SingleResultFuture<WriteResult> future, final Decoder<T> decoder,
+                               final Decoder<BsonDocument> rawDecoder, final MongoNamespace namespace,
+                               final RequestMessage nextMessage, final boolean ordered, final WriteConcern writeConcern,
+                               final long requestId, final Connection connection) {
         // CHECKSTYLE:ON
-        super(decoder, requestId, connection.getServerAddress());
+        super(decoder, rawDecoder, requestId, connection.getServerAddress());
         this.future = future;
         this.namespace = namespace;
         this.nextMessage = nextMessage;
@@ -53,7 +53,7 @@ class WriteResultCallback extends CommandResultBaseCallback {
     }
 
     @Override
-    protected boolean callCallback(final CommandResult commandResult, final MongoException e) {
+    protected boolean callCallback(final CommandResult<T> commandResult, final MongoException e) {
         boolean done = true;
         if (e != null) {
             future.init(null, e);

--- a/driver/src/test/acceptance/org/mongodb/acceptancetest/core/DatabaseAcceptanceTest.java
+++ b/driver/src/test/acceptance/org/mongodb/acceptancetest/core/DatabaseAcceptanceTest.java
@@ -16,7 +16,6 @@
 
 package org.mongodb.acceptancetest.core;
 
-import org.bson.BsonDocument;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mongodb.CreateCollectionOptions;
@@ -60,7 +59,7 @@ public class DatabaseAcceptanceTest extends DatabaseTestCase {
         MongoCollection<Document> collection = database.getCollection(getCollectionName());
         Document collStatsCommand = new Document("collStats", getCollectionName());
         Boolean isCapped = database.executeCommand(collStatsCommand, ReadPreference.primary())
-                                   .getResponse().getBoolean("capped").getValue();
+                                   .getResponse().getBoolean("capped");
         assertThat(isCapped, is(true));
 
         assertThat("Should have the default index on _id", collection.tools().getIndexes().size(), is(1));
@@ -76,7 +75,7 @@ public class DatabaseAcceptanceTest extends DatabaseTestCase {
         MongoCollection<Document> collection = database.getCollection(getCollectionName());
         Document collStatsCommand = new Document("collStats", getCollectionName());
         Boolean isCapped = database.executeCommand(collStatsCommand, ReadPreference.primary())
-                                   .getResponse().getBoolean("capped").getValue();
+                                   .getResponse().getBoolean("capped");
         assertThat(isCapped, is(true));
 
         assertThat("Should NOT have the default index on _id", collection.tools().getIndexes().size(), is(0));
@@ -95,8 +94,8 @@ public class DatabaseAcceptanceTest extends DatabaseTestCase {
         assertThat(collections.contains(getCollectionName()), is(true));
 
         Document collStatsCommand = new Document("collStats", getCollectionName());
-        BsonDocument collectionStatistics = database.executeCommand(collStatsCommand, ReadPreference.primary()).getResponse();
-        assertThat("max is set correctly in collection statistics", collectionStatistics.getInt32("max").getValue(), is(maxDocuments));
+        Document collectionStatistics = database.executeCommand(collStatsCommand, ReadPreference.primary()).getResponse();
+        assertThat("max is set correctly in collection statistics", collectionStatistics.getInteger("max"), is(maxDocuments));
     }
 
     @Test

--- a/driver/src/test/functional/org/mongodb/connection/ServerMonitorSpecification.groovy
+++ b/driver/src/test/functional/org/mongodb/connection/ServerMonitorSpecification.groovy
@@ -66,9 +66,8 @@ class ServerMonitorSpecification extends FunctionalSpecification {
 
     def 'should return server version'() {
         given:
-        CommandResult commandResult = database.executeCommand(new Document('buildinfo', 1), ReadPreference.primary())
-        def expectedVersion = new ServerVersion(commandResult.getResponse().getArray('versionArray')
-                                                             .subList(0, 3)*.getValue() as List<Integer>)
+        CommandResult<Document> commandResult = database.executeCommand(new Document('buildinfo', 1), ReadPreference.primary())
+        def expectedVersion = new ServerVersion(((List<Integer>) commandResult.getResponse().get('versionArray')).subList(0, 3))
 
         when:
         latch.await()
@@ -84,8 +83,8 @@ class ServerMonitorSpecification extends FunctionalSpecification {
         assumeTrue(serverVersionAtLeast(asList(2, 5, 5)))
 
         given:
-        CommandResult commandResult = database.executeCommand(new Document('ismaster', 1), ReadPreference.primary())
-        def expected = commandResult.response.getInt32('maxWriteBatchSize').getValue()
+        CommandResult<Document> commandResult = database.executeCommand(new Document('ismaster', 1), ReadPreference.primary())
+        def expected = commandResult.response.getInteger('maxWriteBatchSize')
 
         when:
         latch.await()

--- a/driver/src/test/functional/org/mongodb/operation/AggregateExplainOperationSpecification.groovy
+++ b/driver/src/test/functional/org/mongodb/operation/AggregateExplainOperationSpecification.groovy
@@ -19,6 +19,7 @@ package org.mongodb.operation
 import category.Async
 import org.bson.BsonDocument
 import org.bson.BsonString
+import org.bson.codecs.BsonDocumentCodec
 import org.junit.experimental.categories.Category
 import org.mongodb.AggregationOptions
 import org.mongodb.Document
@@ -32,11 +33,13 @@ import static org.mongodb.Fixture.serverVersionAtLeast
 
 class AggregateExplainOperationSpecification extends FunctionalSpecification {
 
+    def decoder = new BsonDocumentCodec()
+
     def 'should be able to explain an empty pipeline'() {
         assumeTrue(serverVersionAtLeast(asList(2, 6, 0)))
 
         given:
-        AggregateExplainOperation op = new AggregateExplainOperation(getNamespace(), [], aggregateOptions)
+        AggregateExplainOperation op = new AggregateExplainOperation(getNamespace(), [], aggregateOptions, decoder)
 
         when:
         def result = op.execute(getBinding());
@@ -55,7 +58,7 @@ class AggregateExplainOperationSpecification extends FunctionalSpecification {
         assumeTrue(serverVersionAtLeast(asList(2, 6, 0)))
 
         given:
-        AggregateExplainOperation op = new AggregateExplainOperation(getNamespace(), [], aggregateOptions)
+        AggregateExplainOperation op = new AggregateExplainOperation(getNamespace(), [], aggregateOptions, decoder)
 
         when:
         def result = op.executeAsync(getAsyncBinding()).get();
@@ -76,7 +79,7 @@ class AggregateExplainOperationSpecification extends FunctionalSpecification {
         def match = new BsonDocument('job', new BsonString('plumber'))
         AggregateExplainOperation op = new AggregateExplainOperation(getNamespace(),
                                                                      [new BsonDocument('$match', match)],
-                                                                     aggregateOptions)
+                                                                     aggregateOptions, decoder)
 
         when:
         def result = op.execute(getBinding());
@@ -100,7 +103,7 @@ class AggregateExplainOperationSpecification extends FunctionalSpecification {
         def match = new BsonDocument('job', new BsonString('plumber'))
         AggregateExplainOperation op = new AggregateExplainOperation(getNamespace(),
                                                                      [new BsonDocument('$match', match)],
-                                                                     aggregateOptions)
+                                                                     aggregateOptions, decoder)
         when:
         def result = op.executeAsync(getAsyncBinding()).get();
 

--- a/driver/src/test/functional/org/mongodb/operation/AggregateToCollectionOperationSpecification.groovy
+++ b/driver/src/test/functional/org/mongodb/operation/AggregateToCollectionOperationSpecification.groovy
@@ -36,7 +36,7 @@ import static org.mongodb.Fixture.serverVersionAtLeast
 class AggregateToCollectionOperationSpecification extends FunctionalSpecification {
 
     @Shared
-            outCollection
+    outCollection
 
     def setup() {
         outCollection = initialiseCollection(getDefaultDatabase(), 'aggregateCollection')

--- a/driver/src/test/functional/org/mongodb/operation/CommandOperationSpecification.groovy
+++ b/driver/src/test/functional/org/mongodb/operation/CommandOperationSpecification.groovy
@@ -22,6 +22,7 @@ import org.bson.BsonBinary
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonString
+import org.bson.codecs.BsonDocumentCodec
 import org.junit.experimental.categories.Category
 import org.mongodb.FunctionalSpecification
 import org.mongodb.MongoExecutionTimeoutException
@@ -41,7 +42,8 @@ class CommandOperationSpecification extends FunctionalSpecification {
     def 'should execute command'() {
         given:
         def commandOperation = new CommandReadOperation(getNamespace().databaseName,
-                                                        new BsonDocument('count', new BsonString(getCollectionName()))
+                                                        new BsonDocument('count', new BsonString(getCollectionName())),
+                                                        new BsonDocumentCodec()
         )
         when:
         def result = commandOperation.execute(getBinding())
@@ -57,7 +59,8 @@ class CommandOperationSpecification extends FunctionalSpecification {
                                                       .append('query', new BsonDocument('_id', new BsonInt32(42)))
                                                       .append('update',
                                                               new BsonDocument('_id', new BsonInt32(42))
-                                                                      .append('b', new BsonBinary(new byte[16 * 1024 * 1024 - 30])))
+                                                                      .append('b', new BsonBinary(new byte[16 * 1024 * 1024 - 30]))),
+                                              new BsonDocumentCodec()
         )
                 .execute(getBinding())
 
@@ -68,7 +71,8 @@ class CommandOperationSpecification extends FunctionalSpecification {
     def 'should execute command asynchronously'() {
         given:
         def commandOperation = new CommandReadOperation(getNamespace().databaseName,
-                                                        new BsonDocument('count', new BsonString(getCollectionName()))
+                                                        new BsonDocument('count', new BsonString(getCollectionName())),
+                                                        new BsonDocumentCodec()
         )
         when:
         def result = commandOperation.executeAsync(getAsyncBinding()).get()
@@ -85,7 +89,8 @@ class CommandOperationSpecification extends FunctionalSpecification {
         given:
         def commandOperation = new CommandReadOperation(getNamespace().databaseName,
                                                         new BsonDocument('count', new BsonString(getCollectionName()))
-                                                                .append('maxTimeMS', new BsonInt32(1))
+                                                                .append('maxTimeMS', new BsonInt32(1)),
+                                                        new BsonDocumentCodec()
         )
         enableMaxTimeFailPoint()
 
@@ -107,7 +112,8 @@ class CommandOperationSpecification extends FunctionalSpecification {
         given:
         def commandOperation = new CommandReadOperation(getNamespace().databaseName,
                                                         new BsonDocument('count', new BsonString(getCollectionName()))
-                                                                .append('maxTimeMS', new BsonInt32(1))
+                                                                .append('maxTimeMS', new BsonInt32(1)),
+                                                        new BsonDocumentCodec()
         )
         enableMaxTimeFailPoint()
 

--- a/driver/src/test/unit/org/mongodb/CommandResultSpecification.groovy
+++ b/driver/src/test/unit/org/mongodb/CommandResultSpecification.groovy
@@ -21,54 +21,57 @@ import org.bson.BsonDocument
 import org.bson.BsonDouble
 import org.bson.BsonInt32
 import org.bson.BsonString
+import org.bson.codecs.BsonDocumentCodec
 import org.mongodb.connection.ServerAddress
 import spock.lang.Specification
 
 class CommandResultSpecification extends Specification {
     def 'when ok field is missing then ok property should be false'() {
         expect:
-        !new CommandResult(new ServerAddress(), new BsonDocument(), 1).ok
+        !new CommandResult<BsonDocument>(new ServerAddress(), new BsonDocument(), 1, new BsonDocumentCodec()).ok
     }
 
     def 'when ok field is false then ok property should be false'() {
         expect:
-        !new CommandResult(new ServerAddress(), new BsonDocument('ok', BsonBoolean.FALSE), 1).ok
+        !new CommandResult<BsonDocument>(new ServerAddress(), new BsonDocument('ok', BsonBoolean.FALSE), 1, new BsonDocumentCodec()).ok
     }
 
     def 'when ok field is true then ok property should be true'() {
         expect:
-        new CommandResult(new ServerAddress(), new BsonDocument('ok', BsonBoolean.TRUE), 1).ok
+        new CommandResult<BsonDocument>(new ServerAddress(), new BsonDocument('ok', BsonBoolean.TRUE), 1, new BsonDocumentCodec()).ok
     }
 
     def 'when ok field is zero then ok property should be false'() {
         expect:
-        !new CommandResult(new ServerAddress(), new BsonDocument('ok', new BsonDouble(0)), 1).ok
-        !new CommandResult(new ServerAddress(), new BsonDocument('ok', new BsonInt32(0)), 1).ok
+        !new CommandResult<BsonDocument>(new ServerAddress(), new BsonDocument('ok', new BsonDouble(0)), 1, new BsonDocumentCodec()).ok
+        !new CommandResult<BsonDocument>(new ServerAddress(), new BsonDocument('ok', new BsonInt32(0)), 1, new BsonDocumentCodec()).ok
     }
 
     def 'when ok field is one then ok property should be true'() {
         expect:
-        new CommandResult(new ServerAddress(), new BsonDocument('ok', new BsonDouble(1)), 1).ok
-        new CommandResult(new ServerAddress(), new BsonDocument('ok', new BsonInt32(1)), 1).ok
+        new CommandResult<BsonDocument>(new ServerAddress(), new BsonDocument('ok', new BsonDouble(1)), 1, new BsonDocumentCodec()).ok
+        new CommandResult<BsonDocument>(new ServerAddress(), new BsonDocument('ok', new BsonInt32(1)), 1, new BsonDocumentCodec()).ok
     }
 
     def 'when code field is missing then code property should be -1'() {
         expect:
-        new CommandResult(new ServerAddress(), new BsonDocument(), 1).errorCode == -1
+        new CommandResult<BsonDocument>(new ServerAddress(), new BsonDocument(), 1, new BsonDocumentCodec()).errorCode == -1
     }
 
     def 'when code field is present then code property should be equal to it'() {
         expect:
-        new CommandResult(new ServerAddress(), new BsonDocument('code', new BsonInt32(11000)), 1).errorCode == 11000
+        new CommandResult<BsonDocument>(new ServerAddress(), new BsonDocument('code', new BsonInt32(11000)), 1,
+                                        new BsonDocumentCodec()).errorCode == 11000
     }
 
     def 'when errmsg field is missing then errorMessage property should be null'() {
         expect:
-        new CommandResult(new ServerAddress(), new BsonDocument(), 1).errorMessage == null
+        new CommandResult<BsonDocument>(new ServerAddress(), new BsonDocument(), 1, new BsonDocumentCodec()).errorMessage == null
     }
 
     def 'when errmsg field is present then errorMessage property should equal to it'() {
         expect:
-        new CommandResult(new ServerAddress(), new BsonDocument('errmsg', new BsonString('Hello')), 1).errorMessage == 'Hello'
+        new CommandResult<BsonDocument>(new ServerAddress(), new BsonDocument('errmsg', new BsonString('Hello')), 1,
+                                        new BsonDocumentCodec()).errorMessage == 'Hello'
     }
 }

--- a/driver/src/test/unit/org/mongodb/protocol/WriteCommandHelperSpecification.groovy
+++ b/driver/src/test/unit/org/mongodb/protocol/WriteCommandHelperSpecification.groovy
@@ -20,6 +20,7 @@ import org.bson.BsonArray
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonString
+import org.bson.codecs.BsonDocumentCodec
 import org.mongodb.BulkWriteError
 import org.mongodb.BulkWriteUpsert
 import org.mongodb.CommandResult
@@ -144,6 +145,6 @@ class WriteCommandHelperSpecification extends Specification {
 
 
     def getCommandResult(BsonDocument document) {
-        new CommandResult(new ServerAddress(), document, 1)
+        new CommandResult<BsonDocument>(new ServerAddress(), document, 1, new BsonDocumentCodec())
     }
 }


### PR DESCRIPTION
CommandResult<T> returns T for getResponse.
The BsonDocument is still available in getRawResponse() and getResponse lazily decodes to T
CommandOperationHelper was refactored to take a decoder and reorganised to make it easier
to read / refactor in the future.

JAVA-1303
