### PR TITLE
Added abstract Filter class

### DIFF
--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -17,7 +17,9 @@
 package org.bson;
 
 import org.bson.codecs.BsonDocumentCodec;
+import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
+import org.bson.json.JsonReader;
 import org.bson.json.JsonWriter;
 
 import java.io.Serializable;
@@ -39,6 +41,16 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, S
     private static final long serialVersionUID = -8366220692735186027L;
 
     private final Map<String, BsonValue> map = new LinkedHashMap<String, BsonValue>();
+
+    /**
+     * Create a BsonDocument from a JSON String representation.
+     *
+     * @param json a JSON string
+     * @return a BSON document
+     */
+    public static BsonDocument parse(final String json) {
+        return new BsonDocumentCodec().decode(new JsonReader(json), DecoderContext.builder().build());
+    }
 
     /**
      * Construct a new instance with the given list {@code BsonElement}, none of which may be null.

--- a/bson/src/test/unit/org/bson/BsonDocumentTest.java
+++ b/bson/src/test/unit/org/bson/BsonDocumentTest.java
@@ -82,4 +82,9 @@ public class BsonDocumentTest {
     public void toStringShouldEqualToJson() {
         assertEquals(document.toJson(), document.toString());
     }
+
+    @Test
+    public void shouldParseJson() {
+        assertEquals(new BsonDocument("a", new BsonInt32(1)), BsonDocument.parse("{\"a\" : 1}"));
+    }
 }

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -51,6 +51,7 @@
     </ruleset-ref>
     <ruleset-ref path='rulesets/generic.xml'/>
     <ruleset-ref path='rulesets/groovyism.xml'>
+        <exclude name="ExplicitCallToAndMethod"/>
         <exclude name="ExplicitCallToCompareToMethod"/>
         <exclude name='GetterMethodCouldBeProperty'/>
      </ruleset-ref>

--- a/driver-core/src/main/com/mongodb/client/model/Filter.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filter.java
@@ -5,10 +5,29 @@ import org.bson.BsonDocumentWrapper;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 
+/**
+ * A representation of a query filter.
+ *
+ * @since 3.0
+ */
 public abstract class Filter {
 
+    /**
+     * Render the filter into a BsonDocument.
+     *
+     * @param documentClass the document class in scope for the collection
+     * @param codecRegistry the codec registry
+     * @param <TDocument> the type of the document class
+     * @return the filter as a BsonDocument
+     */
     public abstract <TDocument> BsonDocument render(Class<TDocument> documentClass, CodecRegistry codecRegistry);
 
+    /**
+     * A static factory method that converts a BsonDocument to a Filter.
+     *
+     * @param document the document
+     * @return the filter
+     */
     public static Filter asFilter(final BsonDocument document) {
         return new Filter() {
             @Override
@@ -18,6 +37,12 @@ public abstract class Filter {
         };
     }
 
+    /**
+     * A static factory method that converts a Document to a Filter.
+     *
+     * @param document the document
+     * @return the filter
+     */
     public static Filter asFilter(final Document document) {
         return new Filter() {
             @Override
@@ -27,6 +52,12 @@ public abstract class Filter {
         };
     }
 
+    /**
+     * A static factory method that converts a JSON string to a Filter.
+     *
+     * @param json the document as a JSON string
+     * @return the filter
+     */
     public static Filter asFilter(final String json) {
         return new Filter() {
             @Override
@@ -36,6 +67,12 @@ public abstract class Filter {
         };
     }
 
+    /**
+     * A static factory method that converts any Object to a Filter.  Use this with care.
+     *
+     * @param document the document
+     * @return the filter
+     */
     public static Filter asFilter(final Object document) {
         return new Filter() {
             @Override

--- a/driver-core/src/main/com/mongodb/client/model/Filter.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filter.java
@@ -7,12 +7,12 @@ import org.bson.codecs.configuration.CodecRegistry;
 
 public abstract class Filter {
 
-    public abstract <TDocument> BsonDocument render(Class<TDocument> collectionClass, CodecRegistry codecRegistry);
+    public abstract <TDocument> BsonDocument render(Class<TDocument> documentClass, CodecRegistry codecRegistry);
 
     public static Filter asFilter(final BsonDocument document) {
         return new Filter() {
             @Override
-            public <C> BsonDocument render(final Class<C> collectionClass, final CodecRegistry codecRegistry) {
+            public <C> BsonDocument render(final Class<C> documentClass, final CodecRegistry codecRegistry) {
                 return document;
             }
         };
@@ -21,7 +21,7 @@ public abstract class Filter {
     public static Filter asFilter(final Document document) {
         return new Filter() {
             @Override
-            public <C> BsonDocument render(final Class<C> collectionClass, final CodecRegistry codecRegistry) {
+            public <C> BsonDocument render(final Class<C> documentClass, final CodecRegistry codecRegistry) {
                 return new BsonDocumentWrapper<Document>(document, codecRegistry.get(Document.class));
             }
         };
@@ -30,7 +30,7 @@ public abstract class Filter {
     public static Filter asFilter(final String json) {
         return new Filter() {
             @Override
-            public <T> BsonDocument render(final Class<T> collectionClass, final CodecRegistry codecRegistry) {
+            public <T> BsonDocument render(final Class<T> documentClass, final CodecRegistry codecRegistry) {
                 return BsonDocument.parse(json);
             }
         };
@@ -39,9 +39,9 @@ public abstract class Filter {
     public static Filter asFilter(final Object document) {
         return new Filter() {
             @Override
-            public <C> BsonDocument render(final Class<C> collectionClass, final CodecRegistry codecRegistry) {
+            public <C> BsonDocument render(final Class<C> documentClass, final CodecRegistry codecRegistry) {
                 if (document instanceof String) {
-                    return asFilter((String) document).render(collectionClass, codecRegistry);
+                    return asFilter((String) document).render(documentClass, codecRegistry);
                 }
                 return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
             }

--- a/driver-core/src/main/com/mongodb/client/model/Filter.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filter.java
@@ -1,0 +1,52 @@
+package com.mongodb.client.model;
+
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWrapper;
+import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
+
+public abstract class Filter {
+
+    public abstract <TDocument> BsonDocument render(Class<TDocument> collectionClass, CodecRegistry codecRegistry);
+
+    public static Filter asFilter(final BsonDocument document) {
+        return new Filter() {
+            @Override
+            public <C> BsonDocument render(final Class<C> collectionClass, final CodecRegistry codecRegistry) {
+                return document;
+            }
+        };
+    }
+
+    public static Filter asFilter(final Document document) {
+        return new Filter() {
+            @Override
+            public <C> BsonDocument render(final Class<C> collectionClass, final CodecRegistry codecRegistry) {
+                return new BsonDocumentWrapper<Document>(document, codecRegistry.get(Document.class));
+            }
+        };
+    }
+
+    public static Filter asFilter(final String json) {
+        return new Filter() {
+            @Override
+            public <T> BsonDocument render(final Class<T> collectionClass, final CodecRegistry codecRegistry) {
+                return BsonDocument.parse(json);
+            }
+        };
+    }
+
+    public static Filter asFilter(final Object document) {
+        return new Filter() {
+            @Override
+            public <C> BsonDocument render(final Class<C> collectionClass, final CodecRegistry codecRegistry) {
+                if (document instanceof String) {
+                    return asFilter((String) document).render(collectionClass, codecRegistry);
+                }
+                return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
+            }
+        };
+    }
+}
+
+

--- a/driver-core/src/main/com/mongodb/client/model/FilterBuilder.java
+++ b/driver-core/src/main/com/mongodb/client/model/FilterBuilder.java
@@ -1,0 +1,297 @@
+package com.mongodb.client.model;
+
+import org.bson.BsonArray;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWriter;
+import org.bson.BsonValue;
+import org.bson.codecs.Encoder;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import java.util.Map;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static java.util.Arrays.asList;
+
+/**
+ * A builder for {@link Filter} instances
+ *
+ * @since 3.0
+ */
+public final class FilterBuilder {
+
+    private FilterBuilder() {
+    }
+
+    /**
+     * Creates a filter that ands together the provided list of filters.  Note that this will only generate a "$and" operator if absolutely
+     * necessary, as the query language implicity ands together all the keys.
+     *
+     * @param filters the list of filters to and together
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/and $and
+     */
+    public static Filter and(final Iterable<Filter> filters) {
+        return new AndFilter(filters);
+    }
+
+    /**
+     * Creates a filter that ands together the provided list of filters.  Note that this will only generate a "$and" operator if absolutely
+     * necessary, as the query language implicity ands together all the keys.
+     *
+     * @param filters the list of filters to and together
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/and $and
+     */
+    public static Filter and(final Filter... filters) {
+        return and(asList(filters));
+    }
+
+    /**
+     * Creates a filter that ands together the provided list of filters.  Note that this will only generate a "$and" operator if absolutely
+     * necessary, as the query language implicity ands together all the keys.
+     *
+     * @param filters the list of filters to and together
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/and $and
+     */
+    public static Filter or(final Iterable<Filter> filters) {
+        return new OrFilter(filters);
+    }
+
+    /**
+     * Creates a filter that ands together the provided list of filters.  Note that this will only generate a "$and" operator if absolutely
+     * necessary, as the query language implicity ands together all the keys.
+     *
+     * @param filters the list of filters to and together
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/and $and
+     */
+    public static Filter or(final Filter... filters) {
+        return or(asList(filters));
+    }
+
+    /**
+     * Creates a filter that matches all documents where the value of the field name equals the specified value. Note that this does
+     * actually generate a $eq operator, as the query language doesn't require it.
+     *
+     * @param fieldName the field name
+     * @param value     the value
+     * @param <TField>  the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/eq $eq
+     */
+    public static <TField> Filter eq(final String fieldName, final TField value) {
+        return new Filter() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public <TDocument> BsonDocument render(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+                BsonDocumentWriter writer = new BsonDocumentWriter(new BsonDocument());
+
+                writer.writeStartDocument();
+                writer.writeName(fieldName);
+                ((Encoder) codecRegistry.get(value.getClass())).encode(writer, value, EncoderContext.builder().build());
+                writer.writeEndDocument();
+
+                return writer.getDocument();
+            }
+        };
+    }
+
+
+    /**
+     * Creates a filter that matches all documents that contain the given field.
+     *
+     * @param fieldName the field name
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/exists $exists
+     */
+    public static Filter exists(final String fieldName) {
+        return exists(fieldName, true);
+    }
+
+    /**
+     * Creates a filter that matches all documents that either contain or do not contain the given field, depending on the value of the
+     * exists parameter.
+     *
+     * @param fieldName the field name
+     * @param exists true to check for existence, false to check for absence
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/exists $exists
+     */
+
+    public static Filter exists(final String fieldName, final boolean exists) {
+        return new OperatorFilter<BsonBoolean>("$exists", fieldName, BsonBoolean.valueOf(exists));
+    }
+
+    /**
+     * Creates a filter that matches all documents where the value of the given field is greater than the specified value.
+     *
+     * @param fieldName the field name
+     * @param value the value
+     * @param <TField> the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/gt $gt
+     */
+    public static <TField> Filter gt(final String fieldName, final TField value) {
+
+        return new OperatorFilter<TField>("$gt", fieldName, value);
+    }
+
+    /**
+     * Creates a filter that matches all documents where the value of the given field is less than the specified value.
+     *
+     * @param fieldName the field name
+     * @param value the value
+     * @param <TField> the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/gt $gt
+     */
+    public static <TField> Filter lt(final String fieldName, final TField value) {
+        return new OperatorFilter<TField>("$lt", fieldName, value);
+    }
+
+    /**
+     * Creates a filter that matches all documents where the value of the given field is greater than or equal to the specified value.
+     *
+     * @param fieldName the field name
+     * @param value the value
+     * @param <TField> the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/gt $gt
+     */
+    public static <TField> Filter gte(final String fieldName, final TField value) {
+        return new OperatorFilter<TField>("$gte", fieldName, value);
+    }
+
+    /**
+     * Creates a filter that matches all documents where the value of the given field is less than or equal to the specified value.
+     *
+     * @param fieldName the field name
+     * @param value the value
+     * @param <TField> the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/gt $gt
+     */
+    public static <TField> Filter lte(final String fieldName, final TField value) {
+        return new OperatorFilter<TField>("$lte", fieldName, value);
+    }
+
+    private static final class OperatorFilter<TField> extends Filter {
+        private final String operatorName;
+        private final String fieldName;
+        private final TField value;
+
+        OperatorFilter(final String operatorName, final String fieldName, final TField value) {
+            this.operatorName = notNull("operatorName", operatorName);
+            this.fieldName = notNull("fieldName", fieldName);
+            this.value = value;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <TDocument> BsonDocument render(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+            BsonDocumentWriter writer = new BsonDocumentWriter(new BsonDocument());
+
+            writer.writeStartDocument();
+            writer.writeName(fieldName);
+            writer.writeStartDocument();
+            writer.writeName(operatorName);
+            ((Encoder) codecRegistry.get(value.getClass())).encode(writer, value, EncoderContext.builder().build());
+            writer.writeEndDocument();
+            writer.writeEndDocument();
+
+            return writer.getDocument();
+        }
+    }
+
+    private static class AndFilter extends Filter {
+        private final Iterable<Filter> filters;
+
+        public AndFilter(final Iterable<Filter> filters) {
+            this.filters = filters;
+        }
+
+        @Override
+        public <TDocument> BsonDocument render(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+            BsonDocument andFilter = new BsonDocument();
+
+            for (Filter filter : filters) {
+                BsonDocument renderedFilter = filter.render(documentClass, codecRegistry);
+                for (Map.Entry<String, BsonValue> element : renderedFilter.entrySet()) {
+                    addClause(andFilter, element);
+                }
+            }
+
+            return andFilter;
+        }
+
+        private void addClause(final BsonDocument document, final Map.Entry<String, BsonValue> clause) {
+            if (clause.getKey().equals("$and")) {
+                for (BsonValue value : clause.getValue().asArray()) {
+                    for (Map.Entry<String, BsonValue> element : value.asDocument().entrySet()) {
+                        addClause(document, element);
+                    }
+                }
+            } else if (document.size() == 1 && document.keySet().iterator().next().equals("$and")) {
+                document.get("$and").asArray().add(new BsonDocument(clause.getKey(), clause.getValue()));
+            } else if (document.containsKey(clause.getKey())) {
+                if (document.get(clause.getKey()).isDocument() && clause.getValue().isDocument()) {
+                    BsonDocument existingClauseValue = document.get(clause.getKey()).asDocument();
+                    BsonDocument clauseValue = clause.getValue().asDocument();
+                    if (keysIntersect(clauseValue, existingClauseValue)) {
+                        promoteFilterToDollarForm(document, clause);
+                    } else {
+                        existingClauseValue.putAll(clauseValue);
+                    }
+                } else {
+                    promoteFilterToDollarForm(document, clause);
+                }
+            } else {
+                document.append(clause.getKey(), clause.getValue());
+            }
+        }
+
+        private boolean keysIntersect(final BsonDocument first, final BsonDocument second) {
+            for (String name : first.keySet()) {
+                if (second.containsKey(name)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private void promoteFilterToDollarForm(final BsonDocument document, final Map.Entry<String, BsonValue> clause) {
+            BsonArray clauses = new BsonArray();
+            for (Map.Entry<String, BsonValue> queryElement : document.entrySet()) {
+                clauses.add(new BsonDocument(queryElement.getKey(), queryElement.getValue()));
+            }
+            clauses.add(new BsonDocument(clause.getKey(), clause.getValue()));
+            document.clear();
+            document.put("$and", clauses);
+        }
+    }
+
+    private static class OrFilter extends Filter {
+        private final Iterable<Filter> filters;
+
+        public OrFilter(final Iterable<Filter> filters) {
+            this.filters = filters;
+        }
+
+        @Override
+        public <TDocument> BsonDocument render(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+            BsonDocument orFilter = new BsonDocument();
+
+            BsonArray filtersArray = new BsonArray();
+            for (Filter filter : filters) {
+                filtersArray.add(filter.render(documentClass, codecRegistry));
+            }
+
+            orFilter.put("$or", filtersArray);
+
+            return orFilter;
+        }
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/FilterBuilderSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FilterBuilderSpecification.groovy
@@ -1,0 +1,84 @@
+package com.mongodb.client.model
+
+import org.bson.BsonDocument
+import org.bson.codecs.BsonValueCodecProvider
+import org.bson.codecs.ValueCodecProvider
+import org.bson.codecs.configuration.RootCodecRegistry
+import spock.lang.Specification
+
+import static com.mongodb.client.model.FilterBuilder.and
+import static com.mongodb.client.model.FilterBuilder.eq
+import static com.mongodb.client.model.FilterBuilder.exists
+import static com.mongodb.client.model.FilterBuilder.gt
+import static com.mongodb.client.model.FilterBuilder.gte
+import static com.mongodb.client.model.FilterBuilder.lt
+import static com.mongodb.client.model.FilterBuilder.lte
+import static com.mongodb.client.model.FilterBuilder.or
+import static org.bson.BsonDocument.parse
+
+class FilterBuilderSpecification extends Specification {
+    def codecRegistry = new RootCodecRegistry([new BsonValueCodecProvider(), new ValueCodecProvider()]);
+
+    def 'should render filter for eq'() {
+       expect:
+       eq('x', 1).render(BsonDocument, codecRegistry) == parse('{x : 1}')
+    }
+
+    def 'should render filter for $gt'() {
+        expect:
+        gt('x', 1).render(BsonDocument, codecRegistry) == parse('{x : {$gt : 1} }')
+    }
+
+    def 'should render filter for $lt'() {
+        expect:
+        lt('x', 1).render(BsonDocument, codecRegistry) == parse('{x : {$lt : 1} }')
+    }
+
+    def 'should render filter for $gte'() {
+        expect:
+        gte('x', 1).render(BsonDocument, codecRegistry) == parse('{x : {$gte : 1} }')
+    }
+
+    def 'should render filter for $lte'() {
+        expect:
+        lte('x', 1).render(BsonDocument, codecRegistry) == parse('{x : {$lte : 1} }')
+    }
+
+    def 'should render filter for $exists'() {
+        expect:
+        exists('x').render(BsonDocument, codecRegistry) == parse('{x : {$exists : true} }')
+
+        exists('x', false).render(BsonDocument, codecRegistry) == parse('{x : {$exists : false} }')
+    }
+
+    def 'should render filter for or'() {
+        expect:
+        or([eq('x', 1), eq('y', 2)]).render(BsonDocument, codecRegistry) == parse('{$or : [{x : 1}, {y : 2}]}')
+        or(eq('x', 1), eq('y', 2)).render(BsonDocument, codecRegistry) == parse('{$or : [{x : 1}, {y : 2}]}')
+    }
+
+    def 'should render filter for and'() {
+        expect:
+        and([eq('x', 1), eq('y', 2)]).render(BsonDocument, codecRegistry) == parse('{x : 1, y : 2}')
+        and(eq('x', 1), eq('y', 2)).render(BsonDocument, codecRegistry) == parse('{x : 1, y : 2}')
+    }
+
+    def 'should render and with clashing keys by promoting to dollar form'() {
+        expect:
+        and([eq('a', 1), eq('a', 2)]).render(BsonDocument, codecRegistry) == parse('{$and: [{a: 1}, {a: 2}]}');
+    }
+
+    def 'should flatten multiple operators for the same key'() {
+        expect:
+        and([gt('a', 1), lt('a', 9)]).render(BsonDocument, codecRegistry) == parse('{a : {$gt : 1, $lt : 9}}');
+    }
+
+    def 'should flatten nested and filter'() {
+        expect:
+        and([and([eq('a', 1), eq('b', 2)]), eq('c', 3)]).render(BsonDocument, codecRegistry) == parse('{a : 1, b : 2, c : 3}')
+        and([and([eq('a', 1), eq('a', 2)]), eq('c', 3)]).render(BsonDocument, codecRegistry) == parse('{$and:[{a : 1}, {a : 2}, {c : 3}] }')
+        and([lt('a', 1), lt('b', 2)]).render(BsonDocument, codecRegistry) == parse('{a : {$lt : 1}, b : {$lt : 2} }')
+        and([lt('a', 1), lt('a', 2)]).render(BsonDocument, codecRegistry) == parse('{$and : [{a : {$lt : 1}}, {a : {$lt : 2}}]}')
+    }
+
+}

--- a/driver/src/examples/tour/NewQuickTour.java
+++ b/driver/src/examples/tour/NewQuickTour.java
@@ -34,6 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static com.mongodb.client.model.Filter.asFilter;
+
 /**
  * The tutorial from the 3.0 API version of http://www.mongodb.org/display/DOCS/Java+Tutorial.
  */
@@ -105,11 +107,11 @@ public class NewQuickTour {
         }
 
         // now use a query to get 1 document out
-        myDoc = collection.find(new Document("i", 71)).first();
+        myDoc = collection.find(asFilter(new Document("i", 71))).first();
         System.out.println(myDoc);
 
         // now use a range query to get a larger subset
-        cursor = collection.find(new Document("i", new Document("$gt", 50))).iterator();
+        cursor = collection.find(asFilter(new Document("i", new Document("$gt", 50)))).iterator();
 
         try {
             while (cursor.hasNext()) {
@@ -120,7 +122,7 @@ public class NewQuickTour {
         }
 
         // range query with multiple constraints
-        cursor = collection.find(new Document("i", new Document("$gt", 50).append("$lte", 100))).iterator();
+        cursor = collection.find(asFilter(new Document("i", new Document("$gt", 50).append("$lte", 100)))).iterator();
 
         try {
             while (cursor.hasNext()) {
@@ -193,7 +195,7 @@ public class NewQuickTour {
 
         // Find the highest scoring match
         Document projection = new Document("score", new Document("$meta", "textScore"));
-        myDoc = collection.find(textSearch).projection(projection).first();
+        myDoc = collection.find(asFilter(textSearch)).projection(projection).first();
         System.out.println("Highest scoring document: " + myDoc);
 
         // release resources

--- a/driver/src/examples/tour/NewQuickTour.java
+++ b/driver/src/examples/tour/NewQuickTour.java
@@ -185,12 +185,12 @@ public class NewQuickTour {
         // Find using the text index
         Document search = new Document("$search", "textual content -irrelevant");
         Document textSearch = new Document("$text", search);
-        long matchCount = collection.count(textSearch);
+        long matchCount = collection.count(asFilter(textSearch));
         System.out.println("Text search matches: " + matchCount);
 
         // Find using the $language operator
         textSearch = new Document("$text", search.append("$language", "english"));
-        matchCount = collection.count(textSearch);
+        matchCount = collection.count(asFilter(textSearch));
         System.out.println("Text search matches (english): " + matchCount);
 
         // Find the highest scoring match

--- a/driver/src/main/com/mongodb/AggregateIterableImpl.java
+++ b/driver/src/main/com/mongodb/AggregateIterableImpl.java
@@ -34,82 +34,86 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.client.model.Filter.asFilter;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-class AggregateIterableImpl<T> implements AggregateIterable<T> {
+class AggregateIterableImpl<TResult, TDocument> implements AggregateIterable<TResult> {
     private final MongoNamespace namespace;
-    private final Class<T> clazz;
+    private final Class<TResult> clazz;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final OperationExecutor executor;
     private final List<?> pipeline;
+    private final Class<TDocument> collectionClass;
 
     private Boolean allowDiskUse;
     private Integer batchSize;
     private long maxTimeMS;
     private Boolean useCursor;
 
-    AggregateIterableImpl(final MongoNamespace namespace, final Class<T> clazz, final CodecRegistry codecRegistry,
+    AggregateIterableImpl(final MongoNamespace namespace, final Class<TResult> clazz, final Class<TDocument> collectionClass,
+                          final CodecRegistry codecRegistry,
                           final ReadPreference readPreference, final OperationExecutor executor, final List<?> pipeline) {
-            this.namespace = notNull("namespace", namespace);
-            this.clazz = notNull("clazz", clazz);
-            this.codecRegistry = notNull("codecRegistry", codecRegistry);
-            this.readPreference = notNull("readPreference", readPreference);
-            this.executor = notNull("executor", executor);
-            this.pipeline = notNull("pipeline", pipeline);
+        this.namespace = notNull("namespace", namespace);
+        this.clazz = notNull("clazz", clazz);
+        this.collectionClass = notNull("collectionClass", collectionClass);
+        this.codecRegistry = notNull("codecRegistry", codecRegistry);
+        this.readPreference = notNull("readPreference", readPreference);
+        this.executor = notNull("executor", executor);
+        this.pipeline = notNull("pipeline", pipeline);
     }
 
     @Override
-    public AggregateIterable<T> allowDiskUse(final Boolean allowDiskUse) {
+    public AggregateIterable<TResult> allowDiskUse(final Boolean allowDiskUse) {
         this.allowDiskUse = allowDiskUse;
         return this;
     }
 
     @Override
-    public AggregateIterable<T> batchSize(final int batchSize) {
+    public AggregateIterable<TResult> batchSize(final int batchSize) {
         this.batchSize = batchSize;
         return this;
     }
 
     @Override
-    public AggregateIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public AggregateIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public AggregateIterable<T> useCursor(final Boolean useCursor) {
+    public AggregateIterable<TResult> useCursor(final Boolean useCursor) {
         this.useCursor = useCursor;
         return this;
     }
 
     @Override
-    public MongoCursor<T> iterator() {
+    public MongoCursor<TResult> iterator() {
         return execute().iterator();
     }
 
     @Override
-    public T first() {
+    public TResult first() {
         return execute().first();
     }
 
     @Override
-    public <U> MongoIterable<U> map(final Function<T, U> mapper) {
-        return new MappingIterable<T, U>(this, mapper);
+    public <U> MongoIterable<U> map(final Function<TResult, U> mapper) {
+        return new MappingIterable<TResult, U>(this, mapper);
     }
 
     @Override
-    public void forEach(final Block<? super T> block) {
+    public void forEach(final Block<? super TResult> block) {
         execute().forEach(block);
     }
 
     @Override
-    public <A extends Collection<? super T>> A into(final A target) {
+    public <A extends Collection<? super TResult>> A into(final A target) {
         return execute().into(target);
     }
 
-    private MongoIterable<T> execute() {
+    private MongoIterable<TResult> execute() {
         List<BsonDocument> aggregateList = createBsonDocumentList(pipeline);
 
         BsonValue outCollection = aggregateList.size() == 0 ? null : aggregateList.get(aggregateList.size() - 1).get("$out");
@@ -119,10 +123,12 @@ class AggregateIterableImpl<T> implements AggregateIterable<T> {
                     .maxTime(maxTimeMS, MILLISECONDS)
                     .allowDiskUse(allowDiskUse);
             executor.execute(operation);
-            return new FindIterableImpl<T>(new MongoNamespace(namespace.getDatabaseName(), outCollection.asString().getValue()),
-                    clazz, codecRegistry, readPreference, executor, new BsonDocument(), new FindOptions()).batchSize(batchSize);
+            return new FindIterableImpl<TResult, TDocument>(new MongoNamespace(namespace.getDatabaseName(),
+                                                                               outCollection.asString().getValue()),
+                    clazz, collectionClass, codecRegistry, readPreference, executor, asFilter(new BsonDocument()),
+                    new FindOptions()).batchSize(batchSize);
         } else {
-            return new OperationIterable<T>(new AggregateOperation<T>(namespace, aggregateList, codecRegistry.get(clazz))
+            return new OperationIterable<TResult>(new AggregateOperation<TResult>(namespace, aggregateList, codecRegistry.get(clazz))
                     .maxTime(maxTimeMS, MILLISECONDS)
                     .allowDiskUse(allowDiskUse)
                     .batchSize(batchSize)

--- a/driver/src/main/com/mongodb/MapReduceIterableImpl.java
+++ b/driver/src/main/com/mongodb/MapReduceIterableImpl.java
@@ -34,16 +34,18 @@ import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.client.model.Filter.asFilter;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-class MapReduceIterableImpl<T> implements MapReduceIterable<T> {
+class MapReduceIterableImpl<TResult, TDocument> implements MapReduceIterable<TResult> {
     private final MongoNamespace namespace;
-    private final Class<T> clazz;
+    private final Class<TResult> clazz;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final OperationExecutor executor;
     private final String mapFunction;
     private final String reduceFunction;
+    private final Class<TDocument> collectionClass;
 
     private boolean inline = true;
     private String collectionName;
@@ -61,11 +63,13 @@ class MapReduceIterableImpl<T> implements MapReduceIterable<T> {
     private boolean nonAtomic;
     private int batchSize;
 
-    MapReduceIterableImpl(final MongoNamespace namespace, final Class<T> clazz, final CodecRegistry codecRegistry,
+    MapReduceIterableImpl(final MongoNamespace namespace, final Class<TResult> clazz, final Class<TDocument> collectionClass,
+                          final CodecRegistry codecRegistry,
                           final ReadPreference readPreference, final OperationExecutor executor, final String mapFunction,
                           final String reduceFunction) {
         this.namespace = notNull("namespace", namespace);
         this.clazz = notNull("clazz", clazz);
+        this.collectionClass = notNull("collectionClass", collectionClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.executor = notNull("executor", executor);
@@ -74,120 +78,120 @@ class MapReduceIterableImpl<T> implements MapReduceIterable<T> {
     }
 
     @Override
-    public MapReduceIterable<T> collectionName(final String collectionName) {
+    public MapReduceIterable<TResult> collectionName(final String collectionName) {
         this.collectionName = notNull("collectionName", collectionName);
         this.inline = false;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> finalizeFunction(final String finalizeFunction) {
+    public MapReduceIterable<TResult> finalizeFunction(final String finalizeFunction) {
         this.finalizeFunction = finalizeFunction;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> scope(final Object scope) {
+    public MapReduceIterable<TResult> scope(final Object scope) {
         this.scope = scope;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> sort(final Object sort) {
+    public MapReduceIterable<TResult> sort(final Object sort) {
         this.sort = sort;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> filter(final Object filter) {
+    public MapReduceIterable<TResult> filter(final Object filter) {
         this.filter = filter;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> limit(final int limit) {
+    public MapReduceIterable<TResult> limit(final int limit) {
         this.limit = limit;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> jsMode(final boolean jsMode) {
+    public MapReduceIterable<TResult> jsMode(final boolean jsMode) {
         this.jsMode = jsMode;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> verbose(final boolean verbose) {
+    public MapReduceIterable<TResult> verbose(final boolean verbose) {
         this.verbose = verbose;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public MapReduceIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> action(final MapReduceAction action) {
+    public MapReduceIterable<TResult> action(final MapReduceAction action) {
         this.action = action;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> databaseName(final String databaseName) {
+    public MapReduceIterable<TResult> databaseName(final String databaseName) {
         this.databaseName = databaseName;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> sharded(final boolean sharded) {
+    public MapReduceIterable<TResult> sharded(final boolean sharded) {
         this.sharded = sharded;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> nonAtomic(final boolean nonAtomic) {
+    public MapReduceIterable<TResult> nonAtomic(final boolean nonAtomic) {
         this.nonAtomic = nonAtomic;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> batchSize(final int batchSize) {
+    public MapReduceIterable<TResult> batchSize(final int batchSize) {
         this.batchSize = batchSize;
         return this;
     }
 
     @Override
-    public MongoCursor<T> iterator() {
+    public MongoCursor<TResult> iterator() {
         return execute().iterator();
     }
 
     @Override
-    public T first() {
+    public TResult first() {
         return execute().first();
     }
 
     @Override
-    public <U> MongoIterable<U> map(final Function<T, U> mapper) {
-        return new MappingIterable<T, U>(this, mapper);
+    public <U> MongoIterable<U> map(final Function<TResult, U> mapper) {
+        return new MappingIterable<TResult, U>(this, mapper);
     }
 
     @Override
-    public void forEach(final Block<? super T> block) {
+    public void forEach(final Block<? super TResult> block) {
         execute().forEach(block);
     }
 
     @Override
-    public <A extends Collection<? super T>> A into(final A target) {
+    public <A extends Collection<? super TResult>> A into(final A target) {
         return execute().into(target);
     }
 
-    MongoIterable<T> execute() {
+    MongoIterable<TResult> execute() {
         if (inline) {
-            MapReduceWithInlineResultsOperation<T> operation =
-                    new MapReduceWithInlineResultsOperation<T>(namespace,
+            MapReduceWithInlineResultsOperation<TResult> operation =
+                    new MapReduceWithInlineResultsOperation<TResult>(namespace,
                             new BsonJavaScript(mapFunction),
                             new BsonJavaScript(reduceFunction),
                             codecRegistry.get(clazz))
@@ -201,7 +205,7 @@ class MapReduceIterableImpl<T> implements MapReduceIterable<T> {
             if (finalizeFunction != null) {
                 operation.finalizeFunction(new BsonJavaScript(finalizeFunction));
             }
-            return new OperationIterable<T>(operation, readPreference, executor);
+            return new OperationIterable<TResult>(operation, readPreference, executor);
         } else {
             MapReduceToCollectionOperation operation =
                     new MapReduceToCollectionOperation(namespace, new BsonJavaScript(mapFunction), new BsonJavaScript(reduceFunction),
@@ -224,8 +228,9 @@ class MapReduceIterableImpl<T> implements MapReduceIterable<T> {
             executor.execute(operation);
 
             String dbName = databaseName != null ? databaseName : namespace.getDatabaseName();
-            return new FindIterableImpl<T>(new MongoNamespace(dbName, collectionName), clazz, codecRegistry,
-                    primary(), executor, new BsonDocument(), new FindOptions()).batchSize(batchSize);
+            return new FindIterableImpl<TResult, TDocument>(new MongoNamespace(dbName, collectionName), clazz, collectionClass,
+                                                            codecRegistry, primary(), executor, asFilter(new BsonDocument()),
+                                                            new FindOptions()).batchSize(batchSize);
         }
     }
 

--- a/driver/src/main/com/mongodb/MongoCollectionImpl.java
+++ b/driver/src/main/com/mongodb/MongoCollectionImpl.java
@@ -331,27 +331,27 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    public TDocument findOneAndDelete(final Object filter) {
+    public TDocument findOneAndDelete(final Filter filter) {
         return findOneAndDelete(filter, new FindOneAndDeleteOptions());
     }
 
     @Override
-    public TDocument findOneAndDelete(final Object filter, final FindOneAndDeleteOptions options) {
+    public TDocument findOneAndDelete(final Filter filter, final FindOneAndDeleteOptions options) {
         return executor.execute(new FindAndDeleteOperation<TDocument>(namespace, getCodec())
-                                .filter(asBson(filter))
+                                .filter(render(filter))
                                 .projection(asBson(options.getProjection()))
                                 .sort(asBson(options.getSort())));
     }
 
     @Override
-    public TDocument findOneAndReplace(final Object filter, final TDocument replacement) {
+    public TDocument findOneAndReplace(final Filter filter, final TDocument replacement) {
         return findOneAndReplace(filter, replacement, new FindOneAndReplaceOptions());
     }
 
     @Override
-    public TDocument findOneAndReplace(final Object filter, final TDocument replacement, final FindOneAndReplaceOptions options) {
+    public TDocument findOneAndReplace(final Filter filter, final TDocument replacement, final FindOneAndReplaceOptions options) {
         return executor.execute(new FindAndReplaceOperation<TDocument>(namespace, getCodec(), asBson(replacement))
-                                .filter(asBson(filter))
+                                .filter(render(filter))
                                 .projection(asBson(options.getProjection()))
                                 .sort(asBson(options.getSort()))
                                 .returnOriginal(options.getReturnOriginal())
@@ -359,14 +359,14 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    public TDocument findOneAndUpdate(final Object filter, final Object update) {
+    public TDocument findOneAndUpdate(final Filter filter, final Object update) {
         return findOneAndUpdate(filter, update, new FindOneAndUpdateOptions());
     }
 
     @Override
-    public TDocument findOneAndUpdate(final Object filter, final Object update, final FindOneAndUpdateOptions options) {
+    public TDocument findOneAndUpdate(final Filter filter, final Object update, final FindOneAndUpdateOptions options) {
         return executor.execute(new FindAndUpdateOperation<TDocument>(namespace, getCodec(), asBson(update))
-                                .filter(asBson(filter))
+                                .filter(render(filter))
                                 .projection(asBson(options.getProjection()))
                                 .sort(asBson(options.getSort()))
                                 .returnOriginal(options.getReturnOriginal())

--- a/driver/src/main/com/mongodb/MongoCollectionImpl.java
+++ b/driver/src/main/com/mongodb/MongoCollectionImpl.java
@@ -140,18 +140,18 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public long count() {
-        return count(new Document(), new CountOptions());
+        return count(asFilter(new BsonDocument()), new CountOptions());
     }
 
     @Override
-    public long count(final Object filter) {
+    public long count(final Filter filter) {
         return count(filter, new CountOptions());
     }
 
     @Override
-    public long count(final Object filter, final CountOptions options) {
+    public long count(final Filter filter, final CountOptions options) {
         CountOperation operation = new CountOperation(namespace)
-                                       .filter(asBson(filter))
+                                       .filter(filter.render(documentClass, codecRegistry))
                                        .skip(options.getSkip())
                                        .limit(options.getLimit())
                                        .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS);

--- a/driver/src/main/com/mongodb/MongoCollectionImpl.java
+++ b/driver/src/main/com/mongodb/MongoCollectionImpl.java
@@ -32,6 +32,7 @@ import com.mongodb.client.model.CountOptions;
 import com.mongodb.client.model.CreateIndexOptions;
 import com.mongodb.client.model.DeleteManyModel;
 import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.Filter;
 import com.mongodb.client.model.FindOneAndDeleteOptions;
 import com.mongodb.client.model.FindOneAndReplaceOptions;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
@@ -69,22 +70,23 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.client.model.Filter.asFilter;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-class MongoCollectionImpl<T> implements MongoCollection<T> {
+class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private final MongoNamespace namespace;
-    private final Class<T> clazz;
+    private final Class<TDocument> documentClass;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final WriteConcern writeConcern;
     private final OperationExecutor executor;
 
-    MongoCollectionImpl(final MongoNamespace namespace, final Class<T> clazz, final CodecRegistry codecRegistry,
+    MongoCollectionImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final CodecRegistry codecRegistry,
                         final ReadPreference readPreference, final WriteConcern writeConcern, final OperationExecutor executor) {
         this.namespace = notNull("namespace", namespace);
-        this.clazz = notNull("clazz", clazz);
+        this.documentClass = notNull("clazz", documentClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.writeConcern = notNull("writeConcern", writeConcern);
@@ -97,8 +99,8 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public Class<T> getDefaultClass() {
-        return clazz;
+    public Class<TDocument> getDocumentClass() {
+        return documentClass;
     }
 
     @Override
@@ -117,23 +119,23 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public <C> MongoCollection<C> withDefaultClass(final Class<C> clazz) {
-        return new MongoCollectionImpl<C>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
+    public <TResult> MongoCollection<TResult> withDocumentClass(final Class<TResult> clazz) {
+        return new MongoCollectionImpl<TResult>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
     }
 
     @Override
-    public MongoCollection<T> withCodecRegistry(final CodecRegistry codecRegistry) {
-        return new MongoCollectionImpl<T>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
+    public MongoCollection<TDocument> withCodecRegistry(final CodecRegistry codecRegistry) {
+        return new MongoCollectionImpl<TDocument>(namespace, documentClass, codecRegistry, readPreference, writeConcern, executor);
     }
 
     @Override
-    public MongoCollection<T> withReadPreference(final ReadPreference readPreference) {
-        return new MongoCollectionImpl<T>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
+    public MongoCollection<TDocument> withReadPreference(final ReadPreference readPreference) {
+        return new MongoCollectionImpl<TDocument>(namespace, documentClass, codecRegistry, readPreference, writeConcern, executor);
     }
 
     @Override
-    public MongoCollection<T> withWriteConcern(final WriteConcern writeConcern) {
-        return new MongoCollectionImpl<T>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
+    public MongoCollection<TDocument> withWriteConcern(final WriteConcern writeConcern) {
+        return new MongoCollectionImpl<TDocument>(namespace, documentClass, codecRegistry, readPreference, writeConcern, executor);
     }
 
     @Override
@@ -162,28 +164,29 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public <C> DistinctIterable<C> distinct(final String fieldName, final Class<C> clazz) {
-        return new DistinctIterableImpl<C>(namespace, clazz, codecRegistry, readPreference, executor, fieldName);
+    public <TResult> DistinctIterable<TResult> distinct(final String fieldName, final Class<TResult> clazz) {
+        return new DistinctIterableImpl<TResult>(namespace, clazz, codecRegistry, readPreference, executor, fieldName);
     }
 
     @Override
-    public FindIterable<T> find() {
-        return find(new BsonDocument(), clazz);
+    public FindIterable<TDocument> find() {
+        return find(asFilter(new BsonDocument()), documentClass);
     }
 
     @Override
-    public <C> FindIterable<C> find(final Class<C> clazz) {
-        return find(new BsonDocument(), clazz);
+    public <TResult> FindIterable<TResult> find(final Class<TResult> clazz) {
+        return find(asFilter(new BsonDocument()), clazz);
     }
 
     @Override
-    public FindIterable<T> find(final Object filter) {
-        return find(filter, clazz);
+    public FindIterable<TDocument> find(final Filter filter) {
+        return find(filter, documentClass);
     }
 
     @Override
-    public <C> FindIterable<C> find(final Object filter, final Class<C> clazz) {
-        return new FindIterableImpl<C>(namespace, clazz, codecRegistry, readPreference, executor, filter, new FindOptions());
+    public <TResult> FindIterable<TResult> find(final Filter filter, final Class<TResult> clazz) {
+        return new FindIterableImpl<TResult, TDocument>(namespace, clazz, this.documentClass, codecRegistry, readPreference, executor,
+                                                        filter, new FindOptions());
     }
 
     @Override
@@ -192,8 +195,9 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public <C> AggregateIterable<C> aggregate(final List<?> pipeline, final Class<C> clazz) {
-        return new AggregateIterableImpl<C>(namespace, clazz, codecRegistry, readPreference, executor, pipeline);
+    public <TResult> AggregateIterable<TResult> aggregate(final List<?> pipeline, final Class<TResult> clazz) {
+        return new AggregateIterableImpl<TResult, TDocument>(namespace, clazz, this.documentClass, codecRegistry, readPreference, executor,
+                                                             pipeline);
     }
 
     @Override
@@ -202,49 +206,51 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public <C> MapReduceIterable<C> mapReduce(final String mapFunction, final String reduceFunction, final Class<C> clazz) {
-        return new MapReduceIterableImpl<C>(namespace, clazz, codecRegistry, readPreference, executor, mapFunction, reduceFunction);
+    public <TResult> MapReduceIterable<TResult> mapReduce(final String mapFunction, final String reduceFunction,
+                                                          final Class<TResult> clazz) {
+        return new MapReduceIterableImpl<TResult, TDocument>(namespace, clazz, this.documentClass, codecRegistry, readPreference, executor,
+                                                             mapFunction, reduceFunction);
     }
 
     @Override
-    public BulkWriteResult bulkWrite(final List<? extends WriteModel<? extends T>> requests) {
+    public BulkWriteResult bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests) {
         return bulkWrite(requests, new BulkWriteOptions());
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public BulkWriteResult bulkWrite(final List<? extends WriteModel<? extends T>> requests, final BulkWriteOptions options) {
+    public BulkWriteResult bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests, final BulkWriteOptions options) {
         List<WriteRequest> writeRequests = new ArrayList<WriteRequest>(requests.size());
-        for (WriteModel<? extends T> writeModel : requests) {
+        for (WriteModel<? extends TDocument> writeModel : requests) {
             WriteRequest writeRequest;
             if (writeModel instanceof InsertOneModel) {
-                InsertOneModel<T> insertOneModel = (InsertOneModel<T>) writeModel;
+                InsertOneModel<TDocument> insertOneModel = (InsertOneModel<TDocument>) writeModel;
                 if (getCodec() instanceof CollectibleCodec) {
-                    ((CollectibleCodec<T>) getCodec()).generateIdIfAbsentFromDocument(insertOneModel.getDocument());
+                    ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(insertOneModel.getDocument());
                 }
                 writeRequest = new InsertRequest(asBson(insertOneModel.getDocument()));
             } else if (writeModel instanceof ReplaceOneModel) {
-                ReplaceOneModel<T> replaceOneModel = (ReplaceOneModel<T>) writeModel;
+                ReplaceOneModel<TDocument> replaceOneModel = (ReplaceOneModel<TDocument>) writeModel;
                 writeRequest = new UpdateRequest(asBson(replaceOneModel.getFilter()), asBson(replaceOneModel.getReplacement()),
                                                  WriteRequest.Type.REPLACE)
                                    .upsert(replaceOneModel.getOptions().isUpsert());
             } else if (writeModel instanceof UpdateOneModel) {
-                UpdateOneModel<T> updateOneModel = (UpdateOneModel<T>) writeModel;
+                UpdateOneModel<TDocument> updateOneModel = (UpdateOneModel<TDocument>) writeModel;
                 writeRequest = new UpdateRequest(asBson(updateOneModel.getFilter()), asBson(updateOneModel.getUpdate()),
                                                  WriteRequest.Type.UPDATE)
                                    .multi(false)
                                    .upsert(updateOneModel.getOptions().isUpsert());
             } else if (writeModel instanceof UpdateManyModel) {
-                UpdateManyModel<T> updateManyModel = (UpdateManyModel<T>) writeModel;
+                UpdateManyModel<TDocument> updateManyModel = (UpdateManyModel<TDocument>) writeModel;
                 writeRequest = new UpdateRequest(asBson(updateManyModel.getFilter()), asBson(updateManyModel.getUpdate()),
                                                  WriteRequest.Type.UPDATE)
                                    .multi(true)
                                    .upsert(updateManyModel.getOptions().isUpsert());
             } else if (writeModel instanceof DeleteOneModel) {
-                DeleteOneModel<T> deleteOneModel = (DeleteOneModel<T>) writeModel;
+                DeleteOneModel<TDocument> deleteOneModel = (DeleteOneModel<TDocument>) writeModel;
                 writeRequest = new DeleteRequest(asBson(deleteOneModel.getFilter())).multi(false);
             } else if (writeModel instanceof DeleteManyModel) {
-                DeleteManyModel<T> deleteManyModel = (DeleteManyModel<T>) writeModel;
+                DeleteManyModel<TDocument> deleteManyModel = (DeleteManyModel<TDocument>) writeModel;
                 writeRequest = new DeleteRequest(asBson(deleteManyModel.getFilter())).multi(true);
             } else {
                 throw new UnsupportedOperationException(format("WriteModel of type %s is not supported", writeModel.getClass()));
@@ -254,29 +260,29 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
         }
 
         return executor.execute(new MixedBulkWriteOperation(namespace, writeRequests, options.isOrdered(),
-                this.writeConcern));
+                                                            this.writeConcern));
     }
 
     @Override
-    public void insertOne(final T document) {
+    public void insertOne(final TDocument document) {
         if (getCodec() instanceof CollectibleCodec) {
-            ((CollectibleCodec<T>) getCodec()).generateIdIfAbsentFromDocument(document);
+            ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
         }
 
         executeSingleWriteRequest(new InsertRequest(asBson(document)));
     }
 
     @Override
-    public void insertMany(final List<? extends T> documents) {
+    public void insertMany(final List<? extends TDocument> documents) {
         insertMany(documents, new InsertManyOptions());
     }
 
     @Override
-    public void insertMany(final List<? extends T> documents, final InsertManyOptions options) {
+    public void insertMany(final List<? extends TDocument> documents, final InsertManyOptions options) {
         List<InsertRequest> requests = new ArrayList<InsertRequest>(documents.size());
-        for (T document : documents) {
+        for (TDocument document : documents) {
             if (getCodec() instanceof CollectibleCodec) {
-                ((CollectibleCodec<T>) getCodec()).generateIdIfAbsentFromDocument(document);
+                ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
             }
             requests.add(new InsertRequest(asBson(document)));
         }
@@ -294,12 +300,12 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public UpdateResult replaceOne(final Object filter, final T replacement) {
+    public UpdateResult replaceOne(final Object filter, final TDocument replacement) {
         return replaceOne(filter, replacement, new UpdateOptions());
     }
 
     @Override
-    public UpdateResult replaceOne(final Object filter, final T replacement, final UpdateOptions updateOptions) {
+    public UpdateResult replaceOne(final Object filter, final TDocument replacement, final UpdateOptions updateOptions) {
         return toUpdateResult(executeSingleWriteRequest(new UpdateRequest(asBson(filter), asBson(replacement), WriteRequest.Type.REPLACE)
                                                         .upsert(updateOptions.isUpsert())));
     }
@@ -325,46 +331,46 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public T findOneAndDelete(final Object filter) {
+    public TDocument findOneAndDelete(final Object filter) {
         return findOneAndDelete(filter, new FindOneAndDeleteOptions());
     }
 
     @Override
-    public T findOneAndDelete(final Object filter, final FindOneAndDeleteOptions options) {
-        return executor.execute(new FindAndDeleteOperation<T>(namespace, getCodec())
-                .filter(asBson(filter))
-                .projection(asBson(options.getProjection()))
-                .sort(asBson(options.getSort())));
+    public TDocument findOneAndDelete(final Object filter, final FindOneAndDeleteOptions options) {
+        return executor.execute(new FindAndDeleteOperation<TDocument>(namespace, getCodec())
+                                .filter(asBson(filter))
+                                .projection(asBson(options.getProjection()))
+                                .sort(asBson(options.getSort())));
     }
 
     @Override
-    public T findOneAndReplace(final Object filter, final T replacement) {
+    public TDocument findOneAndReplace(final Object filter, final TDocument replacement) {
         return findOneAndReplace(filter, replacement, new FindOneAndReplaceOptions());
     }
 
     @Override
-    public T findOneAndReplace(final Object filter, final T replacement, final FindOneAndReplaceOptions options) {
-        return executor.execute(new FindAndReplaceOperation<T>(namespace, getCodec(), asBson(replacement))
-                .filter(asBson(filter))
-                .projection(asBson(options.getProjection()))
-                .sort(asBson(options.getSort()))
-                .returnOriginal(options.getReturnOriginal())
-                .upsert(options.isUpsert()));
+    public TDocument findOneAndReplace(final Object filter, final TDocument replacement, final FindOneAndReplaceOptions options) {
+        return executor.execute(new FindAndReplaceOperation<TDocument>(namespace, getCodec(), asBson(replacement))
+                                .filter(asBson(filter))
+                                .projection(asBson(options.getProjection()))
+                                .sort(asBson(options.getSort()))
+                                .returnOriginal(options.getReturnOriginal())
+                                .upsert(options.isUpsert()));
     }
 
     @Override
-    public T findOneAndUpdate(final Object filter, final Object update) {
+    public TDocument findOneAndUpdate(final Object filter, final Object update) {
         return findOneAndUpdate(filter, update, new FindOneAndUpdateOptions());
     }
 
     @Override
-    public T findOneAndUpdate(final Object filter, final Object update, final FindOneAndUpdateOptions options) {
-        return executor.execute(new FindAndUpdateOperation<T>(namespace, getCodec(), asBson(update))
-                .filter(asBson(filter))
-                .projection(asBson(options.getProjection()))
-                .sort(asBson(options.getSort()))
-                .returnOriginal(options.getReturnOriginal())
-                .upsert(options.isUpsert()));
+    public TDocument findOneAndUpdate(final Object filter, final Object update, final FindOneAndUpdateOptions options) {
+        return executor.execute(new FindAndUpdateOperation<TDocument>(namespace, getCodec(), asBson(update))
+                                .filter(asBson(filter))
+                                .projection(asBson(options.getProjection()))
+                                .sort(asBson(options.getSort()))
+                                .returnOriginal(options.getReturnOriginal())
+                                .upsert(options.isUpsert()));
     }
 
     @Override
@@ -403,8 +409,8 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public <C> ListIndexesIterable<C> listIndexes(final Class<C> clazz) {
-        return new ListIndexesIterableImpl<C>(getNamespace(), clazz, codecRegistry, ReadPreference.primary(), executor);
+    public <TResult> ListIndexesIterable<TResult> listIndexes(final Class<TResult> clazz) {
+        return new ListIndexesIterableImpl<TResult>(getNamespace(), clazz, codecRegistry, ReadPreference.primary(), executor);
     }
 
     @Override
@@ -465,8 +471,8 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
         }
     }
 
-    private Codec<T> getCodec() {
-        return getCodec(clazz);
+    private Codec<TDocument> getCodec() {
+        return getCodec(documentClass);
     }
 
     private <C> Codec<C> getCodec(final Class<C> clazz) {

--- a/driver/src/main/com/mongodb/client/FindIterable.java
+++ b/driver/src/main/com/mongodb/client/FindIterable.java
@@ -17,6 +17,7 @@
 package com.mongodb.client;
 
 import com.mongodb.CursorType;
+import com.mongodb.client.model.Filter;
 
 import java.util.concurrent.TimeUnit;
 
@@ -35,7 +36,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Filter
      */
-    FindIterable<T> filter(Object filter);
+    FindIterable<T> filter(Filter filter);
 
     /**
      * Sets the limit to apply.

--- a/driver/src/main/com/mongodb/client/MongoCollection.java
+++ b/driver/src/main/com/mongodb/client/MongoCollection.java
@@ -24,6 +24,7 @@ import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.CountOptions;
 import com.mongodb.client.model.CreateIndexOptions;
+import com.mongodb.client.model.Filter;
 import com.mongodb.client.model.FindOneAndDeleteOptions;
 import com.mongodb.client.model.FindOneAndReplaceOptions;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
@@ -43,11 +44,11 @@ import java.util.List;
  *
  * <p>Note: Additions to this interface will not be considered to break binary compatibility.</p>
  *
- * @param <T> The type that this collection will encode documents from and decode documents to.
+ * @param <TDocument> The type that this collection will encode documents from and decode documents to.
  * @since 3.0
  */
 @ThreadSafe
-public interface MongoCollection<T> {
+public interface MongoCollection<TDocument> {
 
     /**
      * Gets the namespace of this collection.
@@ -61,7 +62,7 @@ public interface MongoCollection<T> {
      *
      * @return the default class to cast any documents into
      */
-    Class<T> getDefaultClass();
+    Class<TDocument> getDocumentClass();
 
     /**
      * Get the codec registry for the MongoCollection.
@@ -88,10 +89,10 @@ public interface MongoCollection<T> {
      * Create a new MongoCollection instance with a different default class to cast any documents returned from the database into..
      *
      * @param clazz the default class to cast any documents returned from the database into.
-     * @param <C> The type that the new collection will encode documents from and decode documents to
+     * @param <TResult> The type that the new collection will encode documents from and decode documents to
      * @return a new MongoCollection instance with the different default class
      */
-    <C> MongoCollection<C> withDefaultClass(Class<C> clazz);
+    <TResult> MongoCollection<TResult> withDocumentClass(Class<TResult> clazz);
 
     /**
      * Create a new MongoCollection instance with a different codec registry.
@@ -99,7 +100,7 @@ public interface MongoCollection<T> {
      * @param codecRegistry the new {@link org.bson.codecs.configuration.CodecRegistry} for the collection
      * @return a new MongoCollection instance with the different codec registry
      */
-    MongoCollection<T> withCodecRegistry(CodecRegistry codecRegistry);
+    MongoCollection<TDocument> withCodecRegistry(CodecRegistry codecRegistry);
 
     /**
      * Create a new MongoCollection instance with a different read preference.
@@ -107,7 +108,7 @@ public interface MongoCollection<T> {
      * @param readPreference the new {@link com.mongodb.ReadPreference} for the collection
      * @return a new MongoCollection instance with the different readPreference
      */
-    MongoCollection<T> withReadPreference(ReadPreference readPreference);
+    MongoCollection<TDocument> withReadPreference(ReadPreference readPreference);
 
     /**
      * Create a new MongoCollection instance with a different write concern.
@@ -115,7 +116,7 @@ public interface MongoCollection<T> {
      * @param writeConcern the new {@link com.mongodb.WriteConcern} for the collection
      * @return a new MongoCollection instance with the different writeConcern
      */
-    MongoCollection<T> withWriteConcern(WriteConcern writeConcern);
+    MongoCollection<TDocument> withWriteConcern(WriteConcern writeConcern);
 
     /**
      * Counts the number of documents in the collection.
@@ -146,11 +147,11 @@ public interface MongoCollection<T> {
      *
      * @param fieldName the field name
      * @param clazz     the default class to cast any distinct items into.
-     * @param <C>       the target type of the iterable.
+     * @param <TResult>       the target type of the iterable.
      * @return an iterable of distinct values
      * @mongodb.driver.manual reference/command/distinct/ Distinct
      */
-    <C> DistinctIterable<C> distinct(String fieldName, Class<C> clazz);
+    <TResult> DistinctIterable<TResult> distinct(String fieldName, Class<TResult> clazz);
 
     /**
      * Finds all documents in the collection.
@@ -158,17 +159,17 @@ public interface MongoCollection<T> {
      * @return the find iterable interface
      * @mongodb.driver.manual tutorial/query-documents/ Find
      */
-    FindIterable<T> find();
+    FindIterable<TDocument> find();
 
     /**
      * Finds all documents in the collection.
      *
      * @param clazz the class to decode each document into
-     * @param <C>   the target document type of the iterable.
+     * @param <TResult>   the target document type of the iterable.
      * @return the find iterable interface
      * @mongodb.driver.manual tutorial/query-documents/ Find
      */
-    <C> FindIterable<C> find(Class<C> clazz);
+    <TResult> FindIterable<TResult> find(Class<TResult> clazz);
 
     /**
      * Finds all documents in the collection.
@@ -177,18 +178,18 @@ public interface MongoCollection<T> {
      * @return the find iterable interface
      * @mongodb.driver.manual tutorial/query-documents/ Find
      */
-    FindIterable<T> find(Object filter);
+    FindIterable<TDocument> find(Filter filter);
 
     /**
      * Finds all documents in the collection.
      *
      * @param filter the query filter
      * @param clazz  the class to decode each document into
-     * @param <C>    the target document type of the iterable.
+     * @param <TResult>    the target document type of the iterable.
      * @return the find iterable interface
      * @mongodb.driver.manual tutorial/query-documents/ Find
      */
-    <C> FindIterable<C> find(Object filter, Class<C> clazz);
+    <TResult> FindIterable<TResult> find(Filter filter, Class<TResult> clazz);
 
     /**
      * Aggregates documents according to the specified aggregation pipeline.
@@ -205,12 +206,12 @@ public interface MongoCollection<T> {
      *
      * @param pipeline the aggregate pipeline
      * @param clazz    the class to decode each document into
-     * @param <C>      the target document type of the iterable.
+     * @param <TResult>      the target document type of the iterable.
      * @return an iterable containing the result of the aggregation operation
      * @mongodb.driver.manual aggregation/ Aggregation
      * @mongodb.server.release 2.2
      */
-    <C> AggregateIterable<C> aggregate(List<?> pipeline, Class<C> clazz);
+    <TResult> AggregateIterable<TResult> aggregate(List<?> pipeline, Class<TResult> clazz);
 
     /**
      * Aggregates documents according to the specified map-reduce function.
@@ -228,11 +229,11 @@ public interface MongoCollection<T> {
      * @param mapFunction    A JavaScript function that associates or "maps" a value with a key and emits the key and value pair.
      * @param reduceFunction A JavaScript function that "reduces" to a single object all the values associated with a particular key.
      * @param clazz          the class to decode each resulting document into.
-     * @param <C>            the target document type of the iterable.
+     * @param <TResult>            the target document type of the iterable.
      * @return an iterable containing the result of the map-reduce operation
      * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
      */
-    <C> MapReduceIterable<C> mapReduce(String mapFunction, String reduceFunction, Class<C> clazz);
+    <TResult> MapReduceIterable<TResult> mapReduce(String mapFunction, String reduceFunction, Class<TResult> clazz);
 
     /**
      * Executes a mix of inserts, updates, replaces, and deletes.
@@ -242,7 +243,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoBulkWriteException if there's an exception in the bulk write operation
      * @throws com.mongodb.MongoException          if there's an exception running the operation
      */
-    BulkWriteResult bulkWrite(List<? extends WriteModel<? extends T>> requests);
+    BulkWriteResult bulkWrite(List<? extends WriteModel<? extends TDocument>> requests);
 
     /**
      * Executes a mix of inserts, updates, replaces, and deletes.
@@ -253,7 +254,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoBulkWriteException if there's an exception in the bulk write operation
      * @throws com.mongodb.MongoException          if there's an exception running the operation
      */
-    BulkWriteResult bulkWrite(List<? extends WriteModel<? extends T>> requests, BulkWriteOptions options);
+    BulkWriteResult bulkWrite(List<? extends WriteModel<? extends TDocument>> requests, BulkWriteOptions options);
 
     /**
      * Inserts the provided document. If the document is missing an identifier, the driver should generate one.
@@ -263,7 +264,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
      * @throws com.mongodb.MongoException             if the write failed due some other failure
      */
-    void insertOne(T document);
+    void insertOne(TDocument document);
 
     /**
      * Inserts one or more documents.  A call to this method is equivalent to a call to the {@code bulkWrite} method
@@ -273,7 +274,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoException          if the write failed due some other failure
      * @see com.mongodb.client.MongoCollection#bulkWrite
      */
-    void insertMany(List<? extends T> documents);
+    void insertMany(List<? extends TDocument> documents);
 
     /**
      * Inserts one or more documents.  A call to this method is equivalent to a call to the {@code bulkWrite} method
@@ -284,7 +285,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.WriteConcernException if the write failed due being unable to fulfil the write concern
      * @throws com.mongodb.MongoException        if the write failed due some other failure
      */
-    void insertMany(List<? extends T> documents, InsertManyOptions options);
+    void insertMany(List<? extends TDocument> documents, InsertManyOptions options);
 
     /**
      * Removes at most one document from the collection that matches the given filter.  If no documents match, the collection is not
@@ -320,7 +321,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoException             if the write failed due some other failure
      * @mongodb.driver.manual tutorial/modify-documents/#replace-the-document Replace
      */
-    UpdateResult replaceOne(Object filter, T replacement);
+    UpdateResult replaceOne(Object filter, TDocument replacement);
 
     /**
      * Replace a document in the collection according to the specified arguments.
@@ -334,7 +335,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoException             if the write failed due some other failure
      * @mongodb.driver.manual tutorial/modify-documents/#replace-the-document Replace
      */
-    UpdateResult replaceOne(Object filter, T replacement, UpdateOptions updateOptions);
+    UpdateResult replaceOne(Object filter, TDocument replacement, UpdateOptions updateOptions);
 
     /**
      * Update a single document in the collection according to the specified arguments.
@@ -408,7 +409,7 @@ public interface MongoCollection<T> {
      * @param filter the query filter to find the document with
      * @return the document that was removed.  If no documents matched the query filter, then null will be returned
      */
-    T findOneAndDelete(Object filter);
+    TDocument findOneAndDelete(Object filter);
 
     /**
      * Atomically find a document and remove it.
@@ -417,7 +418,7 @@ public interface MongoCollection<T> {
      * @param options the options to apply to the operation
      * @return the document that was removed.  If no documents matched the query filter, then null will be returned
      */
-    T findOneAndDelete(Object filter, FindOneAndDeleteOptions options);
+    TDocument findOneAndDelete(Object filter, FindOneAndDeleteOptions options);
 
     /**
      * Atomically find a document and replace it.
@@ -428,7 +429,7 @@ public interface MongoCollection<T> {
      * document as it was before the update or as it is after the update.  If no documents matched the query filter, then null will be
      * returned
      */
-    T findOneAndReplace(Object filter, T replacement);
+    TDocument findOneAndReplace(Object filter, TDocument replacement);
 
     /**
      * Atomically find a document and replace it.
@@ -440,7 +441,7 @@ public interface MongoCollection<T> {
      * document as it was before the update or as it is after the update.  If no documents matched the query filter, then null will be
      * returned
      */
-    T findOneAndReplace(Object filter, T replacement, FindOneAndReplaceOptions options);
+    TDocument findOneAndReplace(Object filter, TDocument replacement, FindOneAndReplaceOptions options);
 
     /**
      * Atomically find a document and update it.
@@ -452,7 +453,7 @@ public interface MongoCollection<T> {
      * @return the document that was updated before the update was applied.  If no documents matched the query filter, then null will be
      * returned
      */
-    T findOneAndUpdate(Object filter, Object update);
+    TDocument findOneAndUpdate(Object filter, Object update);
 
     /**
      * Atomically find a document and update it.
@@ -466,7 +467,7 @@ public interface MongoCollection<T> {
      * document as it was before the update or as it is after the update.  If no documents matched the query filter, then null will be
      * returned
      */
-    T findOneAndUpdate(Object filter, Object update, FindOneAndUpdateOptions options);
+    TDocument findOneAndUpdate(Object filter, Object update, FindOneAndUpdateOptions options);
 
     /**
      * Drops this collection from the Database.
@@ -502,11 +503,11 @@ public interface MongoCollection<T> {
      * Get all the indexes in this collection.
      *
      * @param clazz    the class to decode each document into
-     * @param <C>      the target document type of the iterable.
+     * @param <TResult>      the target document type of the iterable.
      * @return the list indexes iterable interface
      * @mongodb.driver.manual reference/command/listIndexes/ listIndexes
      */
-    <C> ListIndexesIterable<C> listIndexes(Class<C> clazz);
+    <TResult> ListIndexesIterable<TResult> listIndexes(Class<TResult> clazz);
 
     /**
      * Drops the given index.

--- a/driver/src/main/com/mongodb/client/MongoCollection.java
+++ b/driver/src/main/com/mongodb/client/MongoCollection.java
@@ -409,7 +409,7 @@ public interface MongoCollection<TDocument> {
      * @param filter the query filter to find the document with
      * @return the document that was removed.  If no documents matched the query filter, then null will be returned
      */
-    TDocument findOneAndDelete(Object filter);
+    TDocument findOneAndDelete(Filter filter);
 
     /**
      * Atomically find a document and remove it.
@@ -418,7 +418,7 @@ public interface MongoCollection<TDocument> {
      * @param options the options to apply to the operation
      * @return the document that was removed.  If no documents matched the query filter, then null will be returned
      */
-    TDocument findOneAndDelete(Object filter, FindOneAndDeleteOptions options);
+    TDocument findOneAndDelete(Filter filter, FindOneAndDeleteOptions options);
 
     /**
      * Atomically find a document and replace it.
@@ -429,7 +429,7 @@ public interface MongoCollection<TDocument> {
      * document as it was before the update or as it is after the update.  If no documents matched the query filter, then null will be
      * returned
      */
-    TDocument findOneAndReplace(Object filter, TDocument replacement);
+    TDocument findOneAndReplace(Filter filter, TDocument replacement);
 
     /**
      * Atomically find a document and replace it.
@@ -441,7 +441,7 @@ public interface MongoCollection<TDocument> {
      * document as it was before the update or as it is after the update.  If no documents matched the query filter, then null will be
      * returned
      */
-    TDocument findOneAndReplace(Object filter, TDocument replacement, FindOneAndReplaceOptions options);
+    TDocument findOneAndReplace(Filter filter, TDocument replacement, FindOneAndReplaceOptions options);
 
     /**
      * Atomically find a document and update it.
@@ -453,7 +453,7 @@ public interface MongoCollection<TDocument> {
      * @return the document that was updated before the update was applied.  If no documents matched the query filter, then null will be
      * returned
      */
-    TDocument findOneAndUpdate(Object filter, Object update);
+    TDocument findOneAndUpdate(Filter filter, Object update);
 
     /**
      * Atomically find a document and update it.
@@ -467,7 +467,7 @@ public interface MongoCollection<TDocument> {
      * document as it was before the update or as it is after the update.  If no documents matched the query filter, then null will be
      * returned
      */
-    TDocument findOneAndUpdate(Object filter, Object update, FindOneAndUpdateOptions options);
+    TDocument findOneAndUpdate(Filter filter, Object update, FindOneAndUpdateOptions options);
 
     /**
      * Drops this collection from the Database.

--- a/driver/src/main/com/mongodb/client/MongoCollection.java
+++ b/driver/src/main/com/mongodb/client/MongoCollection.java
@@ -131,7 +131,7 @@ public interface MongoCollection<TDocument> {
      * @param filter the query filter
      * @return the number of documents in the collection
      */
-    long count(Object filter);
+    long count(Filter filter);
 
     /**
      * Counts the number of documents in the collection according to the given options.
@@ -140,7 +140,7 @@ public interface MongoCollection<TDocument> {
      * @param options the options describing the count
      * @return the number of documents in the collection
      */
-    long count(Object filter, CountOptions options);
+    long count(Filter filter, CountOptions options);
 
     /**
      * Gets the distinct values of the specified field name.

--- a/driver/src/main/com/mongodb/client/MongoCollection.java
+++ b/driver/src/main/com/mongodb/client/MongoCollection.java
@@ -297,7 +297,7 @@ public interface MongoCollection<TDocument> {
      * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
      * @throws com.mongodb.MongoException             if the write failed due some other failure
      */
-    DeleteResult deleteOne(Object filter);
+    DeleteResult deleteOne(Filter filter);
 
     /**
      * Removes all documents from the collection that match the given query filter.  If no documents match, the collection is not modified.
@@ -308,7 +308,7 @@ public interface MongoCollection<TDocument> {
      * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
      * @throws com.mongodb.MongoException             if the write failed due some other failure
      */
-    DeleteResult deleteMany(Object filter);
+    DeleteResult deleteMany(Filter filter);
 
     /**
      * Replace a document in the collection according to the specified arguments.
@@ -321,7 +321,7 @@ public interface MongoCollection<TDocument> {
      * @throws com.mongodb.MongoException             if the write failed due some other failure
      * @mongodb.driver.manual tutorial/modify-documents/#replace-the-document Replace
      */
-    UpdateResult replaceOne(Object filter, TDocument replacement);
+    UpdateResult replaceOne(Filter filter, TDocument replacement);
 
     /**
      * Replace a document in the collection according to the specified arguments.
@@ -335,7 +335,7 @@ public interface MongoCollection<TDocument> {
      * @throws com.mongodb.MongoException             if the write failed due some other failure
      * @mongodb.driver.manual tutorial/modify-documents/#replace-the-document Replace
      */
-    UpdateResult replaceOne(Object filter, TDocument replacement, UpdateOptions updateOptions);
+    UpdateResult replaceOne(Filter filter, TDocument replacement, UpdateOptions updateOptions);
 
     /**
      * Update a single document in the collection according to the specified arguments.
@@ -351,7 +351,7 @@ public interface MongoCollection<TDocument> {
      * @mongodb.driver.manual tutorial/modify-documents/ Updates
      * @mongodb.driver.manual reference/operator/update/ Update Operators
      */
-    UpdateResult updateOne(Object filter, Object update);
+    UpdateResult updateOne(Filter filter, Object update);
 
     /**
      * Update a single document in the collection according to the specified arguments.
@@ -368,7 +368,7 @@ public interface MongoCollection<TDocument> {
      * @mongodb.driver.manual tutorial/modify-documents/ Updates
      * @mongodb.driver.manual reference/operator/update/ Update Operators
      */
-    UpdateResult updateOne(Object filter, Object update, UpdateOptions updateOptions);
+    UpdateResult updateOne(Filter filter, Object update, UpdateOptions updateOptions);
 
     /**
      * Update a single document in the collection according to the specified arguments.
@@ -384,7 +384,7 @@ public interface MongoCollection<TDocument> {
      * @mongodb.driver.manual tutorial/modify-documents/ Updates
      * @mongodb.driver.manual reference/operator/update/ Update Operators
      */
-    UpdateResult updateMany(Object filter, Object update);
+    UpdateResult updateMany(Filter filter, Object update);
 
     /**
      * Update a single document in the collection according to the specified arguments.
@@ -401,7 +401,7 @@ public interface MongoCollection<TDocument> {
      * @mongodb.driver.manual tutorial/modify-documents/ Updates
      * @mongodb.driver.manual reference/operator/update/ Update Operators
      */
-    UpdateResult updateMany(Object filter, Object update, UpdateOptions updateOptions);
+    UpdateResult updateMany(Filter filter, Object update, UpdateOptions updateOptions);
 
     /**
      * Atomically find a document and remove it.

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/atomicoperations/FindAndDeleteAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/atomicoperations/FindAndDeleteAcceptanceTest.java
@@ -47,7 +47,7 @@ public class FindAndDeleteAcceptanceTest extends DatabaseTestCase {
 
         // when
         Document filter = new Document(KEY, VALUE_TO_CARE_ABOUT);
-        Document documentRetrieved = collection.findOneAndDelete(filter);
+        Document documentRetrieved = collection.findOneAndDelete(asFilter(filter));
 
         // then
         assertThat("Document should have been deleted from the collection", collection.count(), is(0L));
@@ -68,7 +68,7 @@ public class FindAndDeleteAcceptanceTest extends DatabaseTestCase {
 
         // when
         Document filter = new Document(KEY, VALUE_TO_CARE_ABOUT);
-        Document documentRetrieved = collection.findOneAndDelete(filter);
+        Document documentRetrieved = collection.findOneAndDelete(asFilter(filter));
 
         // then
         assertThat("Document should have been deleted from the collection", collection.count(), is(2L));
@@ -88,7 +88,7 @@ public class FindAndDeleteAcceptanceTest extends DatabaseTestCase {
 
         // when
         Document filter = new Document(KEY, VALUE_TO_CARE_ABOUT);
-        Document documentRetrieved = collection.findOneAndDelete(filter);
+        Document documentRetrieved = collection.findOneAndDelete(asFilter(filter));
 
         // then
         assertThat("Document should have been deleted from the collection", collection.count(), is(2L));
@@ -110,7 +110,7 @@ public class FindAndDeleteAcceptanceTest extends DatabaseTestCase {
         Document filter = new Document(KEY, VALUE_TO_CARE_ABOUT);
         assertThat(collection.count(asFilter(filter), new CountOptions()), is(3L));
 
-        Document documentRetrieved = collection.findOneAndDelete(filter);
+        Document documentRetrieved = collection.findOneAndDelete(asFilter(filter));
 
         // then
         assertThat("Document should have been deleted from the collection", collection.count(), is(2L));
@@ -132,7 +132,8 @@ public class FindAndDeleteAcceptanceTest extends DatabaseTestCase {
 
         // when
         Document filter = new Document(KEY, VALUE_TO_CARE_ABOUT);
-        Document documentRetrieved = collection.findOneAndDelete(filter, new FindOneAndDeleteOptions().sort(new Document(secondKey, 1)));
+        Document documentRetrieved = collection.findOneAndDelete(asFilter(filter),
+                                                                 new FindOneAndDeleteOptions().sort(new Document(secondKey, 1)));
 
         // then
         assertThat("Document should have been deleted from the collection", collection.count(), is(2L));
@@ -144,7 +145,7 @@ public class FindAndDeleteAcceptanceTest extends DatabaseTestCase {
     public void shouldReturnNullIfNoDocumentRemoved() {
         // when
         Document filter = new Document(KEY, VALUE_TO_CARE_ABOUT);
-        Document documentRetrieved = collection.findOneAndDelete(filter);
+        Document documentRetrieved = collection.findOneAndDelete(asFilter(filter));
 
         // then
         assertThat(documentRetrieved, is(nullValue()));
@@ -160,7 +161,7 @@ public class FindAndDeleteAcceptanceTest extends DatabaseTestCase {
         collection.insertOne(sam);
 
         // when
-        Document removedDocument = collection.findOneAndDelete(new Document("name", "Pete"));
+        Document removedDocument = collection.findOneAndDelete(asFilter(new Document("name", "Pete")));
 
         // then
         assertThat(collection.count(), is(1L));

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/atomicoperations/FindAndDeleteAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/atomicoperations/FindAndDeleteAcceptanceTest.java
@@ -22,6 +22,7 @@ import com.mongodb.client.model.FindOneAndDeleteOptions;
 import org.bson.Document;
 import org.junit.Test;
 
+import static com.mongodb.client.model.Filter.asFilter;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -107,7 +108,7 @@ public class FindAndDeleteAcceptanceTest extends DatabaseTestCase {
 
         // when
         Document filter = new Document(KEY, VALUE_TO_CARE_ABOUT);
-        assertThat(collection.count(filter, new CountOptions()), is(3L));
+        assertThat(collection.count(asFilter(filter), new CountOptions()), is(3L));
 
         Document documentRetrieved = collection.findOneAndDelete(filter);
 

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/atomicoperations/FindAndReplaceAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/atomicoperations/FindAndReplaceAcceptanceTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Date;
 
+import static com.mongodb.client.model.Filter.asFilter;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertNull;
@@ -53,7 +54,7 @@ public class FindAndReplaceAcceptanceTest extends DatabaseTestCase {
 
         assertThat(collection.count(), is(1L));
 
-        Document document = collection.findOneAndReplace(new Document(KEY, VALUE_TO_CARE_ABOUT),
+        Document document = collection.findOneAndReplace(asFilter(new Document(KEY, VALUE_TO_CARE_ABOUT)),
                                                          new Document("foo", "bar").append("_id", documentInserted.get("_id")));
 
         assertThat("Document, retrieved from replaceAndGet should match the document inserted before",
@@ -75,7 +76,7 @@ public class FindAndReplaceAcceptanceTest extends DatabaseTestCase {
         assertThat(collection.count(), is(1L));
 
         Worker jordan = new Worker(pat.getId(), "Jordan", "Engineer", new Date(), 1);
-        Worker returnedDocument = collection.findOneAndReplace(new Document("name", "Pat"), jordan);
+        Worker returnedDocument = collection.findOneAndReplace(asFilter(new Document("name", "Pat")), jordan);
 
         assertThat("Document, retrieved from getOneAndReplace, should match the document inserted before",
                    returnedDocument, equalTo(pat));
@@ -95,7 +96,7 @@ public class FindAndReplaceAcceptanceTest extends DatabaseTestCase {
         assertThat(collection.count(), is(1L));
 
         Worker jordan = new Worker(pat.getId(), "Jordan", "Engineer", new Date(), 7);
-        Worker returnedDocument = collection.findOneAndReplace(new Document("name", "Pat"), jordan,
+        Worker returnedDocument = collection.findOneAndReplace(asFilter(new Document("name", "Pat")), jordan,
                                                                new FindOneAndReplaceOptions().returnOriginal(false));
 
         assertThat("Worker retrieved from replaceOneAndGet should match the updated Worker",
@@ -111,7 +112,7 @@ public class FindAndReplaceAcceptanceTest extends DatabaseTestCase {
 
         assertThat(collection.count(), is(1L));
 
-        Document document = collection.findOneAndReplace(new Document(KEY, VALUE_TO_CARE_ABOUT), documentReplacement,
+        Document document = collection.findOneAndReplace(asFilter(new Document(KEY, VALUE_TO_CARE_ABOUT)), documentReplacement,
                                                          new FindOneAndReplaceOptions().returnOriginal(false));
 
 
@@ -126,7 +127,7 @@ public class FindAndReplaceAcceptanceTest extends DatabaseTestCase {
 
         assertThat(collection.count(), is(1L));
 
-        Document document = collection.findOneAndReplace(new Document(KEY, "bar"), new Document("foo", "bar"));
+        Document document = collection.findOneAndReplace(asFilter(new Document(KEY, "bar")), new Document("foo", "bar"));
 
         assertNull("Document retrieved from getOneAndReplace should be null when no matching document found", document);
     }
@@ -138,7 +139,7 @@ public class FindAndReplaceAcceptanceTest extends DatabaseTestCase {
 
         assertThat(collection.count(), is(1L));
 
-        Document document = collection.findOneAndReplace(new Document(KEY, "bar"), new Document("foo", "bar"));
+        Document document = collection.findOneAndReplace(asFilter(new Document(KEY, "bar")), new Document("foo", "bar"));
 
         assertNull("Document retrieved from replaceOneAndGet should be null when no matching document found", document);
     }
@@ -152,7 +153,7 @@ public class FindAndReplaceAcceptanceTest extends DatabaseTestCase {
 
         Document replacementDocument = new Document("_id", new ObjectId()).append("foo", "bar");
 
-        Document document = collection.findOneAndReplace(new Document(KEY, "valueThatDoesNotMatch"),
+        Document document = collection.findOneAndReplace(asFilter(new Document(KEY, "valueThatDoesNotMatch")),
                                                          replacementDocument,
                                                          new FindOneAndReplaceOptions()
                                                              .upsert(true)

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/atomicoperations/FindAndUpdateAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/atomicoperations/FindAndUpdateAcceptanceTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Date;
 
+import static com.mongodb.client.model.Filter.asFilter;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertNull;
@@ -49,7 +50,7 @@ public class FindAndUpdateAcceptanceTest extends DatabaseTestCase {
         assertThat(collection.count(), is(1L));
 
         Document updateOperation = new Document("$inc", new Document("someNumber", 1));
-        Document documentBeforeChange = collection.findOneAndUpdate(new Document(KEY, VALUE_TO_CARE_ABOUT), updateOperation);
+        Document documentBeforeChange = collection.findOneAndUpdate(asFilter(new Document(KEY, VALUE_TO_CARE_ABOUT)), updateOperation);
 
         assertThat("Document returned from getOneAndUpdate should be the original document",
                    (Integer) documentBeforeChange.get("someNumber"), equalTo(11));
@@ -63,7 +64,7 @@ public class FindAndUpdateAcceptanceTest extends DatabaseTestCase {
         assertThat(collection.count(), is(1L));
 
         Document updateOperation = new Document("$inc", new Document("someNumber", 1));
-        Document updatedDocument = collection.findOneAndUpdate(new Document(KEY, VALUE_TO_CARE_ABOUT),
+        Document updatedDocument = collection.findOneAndUpdate(asFilter(new Document(KEY, VALUE_TO_CARE_ABOUT)),
                                                                updateOperation,
                                                                new FindOneAndUpdateOptions().returnOriginal(false));
 
@@ -85,7 +86,7 @@ public class FindAndUpdateAcceptanceTest extends DatabaseTestCase {
         assertThat(collection.count(), is(1L));
 
         Document updateOperation = new Document("$inc", new Document("numberOfJobs", 1));
-        Worker updatedDocument = collection.findOneAndUpdate(new Document("name", "Pat"), updateOperation,
+        Worker updatedDocument = collection.findOneAndUpdate(asFilter(new Document("name", "Pat")), updateOperation,
                                                              new FindOneAndUpdateOptions().returnOriginal(false));
 
         assertThat("Worker returned from updateOneAndGet should have the",
@@ -100,7 +101,7 @@ public class FindAndUpdateAcceptanceTest extends DatabaseTestCase {
         assertThat(collection.count(), is(1L));
 
         Document updateOperation = new Document("$inc", new Document("someNumber", 1));
-        Document document = collection.findOneAndUpdate(new Document(KEY, "someValueThatDoesNotExist"), updateOperation);
+        Document document = collection.findOneAndUpdate(asFilter(new Document(KEY, "someValueThatDoesNotExist")), updateOperation);
 
         assertNull("Document retrieved from getOneAndUpdate should be null", document);
     }
@@ -114,7 +115,7 @@ public class FindAndUpdateAcceptanceTest extends DatabaseTestCase {
 
         String newValueThatDoesNotMatchAnythingInDatabase = "valueThatDoesNotMatch";
         Document updateOperation = new Document("$inc", new Document("someNumber", 1));
-        Document document = collection.findOneAndUpdate(new Document(KEY, newValueThatDoesNotMatchAnythingInDatabase),
+        Document document = collection.findOneAndUpdate(asFilter(new Document(KEY, newValueThatDoesNotMatchAnythingInDatabase)),
                                                         updateOperation,
                                                         new FindOneAndUpdateOptions().upsert(true).returnOriginal(false));
 

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/DeleteAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/DeleteAcceptanceTest.java
@@ -20,6 +20,7 @@ import com.mongodb.client.DatabaseTestCase;
 import org.bson.Document;
 import org.junit.Test;
 
+import static com.mongodb.client.model.Filter.asFilter;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -39,7 +40,7 @@ public class DeleteAcceptanceTest extends DatabaseTestCase {
 
         // When
         Document filter = new Document("a", 1);
-        collection.deleteOne(filter);
+        collection.deleteOne(asFilter(filter));
 
         // Then
         assertThat(collection.count(), is(1L));
@@ -55,7 +56,7 @@ public class DeleteAcceptanceTest extends DatabaseTestCase {
 
         // When
         Document filter = new Document("a", 1);
-        collection.deleteMany(filter);
+        collection.deleteMany(asFilter(filter));
 
         // Then
         assertThat(collection.count(), is(0L));

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/InsertAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/InsertAcceptanceTest.java
@@ -20,6 +20,7 @@ import com.mongodb.client.DatabaseTestCase;
 import org.bson.Document;
 import org.junit.Test;
 
+import static com.mongodb.client.model.Filter.asFilter;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -34,7 +35,7 @@ public class InsertAcceptanceTest extends DatabaseTestCase {
         // Then
         assertThat(collection.count(), is(1L));
 
-        Document insertedDocument = collection.find(new Document("name", "Billy")).first();
+        Document insertedDocument = collection.find(asFilter(new Document("name", "Billy"))).first();
         assertThat(insertedDocument.getString("name"), is("Billy"));
     }
 }

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/ReplaceAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/ReplaceAcceptanceTest.java
@@ -22,6 +22,7 @@ import com.mongodb.client.model.UpdateOptions;
 import org.bson.Document;
 import org.junit.Test;
 
+import static com.mongodb.client.model.Filter.asFilter;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -42,7 +43,7 @@ public class ReplaceAcceptanceTest extends DatabaseTestCase {
         collection.replaceOne(filter, newDocumentWithoutFieldForA);
 
         // Then
-        Document document = collection.find(filter).first();
+        Document document = collection.find(asFilter(filter)).first();
         assertThat(document, is(newDocumentWithoutFieldForA));
     }
 
@@ -57,7 +58,7 @@ public class ReplaceAcceptanceTest extends DatabaseTestCase {
 
         // then
         assertThat(collection.count(), is(1L));
-        assertThat(collection.find(new Document("_id", 3)).iterator().next(), is(replacement));
+        assertThat(collection.find(asFilter(new Document("_id", 3))).iterator().next(), is(replacement));
     }
 
     @Test
@@ -73,7 +74,7 @@ public class ReplaceAcceptanceTest extends DatabaseTestCase {
 
         // then
         assertThat(collection.count(), is(1L));
-        assertThat(collection.find(new Document("_id", 3)).iterator().next(),  is(replacement));
+        assertThat(collection.find(asFilter(new Document("_id", 3))).iterator().next(),  is(replacement));
     }
 
     @Test

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/ReplaceAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/ReplaceAcceptanceTest.java
@@ -40,7 +40,7 @@ public class ReplaceAcceptanceTest extends DatabaseTestCase {
         // When
         Document filter = new Document("_id", 2);
         Document newDocumentWithoutFieldForA = new Document("_id", 2).append("x", 7);
-        collection.replaceOne(filter, newDocumentWithoutFieldForA);
+        collection.replaceOne(asFilter(filter), newDocumentWithoutFieldForA);
 
         // Then
         Document document = collection.find(asFilter(filter)).first();
@@ -54,7 +54,7 @@ public class ReplaceAcceptanceTest extends DatabaseTestCase {
 
         // when
         Document replacement = new Document("_id", 3).append("x", 2);
-        collection.replaceOne(new Document(), replacement, new UpdateOptions().upsert(true));
+        collection.replaceOne(asFilter(new Document()), replacement, new UpdateOptions().upsert(true));
 
         // then
         assertThat(collection.count(), is(1L));
@@ -65,12 +65,12 @@ public class ReplaceAcceptanceTest extends DatabaseTestCase {
     public void shouldReplaceTheDocumentIfReplacingWithUpsertAndDocumentIsFoundInCollection() {
         // given
         Document originalDocument = new Document("_id", 3).append("x", 2);
-        collection.replaceOne(new Document(), originalDocument, new UpdateOptions().upsert(true));
+        collection.replaceOne(asFilter(new Document()), originalDocument, new UpdateOptions().upsert(true));
         assertThat(collection.count(), is(1L));
 
         // when
         Document replacement = originalDocument.append("y", 5);
-        collection.replaceOne(new Document(), replacement, new UpdateOptions().upsert(true));
+        collection.replaceOne(asFilter(new Document()), replacement, new UpdateOptions().upsert(true));
 
         // then
         assertThat(collection.count(), is(1L));
@@ -87,7 +87,7 @@ public class ReplaceAcceptanceTest extends DatabaseTestCase {
         Document filter = new Document("a", 1);
         Document newDocumentWithDifferentId = new Document("_id", 2).append("a", 3);
         try {
-            collection.replaceOne(filter, newDocumentWithDifferentId);
+            collection.replaceOne(asFilter(filter), newDocumentWithDifferentId);
             fail("Should have thrown an exception");
         } catch (MongoWriteException e) {
             // Then

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/UpdateAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/UpdateAcceptanceTest.java
@@ -22,6 +22,7 @@ import com.mongodb.client.model.UpdateOptions;
 import org.bson.Document;
 import org.junit.Test;
 
+import static com.mongodb.client.model.Filter.asFilter;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -74,7 +75,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
         // then
         assertThat(collection.count(), is(2L));
         Document expectedDocument = new Document("_id", 2).append("x", 5);
-        assertThat(collection.find(filter).iterator().next(), is(expectedDocument));
+        assertThat(collection.find(asFilter(filter)).iterator().next(), is(expectedDocument));
     }
 
     @Test
@@ -90,7 +91,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
         // then
         assertThat(collection.count(), is(2L));
         Document expectedDocument = new Document("_id", 2).append("x", 5);
-        assertThat(collection.find(filter).iterator().next(), is(expectedDocument));
+        assertThat(collection.find(asFilter(filter)).iterator().next(), is(expectedDocument));
     }
 
     @Test

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/UpdateAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/UpdateAcceptanceTest.java
@@ -107,7 +107,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
         collection.updateMany(filter, new Document("$set", new Document("x", 5)), new UpdateOptions().upsert(true));
 
         // then
-        assertThat(collection.count(new Document("x", 5), new CountOptions()), is(2L));
+        assertThat(collection.count(asFilter(new Document("x", 5)), new CountOptions()), is(2L));
     }
 
     @Test
@@ -123,7 +123,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
         collection.updateOne(filter, new Document("$set", new Document("x", 5)), new UpdateOptions().upsert(true));
 
         // then
-        assertThat(collection.count(new Document("x", 5), new CountOptions()), is(1L));
+        assertThat(collection.count(asFilter(new Document("x", 5)), new CountOptions()), is(1L));
     }
 
     @Test
@@ -140,7 +140,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
         collection.updateOne(filter, incrementXValueByOne);
 
         // Then
-        assertThat(collection.count(new Document("x", 4), new CountOptions()), is(1L));
+        assertThat(collection.count(asFilter(new Document("x", 4)), new CountOptions()), is(1L));
     }
 
     @Test
@@ -157,7 +157,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
         collection.updateMany(filter, incrementXValueByOne);
 
         // Then
-        assertThat(collection.count(new Document("x", 4), new CountOptions()), is(2L));
+        assertThat(collection.count(asFilter(new Document("x", 4)), new CountOptions()), is(2L));
     }
 
 }

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/UpdateAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/UpdateAcceptanceTest.java
@@ -39,7 +39,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
         collection.insertOne(originalDocument);
 
         // when
-        collection.updateOne(new Document("_id", 1), new Document("$set", new Document("x", 2)));
+        collection.updateOne(asFilter(new Document("_id", 1)), new Document("$set", new Document("x", 2)));
 
         // then
         assertThat(collection.count(), is(1L));
@@ -54,7 +54,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
         collection.insertOne(originalDocument);
 
         // when
-        collection.updateOne(new Document("_id", 1), new Document("$inc", new Document("x", 1)));
+        collection.updateOne(asFilter(new Document("_id", 1)), new Document("$inc", new Document("x", 1)));
 
         // then
         assertThat(collection.count(), is(1L));
@@ -70,7 +70,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
 
         // when
         Document filter = new Document("_id", 2);
-        collection.updateMany(filter, new Document("$set", new Document("x", 5)), new UpdateOptions().upsert(true));
+        collection.updateMany(asFilter(filter), new Document("$set", new Document("x", 5)), new UpdateOptions().upsert(true));
 
         // then
         assertThat(collection.count(), is(2L));
@@ -86,7 +86,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
 
         // when
         Document filter = new Document("_id", 2);
-        collection.updateOne(filter, new Document("$set", new Document("x", 5)), new UpdateOptions().upsert(true));
+        collection.updateOne(asFilter(filter), new Document("$set", new Document("x", 5)), new UpdateOptions().upsert(true));
 
         // then
         assertThat(collection.count(), is(2L));
@@ -104,7 +104,8 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
 
         // when
         Document filter = new Document("x", 3);
-        collection.updateMany(filter, new Document("$set", new Document("x", 5)), new UpdateOptions().upsert(true));
+        collection.updateMany(asFilter(filter), new Document("$set", new Document("x", 5)), new UpdateOptions().upsert(true));
+
 
         // then
         assertThat(collection.count(asFilter(new Document("x", 5)), new CountOptions()), is(2L));
@@ -120,7 +121,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
 
         // when
         Document filter = new Document("x", 3);
-        collection.updateOne(filter, new Document("$set", new Document("x", 5)), new UpdateOptions().upsert(true));
+        collection.updateOne(asFilter(filter), new Document("$set", new Document("x", 5)), new UpdateOptions().upsert(true));
 
         // then
         assertThat(collection.count(asFilter(new Document("x", 5)), new CountOptions()), is(1L));
@@ -137,7 +138,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
         // When
         Document filter = new Document("a", 1);
         Document incrementXValueByOne = new Document("$inc", new Document("x", 1));
-        collection.updateOne(filter, incrementXValueByOne);
+        collection.updateOne(asFilter(filter), incrementXValueByOne);
 
         // Then
         assertThat(collection.count(asFilter(new Document("x", 4)), new CountOptions()), is(1L));
@@ -154,7 +155,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
         // When
         Document filter = new Document("a", 1);
         Document incrementXValueByOne = new Document("$inc", new Document("x", 1));
-        collection.updateMany(filter, incrementXValueByOne);
+        collection.updateMany(asFilter(filter), incrementXValueByOne);
 
         // Then
         assertThat(collection.count(asFilter(new Document("x", 4)), new CountOptions()), is(2L));

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/querying/FilterAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/querying/FilterAcceptanceTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.mongodb.client.model.Filter.asFilter;
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -37,7 +38,7 @@ public class FilterAcceptanceTest extends DatabaseTestCase {
         int numberOfDocuments = 10;
         initialiseCollectionWithDocuments(numberOfDocuments);
 
-        List<Document> filteredCollection = collection.find().filter(new Document("_id", 3))
+        List<Document> filteredCollection = collection.find().filter(asFilter(new Document("_id", 3)))
                                                              .into(new ArrayList<Document>());
         assertEquals(1, filteredCollection.size());
         assertThat((Integer) filteredCollection.get(0).get("_id"), is(3));
@@ -117,7 +118,7 @@ public class FilterAcceptanceTest extends DatabaseTestCase {
         initialiseCollectionWithDocuments(numberOfDocuments);
 
         MongoCursor<Document> filterResults = collection.find()
-                                                        .filter(new Document("_id", new Document("$gt", 2)))
+                                                        .filter(asFilter(new Document("_id", new Document("$gt", 2))))
                                                         .sort(new Document("_id", 1))
                                                         .iterator();
 
@@ -139,7 +140,7 @@ public class FilterAcceptanceTest extends DatabaseTestCase {
     @Test(expected = MongoQueryException.class)
     public void shouldThrowQueryFailureException() {
         collection.insertOne(new Document("loc", asList(0.0, 0.0)));
-        collection.find().filter(new Document("loc", new Document("$near", asList(0.0, 0.0)))).first();
+        collection.find().filter(asFilter(new Document("loc", new Document("$near", asList(0.0, 0.0))))).first();
     }
 
     @Test

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/querying/QueryAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/querying/QueryAcceptanceTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 
 import static com.mongodb.QueryOperators.TYPE;
 import static com.mongodb.client.QueryBuilder.query;
+import static com.mongodb.client.model.Filter.asFilter;
 import static java.util.Arrays.asList;
 import static org.bson.BsonType.INT32;
 import static org.bson.BsonType.INT64;
@@ -55,7 +56,7 @@ public class QueryAcceptanceTest extends DatabaseTestCase {
         collection.insertOne(new Document("name", "Bob"));
 
         Document query = new Document("name", "Bob");
-        MongoCursor<Document> results = collection.find().filter(query).iterator();
+        MongoCursor<Document> results = collection.find().filter(asFilter(query)).iterator();
 
         assertThat(results.next().get("name").toString(), is("Bob"));
     }
@@ -65,7 +66,7 @@ public class QueryAcceptanceTest extends DatabaseTestCase {
         collection.insertOne(new Document("name", "Bob"));
 
         Document query = new Document("name", "Bob");
-        MongoCursor<Document> results = collection.find(query).iterator();
+        MongoCursor<Document> results = collection.find(asFilter(query)).iterator();
 
         assertThat(results.next().get("name").toString(), is("Bob"));
     }
@@ -80,7 +81,7 @@ public class QueryAcceptanceTest extends DatabaseTestCase {
                 .withCodecRegistry(codecRegistry);
         collection.insertOne(new Person("Bob"));
 
-        MongoCursor<Person> results = collection.find(new Document("name", "Bob")).iterator();
+        MongoCursor<Person> results = collection.find(asFilter(new Document("name", "Bob"))).iterator();
 
         assertThat(results.next().name, is("Bob"));
     }
@@ -93,7 +94,7 @@ public class QueryAcceptanceTest extends DatabaseTestCase {
         collection.insertOne(new Document("product", "SomethingElse").append("numTimesOrdered", 10));
 
         List<Document> results = new ArrayList<Document>();
-        collection.find(new Document("numTimesOrdered", new Document("$type", 16)))
+        collection.find(asFilter(new Document("numTimesOrdered", new Document("$type", 16))))
                   .sort(new Document("numTimesOrdered", -1)).into(results);
 
         assertThat(results.size(), is(2));
@@ -113,7 +114,7 @@ public class QueryAcceptanceTest extends DatabaseTestCase {
         //TODO make BSON type serializable
         Document filter = new Document("$or", asList(new Document("numTimesOrdered", new Document("$type", INT32.getValue())),
                                                      new Document("numTimesOrdered", new Document("$type", INT64.getValue()))));
-        collection.find(filter).sort(new Document("numTimesOrdered", -1)).into(results);
+        collection.find(asFilter(filter)).sort(new Document("numTimesOrdered", -1)).into(results);
 
         assertThat(results.size(), is(3));
         assertThat(results.get(0).get("product").toString(), is("VeryPopular"));
@@ -149,7 +150,7 @@ public class QueryAcceptanceTest extends DatabaseTestCase {
         Document filter = new QueryBuilder().or(query("numTimesOrdered").is(query(TYPE).is(INT32.getValue())))
                                             .or(query("numTimesOrdered").is(query(TYPE).is(INT64.getValue())))
                                             .toDocument();
-        collection.find(filter).sort(new Document("numTimesOrdered", -1)).into(results);
+        collection.find(asFilter(filter)).sort(new Document("numTimesOrdered", -1)).into(results);
 
         assertThat(results.size(), is(3));
         assertThat(results.get(0).get("product").toString(), is("VeryPopular"));

--- a/driver/src/test/functional/com/mongodb/client/MongoCollectionTest.java
+++ b/driver/src/test/functional/com/mongodb/client/MongoCollectionTest.java
@@ -56,7 +56,7 @@ public class MongoCollectionTest extends DatabaseTestCase {
         Concrete doc = new Concrete(new ObjectId(), "str", 5, 10L, 4.0, 3290482390480L);
         collection.insertOne(doc);
 
-        Concrete newDoc = collection.findOneAndUpdate(new Document("i", 5), new Document("$set", new Document("i", 6)));
+        Concrete newDoc = collection.findOneAndUpdate(asFilter(new Document("i", 5)), new Document("$set", new Document("i", 6)));
 
         assertNotNull(newDoc);
         assertEquals(doc, newDoc);

--- a/driver/src/test/functional/com/mongodb/client/MongoCollectionTest.java
+++ b/driver/src/test/functional/com/mongodb/client/MongoCollectionTest.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.mongodb.client.model.Filter.asFilter;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -47,7 +48,7 @@ public class MongoCollectionTest extends DatabaseTestCase {
                 new ConcreteCodecProvider()));
         MongoCollection<Concrete> collection = database
                 .getCollection(getCollectionName())
-                .withDefaultClass(Concrete.class)
+                .withDocumentClass(Concrete.class)
                 .withCodecRegistry(codecRegistry)
                 .withReadPreference(ReadPreference.primary())
                 .withWriteConcern(WriteConcern.ACKNOWLEDGED);
@@ -69,7 +70,7 @@ public class MongoCollectionTest extends DatabaseTestCase {
                 new ConcreteCodecProvider()));
         MongoCollection<Concrete> collection = database
                 .getCollection(getCollectionName())
-                .withDefaultClass(Concrete.class)
+                .withDocumentClass(Concrete.class)
                 .withCodecRegistry(codecRegistry)
                 .withReadPreference(ReadPreference.primary())
                 .withWriteConcern(WriteConcern.ACKNOWLEDGED);
@@ -81,7 +82,7 @@ public class MongoCollectionTest extends DatabaseTestCase {
         collection.insertOne(secondItem);
 
         // when
-        List<String> listOfStringObjectIds = collection.find(new Document("i", 1))
+        List<String> listOfStringObjectIds = collection.find(asFilter(new Document("i", 1)))
                                                        .map(new Function<Concrete, ObjectId>() {
                                                            @Override
                                                            public ObjectId apply(final Concrete concrete) {
@@ -100,7 +101,7 @@ public class MongoCollectionTest extends DatabaseTestCase {
         assertThat(listOfStringObjectIds.get(0), is(firstItem.getId().toString()));
 
         // when
-        List<ObjectId> listOfObjectIds = collection.find(new Document("i", 1))
+        List<ObjectId> listOfObjectIds = collection.find(asFilter(new Document("i", 1)))
                                                    .map(new Function<Concrete, ObjectId>() {
                                                        @Override
                                                        public ObjectId apply(final Concrete concrete) {

--- a/driver/src/test/unit/com/mongodb/AggregateIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/AggregateIterableSpecification.groovy
@@ -50,7 +50,7 @@ class AggregateIterableSpecification extends Specification {
         given:
         def executor = new TestOperationExecutor([null, null, null, null, null]);
         def pipeline = [new Document('$match', 1)]
-        def aggregationIterable = new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
+        def aggregationIterable = new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 pipeline)
 
         when: 'default input should be as expected'
@@ -85,7 +85,7 @@ class AggregateIterableSpecification extends Specification {
         def pipeline = [new Document('$match', 1), new Document('$out', collectionName)]
 
         when: 'aggregation includes $out'
-        new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
+        new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 pipeline)
                 .batchSize(99)
                 .maxTime(999, MILLISECONDS)
@@ -113,7 +113,7 @@ class AggregateIterableSpecification extends Specification {
         def codecRegistry = new RootCodecRegistry(asList(new ValueCodecProvider(), new BsonValueCodecProvider()))
         def executor = new TestOperationExecutor([new MongoException('failure')])
         def pipeline = [new BsonDocument('$match', new BsonInt32(1))]
-        def aggregationIterable = new AggregateIterableImpl<BsonDocument>(namespace, BsonDocument, codecRegistry, readPreference, executor,
+        def aggregationIterable = new AggregateIterableImpl(namespace, BsonDocument, BsonDocument, codecRegistry, readPreference, executor,
                 pipeline)
 
         when: 'The operation fails with an exception'
@@ -123,7 +123,7 @@ class AggregateIterableSpecification extends Specification {
         thrown(MongoException)
 
         when: 'a codec is missing'
-        new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
+        new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 pipeline).iterator()
 
         then:
@@ -152,7 +152,7 @@ class AggregateIterableSpecification extends Specification {
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
-        def mongoIterable = new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
+        def mongoIterable = new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 [new Document('$match', 1)])
 
         when:

--- a/driver/src/test/unit/com/mongodb/FindIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/FindIterableSpecification.groovy
@@ -31,6 +31,7 @@ import spock.lang.Specification
 
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
+import static com.mongodb.client.model.Filter.asFilter
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static spock.util.matcher.HamcrestSupport.expect
 
@@ -57,8 +58,8 @@ class FindIterableSpecification extends Specification {
                                            .oplogReplay(false)
                                            .noCursorTimeout(false)
                                            .partial(false)
-        def findIterable = new FindIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
-                new Document('filter', 1), findOptions)
+        def findIterable = new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                          asFilter(new Document('filter', 1)), findOptions)
 
         when: 'default input should be as expected'
         findIterable.iterator()
@@ -82,7 +83,7 @@ class FindIterableSpecification extends Specification {
         readPreference == secondary()
 
         when: 'overriding initial options'
-        findIterable.filter(new Document('filter', 2))
+        findIterable.filter(asFilter(new Document('filter', 2)))
                   .sort(new Document('sort', 2))
                   .modifiers(new Document('modifier', 2))
                   .projection(new Document('projection', 2))
@@ -120,11 +121,11 @@ class FindIterableSpecification extends Specification {
         given:
         def executor = new TestOperationExecutor([null, null]);
         def findOptions = new FindOptions()
-        def findIterable = new FindIterableImpl<Document>(namespace,  Document, codecRegistry, readPreference, executor,
-                new Document('filter', 1), findOptions)
+        def findIterable = new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                asFilter(new Document('filter', 1)), findOptions)
 
         when:
-        findIterable.filter(new Document('filter', 1))
+        findIterable.filter(asFilter(new Document('filter', 1)))
                   .sort(new BsonDocument('sort', new BsonInt32(1)))
                   .modifiers(new BasicDBObject('modifier', 1))
                   .iterator()
@@ -164,8 +165,8 @@ class FindIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
         def findOptions = new FindOptions()
-        def mongoIterable = new FindIterableImpl<Document>(namespace,  Document, codecRegistry, readPreference, executor, new Document(),
-                findOptions)
+        def mongoIterable = new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                           asFilter(new Document()), findOptions)
 
         when:
         def results = mongoIterable.first()

--- a/driver/src/test/unit/com/mongodb/MapReduceIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MapReduceIterableSpecification.groovy
@@ -50,7 +50,7 @@ class MapReduceIterableSpecification extends Specification {
     def 'should build the expected MapReduceWithInlineResultsOperation'() {
         given:
         def executor = new TestOperationExecutor([null, null]);
-        def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
+        def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 'map', 'reduce')
 
         when: 'default input should be as expected'
@@ -95,7 +95,7 @@ class MapReduceIterableSpecification extends Specification {
 
         when: 'mapReduce to a collection'
         def collectionNamespace = new MongoNamespace('dbName', 'collName')
-        def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
+        def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 'map', 'reduce')
                 .collectionName(collectionNamespace.getCollectionName())
                 .databaseName(collectionNamespace.getDatabaseName())
@@ -144,7 +144,7 @@ class MapReduceIterableSpecification extends Specification {
         given:
         def codecRegistry = new RootCodecRegistry(asList(new ValueCodecProvider(), new BsonValueCodecProvider()))
         def executor = new TestOperationExecutor([new MongoException('failure')])
-        def mapReduceIterable = new MapReduceIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor,
+        def mapReduceIterable = new MapReduceIterableImpl(namespace, BsonDocument, BsonDocument, codecRegistry, readPreference, executor,
                 'map', 'reduce')
 
 
@@ -155,7 +155,7 @@ class MapReduceIterableSpecification extends Specification {
         thrown(MongoException)
 
         when: 'a codec is missing'
-        new MapReduceIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
+        new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 'map', 'reduce').iterator()
 
         then:
@@ -185,7 +185,7 @@ class MapReduceIterableSpecification extends Specification {
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
-        def mongoIterable = new MapReduceIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor,
+        def mongoIterable = new MapReduceIterableImpl(namespace, BsonDocument, BsonDocument, codecRegistry, readPreference, executor,
                 'map', 'reduce')
 
         when:

--- a/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
@@ -63,6 +63,7 @@ import static com.mongodb.bulk.WriteRequest.Type.DELETE
 import static com.mongodb.bulk.WriteRequest.Type.INSERT
 import static com.mongodb.bulk.WriteRequest.Type.REPLACE
 import static com.mongodb.bulk.WriteRequest.Type.UPDATE
+import static com.mongodb.client.model.Filter.asFilter
 import static java.util.Arrays.asList
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static spock.util.matcher.HamcrestSupport.expect
@@ -90,10 +91,10 @@ class MongoCollectionSpecification extends Specification {
 
         when:
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, writeConcern,
-                executor).withDefaultClass(newClass)
+                executor).withDocumentClass(newClass)
 
         then:
-        collection.getDefaultClass() == newClass
+        collection.getDocumentClass() == newClass
         expect collection, isTheSameAs(new MongoCollectionImpl(namespace, newClass, codecRegistry, readPreference, writeConcern,
                 executor))
     }
@@ -195,29 +196,29 @@ class MongoCollectionSpecification extends Specification {
         def findIterable = collection.find()
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
-                new BsonDocument(), new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                              asFilter(new BsonDocument()), new FindOptions()))
 
         when:
         findIterable = collection.find(BsonDocument)
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor,
-                new BsonDocument(), new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, BsonDocument, Document, codecRegistry, readPreference, executor,
+                                                              asFilter(new BsonDocument()), new FindOptions()))
 
         when:
-        findIterable = collection.find(new Document())
+        findIterable = collection.find(asFilter(new Document()))
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, codecRegistry, readPreference, executor, new Document(),
-                new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                              asFilter(new Document()), new FindOptions()))
 
         when:
-        findIterable = collection.find(new Document(), BsonDocument)
+        findIterable = collection.find(asFilter(new Document()), BsonDocument)
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor,
-                new Document(), new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, BsonDocument, Document, codecRegistry, readPreference, executor,
+                                                              asFilter(new Document()), new FindOptions()))
     }
 
     def 'should create AggregateIterable correctly'() {
@@ -229,14 +230,15 @@ class MongoCollectionSpecification extends Specification {
         def aggregateIterable = collection.aggregate([new Document('$match', 1)])
 
         then:
-        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
-                [new Document('$match', 1)]))
+        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference,
+                                                                        executor, [new Document('$match', 1)]))
 
         when:
         aggregateIterable = collection.aggregate([new Document('$match', 1)], BsonDocument)
 
         then:
-        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor,
+        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, BsonDocument, Document, codecRegistry, readPreference,
+                                                                        executor,
                 [new Document('$match', 1)]))
     }
 
@@ -249,8 +251,8 @@ class MongoCollectionSpecification extends Specification {
         def mapReduceIterable = collection.mapReduce('map', 'reduce')
 
         then:
-        expect mapReduceIterable, isTheSameAs(new MapReduceIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
-                'map', 'reduce'))
+        expect mapReduceIterable, isTheSameAs(new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference,
+                                                                        executor, 'map', 'reduce'))
     }
 
     def 'bulkWrite should use MixedBulkWriteOperation correctly'() {

--- a/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
@@ -543,14 +543,14 @@ class MongoCollectionSpecification extends Specification {
         def expectedOperation = new FindAndDeleteOperation(namespace, new DocumentCodec()).filter(new BsonDocument('a', new BsonInt32(1)))
 
         when:
-        collection.findOneAndDelete(new Document('a', 1))
+        collection.findOneAndDelete(asFilter(new Document('a', 1)))
         def operation = executor.getWriteOperation() as FindAndDeleteOperation
 
         then:
         expect operation, isTheSameAs(expectedOperation)
 
         when:
-        collection.findOneAndDelete(new Document('a', 1), new FindOneAndDeleteOptions().projection(new Document('projection', 1)))
+        collection.findOneAndDelete(asFilter(new Document('a', 1)), new FindOneAndDeleteOptions().projection(new Document('projection', 1)))
         operation = executor.getWriteOperation() as FindAndDeleteOperation
 
         then:
@@ -571,14 +571,14 @@ class MongoCollectionSpecification extends Specification {
                 .filter(new BsonDocument('a', new BsonInt32(1)))
 
         when:
-        collection.findOneAndReplace(new Document('a', 1), new Document('a', 10))
+        collection.findOneAndReplace(asFilter(new Document('a', 1)), new Document('a', 10))
         def operation = executor.getWriteOperation() as FindAndReplaceOperation
 
         then:
         expect operation, isTheSameAs(expectedOperation)
 
         when:
-        collection.findOneAndReplace(new Document('a', 1), new Document('a', 10),
+        collection.findOneAndReplace(asFilter(new Document('a', 1)), new Document('a', 10),
                                      new FindOneAndReplaceOptions().projection(new Document('projection', 1)))
         operation = executor.getWriteOperation() as FindAndReplaceOperation
 
@@ -600,14 +600,14 @@ class MongoCollectionSpecification extends Specification {
                 .filter(new BsonDocument('a', new BsonInt32(1)))
 
         when:
-        collection.findOneAndUpdate(new Document('a', 1), new Document('a', 10))
+        collection.findOneAndUpdate(asFilter(new Document('a', 1)), new Document('a', 10))
         def operation = executor.getWriteOperation() as FindAndUpdateOperation
 
         then:
         expect operation, isTheSameAs(expectedOperation)
 
         when:
-        collection.findOneAndUpdate(new Document('a', 1), new Document('a', 10),
+        collection.findOneAndUpdate(asFilter(new Document('a', 1)), new Document('a', 10),
                                     new FindOneAndUpdateOptions().projection(new Document('projection', 1)))
         operation = executor.getWriteOperation() as FindAndUpdateOperation
 

--- a/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
@@ -371,7 +371,7 @@ class MongoCollectionSpecification extends Specification {
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, writeConcern, executor)
 
         when:
-        def result = collection.deleteOne(new Document('_id', 1))
+        def result = collection.deleteOne(asFilter(new Document('_id', 1)))
         def operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
@@ -393,7 +393,7 @@ class MongoCollectionSpecification extends Specification {
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, writeConcern, executor)
 
         when:
-        def result = collection.deleteMany(new Document('_id', 1))
+        def result = collection.deleteMany(asFilter(new Document('_id', 1)))
         def operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
@@ -415,7 +415,7 @@ class MongoCollectionSpecification extends Specification {
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, writeConcern, executor)
 
         when:
-        def result = collection.replaceOne(new Document('a', 1), new Document('a', 10))
+        def result = collection.replaceOne(asFilter(new Document('a', 1)), new Document('a', 10))
         def operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
@@ -445,7 +445,7 @@ class MongoCollectionSpecification extends Specification {
         }
 
         when:
-        def result = collection.updateOne(new Document('a', 1), new Document('a', 10))
+        def result = collection.updateOne(asFilter(new Document('a', 1)), new Document('a', 10))
         def operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
@@ -453,7 +453,7 @@ class MongoCollectionSpecification extends Specification {
         result == expectedResult
 
         when:
-        result = collection.updateOne(new Document('a', 1), new Document('a', 10), new UpdateOptions().upsert(true))
+        result = collection.updateOne(asFilter(new Document('a', 1)), new Document('a', 10), new UpdateOptions().upsert(true))
         operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
@@ -480,7 +480,7 @@ class MongoCollectionSpecification extends Specification {
         }
 
         when:
-        def result = collection.updateMany(new Document('a', 1), new Document('a', 10))
+        def result = collection.updateMany(asFilter(new Document('a', 1)), new Document('a', 10))
         def operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:
@@ -488,7 +488,7 @@ class MongoCollectionSpecification extends Specification {
         result == expectedResult
 
         when:
-        result = collection.updateMany(new Document('a', 1), new Document('a', 10), new UpdateOptions().upsert(true))
+        result = collection.updateMany(asFilter(new Document('a', 1)), new Document('a', 10), new UpdateOptions().upsert(true))
         operation = executor.getWriteOperation() as MixedBulkWriteOperation
 
         then:

--- a/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
@@ -160,7 +160,7 @@ class MongoCollectionSpecification extends Specification {
 
         when:
         filter = new BsonDocument('a', new BsonInt32(1))
-        collection.count(filter)
+        collection.count(asFilter(filter))
         operation = executor.getReadOperation() as CountOperation
 
         then:
@@ -168,7 +168,7 @@ class MongoCollectionSpecification extends Specification {
 
         when:
         def hint = new BsonDocument('hint', new BsonInt32(1))
-        collection.count(filter, new CountOptions().hint(hint).skip(10).limit(100).maxTime(100, MILLISECONDS))
+        collection.count(asFilter(filter), new CountOptions().hint(hint).skip(10).limit(100).maxTime(100, MILLISECONDS))
         operation = executor.getReadOperation() as CountOperation
 
         then:


### PR DESCRIPTION
and using it in sync MongoCollection everywhere a filter was previously taken as an object.

Also did a POC of a FilterBuilder which is missing a lot of operators but proves the point that it can be done cleanly. I particularly like that all the methods are static and can therefore be statically imported, so you can make calls like:

    collection.find(and(eq("x", 1), eq("y", 2), gt("z", 3)));

If everyone is happy with this we can proceed to eradicate Object everywhere else as well.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongodb/mongo-java-driver/294)
<!-- Reviewable:end -->
