### PR TITLE
[JAVA-1391] Javadoc for com.mongodb.codecs package

### DIFF
--- a/bson/src/main/org/bson/codecs/Codec.java
+++ b/bson/src/main/org/bson/codecs/Codec.java
@@ -17,7 +17,7 @@
 package org.bson.codecs;
 
 /**
- * A class that can both encode and decode values should implement this interface.
+ * Implementations of this interface can both encode and decode values of type {@code T}. 
  *
  * @param <T> the value type
  *

--- a/driver-core/src/main/com/mongodb/codecs/BinaryToByteArrayTransformer.java
+++ b/driver-core/src/main/com/mongodb/codecs/BinaryToByteArrayTransformer.java
@@ -18,6 +18,11 @@ package com.mongodb.codecs;
 
 import org.bson.BsonBinary;
 
+/**
+ * Turns a {@code BsonBinary} into a byte array.
+ *
+ * @since 3.0
+ */
 public class BinaryToByteArrayTransformer implements BinaryTransformer<byte[]> {
     @Override
     public byte[] transform(final BsonBinary binary) {

--- a/driver-core/src/main/com/mongodb/codecs/BinaryToUUIDTransformer.java
+++ b/driver-core/src/main/com/mongodb/codecs/BinaryToUUIDTransformer.java
@@ -21,7 +21,7 @@ import org.bson.BsonBinary;
 import java.util.UUID;
 
 /**
- * A transformer from Binary to UUID.
+ * A transformer from {@code BsonBinary} to {@code UUID}.
  *
  * @since 3.0
  */

--- a/driver-core/src/main/com/mongodb/codecs/BinaryTransformer.java
+++ b/driver-core/src/main/com/mongodb/codecs/BinaryTransformer.java
@@ -19,10 +19,17 @@ package com.mongodb.codecs;
 import org.bson.BsonBinary;
 
 /**
- * An interface to define transformers from a Binary instance to an instance of T
+ * An interface to define transformers from a {@code BsonBinary} instance to an instance of T
  *
  * @param <T> the type to transform to
+ * @since 3.0
  */
 public interface BinaryTransformer<T> {
+    /**
+     * Converts the {@code BsonBinary} to a {@code T}.
+     *
+     * @param binary the {@code BsonBinary} to transform
+     * @return an instance of {@code T}
+     */
     T transform(BsonBinary binary);
 }

--- a/driver-core/src/main/com/mongodb/codecs/BooleanCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/BooleanCodec.java
@@ -22,6 +22,11 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 
+/**
+ * Encodes and decodes {@code Boolean} objects.
+ *
+ * @since 3.0
+ */
 public class BooleanCodec implements Codec<Boolean> {
     @Override
     public void encode(final BsonWriter writer, final Boolean value, final EncoderContext encoderContext) {

--- a/driver-core/src/main/com/mongodb/codecs/ByteArrayCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/ByteArrayCodec.java
@@ -23,6 +23,11 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 
+/**
+ * Encodes and decodes byte arrays.
+ *
+ * @since 3.0
+ */
 public class ByteArrayCodec implements Codec<byte[]> {
     @Override
     public void encode(final BsonWriter writer, final byte[] value, final EncoderContext encoderContext) {

--- a/driver-core/src/main/com/mongodb/codecs/ByteCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/ByteCodec.java
@@ -22,6 +22,11 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 
+/**
+ * Encodes and decodes {@code Byte} objects.
+ *
+ * @since 3.0
+ */
 public class ByteCodec implements Codec<Byte> {
     @Override
     public void encode(final BsonWriter writer, final Byte value, final EncoderContext encoderContext) {

--- a/driver-core/src/main/com/mongodb/codecs/CodeWithScopeCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/CodeWithScopeCodec.java
@@ -25,13 +25,18 @@ import org.mongodb.CodeWithScope;
 import org.mongodb.Document;
 
 /**
- * A Codec for CodeWithScope instances.
+ * Encodes and decodes {@code CodeWithScope} instances.
  *
  * @since 3.0
  */
 public class CodeWithScopeCodec implements Codec<CodeWithScope> {
     private final Codec<Document> documentCodec;
 
+    /**
+     * Creates a new CodeWithScopeCodec.
+     *
+     * @param documentCodec a Codec for encoding and decoding the {@link org.mongodb.CodeWithScope#getScope()}.
+     */
     public CodeWithScopeCodec(final Codec<Document> documentCodec) {
         this.documentCodec = documentCodec;
     }

--- a/driver-core/src/main/com/mongodb/codecs/CollectibleCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/CollectibleCodec.java
@@ -23,6 +23,7 @@ import org.bson.codecs.Codec;
  * A Codec that generates complete BSON documents for storage in a MongoDB collection.
  *
  * @param <T> the document type
+ * @since 3.0
  */
 public interface CollectibleCodec<T> extends Codec<T> {
     /**
@@ -41,8 +42,8 @@ public interface CollectibleCodec<T> extends Codec<T> {
     boolean documentHasId(T document);
 
     /**
-     * Gets the _id of the given document if it contains one, otherwise throws {@code IllegalArgumentException}.  To avoid the latter
-     * case, call {@code documentHasId} first to check.
+     * Gets the _id of the given document if it contains one, otherwise throws {@code IllegalArgumentException}.  To avoid the latter case,
+     * call {@code documentHasId} first to check.
      *
      * @param document the document from which to get the _id
      * @return the _id of the document

--- a/driver-core/src/main/com/mongodb/codecs/DateCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/DateCodec.java
@@ -24,6 +24,11 @@ import org.bson.codecs.EncoderContext;
 
 import java.util.Date;
 
+/**
+ * Encodes and decodes {@code java.util.Date} objects.
+ *
+ * @since 3.0
+ */
 public class DateCodec implements Codec<Date> {
     @Override
     public void encode(final BsonWriter writer, final Date value, final EncoderContext encoderContext) {

--- a/driver-core/src/main/com/mongodb/codecs/DocumentCodecProvider.java
+++ b/driver-core/src/main/com/mongodb/codecs/DocumentCodecProvider.java
@@ -46,16 +46,17 @@ public class DocumentCodecProvider implements CodecProvider {
     private final BsonTypeClassMap bsonTypeClassMap;
 
     /**
-     *  Construct a new instance with a default {@code BsonTypeClassMap}.
+     * Construct a new instance with a default {@code BsonTypeClassMap}.
      */
     public DocumentCodecProvider() {
         this(new BsonTypeClassMap());
     }
 
     /**
-     *  Construct a new instance with the given instance of {@code BsonTypeClassMap}.
+     * Construct a new instance with the given instance of {@code BsonTypeClassMap}.
      *
-     * @param bsonTypeClassMap the {@code BsonTypeClassMap} with which to construct instances of {@code DocumentCodec} and {@code ListCodec}
+     * @param bsonTypeClassMap the {@code BsonTypeClassMap} with which to construct instances of {@code DocumentCodec} and {@code
+     *                         ListCodec}
      */
     public DocumentCodecProvider(final BsonTypeClassMap bsonTypeClassMap) {
         this.bsonTypeClassMap = bsonTypeClassMap;

--- a/driver-core/src/main/com/mongodb/codecs/DoubleCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/DoubleCodec.java
@@ -22,6 +22,11 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 
+/**
+ * Encodes and decodes {@code Double} objects.
+ *
+ * @since 3.0
+ */
 public class DoubleCodec implements Codec<Double> {
     @Override
     public void encode(final BsonWriter writer, final Double value, final EncoderContext encoderContext) {

--- a/driver-core/src/main/com/mongodb/codecs/FloatCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/FloatCodec.java
@@ -23,7 +23,9 @@ import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 
 /**
- * Float codec
+ * Encodes and decodes {@code Float} objects.
+ *
+ * @since 3.0
  */
 public class FloatCodec implements Codec<Float> {
     @Override

--- a/driver-core/src/main/com/mongodb/codecs/IdGenerator.java
+++ b/driver-core/src/main/com/mongodb/codecs/IdGenerator.java
@@ -16,6 +16,16 @@
 
 package com.mongodb.codecs;
 
+/**
+ * Classes that implement this interface define a way to create IDs for MongoDB documents.
+ *
+ * @since 3.0
+ */
 public interface IdGenerator {
+    /**
+     * Generates an ID for a MongoDB Document.
+     *
+     * @return any type of Object representing an ID.
+     */
     Object generate();
 }

--- a/driver-core/src/main/com/mongodb/codecs/IntegerCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/IntegerCodec.java
@@ -22,6 +22,11 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 
+/**
+ * Encodes and decodes {@code Integer} objects.
+ *
+ * @since 3.0
+ */
 public class IntegerCodec implements Codec<Integer> {
     @Override
     public void encode(final BsonWriter writer, final Integer value, final EncoderContext encoderContext) {

--- a/driver-core/src/main/com/mongodb/codecs/ListCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/ListCodec.java
@@ -27,11 +27,23 @@ import org.bson.codecs.configuration.CodecRegistry;
 import java.util.ArrayList;
 import java.util.List;
 
-@SuppressWarnings({ "unchecked", "rawtypes"})
+/**
+ * Encodes and decodes {@code List} objects.  The lists are never going to use the generic types as these are erased.
+ *
+ * @since 3.0
+ */
+@SuppressWarnings({"unchecked", "rawtypes"})
 public class ListCodec implements Codec<List> {
     private final CodecRegistry registry;
     private final BsonTypeClassMap bsonTypeClassMap;
 
+    /**
+     * Creates a new {@code ListCodec}, which will use the given {@code CodecRegistry} and {@code BsonTypeClassMap} for encoding and
+     * decoding the values in the List.
+     *
+     * @param registry         contains the codecs required to encode and decode {@code List} values
+     * @param bsonTypeClassMap will be used for decoding BSON values into the List.
+     */
     public ListCodec(final CodecRegistry registry, final BsonTypeClassMap bsonTypeClassMap) {
         this.registry = registry;
         this.bsonTypeClassMap = bsonTypeClassMap;

--- a/driver-core/src/main/com/mongodb/codecs/LongCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/LongCodec.java
@@ -22,6 +22,12 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 
+/**
+ * Encodes and decodes {@code Long} objects.
+ *
+ * @since 3.0
+ */
+
 public class LongCodec implements Codec<Long> {
     @Override
     public void encode(final BsonWriter writer, final Long value, final EncoderContext encoderContext) {

--- a/driver-core/src/main/com/mongodb/codecs/ObjectIdGenerator.java
+++ b/driver-core/src/main/com/mongodb/codecs/ObjectIdGenerator.java
@@ -18,6 +18,11 @@ package com.mongodb.codecs;
 
 import org.bson.types.ObjectId;
 
+/**
+ * Creates new {@code ObjectId} instances as IDs for MongoDB Documents.
+ *
+ * @since 3.0
+ */
 public class ObjectIdGenerator implements IdGenerator {
     @Override
     public Object generate() {

--- a/driver-core/src/main/com/mongodb/codecs/PatternCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/PatternCodec.java
@@ -49,7 +49,7 @@ public class PatternCodec implements Codec<Pattern> {
         return Pattern.class;
     }
 
-    public static String getOptionsAsString(final Pattern pattern) {
+    private static String getOptionsAsString(final Pattern pattern) {
         int flags = pattern.flags();
         StringBuilder buf = new StringBuilder();
 
@@ -67,7 +67,7 @@ public class PatternCodec implements Codec<Pattern> {
         return buf.toString();
     }
 
-    public static int getOptionsAsInt(final BsonRegularExpression regularExpression) {
+    private static int getOptionsAsInt(final BsonRegularExpression regularExpression) {
         int optionsInt = 0;
 
         String optionsString = regularExpression.getOptions();
@@ -82,12 +82,10 @@ public class PatternCodec implements Codec<Pattern> {
             RegexFlag flag = RegexFlag.getByCharacter(optionsString.charAt(i));
             if (flag != null) {
                 optionsInt |= flag.javaFlag;
-                //CHECKSTYLE:OFF
                 if (flag.unsupported != null) {
                     // TODO: deal with logging
                     // warnUnsupportedRegex( flag.unsupported );
                 }
-                //CHECKSTYLE:ON
             } else {
                 // TODO: throw a better exception here
                 throw new IllegalArgumentException("unrecognized flag [" + optionsString.charAt(i) + "] " + (int) optionsString.charAt(i));

--- a/driver-core/src/main/com/mongodb/codecs/ShortCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/ShortCodec.java
@@ -22,6 +22,11 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 
+/**
+ * Encodes and decodes {@code Short} objects.
+ *
+ * @since 3.0
+ */
 public class ShortCodec implements Codec<Short> {
     @Override
     public void encode(final BsonWriter writer, final Short value, final EncoderContext encoderContext) {

--- a/driver-core/src/main/com/mongodb/codecs/StringCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/StringCodec.java
@@ -22,6 +22,11 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 
+/**
+ * Encodes and decodes {@code String} objects.
+ *
+ * @since 3.0
+ */
 public class StringCodec implements Codec<String> {
     @Override
     public void encode(final BsonWriter writer, final String value, final EncoderContext encoderContext) {

--- a/driver-core/src/main/com/mongodb/codecs/TransformingBinaryDecoder.java
+++ b/driver-core/src/main/com/mongodb/codecs/TransformingBinaryDecoder.java
@@ -26,12 +26,17 @@ import org.bson.types.Binary;
 import java.util.HashMap;
 import java.util.Map;
 
-@SuppressWarnings("rawtypes")
+/**
+ * Decodes BSON binary types into the appropriate Java types.  Uses the {@code BsonBinarySubType} to determine which {@code
+ * BinaryTransformer} to use to convert the binary type to the right Java object.
+ *
+ * @since 3.0
+ */
 public class TransformingBinaryDecoder implements Decoder<Object> {
-    private final Map<Byte, BinaryTransformer> subTypeTransformerMap;
+    private final Map<Byte, BinaryTransformer<?>> subTypeTransformerMap;
 
-    public TransformingBinaryDecoder() {
-        subTypeTransformerMap = new HashMap<Byte, BinaryTransformer>();
+    {
+        subTypeTransformerMap = new HashMap<Byte, BinaryTransformer<?>>();
         subTypeTransformerMap.put(BsonBinarySubType.BINARY.getValue(), new BinaryToByteArrayTransformer());
         subTypeTransformerMap.put(BsonBinarySubType.OLD_BINARY.getValue(), new BinaryToByteArrayTransformer());
         subTypeTransformerMap.put(BsonBinarySubType.UUID_LEGACY.getValue(), new BinaryToUUIDTransformer());
@@ -40,7 +45,7 @@ public class TransformingBinaryDecoder implements Decoder<Object> {
     @Override
     public Object decode(final BsonReader reader, final DecoderContext decoderContext) {
         BsonBinary binary = reader.readBinaryData();
-        BinaryTransformer transformer = subTypeTransformerMap.get(binary.getType());
+        BinaryTransformer<?> transformer = subTypeTransformerMap.get(binary.getType());
         if (transformer == null) {
             return new Binary(binary.getType(), binary.getData());
         } else {

--- a/driver-core/src/main/com/mongodb/codecs/UUIDCodec.java
+++ b/driver-core/src/main/com/mongodb/codecs/UUIDCodec.java
@@ -26,6 +26,11 @@ import org.bson.codecs.EncoderContext;
 
 import java.util.UUID;
 
+/**
+ * Encodes and decodes {@code UUID} objects.
+ *
+ * @since 3.0
+ */
 public class UUIDCodec implements Codec<UUID> {
     @Override
     public void encode(final BsonWriter writer, final UUID value, final EncoderContext encoderContext) {


### PR DESCRIPTION
Added missing Javadoc for com.mongodb.codecs package. Also some tiny tidy ups, like making methods private and removing @SuppressWarnings where possible.
