### PR TITLE
Ensure String.format is not on the critical path for any operations.

### DIFF
--- a/bson/src/main/org/bson/AbstractBsonReader.java
+++ b/bson/src/main/org/bson/AbstractBsonReader.java
@@ -652,9 +652,9 @@ public abstract class AbstractBsonReader implements Closeable, BsonReader {
             throwInvalidState(methodName, State.VALUE);
         }
         if (currentBsonType != requiredBsonType) {
-            String message = format("%s can only be called when CurrentBSONType is %s, not when CurrentBSONType is %s.",
-                                    methodName, requiredBsonType, currentBsonType);
-            throw new BsonInvalidOperationException(message);
+            throw new BsonInvalidOperationException(format("%s can only be called when CurrentBSONType is %s, " 
+                                                           + "not when CurrentBSONType is %s.",
+                                                           methodName, requiredBsonType, currentBsonType));
         }
     }
 
@@ -668,9 +668,8 @@ public abstract class AbstractBsonReader implements Closeable, BsonReader {
         readBsonType();
         String actualName = readName();
         if (!actualName.equals(expectedName)) {
-            String message = format("Expected element name to be '%s', not '%s'.",
-                                    expectedName, actualName);
-            throw new BsonSerializationException(message);
+            throw new BsonSerializationException(format("Expected element name to be '%s', not '%s'.",
+                                                        expectedName, actualName));
         }
     }
 

--- a/bson/src/main/org/bson/AbstractBsonWriter.java
+++ b/bson/src/main/org/bson/AbstractBsonWriter.java
@@ -491,7 +491,7 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
             throw new IllegalArgumentException("BSON field name can not be null");
         }
         if (!fieldNameValidatorStack.peek().validate(name)) {
-            throw new IllegalArgumentException(String.format("Invalid BSON field name %s", name));
+            throw new IllegalArgumentException(format("Invalid BSON field name %s", name));
         }
         context.name = name;
         state = State.VALUE;
@@ -648,10 +648,9 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
     protected void throwInvalidContextType(final String methodName, final BsonContextType actualContextType,
                                            final BsonContextType... validContextTypes) {
         String validContextTypesString = StringUtils.join(" or ", Arrays.asList(validContextTypes));
-        String message = format("%s can only be called when ContextType is %s, "
-                                + "not when ContextType is %s.", methodName, validContextTypesString,
-                                actualContextType);
-        throw new BsonInvalidOperationException(message);
+        throw new BsonInvalidOperationException(format("%s can only be called when ContextType is %s, "
+                                                       + "not when ContextType is %s.", 
+                                                       methodName, validContextTypesString, actualContextType));
     }
 
     /**
@@ -662,7 +661,6 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
      * @throws BsonInvalidOperationException when the method called is not valid for the current state.
      */
     protected void throwInvalidState(final String methodName, final State... validStates) {
-        String message;
         if (state == State.INITIAL || state == State.SCOPE_DOCUMENT || state == State.DONE) {
             if (!methodName.startsWith("end") && !methodName.equals("writeName")) { // NOPMD
                 //NOPMD collapsing these if statements will not aid readability
@@ -674,16 +672,14 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
                 if (Arrays.asList('A', 'E', 'I', 'O', 'U').contains(typeName.charAt(0))) {
                     article = "An";
                 }
-                message = format("%s %s value cannot be written to the root level of a BSON document.", article,
-                                 typeName);
-                throw new BsonInvalidOperationException(message);
+                throw new BsonInvalidOperationException(format("%s %s value cannot be written to the root level of a BSON document.", 
+                                                               article, typeName));
             }
         }
 
         String validStatesString = StringUtils.join(" or ", Arrays.asList(validStates));
-        message = format("%s can only be called when State is %s, not when State is %s", methodName,
-                         validStatesString, state);
-        throw new BsonInvalidOperationException(message);
+        throw new BsonInvalidOperationException(format("%s can only be called when State is %s, not when State is %s", 
+                                                       methodName, validStatesString, state));
     }
 
     @Override

--- a/bson/src/main/org/bson/BsonBinaryReader.java
+++ b/bson/src/main/org/bson/BsonBinaryReader.java
@@ -93,9 +93,8 @@ public class BsonBinaryReader extends AbstractBsonReader {
                     setState(State.END_OF_DOCUMENT);
                     return BsonType.END_OF_DOCUMENT;
                 default:
-                    String message = format("BSONType EndOfDocument is not valid when ContextType is %s.",
-                                            getContext().getContextType());
-                    throw new BsonSerializationException(message);
+                    throw new BsonSerializationException(format("BSONType EndOfDocument is not valid when ContextType is %s.",
+                                                                getContext().getContextType()));
             }
         } else {
             switch (getContext().getContextType()) {
@@ -395,8 +394,7 @@ public class BsonBinaryReader extends AbstractBsonReader {
         Context popContext(final int position) {
             int actualSize = position - startPosition;
             if (actualSize != size) {
-                String message = format("Expected size to be %d, not %d.", size, actualSize);
-                throw new BsonSerializationException(message);
+                throw new BsonSerializationException(format("Expected size to be %d, not %d.", size, actualSize));
             }
             return getParentContext();
         }

--- a/bson/src/main/org/bson/BsonBinaryWriter.java
+++ b/bson/src/main/org/bson/BsonBinaryWriter.java
@@ -22,6 +22,8 @@ import org.bson.types.ObjectId;
 
 import java.util.Stack;
 
+import static java.lang.String.format;
+
 /**
  * A BsonWriter implementation that writes to a binary stream of data.  This is the most commonly used implementation.
  *
@@ -371,9 +373,8 @@ public class BsonBinaryWriter extends AbstractBsonWriter {
     private void backpatchSize() {
         int size = bsonOutput.getPosition() - getContext().startPosition;
         if (size > maxDocumentSizeStack.peek()) {
-            String message = String.format("Size %d is larger than MaxDocumentSize %d.", size,
-                                           binaryWriterSettings.getMaxDocumentSize());
-            throw new BsonSerializationException(message);
+            throw new BsonSerializationException(format("Size %d is larger than MaxDocumentSize %d.", size,
+                                                        binaryWriterSettings.getMaxDocumentSize()));
         }
         bsonOutput.writeInt32(bsonOutput.getPosition() - size, size);
     }

--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -645,7 +645,7 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, S
     @Override
     public BsonValue put(final String key, final BsonValue value) {
         if (value == null) {
-            throw new IllegalArgumentException(String.format("The value for key %s can not be null", key));
+            throw new IllegalArgumentException(format("The value for key %s can not be null", key));
         }
         if (key.contains("\0")) {
             throw new BSONException(format("BSON cstring '%s' is not valid because it contains a null character at index %d", key,

--- a/bson/src/main/org/bson/BsonValue.java
+++ b/bson/src/main/org/bson/BsonValue.java
@@ -16,6 +16,8 @@
 
 package org.bson;
 
+import static java.lang.String.format;
+
 /**
  * Base class for any BSON type.
  *
@@ -76,8 +78,8 @@ public abstract class BsonValue {
      */
     public BsonNumber asNumber() {
         if (getBsonType() != BsonType.INT32 && getBsonType() != BsonType.INT64 && getBsonType() != BsonType.DOUBLE) {
-            throw new BsonInvalidOperationException(String.format("Value expected to be of a numerical BSON type is of unexpected type %s",
-                                                                  getBsonType()));
+            throw new BsonInvalidOperationException(format("Value expected to be of a numerical BSON type is of unexpected type %s",
+                                                           getBsonType()));
         }
         return (BsonNumber) this;
     }
@@ -392,8 +394,8 @@ public abstract class BsonValue {
 
     private void throwIfInvalidType(final BsonType expectedType) {
         if (getBsonType() != expectedType) {
-            throw new BsonInvalidOperationException(String.format("Value expected to be of type %s is of unexpected type %s",
-                                                                  expectedType, getBsonType()));
+            throw new BsonInvalidOperationException(format("Value expected to be of type %s is of unexpected type %s",
+                                                           expectedType, getBsonType()));
         }
     }
 }

--- a/bson/src/main/org/bson/io/BasicOutputBuffer.java
+++ b/bson/src/main/org/bson/io/BasicOutputBuffer.java
@@ -25,6 +25,8 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.lang.String.format;
+
 /**
  * A BSON output stream that stores the output in a single, un-pooled byte array.
  */
@@ -77,10 +79,10 @@ public class BasicOutputBuffer extends OutputBuffer {
         ensureOpen();
 
         if (absolutePosition < 0) {
-            throw new IllegalArgumentException(String.format("position must be >= 0 but was %d", absolutePosition));
+            throw new IllegalArgumentException(format("position must be >= 0 but was %d", absolutePosition));
         }
         if (absolutePosition > position - 1) {
-            throw new IllegalArgumentException(String.format("position must be <= %d but was %d", position - 1, absolutePosition));
+            throw new IllegalArgumentException(format("position must be <= %d but was %d", position - 1, absolutePosition));
         }
 
         buffer[absolutePosition] = (byte) (0xFF & value);

--- a/bson/src/main/org/bson/json/JsonWriter.java
+++ b/bson/src/main/org/bson/json/JsonWriter.java
@@ -31,6 +31,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
+import static java.lang.String.format;
 import static javax.xml.bind.DatatypeConverter.printBase64Binary;
 
 /**
@@ -145,8 +146,8 @@ public class JsonWriter extends AbstractBsonWriter {
             switch (settings.getOutputMode()) {
                 case SHELL:
                     writeNameHelper(getName());
-                    writer.write(String.format("new BinData(%s, \"%s\")", Integer.toString(binary.getType() & 0xFF),
-                                               printBase64Binary(binary.getData())));
+                    writer.write(format("new BinData(%s, \"%s\")", Integer.toString(binary.getType() & 0xFF),
+                                        printBase64Binary(binary.getData())));
 
                     break;
                 default:
@@ -186,9 +187,9 @@ public class JsonWriter extends AbstractBsonWriter {
                     SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'");
                     dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
                     if (value >= -59014396800000L && value <= 253399536000000L) {
-                        writer.write(String.format("ISODate(\"%s\")", dateFormat.format(new Date(value))));
+                        writer.write(format("ISODate(\"%s\")", dateFormat.format(new Date(value))));
                     } else {
-                        writer.write(String.format("new Date(%d)", value));
+                        writer.write(format("new Date(%d)", value));
                     }
                     break;
                 default:
@@ -235,15 +236,15 @@ public class JsonWriter extends AbstractBsonWriter {
                 case STRICT:
                     writeStartDocument();
                     writeNameHelper("$numberLong");
-                    writer.write(String.format("\"%d\"", value));
+                    writer.write(format("\"%d\"", value));
                     writeEndDocument();
                     break;
                 case SHELL:
                     writeNameHelper(getName());
                     if (value >= Integer.MIN_VALUE && value <= Integer.MAX_VALUE) {
-                        writer.write(String.format("NumberLong(%d)", value));
+                        writer.write(format("NumberLong(%d)", value));
                     } else {
-                        writer.write(String.format("NumberLong(\"%d\")", value));
+                        writer.write(format("NumberLong(\"%d\")", value));
                     }
                     break;
                 default:
@@ -305,7 +306,7 @@ public class JsonWriter extends AbstractBsonWriter {
                     break;
                 case SHELL:
                     writeNameHelper(getName());
-                    writer.write(String.format("ObjectId(\"%s\")", objectId.toString()));
+                    writer.write(format("ObjectId(\"%s\")", objectId.toString()));
                     break;
                 default:
                     throw new BSONException("Unknown output mode" + settings.getOutputMode());
@@ -373,7 +374,7 @@ public class JsonWriter extends AbstractBsonWriter {
                     break;
                 case SHELL:
                     writeNameHelper(getName());
-                    writer.write(String.format("Timestamp(%d, %d)", value.getTime(), value.getInc()));
+                    writer.write(format("Timestamp(%d, %d)", value.getTime(), value.getInc()));
                     break;
                 default:
                     throw new BSONException("Unknown output mode" + settings.getOutputMode());

--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -314,7 +314,9 @@ public class ConnectionString {
     private void warnOnUnsupportedOptions(final Map<String, List<String>> optionsMap) {
         for (final String key : optionsMap.keySet()) {
             if (!ALL_KEYS.contains(key)) {
-                LOGGER.warn(format("Unsupported option '%s' on URI '%s'.", key, uri));
+                if (LOGGER.isWarnEnabled()) {
+                    LOGGER.warn(format("Unsupported option '%s' on URI '%s'.", key, uri));
+                }
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/connection/BaseCluster.java
@@ -104,8 +104,10 @@ abstract class BaseCluster implements Cluster {
                 }
 
                 if (!selectionFailureLogged) {
-                    LOGGER.info(format("No server chosen by %s from cluster description %s. Waiting for %d ms before timing out",
-                                       serverSelector, curDescription, MILLISECONDS.convert(maxWaitTime, timeUnit)));
+                    if (LOGGER.isInfoEnabled()) {
+                        LOGGER.info(format("No server chosen by %s from cluster description %s. Waiting for %d ms before timing out",
+                                           serverSelector, curDescription, MILLISECONDS.convert(maxWaitTime, timeUnit)));
+                    }
                     selectionFailureLogged = true;
                 }
 
@@ -159,8 +161,10 @@ abstract class BaseCluster implements Cluster {
                 }
 
                 if (!selectionFailureLogged) {
-                    LOGGER.info(format("Cluster description not yet available. Waiting for %d ms before timing out",
-                                       MILLISECONDS.convert(maxWaitTime, timeUnit)));
+                    if (LOGGER.isInfoEnabled()) {
+                        LOGGER.info(format("Cluster description not yet available. Waiting for %d ms before timing out",
+                                           MILLISECONDS.convert(maxWaitTime, timeUnit)));
+                    }
                     selectionFailureLogged = true;
                 }
 
@@ -210,7 +214,9 @@ abstract class BaseCluster implements Cluster {
     protected abstract ClusterableServer getServer(ServerAddress serverAddress);
 
     protected synchronized void updateDescription(final ClusterDescription newDescription) {
-        LOGGER.debug(format("Updating cluster description to  %s", newDescription.getShortDescription()));
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(format("Updating cluster description to  %s", newDescription.getShortDescription()));
+        }
 
         description = newDescription;
         CountDownLatch current = phase.getAndSet(new CountDownLatch(1));

--- a/driver-core/src/main/com/mongodb/connection/CommandResultCallback.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandResultCallback.java
@@ -45,7 +45,9 @@ class CommandResultCallback<T> extends CommandResultBaseCallback<BsonDocument> {
         if (e != null) {
             callback.onResult(null, e);
         } else {
-            LOGGER.debug("Command execution completed with status " + ProtocolHelper.isCommandOk(response));
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Command execution completed with status " + ProtocolHelper.isCommandOk(response));
+            }
             if (!ProtocolHelper.isCommandOk(response)) {
                 callback.onResult(null, ProtocolHelper.getCommandFailureException(response, getServerAddress()));
             } else {

--- a/driver-core/src/main/com/mongodb/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultConnectionPool.java
@@ -216,8 +216,10 @@ class DefaultConnectionPool implements ConnectionPool {
      */
     private void incrementGenerationOnSocketException(final InternalConnection connection, final MongoException e) {
         if (e instanceof MongoSocketException && !(e instanceof MongoSocketReadTimeoutException)) {
-            LOGGER.warn(format("Got socket exception on connection [%s] to %s. All connections to %s will be closed.",
-                               getId(connection), serverId.getAddress(), serverId.getAddress()));
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn(format("Got socket exception on connection [%s] to %s. All connections to %s will be closed.",
+                                   getId(connection), serverId.getAddress(), serverId.getAddress()));
+            }
             invalidate();
         }
     }
@@ -346,7 +348,9 @@ class DefaultConnectionPool implements ConnectionPool {
             if (!closed) {
                 connectionPoolListener.connectionRemoved(new ConnectionEvent(getId(connection)));
             }
-            LOGGER.info(format("Closed connection [%s] to %s because %s.", getId(connection), serverId.getAddress(), reason));
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info(format("Closed connection [%s] to %s because %s.", getId(connection), serverId.getAddress(), reason));
+            }
             connection.close();
         }
 

--- a/driver-core/src/main/com/mongodb/connection/GetMoreResultCallback.java
+++ b/driver-core/src/main/com/mongodb/connection/GetMoreResultCallback.java
@@ -25,6 +25,8 @@ import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import org.bson.codecs.Decoder;
 
+import static java.lang.String.format;
+
 class GetMoreResultCallback<T> extends ResponseCallback {
     public static final Logger LOGGER = Loggers.getLogger("protocol.getmore");
     private final SingleResultCallback<QueryResult<T>> callback;
@@ -50,7 +52,11 @@ class GetMoreResultCallback<T> extends ResponseCallback {
                 throw new MongoCursorNotFoundException(cursorId, getServerAddress());
             } else {
                 result = new QueryResult<T>(new ReplyMessage<T>(responseBuffers, decoder, getRequestId()), getServerAddress());
-                LOGGER.debug("GetMore results received " + result.getResults().size() + " documents with cursor " + result.getCursor());
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(format("GetMore results received %s documents with cursor %s",
+                                        result.getResults().size(),
+                                        result.getCursor()));
+                }
             }
         } catch (MongoException me) {
             exceptionResult = me;

--- a/driver-core/src/main/com/mongodb/connection/MultiServerCluster.java
+++ b/driver-core/src/main/com/mongodb/connection/MultiServerCluster.java
@@ -65,8 +65,10 @@ final class MultiServerCluster extends BaseCluster {
         clusterType = settings.getRequiredClusterType();
         replicaSetName = settings.getRequiredReplicaSetName();
 
-        LOGGER.info(format("Cluster created with settings %s", settings.getShortDescription()));
-
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info(format("Cluster created with settings %s", settings.getShortDescription()));
+        }
+        
         // synchronizing this code because addServer registers a callback which is re-entrant to this instance.
         // In other words, we are leaking a reference to "this" from the constructor.
         synchronized (this) {
@@ -131,7 +133,9 @@ final class MultiServerCluster extends BaseCluster {
             if (event.getNewValue().isOk()) {
                 if (clusterType == UNKNOWN && newDescription.getType() != REPLICA_SET_GHOST) {
                     clusterType = newDescription.getClusterType();
-                    LOGGER.info(format("Discovered cluster type of %s", clusterType));
+                    if (LOGGER.isInfoEnabled()) {
+                        LOGGER.info(format("Discovered cluster type of %s", clusterType));
+                    }
                 }
 
                 switch (clusterType) {
@@ -164,7 +168,9 @@ final class MultiServerCluster extends BaseCluster {
         }
 
         if (newDescription.getType() == REPLICA_SET_GHOST) {
-            LOGGER.info(format("Server %s does not appear to be a member of an initiated replica set.", newDescription.getAddress()));
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info(format("Server %s does not appear to be a member of an initiated replica set.", newDescription.getAddress()));
+            }
             return;
         }
 
@@ -214,7 +220,9 @@ final class MultiServerCluster extends BaseCluster {
 
     private void addServer(final ServerAddress serverAddress) {
         if (!addressToServerTupleMap.containsKey(serverAddress)) {
-            LOGGER.info(format("Adding discovered server %s to client view of cluster", serverAddress));
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info(format("Adding discovered server %s to client view of cluster", serverAddress));
+            }
             ClusterableServer server = createServer(serverAddress, new DefaultServerStateListener());
             addressToServerTupleMap.put(serverAddress, new ServerTuple(server, getConnectingServerDescription(serverAddress)));
         }
@@ -227,7 +235,9 @@ final class MultiServerCluster extends BaseCluster {
     private void invalidateOldPrimaries(final ServerAddress newPrimary) {
         for (final ServerTuple serverTuple : addressToServerTupleMap.values()) {
             if (!serverTuple.description.getAddress().equals(newPrimary) && serverTuple.description.isPrimary()) {
-                LOGGER.info(format("Rediscovering type of existing primary %s", serverTuple.description.getAddress()));
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info(format("Rediscovering type of existing primary %s", serverTuple.description.getAddress()));
+                }
                 serverTuple.server.invalidate();
             }
         }
@@ -281,8 +291,10 @@ final class MultiServerCluster extends BaseCluster {
         Set<ServerAddress> allServerAddresses = getAllServerAddresses(serverDescription);
         for (final ServerTuple cur : addressToServerTupleMap.values()) {
             if (!allServerAddresses.contains(cur.description.getAddress())) {
-                LOGGER.info(format("Server %s is no longer a member of the replica set.  Removing from client view of cluster.",
-                                   cur.description.getAddress()));
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info(format("Server %s is no longer a member of the replica set.  Removing from client view of cluster.",
+                                       cur.description.getAddress()));
+                }
                 removeServer(cur.description.getAddress());
             }
         }

--- a/driver-core/src/main/com/mongodb/connection/QueryResultCallback.java
+++ b/driver-core/src/main/com/mongodb/connection/QueryResultCallback.java
@@ -27,6 +27,7 @@ import org.bson.codecs.Decoder;
 import org.bson.codecs.DocumentCodec;
 
 import static com.mongodb.connection.ProtocolHelper.getQueryFailureException;
+import static java.lang.String.format;
 
 class QueryResultCallback<T> extends ResponseCallback {
     public static final Logger LOGGER = Loggers.getLogger("protocol.query");
@@ -54,7 +55,11 @@ class QueryResultCallback<T> extends ResponseCallback {
                 throw getQueryFailureException(getServerAddress(), errorDocument);
             } else {
                 result = new QueryResult<T>(new ReplyMessage<T>(responseBuffers, decoder, getRequestId()), getServerAddress());
-                LOGGER.debug("Query results received " + result.getResults().size() + " documents with cursor " + result.getCursor());
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(format("Query results received %s documents with cursor %s",
+                                        result.getResults().size(),
+                                        result.getCursor()));
+                }
             }
         } catch (MongoException me) {
             exceptionResult = me;

--- a/driver-core/src/main/com/mongodb/connection/SingleServerCluster.java
+++ b/driver-core/src/main/com/mongodb/connection/SingleServerCluster.java
@@ -41,8 +41,10 @@ final class SingleServerCluster extends BaseCluster {
         isTrue("one server in a direct cluster", settings.getHosts().size() == 1);
         isTrue("connection mode is single", settings.getMode() == ClusterConnectionMode.SINGLE);
 
-        LOGGER.info(format("Cluster created with settings %s", settings.getShortDescription()));
-
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info(format("Cluster created with settings %s", settings.getShortDescription()));
+        }
+        
         // synchronized in the constructor because the change listener is re-entrant to this instance.
         // In other words, we are leaking a reference to "this" from the constructor.
         synchronized (this) {

--- a/driver-core/src/main/com/mongodb/connection/WriteCommandProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/WriteCommandProtocol.java
@@ -79,7 +79,9 @@ abstract class WriteCommandProtocol implements Protocol<BulkWriteResult> {
             BsonDocument result = receiveMessage(connection, message);
 
             if (nextMessage != null || batchNum > 1) {
-                getLogger().debug(format("Received response for batch %d", batchNum));
+                if (getLogger().isDebugEnabled()) {
+                    getLogger().debug(format("Received response for batch %d", batchNum));
+                }
             }
 
             if (WriteCommandResultHelper.hasError(result)) {
@@ -118,7 +120,9 @@ abstract class WriteCommandProtocol implements Protocol<BulkWriteResult> {
             final int nextRangeStartIndex = currentRangeStartIndex + itemCount;
 
             if (nextBatchNum > 1) {
-                getLogger().debug(format("Asynchronously sending batch %d", batchNum));
+                if (getLogger().isDebugEnabled()) {
+                    getLogger().debug(format("Asynchronously sending batch %d", batchNum));
+                }
             }
 
             sendMessageAsync(connection, message.getId(), bsonOutput).register(new SingleResultCallback<BsonDocument>() {
@@ -130,7 +134,9 @@ abstract class WriteCommandProtocol implements Protocol<BulkWriteResult> {
                     } else {
 
                         if (nextBatchNum > 1) {
-                            getLogger().debug(format("Asynchronously received response for batch %d", batchNum));
+                            if (getLogger().isDebugEnabled()) {
+                                getLogger().debug(format("Asynchronously received response for batch %d", batchNum));
+                            }
                         }
 
                         if (WriteCommandResultHelper.hasError(result)) {
@@ -164,7 +170,9 @@ abstract class WriteCommandProtocol implements Protocol<BulkWriteResult> {
         try {
             BaseWriteCommandMessage nextMessage = message.encode(bsonOutput);
             if (nextMessage != null || batchNum > 1) {
-                getLogger().debug(format("Sending batch %d", batchNum));
+                if (getLogger().isDebugEnabled()) {
+                    getLogger().debug(format("Sending batch %d", batchNum));
+                }
             }
             connection.sendMessage(bsonOutput.getByteBuffers(), message.getId());
             return nextMessage;

--- a/driver-core/src/main/com/mongodb/connection/WriteProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/WriteProtocol.java
@@ -102,12 +102,16 @@ abstract class WriteProtocol implements Protocol<WriteConcernResult> {
             RequestMessage nextMessage = lastMessage.encode(bsonOutput);
             int batchNum = 1;
             if (nextMessage != null) {
-                getLogger().debug(format("Sending batch %d", batchNum));
+                if (getLogger().isDebugEnabled()) {
+                    getLogger().debug(format("Sending batch %d", batchNum));
+                }
             }
 
             while (nextMessage != null) {
                 batchNum++;
-                getLogger().debug(format("Sending batch %d", batchNum));
+                if (getLogger().isDebugEnabled()) {
+                    getLogger().debug(format("Sending batch %d", batchNum));
+                }
                 lastMessage = nextMessage;
                 nextMessage = nextMessage.encode(bsonOutput);
             }
@@ -153,7 +157,7 @@ abstract class WriteProtocol implements Protocol<WriteConcernResult> {
      * @param settings the message settings
      * @return the request message
      */
-    protected abstract RequestMessage createRequestMessage(final MessageSettings settings);
+    protected abstract RequestMessage createRequestMessage(MessageSettings settings);
 
     /**
      * Gets the namespace.

--- a/driver/src/main/com/mongodb/DBObjectCodec.java
+++ b/driver/src/main/com/mongodb/DBObjectCodec.java
@@ -102,7 +102,7 @@ public class DBObjectCodec implements CollectibleCodec<DBObject> {
     /**
      * Construct an instance.
      *
-     * @param codecRegistry the non-null codec registry
+     *  @param codecRegistry the non-null codec registry
      * @param bsonTypeClassMap the non-null BsonTypeClassMap
      * @param objectFactory the non-null object factory used to create empty DBObject instances when decoding
      */

--- a/driver/src/test/unit/com/mongodb/DBCollectionFunctionalSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/DBCollectionFunctionalSpecification.groovy
@@ -105,7 +105,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         collection.setObjectClass(ClassA)
 
         when:
-        DBObject document = collection.findAndModify(null, ~['_id': idOfExistingDocument, 'c'  : 1])
+        DBObject document = collection.findAndModify(null, ~['_id': idOfExistingDocument, 'c': 1])
 
         then:
         document instanceof ClassA
@@ -118,7 +118,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         collection.setInternalClass('b', ClassB);
 
         when:
-        DBObject document = collection.findAndModify(null, ~['_id': idOfExistingDocument, 'c'  : 1])
+        DBObject document = collection.findAndModify(null, ~['_id': idOfExistingDocument, 'c': 1])
 
         then:
         document.get('a') instanceof ClassA


### PR DESCRIPTION
[Performance] Guided by the profiler, located all places where String.format is used to see if the call needs to be cached, or wrapped inside a conditional; wrapped all calls to logger.warn/info/debug inside a conditional. Performance testing shows these changes do improve the performance of create, read, update and delete methods.
