### PR TITLE
Added Renderable interface

### DIFF
--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -17,7 +17,9 @@
 package org.bson;
 
 import org.bson.codecs.BsonDocumentCodec;
+import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
+import org.bson.json.JsonReader;
 import org.bson.json.JsonWriter;
 
 import java.io.Serializable;
@@ -39,6 +41,16 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, S
     private static final long serialVersionUID = -8366220692735186027L;
 
     private final Map<String, BsonValue> map = new LinkedHashMap<String, BsonValue>();
+
+    /**
+     * Create a BsonDocument from a JSON String representation.
+     *
+     * @param json a JSON string
+     * @return a BSON document
+     */
+    public static BsonDocument parse(final String json) {
+        return new BsonDocumentCodec().decode(new JsonReader(json), DecoderContext.builder().build());
+    }
 
     /**
      * Construct a new instance with the given list {@code BsonElement}, none of which may be null.

--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -19,6 +19,8 @@ package org.bson;
 import org.bson.codecs.BsonDocumentCodec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 import org.bson.json.JsonReader;
 import org.bson.json.JsonWriter;
 
@@ -37,12 +39,13 @@ import static java.lang.String.format;
  *
  * @since 3.0
  */
-public class BsonDocument extends BsonValue implements Map<String, BsonValue>, Serializable {
+public class BsonDocument extends BsonValue implements Map<String, BsonValue>, Serializable, Bson {
     private static final long serialVersionUID = -8366220692735186027L;
 
     private final Map<String, BsonValue> map = new LinkedHashMap<String, BsonValue>();
 
     /**
+     *
      * Create a BsonDocument from a JSON String representation.
      *
      * @param json a JSON string
@@ -77,6 +80,11 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, S
      * Construct an empty document.
      */
     public BsonDocument() {
+    }
+
+    @Override
+    public <C> BsonDocument toBsonDocument(final Class<C> documentClass, final CodecRegistry codecRegistry) {
+        return this;
     }
 
     @Override

--- a/bson/src/main/org/bson/Document.java
+++ b/bson/src/main/org/bson/Document.java
@@ -18,6 +18,8 @@ package org.bson;
 
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.DocumentCodec;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 import org.bson.json.JsonReader;
 import org.bson.types.ObjectId;
 
@@ -35,7 +37,7 @@ import java.util.Set;
  * @mongodb.driver.manual core/document document
  * @since 3.0.0
  */
-public class Document implements Map<String, Object>, Serializable {
+public class Document implements Map<String, Object>, Serializable, Bson {
     private static final long serialVersionUID = 6297731997167536582L;
 
     private final LinkedHashMap<String, Object> documentAsMap;
@@ -77,6 +79,11 @@ public class Document implements Map<String, Object>, Serializable {
     public static Document valueOf(final String s) {
         JsonReader bsonReader = new JsonReader(s);
         return new DocumentCodec().decode(bsonReader, DecoderContext.builder().build());
+    }
+
+    @Override
+    public <C> BsonDocument toBsonDocument(final Class<C> documentClass, final CodecRegistry codecRegistry) {
+        return new BsonDocumentWrapper<Document>(this, codecRegistry.get(Document.class));
     }
 
     /**

--- a/bson/src/main/org/bson/conversions/Bson.java
+++ b/bson/src/main/org/bson/conversions/Bson.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.conversions;
+
+import org.bson.BsonDocument;
+import org.bson.codecs.configuration.CodecRegistry;
+
+/**
+ * An interface for types that are able to render themselves into a {@code BsonDocument}.
+ *
+ * @since 3.0
+ */
+public interface Bson {
+    /**
+     * Render the filter into a BsonDocument.
+     *
+     * @param documentClass the document class in scope for the collection.  This parameter may be ignored, but it may be used to alter
+     *                      the structure of the returned {@code BsonDocument} based on some knowledge of the document class.
+     * @param codecRegistry the codec registry.  This parameter may be ignored, but it may be used to look up {@code Codec} instances for
+     *                      the document class or any other related class.
+     * @param <TDocument> the type of the document class
+     * @return the BsonDocument
+     */
+    <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry);
+}

--- a/bson/src/test/unit/org/bson/BsonDocumentTest.java
+++ b/bson/src/test/unit/org/bson/BsonDocumentTest.java
@@ -82,4 +82,9 @@ public class BsonDocumentTest {
     public void toStringShouldEqualToJson() {
         assertEquals(document.toJson(), document.toString());
     }
+
+    @Test
+    public void shouldParseJson() {
+        assertEquals(new BsonDocument("a", new BsonInt32(1)), BsonDocument.parse("{\"a\" : 1}"));
+    }
 }

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -51,6 +51,7 @@
     </ruleset-ref>
     <ruleset-ref path='rulesets/generic.xml'/>
     <ruleset-ref path='rulesets/groovyism.xml'>
+        <exclude name="ExplicitCallToAndMethod"/>
         <exclude name="ExplicitCallToCompareToMethod"/>
         <exclude name='GetterMethodCouldBeProperty'/>
      </ruleset-ref>

--- a/driver-async/src/main/com/mongodb/async/client/FindIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/FindIterable.java
@@ -17,6 +17,7 @@
 package com.mongodb.async.client;
 
 import com.mongodb.CursorType;
+import org.bson.conversions.Bson;
 
 import java.util.concurrent.TimeUnit;
 
@@ -35,7 +36,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Filter
      */
-    FindIterable<T> filter(Object filter);
+    FindIterable<T> filter(Bson filter);
 
     /**
      * Sets the limit to apply.
@@ -71,7 +72,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/operator/query-modifier/ Query Modifiers
      */
-    FindIterable<T> modifiers(Object modifiers);
+    FindIterable<T> modifiers(Bson modifiers);
 
     /**
      * Sets a document describing the fields to return for all matching documents.
@@ -80,7 +81,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Projection
      */
-    FindIterable<T> projection(Object projection);
+    FindIterable<T> projection(Bson projection);
     /**
      * Sets the sort criteria to apply to the query.
      *
@@ -88,7 +89,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.sort/ Sort
      */
-    FindIterable<T> sort(Object sort);
+    FindIterable<T> sort(Bson sort);
 
     /**
      * The server normally times out idle cursors after an inactivity period (10 minutes)

--- a/driver-async/src/main/com/mongodb/async/client/FindIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/FindIterableImpl.java
@@ -21,15 +21,16 @@ import com.mongodb.CursorType;
 import com.mongodb.Function;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
+import com.mongodb.async.AsyncBatchCursor;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.client.model.FindOptions;
-import com.mongodb.async.AsyncBatchCursor;
 import com.mongodb.operation.AsyncOperationExecutor;
 import com.mongodb.operation.FindOperation;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWrapper;
 import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
@@ -59,7 +60,7 @@ class FindIterableImpl<T> implements FindIterable<T> {
     }
 
     @Override
-    public FindIterable<T> filter(final Object filter) {
+    public FindIterable<T> filter(final Bson filter) {
         this.filter = filter;
         return this;
     }
@@ -90,19 +91,19 @@ class FindIterableImpl<T> implements FindIterable<T> {
     }
 
     @Override
-    public FindIterable<T> modifiers(final Object modifiers) {
+    public FindIterable<T> modifiers(final Bson modifiers) {
         findOptions.modifiers(modifiers);
         return this;
     }
 
     @Override
-    public FindIterable<T> projection(final Object projection) {
+    public FindIterable<T> projection(final Bson projection) {
         findOptions.projection(projection);
         return this;
     }
 
     @Override
-    public FindIterable<T> sort(final Object sort) {
+    public FindIterable<T> sort(final Bson sort) {
         findOptions.sort(sort);
         return this;
     }

--- a/driver-async/src/main/com/mongodb/async/client/MongoCollection.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoCollection.java
@@ -36,6 +36,7 @@ import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.List;
 
@@ -44,11 +45,11 @@ import java.util.List;
  *
  * <p>Note: Additions to this interface will not be considered to break binary compatibility.</p>
  *
- * @param <T> The type that this collection will encode documents from and decode documents to.
+ * @param <TDocument> The type that this collection will encode documents from and decode documents to.
  * @since 3.0
  */
 @ThreadSafe
-public interface MongoCollection<T> {
+public interface MongoCollection<TDocument> {
 
     /**
      * Gets the namespace of this collection.
@@ -58,11 +59,11 @@ public interface MongoCollection<T> {
     MongoNamespace getNamespace();
 
     /**
-     * Get the default class to cast any documents returned from the database into.
+     * Get the class of documents stored in this collection.
      *
-     * @return the default class to cast any documents into
+     * @return the class
      */
-    Class<T> getDefaultClass();
+    Class<TDocument> getDocumentClass();
 
     /**
      * Get the codec registry for the MongoCollection.
@@ -89,10 +90,10 @@ public interface MongoCollection<T> {
      * Create a new MongoCollection instance with a different default class to cast any documents returned from the database into..
      *
      * @param clazz the default class to cast any documents returned from the database into.
-     * @param <C> The type that the new collection will encode documents from and decode documents to
+     * @param <NewTDocument> The type that the new collection will encode documents from and decode documents to
      * @return a new MongoCollection instance with the different default class
      */
-    <C> MongoCollection<C> withDefaultClass(Class<C> clazz);
+    <NewTDocument> MongoCollection<NewTDocument> withDocumentClass(Class<NewTDocument> clazz);
 
     /**
      * Create a new MongoCollection instance with a different codec registry.
@@ -100,7 +101,7 @@ public interface MongoCollection<T> {
      * @param codecRegistry the new {@link org.bson.codecs.configuration.CodecRegistry} for the collection
      * @return a new MongoCollection instance with the different codec registry
      */
-    MongoCollection<T> withCodecRegistry(CodecRegistry codecRegistry);
+    MongoCollection<TDocument> withCodecRegistry(CodecRegistry codecRegistry);
 
     /**
      * Create a new MongoCollection instance with a different read preference.
@@ -108,7 +109,7 @@ public interface MongoCollection<T> {
      * @param readPreference the new {@link com.mongodb.ReadPreference} for the collection
      * @return a new MongoCollection instance with the different readPreference
      */
-    MongoCollection<T> withReadPreference(ReadPreference readPreference);
+    MongoCollection<TDocument> withReadPreference(ReadPreference readPreference);
 
     /**
      * Create a new MongoCollection instance with a different write concern.
@@ -116,7 +117,7 @@ public interface MongoCollection<T> {
      * @param writeConcern the new {@link com.mongodb.WriteConcern} for the collection
      * @return a new MongoCollection instance with the different writeConcern
      */
-    MongoCollection<T> withWriteConcern(WriteConcern writeConcern);
+    MongoCollection<TDocument> withWriteConcern(WriteConcern writeConcern);
 
     /**
      * Counts the number of documents in the collection.
@@ -131,7 +132,7 @@ public interface MongoCollection<T> {
      * @param filter   the query filter
      * @param callback the callback passed the number of documents in the collection
      */
-    void count(Object filter, SingleResultCallback<Long> callback);
+    void count(Bson filter, SingleResultCallback<Long> callback);
 
     /**
      * Counts the number of documents in the collection according to the given options.
@@ -140,18 +141,18 @@ public interface MongoCollection<T> {
      * @param options  the options describing the count
      * @param callback the callback passed the number of documents in the collection
      */
-    void count(Object filter, CountOptions options, SingleResultCallback<Long> callback);
+    void count(Bson filter, CountOptions options, SingleResultCallback<Long> callback);
 
     /**
      * Gets the distinct values of the specified field name.
      *
      * @param fieldName the field name
      * @param clazz     the default class to cast any distinct items into.
-     * @param <C>       the target type of the iterable.
+     * @param <TResult>       the target type of the iterable.
      * @return an iterable of distinct values
      * @mongodb.driver.manual reference/command/distinct/ Distinct
      */
-    <C> DistinctIterable<C> distinct(String fieldName, Class<C> clazz);
+    <TResult> DistinctIterable<TResult> distinct(String fieldName, Class<TResult> clazz);
 
     /**
      * Finds all documents in the collection.
@@ -159,17 +160,17 @@ public interface MongoCollection<T> {
      * @return the find iterable interface
      * @mongodb.driver.manual tutorial/query-documents/ Find
      */
-    FindIterable<T> find();
+    FindIterable<TDocument> find();
 
     /**
      * Finds all documents in the collection.
      *
      * @param clazz the class to decode each document into
-     * @param <C>   the target document type of the iterable.
+     * @param <TResult>   the target document type of the iterable.
      * @return the find iterable interface
      * @mongodb.driver.manual tutorial/query-documents/ Find
      */
-    <C> FindIterable<C> find(Class<C> clazz);
+    <TResult> FindIterable<TResult> find(Class<TResult> clazz);
 
     /**
      * Finds all documents in the collection.
@@ -178,18 +179,18 @@ public interface MongoCollection<T> {
      * @return the find iterable interface
      * @mongodb.driver.manual tutorial/query-documents/ Find
      */
-    FindIterable<T> find(Object filter);
+    FindIterable<TDocument> find(Bson filter);
 
     /**
      * Finds all documents in the collection.
      *
      * @param filter the query filter
      * @param clazz  the class to decode each document into
-     * @param <C>    the target document type of the iterable.
+     * @param <TResult>    the target document type of the iterable.
      * @return the find iterable interface
      * @mongodb.driver.manual tutorial/query-documents/ Find
      */
-    <C> FindIterable<C> find(Object filter, Class<C> clazz);
+    <TResult> FindIterable<TResult> find(Bson filter, Class<TResult> clazz);
 
     /**
      * Aggregates documents according to the specified aggregation pipeline.  If the pipeline ends with a $out stage, the returned
@@ -200,7 +201,7 @@ public interface MongoCollection<T> {
      * @return an iterable containing the result of the aggregation operation
      * @mongodb.driver.manual aggregation/ Aggregation
      */
-    AggregateIterable<Document> aggregate(List<?> pipeline);
+    AggregateIterable<Document> aggregate(List<? extends Bson> pipeline);
 
     /**
      * Aggregates documents according to the specified aggregation pipeline.  If the pipeline ends with a $out stage, the returned
@@ -209,11 +210,11 @@ public interface MongoCollection<T> {
      *
      * @param pipeline the aggregate pipeline
      * @param clazz    the class to decode each document into
-     * @param <C>      the target document type of the iterable.
+     * @param <TResult>      the target document type of the iterable.
      * @return an iterable containing the result of the aggregation operation
      * @mongodb.driver.manual aggregation/ Aggregation
      */
-    <C> AggregateIterable<C> aggregate(List<?> pipeline, Class<C> clazz);
+    <TResult> AggregateIterable<TResult> aggregate(List<? extends Bson> pipeline, Class<TResult> clazz);
 
     /**
      * Aggregates documents according to the specified map-reduce function.
@@ -231,11 +232,11 @@ public interface MongoCollection<T> {
      * @param mapFunction    A JavaScript function that associates or "maps" a value with a key and emits the key and value pair.
      * @param reduceFunction A JavaScript function that "reduces" to a single object all the values associated with a particular key.
      * @param clazz          the class to decode each resulting document into.
-     * @param <C>            the target document type of the iterable.
+     * @param <TResult>            the target document type of the iterable.
      * @return an iterable containing the result of the map-reduce operation
      * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
      */
-    <C> MapReduceIterable<C> mapReduce(String mapFunction, String reduceFunction, Class<C> clazz);
+    <TResult> MapReduceIterable<TResult> mapReduce(String mapFunction, String reduceFunction, Class<TResult> clazz);
 
     /**
      * Executes a mix of inserts, updates, replaces, and deletes.
@@ -243,7 +244,7 @@ public interface MongoCollection<T> {
      * @param requests the writes to execute
      * @param callback the callback passed the result of the bulk write
      */
-    void bulkWrite(List<? extends WriteModel<? extends T>> requests, SingleResultCallback<BulkWriteResult> callback);
+    void bulkWrite(List<? extends WriteModel<? extends TDocument>> requests, SingleResultCallback<BulkWriteResult> callback);
 
     /**
      * Executes a mix of inserts, updates, replaces, and deletes.
@@ -252,7 +253,7 @@ public interface MongoCollection<T> {
      * @param options  the options to apply to the bulk write operation
      * @param callback the callback passed the result of the bulk write
      */
-    void bulkWrite(List<? extends WriteModel<? extends T>> requests, BulkWriteOptions options,
+    void bulkWrite(List<? extends WriteModel<? extends TDocument>> requests, BulkWriteOptions options,
                    SingleResultCallback<BulkWriteResult> callback);
 
     /**
@@ -264,7 +265,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoWriteConcernException returned via the callback
      * @throws com.mongodb.MongoException             returned via the callback
      */
-    void insertOne(T document, SingleResultCallback<Void> callback);
+    void insertOne(TDocument document, SingleResultCallback<Void> callback);
 
     /**
      * Inserts one or more documents.  A call to this method is equivalent to a call to the {@code bulkWrite} method
@@ -275,7 +276,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoException          if the write failed due some other failure
      * @see com.mongodb.async.client.MongoCollection#bulkWrite
      */
-    void insertMany(List<? extends T> documents, SingleResultCallback<Void> callback);
+    void insertMany(List<? extends TDocument> documents, SingleResultCallback<Void> callback);
 
     /**
      * Inserts one or more documents.  A call to this method is equivalent to a call to the {@code bulkWrite} method
@@ -287,7 +288,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoException          if the write failed due some other failure
      * @see com.mongodb.async.client.MongoCollection#bulkWrite
      */
-    void insertMany(List<? extends T> documents, InsertManyOptions options, SingleResultCallback<Void> callback);
+    void insertMany(List<? extends TDocument> documents, InsertManyOptions options, SingleResultCallback<Void> callback);
 
     /**
      * Removes at most one document from the collection that matches the given filter.  If no documents match, the collection is not
@@ -299,7 +300,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoWriteConcernException returned via the callback
      * @throws com.mongodb.MongoException             returned via the callback
      */
-    void deleteOne(Object filter, SingleResultCallback<DeleteResult> callback);
+    void deleteOne(Bson filter, SingleResultCallback<DeleteResult> callback);
 
     /**
      * Removes all documents from the collection that match the given query filter.  If no documents match, the collection is not modified.
@@ -310,7 +311,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoWriteConcernException returned via the callback
      * @throws com.mongodb.MongoException             returned via the callback
      */
-    void deleteMany(Object filter, SingleResultCallback<DeleteResult> callback);
+    void deleteMany(Bson filter, SingleResultCallback<DeleteResult> callback);
 
     /**
      * Replace a document in the collection according to the specified arguments.
@@ -323,7 +324,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoException             returned via the callback
      * @mongodb.driver.manual tutorial/modify-documents/#replace-the-document Replace
      */
-    void replaceOne(Object filter, T replacement, SingleResultCallback<UpdateResult> callback);
+    void replaceOne(Bson filter, TDocument replacement, SingleResultCallback<UpdateResult> callback);
 
     /**
      * Replace a document in the collection according to the specified arguments.
@@ -337,15 +338,13 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoException             returned via the callback
      * @mongodb.driver.manual tutorial/modify-documents/#replace-the-document Replace
      */
-    void replaceOne(Object filter, T replacement, UpdateOptions options, SingleResultCallback<UpdateResult> callback);
+    void replaceOne(Bson filter, TDocument replacement, UpdateOptions options, SingleResultCallback<UpdateResult> callback);
 
     /**
      * Update a single document in the collection according to the specified arguments.
      *
-     * @param filter   a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec} is
-     *                 registered
-     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators. This
-     *                 can be of any type for which a {@code Codec} is registered
+     * @param filter   a document describing the query filter, which may not be null.
+     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators.
      * @param callback the callback passed the result of the update one operation
      * @throws com.mongodb.MongoWriteException        returned via the callback
      * @throws com.mongodb.MongoWriteConcernException returned via the callback
@@ -353,15 +352,13 @@ public interface MongoCollection<T> {
      * @mongodb.driver.manual tutorial/modify-documents/ Updates
      * @mongodb.driver.manual reference/operator/update/ Update Operators
      */
-    void updateOne(Object filter, Object update, SingleResultCallback<UpdateResult> callback);
+    void updateOne(Bson filter, Bson update, SingleResultCallback<UpdateResult> callback);
 
     /**
      * Update a single document in the collection according to the specified arguments.
      *
-     * @param filter   a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec} is
-     *                 registered
-     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators. This
-     *                 can be of any type for which a {@code Codec} is registered
+     * @param filter   a document describing the query filter, which may not be null.
+     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators.
      * @param options  the options to apply to the update operation
      * @param callback the callback passed the result of the update one operation
      * @throws com.mongodb.MongoWriteException        returned via the callback
@@ -370,15 +367,13 @@ public interface MongoCollection<T> {
      * @mongodb.driver.manual tutorial/modify-documents/ Updates
      * @mongodb.driver.manual reference/operator/update/ Update Operators
      */
-    void updateOne(Object filter, Object update, UpdateOptions options, SingleResultCallback<UpdateResult> callback);
+    void updateOne(Bson filter, Bson update, UpdateOptions options, SingleResultCallback<UpdateResult> callback);
 
     /**
      * Update a single document in the collection according to the specified arguments.
      *
-     * @param filter   a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec} is
-     *                 registered
-     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators. This
-     *                 can be of any type for which a {@code Codec} is registered
+     * @param filter   a document describing the query filter, which may not be null.
+     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators. T
      * @param callback the callback passed the result of the update one operation
      * @throws com.mongodb.MongoWriteException        returned via the callback
      * @throws com.mongodb.MongoWriteConcernException returned via the callback
@@ -386,15 +381,13 @@ public interface MongoCollection<T> {
      * @mongodb.driver.manual tutorial/modify-documents/ Updates
      * @mongodb.driver.manual reference/operator/update/ Update Operators
      */
-    void updateMany(Object filter, Object update, SingleResultCallback<UpdateResult> callback);
+    void updateMany(Bson filter, Bson update, SingleResultCallback<UpdateResult> callback);
 
     /**
      * Update a single document in the collection according to the specified arguments.
      *
-     * @param filter   a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec} is
-     *                 registered
-     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators. This
-     *                 can be of any type for which a {@code Codec} is registered
+     * @param filter   a document describing the query filter, which may not be null.
+     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators.
      * @param options  the options to apply to the update operation
      * @param callback the callback passed the result of the update one operation
      * @throws com.mongodb.MongoWriteException        returned via the callback
@@ -403,7 +396,7 @@ public interface MongoCollection<T> {
      * @mongodb.driver.manual tutorial/modify-documents/ Updates
      * @mongodb.driver.manual reference/operator/update/ Update Operators
      */
-    void updateMany(Object filter, Object update, UpdateOptions options, SingleResultCallback<UpdateResult> callback);
+    void updateMany(Bson filter, Bson update, UpdateOptions options, SingleResultCallback<UpdateResult> callback);
 
     /**
      * Atomically find a document and remove it.
@@ -412,7 +405,7 @@ public interface MongoCollection<T> {
      * @param callback the callback passed the document that was removed.  If no documents matched the query filter, then null will be
      *                 returned
      */
-    void findOneAndDelete(Object filter, SingleResultCallback<T> callback);
+    void findOneAndDelete(Bson filter, SingleResultCallback<TDocument> callback);
 
     /**
      * Atomically find a document and remove it.
@@ -422,7 +415,7 @@ public interface MongoCollection<T> {
      * @param callback the callback passed the document that was removed.  If no documents matched the query filter, then null will be
      *                 returned
      */
-    void findOneAndDelete(Object filter, FindOneAndDeleteOptions options, SingleResultCallback<T> callback);
+    void findOneAndDelete(Bson filter, FindOneAndDeleteOptions options, SingleResultCallback<TDocument> callback);
 
     /**
      * Atomically find a document and replace it.
@@ -433,7 +426,7 @@ public interface MongoCollection<T> {
      *                    property, this will either be the document as it was before the update or as it is after the update.  If no
      *                    documents matched the query filter, then null will be returned
      */
-    void findOneAndReplace(Object filter, T replacement, SingleResultCallback<T> callback);
+    void findOneAndReplace(Bson filter, TDocument replacement, SingleResultCallback<TDocument> callback);
 
     /**
      * Atomically find a document and replace it.
@@ -445,33 +438,29 @@ public interface MongoCollection<T> {
      *                    property, this will either be the document as it was before the update or as it is after the update.  If no
      *                    documents matched the query filter, then null will be returned
      */
-    void findOneAndReplace(Object filter, T replacement, FindOneAndReplaceOptions options, SingleResultCallback<T> callback);
+    void findOneAndReplace(Bson filter, TDocument replacement, FindOneAndReplaceOptions options, SingleResultCallback<TDocument> callback);
 
     /**
      * Atomically find a document and update it.
      *
-     * @param filter   a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec} is
-     *                 registered
-     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators. This
-     *                 can be of any type for which a {@code Codec} is registered
+     * @param filter   a document describing the query filter, which may not be null.
+     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators.
      * @param callback the callback passed the document that was updated before the update was applied.  If no documents matched the query
      *                 filter, then null will be returned
      */
-    void findOneAndUpdate(Object filter, Object update, SingleResultCallback<T> callback);
+    void findOneAndUpdate(Bson filter, Bson update, SingleResultCallback<TDocument> callback);
 
     /**
      * Atomically find a document and update it.
      *
-     * @param filter   a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec} is
-     *                 registered
-     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators. This
-     *                 can be of any type for which a {@code Codec} is registered
+     * @param filter   a document describing the query filter, which may not be null.
+     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators.
      * @param options  the options to apply to the operation
      * @param callback the callback passed the document that was updated.  Depending on the value of the {@code returnOriginal} property,
      *                 this will either be the document as it was before the update or as it is after the update.  If no documents matched
      *                 the query filter, then null will be returned
      */
-    void findOneAndUpdate(Object filter, Object update, FindOneAndUpdateOptions options, SingleResultCallback<T> callback);
+    void findOneAndUpdate(Bson filter, Bson update, FindOneAndUpdateOptions options, SingleResultCallback<TDocument> callback);
 
     /**
      * Drops this collection from the Database.
@@ -484,23 +473,21 @@ public interface MongoCollection<T> {
     /**
      * Creates an index.
      *
-     * @param key      an object describing the index key(s), which may not be null. This can be of any type for which a {@code Codec} is
-     *                 registered
+     * @param key      an object describing the index key(s), which may not be null.
      * @param callback the callback that is completed once the index has been created
      * @mongodb.driver.manual reference/method/db.collection.ensureIndex Ensure Index
      */
-    void createIndex(Object key, SingleResultCallback<Void> callback);
+    void createIndex(Bson key, SingleResultCallback<Void> callback);
 
     /**
      * Creates an index.
      *
-     * @param key      an object describing the index key(s), which may not be null. This can be of any type for which a {@code Codec} is
-     *                 registered
+     * @param key      an object describing the index key(s), which may not be null.
      * @param options  the options for the index
      * @param callback the callback that is completed once the index has been created
      * @mongodb.driver.manual reference/method/db.collection.ensureIndex Ensure Index
      */
-    void createIndex(Object key, CreateIndexOptions options, SingleResultCallback<Void> callback);
+    void createIndex(Bson key, CreateIndexOptions options, SingleResultCallback<Void> callback);
 
     /**
      * Get all the indexes in this collection.
@@ -514,11 +501,11 @@ public interface MongoCollection<T> {
      * Get all the indexes in this collection.
      *
      * @param clazz    the class to decode each document into
-     * @param <C>      the target document type of the iterable.
+     * @param <TResult>      the target document type of the iterable.
      * @return the list indexes iterable interface
      * @mongodb.driver.manual reference/command/listIndexes/ listIndexes
      */
-    <C> ListIndexesIterable<C> listIndexes(Class<C> clazz);
+    <TResult> ListIndexesIterable<TResult> listIndexes(Class<TResult> clazz);
 
     /**
      * Drops the given index.

--- a/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
@@ -66,6 +66,7 @@ import org.bson.Document;
 import org.bson.codecs.Codec;
 import org.bson.codecs.CollectibleCodec;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -76,15 +77,15 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-class MongoCollectionImpl<T> implements MongoCollection<T> {
+class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private final MongoNamespace namespace;
-    private final Class<T> clazz;
+    private final Class<TDocument> clazz;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final WriteConcern writeConcern;
     private final AsyncOperationExecutor executor;
 
-    MongoCollectionImpl(final MongoNamespace namespace, final Class<T> clazz, final CodecRegistry codecRegistry,
+    MongoCollectionImpl(final MongoNamespace namespace, final Class<TDocument> clazz, final CodecRegistry codecRegistry,
                         final ReadPreference readPreference, final WriteConcern writeConcern, final AsyncOperationExecutor executor) {
         this.namespace = notNull("namespace", namespace);
         this.clazz = notNull("clazz", clazz);
@@ -100,7 +101,7 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public Class<T> getDefaultClass() {
+    public Class<TDocument> getDocumentClass() {
         return clazz;
     }
 
@@ -120,23 +121,23 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public <C> MongoCollection<C> withDefaultClass(final Class<C> clazz) {
-        return new MongoCollectionImpl<C>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
+    public <NewTDocument> MongoCollection<NewTDocument> withDocumentClass(final Class<NewTDocument> clazz) {
+        return new MongoCollectionImpl<NewTDocument>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
     }
 
     @Override
-    public MongoCollection<T> withCodecRegistry(final CodecRegistry codecRegistry) {
-        return new MongoCollectionImpl<T>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
+    public MongoCollection<TDocument> withCodecRegistry(final CodecRegistry codecRegistry) {
+        return new MongoCollectionImpl<TDocument>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
     }
 
     @Override
-    public MongoCollection<T> withReadPreference(final ReadPreference readPreference) {
-        return new MongoCollectionImpl<T>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
+    public MongoCollection<TDocument> withReadPreference(final ReadPreference readPreference) {
+        return new MongoCollectionImpl<TDocument>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
     }
 
     @Override
-    public MongoCollection<T> withWriteConcern(final WriteConcern writeConcern) {
-        return new MongoCollectionImpl<T>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
+    public MongoCollection<TDocument> withWriteConcern(final WriteConcern writeConcern) {
+        return new MongoCollectionImpl<TDocument>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
     }
 
     @Override
@@ -145,19 +146,19 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public void count(final Object filter, final SingleResultCallback<Long> callback) {
+    public void count(final Bson filter, final SingleResultCallback<Long> callback) {
         count(filter, new CountOptions(), callback);
     }
 
     @Override
-    public void count(final Object filter, final CountOptions options, final SingleResultCallback<Long> callback) {
+    public void count(final Bson filter, final CountOptions options, final SingleResultCallback<Long> callback) {
         CountOperation operation = new CountOperation(namespace)
-                                   .filter(asBson(filter))
+                                   .filter(toBsonDocument(filter))
                                    .skip(options.getSkip())
                                    .limit(options.getLimit())
                                    .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS);
         if (options.getHint() != null) {
-            operation.hint(asBson(options.getHint()));
+            operation.hint(toBsonDocument(options.getHint()));
         } else if (options.getHintString() != null) {
             operation.hint(new BsonString(options.getHintString()));
         }
@@ -165,38 +166,38 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public <C> DistinctIterable<C> distinct(final String fieldName, final Class<C> clazz) {
-        return new DistinctIterableImpl<C>(namespace, clazz, codecRegistry, readPreference, executor, fieldName);
+    public <TResult> DistinctIterable<TResult> distinct(final String fieldName, final Class<TResult> clazz) {
+        return new DistinctIterableImpl<TResult>(namespace, clazz, codecRegistry, readPreference, executor, fieldName);
     }
 
     @Override
-    public FindIterable<T> find() {
+    public FindIterable<TDocument> find() {
         return find(new BsonDocument(), clazz);
     }
 
     @Override
-    public <C> FindIterable<C> find(final Class<C> clazz) {
+    public <TResult> FindIterable<TResult> find(final Class<TResult> clazz) {
         return find(new BsonDocument(), clazz);
     }
 
     @Override
-    public FindIterable<T> find(final Object filter) {
+    public FindIterable<TDocument> find(final Bson filter) {
         return find(filter, clazz);
     }
 
     @Override
-    public <C> FindIterable<C> find(final Object filter, final Class<C> clazz) {
-        return new FindIterableImpl<C>(namespace, clazz, codecRegistry, readPreference, executor, filter, new FindOptions());
+    public <TResult> FindIterable<TResult> find(final Bson filter, final Class<TResult> clazz) {
+        return new FindIterableImpl<TResult>(namespace, clazz, codecRegistry, readPreference, executor, filter, new FindOptions());
     }
 
     @Override
-    public AggregateIterable<Document> aggregate(final List<?> pipeline) {
+    public AggregateIterable<Document> aggregate(final List<? extends Bson> pipeline) {
         return aggregate(pipeline, Document.class);
     }
 
     @Override
-    public <C> AggregateIterable<C> aggregate(final List<?> pipeline, final Class<C> clazz) {
-        return new AggregateIterableImpl<C>(namespace, clazz, codecRegistry, readPreference, executor, pipeline);
+    public <TResult> AggregateIterable<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> clazz) {
+        return new AggregateIterableImpl<TResult>(namespace, clazz, codecRegistry, readPreference, executor, pipeline);
     }
 
     @Override
@@ -205,51 +206,54 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public <C> MapReduceIterable<C> mapReduce(final String mapFunction, final String reduceFunction, final Class<C> clazz) {
-        return new MapReduceIterableImpl<C>(namespace, clazz, codecRegistry, readPreference, executor, mapFunction, reduceFunction);
+    public <TResult> MapReduceIterable<TResult> mapReduce(final String mapFunction, final String reduceFunction,
+                                                          final Class<TResult> clazz) {
+        return new MapReduceIterableImpl<TResult>(namespace, clazz, codecRegistry, readPreference, executor, mapFunction, reduceFunction);
     }
 
     @Override
-    public void bulkWrite(final List<? extends WriteModel<? extends T>> requests, final SingleResultCallback<BulkWriteResult> callback) {
+    public void bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests,
+                          final SingleResultCallback<BulkWriteResult> callback) {
         bulkWrite(requests, new BulkWriteOptions(), callback);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public void bulkWrite(final List<? extends WriteModel<? extends T>> requests, final BulkWriteOptions options,
+    public void bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests, final BulkWriteOptions options,
                           final SingleResultCallback<BulkWriteResult> callback) {
         List<WriteRequest> writeRequests = new ArrayList<WriteRequest>(requests.size());
-        for (WriteModel<? extends T> writeModel : requests) {
+        for (WriteModel<? extends TDocument> writeModel : requests) {
             WriteRequest writeRequest;
             if (writeModel instanceof InsertOneModel) {
-                InsertOneModel<T> insertOneModel = (InsertOneModel<T>) writeModel;
+                InsertOneModel<TDocument> insertOneModel = (InsertOneModel<TDocument>) writeModel;
                 if (getCodec() instanceof CollectibleCodec) {
-                    ((CollectibleCodec<T>) getCodec()).generateIdIfAbsentFromDocument(insertOneModel.getDocument());
+                    ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(insertOneModel.getDocument());
                 }
-                writeRequest = new InsertRequest(asBson(insertOneModel.getDocument()));
+                writeRequest = new InsertRequest(documentToBsonDocument(insertOneModel.getDocument()));
             } else if (writeModel instanceof ReplaceOneModel) {
-                ReplaceOneModel<T> replaceOneModel = (ReplaceOneModel<T>) writeModel;
-                writeRequest = new UpdateRequest(asBson(replaceOneModel.getFilter()), asBson(replaceOneModel.getReplacement()),
+                ReplaceOneModel<TDocument> replaceOneModel = (ReplaceOneModel<TDocument>) writeModel;
+                writeRequest = new UpdateRequest(toBsonDocument(replaceOneModel.getFilter()), documentToBsonDocument(replaceOneModel
+                                                                                                             .getReplacement()),
                                                  WriteRequest.Type.REPLACE)
                                .upsert(replaceOneModel.getOptions().isUpsert());
             } else if (writeModel instanceof UpdateOneModel) {
-                UpdateOneModel<T> updateOneModel = (UpdateOneModel<T>) writeModel;
-                writeRequest = new UpdateRequest(asBson(updateOneModel.getFilter()), asBson(updateOneModel.getUpdate()),
+                UpdateOneModel<TDocument> updateOneModel = (UpdateOneModel<TDocument>) writeModel;
+                writeRequest = new UpdateRequest(toBsonDocument(updateOneModel.getFilter()), toBsonDocument(updateOneModel.getUpdate()),
                                                  WriteRequest.Type.UPDATE)
                                .multi(false)
                                .upsert(updateOneModel.getOptions().isUpsert());
             } else if (writeModel instanceof UpdateManyModel) {
-                UpdateManyModel<T> updateManyModel = (UpdateManyModel<T>) writeModel;
-                writeRequest = new UpdateRequest(asBson(updateManyModel.getFilter()), asBson(updateManyModel.getUpdate()),
+                UpdateManyModel<TDocument> updateManyModel = (UpdateManyModel<TDocument>) writeModel;
+                writeRequest = new UpdateRequest(toBsonDocument(updateManyModel.getFilter()), toBsonDocument(updateManyModel.getUpdate()),
                                                  WriteRequest.Type.UPDATE)
                                .multi(true)
                                .upsert(updateManyModel.getOptions().isUpsert());
             } else if (writeModel instanceof DeleteOneModel) {
-                DeleteOneModel<T> deleteOneModel = (DeleteOneModel<T>) writeModel;
-                writeRequest = new DeleteRequest(asBson(deleteOneModel.getFilter())).multi(false);
+                DeleteOneModel<TDocument> deleteOneModel = (DeleteOneModel<TDocument>) writeModel;
+                writeRequest = new DeleteRequest(toBsonDocument(deleteOneModel.getFilter())).multi(false);
             } else if (writeModel instanceof DeleteManyModel) {
-                DeleteManyModel<T> deleteManyModel = (DeleteManyModel<T>) writeModel;
-                writeRequest = new DeleteRequest(asBson(deleteManyModel.getFilter())).multi(true);
+                DeleteManyModel<TDocument> deleteManyModel = (DeleteManyModel<TDocument>) writeModel;
+                writeRequest = new DeleteRequest(toBsonDocument(deleteManyModel.getFilter())).multi(true);
             } else {
                 throw new UnsupportedOperationException(format("WriteModel of type %s is not supported", writeModel.getClass()));
             }
@@ -261,11 +265,11 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public void insertOne(final T document, final SingleResultCallback<Void> callback) {
+    public void insertOne(final TDocument document, final SingleResultCallback<Void> callback) {
         if (getCodec() instanceof CollectibleCodec) {
-            ((CollectibleCodec<T>) getCodec()).generateIdIfAbsentFromDocument(document);
+            ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
         }
-        executeSingleWriteRequest(new InsertRequest(asBson(document)), new SingleResultCallback<BulkWriteResult>() {
+        executeSingleWriteRequest(new InsertRequest(documentToBsonDocument(document)), new SingleResultCallback<BulkWriteResult>() {
             @Override
             public void onResult(final BulkWriteResult result, final Throwable t) {
                 callback.onResult(null, t);
@@ -274,19 +278,19 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public void insertMany(final List<? extends T> documents, final SingleResultCallback<Void> callback) {
+    public void insertMany(final List<? extends TDocument> documents, final SingleResultCallback<Void> callback) {
         insertMany(documents, new InsertManyOptions(), callback);
     }
 
     @Override
-    public void insertMany(final List<? extends T> documents, final InsertManyOptions options,
+    public void insertMany(final List<? extends TDocument> documents, final InsertManyOptions options,
                            final SingleResultCallback<Void> callback) {
         List<InsertRequest> requests = new ArrayList<InsertRequest>(documents.size());
-        for (T document : documents) {
+        for (TDocument document : documents) {
             if (getCodec() instanceof CollectibleCodec) {
-                ((CollectibleCodec<T>) getCodec()).generateIdIfAbsentFromDocument(document);
+                ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
             }
-            requests.add(new InsertRequest(asBson(document)));
+            requests.add(new InsertRequest(documentToBsonDocument(document)));
         }
         executor.execute(new MixedBulkWriteOperation(namespace, requests, options.isOrdered(), writeConcern),
                          errorHandlingCallback(new SingleResultCallback<BulkWriteResult>() {
@@ -298,24 +302,24 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public void deleteOne(final Object filter, final SingleResultCallback<DeleteResult> callback) {
+    public void deleteOne(final Bson filter, final SingleResultCallback<DeleteResult> callback) {
         delete(filter, false, callback);
     }
 
     @Override
-    public void deleteMany(final Object filter, final SingleResultCallback<DeleteResult> callback) {
+    public void deleteMany(final Bson filter, final SingleResultCallback<DeleteResult> callback) {
         delete(filter, true, callback);
     }
 
     @Override
-    public void replaceOne(final Object filter, final T replacement, final SingleResultCallback<UpdateResult> callback) {
+    public void replaceOne(final Bson filter, final TDocument replacement, final SingleResultCallback<UpdateResult> callback) {
         replaceOne(filter, replacement, new UpdateOptions(), callback);
     }
 
     @Override
-    public void replaceOne(final Object filter, final T replacement, final UpdateOptions options,
+    public void replaceOne(final Bson filter, final TDocument replacement, final UpdateOptions options,
                            final SingleResultCallback<UpdateResult> callback) {
-        executeSingleWriteRequest(new UpdateRequest(asBson(filter), asBson(replacement), WriteRequest.Type.REPLACE)
+        executeSingleWriteRequest(new UpdateRequest(toBsonDocument(filter), documentToBsonDocument(replacement), WriteRequest.Type.REPLACE)
                                   .upsert(options.isUpsert()),
                                   new SingleResultCallback<BulkWriteResult>() {
                                       @Override
@@ -330,68 +334,68 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public void updateOne(final Object filter, final Object update, final SingleResultCallback<UpdateResult> callback) {
+    public void updateOne(final Bson filter, final Bson update, final SingleResultCallback<UpdateResult> callback) {
         updateOne(filter, update, new UpdateOptions(), callback);
     }
 
     @Override
-    public void updateOne(final Object filter, final Object update, final UpdateOptions options,
+    public void updateOne(final Bson filter, final Bson update, final UpdateOptions options,
                           final SingleResultCallback<UpdateResult> callback) {
         update(filter, update, options, false, callback);
     }
 
     @Override
-    public void updateMany(final Object filter, final Object update, final SingleResultCallback<UpdateResult> callback) {
+    public void updateMany(final Bson filter, final Bson update, final SingleResultCallback<UpdateResult> callback) {
         updateMany(filter, update, new UpdateOptions(), callback);
     }
 
     @Override
-    public void updateMany(final Object filter, final Object update, final UpdateOptions options,
+    public void updateMany(final Bson filter, final Bson update, final UpdateOptions options,
                            final SingleResultCallback<UpdateResult> callback) {
         update(filter, update, options, true, callback);
     }
 
     @Override
-    public void findOneAndDelete(final Object filter, final SingleResultCallback<T> callback) {
+    public void findOneAndDelete(final Bson filter, final SingleResultCallback<TDocument> callback) {
         findOneAndDelete(filter, new FindOneAndDeleteOptions(), callback);
     }
 
     @Override
-    public void findOneAndDelete(final Object filter, final FindOneAndDeleteOptions options, final SingleResultCallback<T> callback) {
-        executor.execute(new FindAndDeleteOperation<T>(namespace, getCodec())
-                         .filter(asBson(filter))
-                         .projection(asBson(options.getProjection()))
-                         .sort(asBson(options.getSort())), callback);
+    public void findOneAndDelete(final Bson filter, final FindOneAndDeleteOptions options, final SingleResultCallback<TDocument> callback) {
+        executor.execute(new FindAndDeleteOperation<TDocument>(namespace, getCodec())
+                         .filter(toBsonDocument(filter))
+                         .projection(toBsonDocument(options.getProjection()))
+                         .sort(toBsonDocument(options.getSort())), callback);
     }
 
     @Override
-    public void findOneAndReplace(final Object filter, final T replacement, final SingleResultCallback<T> callback) {
+    public void findOneAndReplace(final Bson filter, final TDocument replacement, final SingleResultCallback<TDocument> callback) {
         findOneAndReplace(filter, replacement, new FindOneAndReplaceOptions(), callback);
     }
 
     @Override
-    public void findOneAndReplace(final Object filter, final T replacement, final FindOneAndReplaceOptions options,
-                                  final SingleResultCallback<T> callback) {
-        executor.execute(new FindAndReplaceOperation<T>(namespace, getCodec(), asBson(replacement))
-                         .filter(asBson(filter))
-                         .projection(asBson(options.getProjection()))
-                         .sort(asBson(options.getSort()))
+    public void findOneAndReplace(final Bson filter, final TDocument replacement, final FindOneAndReplaceOptions options,
+                                  final SingleResultCallback<TDocument> callback) {
+        executor.execute(new FindAndReplaceOperation<TDocument>(namespace, getCodec(), documentToBsonDocument(replacement))
+                         .filter(toBsonDocument(filter))
+                         .projection(toBsonDocument(options.getProjection()))
+                         .sort(toBsonDocument(options.getSort()))
                          .returnOriginal(options.getReturnOriginal())
                          .upsert(options.isUpsert()), callback);
     }
 
     @Override
-    public void findOneAndUpdate(final Object filter, final Object update, final SingleResultCallback<T> callback) {
+    public void findOneAndUpdate(final Bson filter, final Bson update, final SingleResultCallback<TDocument> callback) {
         findOneAndUpdate(filter, update, new FindOneAndUpdateOptions(), callback);
     }
 
     @Override
-    public void findOneAndUpdate(final Object filter, final Object update, final FindOneAndUpdateOptions options,
-                                 final SingleResultCallback<T> callback) {
-        executor.execute(new FindAndUpdateOperation<T>(namespace, getCodec(), asBson(update))
-                         .filter(asBson(filter))
-                         .projection(asBson(options.getProjection()))
-                         .sort(asBson(options.getSort()))
+    public void findOneAndUpdate(final Bson filter, final Bson update, final FindOneAndUpdateOptions options,
+                                 final SingleResultCallback<TDocument> callback) {
+        executor.execute(new FindAndUpdateOperation<TDocument>(namespace, getCodec(), toBsonDocument(update))
+                         .filter(toBsonDocument(filter))
+                         .projection(toBsonDocument(options.getProjection()))
+                         .sort(toBsonDocument(options.getSort()))
                          .returnOriginal(options.getReturnOriginal())
                          .upsert(options.isUpsert()), callback);
     }
@@ -402,20 +406,20 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public void createIndex(final Object key, final SingleResultCallback<Void> callback) {
+    public void createIndex(final Bson key, final SingleResultCallback<Void> callback) {
         createIndex(key, new CreateIndexOptions(), callback);
     }
 
     @Override
-    public void createIndex(final Object key, final CreateIndexOptions options, final SingleResultCallback<Void> callback) {
-        executor.execute(new CreateIndexOperation(getNamespace(), asBson(key))
+    public void createIndex(final Bson key, final CreateIndexOptions options, final SingleResultCallback<Void> callback) {
+        executor.execute(new CreateIndexOperation(getNamespace(), toBsonDocument(key))
                          .name(options.getName())
                          .background(options.isBackground())
                          .unique(options.isUnique())
                          .sparse(options.isSparse())
                          .expireAfterSeconds(options.getExpireAfterSeconds())
                          .version(options.getVersion())
-                         .weights(asBson(options.getWeights()))
+                         .weights(toBsonDocument(options.getWeights()))
                          .defaultLanguage(options.getDefaultLanguage())
                          .languageOverride(options.getLanguageOverride())
                          .textIndexVersion(options.getTextIndexVersion())
@@ -432,8 +436,8 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public <C> ListIndexesIterable<C> listIndexes(final Class<C> clazz) {
-        return new ListIndexesIterableImpl<C>(namespace, clazz, codecRegistry, readPreference, executor);
+    public <TResult> ListIndexesIterable<TResult> listIndexes(final Class<TResult> clazz) {
+        return new ListIndexesIterableImpl<TResult>(namespace, clazz, codecRegistry, readPreference, executor);
     }
 
     @Override
@@ -458,8 +462,8 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
                          .dropTarget(options.isDropTarget()), callback);
     }
 
-    private void delete(final Object filter, final boolean multi, final SingleResultCallback<DeleteResult> callback) {
-        executeSingleWriteRequest(new DeleteRequest(asBson(filter)).multi(multi), new SingleResultCallback<BulkWriteResult>() {
+    private void delete(final Bson filter, final boolean multi, final SingleResultCallback<DeleteResult> callback) {
+        executeSingleWriteRequest(new DeleteRequest(toBsonDocument(filter)).multi(multi), new SingleResultCallback<BulkWriteResult>() {
             @Override
             public void onResult(final BulkWriteResult result, final Throwable t) {
                 if (t != null) {
@@ -476,9 +480,9 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
         });
     }
 
-    private void update(final Object filter, final Object update, final UpdateOptions updateOptions, final boolean multi,
+    private void update(final Bson filter, final Bson update, final UpdateOptions updateOptions, final boolean multi,
                         final SingleResultCallback<UpdateResult> callback) {
-        executeSingleWriteRequest(new UpdateRequest(asBson(filter), asBson(update), WriteRequest.Type.UPDATE)
+        executeSingleWriteRequest(new UpdateRequest(toBsonDocument(filter), toBsonDocument(update), WriteRequest.Type.UPDATE)
                                   .upsert(updateOptions.isUpsert()).multi(multi), new SingleResultCallback<BulkWriteResult>() {
             @Override
             public void onResult(final BulkWriteResult result, final Throwable t) {
@@ -522,16 +526,19 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
         }
     }
 
-    private Codec<T> getCodec() {
+    private Codec<TDocument> getCodec() {
         return getCodec(clazz);
     }
 
-    private <C> Codec<C> getCodec(final Class<C> clazz) {
+    private <TResult> Codec<TResult> getCodec(final Class<TResult> clazz) {
         return codecRegistry.get(clazz);
     }
 
-    private BsonDocument asBson(final Object document) {
+    private BsonDocument documentToBsonDocument(final TDocument document) {
         return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
     }
 
+    private BsonDocument toBsonDocument(final Bson document) {
+        return document == null ? null : document.toBsonDocument(clazz, codecRegistry);
+    }
 }

--- a/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
@@ -107,10 +107,10 @@ class MongoCollectionSpecification extends Specification {
 
         when:
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, writeConcern,
-                executor).withDefaultClass(newClass)
+                executor).withDocumentClass(newClass)
 
         then:
-        collection.getDefaultClass() == newClass
+        collection.getDocumentClass() == newClass
         expect collection, isTheSameAs(new MongoCollectionImpl(namespace, newClass, codecRegistry, readPreference, writeConcern,
                 executor))
     }

--- a/driver-core/src/main/com/mongodb/client/model/CountOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/CountOptions.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.client.model;
 
+import org.bson.conversions.Bson;
+
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
@@ -27,7 +29,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  * @mongodb.driver.manual reference/command/count/ Count
  */
 public class CountOptions {
-    private Object hint;
+    private Bson hint;
     private String hintString;
     private long limit;
     private long maxTimeMS;
@@ -38,7 +40,7 @@ public class CountOptions {
      *
      * @return the hint, which should describe an existing
      */
-    public Object getHint() {
+    public Bson getHint() {
         return hint;
     }
 
@@ -57,7 +59,7 @@ public class CountOptions {
      * @param hint a document describing the index which should be used for this operation.
      * @return this
      */
-    public CountOptions hint(final Object hint) {
+    public CountOptions hint(final Bson hint) {
         this.hint = hint;
         return this;
     }

--- a/driver-core/src/main/com/mongodb/client/model/CreateIndexOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/CreateIndexOptions.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.client.model;
 
+import org.bson.conversions.Bson;
+
 import java.util.List;
 
 import static com.mongodb.assertions.Assertions.isTrueArgument;
@@ -36,7 +38,7 @@ public class CreateIndexOptions {
     private boolean sparse;
     private Integer expireAfterSeconds;
     private Integer version;
-    private Object weights;
+    private Bson weights;
     private String defaultLanguage;
     private String languageOverride;
     private Integer textIndexVersion;
@@ -177,7 +179,7 @@ public class CreateIndexOptions {
      * @return the weighting object
      * @mongodb.driver.manual tutorial/control-results-of-text-search Control Search Results with Weights
      */
-    public Object getWeights() {
+    public Bson getWeights() {
         return weights;
     }
 
@@ -191,7 +193,7 @@ public class CreateIndexOptions {
      * @return this
      * @mongodb.driver.manual tutorial/control-results-of-text-search Control Search Results with Weights
      */
-    public CreateIndexOptions weights(final Object weights) {
+    public CreateIndexOptions weights(final Bson weights) {
         this.weights = weights;
         return this;
     }

--- a/driver-core/src/main/com/mongodb/client/model/DeleteManyModel.java
+++ b/driver-core/src/main/com/mongodb/client/model/DeleteManyModel.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.client.model;
 
+import org.bson.conversions.Bson;
+
 import static com.mongodb.assertions.Assertions.notNull;
 
 /**
@@ -27,15 +29,14 @@ import static com.mongodb.assertions.Assertions.notNull;
  * @mongodb.driver.manual tutorial/remove-documents/ Remove
  */
 public final class DeleteManyModel<T> extends WriteModel<T> {
-    private final Object filter;
+    private final Bson filter;
 
     /**
      * Construct a new instance.
      *
-     * @param filter a document describing the query filter, which may not be null. The filter can be of any type for which a
-     * {@code Codec} is registered
+     * @param filter a document describing the query filter, which may not be null.
      */
-    public DeleteManyModel(final Object filter) {
+    public DeleteManyModel(final Bson filter) {
         this.filter = notNull("filter", filter);
     }
 
@@ -44,7 +45,7 @@ public final class DeleteManyModel<T> extends WriteModel<T> {
      *
      * @return the query filter
      */
-    public Object getFilter() {
+    public Bson getFilter() {
         return filter;
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/DeleteOneModel.java
+++ b/driver-core/src/main/com/mongodb/client/model/DeleteOneModel.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.client.model;
 
+import org.bson.conversions.Bson;
+
 import static com.mongodb.assertions.Assertions.notNull;
 
 /**
@@ -27,15 +29,14 @@ import static com.mongodb.assertions.Assertions.notNull;
  * @mongodb.driver.manual tutorial/remove-documents/ Remove
  */
 public class DeleteOneModel<T> extends WriteModel<T> {
-    private final Object filter;
+    private final Bson filter;
 
     /**
      * Construct a new instance.
      *
-     * @param filter a document describing the query filter, which may not be null. The filter can be of any type for which a
-     * {@code Codec} is registered
+     * @param filter a document describing the query filter, which may not be null.
      */
-    public DeleteOneModel(final Object filter) {
+    public DeleteOneModel(final Bson filter) {
         this.filter = notNull("filter", filter);
     }
 
@@ -44,7 +45,7 @@ public class DeleteOneModel<T> extends WriteModel<T> {
      *
      * @return the query filter
      */
-    public Object getFilter() {
+    public Bson getFilter() {
         return filter;
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/Filters.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filters.java
@@ -1,0 +1,300 @@
+package com.mongodb.client.model;
+
+import org.bson.BsonArray;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWriter;
+import org.bson.BsonValue;
+import org.bson.codecs.Encoder;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.util.Map;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static java.util.Arrays.asList;
+
+/**
+ * A factory for query filters. A convenient way to use this class is to statically import all of its methods, which allows usage like:
+ * <p><blockquote><pre>
+ *    collection.find(and(eq("x", 1), lt("y", 3)));
+ * </p></pre></blockquote>
+ * @since 3.0
+ */
+public final class Filters {
+
+    private Filters() {
+    }
+
+    /**
+     * Creates a filter that ands together the provided list of filters.  Note that this will only generate a "$and" operator if absolutely
+     * necessary, as the query language implicity ands together all the keys.
+     *
+     * @param filters the list of filters to and together
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/and $and
+     */
+    public static Bson and(final Iterable<Bson> filters) {
+        return new AndFilter(filters);
+    }
+
+    /**
+     * Creates a filter that ands together the provided list of filters.  Note that this will only generate a "$and" operator if absolutely
+     * necessary, as the query language implicity ands together all the keys.
+     *
+     * @param filters the list of filters to and together
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/and $and
+     */
+    public static Bson and(final Bson... filters) {
+        return and(asList(filters));
+    }
+
+    /**
+     * Creates a filter that ands together the provided list of filters.  Note that this will only generate a "$and" operator if absolutely
+     * necessary, as the query language implicity ands together all the keys.
+     *
+     * @param filters the list of filters to and together
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/and $and
+     */
+    public static Bson or(final Iterable<Bson> filters) {
+        return new OrFilter(filters);
+    }
+
+    /**
+     * Creates a filter that ands together the provided list of filters.  Note that this will only generate a "$and" operator if absolutely
+     * necessary, as the query language implicity ands together all the keys.
+     *
+     * @param filters the list of filters to and together
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/and $and
+     */
+    public static Bson or(final Bson... filters) {
+        return or(asList(filters));
+    }
+
+    /**
+     * Creates a filter that matches all documents where the value of the field name equals the specified value. Note that this does
+     * actually generate a $eq operator, as the query language doesn't require it.
+     *
+     * @param fieldName the field name
+     * @param value     the value
+     * @param <TField>  the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/eq $eq
+     */
+    public static <TField> Bson eq(final String fieldName, final TField value) {
+        return new Bson() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+                BsonDocumentWriter writer = new BsonDocumentWriter(new BsonDocument());
+
+                writer.writeStartDocument();
+                writer.writeName(fieldName);
+                ((Encoder) codecRegistry.get(value.getClass())).encode(writer, value, EncoderContext.builder().build());
+                writer.writeEndDocument();
+
+                return writer.getDocument();
+            }
+        };
+    }
+
+
+    /**
+     * Creates a filter that matches all documents that contain the given field.
+     *
+     * @param fieldName the field name
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/exists $exists
+     */
+    public static Bson exists(final String fieldName) {
+        return exists(fieldName, true);
+    }
+
+    /**
+     * Creates a filter that matches all documents that either contain or do not contain the given field, depending on the value of the
+     * exists parameter.
+     *
+     * @param fieldName the field name
+     * @param exists true to check for existence, false to check for absence
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/exists $exists
+     */
+
+    public static Bson exists(final String fieldName, final boolean exists) {
+        return new OperatorFilter<BsonBoolean>("$exists", fieldName, BsonBoolean.valueOf(exists));
+    }
+
+    /**
+     * Creates a filter that matches all documents where the value of the given field is greater than the specified value.
+     *
+     * @param fieldName the field name
+     * @param value the value
+     * @param <TField> the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/gt $gt
+     */
+    public static <TField> Bson gt(final String fieldName, final TField value) {
+
+        return new OperatorFilter<TField>("$gt", fieldName, value);
+    }
+
+    /**
+     * Creates a filter that matches all documents where the value of the given field is less than the specified value.
+     *
+     * @param fieldName the field name
+     * @param value the value
+     * @param <TField> the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/gt $gt
+     */
+    public static <TField> Bson lt(final String fieldName, final TField value) {
+        return new OperatorFilter<TField>("$lt", fieldName, value);
+    }
+
+    /**
+     * Creates a filter that matches all documents where the value of the given field is greater than or equal to the specified value.
+     *
+     * @param fieldName the field name
+     * @param value the value
+     * @param <TField> the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/gt $gt
+     */
+    public static <TField> Bson gte(final String fieldName, final TField value) {
+        return new OperatorFilter<TField>("$gte", fieldName, value);
+    }
+
+    /**
+     * Creates a filter that matches all documents where the value of the given field is less than or equal to the specified value.
+     *
+     * @param fieldName the field name
+     * @param value the value
+     * @param <TField> the value type
+     * @return the filter
+     * @mongodb.driver.manual reference/operator/query/gt $gt
+     */
+    public static <TField> Bson lte(final String fieldName, final TField value) {
+        return new OperatorFilter<TField>("$lte", fieldName, value);
+    }
+
+    private static final class OperatorFilter<TField> implements Bson {
+        private final String operatorName;
+        private final String fieldName;
+        private final TField value;
+
+        OperatorFilter(final String operatorName, final String fieldName, final TField value) {
+            this.operatorName = notNull("operatorName", operatorName);
+            this.fieldName = notNull("fieldName", fieldName);
+            this.value = value;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+            BsonDocumentWriter writer = new BsonDocumentWriter(new BsonDocument());
+
+            writer.writeStartDocument();
+            writer.writeName(fieldName);
+            writer.writeStartDocument();
+            writer.writeName(operatorName);
+            ((Encoder) codecRegistry.get(value.getClass())).encode(writer, value, EncoderContext.builder().build());
+            writer.writeEndDocument();
+            writer.writeEndDocument();
+
+            return writer.getDocument();
+        }
+    }
+
+    private static class AndFilter implements Bson {
+        private final Iterable<Bson> filters;
+
+        public AndFilter(final Iterable<Bson> filters) {
+            this.filters = filters;
+        }
+
+        @Override
+        public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+            BsonDocument andRenderable = new BsonDocument();
+
+            for (Bson filter : filters) {
+                BsonDocument renderedRenderable = filter.toBsonDocument(documentClass, codecRegistry);
+                for (Map.Entry<String, BsonValue> element : renderedRenderable.entrySet()) {
+                    addClause(andRenderable, element);
+                }
+            }
+
+            return andRenderable;
+        }
+
+        private void addClause(final BsonDocument document, final Map.Entry<String, BsonValue> clause) {
+            if (clause.getKey().equals("$and")) {
+                for (BsonValue value : clause.getValue().asArray()) {
+                    for (Map.Entry<String, BsonValue> element : value.asDocument().entrySet()) {
+                        addClause(document, element);
+                    }
+                }
+            } else if (document.size() == 1 && document.keySet().iterator().next().equals("$and")) {
+                document.get("$and").asArray().add(new BsonDocument(clause.getKey(), clause.getValue()));
+            } else if (document.containsKey(clause.getKey())) {
+                if (document.get(clause.getKey()).isDocument() && clause.getValue().isDocument()) {
+                    BsonDocument existingClauseValue = document.get(clause.getKey()).asDocument();
+                    BsonDocument clauseValue = clause.getValue().asDocument();
+                    if (keysIntersect(clauseValue, existingClauseValue)) {
+                        promoteRenderableToDollarForm(document, clause);
+                    } else {
+                        existingClauseValue.putAll(clauseValue);
+                    }
+                } else {
+                    promoteRenderableToDollarForm(document, clause);
+                }
+            } else {
+                document.append(clause.getKey(), clause.getValue());
+            }
+        }
+
+        private boolean keysIntersect(final BsonDocument first, final BsonDocument second) {
+            for (String name : first.keySet()) {
+                if (second.containsKey(name)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private void promoteRenderableToDollarForm(final BsonDocument document, final Map.Entry<String, BsonValue> clause) {
+            BsonArray clauses = new BsonArray();
+            for (Map.Entry<String, BsonValue> queryElement : document.entrySet()) {
+                clauses.add(new BsonDocument(queryElement.getKey(), queryElement.getValue()));
+            }
+            clauses.add(new BsonDocument(clause.getKey(), clause.getValue()));
+            document.clear();
+            document.put("$and", clauses);
+        }
+    }
+
+    private static class OrFilter implements Bson {
+        private final Iterable<Bson> filters;
+
+        public OrFilter(final Iterable<Bson> filters) {
+            this.filters = filters;
+        }
+
+        @Override
+        public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+            BsonDocument orRenderable = new BsonDocument();
+
+            BsonArray filtersArray = new BsonArray();
+            for (Bson filter : filters) {
+                filtersArray.add(filter.toBsonDocument(documentClass, codecRegistry));
+            }
+
+            orRenderable.put("$or", filtersArray);
+
+            return orRenderable;
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/FindOneAndDeleteOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/FindOneAndDeleteOptions.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.client.model;
 
+import org.bson.conversions.Bson;
+
 /**
  * The options to apply to an operation that atomically finds a document and deletes it.
  *
@@ -23,8 +25,8 @@ package com.mongodb.client.model;
  * @mongodb.driver.manual reference/command/findAndModify/
  */
 public class FindOneAndDeleteOptions {
-    private Object projection;
-    private Object sort;
+    private Bson projection;
+    private Bson sort;
 
     /**
      * Gets a document describing the fields to return for all matching documents.
@@ -32,19 +34,18 @@ public class FindOneAndDeleteOptions {
      * @return the project document, which may be null
      * @mongodb.driver.manual tutorial/project-fields-from-query-results Projection
      */
-    public Object getProjection() {
+    public Bson getProjection() {
         return projection;
     }
 
     /**
      * Sets a document describing the fields to return for all matching documents.
      *
-     * @param projection the project document, which may be null. This can be of any type for which a
-     * {@code Codec} is registered
+     * @param projection the project document, which may be null.
      * @return this
      * @mongodb.driver.manual tutorial/project-fields-from-query-results Projection
      */
-    public FindOneAndDeleteOptions projection(final Object projection) {
+    public FindOneAndDeleteOptions projection(final Bson projection) {
         this.projection = projection;
         return this;
     }
@@ -56,19 +57,18 @@ public class FindOneAndDeleteOptions {
      * @return a document describing the sort criteria
      * @mongodb.driver.manual reference/method/cursor.sort/ Sort
      */
-    public Object getSort() {
+    public Bson getSort() {
         return sort;
     }
 
     /**
      * Sets the sort criteria to apply to the query.
      *
-     * @param sort the sort criteria, which may be null. This can be of any type for which a
-     * {@code Codec} is registered
+     * @param sort the sort criteria, which may be null.
      * @return this
      * @mongodb.driver.manual reference/method/cursor.sort/ Sort
      */
-    public FindOneAndDeleteOptions sort(final Object sort) {
+    public FindOneAndDeleteOptions sort(final Bson sort) {
         this.sort = sort;
         return this;
     }

--- a/driver-core/src/main/com/mongodb/client/model/FindOneAndReplaceOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/FindOneAndReplaceOptions.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.client.model;
 
+import org.bson.conversions.Bson;
+
 /**
  * The options to apply to an operation that atomically finds a document and replaces it.
  *
@@ -23,8 +25,8 @@ package com.mongodb.client.model;
  * @since 3.0
  */
 public class FindOneAndReplaceOptions {
-    private Object projection;
-    private Object sort;
+    private Bson projection;
+    private Bson sort;
     private boolean upsert;
     private boolean returnOriginal = true;
 
@@ -34,18 +36,18 @@ public class FindOneAndReplaceOptions {
      * @return the project document, which may be null
      * @mongodb.driver.manual tutorial/project-fields-from-query-results Projection
      */
-    public Object getProjection() {
+    public Bson getProjection() {
         return projection;
     }
 
     /**
      * Sets a document describing the fields to return for all matching documents.
      *
-     * @param projection the project document, which may be null. This can be of any type for which a {@code Codec} is registered
+     * @param projection the project document, which may be null.
      * @return this
      * @mongodb.driver.manual tutorial/project-fields-from-query-results Projection
      */
-    public FindOneAndReplaceOptions projection(final Object projection) {
+    public FindOneAndReplaceOptions projection(final Bson projection) {
         this.projection = projection;
         return this;
     }
@@ -57,18 +59,18 @@ public class FindOneAndReplaceOptions {
      * @return a document describing the sort criteria
      * @mongodb.driver.manual reference/method/cursor.sort/ Sort
      */
-    public Object getSort() {
+    public Bson getSort() {
         return sort;
     }
 
     /**
      * Sets the sort criteria to apply to the query.
      *
-     * @param sort the sort criteria, which may be null. This can be of any type for which a {@code Codec} is registered
+     * @param sort the sort criteria, which may be null.
      * @return this
      * @mongodb.driver.manual reference/method/cursor.sort/ Sort
      */
-    public FindOneAndReplaceOptions sort(final Object sort) {
+    public FindOneAndReplaceOptions sort(final Bson sort) {
         this.sort = sort;
         return this;
     }

--- a/driver-core/src/main/com/mongodb/client/model/FindOneAndUpdateOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/FindOneAndUpdateOptions.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.client.model;
 
+import org.bson.conversions.Bson;
+
 /**
  * The options to apply to an operation that atomically finds a document and updates it.
  *
@@ -23,8 +25,8 @@ package com.mongodb.client.model;
  * @mongodb.driver.manual reference/command/findAndModify/
  */
 public class FindOneAndUpdateOptions {
-    private Object projection;
-    private Object sort;
+    private Bson projection;
+    private Bson sort;
     private boolean upsert;
     private boolean returnOriginal = true;
 
@@ -34,19 +36,18 @@ public class FindOneAndUpdateOptions {
      * @return the project document, which may be null
      * @mongodb.driver.manual tutorial/project-fields-from-query-results Projection
      */
-    public Object getProjection() {
+    public Bson getProjection() {
         return projection;
     }
 
     /**
      * Sets a document describing the fields to return for all matching documents.
      *
-     * @param projection the project document, which may be null. This can be of any type for which a
-     * {@code Codec} is registered
+     * @param projection the project document, which may be null.
      * @return this
      * @mongodb.driver.manual tutorial/project-fields-from-query-results Projection
      */
-    public FindOneAndUpdateOptions projection(final Object projection) {
+    public FindOneAndUpdateOptions projection(final Bson projection) {
         this.projection = projection;
         return this;
     }
@@ -58,19 +59,18 @@ public class FindOneAndUpdateOptions {
      * @return a document describing the sort criteria
      * @mongodb.driver.manual reference/method/cursor.sort/ Sort
      */
-    public Object getSort() {
+    public Bson getSort() {
         return sort;
     }
 
     /**
      * Sets the sort criteria to apply to the query.
      *
-     * @param sort the sort criteria, which may be null. This can be of any type for which a
-     * {@code Codec} is registered
+     * @param sort the sort criteria, which may be null.
      * @return this
      * @mongodb.driver.manual reference/method/cursor.sort/ Sort
      */
-    public FindOneAndUpdateOptions sort(final Object sort) {
+    public FindOneAndUpdateOptions sort(final Bson sort) {
         this.sort = sort;
         return this;
     }

--- a/driver-core/src/main/com/mongodb/client/model/FindOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/FindOptions.java
@@ -17,6 +17,7 @@
 package com.mongodb.client.model;
 
 import com.mongodb.CursorType;
+import org.bson.conversions.Bson;
 
 import java.util.concurrent.TimeUnit;
 
@@ -32,11 +33,11 @@ import static com.mongodb.assertions.Assertions.notNull;
 public final class FindOptions {
     private int batchSize;
     private int limit;
-    private Object modifiers;
-    private Object projection;
+    private Bson modifiers;
+    private Bson projection;
     private long maxTimeMS;
     private int skip;
-    private Object sort;
+    private Bson sort;
     private CursorType cursorType = CursorType.NonTailable;
     private boolean noCursorTimeout;
     private boolean oplogReplay;
@@ -165,7 +166,7 @@ public final class FindOptions {
      * @return the query modifiers, which may be null
      * @mongodb.driver.manual reference/operator/query-modifier/ Query Modifiers
      */
-    public Object getModifiers() {
+    public Bson getModifiers() {
         return modifiers;
     }
 
@@ -176,7 +177,7 @@ public final class FindOptions {
      * @return this
      * @mongodb.driver.manual reference/operator/query-modifier/ Query Modifiers
      */
-    public FindOptions modifiers(final Object modifiers) {
+    public FindOptions modifiers(final Bson modifiers) {
         this.modifiers = modifiers;
         return this;
     }
@@ -187,7 +188,7 @@ public final class FindOptions {
      * @return the project document, which may be null
      * @mongodb.driver.manual reference/method/db.collection.find/ Projection
      */
-    public Object getProjection() {
+    public Bson getProjection() {
         return projection;
     }
 
@@ -198,7 +199,7 @@ public final class FindOptions {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Projection
      */
-    public FindOptions projection(final Object projection) {
+    public FindOptions projection(final Bson projection) {
         this.projection = projection;
         return this;
     }
@@ -210,7 +211,7 @@ public final class FindOptions {
      * @return a document describing the sort criteria
      * @mongodb.driver.manual reference/method/cursor.sort/ Sort
      */
-    public Object getSort() {
+    public Bson getSort() {
         return sort;
     }
 
@@ -221,7 +222,7 @@ public final class FindOptions {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.sort/ Sort
      */
-    public FindOptions sort(final Object sort) {
+    public FindOptions sort(final Bson sort) {
         this.sort = sort;
         return this;
     }

--- a/driver-core/src/main/com/mongodb/client/model/ReplaceOneModel.java
+++ b/driver-core/src/main/com/mongodb/client/model/ReplaceOneModel.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.client.model;
 
+import org.bson.conversions.Bson;
+
 import static com.mongodb.assertions.Assertions.notNull;
 
 /**
@@ -26,30 +28,28 @@ import static com.mongodb.assertions.Assertions.notNull;
  * @mongodb.driver.manual tutorial/modify-documents/#replace-the-document Replace
  */
 public final class ReplaceOneModel<T> extends WriteModel<T> {
-    private final Object filter;
+    private final Bson filter;
     private final T replacement;
     private final UpdateOptions options;
 
     /**
      * Construct a new instance.
      *
-     * @param filter    a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec}
-     *                    is registered
+     * @param filter    a document describing the query filter, which may not be null.
      * @param replacement the replacement document
      */
-    public ReplaceOneModel(final Object filter, final T replacement) {
+    public ReplaceOneModel(final Bson filter, final T replacement) {
         this(filter, replacement, new UpdateOptions());
     }
 
     /**
      * Construct a new instance.
      *
-     * @param filter    a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec}
-     *                    is registered
+     * @param filter    a document describing the query filter, which may not be null.
      * @param replacement the replacement document
      * @param options     the options to apply
      */
-    public ReplaceOneModel(final Object filter, final T replacement, final UpdateOptions options) {
+    public ReplaceOneModel(final Bson filter, final T replacement, final UpdateOptions options) {
         this.filter = notNull("filter", filter);
         this.replacement = notNull("replacement", replacement);
         this.options = notNull("options", options);
@@ -60,7 +60,7 @@ public final class ReplaceOneModel<T> extends WriteModel<T> {
      *
      * @return the query filter
      */
-    public Object getFilter() {
+    public Bson getFilter() {
         return filter;
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/UpdateManyModel.java
+++ b/driver-core/src/main/com/mongodb/client/model/UpdateManyModel.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.client.model;
 
+import org.bson.conversions.Bson;
+
 import static com.mongodb.assertions.Assertions.notNull;
 
 /**
@@ -29,32 +31,30 @@ import static com.mongodb.assertions.Assertions.notNull;
  * @mongodb.driver.manual reference/operator/update/ Update Operators
  */
 public final class UpdateManyModel<T> extends WriteModel<T> {
-    private final Object filter;
-    private final Object update;
+    private final Bson filter;
+    private final Bson update;
     private final UpdateOptions options;
 
     /**
      * Construct a new instance.
      *
-     * @param filter a document describing the query filter, which may not be null. This can be of any type for which a
-     * {@code Codec} is registered
+     * @param filter a document describing the query filter, which may not be null.
      * @param update a document describing the update, which may not be null. The update to apply must include only update
-     * operators. This can be of any type for which a {@code Codec} is registered
+     * operators.
      */
-    public UpdateManyModel(final Object filter, final Object update) {
+    public UpdateManyModel(final Bson filter, final Bson update) {
         this(filter, update, new UpdateOptions());
     }
 
     /**
      * Construct a new instance.
      *
-     * @param filter a document describing the query filter, which may not be null. This can be of any type for which a
-     * {@code Codec} is registered
+     * @param filter a document describing the query filter, which may not be null.
      * @param update a document describing the update, which may not be null. The update to apply must include only update
-     * operators. This can be of any type for which a {@code Codec} is registered
+     * operators.
      * @param options the options to apply
      */
-    public UpdateManyModel(final Object filter, final Object update, final UpdateOptions options) {
+    public UpdateManyModel(final Bson filter, final Bson update, final UpdateOptions options) {
         this.filter = notNull("filter", filter);
         this.update = notNull("update", update);
         this.options = notNull("options", options);
@@ -65,7 +65,7 @@ public final class UpdateManyModel<T> extends WriteModel<T> {
      *
      * @return the query filtert
      */
-    public Object getFilter() {
+    public Bson getFilter() {
         return filter;
     }
 
@@ -75,7 +75,7 @@ public final class UpdateManyModel<T> extends WriteModel<T> {
      *
      * @return the document specifying the updates to apply
      */
-    public Object getUpdate() {
+    public Bson getUpdate() {
         return update;
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/UpdateOneModel.java
+++ b/driver-core/src/main/com/mongodb/client/model/UpdateOneModel.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.client.model;
 
+import org.bson.conversions.Bson;
+
 import static com.mongodb.assertions.Assertions.notNull;
 
 /**
@@ -29,32 +31,28 @@ import static com.mongodb.assertions.Assertions.notNull;
  * @since 3.0
  */
 public final class UpdateOneModel<T> extends WriteModel<T> {
-    private final Object filter;
-    private final Object update;
+    private final Bson filter;
+    private final Bson update;
     private final UpdateOptions options;
 
     /**
      * Construct a new instance.
      *
-     * @param filter a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec} is
-     *                 registered
-     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators. This
-     *                 can be of any type for which a {@code Codec} is registered
+     * @param filter a document describing the query filter, which may not be null.
+     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators.
      */
-    public UpdateOneModel(final Object filter, final Object update) {
+    public UpdateOneModel(final Bson filter, final Bson update) {
         this(filter, update, new UpdateOptions());
     }
 
     /**
      * Construct a new instance.
      *
-     * @param filter a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec} is
-     *                 registered
-     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators. This
-     *                 can be of any type for which a {@code Codec} is registered
+     * @param filter a document describing the query filter, which may not be null.
+     * @param update   a document describing the update, which may not be null. The update to apply must include only update operators.
      * @param options the options to apply
      */
-    public UpdateOneModel(final Object filter, final Object update, final UpdateOptions options) {
+    public UpdateOneModel(final Bson filter, final Bson update, final UpdateOptions options) {
         this.filter = notNull("filter", filter);
         this.update = notNull("update", update);
         this.options = notNull("options", options);
@@ -65,7 +63,7 @@ public final class UpdateOneModel<T> extends WriteModel<T> {
      *
      * @return the query filter
      */
-    public Object getFilter() {
+    public Bson getFilter() {
         return filter;
     }
 
@@ -74,7 +72,7 @@ public final class UpdateOneModel<T> extends WriteModel<T> {
      *
      * @return the document specifying the updates to apply
      */
-    public Object getUpdate() {
+    public Bson getUpdate() {
         return update;
     }
 

--- a/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
@@ -1,0 +1,84 @@
+package com.mongodb.client.model
+
+import org.bson.BsonDocument
+import org.bson.codecs.BsonValueCodecProvider
+import org.bson.codecs.ValueCodecProvider
+import org.bson.codecs.configuration.RootCodecRegistry
+import spock.lang.Specification
+
+import static Filters.and
+import static Filters.eq
+import static Filters.exists
+import static Filters.gt
+import static Filters.gte
+import static Filters.lt
+import static Filters.lte
+import static Filters.or
+import static org.bson.BsonDocument.parse
+
+class FiltersSpecification extends Specification {
+    def codecRegistry = new RootCodecRegistry([new BsonValueCodecProvider(), new ValueCodecProvider()]);
+
+    def 'should render filter for eq'() {
+       expect:
+       eq('x', 1).toBsonDocument(BsonDocument, codecRegistry) == parse('{x : 1}')
+    }
+
+    def 'should render filter for $gt'() {
+        expect:
+        gt('x', 1).toBsonDocument(BsonDocument, codecRegistry) == parse('{x : {$gt : 1} }')
+    }
+
+    def 'should render filter for $lt'() {
+        expect:
+        lt('x', 1).toBsonDocument(BsonDocument, codecRegistry) == parse('{x : {$lt : 1} }')
+    }
+
+    def 'should render filter for $gte'() {
+        expect:
+        gte('x', 1).toBsonDocument(BsonDocument, codecRegistry) == parse('{x : {$gte : 1} }')
+    }
+
+    def 'should render filter for $lte'() {
+        expect:
+        lte('x', 1).toBsonDocument(BsonDocument, codecRegistry) == parse('{x : {$lte : 1} }')
+    }
+
+    def 'should render filter for $exists'() {
+        expect:
+        exists('x').toBsonDocument(BsonDocument, codecRegistry) == parse('{x : {$exists : true} }')
+
+        exists('x', false).toBsonDocument(BsonDocument, codecRegistry) == parse('{x : {$exists : false} }')
+    }
+
+    def 'should render filter for or'() {
+        expect:
+        or([eq('x', 1), eq('y', 2)]).toBsonDocument(BsonDocument, codecRegistry) == parse('{$or : [{x : 1}, {y : 2}]}')
+        or(eq('x', 1), eq('y', 2)).toBsonDocument(BsonDocument, codecRegistry) == parse('{$or : [{x : 1}, {y : 2}]}')
+    }
+
+    def 'should render filter for and'() {
+        expect:
+        and([eq('x', 1), eq('y', 2)]).toBsonDocument(BsonDocument, codecRegistry) == parse('{x : 1, y : 2}')
+        and(eq('x', 1), eq('y', 2)).toBsonDocument(BsonDocument, codecRegistry) == parse('{x : 1, y : 2}')
+    }
+
+    def 'should render and with clashing keys by promoting to dollar form'() {
+        expect:
+        and([eq('a', 1), eq('a', 2)]).toBsonDocument(BsonDocument, codecRegistry) == parse('{$and: [{a: 1}, {a: 2}]}');
+    }
+
+    def 'should flatten multiple operators for the same key'() {
+        expect:
+        and([gt('a', 1), lt('a', 9)]).toBsonDocument(BsonDocument, codecRegistry) == parse('{a : {$gt : 1, $lt : 9}}');
+    }
+
+    def 'should flatten nested and filter'() {
+        expect:
+        and([and([eq('a', 1), eq('b', 2)]), eq('c', 3)]).toBsonDocument(BsonDocument, codecRegistry) == parse('{a : 1, b : 2, c : 3}')
+        and([and([eq('a', 1), eq('a', 2)]), eq('c', 3)]).toBsonDocument(BsonDocument, codecRegistry) == parse('{$and:[{a : 1}, {a : 2}, {c : 3}] }')
+        and([lt('a', 1), lt('b', 2)]).toBsonDocument(BsonDocument, codecRegistry) == parse('{a : {$lt : 1}, b : {$lt : 2} }')
+        and([lt('a', 1), lt('a', 2)]).toBsonDocument(BsonDocument, codecRegistry) == parse('{$and : [{a : {$lt : 1}}, {a : {$lt : 2}}]}')
+    }
+
+}

--- a/driver/src/main/com/mongodb/BasicDBObject.java
+++ b/driver/src/main/com/mongodb/BasicDBObject.java
@@ -18,6 +18,10 @@ package com.mongodb;
 
 import com.mongodb.util.JSON;
 import org.bson.BasicBSONObject;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWrapper;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.Map;
 
@@ -31,7 +35,7 @@ import java.util.Map;
  * @mongodb.driver.manual core/document/ MongoDB Documents
  */
 @SuppressWarnings({"rawtypes"})
-public class BasicDBObject extends BasicBSONObject implements DBObject {
+public class BasicDBObject extends BasicBSONObject implements DBObject, Bson {
     private static final long serialVersionUID = -4415279469780082174L;
 
     private boolean isPartialObject;
@@ -133,4 +137,8 @@ public class BasicDBObject extends BasicBSONObject implements DBObject {
         return newCopy;
     }
 
+    @Override
+    public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+        return new BsonDocumentWrapper<BasicDBObject>(this, codecRegistry.get(BasicDBObject.class));
+    }
 }

--- a/driver/src/main/com/mongodb/FindIterableImpl.java
+++ b/driver/src/main/com/mongodb/FindIterableImpl.java
@@ -27,6 +27,7 @@ import org.bson.BsonDocument;
 import org.bson.BsonDocumentWrapper;
 import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
@@ -34,20 +35,23 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-final class FindIterableImpl<T> implements FindIterable<T> {
+final class FindIterableImpl<TResult, TDocument> implements FindIterable<TResult> {
     private final MongoNamespace namespace;
-    private final Class<T> clazz;
+    private final Class<TResult> clazz;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final OperationExecutor executor;
     private final FindOptions findOptions;
-    private Object filter;
+    private final Class<TDocument> collectionClass;
+    private Bson filter;
 
-    FindIterableImpl(final MongoNamespace namespace, final Class<T> clazz, final CodecRegistry codecRegistry,
+    FindIterableImpl(final MongoNamespace namespace, final Class<TResult> clazz, final Class<TDocument> collectionClass,
+                     final CodecRegistry codecRegistry,
                      final ReadPreference readPreference, final OperationExecutor executor,
-                     final Object filter, final FindOptions findOptions) {
+                     final Bson filter, final FindOptions findOptions) {
         this.namespace = notNull("namespace", namespace);
         this.clazz = notNull("clazz", clazz);
+        this.collectionClass = notNull("collectionClass", collectionClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.executor = notNull("executor", executor);
@@ -56,104 +60,104 @@ final class FindIterableImpl<T> implements FindIterable<T> {
     }
 
     @Override
-    public FindIterable<T> filter(final Object filter) {
+    public FindIterable<TResult> filter(final Bson filter) {
         this.filter = filter;
         return this;
     }
 
     @Override
-    public FindIterable<T> limit(final int limit) {
+    public FindIterable<TResult> limit(final int limit) {
         findOptions.limit(limit);
         return this;
     }
 
     @Override
-    public FindIterable<T> skip(final int skip) {
+    public FindIterable<TResult> skip(final int skip) {
         findOptions.skip(skip);
         return this;
     }
 
     @Override
-    public FindIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public FindIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         findOptions.maxTime(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public FindIterable<T> batchSize(final int batchSize) {
+    public FindIterable<TResult> batchSize(final int batchSize) {
         findOptions.batchSize(batchSize);
         return this;
     }
 
     @Override
-    public FindIterable<T> modifiers(final Object modifiers) {
+    public FindIterable<TResult> modifiers(final Bson modifiers) {
         findOptions.modifiers(modifiers);
         return this;
     }
 
     @Override
-    public FindIterable<T> projection(final Object projection) {
+    public FindIterable<TResult> projection(final Bson projection) {
         findOptions.projection(projection);
         return this;
     }
 
     @Override
-    public FindIterable<T> sort(final Object sort) {
+    public FindIterable<TResult> sort(final Bson sort) {
         findOptions.sort(sort);
         return this;
     }
 
     @Override
-    public FindIterable<T> noCursorTimeout(final boolean noCursorTimeout) {
+    public FindIterable<TResult> noCursorTimeout(final boolean noCursorTimeout) {
         findOptions.noCursorTimeout(noCursorTimeout);
         return this;
     }
 
     @Override
-    public FindIterable<T> oplogReplay(final boolean oplogReplay) {
+    public FindIterable<TResult> oplogReplay(final boolean oplogReplay) {
         findOptions.oplogReplay(oplogReplay);
         return this;
     }
 
     @Override
-    public FindIterable<T> partial(final boolean partial) {
+    public FindIterable<TResult> partial(final boolean partial) {
         findOptions.partial(partial);
         return this;
     }
 
     @Override
-    public FindIterable<T> cursorType(final CursorType cursorType) {
+    public FindIterable<TResult> cursorType(final CursorType cursorType) {
         findOptions.cursorType(cursorType);
         return this;
     }
 
     @Override
-    public MongoCursor<T> iterator() {
+    public MongoCursor<TResult> iterator() {
         return execute().iterator();
     }
 
     @Override
-    public T first() {
+    public TResult first() {
         return execute().first();
     }
 
     @Override
-    public <U> MongoIterable<U> map(final Function<T, U> mapper) {
-        return new MappingIterable<T, U>(this, mapper);
+    public <U> MongoIterable<U> map(final Function<TResult, U> mapper) {
+        return new MappingIterable<TResult, U>(this, mapper);
     }
 
     @Override
-    public void forEach(final Block<? super T> block) {
+    public void forEach(final Block<? super TResult> block) {
         execute().forEach(block);
     }
 
     @Override
-    public <A extends Collection<? super T>> A into(final A target) {
+    public <A extends Collection<? super TResult>> A into(final A target) {
         return execute().into(target);
     }
 
-    private MongoIterable<T> execute() {
+    private MongoIterable<TResult> execute() {
         return new FindOperationIterable(createQueryOperation(), this.readPreference, executor);
     }
 
@@ -161,9 +165,9 @@ final class FindIterableImpl<T> implements FindIterable<T> {
         return codecRegistry.get(clazz);
     }
 
-    private FindOperation<T> createQueryOperation() {
-        return new FindOperation<T>(namespace, getCodec(clazz))
-                   .filter(asBson(filter))
+    private FindOperation<TResult> createQueryOperation() {
+        return new FindOperation<TResult>(namespace, getCodec(clazz))
+                   .filter(filter.toBsonDocument(collectionClass, codecRegistry))
                    .batchSize(findOptions.getBatchSize())
                    .skip(findOptions.getSkip())
                    .limit(findOptions.getLimit())
@@ -182,11 +186,11 @@ final class FindIterableImpl<T> implements FindIterable<T> {
         return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
     }
 
-    private final class FindOperationIterable extends OperationIterable<T> {
+    private final class FindOperationIterable extends OperationIterable<TResult> {
         private final ReadPreference readPreference;
         private final OperationExecutor executor;
 
-        FindOperationIterable(final FindOperation<T> operation, final ReadPreference readPreference,
+        FindOperationIterable(final FindOperation<TResult> operation, final ReadPreference readPreference,
                               final OperationExecutor executor) {
             super(operation, readPreference, executor);
             this.readPreference = readPreference;
@@ -194,9 +198,9 @@ final class FindIterableImpl<T> implements FindIterable<T> {
         }
 
         @Override
-        public T first() {
-            FindOperation<T> findFirstOperation = createQueryOperation().batchSize(0).limit(-1);
-            BatchCursor<T> batchCursor = executor.execute(findFirstOperation, readPreference);
+        public TResult first() {
+            FindOperation<TResult> findFirstOperation = createQueryOperation().batchSize(0).limit(-1);
+            BatchCursor<TResult> batchCursor = executor.execute(findFirstOperation, readPreference);
             return batchCursor.hasNext() ? batchCursor.next().iterator().next() : null;
         }
 

--- a/driver/src/main/com/mongodb/MongoCollectionImpl.java
+++ b/driver/src/main/com/mongodb/MongoCollectionImpl.java
@@ -64,6 +64,7 @@ import org.bson.Document;
 import org.bson.codecs.Codec;
 import org.bson.codecs.CollectibleCodec;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -73,18 +74,18 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-class MongoCollectionImpl<T> implements MongoCollection<T> {
+class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private final MongoNamespace namespace;
-    private final Class<T> clazz;
+    private final Class<TDocument> documentClass;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final WriteConcern writeConcern;
     private final OperationExecutor executor;
 
-    MongoCollectionImpl(final MongoNamespace namespace, final Class<T> clazz, final CodecRegistry codecRegistry,
+    MongoCollectionImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final CodecRegistry codecRegistry,
                         final ReadPreference readPreference, final WriteConcern writeConcern, final OperationExecutor executor) {
         this.namespace = notNull("namespace", namespace);
-        this.clazz = notNull("clazz", clazz);
+        this.documentClass = notNull("clazz", documentClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.writeConcern = notNull("writeConcern", writeConcern);
@@ -97,8 +98,8 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public Class<T> getDefaultClass() {
-        return clazz;
+    public Class<TDocument> getDocumentClass() {
+        return documentClass;
     }
 
     @Override
@@ -117,44 +118,44 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public <C> MongoCollection<C> withDefaultClass(final Class<C> clazz) {
-        return new MongoCollectionImpl<C>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
+    public <NewTDocument> MongoCollection<NewTDocument> withDocumentClass(final Class<NewTDocument> clazz) {
+        return new MongoCollectionImpl<NewTDocument>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
     }
 
     @Override
-    public MongoCollection<T> withCodecRegistry(final CodecRegistry codecRegistry) {
-        return new MongoCollectionImpl<T>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
+    public MongoCollection<TDocument> withCodecRegistry(final CodecRegistry codecRegistry) {
+        return new MongoCollectionImpl<TDocument>(namespace, documentClass, codecRegistry, readPreference, writeConcern, executor);
     }
 
     @Override
-    public MongoCollection<T> withReadPreference(final ReadPreference readPreference) {
-        return new MongoCollectionImpl<T>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
+    public MongoCollection<TDocument> withReadPreference(final ReadPreference readPreference) {
+        return new MongoCollectionImpl<TDocument>(namespace, documentClass, codecRegistry, readPreference, writeConcern, executor);
     }
 
     @Override
-    public MongoCollection<T> withWriteConcern(final WriteConcern writeConcern) {
-        return new MongoCollectionImpl<T>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
+    public MongoCollection<TDocument> withWriteConcern(final WriteConcern writeConcern) {
+        return new MongoCollectionImpl<TDocument>(namespace, documentClass, codecRegistry, readPreference, writeConcern, executor);
     }
 
     @Override
     public long count() {
-        return count(new Document(), new CountOptions());
+        return count(new BsonDocument(), new CountOptions());
     }
 
     @Override
-    public long count(final Object filter) {
+    public long count(final Bson filter) {
         return count(filter, new CountOptions());
     }
 
     @Override
-    public long count(final Object filter, final CountOptions options) {
+    public long count(final Bson filter, final CountOptions options) {
         CountOperation operation = new CountOperation(namespace)
-                                       .filter(asBson(filter))
+                                       .filter(toBsonDocument(filter))
                                        .skip(options.getSkip())
                                        .limit(options.getLimit())
                                        .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS);
         if (options.getHint() != null) {
-            operation.hint(asBson(options.getHint()));
+            operation.hint(toBsonDocument(options.getHint()));
         } else if (options.getHintString() != null) {
             operation.hint(new BsonString(options.getHintString()));
         }
@@ -162,38 +163,40 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public <C> DistinctIterable<C> distinct(final String fieldName, final Class<C> clazz) {
-        return new DistinctIterableImpl<C>(namespace, clazz, codecRegistry, readPreference, executor, fieldName);
+    public <TResult> DistinctIterable<TResult> distinct(final String fieldName, final Class<TResult> clazz) {
+        return new DistinctIterableImpl<TResult>(namespace, clazz, codecRegistry, readPreference, executor, fieldName);
     }
 
     @Override
-    public FindIterable<T> find() {
+    public FindIterable<TDocument> find() {
+        return find(new BsonDocument(), documentClass);
+    }
+
+    @Override
+    public <TResult> FindIterable<TResult> find(final Class<TResult> clazz) {
         return find(new BsonDocument(), clazz);
     }
 
     @Override
-    public <C> FindIterable<C> find(final Class<C> clazz) {
-        return find(new BsonDocument(), clazz);
+    public FindIterable<TDocument> find(final Bson filter) {
+        return find(filter, documentClass);
     }
 
     @Override
-    public FindIterable<T> find(final Object filter) {
-        return find(filter, clazz);
+    public <TResult> FindIterable<TResult> find(final Bson filter, final Class<TResult> clazz) {
+        return new FindIterableImpl<TResult, TDocument>(namespace, clazz, this.documentClass, codecRegistry, readPreference, executor,
+                                                        filter, new FindOptions());
     }
 
     @Override
-    public <C> FindIterable<C> find(final Object filter, final Class<C> clazz) {
-        return new FindIterableImpl<C>(namespace, clazz, codecRegistry, readPreference, executor, filter, new FindOptions());
-    }
-
-    @Override
-    public AggregateIterable<Document> aggregate(final List<?> pipeline) {
+    public AggregateIterable<Document> aggregate(final List<? extends Bson> pipeline) {
         return aggregate(pipeline, Document.class);
     }
 
     @Override
-    public <C> AggregateIterable<C> aggregate(final List<?> pipeline, final Class<C> clazz) {
-        return new AggregateIterableImpl<C>(namespace, clazz, codecRegistry, readPreference, executor, pipeline);
+    public <TResult> AggregateIterable<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> clazz) {
+        return new AggregateIterableImpl<TResult, TDocument>(namespace, clazz, this.documentClass, codecRegistry, readPreference, executor,
+                                                             pipeline);
     }
 
     @Override
@@ -202,50 +205,53 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public <C> MapReduceIterable<C> mapReduce(final String mapFunction, final String reduceFunction, final Class<C> clazz) {
-        return new MapReduceIterableImpl<C>(namespace, clazz, codecRegistry, readPreference, executor, mapFunction, reduceFunction);
+    public <TResult> MapReduceIterable<TResult> mapReduce(final String mapFunction, final String reduceFunction,
+                                                          final Class<TResult> clazz) {
+        return new MapReduceIterableImpl<TResult, TDocument>(namespace, clazz, this.documentClass, codecRegistry, readPreference, executor,
+                                                             mapFunction, reduceFunction);
     }
 
     @Override
-    public BulkWriteResult bulkWrite(final List<? extends WriteModel<? extends T>> requests) {
+    public BulkWriteResult bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests) {
         return bulkWrite(requests, new BulkWriteOptions());
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public BulkWriteResult bulkWrite(final List<? extends WriteModel<? extends T>> requests, final BulkWriteOptions options) {
+    public BulkWriteResult bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests, final BulkWriteOptions options) {
         List<WriteRequest> writeRequests = new ArrayList<WriteRequest>(requests.size());
-        for (WriteModel<? extends T> writeModel : requests) {
+        for (WriteModel<? extends TDocument> writeModel : requests) {
             WriteRequest writeRequest;
             if (writeModel instanceof InsertOneModel) {
-                InsertOneModel<T> insertOneModel = (InsertOneModel<T>) writeModel;
+                InsertOneModel<TDocument> insertOneModel = (InsertOneModel<TDocument>) writeModel;
                 if (getCodec() instanceof CollectibleCodec) {
-                    ((CollectibleCodec<T>) getCodec()).generateIdIfAbsentFromDocument(insertOneModel.getDocument());
+                    ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(insertOneModel.getDocument());
                 }
-                writeRequest = new InsertRequest(asBson(insertOneModel.getDocument()));
+                writeRequest = new InsertRequest(documentToBsonDocument(insertOneModel.getDocument()));
             } else if (writeModel instanceof ReplaceOneModel) {
-                ReplaceOneModel<T> replaceOneModel = (ReplaceOneModel<T>) writeModel;
-                writeRequest = new UpdateRequest(asBson(replaceOneModel.getFilter()), asBson(replaceOneModel.getReplacement()),
+                ReplaceOneModel<TDocument> replaceOneModel = (ReplaceOneModel<TDocument>) writeModel;
+                writeRequest = new UpdateRequest(toBsonDocument(replaceOneModel.getFilter()), documentToBsonDocument(replaceOneModel
+                                                                                                             .getReplacement()),
                                                  WriteRequest.Type.REPLACE)
                                    .upsert(replaceOneModel.getOptions().isUpsert());
             } else if (writeModel instanceof UpdateOneModel) {
-                UpdateOneModel<T> updateOneModel = (UpdateOneModel<T>) writeModel;
-                writeRequest = new UpdateRequest(asBson(updateOneModel.getFilter()), asBson(updateOneModel.getUpdate()),
+                UpdateOneModel<TDocument> updateOneModel = (UpdateOneModel<TDocument>) writeModel;
+                writeRequest = new UpdateRequest(toBsonDocument(updateOneModel.getFilter()), toBsonDocument(updateOneModel.getUpdate()),
                                                  WriteRequest.Type.UPDATE)
                                    .multi(false)
                                    .upsert(updateOneModel.getOptions().isUpsert());
             } else if (writeModel instanceof UpdateManyModel) {
-                UpdateManyModel<T> updateManyModel = (UpdateManyModel<T>) writeModel;
-                writeRequest = new UpdateRequest(asBson(updateManyModel.getFilter()), asBson(updateManyModel.getUpdate()),
+                UpdateManyModel<TDocument> updateManyModel = (UpdateManyModel<TDocument>) writeModel;
+                writeRequest = new UpdateRequest(toBsonDocument(updateManyModel.getFilter()), toBsonDocument(updateManyModel.getUpdate()),
                                                  WriteRequest.Type.UPDATE)
                                    .multi(true)
                                    .upsert(updateManyModel.getOptions().isUpsert());
             } else if (writeModel instanceof DeleteOneModel) {
-                DeleteOneModel<T> deleteOneModel = (DeleteOneModel<T>) writeModel;
-                writeRequest = new DeleteRequest(asBson(deleteOneModel.getFilter())).multi(false);
+                DeleteOneModel<TDocument> deleteOneModel = (DeleteOneModel<TDocument>) writeModel;
+                writeRequest = new DeleteRequest(toBsonDocument(deleteOneModel.getFilter())).multi(false);
             } else if (writeModel instanceof DeleteManyModel) {
-                DeleteManyModel<T> deleteManyModel = (DeleteManyModel<T>) writeModel;
-                writeRequest = new DeleteRequest(asBson(deleteManyModel.getFilter())).multi(true);
+                DeleteManyModel<TDocument> deleteManyModel = (DeleteManyModel<TDocument>) writeModel;
+                writeRequest = new DeleteRequest(toBsonDocument(deleteManyModel.getFilter())).multi(true);
             } else {
                 throw new UnsupportedOperationException(format("WriteModel of type %s is not supported", writeModel.getClass()));
             }
@@ -254,117 +260,118 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
         }
 
         return executor.execute(new MixedBulkWriteOperation(namespace, writeRequests, options.isOrdered(),
-                this.writeConcern));
+                                                            this.writeConcern));
     }
 
     @Override
-    public void insertOne(final T document) {
+    public void insertOne(final TDocument document) {
         if (getCodec() instanceof CollectibleCodec) {
-            ((CollectibleCodec<T>) getCodec()).generateIdIfAbsentFromDocument(document);
+            ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
         }
 
-        executeSingleWriteRequest(new InsertRequest(asBson(document)));
+        executeSingleWriteRequest(new InsertRequest(documentToBsonDocument(document)));
     }
 
     @Override
-    public void insertMany(final List<? extends T> documents) {
+    public void insertMany(final List<? extends TDocument> documents) {
         insertMany(documents, new InsertManyOptions());
     }
 
     @Override
-    public void insertMany(final List<? extends T> documents, final InsertManyOptions options) {
+    public void insertMany(final List<? extends TDocument> documents, final InsertManyOptions options) {
         List<InsertRequest> requests = new ArrayList<InsertRequest>(documents.size());
-        for (T document : documents) {
+        for (TDocument document : documents) {
             if (getCodec() instanceof CollectibleCodec) {
-                ((CollectibleCodec<T>) getCodec()).generateIdIfAbsentFromDocument(document);
+                ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
             }
-            requests.add(new InsertRequest(asBson(document)));
+            requests.add(new InsertRequest(documentToBsonDocument(document)));
         }
         executor.execute(new MixedBulkWriteOperation(namespace, requests, options.isOrdered(), this.writeConcern));
     }
 
     @Override
-    public DeleteResult deleteOne(final Object filter) {
+    public DeleteResult deleteOne(final Bson filter) {
         return delete(filter, false);
     }
 
     @Override
-    public DeleteResult deleteMany(final Object filter) {
+    public DeleteResult deleteMany(final Bson filter) {
         return delete(filter, true);
     }
 
     @Override
-    public UpdateResult replaceOne(final Object filter, final T replacement) {
+    public UpdateResult replaceOne(final Bson filter, final TDocument replacement) {
         return replaceOne(filter, replacement, new UpdateOptions());
     }
 
     @Override
-    public UpdateResult replaceOne(final Object filter, final T replacement, final UpdateOptions updateOptions) {
-        return toUpdateResult(executeSingleWriteRequest(new UpdateRequest(asBson(filter), asBson(replacement), WriteRequest.Type.REPLACE)
+    public UpdateResult replaceOne(final Bson filter, final TDocument replacement, final UpdateOptions updateOptions) {
+        return toUpdateResult(executeSingleWriteRequest(new UpdateRequest(toBsonDocument(filter), documentToBsonDocument(replacement),
+                                                                          WriteRequest.Type.REPLACE)
                                                         .upsert(updateOptions.isUpsert())));
     }
 
     @Override
-    public UpdateResult updateOne(final Object filter, final Object update) {
+    public UpdateResult updateOne(final Bson filter, final Bson update) {
         return updateOne(filter, update, new UpdateOptions());
     }
 
     @Override
-    public UpdateResult updateOne(final Object filter, final Object update, final UpdateOptions updateOptions) {
+    public UpdateResult updateOne(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
         return update(filter, update, updateOptions, false);
     }
 
     @Override
-    public UpdateResult updateMany(final Object filter, final Object update) {
+    public UpdateResult updateMany(final Bson filter, final Bson update) {
         return updateMany(filter, update, new UpdateOptions());
     }
 
     @Override
-    public UpdateResult updateMany(final Object filter, final Object update, final UpdateOptions updateOptions) {
+    public UpdateResult updateMany(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
         return update(filter, update, updateOptions, true);
     }
 
     @Override
-    public T findOneAndDelete(final Object filter) {
+    public TDocument findOneAndDelete(final Bson filter) {
         return findOneAndDelete(filter, new FindOneAndDeleteOptions());
     }
 
     @Override
-    public T findOneAndDelete(final Object filter, final FindOneAndDeleteOptions options) {
-        return executor.execute(new FindAndDeleteOperation<T>(namespace, getCodec())
-                .filter(asBson(filter))
-                .projection(asBson(options.getProjection()))
-                .sort(asBson(options.getSort())));
+    public TDocument findOneAndDelete(final Bson filter, final FindOneAndDeleteOptions options) {
+        return executor.execute(new FindAndDeleteOperation<TDocument>(namespace, getCodec())
+                                .filter(toBsonDocument(filter))
+                                .projection(toBsonDocument(options.getProjection()))
+                                .sort(toBsonDocument(options.getSort())));
     }
 
     @Override
-    public T findOneAndReplace(final Object filter, final T replacement) {
+    public TDocument findOneAndReplace(final Bson filter, final TDocument replacement) {
         return findOneAndReplace(filter, replacement, new FindOneAndReplaceOptions());
     }
 
     @Override
-    public T findOneAndReplace(final Object filter, final T replacement, final FindOneAndReplaceOptions options) {
-        return executor.execute(new FindAndReplaceOperation<T>(namespace, getCodec(), asBson(replacement))
-                .filter(asBson(filter))
-                .projection(asBson(options.getProjection()))
-                .sort(asBson(options.getSort()))
-                .returnOriginal(options.getReturnOriginal())
-                .upsert(options.isUpsert()));
+    public TDocument findOneAndReplace(final Bson filter, final TDocument replacement, final FindOneAndReplaceOptions options) {
+        return executor.execute(new FindAndReplaceOperation<TDocument>(namespace, getCodec(), documentToBsonDocument(replacement))
+                                .filter(toBsonDocument(filter))
+                                .projection(toBsonDocument(options.getProjection()))
+                                .sort(toBsonDocument(options.getSort()))
+                                .returnOriginal(options.getReturnOriginal())
+                                .upsert(options.isUpsert()));
     }
 
     @Override
-    public T findOneAndUpdate(final Object filter, final Object update) {
+    public TDocument findOneAndUpdate(final Bson filter, final Bson update) {
         return findOneAndUpdate(filter, update, new FindOneAndUpdateOptions());
     }
 
     @Override
-    public T findOneAndUpdate(final Object filter, final Object update, final FindOneAndUpdateOptions options) {
-        return executor.execute(new FindAndUpdateOperation<T>(namespace, getCodec(), asBson(update))
-                .filter(asBson(filter))
-                .projection(asBson(options.getProjection()))
-                .sort(asBson(options.getSort()))
-                .returnOriginal(options.getReturnOriginal())
-                .upsert(options.isUpsert()));
+    public TDocument findOneAndUpdate(final Bson filter, final Bson update, final FindOneAndUpdateOptions options) {
+        return executor.execute(new FindAndUpdateOperation<TDocument>(namespace, getCodec(), toBsonDocument(update))
+                                .filter(toBsonDocument(filter))
+                                .projection(toBsonDocument(options.getProjection()))
+                                .sort(toBsonDocument(options.getSort()))
+                                .returnOriginal(options.getReturnOriginal())
+                                .upsert(options.isUpsert()));
     }
 
     @Override
@@ -373,20 +380,20 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public void createIndex(final Object key) {
+    public void createIndex(final Bson key) {
         createIndex(key, new CreateIndexOptions());
     }
 
     @Override
-    public void createIndex(final Object key, final CreateIndexOptions createIndexOptions) {
-        executor.execute(new CreateIndexOperation(getNamespace(), asBson(key))
+    public void createIndex(final Bson key, final CreateIndexOptions createIndexOptions) {
+        executor.execute(new CreateIndexOperation(getNamespace(), toBsonDocument(key))
                          .name(createIndexOptions.getName())
                          .background(createIndexOptions.isBackground())
                          .unique(createIndexOptions.isUnique())
                          .sparse(createIndexOptions.isSparse())
                          .expireAfterSeconds(createIndexOptions.getExpireAfterSeconds())
                          .version(createIndexOptions.getVersion())
-                         .weights(asBson(createIndexOptions.getWeights()))
+                         .weights(toBsonDocument(createIndexOptions.getWeights()))
                          .defaultLanguage(createIndexOptions.getDefaultLanguage())
                          .languageOverride(createIndexOptions.getLanguageOverride())
                          .textIndexVersion(createIndexOptions.getTextIndexVersion())
@@ -403,8 +410,8 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
     }
 
     @Override
-    public <C> ListIndexesIterable<C> listIndexes(final Class<C> clazz) {
-        return new ListIndexesIterableImpl<C>(getNamespace(), clazz, codecRegistry, ReadPreference.primary(), executor);
+    public <TResult> ListIndexesIterable<TResult> listIndexes(final Class<TResult> clazz) {
+        return new ListIndexesIterableImpl<TResult>(getNamespace(), clazz, codecRegistry, ReadPreference.primary(), executor);
     }
 
     @Override
@@ -428,8 +435,8 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
                              .dropTarget(renameCollectionOptions.isDropTarget()));
     }
 
-    private DeleteResult delete(final Object filter, final boolean multi) {
-        com.mongodb.bulk.BulkWriteResult result = executeSingleWriteRequest(new DeleteRequest(asBson(filter)).multi(multi));
+    private DeleteResult delete(final Bson filter, final boolean multi) {
+        com.mongodb.bulk.BulkWriteResult result = executeSingleWriteRequest(new DeleteRequest(toBsonDocument(filter)).multi(multi));
         if (result.wasAcknowledged()) {
             return DeleteResult.acknowledged(result.getDeletedCount());
         } else {
@@ -437,8 +444,9 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
         }
     }
 
-    private UpdateResult update(final Object filter, final Object update, final UpdateOptions updateOptions, final boolean multi) {
-        return toUpdateResult(executeSingleWriteRequest(new UpdateRequest(asBson(filter), asBson(update), WriteRequest.Type.UPDATE)
+    private UpdateResult update(final Bson filter, final Bson update, final UpdateOptions updateOptions, final boolean multi) {
+        return toUpdateResult(executeSingleWriteRequest(new UpdateRequest(toBsonDocument(filter), toBsonDocument(update),
+                                                                          WriteRequest.Type.UPDATE)
                                                         .upsert(updateOptions.isUpsert()).multi(multi)));
     }
 
@@ -465,16 +473,19 @@ class MongoCollectionImpl<T> implements MongoCollection<T> {
         }
     }
 
-    private Codec<T> getCodec() {
-        return getCodec(clazz);
+    private Codec<TDocument> getCodec() {
+        return getCodec(documentClass);
     }
 
     private <C> Codec<C> getCodec(final Class<C> clazz) {
         return codecRegistry.get(clazz);
     }
 
-    private BsonDocument asBson(final Object document) {
+    private BsonDocument documentToBsonDocument(final TDocument document) {
         return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
     }
 
+    private BsonDocument toBsonDocument(final Bson bson) {
+        return bson == null ? null : bson.toBsonDocument(documentClass, codecRegistry);
+    }
 }

--- a/driver/src/main/com/mongodb/client/FindIterable.java
+++ b/driver/src/main/com/mongodb/client/FindIterable.java
@@ -17,6 +17,7 @@
 package com.mongodb.client;
 
 import com.mongodb.CursorType;
+import org.bson.conversions.Bson;
 
 import java.util.concurrent.TimeUnit;
 
@@ -35,7 +36,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Filter
      */
-    FindIterable<T> filter(Object filter);
+    FindIterable<T> filter(Bson filter);
 
     /**
      * Sets the limit to apply.
@@ -71,7 +72,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/operator/query-modifier/ Query Modifiers
      */
-    FindIterable<T> modifiers(Object modifiers);
+    FindIterable<T> modifiers(Bson modifiers);
 
     /**
      * Sets a document describing the fields to return for all matching documents.
@@ -80,7 +81,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Projection
      */
-    FindIterable<T> projection(Object projection);
+    FindIterable<T> projection(Bson projection);
     /**
      * Sets the sort criteria to apply to the query.
      *
@@ -88,7 +89,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.sort/ Sort
      */
-    FindIterable<T> sort(Object sort);
+    FindIterable<T> sort(Bson sort);
 
     /**
      * The server normally times out idle cursors after an inactivity period (10 minutes)

--- a/driver/src/main/com/mongodb/client/MongoCollection.java
+++ b/driver/src/main/com/mongodb/client/MongoCollection.java
@@ -35,6 +35,7 @@ import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.List;
 
@@ -43,11 +44,11 @@ import java.util.List;
  *
  * <p>Note: Additions to this interface will not be considered to break binary compatibility.</p>
  *
- * @param <T> The type that this collection will encode documents from and decode documents to.
+ * @param <TDocument> The type that this collection will encode documents from and decode documents to.
  * @since 3.0
  */
 @ThreadSafe
-public interface MongoCollection<T> {
+public interface MongoCollection<TDocument> {
 
     /**
      * Gets the namespace of this collection.
@@ -57,11 +58,11 @@ public interface MongoCollection<T> {
     MongoNamespace getNamespace();
 
     /**
-     * Get the default class to cast any documents returned from the database into.
+     * Get the class of documents stored in this collection.
      *
-     * @return the default class to cast any documents into
+     * @return the class
      */
-    Class<T> getDefaultClass();
+    Class<TDocument> getDocumentClass();
 
     /**
      * Get the codec registry for the MongoCollection.
@@ -88,10 +89,10 @@ public interface MongoCollection<T> {
      * Create a new MongoCollection instance with a different default class to cast any documents returned from the database into..
      *
      * @param clazz the default class to cast any documents returned from the database into.
-     * @param <C> The type that the new collection will encode documents from and decode documents to
+     * @param <NewTDocument> The type that the new collection will encode documents from and decode documents to
      * @return a new MongoCollection instance with the different default class
      */
-    <C> MongoCollection<C> withDefaultClass(Class<C> clazz);
+    <NewTDocument> MongoCollection<NewTDocument> withDocumentClass(Class<NewTDocument> clazz);
 
     /**
      * Create a new MongoCollection instance with a different codec registry.
@@ -99,7 +100,7 @@ public interface MongoCollection<T> {
      * @param codecRegistry the new {@link org.bson.codecs.configuration.CodecRegistry} for the collection
      * @return a new MongoCollection instance with the different codec registry
      */
-    MongoCollection<T> withCodecRegistry(CodecRegistry codecRegistry);
+    MongoCollection<TDocument> withCodecRegistry(CodecRegistry codecRegistry);
 
     /**
      * Create a new MongoCollection instance with a different read preference.
@@ -107,7 +108,7 @@ public interface MongoCollection<T> {
      * @param readPreference the new {@link com.mongodb.ReadPreference} for the collection
      * @return a new MongoCollection instance with the different readPreference
      */
-    MongoCollection<T> withReadPreference(ReadPreference readPreference);
+    MongoCollection<TDocument> withReadPreference(ReadPreference readPreference);
 
     /**
      * Create a new MongoCollection instance with a different write concern.
@@ -115,7 +116,7 @@ public interface MongoCollection<T> {
      * @param writeConcern the new {@link com.mongodb.WriteConcern} for the collection
      * @return a new MongoCollection instance with the different writeConcern
      */
-    MongoCollection<T> withWriteConcern(WriteConcern writeConcern);
+    MongoCollection<TDocument> withWriteConcern(WriteConcern writeConcern);
 
     /**
      * Counts the number of documents in the collection.
@@ -130,7 +131,7 @@ public interface MongoCollection<T> {
      * @param filter the query filter
      * @return the number of documents in the collection
      */
-    long count(Object filter);
+    long count(Bson filter);
 
     /**
      * Counts the number of documents in the collection according to the given options.
@@ -139,18 +140,18 @@ public interface MongoCollection<T> {
      * @param options the options describing the count
      * @return the number of documents in the collection
      */
-    long count(Object filter, CountOptions options);
+    long count(Bson filter, CountOptions options);
 
     /**
      * Gets the distinct values of the specified field name.
      *
      * @param fieldName the field name
      * @param clazz     the default class to cast any distinct items into.
-     * @param <C>       the target type of the iterable.
+     * @param <TResult>       the target type of the iterable.
      * @return an iterable of distinct values
      * @mongodb.driver.manual reference/command/distinct/ Distinct
      */
-    <C> DistinctIterable<C> distinct(String fieldName, Class<C> clazz);
+    <TResult> DistinctIterable<TResult> distinct(String fieldName, Class<TResult> clazz);
 
     /**
      * Finds all documents in the collection.
@@ -158,17 +159,17 @@ public interface MongoCollection<T> {
      * @return the find iterable interface
      * @mongodb.driver.manual tutorial/query-documents/ Find
      */
-    FindIterable<T> find();
+    FindIterable<TDocument> find();
 
     /**
      * Finds all documents in the collection.
      *
      * @param clazz the class to decode each document into
-     * @param <C>   the target document type of the iterable.
+     * @param <TResult>   the target document type of the iterable.
      * @return the find iterable interface
      * @mongodb.driver.manual tutorial/query-documents/ Find
      */
-    <C> FindIterable<C> find(Class<C> clazz);
+    <TResult> FindIterable<TResult> find(Class<TResult> clazz);
 
     /**
      * Finds all documents in the collection.
@@ -177,18 +178,18 @@ public interface MongoCollection<T> {
      * @return the find iterable interface
      * @mongodb.driver.manual tutorial/query-documents/ Find
      */
-    FindIterable<T> find(Object filter);
+    FindIterable<TDocument> find(Bson filter);
 
     /**
      * Finds all documents in the collection.
      *
      * @param filter the query filter
      * @param clazz  the class to decode each document into
-     * @param <C>    the target document type of the iterable.
+     * @param <TResult>    the target document type of the iterable.
      * @return the find iterable interface
      * @mongodb.driver.manual tutorial/query-documents/ Find
      */
-    <C> FindIterable<C> find(Object filter, Class<C> clazz);
+    <TResult> FindIterable<TResult> find(Bson filter, Class<TResult> clazz);
 
     /**
      * Aggregates documents according to the specified aggregation pipeline.
@@ -198,19 +199,19 @@ public interface MongoCollection<T> {
      * @mongodb.driver.manual aggregation/ Aggregation
      * @mongodb.server.release 2.2
      */
-    AggregateIterable<Document> aggregate(List<?> pipeline);
+    AggregateIterable<Document> aggregate(List<? extends Bson> pipeline);
 
     /**
      * Aggregates documents according to the specified aggregation pipeline.
      *
      * @param pipeline the aggregate pipeline
      * @param clazz    the class to decode each document into
-     * @param <C>      the target document type of the iterable.
+     * @param <TResult>      the target document type of the iterable.
      * @return an iterable containing the result of the aggregation operation
      * @mongodb.driver.manual aggregation/ Aggregation
      * @mongodb.server.release 2.2
      */
-    <C> AggregateIterable<C> aggregate(List<?> pipeline, Class<C> clazz);
+    <TResult> AggregateIterable<TResult> aggregate(List<? extends Bson> pipeline, Class<TResult> clazz);
 
     /**
      * Aggregates documents according to the specified map-reduce function.
@@ -228,11 +229,11 @@ public interface MongoCollection<T> {
      * @param mapFunction    A JavaScript function that associates or "maps" a value with a key and emits the key and value pair.
      * @param reduceFunction A JavaScript function that "reduces" to a single object all the values associated with a particular key.
      * @param clazz          the class to decode each resulting document into.
-     * @param <C>            the target document type of the iterable.
+     * @param <TResult>            the target document type of the iterable.
      * @return an iterable containing the result of the map-reduce operation
      * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
      */
-    <C> MapReduceIterable<C> mapReduce(String mapFunction, String reduceFunction, Class<C> clazz);
+    <TResult> MapReduceIterable<TResult> mapReduce(String mapFunction, String reduceFunction, Class<TResult> clazz);
 
     /**
      * Executes a mix of inserts, updates, replaces, and deletes.
@@ -242,7 +243,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoBulkWriteException if there's an exception in the bulk write operation
      * @throws com.mongodb.MongoException          if there's an exception running the operation
      */
-    BulkWriteResult bulkWrite(List<? extends WriteModel<? extends T>> requests);
+    BulkWriteResult bulkWrite(List<? extends WriteModel<? extends TDocument>> requests);
 
     /**
      * Executes a mix of inserts, updates, replaces, and deletes.
@@ -253,7 +254,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoBulkWriteException if there's an exception in the bulk write operation
      * @throws com.mongodb.MongoException          if there's an exception running the operation
      */
-    BulkWriteResult bulkWrite(List<? extends WriteModel<? extends T>> requests, BulkWriteOptions options);
+    BulkWriteResult bulkWrite(List<? extends WriteModel<? extends TDocument>> requests, BulkWriteOptions options);
 
     /**
      * Inserts the provided document. If the document is missing an identifier, the driver should generate one.
@@ -263,7 +264,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
      * @throws com.mongodb.MongoException             if the write failed due some other failure
      */
-    void insertOne(T document);
+    void insertOne(TDocument document);
 
     /**
      * Inserts one or more documents.  A call to this method is equivalent to a call to the {@code bulkWrite} method
@@ -273,7 +274,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoException          if the write failed due some other failure
      * @see com.mongodb.client.MongoCollection#bulkWrite
      */
-    void insertMany(List<? extends T> documents);
+    void insertMany(List<? extends TDocument> documents);
 
     /**
      * Inserts one or more documents.  A call to this method is equivalent to a call to the {@code bulkWrite} method
@@ -284,7 +285,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.WriteConcernException if the write failed due being unable to fulfil the write concern
      * @throws com.mongodb.MongoException        if the write failed due some other failure
      */
-    void insertMany(List<? extends T> documents, InsertManyOptions options);
+    void insertMany(List<? extends TDocument> documents, InsertManyOptions options);
 
     /**
      * Removes at most one document from the collection that matches the given filter.  If no documents match, the collection is not
@@ -296,7 +297,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
      * @throws com.mongodb.MongoException             if the write failed due some other failure
      */
-    DeleteResult deleteOne(Object filter);
+    DeleteResult deleteOne(Bson filter);
 
     /**
      * Removes all documents from the collection that match the given query filter.  If no documents match, the collection is not modified.
@@ -307,7 +308,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
      * @throws com.mongodb.MongoException             if the write failed due some other failure
      */
-    DeleteResult deleteMany(Object filter);
+    DeleteResult deleteMany(Bson filter);
 
     /**
      * Replace a document in the collection according to the specified arguments.
@@ -320,7 +321,7 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoException             if the write failed due some other failure
      * @mongodb.driver.manual tutorial/modify-documents/#replace-the-document Replace
      */
-    UpdateResult replaceOne(Object filter, T replacement);
+    UpdateResult replaceOne(Bson filter, TDocument replacement);
 
     /**
      * Replace a document in the collection according to the specified arguments.
@@ -334,15 +335,13 @@ public interface MongoCollection<T> {
      * @throws com.mongodb.MongoException             if the write failed due some other failure
      * @mongodb.driver.manual tutorial/modify-documents/#replace-the-document Replace
      */
-    UpdateResult replaceOne(Object filter, T replacement, UpdateOptions updateOptions);
+    UpdateResult replaceOne(Bson filter, TDocument replacement, UpdateOptions updateOptions);
 
     /**
      * Update a single document in the collection according to the specified arguments.
      *
-     * @param filter a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec} is
-     *               registered
-     * @param update a document describing the update, which may not be null. The update to apply must include only update operators. This
-     *               can be of any type for which a {@code Codec} is registered
+     * @param filter a document describing the query filter, which may not be null.
+     * @param update a document describing the update, which may not be null. The update to apply must include only update operators.
      * @return the result of the update one operation
      * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the update command
      * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
@@ -350,15 +349,13 @@ public interface MongoCollection<T> {
      * @mongodb.driver.manual tutorial/modify-documents/ Updates
      * @mongodb.driver.manual reference/operator/update/ Update Operators
      */
-    UpdateResult updateOne(Object filter, Object update);
+    UpdateResult updateOne(Bson filter, Bson update);
 
     /**
      * Update a single document in the collection according to the specified arguments.
      *
-     * @param filter        a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec}
-     *                      is registered
+     * @param filter        a document describing the query filter, which may not be null.
      * @param update        a document describing the update, which may not be null. The update to apply must include only update operators.
-     *                      This can be of any type for which a {@code Codec} is registered
      * @param updateOptions the options to apply to the update operation
      * @return the result of the update one operation
      * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the update command
@@ -367,15 +364,13 @@ public interface MongoCollection<T> {
      * @mongodb.driver.manual tutorial/modify-documents/ Updates
      * @mongodb.driver.manual reference/operator/update/ Update Operators
      */
-    UpdateResult updateOne(Object filter, Object update, UpdateOptions updateOptions);
+    UpdateResult updateOne(Bson filter, Bson update, UpdateOptions updateOptions);
 
     /**
      * Update a single document in the collection according to the specified arguments.
      *
-     * @param filter a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec} is
-     *               registered
-     * @param update a document describing the update, which may not be null. The update to apply must include only update operators. This
-     *               can be of any type for which a {@code Codec} is registered
+     * @param filter a document describing the query filter, which may not be null.
+     * @param update a document describing the update, which may not be null. The update to apply must include only update operators.
      * @return the result of the update one operation
      * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the update command
      * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
@@ -383,15 +378,13 @@ public interface MongoCollection<T> {
      * @mongodb.driver.manual tutorial/modify-documents/ Updates
      * @mongodb.driver.manual reference/operator/update/ Update Operators
      */
-    UpdateResult updateMany(Object filter, Object update);
+    UpdateResult updateMany(Bson filter, Bson update);
 
     /**
      * Update a single document in the collection according to the specified arguments.
      *
-     * @param filter        a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec}
-     *                      is registered
+     * @param filter        a document describing the query filter, which may not be null.
      * @param update        a document describing the update, which may not be null. The update to apply must include only update operators.
-     *                      This can be of any type for which a {@code Codec} is registered
      * @param updateOptions the options to apply to the update operation
      * @return the result of the update one operation
      * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the update command
@@ -400,7 +393,7 @@ public interface MongoCollection<T> {
      * @mongodb.driver.manual tutorial/modify-documents/ Updates
      * @mongodb.driver.manual reference/operator/update/ Update Operators
      */
-    UpdateResult updateMany(Object filter, Object update, UpdateOptions updateOptions);
+    UpdateResult updateMany(Bson filter, Bson update, UpdateOptions updateOptions);
 
     /**
      * Atomically find a document and remove it.
@@ -408,7 +401,7 @@ public interface MongoCollection<T> {
      * @param filter the query filter to find the document with
      * @return the document that was removed.  If no documents matched the query filter, then null will be returned
      */
-    T findOneAndDelete(Object filter);
+    TDocument findOneAndDelete(Bson filter);
 
     /**
      * Atomically find a document and remove it.
@@ -417,7 +410,7 @@ public interface MongoCollection<T> {
      * @param options the options to apply to the operation
      * @return the document that was removed.  If no documents matched the query filter, then null will be returned
      */
-    T findOneAndDelete(Object filter, FindOneAndDeleteOptions options);
+    TDocument findOneAndDelete(Bson filter, FindOneAndDeleteOptions options);
 
     /**
      * Atomically find a document and replace it.
@@ -428,7 +421,7 @@ public interface MongoCollection<T> {
      * document as it was before the update or as it is after the update.  If no documents matched the query filter, then null will be
      * returned
      */
-    T findOneAndReplace(Object filter, T replacement);
+    TDocument findOneAndReplace(Bson filter, TDocument replacement);
 
     /**
      * Atomically find a document and replace it.
@@ -440,33 +433,29 @@ public interface MongoCollection<T> {
      * document as it was before the update or as it is after the update.  If no documents matched the query filter, then null will be
      * returned
      */
-    T findOneAndReplace(Object filter, T replacement, FindOneAndReplaceOptions options);
+    TDocument findOneAndReplace(Bson filter, TDocument replacement, FindOneAndReplaceOptions options);
 
     /**
      * Atomically find a document and update it.
      *
-     * @param filter a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec} is
-     *               registered
-     * @param update a document describing the update, which may not be null. The update to apply must include only update operators. This
-     *               can be of any type for which a {@code Codec} is registered
+     * @param filter a document describing the query filter, which may not be null.
+     * @param update a document describing the update, which may not be null. The update to apply must include only update operators.
      * @return the document that was updated before the update was applied.  If no documents matched the query filter, then null will be
      * returned
      */
-    T findOneAndUpdate(Object filter, Object update);
+    TDocument findOneAndUpdate(Bson filter, Bson update);
 
     /**
      * Atomically find a document and update it.
      *
-     * @param filter  a document describing the query filter, which may not be null. This can be of any type for which a {@code Codec} is
-     *                registered
-     * @param update  a document describing the update, which may not be null. The update to apply must include only update operators. This
-     *                can be of any type for which a {@code Codec} is registered
+     * @param filter  a document describing the query filter, which may not be null.
+     * @param update  a document describing the update, which may not be null. The update to apply must include only update operators.
      * @param options the options to apply to the operation
      * @return the document that was updated.  Depending on the value of the {@code returnOriginal} property, this will either be the
      * document as it was before the update or as it is after the update.  If no documents matched the query filter, then null will be
      * returned
      */
-    T findOneAndUpdate(Object filter, Object update, FindOneAndUpdateOptions options);
+    TDocument findOneAndUpdate(Bson filter, Bson update, FindOneAndUpdateOptions options);
 
     /**
      * Drops this collection from the Database.
@@ -476,19 +465,17 @@ public interface MongoCollection<T> {
     void dropCollection();
 
     /**
-     * @param key an object describing the index key(s), which may not be null. This can be of any type for which a {@code Codec} is
-     *            registered
+     * @param key an object describing the index key(s), which may not be null.
      * @mongodb.driver.manual reference/method/db.collection.ensureIndex Ensure Index
      */
-    void createIndex(Object key);
+    void createIndex(Bson key);
 
     /**
-     * @param key                an object describing the index key(s), which may not be null. This can be of any type for which a {@code
-     *                           Codec} is registered
+     * @param key                an object describing the index key(s), which may not be null.
      * @param createIndexOptions the options for the index
      * @mongodb.driver.manual reference/method/db.collection.ensureIndex Ensure Index
      */
-    void createIndex(Object key, CreateIndexOptions createIndexOptions);
+    void createIndex(Bson key, CreateIndexOptions createIndexOptions);
 
     /**
      * Get all the indexes in this collection.
@@ -502,11 +489,11 @@ public interface MongoCollection<T> {
      * Get all the indexes in this collection.
      *
      * @param clazz    the class to decode each document into
-     * @param <C>      the target document type of the iterable.
+     * @param <TResult>      the target document type of the iterable.
      * @return the list indexes iterable interface
      * @mongodb.driver.manual reference/command/listIndexes/ listIndexes
      */
-    <C> ListIndexesIterable<C> listIndexes(Class<C> clazz);
+    <TResult> ListIndexesIterable<TResult> listIndexes(Class<TResult> clazz);
 
     /**
      * Drops the given index.

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/atomicoperations/FindAndUpdateAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/atomicoperations/FindAndUpdateAcceptanceTest.java
@@ -63,8 +63,7 @@ public class FindAndUpdateAcceptanceTest extends DatabaseTestCase {
         assertThat(collection.count(), is(1L));
 
         Document updateOperation = new Document("$inc", new Document("someNumber", 1));
-        Document updatedDocument = collection.findOneAndUpdate(new Document(KEY, VALUE_TO_CARE_ABOUT),
-                                                               updateOperation,
+        Document updatedDocument = collection.findOneAndUpdate(new Document(KEY, VALUE_TO_CARE_ABOUT), updateOperation,
                                                                new FindOneAndUpdateOptions().returnOriginal(false));
 
         assertThat("Document returned from updateOneAndGet should be the updated document",
@@ -114,8 +113,7 @@ public class FindAndUpdateAcceptanceTest extends DatabaseTestCase {
 
         String newValueThatDoesNotMatchAnythingInDatabase = "valueThatDoesNotMatch";
         Document updateOperation = new Document("$inc", new Document("someNumber", 1));
-        Document document = collection.findOneAndUpdate(new Document(KEY, newValueThatDoesNotMatchAnythingInDatabase),
-                                                        updateOperation,
+        Document document = collection.findOneAndUpdate(new Document(KEY, newValueThatDoesNotMatchAnythingInDatabase), updateOperation,
                                                         new FindOneAndUpdateOptions().upsert(true).returnOriginal(false));
 
         assertThat(collection.count(), is(2L));

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/UpdateAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/crud/UpdateAcceptanceTest.java
@@ -105,6 +105,7 @@ public class UpdateAcceptanceTest extends DatabaseTestCase {
         Document filter = new Document("x", 3);
         collection.updateMany(filter, new Document("$set", new Document("x", 5)), new UpdateOptions().upsert(true));
 
+
         // then
         assertThat(collection.count(new Document("x", 5), new CountOptions()), is(2L));
     }

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/querying/FilterAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/querying/FilterAcceptanceTest.java
@@ -37,8 +37,7 @@ public class FilterAcceptanceTest extends DatabaseTestCase {
         int numberOfDocuments = 10;
         initialiseCollectionWithDocuments(numberOfDocuments);
 
-        List<Document> filteredCollection = collection.find().filter(new Document("_id", 3))
-                                                             .into(new ArrayList<Document>());
+        List<Document> filteredCollection = collection.find().filter(new Document("_id", 3)).into(new ArrayList<Document>());
         assertEquals(1, filteredCollection.size());
         assertThat((Integer) filteredCollection.get(0).get("_id"), is(3));
     }

--- a/driver/src/test/functional/com/mongodb/client/MongoCollectionTest.java
+++ b/driver/src/test/functional/com/mongodb/client/MongoCollectionTest.java
@@ -47,7 +47,7 @@ public class MongoCollectionTest extends DatabaseTestCase {
                 new ConcreteCodecProvider()));
         MongoCollection<Concrete> collection = database
                 .getCollection(getCollectionName())
-                .withDefaultClass(Concrete.class)
+                .withDocumentClass(Concrete.class)
                 .withCodecRegistry(codecRegistry)
                 .withReadPreference(ReadPreference.primary())
                 .withWriteConcern(WriteConcern.ACKNOWLEDGED);
@@ -55,7 +55,8 @@ public class MongoCollectionTest extends DatabaseTestCase {
         Concrete doc = new Concrete(new ObjectId(), "str", 5, 10L, 4.0, 3290482390480L);
         collection.insertOne(doc);
 
-        Concrete newDoc = collection.findOneAndUpdate(new Document("i", 5), new Document("$set", new Document("i", 6)));
+        Concrete newDoc = collection.findOneAndUpdate(new Document("i", 5),
+                                                      new Document("$set", new Document("i", 6)));
 
         assertNotNull(newDoc);
         assertEquals(doc, newDoc);
@@ -69,7 +70,7 @@ public class MongoCollectionTest extends DatabaseTestCase {
                 new ConcreteCodecProvider()));
         MongoCollection<Concrete> collection = database
                 .getCollection(getCollectionName())
-                .withDefaultClass(Concrete.class)
+                .withDocumentClass(Concrete.class)
                 .withCodecRegistry(codecRegistry)
                 .withReadPreference(ReadPreference.primary())
                 .withWriteConcern(WriteConcern.ACKNOWLEDGED);

--- a/driver/src/test/unit/com/mongodb/AggregateIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/AggregateIterableSpecification.groovy
@@ -50,7 +50,7 @@ class AggregateIterableSpecification extends Specification {
         given:
         def executor = new TestOperationExecutor([null, null, null, null, null]);
         def pipeline = [new Document('$match', 1)]
-        def aggregationIterable = new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
+        def aggregationIterable = new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 pipeline)
 
         when: 'default input should be as expected'
@@ -85,7 +85,7 @@ class AggregateIterableSpecification extends Specification {
         def pipeline = [new Document('$match', 1), new Document('$out', collectionName)]
 
         when: 'aggregation includes $out'
-        new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
+        new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 pipeline)
                 .batchSize(99)
                 .maxTime(999, MILLISECONDS)
@@ -113,7 +113,7 @@ class AggregateIterableSpecification extends Specification {
         def codecRegistry = new RootCodecRegistry(asList(new ValueCodecProvider(), new BsonValueCodecProvider()))
         def executor = new TestOperationExecutor([new MongoException('failure')])
         def pipeline = [new BsonDocument('$match', new BsonInt32(1))]
-        def aggregationIterable = new AggregateIterableImpl<BsonDocument>(namespace, BsonDocument, codecRegistry, readPreference, executor,
+        def aggregationIterable = new AggregateIterableImpl(namespace, BsonDocument, BsonDocument, codecRegistry, readPreference, executor,
                 pipeline)
 
         when: 'The operation fails with an exception'
@@ -123,7 +123,7 @@ class AggregateIterableSpecification extends Specification {
         thrown(MongoException)
 
         when: 'a codec is missing'
-        new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
+        new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 pipeline).iterator()
 
         then:
@@ -152,7 +152,7 @@ class AggregateIterableSpecification extends Specification {
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
-        def mongoIterable = new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
+        def mongoIterable = new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 [new Document('$match', 1)])
 
         when:

--- a/driver/src/test/unit/com/mongodb/FindIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/FindIterableSpecification.groovy
@@ -57,8 +57,8 @@ class FindIterableSpecification extends Specification {
                                            .oplogReplay(false)
                                            .noCursorTimeout(false)
                                            .partial(false)
-        def findIterable = new FindIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
-                new Document('filter', 1), findOptions)
+        def findIterable = new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                          new Document('filter', 1), findOptions)
 
         when: 'default input should be as expected'
         findIterable.iterator()
@@ -120,13 +120,13 @@ class FindIterableSpecification extends Specification {
         given:
         def executor = new TestOperationExecutor([null, null]);
         def findOptions = new FindOptions()
-        def findIterable = new FindIterableImpl<Document>(namespace,  Document, codecRegistry, readPreference, executor,
-                new Document('filter', 1), findOptions)
+        def findIterable = new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                new Document('filter', 1), findOptions)
 
         when:
         findIterable.filter(new Document('filter', 1))
                   .sort(new BsonDocument('sort', new BsonInt32(1)))
-                  .modifiers(new BasicDBObject('modifier', 1))
+                  .modifiers(new Document('modifier', 1))
                   .iterator()
 
         def operation = executor.getReadOperation() as FindOperation<Document>
@@ -164,8 +164,8 @@ class FindIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
         def findOptions = new FindOptions()
-        def mongoIterable = new FindIterableImpl<Document>(namespace,  Document, codecRegistry, readPreference, executor, new Document(),
-                findOptions)
+        def mongoIterable = new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                           new Document(), findOptions)
 
         when:
         def results = mongoIterable.first()

--- a/driver/src/test/unit/com/mongodb/MapReduceIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MapReduceIterableSpecification.groovy
@@ -50,7 +50,7 @@ class MapReduceIterableSpecification extends Specification {
     def 'should build the expected MapReduceWithInlineResultsOperation'() {
         given:
         def executor = new TestOperationExecutor([null, null]);
-        def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
+        def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 'map', 'reduce')
 
         when: 'default input should be as expected'
@@ -95,7 +95,7 @@ class MapReduceIterableSpecification extends Specification {
 
         when: 'mapReduce to a collection'
         def collectionNamespace = new MongoNamespace('dbName', 'collName')
-        def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
+        def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 'map', 'reduce')
                 .collectionName(collectionNamespace.getCollectionName())
                 .databaseName(collectionNamespace.getDatabaseName())
@@ -144,7 +144,7 @@ class MapReduceIterableSpecification extends Specification {
         given:
         def codecRegistry = new RootCodecRegistry(asList(new ValueCodecProvider(), new BsonValueCodecProvider()))
         def executor = new TestOperationExecutor([new MongoException('failure')])
-        def mapReduceIterable = new MapReduceIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor,
+        def mapReduceIterable = new MapReduceIterableImpl(namespace, BsonDocument, BsonDocument, codecRegistry, readPreference, executor,
                 'map', 'reduce')
 
 
@@ -155,7 +155,7 @@ class MapReduceIterableSpecification extends Specification {
         thrown(MongoException)
 
         when: 'a codec is missing'
-        new MapReduceIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
+        new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
                 'map', 'reduce').iterator()
 
         then:
@@ -185,7 +185,7 @@ class MapReduceIterableSpecification extends Specification {
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
-        def mongoIterable = new MapReduceIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor,
+        def mongoIterable = new MapReduceIterableImpl(namespace, BsonDocument, BsonDocument, codecRegistry, readPreference, executor,
                 'map', 'reduce')
 
         when:

--- a/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
@@ -90,10 +90,10 @@ class MongoCollectionSpecification extends Specification {
 
         when:
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, writeConcern,
-                executor).withDefaultClass(newClass)
+                executor).withDocumentClass(newClass)
 
         then:
-        collection.getDefaultClass() == newClass
+        collection.getDocumentClass() == newClass
         expect collection, isTheSameAs(new MongoCollectionImpl(namespace, newClass, codecRegistry, readPreference, writeConcern,
                 executor))
     }
@@ -195,29 +195,29 @@ class MongoCollectionSpecification extends Specification {
         def findIterable = collection.find()
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
-                new BsonDocument(), new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                              new BsonDocument(), new FindOptions()))
 
         when:
         findIterable = collection.find(BsonDocument)
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor,
-                new BsonDocument(), new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, BsonDocument, Document, codecRegistry, readPreference, executor,
+                                                              new BsonDocument(), new FindOptions()))
 
         when:
         findIterable = collection.find(new Document())
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, codecRegistry, readPreference, executor, new Document(),
-                new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                              new Document(), new FindOptions()))
 
         when:
         findIterable = collection.find(new Document(), BsonDocument)
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor,
-                new Document(), new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, BsonDocument, Document, codecRegistry, readPreference, executor,
+                                                              new Document(), new FindOptions()))
     }
 
     def 'should create AggregateIterable correctly'() {
@@ -229,14 +229,15 @@ class MongoCollectionSpecification extends Specification {
         def aggregateIterable = collection.aggregate([new Document('$match', 1)])
 
         then:
-        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
-                [new Document('$match', 1)]))
+        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference,
+                                                                        executor, [new Document('$match', 1)]))
 
         when:
         aggregateIterable = collection.aggregate([new Document('$match', 1)], BsonDocument)
 
         then:
-        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor,
+        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, BsonDocument, Document, codecRegistry, readPreference,
+                                                                        executor,
                 [new Document('$match', 1)]))
     }
 
@@ -249,8 +250,8 @@ class MongoCollectionSpecification extends Specification {
         def mapReduceIterable = collection.mapReduce('map', 'reduce')
 
         then:
-        expect mapReduceIterable, isTheSameAs(new MapReduceIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
-                'map', 'reduce'))
+        expect mapReduceIterable, isTheSameAs(new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference,
+                                                                        executor, 'map', 'reduce'))
     }
 
     def 'bulkWrite should use MixedBulkWriteOperation correctly'() {


### PR DESCRIPTION
OK, this is take two.  In this patch, there's a Renderable interface and most occurrences of Object in MongoCollection and in the model classes have been replaced with Renderable.  In addition, Document and BsonDocument have been retrofitted to implement Renderable, and all the methods on FilterBuilder also return Renderable.