### PR TITLE
JAVA-1529: JSON Parser now does not allow unmatched trailing quotes on field names

### DIFF
--- a/src/main/com/mongodb/util/JSONCallback.java
+++ b/src/main/com/mongodb/util/JSONCallback.java
@@ -35,10 +35,7 @@ import org.bson.types.ObjectId;
 
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.SimpleTimeZone;
-import java.util.UUID;
+import java.util.*;
 import java.util.regex.Pattern;
 
 /**
@@ -134,6 +131,16 @@ public class JSONCallback extends BasicBSONCallback {
             o = !BSON.hasDecodeHooks() ? o : BSON.applyDecodingHooks( o );
             setRoot(o);
         }
+
+        Iterator<String> itr = b.keySet().iterator();
+        while( itr.hasNext() ) {
+            String k = itr.next();
+            if( k.contains("\"") ) {
+                throw new JSONParseException("SyntaxError: Unexpected token ILLEGAL",0);
+            }
+        }
+
+
         return o;
     }
 

--- a/src/test/com/mongodb/util/JSONTest.java
+++ b/src/test/com/mongodb/util/JSONTest.java
@@ -180,6 +180,25 @@ public class JSONTest extends com.mongodb.util.TestCase {
         }
         assertEquals(threw, true);
         threw = false;
+
+        try {
+            JSON.parse("{ a\": 1 }");
+        }
+        catch(JSONParseException e) {
+            threw = true;
+        }
+        assertEquals(threw, true);
+        threw = false;
+
+        try {
+            JSON.parse("{ a: { b\":1 } }");
+        }
+        catch(JSONParseException e) {
+            threw = true;
+        }
+        assertEquals(threw, true);
+        threw = false;
+
     }
 
     @Test


### PR DESCRIPTION
1. JSONTest.java file to include 2 tests 
           JSON.parse("{ a\": 1 }");
           JSON.parse("{ a: { b\":1 } }");
Both of the above test cases should throw JSONParseException because of unmatched quote.

2. Added a snippet of code in file JSONCallback.java in the objectDone() method to fix the given issue.