### PR TITLE
Update JSONCallback.java

### DIFF
--- a/src/main/com/mongodb/util/JSONCallback.java
+++ b/src/main/com/mongodb/util/JSONCallback.java
@@ -93,6 +93,18 @@ public class JSONCallback extends BasicBSONCallback {
                     format.setCalendar(new GregorianCalendar(new SimpleTimeZone(0, "GMT")));
                     o = format.parse(b.get("$date").toString(), new ParsePosition(0));
                 }
+                if (o == null) {
+                    // try timezone
+                    format = new SimpleDateFormat(_msDateFormat_TZ);
+                    format.setCalendar(new GregorianCalendar(new SimpleTimeZone(0, "GMT")));
+                    o = format.parse(b.get("$date").toString(), new ParsePosition(0));
+                }
+                if (o == null) {
+                    // try older format timezone
+                    format = new SimpleDateFormat(_secDateFormat_TZ);
+                    format.setCalendar(new GregorianCalendar(new SimpleTimeZone(0, "GMT")));
+                    o = format.parse(b.get("$date").toString(), new ParsePosition(0));
+                }
             }
         } else if (b.containsField("$regex")) {
             o = Pattern.compile((String) b.get("$regex"),
@@ -141,4 +153,6 @@ public class JSONCallback extends BasicBSONCallback {
 
     public static final String _msDateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
     public static final String _secDateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    public static final String _msDateFormat_TZ = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+	public static final String _secDateFormat_TZ = "yyyy-MM-dd'T'HH:mm:ssZ";
 }

--- a/src/test/com/mongodb/util/JSONCallbackTest.java
+++ b/src/test/com/mongodb/util/JSONCallbackTest.java
@@ -62,6 +62,24 @@ public class JSONCallbackTest extends com.mongodb.util.TestCase {
         assertEquals(
                 parsedDate.compareTo(format.parse(format.format(rightNow), new ParsePosition(0))), 0);
 
+        // Test formatted dates with ms granularity and timezone offset
+        format = new SimpleDateFormat(JSONCallback._msDateFormat_TZ);
+        format.setCalendar(new GregorianCalendar(new SimpleTimeZone(1, "GMT")));
+
+        parsedDate = (Date) JSON.parse("{ \"$date\" : \"" + format.format(rightNow) + "\"}");
+        assertEquals(
+                parsedDate.compareTo(format.parse(format.format(rightNow), new ParsePosition(0))), 0);
+
+        // Test formatted dates with sec granularity
+        format = new SimpleDateFormat(JSONCallback._secDateFormat_TZ);
+        format.setCalendar(new GregorianCalendar(new SimpleTimeZone(1, "GMT")));
+
+        parsedDate = (Date) JSON.parse("{ \"$date\" : \"" + format.format(rightNow) + "\"}");
+        assertEquals(
+                parsedDate.compareTo(format.parse(format.format(rightNow), new ParsePosition(0))), 0);
+
+        
+        
     }
 
     @Test


### PR DESCRIPTION
This change supports datetimes in different timezone.
You can insert for example this document:
		String o = "{"
				+ "\"fdata\" : {$date: \"2011-11-21T14:30:00.123-0400\"},"
				+ "\"fdat2\" : {$date: \"2011-11-21T14:30:00.123Z\"},"
				+ "\"fdat3\" : {$date: \"2011-11-21T14:30:00-0400\"},"
				+ "\"fdat4\" : {$date: \"2011-11-21T14:30:00Z\"}"
				+ "}";
	DBObject dbo = (DBObject)JSON.parse(o.toString());
        coll.insert(dbo);
and obtain four dates.