### PR TITLE
Decouple OptionalFinalizer from QueryResultIterator's implicit 'this' re...

### DIFF
--- a/src/main/com/mongodb/QueryResultIterator.java
+++ b/src/main/com/mongodb/QueryResultIterator.java
@@ -116,7 +116,7 @@ class QueryResultIterator implements Cursor {
     }
 
     public boolean tryHasNext() {
-        if (closed) {
+        if (closed[0]) {
             throw new IllegalStateException("Iterator has been closed");
         }
 
@@ -124,7 +124,7 @@ class QueryResultIterator implements Cursor {
             return true;
         }
 
-        if (_cursorId != 0) {
+        if (_cursorId[0] != 0) {
             getMore();
         }
         return _curSize > 0;


### PR DESCRIPTION
Decouple OptionalFinalizer from QueryResultIterator's implicit 'this' reference and everything that comes with it.

https://github.com/mongodb/mongo-java-driver/pull/270
