### PR TITLE
Allow DB class injection using CDI

### DIFF
--- a/src/main/com/mongodb/DB.java
+++ b/src/main/com/mongodb/DB.java
@@ -16,14 +16,15 @@
 
 package com.mongodb;
 
-import com.mongodb.util.Util;
-import org.bson.BSONObject;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.bson.BSONObject;
+
+import com.mongodb.util.Util;
 
 /**
  * A thread-safe client view of a logical database in a MongoDB cluster. A DB instance can be achieved from a {@link MongoClient} instance
@@ -56,6 +57,16 @@ public abstract class DB {
         _obedientCommands.add("listCollections");
     }
 
+    /**
+     * CDI eyes only
+     * @deprecated CDI eyes only
+     */
+    public DB() {
+    	_options = null;
+    	_name = null;
+    	_mongo = null;
+    }
+    
     /**
      * Constructs a new instance of the {@code DB}.
      *


### PR DESCRIPTION
The current CDI version has a limitation that managed beans must have a default constructor.

When using `mongo-java-driver` it would be nice to being able to inject `DB` instance into DAOs, but nowadays we can't do it because `DB` doesn't have a default constructor and CDI fails when tries to inject it.

This PR introduces a default constructor that should only be used by CDI, to allow the dependency injection. That's why we are marking the constructor as deprecated.

```
The following Java types cannot be proxied by the container:

classes which don't have a non-private constructor with no parameters, and
classes which are declared final or have a final method,
arrays and primitive types.
```
http://docs.jboss.org/weld/reference/2.1.2.Final/en-US/html_single/#d0e1464