### PR TITLE
[JAVA-1410] Documenting com.mongodb.util

### DIFF
--- a/driver/src/main/com/mongodb/util/JSONCallback.java
+++ b/driver/src/main/com/mongodb/util/JSONCallback.java
@@ -25,6 +25,7 @@ import com.mongodb.DBRef;
 import org.bson.BSON;
 import org.bson.BSONObject;
 import org.bson.BasicBSONCallback;
+import org.bson.BsonUndefined;
 import org.bson.types.BSONTimestamp;
 import org.bson.types.Binary;
 import org.bson.types.Code;
@@ -32,7 +33,6 @@ import org.bson.types.CodeWScope;
 import org.bson.types.MaxKey;
 import org.bson.types.MinKey;
 import org.bson.types.ObjectId;
-import org.bson.BsonUndefined;
 
 import javax.xml.bind.DatatypeConverter;
 import java.text.ParsePosition;
@@ -43,6 +43,9 @@ import java.util.SimpleTimeZone;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+/**
+ * Converts JSON to DBObjects and vice versa.
+ */
 public class JSONCallback extends BasicBSONCallback {
 
     @Override
@@ -55,11 +58,13 @@ public class JSONCallback extends BasicBSONCallback {
         return new BasicDBList();
     }
 
+    @Override
     public void objectStart(final boolean array, final String name) {
         _lastArray = array;
         super.objectStart(array, name);
     }
 
+    @Override
     public Object objectDone() {
         String name = curName();
         Object o = super.objectDone();

--- a/driver/src/main/com/mongodb/util/JSONParseException.java
+++ b/driver/src/main/com/mongodb/util/JSONParseException.java
@@ -34,6 +34,7 @@ public class JSONParseException extends RuntimeException {
     final String jsonString;
     final int pos;
 
+    @Override
     public String getMessage() {
         StringBuilder sb = new StringBuilder();
         sb.append("\n");

--- a/driver/src/main/com/mongodb/util/Util.java
+++ b/driver/src/main/com/mongodb/util/Util.java
@@ -20,7 +20,16 @@ import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+/**
+ * General utilities that are useful throughout the driver.
+ */
 public class Util {
+    /**
+     * Converts the given byte buffer to a hexadecimal string using {@link java.lang.Integer#toHexString(int)}.
+     *
+     * @param bytes the bytes to convert to hex
+     * @return a String containing the hex representation of the given bytes.
+     */
     public static String toHex(final byte[] bytes) {
         StringBuilder sb = new StringBuilder();
 
@@ -32,19 +41,16 @@ public class Util {
             }
             sb.append(s);
         }
-
         return sb.toString();
-
     }
 
     /**
-     * Produce hex representation of the MD5 digest of a byte array
+     * Produce hex representation of the MD5 digest of a byte array.
      *
      * @param data bytes to digest
      * @return hex string of the MD5 digest
      */
     public static String hexMD5(final byte[] data) {
-
         try {
             MessageDigest md5 = MessageDigest.getInstance("MD5");
 
@@ -58,6 +64,14 @@ public class Util {
         }
     }
 
+    /**
+     * Produce hex representation of the MD5 digest of a byte array.
+     *
+     * @param buf    byte buffer containing the bytes to digest
+     * @param offset the position to start reading bytes from
+     * @param len    the number of bytes to read from the buffer
+     * @return hex string of the MD5 digest
+     */
     public static String hexMD5(final ByteBuffer buf, final int offset, final int len) {
         byte[] b = new byte[len];
         for (int i = 0; i < len; i++) {

--- a/driver/src/main/com/mongodb/util/package-info.java
+++ b/driver/src/main/com/mongodb/util/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2014 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains classes that can be used everywhere in the driver, and have no specific domain.
+ */
+package com.mongodb.util;


### PR DESCRIPTION
As per the first pass of documenting the legacy API:
- Adding missing Javadoc for public classes and methods
- Applied simple standardisation to existing documentation (formatting, capitalisation)
- Renamed params, and occasionally variables, where appropriate for better readability.
- @Override used to ensure parent documentation applied to child methods.

Although existing documentation has been scanned, no effort has been made to ensure its correctness.
