### PR TITLE
Expose the ServerType and ClusterType enumerations for public consumption

### DIFF
--- a/src/main/com/mongodb/ClusterType.java
+++ b/src/main/com/mongodb/ClusterType.java
@@ -19,7 +19,7 @@ package com.mongodb;
 /**
  * An enumeration of all possible cluster types.
  */
-enum ClusterType {
+public enum ClusterType {
     /**
      * A standalone mongod server.  A cluster of one.
      */

--- a/src/main/com/mongodb/ServerMonitor.java
+++ b/src/main/com/mongodb/ServerMonitor.java
@@ -244,7 +244,7 @@ class ServerMonitor {
                                 .state(ServerConnectionState.Connected)
                                 .version(getVersion(buildInfoResult))
                                 .address(commandResult.getServerUsed())
-                                .type(getServerType(commandResult))
+                                .type(ServerType.getServerType(commandResult))
                                 .hosts(listToSet((List<String>) commandResult.get("hosts")))
                                 .passives(listToSet((List<String>) commandResult.get("passives")))
                                 .arbiters(listToSet((List<String>) commandResult.get("arbiters")))
@@ -272,38 +272,6 @@ class ServerMonitor {
         } else {
             return new HashSet<String>(list);
         }
-    }
-
-    private static ServerType getServerType(final BasicDBObject isMasterResult) {
-        if (isReplicaSetMember(isMasterResult)) {
-            if (isMasterResult.getBoolean("ismaster", false)) {
-                return ServerType.ReplicaSetPrimary;
-            }
-
-            if (isMasterResult.getBoolean("secondary", false)) {
-                return ServerType.ReplicaSetSecondary;
-            }
-
-            if (isMasterResult.getBoolean("arbiterOnly", false)) {
-                return ServerType.ReplicaSetArbiter;
-            }
-
-            if (isMasterResult.containsKey("setName") && isMasterResult.containsField("hosts")) {
-                return ServerType.ReplicaSetOther;
-            }
-
-            return ServerType.ReplicaSetGhost;
-        }
-
-        if (isMasterResult.containsKey("msg") && isMasterResult.get("msg").equals("isdbgrid")) {
-            return ServerType.ShardRouter;
-        }
-
-        return ServerType.StandAlone;
-    }
-
-    private static boolean isReplicaSetMember(final BasicDBObject isMasterResult) {
-        return isMasterResult.containsKey("setName") || isMasterResult.getBoolean("isreplicaset", false);
     }
 
     private static Tags getTagsFromDocument(final DBObject tagsDocuments) {

--- a/src/test/com/mongodb/ServerTypeTest.java
+++ b/src/test/com/mongodb/ServerTypeTest.java
@@ -1,0 +1,20 @@
+package com.mongodb;
+
+import com.mongodb.util.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ServerTypeTest extends TestCase {
+    @Test
+    public void testGetServerType_MongoClient() throws Exception {
+        ServerType type = ServerType.getServerType(getMongoClient());
+        assertNotNull(type);
+    }
+
+    @Test
+    public void testGetServerType_DB() throws Exception {
+        ServerType type = ServerType.getServerType(getDatabase());
+        assertNotNull(type);
+    }
+}


### PR DESCRIPTION
Expose the ServerType and ClusterType enumerations for public consumption. Re-use the private method that was used by the ServerMonitor class to determine the ServerType for a DB or MongoClient.
