### PR TITLE
Add isValidatingDBObjects and setValidateDBObjects to DBCollection

### DIFF
--- a/src/main/com/mongodb/DBCollection.java
+++ b/src/main/com/mongodb/DBCollection.java
@@ -64,6 +64,25 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 @SuppressWarnings("unchecked")
 public abstract class DBCollection {
 
+    private boolean validateDBObjects = true;
+
+    /**
+     *
+     * @return wheter or not this collection validates DBObjects prior to insertion
+     */
+    public boolean isValidatingDBObjects() {
+        return validateDBObjects;
+    }
+
+    /**
+     * Specify whether or not to validate json prior to insertion
+     *
+     * @param val boolean whether or not to validate DBObjects
+     */
+    public void setValidateDBObjects(boolean val) {
+        validateDBObjects = val;
+    }
+
     /**
      * Insert documents into a collection. If the collection does not exists on the server, then it will be created. If the new document
      * does not contain an '_id' field, it will be added.
@@ -1780,7 +1799,7 @@ public abstract class DBCollection {
      * Checks key strings for invalid characters.
      */
     private void _checkKeys( DBObject o ) {
-        if ( o instanceof LazyDBObject || o instanceof LazyDBList )
+        if ( o instanceof LazyDBObject || o instanceof LazyDBList || !validateDBObjects )
             return;
 
         for ( String s : o.keySet() ){

--- a/src/test/com/mongodb/DBCollectionTest.java
+++ b/src/test/com/mongodb/DBCollectionTest.java
@@ -431,6 +431,21 @@ public class DBCollectionTest extends TestCase {
     }
 
     @Test
+    public void testNonValidatingDocKeysPass() {
+        DBObject obj = BasicDBObjectBuilder.start().add("_id", "lazydottest1").add("x",1).add("y",2).add("foo.bar","baz").get();
+
+        // Disable validation on the collection
+        collection.setValidateDBObjects(false);
+        collection.insert(obj);
+
+        DBObject insertedObj = collection.findOne();
+        assertEquals("lazydottest1", insertedObj.get("_id"));
+        assertEquals(1, insertedObj.get("x"));
+        assertEquals(2, insertedObj.get("y"));
+        assertEquals("baz", insertedObj.get("foo.bar"));
+    }
+
+    @Test
     public void testFindAndUpdateTimeout() {
         assumeFalse(isSharded(getMongoClient()));
         checkServerVersion(2.5);


### PR DESCRIPTION
In some cases, validation can be computationally expensive and
unnecessary.  In other situations, a DBEncoder might be in
use which takes invalid data and transforms it into something
valid for mongo.  Ultimately it would be preferable if enough
was exposed that I could subclass DBCollection.
