### PR TITLE
Utility functions to view state of BulkWriteOperation objects

### DIFF
--- a/src/main/com/mongodb/BulkWriteOperation.java
+++ b/src/main/com/mongodb/BulkWriteOperation.java
@@ -112,5 +112,12 @@ public class BulkWriteOperation {
         requests.add(request);
     }
 
+    /**
+     * Returns true if the bulk operations have been executed.
+     * @return whether the bulk operations have been executed
+     */
+    public boolean isExecuted() {
+    	return closed;
+    }
 
 }

--- a/src/main/com/mongodb/BulkWriteOperation.java
+++ b/src/main/com/mongodb/BulkWriteOperation.java
@@ -120,4 +120,11 @@ public class BulkWriteOperation {
     	return closed;
     }
 
+    /**
+     * Returns the number of requests added to the bulk operation
+     * @return number of requests added to the bulk operation
+     */
+    public int requestCount() {
+    	return requests.size();
+    }
 }

--- a/src/test/com/mongodb/BulkWriteOperationSpecification.groovy
+++ b/src/test/com/mongodb/BulkWriteOperationSpecification.groovy
@@ -802,6 +802,21 @@ class BulkWriteOperationSpecification extends FunctionalSpecification {
         where:
         ordered << [true, false]
     }
+    
+    def 'when the operation has been executed isExecuted should return true'() {
+    	given:
+    	def operation = initializeBulkOperation(ordered)
+    	addWritesToOperation(operation)
+    	
+    	when:
+    	operation.execute()
+    	
+    	then:
+    	operation.isExecuted() == true
+
+    	where:
+        ordered << [true, false]
+    }
 
     private static void addWritesToOperation(BulkWriteOperation operation) {
         operation.find(new BasicDBObject('_id', 1)).updateOne(new BasicDBObject('$set', new BasicDBObject('x', 2)))

--- a/src/test/com/mongodb/BulkWriteOperationSpecification.groovy
+++ b/src/test/com/mongodb/BulkWriteOperationSpecification.groovy
@@ -817,6 +817,21 @@ class BulkWriteOperationSpecification extends FunctionalSpecification {
     	where:
         ordered << [true, false]
     }
+    
+    def 'view number of requests added to operation'() {
+    	given:
+    	def operation = initializeBulkOperation(ordered)
+    	
+    	when:
+    	operation.insert(new BasicDBObject('_id', 1))
+    	operation.insert(new BasicDBObject('_id', 2))
+    	
+    	then:
+    	operation.requestCount() == 2
+    	
+    	where:
+    	ordered << [true, false]
+    }
 
     private static void addWritesToOperation(BulkWriteOperation operation) {
         operation.find(new BasicDBObject('_id', 1)).updateOne(new BasicDBObject('$set', new BasicDBObject('x', 2)))


### PR DESCRIPTION
BulkWriteOperation.execute() will throw an exception if the operations have all ready been executed or no operations have been added to the object, but it doesn't provide any way to test if this is the case. I have added two simple methods which make it possible.

For me the practical use-case is that we often create have thousands of operations to run in bulk, but would like to run execute when n have been added. We can easily do this by adding an external counter, but it makes much more sense for the BulkWriteOperation to make this information available. This also removes the need for code like the one below when no operations have been added to the object.

    try {
       bulkOp.execute();
    } catch (IllegalStateException ise) {
       //Do nothing
    }

