### PR TITLE
Provide capability to add custom context information into Decoder/Encode...

### DIFF
--- a/bson/src/main/org/bson/codecs/DecoderContext.java
+++ b/bson/src/main/org/bson/codecs/DecoderContext.java
@@ -16,13 +16,18 @@
 
 package org.bson.codecs;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
- * The context for decoding values to BSON.  Currently this is a placeholder, as there is nothing needed yet.
+ * The context for decoding values to BSON. Currently this is a placeholder, as there is nothing needed yet.
  *
  * @see org.bson.codecs.Decoder
  * @since 3.0
  */
 public final class DecoderContext {
+    private Map<String, Object> context;
+
     /**
      * Create a builder.
      *
@@ -36,11 +41,27 @@ public final class DecoderContext {
      * A builder for {@code DecoderContext} instances.
      */
     public static final class Builder {
+        private Map<String, Object> context;
+
         private Builder() {
+            context = new HashMap<String, Object>();
+        }
+
+        /**
+         * Method to add arbitrary decoding context information to the context
+         *
+         * @param key   identifier for the configuration
+         * @param value configuration value
+         * @return
+         */
+        public Builder addParameter(final String key, final Object value) {
+            context.put(key, value);
+            return this;
         }
 
         /**
          * Build an instance of {@code DecoderContext}.
+         *
          * @return the decoder context
          */
         public DecoderContext build() {
@@ -49,5 +70,17 @@ public final class DecoderContext {
     }
 
     private DecoderContext(final Builder builder) {
+        context = new HashMap<String, Object>(builder.context);
+    }
+
+    /**
+     * Returns the decoding context information associated with the given key, or null if no such key exists in the
+     * context
+     *
+     * @param key
+     * @return object associated with the given key or null if no such key exists
+     */
+    public Object getParameter(final String key) {
+        return context.get(key);
     }
 }

--- a/bson/src/main/org/bson/codecs/EncoderContext.java
+++ b/bson/src/main/org/bson/codecs/EncoderContext.java
@@ -16,6 +16,9 @@
 
 package org.bson.codecs;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.bson.BsonWriter;
 
 /**
@@ -29,6 +32,8 @@ public final class EncoderContext {
     private static final EncoderContext DEFAULT_CONTEXT = EncoderContext.builder().build();
 
     private final boolean encodingCollectibleDocument;
+
+    private Map<String, Object> context;
 
     /**
      * Create a builder.
@@ -44,8 +49,10 @@ public final class EncoderContext {
      */
     public static final class Builder {
         private boolean encodingCollectibleDocument;
+        private Map<String, Object> context;
 
         private Builder() {
+            context = new HashMap<String, Object>();
         }
 
         /**
@@ -60,7 +67,20 @@ public final class EncoderContext {
         }
 
         /**
+         * Method to add arbitrary encoding context information to the context
+         *
+         * @param key   identifier for the configuration
+         * @param value configuration value
+         * @return
+         */
+        public Builder addParameter(final String key, final Object value) {
+            context.put(key, value);
+            return this;
+        }
+
+        /**
          * Build an instance of {@code EncoderContext}.
+         *
          * @return the encoder context
          */
         public EncoderContext build() {
@@ -83,9 +103,9 @@ public final class EncoderContext {
      * Creates a child context based on this and serializes the value with it to the writer.
      *
      * @param encoder the encoder to encode value with
-     * @param writer the writer to encode to
-     * @param value the value to encode
-     * @param <T> the type of the value
+     * @param writer  the writer to encode to
+     * @param value   the value to encode
+     * @param <T>     the type of the value
      */
     public <T> void encodeWithChildContext(final Encoder<T> encoder, final BsonWriter writer, final T value) {
         encoder.encode(writer, value, DEFAULT_CONTEXT);
@@ -93,5 +113,17 @@ public final class EncoderContext {
 
     private EncoderContext(final Builder builder) {
         encodingCollectibleDocument = builder.encodingCollectibleDocument;
+        context = new HashMap<String, Object>(builder.context);
+    }
+
+    /**
+     * Returns the encoding context information associated with the given key, or null if no such key exists in the
+     * context
+     *
+     * @param key
+     * @return object associated with the given key or null if no such key exists
+     */
+    public Object getParameter(final String key) {
+        return context.get(key);
     }
 }

--- a/bson/src/test/org/bson/codecs/ContextTest.java
+++ b/bson/src/test/org/bson/codecs/ContextTest.java
@@ -1,0 +1,20 @@
+package org.bson.codecs;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ContextTest {
+
+    @Test
+    public void testDecoderContext() {
+        DecoderContext dctx = DecoderContext.builder().addParameter("test", "value").build();
+        assertEquals(dctx.getParameter("test"), "value");
+    }
+
+    @Test
+    public void testEncoderContextCustomProperty() {
+        EncoderContext ectx = EncoderContext.builder().addParameter("test", "value").build();
+        assertEquals(ectx.getParameter("test"), "value");
+    }
+}

--- a/driver-core/src/main/com/mongodb/codecs/DocumentCodecProvider.java
+++ b/driver-core/src/main/com/mongodb/codecs/DocumentCodecProvider.java
@@ -78,10 +78,10 @@ public class DocumentCodecProvider implements CodecProvider {
             return (Codec<T>) new DocumentCodec(registry, bsonTypeClassMap);
         }
 
+
         if (List.class.isAssignableFrom(clazz)) {
             return (Codec<T>) new ListCodec(registry, bsonTypeClassMap);
         }
-
         return null;
     }
 

--- a/driver/src/test/acceptance/org/mongodb/acceptancetest/codecs/CodecContextTest.java
+++ b/driver/src/test/acceptance/org/mongodb/acceptancetest/codecs/CodecContextTest.java
@@ -1,0 +1,190 @@
+package org.mongodb.acceptancetest.codecs;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonValue;
+import org.bson.BsonWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.configuration.RootCodecRegistry;
+import org.junit.Test;
+import org.mongodb.DatabaseTestCase;
+import org.mongodb.MongoCollection;
+import org.mongodb.codecs.BsonTypeClassMap;
+import org.mongodb.codecs.CollectibleCodec;
+import org.mongodb.codecs.DocumentCodecProvider;
+import org.mongodb.codecs.ListCodec;
+
+public class CodecContextTest extends DatabaseTestCase {
+
+	@Test
+	public void codecContextTest() {
+		MongoCollection col = database.getCollection("codecContextTest", new CustomCodec());
+
+		List<TestObject> list = Arrays.asList(TOHandler.createInstance().setValue(3),
+				TOHandler.createInstance().setValue(2).setInner(TOHandler.createInstance().setValue(3)));
+
+		col.save(TOHandler.createInstance().setValue(3).setInner(
+				TOHandler.createInstance().setValue(3).setInner(TOHandler.createInstance().setValue(2).setInners(list))));
+		System.out.println("test");
+	}
+
+	private static class CustomCodec implements CollectibleCodec<TestObject> {
+		CodecRegistry registry = new RootCodecRegistry(Arrays.asList(new TestCodecProvider(),
+				new DocumentCodecProvider()));
+
+		@Override
+		public void encode(BsonWriter writer, TestObject value, EncoderContext encoderContext) {
+			boolean asString = encoderContext.getParameter("asString") != null
+					&& (Boolean) encoderContext.getParameter("asString") == true;
+			EncoderContext newContext = EncoderContext.builder().addParameter("asString", !asString).build();
+			// lets alternate between settings
+			writer.writeStartDocument();
+
+			if (value == null) {
+				writer.writeEndDocument();
+				return;
+			}
+
+			if (asString) {
+				// toggle encoderContext
+
+				writer.writeName("value");
+				switch (value.getValue()) {
+				case 3:
+					writer.writeString("drei");
+					break;
+				case 2:
+					writer.writeString("zwo");
+					break;
+				default:
+					writer.writeString("N/A");
+				}
+			} else {
+				writer.writeInt32("value", value.getValue());
+			}
+
+			if (value.getInners() != null && value.getInners().size() != 0) {
+				writer.writeName("array");
+				Codec codec = registry.get(List.class);
+				codec.encode(writer, value.getInners(), newContext);
+			}
+
+			if (value.getInner() != null) {
+				writer.writeName("inner");
+				encode(writer, value.getInner(), newContext);
+			}
+			writer.writeEndDocument();
+		}
+
+		@Override
+		public Class getEncoderClass() {
+			return TestObject.class;
+		}
+
+		@Override
+		public TestObject decode(BsonReader reader, DecoderContext decoderContext) {
+			return null;
+		}
+
+		@Override
+		public void generateIdIfAbsentFromDocument(TestObject document) {
+
+		}
+
+		@Override
+		public boolean documentHasId(TestObject document) {
+			return false;
+		}
+
+		@Override
+		public BsonValue getDocumentId(TestObject document) {
+			return null;
+		}
+	}
+
+	private static interface TestObject {
+		public int getValue();
+
+		public TestObject setValue(int o);
+
+		public TestObject getInner();
+
+		public TestObject setInner(TestObject inner);
+
+		public List<TestObject> getInners();
+
+		public TestObject setInners(List<TestObject> inners);
+	}
+
+	private static class TOHandler implements InvocationHandler {
+
+		private Object value;
+
+		private TestObject inner;
+
+		private List<TestObject> inners = new ArrayList();
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+			if ("setValue".equals(method.getName())) {
+				value = args[0];
+				return proxy;
+			} else if ("getValue".equals(method.getName())) {
+				return value;
+			}
+			if ("setInner".equals(method.getName())) {
+				inner = (TestObject) args[0];
+				return proxy;
+			} else if ("getInner".equals(method.getName())) {
+				return inner;
+			}
+			if ("setInners".equals(method.getName())) {
+				inners = (List<TestObject>) args[0];
+				return proxy;
+			} else if ("getInners".equals(method.getName())) {
+				return inners;
+			}
+			return null;
+		}
+
+		static TestObject createInstance() {
+			return (TestObject) Proxy.newProxyInstance(TOHandler.class.getClassLoader(),
+					new Class<?>[] { TestObject.class }, new TOHandler());
+		}
+
+	}
+
+	private static class TestCodecProvider implements CodecProvider {
+
+		private Map<BsonType, Class<?>> replacement;
+
+		public TestCodecProvider() {
+			replacement = new HashMap<BsonType, Class<?>>();
+			replacement.put(BsonType.DOCUMENT, TestObject.class);
+		}
+
+		@Override
+		public <T> Codec<T> get(Class<T> clazz, CodecRegistry registry) {
+			if (TestObject.class.isAssignableFrom(clazz)) {
+				return (Codec<T>) new CustomCodec();
+			}
+			if (List.class.isAssignableFrom(clazz)) {
+				return (Codec<T>) new ListCodec(registry, new BsonTypeClassMap(replacement));
+			}
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
Currently it's not possible to add any custom context information to either DecoderContext or EncoderContext (this might be needed for custom codecs). This is because both context lack the capability to add arbitrary information and the classes are final.

I've extended both contexts, so that it's possible to add custom context information.