### PR TITLE
Completed work of replacing Object with the Bson type in the high-level API

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/AggregateIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/AggregateIterable.java
@@ -23,10 +23,10 @@ import java.util.concurrent.TimeUnit;
 /**
  * Iterable for aggregate.
  *
- * @param <T> The type of the result.
+ * @param <TResult> The type of the result.
  * @since 3.0
  */
-public interface AggregateIterable<T> extends MongoIterable<T> {
+public interface AggregateIterable<TResult> extends MongoIterable<TResult> {
 
     /**
      * Enables writing to temporary files. A null value indicates that it's unspecified.
@@ -36,7 +36,7 @@ public interface AggregateIterable<T> extends MongoIterable<T> {
      * @mongodb.driver.manual reference/command/aggregate/ Aggregation
      * @mongodb.server.release 2.6
      */
-    AggregateIterable<T> allowDiskUse(Boolean allowDiskUse);
+    AggregateIterable<TResult> allowDiskUse(Boolean allowDiskUse);
 
     /**
      * Sets the maximum execution time on the server for this operation.
@@ -46,7 +46,7 @@ public interface AggregateIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.maxTimeMS/#cursor.maxTimeMS Max Time
      */
-    AggregateIterable<T> maxTime(long maxTime, TimeUnit timeUnit);
+    AggregateIterable<TResult> maxTime(long maxTime, TimeUnit timeUnit);
 
     /**
      * Sets whether the server should use a cursor to return results.
@@ -56,7 +56,7 @@ public interface AggregateIterable<T> extends MongoIterable<T> {
      * @mongodb.driver.manual reference/command/aggregate/ Aggregation
      * @mongodb.server.release 2.6
      */
-    AggregateIterable<T> useCursor(Boolean useCursor);
+    AggregateIterable<TResult> useCursor(Boolean useCursor);
 
     /**
      * Aggregates documents according to the specified aggregation pipeline, which must end with a $out stage.
@@ -73,5 +73,5 @@ public interface AggregateIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
-    AggregateIterable<T> batchSize(int batchSize);
+    AggregateIterable<TResult> batchSize(int batchSize);
 }

--- a/driver-async/src/main/com/mongodb/async/client/AggregateIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/AggregateIterableImpl.java
@@ -27,9 +27,9 @@ import com.mongodb.operation.AggregateOperation;
 import com.mongodb.operation.AggregateToCollectionOperation;
 import com.mongodb.operation.AsyncOperationExecutor;
 import org.bson.BsonDocument;
-import org.bson.BsonDocumentWrapper;
 import org.bson.BsonValue;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,23 +41,26 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 
-class AggregateIterableImpl<T> implements AggregateIterable<T> {
+class AggregateIterableImpl<TDocument, TResult> implements AggregateIterable<TResult> {
     private final MongoNamespace namespace;
-    private final Class<T> clazz;
+    private final Class<TDocument> documentClass;
+    private final Class<TResult> resultClass;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final AsyncOperationExecutor executor;
-    private final List<?> pipeline;
+    private final List<? extends Bson> pipeline;
 
     private Boolean allowDiskUse;
     private Integer batchSize;
     private long maxTimeMS;
     private Boolean useCursor;
 
-    AggregateIterableImpl(final MongoNamespace namespace, final Class<T> clazz, final CodecRegistry codecRegistry,
-                          final ReadPreference readPreference, final AsyncOperationExecutor executor, final List<?> pipeline) {
+    AggregateIterableImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final Class<TResult> resultClass,
+                          final CodecRegistry codecRegistry, final ReadPreference readPreference, final AsyncOperationExecutor executor,
+                          final List<? extends Bson> pipeline) {
         this.namespace = notNull("namespace", namespace);
-        this.clazz = notNull("clazz", clazz);
+        this.documentClass = documentClass;
+        this.resultClass = notNull("clazz", resultClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.executor = notNull("executor", executor);
@@ -65,33 +68,33 @@ class AggregateIterableImpl<T> implements AggregateIterable<T> {
     }
 
     @Override
-    public AggregateIterable<T> allowDiskUse(final Boolean allowDiskUse) {
+    public AggregateIterable<TResult> allowDiskUse(final Boolean allowDiskUse) {
         this.allowDiskUse = allowDiskUse;
         return this;
     }
 
     @Override
-    public AggregateIterable<T> batchSize(final int batchSize) {
+    public AggregateIterable<TResult> batchSize(final int batchSize) {
         this.batchSize = batchSize;
         return this;
     }
 
     @Override
-    public AggregateIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public AggregateIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public AggregateIterable<T> useCursor(final Boolean useCursor) {
+    public AggregateIterable<TResult> useCursor(final Boolean useCursor) {
         this.useCursor = useCursor;
         return this;
     }
 
     @Override
     public void toCollection(final SingleResultCallback<Void> callback) {
-        List<BsonDocument> aggregateList = createBsonDocumentList(pipeline);
+        List<BsonDocument> aggregateList = createBsonDocumentList();
         BsonValue outCollection = getAggregateOutCollection(aggregateList);
 
         if (outCollection == null) {
@@ -104,48 +107,48 @@ class AggregateIterableImpl<T> implements AggregateIterable<T> {
     }
 
     @Override
-    public void first(final SingleResultCallback<T> callback) {
+    public void first(final SingleResultCallback<TResult> callback) {
         execute().first(callback);
     }
 
     @Override
-    public void forEach(final Block<? super T> block, final SingleResultCallback<Void> callback) {
+    public void forEach(final Block<? super TResult> block, final SingleResultCallback<Void> callback) {
         execute().forEach(block, callback);
     }
 
     @Override
-    public <A extends Collection<? super T>> void into(final A target, final SingleResultCallback<A> callback) {
+    public <A extends Collection<? super TResult>> void into(final A target, final SingleResultCallback<A> callback) {
         execute().into(target, callback);
     }
 
     @Override
-    public <U> MongoIterable<U> map(final Function<T, U> mapper) {
-        return new MappingIterable<T, U>(this, mapper);
+    public <U> MongoIterable<U> map(final Function<TResult, U> mapper) {
+        return new MappingIterable<TResult, U>(this, mapper);
     }
 
     @Override
-    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<T>> callback) {
+    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<TResult>> callback) {
         execute().batchCursor(callback);
     }
 
-    private MongoIterable<T> execute() {
-        List<BsonDocument> aggregateList = createBsonDocumentList(pipeline);
+    private MongoIterable<TResult> execute() {
+        List<BsonDocument> aggregateList = createBsonDocumentList();
         BsonValue outCollection = getAggregateOutCollection(aggregateList);
 
         if (outCollection != null) {
             AggregateToCollectionOperation operation = new AggregateToCollectionOperation(namespace, aggregateList)
                     .maxTime(maxTimeMS, MILLISECONDS)
                     .allowDiskUse(allowDiskUse);
-            MongoIterable<T> delegated = new FindIterableImpl<T>(new MongoNamespace(namespace.getDatabaseName(),
+            MongoIterable<TResult> delegated = new FindIterableImpl<TDocument, TResult>(new MongoNamespace(namespace.getDatabaseName(),
                     outCollection.asString().getValue()),
-                    clazz, codecRegistry, primary(), executor, new BsonDocument(),
+                    documentClass, resultClass, codecRegistry, primary(), executor, new BsonDocument(),
                     new FindOptions());
             if (batchSize != null) {
                 delegated.batchSize(batchSize);
             }
-            return new AwaitingWriteOperationIterable<T, Void>(operation, executor, delegated);
+            return new AwaitingWriteOperationIterable<TResult, Void>(operation, executor, delegated);
         } else {
-            return new OperationIterable<T>(new AggregateOperation<T>(namespace, aggregateList, codecRegistry.get(clazz))
+            return new OperationIterable<TResult>(new AggregateOperation<TResult>(namespace, aggregateList, codecRegistry.get(resultClass))
                     .maxTime(maxTimeMS, MILLISECONDS)
                     .allowDiskUse(allowDiskUse)
                     .batchSize(batchSize)
@@ -159,10 +162,10 @@ class AggregateIterableImpl<T> implements AggregateIterable<T> {
         return aggregateList.size() == 0 ? null : aggregateList.get(aggregateList.size() - 1).get("$out");
     }
 
-    private <D> List<BsonDocument> createBsonDocumentList(final List<D> pipeline) {
+    private List<BsonDocument> createBsonDocumentList() {
         List<BsonDocument> aggregateList = new ArrayList<BsonDocument>(pipeline.size());
-        for (D obj : pipeline) {
-            aggregateList.add(BsonDocumentWrapper.asBsonDocument(obj, codecRegistry));
+        for (Bson document : pipeline) {
+            aggregateList.add(document.toBsonDocument(documentClass, codecRegistry));
         }
         return aggregateList;
     }

--- a/driver-async/src/main/com/mongodb/async/client/DistinctIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/DistinctIterable.java
@@ -17,15 +17,17 @@
 package com.mongodb.async.client;
 
 
+import org.bson.conversions.Bson;
+
 import java.util.concurrent.TimeUnit;
 
 /**
  * Iterable for distinct.
  *
- * @param <T> The type of the result.
+ * @param <TResult> The type of the result.
  * @since 3.0
  */
-public interface DistinctIterable<T> extends MongoIterable<T> {
+public interface DistinctIterable<TResult> extends MongoIterable<TResult> {
 
     /**
      * Sets the query filter to apply to the query.
@@ -34,7 +36,7 @@ public interface DistinctIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Filter
      */
-    DistinctIterable<T> filter(Object filter);
+    DistinctIterable<TResult> filter(Bson filter);
 
     /**
      * Sets the maximum execution time on the server for this operation.
@@ -43,7 +45,7 @@ public interface DistinctIterable<T> extends MongoIterable<T> {
      * @param timeUnit the time unit, which may not be null
      * @return this
      */
-    DistinctIterable<T> maxTime(long maxTime, TimeUnit timeUnit);
+    DistinctIterable<TResult> maxTime(long maxTime, TimeUnit timeUnit);
 
     /**
      * Sets the number of documents to return per batch.
@@ -52,6 +54,6 @@ public interface DistinctIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
-    DistinctIterable<T> batchSize(int batchSize);
+    DistinctIterable<TResult> batchSize(int batchSize);
 
 }

--- a/driver-async/src/main/com/mongodb/async/client/FindIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/FindIterableImpl.java
@@ -27,7 +27,6 @@ import com.mongodb.client.model.FindOptions;
 import com.mongodb.operation.AsyncOperationExecutor;
 import com.mongodb.operation.FindOperation;
 import org.bson.BsonDocument;
-import org.bson.BsonDocumentWrapper;
 import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
@@ -38,20 +37,22 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-class FindIterableImpl<T> implements FindIterable<T> {
+class FindIterableImpl<TDocument, TResult> implements FindIterable<TResult> {
     private final MongoNamespace namespace;
-    private final Class<T> clazz;
+    private final Class<TDocument> documentClass;
+    private final Class<TResult> resultClass;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final AsyncOperationExecutor executor;
     private final FindOptions findOptions;
-    private Object filter;
+    private Bson filter;
 
-    FindIterableImpl(final MongoNamespace namespace, final Class<T> clazz, final CodecRegistry codecRegistry,
-                     final ReadPreference readPreference, final AsyncOperationExecutor executor,
-                     final Object filter, final FindOptions findOptions) {
+    FindIterableImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final Class<TResult> resultClass,
+                     final CodecRegistry codecRegistry, final ReadPreference readPreference, final AsyncOperationExecutor executor,
+                     final Bson filter, final FindOptions findOptions) {
         this.namespace = notNull("namespace", namespace);
-        this.clazz = notNull("clazz", clazz);
+        this.documentClass = notNull("documentClass", documentClass);
+        this.resultClass = notNull("resultClass", resultClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.executor = notNull("executor", executor);
@@ -60,125 +61,125 @@ class FindIterableImpl<T> implements FindIterable<T> {
     }
 
     @Override
-    public FindIterable<T> filter(final Bson filter) {
+    public FindIterable<TResult> filter(final Bson filter) {
         this.filter = filter;
         return this;
     }
 
     @Override
-    public FindIterable<T> limit(final int limit) {
+    public FindIterable<TResult> limit(final int limit) {
         findOptions.limit(limit);
         return this;
     }
 
     @Override
-    public FindIterable<T> skip(final int skip) {
+    public FindIterable<TResult> skip(final int skip) {
         findOptions.skip(skip);
         return this;
     }
 
     @Override
-    public FindIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public FindIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         findOptions.maxTime(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public FindIterable<T> batchSize(final int batchSize) {
+    public FindIterable<TResult> batchSize(final int batchSize) {
         findOptions.batchSize(batchSize);
         return this;
     }
 
     @Override
-    public FindIterable<T> modifiers(final Bson modifiers) {
+    public FindIterable<TResult> modifiers(final Bson modifiers) {
         findOptions.modifiers(modifiers);
         return this;
     }
 
     @Override
-    public FindIterable<T> projection(final Bson projection) {
+    public FindIterable<TResult> projection(final Bson projection) {
         findOptions.projection(projection);
         return this;
     }
 
     @Override
-    public FindIterable<T> sort(final Bson sort) {
+    public FindIterable<TResult> sort(final Bson sort) {
         findOptions.sort(sort);
         return this;
     }
 
     @Override
-    public FindIterable<T> noCursorTimeout(final boolean noCursorTimeout) {
+    public FindIterable<TResult> noCursorTimeout(final boolean noCursorTimeout) {
         findOptions.noCursorTimeout(noCursorTimeout);
         return this;
     }
 
     @Override
-    public FindIterable<T> oplogReplay(final boolean oplogReplay) {
+    public FindIterable<TResult> oplogReplay(final boolean oplogReplay) {
         findOptions.oplogReplay(oplogReplay);
         return this;
     }
 
     @Override
-    public FindIterable<T> partial(final boolean partial) {
+    public FindIterable<TResult> partial(final boolean partial) {
         findOptions.partial(partial);
         return this;
     }
 
     @Override
-    public FindIterable<T> cursorType(final CursorType cursorType) {
+    public FindIterable<TResult> cursorType(final CursorType cursorType) {
         findOptions.cursorType(cursorType);
         return this;
     }
 
     @Override
-    public void first(final SingleResultCallback<T> callback) {
+    public void first(final SingleResultCallback<TResult> callback) {
         execute(createQueryOperation().batchSize(0).limit(-1)).first(callback);
     }
 
     @Override
-    public void forEach(final Block<? super T> block, final SingleResultCallback<Void> callback) {
+    public void forEach(final Block<? super TResult> block, final SingleResultCallback<Void> callback) {
         execute().forEach(block, callback);
     }
 
     @Override
-    public <A extends Collection<? super T>> void into(final A target, final SingleResultCallback<A> callback) {
+    public <A extends Collection<? super TResult>> void into(final A target, final SingleResultCallback<A> callback) {
         execute().into(target, callback);
     }
 
     @Override
-    public <U> MongoIterable<U> map(final Function<T, U> mapper) {
-        return new MappingIterable<T, U>(this, mapper);
+    public <U> MongoIterable<U> map(final Function<TResult, U> mapper) {
+        return new MappingIterable<TResult, U>(this, mapper);
     }
 
     @Override
-    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<T>> callback) {
+    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<TResult>> callback) {
         execute().batchCursor(callback);
     }
 
-    private MongoIterable<T> execute() {
+    private MongoIterable<TResult> execute() {
         return execute(createQueryOperation());
     }
 
-    private MongoIterable<T> execute(final FindOperation<T> operation) {
-        return new OperationIterable<T>(operation, readPreference, executor);
+    private MongoIterable<TResult> execute(final FindOperation<TResult> operation) {
+        return new OperationIterable<TResult>(operation, readPreference, executor);
     }
 
     private <C> Codec<C> getCodec(final Class<C> clazz) {
         return codecRegistry.get(clazz);
     }
 
-    private FindOperation<T> createQueryOperation() {
-        return new FindOperation<T>(namespace, getCodec(clazz))
-               .filter(asBson(filter))
+    private FindOperation<TResult> createQueryOperation() {
+        return new FindOperation<TResult>(namespace, getCodec(resultClass))
+               .filter(toBsonDocument(filter))
                .batchSize(findOptions.getBatchSize())
                .skip(findOptions.getSkip())
                .limit(findOptions.getLimit())
                .maxTime(findOptions.getMaxTime(MILLISECONDS), MILLISECONDS)
-               .modifiers(asBson(findOptions.getModifiers()))
-               .projection(asBson(findOptions.getProjection()))
-               .sort(asBson(findOptions.getSort()))
+               .modifiers(toBsonDocument(findOptions.getModifiers()))
+               .projection(toBsonDocument(findOptions.getProjection()))
+               .sort(toBsonDocument(findOptions.getSort()))
                .cursorType(findOptions.getCursorType())
                .noCursorTimeout(findOptions.isNoCursorTimeout())
                .oplogReplay(findOptions.isOplogReplay())
@@ -186,8 +187,8 @@ class FindIterableImpl<T> implements FindIterable<T> {
                .slaveOk(readPreference.isSlaveOk());
     }
 
-    private BsonDocument asBson(final Object document) {
-        return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
+    private BsonDocument toBsonDocument(final Bson document) {
+        return document == null ? null : document.toBsonDocument(documentClass, codecRegistry);
     }
 
 }

--- a/driver-async/src/main/com/mongodb/async/client/ListCollectionsIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/ListCollectionsIterable.java
@@ -16,15 +16,17 @@
 
 package com.mongodb.async.client;
 
+import org.bson.conversions.Bson;
+
 import java.util.concurrent.TimeUnit;
 
 /**
  * Iterable for ListCollections.
  *
- * @param <T> The type of the result.
+ * @param <TResult> The type of the result.
  * @since 3.0
  */
-public interface ListCollectionsIterable<T> extends MongoIterable<T> {
+public interface ListCollectionsIterable<TResult> extends MongoIterable<TResult> {
 
     /**
      * Sets the query filter to apply to the query.
@@ -33,7 +35,7 @@ public interface ListCollectionsIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Filter
      */
-    ListCollectionsIterable<T> filter(Object filter);
+    ListCollectionsIterable<TResult> filter(Bson filter);
 
     /**
      * Sets the maximum execution time on the server for this operation.
@@ -43,7 +45,7 @@ public interface ListCollectionsIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/operator/meta/maxTimeMS/ Max Time
      */
-    ListCollectionsIterable<T> maxTime(long maxTime, TimeUnit timeUnit);
+    ListCollectionsIterable<TResult> maxTime(long maxTime, TimeUnit timeUnit);
 
     /**
      * Sets the number of documents to return per batch.
@@ -52,5 +54,5 @@ public interface ListCollectionsIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
-    ListCollectionsIterable<T> batchSize(int batchSize);
+    ListCollectionsIterable<TResult> batchSize(int batchSize);
 }

--- a/driver-async/src/main/com/mongodb/async/client/ListCollectionsIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/ListCollectionsIterableImpl.java
@@ -19,14 +19,14 @@ package com.mongodb.async.client;
 import com.mongodb.Block;
 import com.mongodb.Function;
 import com.mongodb.ReadPreference;
-import com.mongodb.async.SingleResultCallback;
 import com.mongodb.async.AsyncBatchCursor;
+import com.mongodb.async.SingleResultCallback;
 import com.mongodb.operation.AsyncOperationExecutor;
 import com.mongodb.operation.ListCollectionsOperation;
 import org.bson.BsonDocument;
-import org.bson.BsonDocumentWrapper;
 import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
@@ -34,92 +34,92 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-final class ListCollectionsIterableImpl<T> implements ListCollectionsIterable<T> {
+final class ListCollectionsIterableImpl<TResult> implements ListCollectionsIterable<TResult> {
     private final String databaseName;
-    private final Class<T> clazz;
+    private final Class<TResult> resultClass;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final AsyncOperationExecutor executor;
 
-    private Object filter;
+    private Bson filter;
     private int batchSize;
     private long maxTimeMS;
 
-    ListCollectionsIterableImpl(final String databaseName, final Class<T> clazz, final CodecRegistry codecRegistry,
+    ListCollectionsIterableImpl(final String databaseName, final Class<TResult> resultClass, final CodecRegistry codecRegistry,
                                 final ReadPreference readPreference, final AsyncOperationExecutor executor) {
         this.databaseName = notNull("databaseName", databaseName);
-        this.clazz = notNull("clazz", clazz);
+        this.resultClass = notNull("resultClass", resultClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.executor = notNull("executor", executor);
     }
 
     @Override
-    public ListCollectionsIterable<T> filter(final Object filter) {
+    public ListCollectionsIterable<TResult> filter(final Bson filter) {
         notNull("filter", filter);
         this.filter = filter;
         return this;
     }
 
     @Override
-    public ListCollectionsIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public ListCollectionsIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         this.maxTimeMS = MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public ListCollectionsIterable<T> batchSize(final int batchSize) {
+    public ListCollectionsIterable<TResult> batchSize(final int batchSize) {
         this.batchSize = batchSize;
         return this;
     }
 
     @Override
-    public void first(final SingleResultCallback<T> callback) {
+    public void first(final SingleResultCallback<TResult> callback) {
         execute(createListCollectionsOperation().batchSize(-1)).first(callback);
     }
 
     @Override
-    public void forEach(final Block<? super T> block, final SingleResultCallback<Void> callback) {
+    public void forEach(final Block<? super TResult> block, final SingleResultCallback<Void> callback) {
         execute().forEach(block, callback);
     }
 
     @Override
-    public <A extends Collection<? super T>> void into(final A target, final SingleResultCallback<A> callback) {
+    public <A extends Collection<? super TResult>> void into(final A target, final SingleResultCallback<A> callback) {
         execute().into(target, callback);
     }
 
     @Override
-    public <U> MongoIterable<U> map(final Function<T, U> mapper) {
-        return new MappingIterable<T, U>(this, mapper);
+    public <U> MongoIterable<U> map(final Function<TResult, U> mapper) {
+        return new MappingIterable<TResult, U>(this, mapper);
     }
 
     @Override
-    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<T>> callback) {
+    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<TResult>> callback) {
         execute().batchCursor(callback);
     }
 
-    private MongoIterable<T> execute() {
+    private MongoIterable<TResult> execute() {
         return execute(createListCollectionsOperation());
     }
 
-    private MongoIterable<T> execute(final ListCollectionsOperation<T> operation) {
-        return new OperationIterable<T>(operation, readPreference, executor);
+    private MongoIterable<TResult> execute(final ListCollectionsOperation<TResult> operation) {
+        return new OperationIterable<TResult>(operation, readPreference, executor);
     }
 
     private <C> Codec<C> getCodec(final Class<C> clazz) {
         return codecRegistry.get(clazz);
     }
 
-    private ListCollectionsOperation<T> createListCollectionsOperation() {
-        return new ListCollectionsOperation<T>(databaseName, getCodec(clazz))
-                .filter(asBson(filter))
+    private ListCollectionsOperation<TResult> createListCollectionsOperation() {
+        return new ListCollectionsOperation<TResult>(databaseName, getCodec(resultClass))
+                .filter(toBsonDocument(filter))
                 .batchSize(batchSize)
                 .maxTime(maxTimeMS, MILLISECONDS);
     }
 
-    private BsonDocument asBson(final Object document) {
-        return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
+    private BsonDocument toBsonDocument(final Bson document) {
+        return document == null ? null : document.toBsonDocument(BsonDocument.class, codecRegistry);
     }
 
 }

--- a/driver-async/src/main/com/mongodb/async/client/ListIndexesIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/ListIndexesIterable.java
@@ -21,10 +21,10 @@ import java.util.concurrent.TimeUnit;
 /**
  * Iterable for ListIndexes.
  *
- * @param <T> The type of the result.
+ * @param <TResult> The type of the result.
  * @since 3.0
  */
-public interface ListIndexesIterable<T> extends MongoIterable<T> {
+public interface ListIndexesIterable<TResult> extends MongoIterable<TResult> {
 
     /**
      * Sets the maximum execution time on the server for this operation.
@@ -34,7 +34,7 @@ public interface ListIndexesIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/operator/meta/maxTimeMS/ Max Time
      */
-    ListIndexesIterable<T> maxTime(long maxTime, TimeUnit timeUnit);
+    ListIndexesIterable<TResult> maxTime(long maxTime, TimeUnit timeUnit);
 
     /**
      * Sets the number of documents to return per batch.
@@ -43,5 +43,5 @@ public interface ListIndexesIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
-    ListIndexesIterable<T> batchSize(int batchSize);
+    ListIndexesIterable<TResult> batchSize(int batchSize);
 }

--- a/driver-async/src/main/com/mongodb/async/client/ListIndexesIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/ListIndexesIterableImpl.java
@@ -20,8 +20,8 @@ import com.mongodb.Block;
 import com.mongodb.Function;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
-import com.mongodb.async.SingleResultCallback;
 import com.mongodb.async.AsyncBatchCursor;
+import com.mongodb.async.SingleResultCallback;
 import com.mongodb.operation.AsyncOperationExecutor;
 import com.mongodb.operation.ListIndexesOperation;
 import org.bson.codecs.Codec;
@@ -33,9 +33,9 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-final class ListIndexesIterableImpl<T> implements ListIndexesIterable<T> {
+final class ListIndexesIterableImpl<TResult> implements ListIndexesIterable<TResult> {
     private final MongoNamespace namespace;
-    private final Class<T> clazz;
+    private final Class<TResult> resultClass;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final AsyncOperationExecutor executor;
@@ -43,67 +43,67 @@ final class ListIndexesIterableImpl<T> implements ListIndexesIterable<T> {
     private int batchSize;
     private long maxTimeMS;
 
-    ListIndexesIterableImpl(final MongoNamespace namespace, final Class<T> clazz, final CodecRegistry codecRegistry,
+    ListIndexesIterableImpl(final MongoNamespace namespace, final Class<TResult> resultClass, final CodecRegistry codecRegistry,
                             final ReadPreference readPreference, final AsyncOperationExecutor executor) {
         this.namespace = notNull("namespace", namespace);
-        this.clazz = notNull("clazz", clazz);
+        this.resultClass = notNull("resultClass", resultClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.executor = notNull("executor", executor);
     }
 
     @Override
-    public ListIndexesIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public ListIndexesIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         this.maxTimeMS = MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public ListIndexesIterable<T> batchSize(final int batchSize) {
+    public ListIndexesIterable<TResult> batchSize(final int batchSize) {
         this.batchSize = batchSize;
         return this;
     }
 
     @Override
-    public void first(final SingleResultCallback<T> callback) {
+    public void first(final SingleResultCallback<TResult> callback) {
         execute(createListIndexesOperation().batchSize(-1)).first(callback);
     }
 
     @Override
-    public void forEach(final Block<? super T> block, final SingleResultCallback<Void> callback) {
+    public void forEach(final Block<? super TResult> block, final SingleResultCallback<Void> callback) {
         execute().forEach(block, callback);
     }
 
     @Override
-    public <A extends Collection<? super T>> void into(final A target, final SingleResultCallback<A> callback) {
+    public <A extends Collection<? super TResult>> void into(final A target, final SingleResultCallback<A> callback) {
         execute().into(target, callback);
     }
 
     @Override
-    public <U> MongoIterable<U> map(final Function<T, U> mapper) {
-        return new MappingIterable<T, U>(this, mapper);
+    public <U> MongoIterable<U> map(final Function<TResult, U> mapper) {
+        return new MappingIterable<TResult, U>(this, mapper);
     }
 
     @Override
-    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<T>> callback) {
+    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<TResult>> callback) {
         execute().batchCursor(callback);
     }
 
-    private MongoIterable<T> execute() {
+    private MongoIterable<TResult> execute() {
         return execute(createListIndexesOperation());
     }
 
-    private MongoIterable<T> execute(final ListIndexesOperation<T> operation) {
-        return new OperationIterable<T>(operation, readPreference, executor);
+    private MongoIterable<TResult> execute(final ListIndexesOperation<TResult> operation) {
+        return new OperationIterable<TResult>(operation, readPreference, executor);
     }
 
     private <C> Codec<C> getCodec(final Class<C> clazz) {
         return codecRegistry.get(clazz);
     }
 
-    private ListIndexesOperation<T> createListIndexesOperation() {
-        return new ListIndexesOperation<T>(namespace, getCodec(clazz))
+    private ListIndexesOperation<TResult> createListIndexesOperation() {
+        return new ListIndexesOperation<TResult>(namespace, getCodec(resultClass))
                 .batchSize(batchSize)
                 .maxTime(maxTimeMS, MILLISECONDS);
     }

--- a/driver-async/src/main/com/mongodb/async/client/MapReduceIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/MapReduceIterable.java
@@ -19,16 +19,17 @@ package com.mongodb.async.client;
 
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.client.model.MapReduceAction;
+import org.bson.conversions.Bson;
 
 import java.util.concurrent.TimeUnit;
 
 /**
  * Iterable for map reduce.
  *
- * @param <T> The type of the result.
+ * @param <TResult> The type of the result.
  * @since 3.0
  */
-public interface MapReduceIterable<T> extends MongoIterable<T> {
+public interface MapReduceIterable<TResult> extends MongoIterable<TResult> {
 
     /**
      * Sets the collectionName for the output of the MapReduce
@@ -38,7 +39,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @param collectionName the name of the collection that you want the map-reduce operation to write its output.
      * @return this
      */
-    MapReduceIterable<T> collectionName(String collectionName);
+    MapReduceIterable<TResult> collectionName(String collectionName);
 
     /**
      * Sets the JavaScript function that follows the reduce method and modifies the output.
@@ -47,7 +48,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/command/mapReduce/#mapreduce-finalize-cmd Requirements for the finalize Function
      */
-    MapReduceIterable<T> finalizeFunction(String finalizeFunction);
+    MapReduceIterable<TResult> finalizeFunction(String finalizeFunction);
 
     /**
      * Sets the global variables that are accessible in the map, reduce and finalize functions.
@@ -56,7 +57,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/command/mapReduce mapReduce
      */
-    MapReduceIterable<T> scope(Object scope);
+    MapReduceIterable<TResult> scope(Bson scope);
 
     /**
      * Sets the sort criteria to apply to the query.
@@ -65,7 +66,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.sort/ Sort
      */
-    MapReduceIterable<T> sort(Object sort);
+    MapReduceIterable<TResult> sort(Bson sort);
 
     /**
      * Sets the query filter to apply to the query.
@@ -74,7 +75,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Filter
      */
-    MapReduceIterable<T> filter(Object filter);
+    MapReduceIterable<TResult> filter(Bson filter);
 
     /**
      * Sets the limit to apply.
@@ -83,7 +84,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.limit/#cursor.limit Limit
      */
-    MapReduceIterable<T> limit(int limit);
+    MapReduceIterable<TResult> limit(int limit);
 
     /**
      * Sets the flag that specifies whether to convert intermediate data into BSON format between the execution of the map and reduce
@@ -94,7 +95,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return jsMode
      * @mongodb.driver.manual reference/command/mapReduce mapReduce
      */
-    MapReduceIterable<T> jsMode(boolean jsMode);
+    MapReduceIterable<TResult> jsMode(boolean jsMode);
 
     /**
      * Sets whether to include the timing information in the result information.
@@ -102,7 +103,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @param verbose whether to include the timing information in the result information.
      * @return this
      */
-    MapReduceIterable<T> verbose(boolean verbose);
+    MapReduceIterable<TResult> verbose(boolean verbose);
 
     /**
      * Sets the maximum execution time on the server for this operation.
@@ -112,7 +113,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.maxTimeMS/#cursor.maxTimeMS Max Time
      */
-    MapReduceIterable<T> maxTime(long maxTime, TimeUnit timeUnit);
+    MapReduceIterable<TResult> maxTime(long maxTime, TimeUnit timeUnit);
 
     /**
      * Specify the {@code MapReduceAction} to be used when writing to a collection.
@@ -120,7 +121,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @param action an {@link com.mongodb.client.model.MapReduceAction} to perform on the collection
      * @return this
      */
-    MapReduceIterable<T> action(MapReduceAction action);
+    MapReduceIterable<TResult> action(MapReduceAction action);
 
     /**
      * Sets the name of the database to output into.
@@ -129,7 +130,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/command/mapReduce/#output-to-a-collection-with-an-action output with an action
      */
-    MapReduceIterable<T> databaseName(String databaseName);
+    MapReduceIterable<TResult> databaseName(String databaseName);
     /**
      * Sets if the output database is sharded
      *
@@ -137,7 +138,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/command/mapReduce/#output-to-a-collection-with-an-action output with an action
      */
-    MapReduceIterable<T> sharded(boolean sharded);
+    MapReduceIterable<TResult> sharded(boolean sharded);
 
     /**
      * Sets if the post-processing step will prevent MongoDB from locking the database.
@@ -148,7 +149,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/command/mapReduce/#output-to-a-collection-with-an-action output with an action
      */
-    MapReduceIterable<T> nonAtomic(boolean nonAtomic);
+    MapReduceIterable<TResult> nonAtomic(boolean nonAtomic);
 
     /**
      * Sets the number of documents to return per batch.
@@ -157,7 +158,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
-    MapReduceIterable<T> batchSize(int batchSize);
+    MapReduceIterable<TResult> batchSize(int batchSize);
 
     /**
      * Aggregates documents to a collection according to the specified map-reduce function with the given options, which must specify a

--- a/driver-async/src/main/com/mongodb/async/client/MapReduceIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MapReduceIterableImpl.java
@@ -29,9 +29,9 @@ import com.mongodb.operation.MapReduceStatistics;
 import com.mongodb.operation.MapReduceToCollectionOperation;
 import com.mongodb.operation.MapReduceWithInlineResultsOperation;
 import org.bson.BsonDocument;
-import org.bson.BsonDocumentWrapper;
 import org.bson.BsonJavaScript;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
@@ -40,9 +40,10 @@ import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-class MapReduceIterableImpl<T> implements MapReduceIterable<T> {
+class MapReduceIterableImpl<TDocument, TResult> implements MapReduceIterable<TResult> {
     private final MongoNamespace namespace;
-    private final Class<T> clazz;
+    private final Class<TDocument> documentClass;
+    private final Class<TResult> resultClass;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final AsyncOperationExecutor executor;
@@ -52,9 +53,9 @@ class MapReduceIterableImpl<T> implements MapReduceIterable<T> {
     private boolean inline = true;
     private String collectionName;
     private String finalizeFunction;
-    private Object scope;
-    private Object filter;
-    private Object sort;
+    private Bson scope;
+    private Bson filter;
+    private Bson sort;
     private int limit;
     private boolean jsMode;
     private boolean verbose = true;
@@ -65,11 +66,12 @@ class MapReduceIterableImpl<T> implements MapReduceIterable<T> {
     private boolean nonAtomic;
     private int batchSize;
 
-    MapReduceIterableImpl(final MongoNamespace namespace, final Class<T> clazz, final CodecRegistry codecRegistry,
-                          final ReadPreference readPreference, final AsyncOperationExecutor executor, final String mapFunction,
-                          final String reduceFunction) {
+    MapReduceIterableImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final Class<TResult> resultClass,
+                          final CodecRegistry codecRegistry, final ReadPreference readPreference, final AsyncOperationExecutor executor,
+                          final String mapFunction, final String reduceFunction) {
         this.namespace = notNull("namespace", namespace);
-        this.clazz = notNull("clazz", clazz);
+        this.documentClass = documentClass;
+        this.resultClass = notNull("resultClass", resultClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.executor = notNull("executor", executor);
@@ -78,87 +80,87 @@ class MapReduceIterableImpl<T> implements MapReduceIterable<T> {
     }
 
     @Override
-    public MapReduceIterable<T> collectionName(final String collectionName) {
+    public MapReduceIterable<TResult> collectionName(final String collectionName) {
         this.collectionName = notNull("collectionName", collectionName);
         this.inline = false;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> finalizeFunction(final String finalizeFunction) {
+    public MapReduceIterable<TResult> finalizeFunction(final String finalizeFunction) {
         this.finalizeFunction = finalizeFunction;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> scope(final Object scope) {
+    public MapReduceIterable<TResult> scope(final Bson scope) {
         this.scope = scope;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> sort(final Object sort) {
+    public MapReduceIterable<TResult> sort(final Bson sort) {
         this.sort = sort;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> filter(final Object filter) {
+    public MapReduceIterable<TResult> filter(final Bson filter) {
         this.filter = filter;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> limit(final int limit) {
+    public MapReduceIterable<TResult> limit(final int limit) {
         this.limit = limit;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> jsMode(final boolean jsMode) {
+    public MapReduceIterable<TResult> jsMode(final boolean jsMode) {
         this.jsMode = jsMode;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> verbose(final boolean verbose) {
+    public MapReduceIterable<TResult> verbose(final boolean verbose) {
         this.verbose = verbose;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public MapReduceIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> action(final MapReduceAction action) {
+    public MapReduceIterable<TResult> action(final MapReduceAction action) {
         this.action = action;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> databaseName(final String databaseName) {
+    public MapReduceIterable<TResult> databaseName(final String databaseName) {
         this.databaseName = databaseName;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> sharded(final boolean sharded) {
+    public MapReduceIterable<TResult> sharded(final boolean sharded) {
         this.sharded = sharded;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> nonAtomic(final boolean nonAtomic) {
+    public MapReduceIterable<TResult> nonAtomic(final boolean nonAtomic) {
         this.nonAtomic = nonAtomic;
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> batchSize(final int batchSize) {
+    public MapReduceIterable<TResult> batchSize(final int batchSize) {
         this.batchSize = batchSize;
         return this;
     }
@@ -178,71 +180,68 @@ class MapReduceIterableImpl<T> implements MapReduceIterable<T> {
     }
 
     @Override
-    public void first(final SingleResultCallback<T> callback) {
+    public void first(final SingleResultCallback<TResult> callback) {
         execute().first(callback);
     }
 
     @Override
-    public void forEach(final Block<? super T> block, final SingleResultCallback<Void> callback) {
+    public void forEach(final Block<? super TResult> block, final SingleResultCallback<Void> callback) {
         execute().forEach(block, callback);
     }
 
     @Override
-    public <A extends Collection<? super T>> void into(final A target, final SingleResultCallback<A> callback) {
+    public <A extends Collection<? super TResult>> void into(final A target, final SingleResultCallback<A> callback) {
         execute().into(target, callback);
     }
 
     @Override
-    public <U> MongoIterable<U> map(final Function<T, U> mapper) {
-        return new MappingIterable<T, U>(this, mapper);
+    public <U> MongoIterable<U> map(final Function<TResult, U> mapper) {
+        return new MappingIterable<TResult, U>(this, mapper);
     }
 
     @Override
-    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<T>> callback) {
+    public void batchCursor(final SingleResultCallback<AsyncBatchCursor<TResult>> callback) {
         execute().batchCursor(callback);
     }
 
-    MongoIterable<T> execute() {
+    MongoIterable<TResult> execute() {
         if (inline) {
-            MapReduceWithInlineResultsOperation<T> operation =
-                    new MapReduceWithInlineResultsOperation<T>(namespace,
+            MapReduceWithInlineResultsOperation<TResult> operation =
+                    new MapReduceWithInlineResultsOperation<TResult>(namespace,
                             new BsonJavaScript(mapFunction),
                             new BsonJavaScript(reduceFunction),
-                            codecRegistry.get(clazz))
-                            .filter(asBson(filter))
+                            codecRegistry.get(resultClass))
+                            .filter(toBsonDocument(filter))
                             .limit(limit)
                             .maxTime(maxTimeMS, MILLISECONDS)
                             .jsMode(jsMode)
-                            .scope(asBson(scope))
-                            .sort(asBson(sort))
+                            .scope(toBsonDocument(scope))
+                            .sort(toBsonDocument(sort))
                             .verbose(verbose);
             if (finalizeFunction != null) {
                 operation.finalizeFunction(new BsonJavaScript(finalizeFunction));
             }
-            return new OperationIterable<T>(operation, readPreference, executor);
+            return new OperationIterable<TResult>(operation, readPreference, executor);
         } else {
             MapReduceToCollectionOperation operation = createMapReduceToCollectionOperation();
 
             String dbName = databaseName != null ? databaseName : namespace.getDatabaseName();
-            MongoIterable<T> delegated = new FindIterableImpl<T>(new MongoNamespace(dbName, collectionName),
-                    clazz, codecRegistry, primary(), executor, new BsonDocument(), new FindOptions()).batchSize(batchSize);
-            return new AwaitingWriteOperationIterable<T, MapReduceStatistics>(operation, executor, delegated);
+            MongoIterable<TResult> delegated = new FindIterableImpl<TDocument, TResult>(new MongoNamespace(dbName, collectionName),
+                    documentClass, resultClass, codecRegistry, primary(), executor, new BsonDocument(),
+                    new FindOptions()).batchSize(batchSize);
+            return new AwaitingWriteOperationIterable<TResult, MapReduceStatistics>(operation, executor, delegated);
         }
-    }
-
-    private BsonDocument asBson(final Object document) {
-        return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
     }
 
     private MapReduceToCollectionOperation createMapReduceToCollectionOperation() {
         MapReduceToCollectionOperation operation = new MapReduceToCollectionOperation(namespace, new BsonJavaScript(mapFunction),
                 new BsonJavaScript(reduceFunction), collectionName)
-                .filter(asBson(filter))
+                .filter(toBsonDocument(filter))
                 .limit(limit)
                 .maxTime(maxTimeMS, MILLISECONDS)
                 .jsMode(jsMode)
-                .scope(asBson(scope))
-                .sort(asBson(sort))
+                .scope(toBsonDocument(scope))
+                .sort(toBsonDocument(sort))
                 .verbose(verbose)
                 .action(action.getValue())
                 .nonAtomic(nonAtomic)
@@ -253,5 +252,9 @@ class MapReduceIterableImpl<T> implements MapReduceIterable<T> {
             operation.finalizeFunction(new BsonJavaScript(finalizeFunction));
         }
         return operation;
+    }
+
+    private BsonDocument toBsonDocument(final Bson document) {
+        return document == null ? null : document.toBsonDocument(documentClass, codecRegistry);
     }
 }

--- a/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
@@ -88,7 +88,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     MongoCollectionImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final CodecRegistry codecRegistry,
                         final ReadPreference readPreference, final WriteConcern writeConcern, final AsyncOperationExecutor executor) {
         this.namespace = notNull("namespace", namespace);
-        this.documentClass = notNull("clazz", documentClass);
+        this.documentClass = notNull("documentClass", documentClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.writeConcern = notNull("writeConcern", writeConcern);
@@ -121,8 +121,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    public <NewTDocument> MongoCollection<NewTDocument> withDocumentClass(final Class<NewTDocument> clazz) {
-        return new MongoCollectionImpl<NewTDocument>(namespace, clazz, codecRegistry, readPreference, writeConcern, executor);
+    public <NewTDocument> MongoCollection<NewTDocument> withDocumentClass(final Class<NewTDocument> documentClass) {
+        return new MongoCollectionImpl<NewTDocument>(namespace, documentClass, codecRegistry, readPreference, writeConcern, executor);
     }
 
     @Override
@@ -166,8 +166,9 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    public <TResult> DistinctIterable<TResult> distinct(final String fieldName, final Class<TResult> clazz) {
-        return new DistinctIterableImpl<TResult>(namespace, clazz, codecRegistry, readPreference, executor, fieldName);
+    public <TResult> DistinctIterable<TResult> distinct(final String fieldName, final Class<TResult> resultClass) {
+        return new DistinctIterableImpl<TDocument, TResult>(namespace, documentClass, resultClass, codecRegistry, readPreference, executor,
+                                                            fieldName);
     }
 
     @Override
@@ -176,8 +177,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    public <TResult> FindIterable<TResult> find(final Class<TResult> clazz) {
-        return find(new BsonDocument(), clazz);
+    public <TResult> FindIterable<TResult> find(final Class<TResult> resultClass) {
+        return find(new BsonDocument(), resultClass);
     }
 
     @Override
@@ -186,8 +187,9 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    public <TResult> FindIterable<TResult> find(final Bson filter, final Class<TResult> clazz) {
-        return new FindIterableImpl<TResult>(namespace, clazz, codecRegistry, readPreference, executor, filter, new FindOptions());
+    public <TResult> FindIterable<TResult> find(final Bson filter, final Class<TResult> resultClass) {
+        return new FindIterableImpl<TDocument, TResult>(namespace, documentClass, resultClass, codecRegistry, readPreference, executor,
+                                                        filter, new FindOptions());
     }
 
     @Override
@@ -196,8 +198,9 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    public <TResult> AggregateIterable<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> clazz) {
-        return new AggregateIterableImpl<TResult>(namespace, clazz, codecRegistry, readPreference, executor, pipeline);
+    public <TResult> AggregateIterable<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass) {
+        return new AggregateIterableImpl<TDocument, TResult>(namespace, documentClass, resultClass, codecRegistry, readPreference, executor,
+                                                             pipeline);
     }
 
     @Override
@@ -207,8 +210,9 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public <TResult> MapReduceIterable<TResult> mapReduce(final String mapFunction, final String reduceFunction,
-                                                          final Class<TResult> clazz) {
-        return new MapReduceIterableImpl<TResult>(namespace, clazz, codecRegistry, readPreference, executor, mapFunction, reduceFunction);
+                                                          final Class<TResult> resultClass) {
+        return new MapReduceIterableImpl<TDocument, TResult>(namespace, documentClass, resultClass, codecRegistry, readPreference, executor,
+                                                             mapFunction, reduceFunction);
     }
 
     @Override
@@ -437,8 +441,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    public <TResult> ListIndexesIterable<TResult> listIndexes(final Class<TResult> clazz) {
-        return new ListIndexesIterableImpl<TResult>(namespace, clazz, codecRegistry, readPreference, executor);
+    public <TResult> ListIndexesIterable<TResult> listIndexes(final Class<TResult> resultClass) {
+        return new ListIndexesIterableImpl<TResult>(namespace, resultClass, codecRegistry, readPreference, executor);
     }
 
     @Override
@@ -531,8 +535,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
         return getCodec(documentClass);
     }
 
-    private <TResult> Codec<TResult> getCodec(final Class<TResult> clazz) {
-        return codecRegistry.get(clazz);
+    private <TResult> Codec<TResult> getCodec(final Class<TResult> resultClass) {
+        return codecRegistry.get(resultClass);
     }
 
     private BsonDocument documentToBsonDocument(final TDocument document) {

--- a/driver-async/src/main/com/mongodb/async/client/MongoDatabase.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoDatabase.java
@@ -23,6 +23,7 @@ import com.mongodb.async.SingleResultCallback;
 import com.mongodb.client.model.CreateCollectionOptions;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 /**
  * The MongoDatabase interface.
@@ -110,7 +111,7 @@ public interface MongoDatabase {
      * @param command  the command to be run
      * @param callback the callback that is passed the command result
      */
-    void executeCommand(Object command, SingleResultCallback<Document> callback);
+    void executeCommand(Bson command, SingleResultCallback<Document> callback);
 
     /**
      * Executes command in the context of the current database.
@@ -119,7 +120,7 @@ public interface MongoDatabase {
      * @param readPreference the {@link com.mongodb.ReadPreference} to be used when executing the command
      * @param callback       the callback that is passed the command result
      */
-    void executeCommand(Object command, ReadPreference readPreference, SingleResultCallback<Document> callback);
+    void executeCommand(Bson command, ReadPreference readPreference, SingleResultCallback<Document> callback);
 
     /**
      * Executes command in the context of the current database.
@@ -129,7 +130,7 @@ public interface MongoDatabase {
      * @param <T>      the type of the class to use instead of {@code Document}.
      * @param callback the callback that is passed the command result
      */
-    <T> void executeCommand(Object command, Class<T> clazz, SingleResultCallback<T> callback);
+    <T> void executeCommand(Bson command, Class<T> clazz, SingleResultCallback<T> callback);
 
     /**
      * Executes command in the context of the current database.
@@ -140,7 +141,7 @@ public interface MongoDatabase {
      * @param <T>            the type of the class to use instead of {@code Document}.
      * @param callback       the callback that is passed the command result
      */
-    <T> void executeCommand(Object command, ReadPreference readPreference, Class<T> clazz, SingleResultCallback<T> callback);
+    <T> void executeCommand(Bson command, ReadPreference readPreference, Class<T> clazz, SingleResultCallback<T> callback);
 
     /**
      * Drops this database.

--- a/driver-async/src/main/com/mongodb/async/client/MongoDatabaseImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoDatabaseImpl.java
@@ -30,10 +30,10 @@ import com.mongodb.operation.DropDatabaseOperation;
 import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.async.client.MongoClientImpl.getDefaultCodecRegistry;
-import static org.bson.BsonDocumentWrapper.asBsonDocument;
 
 class MongoDatabaseImpl implements MongoDatabase {
     private final String name;
@@ -119,27 +119,27 @@ class MongoDatabaseImpl implements MongoDatabase {
     }
 
     @Override
-    public void executeCommand(final Object command, final SingleResultCallback<Document> callback) {
+    public void executeCommand(final Bson command, final SingleResultCallback<Document> callback) {
         executeCommand(command, Document.class, callback);
     }
 
     @Override
-    public void executeCommand(final Object command, final ReadPreference readPreference, final SingleResultCallback<Document> callback) {
+    public void executeCommand(final Bson command, final ReadPreference readPreference, final SingleResultCallback<Document> callback) {
         executeCommand(command, readPreference, Document.class, callback);
     }
 
     @Override
-    public <T> void executeCommand(final Object command, final Class<T> clazz, final SingleResultCallback<T> callback) {
+    public <T> void executeCommand(final Bson command, final Class<T> clazz, final SingleResultCallback<T> callback) {
         notNull("command", command);
-        executor.execute(new CommandWriteOperation<T>(getName(), asBson(command), codecRegistry.get(clazz)), callback);
+        executor.execute(new CommandWriteOperation<T>(getName(), toBsonDocument(command), codecRegistry.get(clazz)), callback);
     }
 
     @Override
-    public <T> void executeCommand(final Object command, final ReadPreference readPreference, final Class<T> clazz,
+    public <T> void executeCommand(final Bson command, final ReadPreference readPreference, final Class<T> clazz,
                                    final SingleResultCallback<T> callback) {
         notNull("command", command);
         notNull("readPreference", readPreference);
-        executor.execute(new CommandReadOperation<T>(getName(), asBson(command), codecRegistry.get(clazz)), readPreference,
+        executor.execute(new CommandReadOperation<T>(getName(), toBsonDocument(command), codecRegistry.get(clazz)), readPreference,
                 callback);
     }
 
@@ -162,10 +162,10 @@ class MongoDatabaseImpl implements MongoDatabase {
                          .autoIndex(createCollectionOptions.isAutoIndex())
                          .maxDocuments(createCollectionOptions.getMaxDocuments())
                          .usePowerOf2Sizes(createCollectionOptions.isUsePowerOf2Sizes())
-                         .storageEngineOptions(asBson(createCollectionOptions.getStorageEngineOptions())), callback);
+                         .storageEngineOptions(toBsonDocument(createCollectionOptions.getStorageEngineOptions())), callback);
     }
 
-    private BsonDocument asBson(final Object document) {
-        return asBsonDocument(document, codecRegistry);
+    private BsonDocument toBsonDocument(final Bson document) {
+        return document == null ? null : document.toBsonDocument(BsonDocument.class, codecRegistry);
     }
 }

--- a/driver-async/src/main/com/mongodb/async/client/MongoIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoIterable.java
@@ -18,25 +18,25 @@ package com.mongodb.async.client;
 
 import com.mongodb.Block;
 import com.mongodb.Function;
-import com.mongodb.async.SingleResultCallback;
 import com.mongodb.async.AsyncBatchCursor;
+import com.mongodb.async.SingleResultCallback;
 
 import java.util.Collection;
 
 /**
  * Operations that allow asynchronous iteration over a collection view.
  *
- * @param <T> the document type
+ * @param <TResult> the result type
  * @since 3.0
  */
-public interface MongoIterable<T> {
+public interface MongoIterable<TResult> {
 
     /**
      * Helper to return the first item in the iterator or null.
      *
      * @param callback a callback that is passed the first item or null.
      */
-    void first(SingleResultCallback<T> callback);
+    void first(SingleResultCallback<TResult> callback);
 
     /**
      * Iterates over all documents in the view, applying the given block to each, and completing the returned future after all documents
@@ -45,7 +45,7 @@ public interface MongoIterable<T> {
      * @param block    the block to apply to each document
      * @param callback a callback that completed once the iteration has completed
      */
-    void forEach(Block<? super T> block, SingleResultCallback<Void> callback);
+    void forEach(Block<? super TResult> block, SingleResultCallback<Void> callback);
 
     /**
      * Iterates over all the documents, adding each to the given target.
@@ -54,7 +54,7 @@ public interface MongoIterable<T> {
      * @param <A>      the collection type
      * @param callback a callback that will be passed the target containing all documents
      */
-    <A extends Collection<? super T>> void into(A target, SingleResultCallback<A> callback);
+    <A extends Collection<? super TResult>> void into(A target, SingleResultCallback<A> callback);
 
     /**
      * Maps this iterable from the source document type to the target document type.
@@ -63,7 +63,7 @@ public interface MongoIterable<T> {
      * @param <U>    the target document type
      * @return an iterable which maps T to U
      */
-    <U> MongoIterable<U> map(Function<T, U> mapper);
+    <U> MongoIterable<U> map(Function<TResult, U> mapper);
 
     /**
      * Sets the number of documents to return per batch.
@@ -72,12 +72,12 @@ public interface MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
-    MongoIterable<T> batchSize(int batchSize);
+    MongoIterable<TResult> batchSize(int batchSize);
 
     /**
      * Provide the underlying {@link com.mongodb.async.AsyncBatchCursor} allowing fine grained control of the cursor.
      *
      * @param callback a callback that will be passed the AsyncBatchCursor
      */
-    void batchCursor(SingleResultCallback<AsyncBatchCursor<T>> callback);
+    void batchCursor(SingleResultCallback<AsyncBatchCursor<TResult>> callback);
 }

--- a/driver-async/src/test/unit/com/mongodb/async/client/AggregateIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/AggregateIterableSpecification.groovy
@@ -57,8 +57,8 @@ class AggregateIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([cursor, cursor, cursor, cursor, cursor]);
         def pipeline = [new Document('$match', 1)]
-        def aggregationIterable = new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
-                pipeline)
+        def aggregationIterable = new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                            pipeline)
 
         when: 'default input should be as expected'
         aggregationIterable.into([]) { result, t -> }
@@ -97,8 +97,7 @@ class AggregateIterableSpecification extends Specification {
         def pipeline = [new Document('$match', 1), new Document('$out', collectionName)]
 
         when: 'aggregation includes $out'
-        new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
-                pipeline)
+        new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor, pipeline)
                 .batchSize(99)
                 .maxTime(999, MILLISECONDS)
                 .allowDiskUse(true)
@@ -121,8 +120,9 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'toCollection should work as expected'
         def futureResultCallback = new FutureResultCallback()
-        new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
-                pipeline).allowDiskUse(true).toCollection(futureResultCallback)
+        new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor, pipeline)
+                .allowDiskUse(true)
+                .toCollection(futureResultCallback);
         futureResultCallback.get()
 
         operation = executor.getWriteOperation() as AggregateToCollectionOperation
@@ -138,8 +138,8 @@ class AggregateIterableSpecification extends Specification {
         def codecRegistry = fromProviders([new ValueCodecProvider(), new BsonValueCodecProvider()])
         def executor = new TestOperationExecutor([new MongoException('failure')])
         def pipeline = [new BsonDocument('$match', new BsonInt32(1))]
-        def aggregationIterable = new AggregateIterableImpl<BsonDocument>(namespace, BsonDocument, codecRegistry, readPreference, executor,
-                pipeline)
+        def aggregationIterable = new AggregateIterableImpl(namespace, Document, BsonDocument, codecRegistry, readPreference, executor,
+                                                            pipeline)
 
         def futureResultCallback = new FutureResultCallback<List<BsonDocument>>()
 
@@ -158,8 +158,8 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'a codec is missing'
         futureResultCallback = new FutureResultCallback<List<BsonDocument>>()
-        new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
-                pipeline).into([], futureResultCallback)
+        new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor, pipeline)
+                .into([], futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -185,8 +185,8 @@ class AggregateIterableSpecification extends Specification {
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor(), cursor()]);
-        def mongoIterable = new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
-                [new BsonDocument('$match', new BsonInt32(1))])
+        def mongoIterable = new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference,
+                                                      executor, [new BsonDocument('$match', new BsonInt32(1))])
 
         when:
         def results = new FutureResultCallback()

--- a/driver-async/src/test/unit/com/mongodb/async/client/DistinctIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/DistinctIterableSpecification.groovy
@@ -53,8 +53,7 @@ class DistinctIterableSpecification extends Specification {
             }
         }
         def executor = new TestOperationExecutor([cursor, cursor]);
-        def distinctIterable = new DistinctIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor, 'field')
-
+        def distinctIterable = new DistinctIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor, 'field')
         when: 'default input should be as expected'
         distinctIterable.into([]) { result, t -> }
 
@@ -80,7 +79,7 @@ class DistinctIterableSpecification extends Specification {
         given:
         def codecRegistry = fromProviders([new ValueCodecProvider(), new BsonValueCodecProvider()])
         def executor = new TestOperationExecutor([new MongoException('failure')])
-        def distinctIterable = new DistinctIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor, 'field')
+        def distinctIterable = new DistinctIterableImpl(namespace, Document, BsonDocument, codecRegistry, readPreference, executor, 'field')
 
         def futureResultCallback = new FutureResultCallback()
 
@@ -120,7 +119,7 @@ class DistinctIterableSpecification extends Specification {
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor(), cursor()]);
-        def mongoIterable = new DistinctIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor, 'field')
+        def mongoIterable = new DistinctIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor, 'field')
 
         when:
         def results = new FutureResultCallback()

--- a/driver-async/src/test/unit/com/mongodb/async/client/FindIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/FindIterableSpecification.groovy
@@ -64,8 +64,8 @@ class FindIterableSpecification extends Specification {
                 .oplogReplay(false)
                 .noCursorTimeout(false)
                 .partial(false)
-        def findIterable = new FindIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
-                new Document('filter', 1), findOptions)
+        def findIterable = new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                new Document('filter', 1), findOptions)
 
         when: 'default input should be as expected'
         findIterable.into([]) { result, t -> }
@@ -132,8 +132,8 @@ class FindIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([cursor]);
         def findOptions = new FindOptions()
-        def findIterable = new FindIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor,
-                new Document('filter', 1), findOptions)
+        def findIterable = new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                new Document('filter', 1), findOptions)
 
         when:
         findIterable.filter(new Document('filter', 1))
@@ -173,8 +173,8 @@ class FindIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor(), cursor()]);
         def findOptions = new FindOptions()
-        def mongoIterable = new FindIterableImpl<Document>(new MongoNamespace('db', 'coll'), Document, codecRegistry, readPreference,
-                executor, new Document(), findOptions)
+        def mongoIterable = new FindIterableImpl(new MongoNamespace('db', 'coll'), Document, Document, codecRegistry,
+                                                 readPreference, executor, new Document(), findOptions)
 
         when:
         def results = new FutureResultCallback()

--- a/driver-async/src/test/unit/com/mongodb/async/client/MapReduceIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MapReduceIterableSpecification.groovy
@@ -58,8 +58,8 @@ class MapReduceIterableSpecification extends Specification {
             }
         }
         def executor = new TestOperationExecutor([cursor, cursor]);
-        def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
-                'map', 'reduce')
+        def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                          'map', 'reduce')
 
         when: 'default input should be as expected'
         mapReduceIterable.into([]) { result, t -> }
@@ -108,8 +108,8 @@ class MapReduceIterableSpecification extends Specification {
 
         when: 'mapReduce to a collection'
         def collectionNamespace = new MongoNamespace('dbName', 'collName')
-        def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
-                'map', 'reduce')
+        def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                          'map', 'reduce')
                 .collectionName(collectionNamespace.getCollectionName())
                 .databaseName(collectionNamespace.getDatabaseName())
                 .filter(new Document('filter', 1))
@@ -167,8 +167,8 @@ class MapReduceIterableSpecification extends Specification {
         given:
         def codecRegistry = fromProviders([new ValueCodecProvider(), new BsonValueCodecProvider()])
         def executor = new TestOperationExecutor([new MongoException('failure')])
-        def mapReduceIterable = new MapReduceIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor,
-                'map', 'reduce')
+        def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, BsonDocument, codecRegistry, readPreference, executor,
+                                                          'map', 'reduce')
 
         def futureResultCallback = new FutureResultCallback<List<BsonDocument>>()
 
@@ -187,8 +187,8 @@ class MapReduceIterableSpecification extends Specification {
 
         when: 'a codec is missing'
         futureResultCallback = new FutureResultCallback<List<BsonDocument>>()
-        new MapReduceIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
-                'map', 'reduce').into([], futureResultCallback)
+        new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                  'map', 'reduce').into([], futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -214,8 +214,8 @@ class MapReduceIterableSpecification extends Specification {
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor(), cursor()]);
-        def mongoIterable = new MapReduceIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
-                'map', 'reduce')
+        def mongoIterable = new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                      'map', 'reduce')
 
         when:
         def results = new FutureResultCallback()

--- a/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
@@ -236,7 +236,9 @@ class MongoCollectionSpecification extends Specification {
         def distinctIterable = collection.distinct('field', String)
 
         then:
-        expect distinctIterable, isTheSameAs(new DistinctIterableImpl(namespace, String, codecRegistry, readPreference, executor, 'field'))
+        expect distinctIterable, isTheSameAs(new DistinctIterableImpl(namespace, Document, String, codecRegistry,
+                                                                      readPreference,
+                                                                      executor, 'field'))
     }
 
     def 'should create FindIterable correctly'() {
@@ -248,29 +250,29 @@ class MongoCollectionSpecification extends Specification {
         def findIterable = collection.find()
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
-                new BsonDocument(), new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                              new BsonDocument(), new FindOptions()))
 
         when:
         findIterable = collection.find(BsonDocument)
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor,
-                new BsonDocument(), new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, BsonDocument, codecRegistry, readPreference,
+                                                              executor, new BsonDocument(), new FindOptions()))
 
         when:
         findIterable = collection.find(new Document())
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, codecRegistry, readPreference, executor, new Document(),
-                new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+                                                              new Document(), new FindOptions()))
 
         when:
         findIterable = collection.find(new Document(), BsonDocument)
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor,
-                new Document(), new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, BsonDocument, codecRegistry, readPreference,
+                                                              executor, new Document(), new FindOptions()))
     }
 
     def 'should use AggregateIterable correctly'() {
@@ -282,15 +284,15 @@ class MongoCollectionSpecification extends Specification {
         def aggregateIterable = collection.aggregate([new Document('$match', 1)])
 
         then:
-        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl<Document>(namespace, Document, codecRegistry, readPreference,
-                executor, [new Document('$match', 1)]))
+        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, Document, Document, codecRegistry,
+                                                                        readPreference, executor, [new Document('$match', 1)]))
 
         when:
         aggregateIterable = collection.aggregate([new Document('$match', 1)], BsonDocument)
 
         then:
-        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl<BsonDocument>(namespace, BsonDocument, codecRegistry,
-                readPreference, executor, [new Document('$match', 1)]))
+        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, Document, BsonDocument, codecRegistry,
+                                                                        readPreference, executor, [new Document('$match', 1)]))
     }
 
     def 'should create MapReduceIterable correctly'() {
@@ -302,8 +304,8 @@ class MongoCollectionSpecification extends Specification {
         def mapReduceIterable = collection.mapReduce('map', 'reduce')
 
         then:
-        expect mapReduceIterable, isTheSameAs(new MapReduceIterableImpl(namespace, Document, codecRegistry, readPreference, executor,
-                'map', 'reduce'))
+        expect mapReduceIterable, isTheSameAs(new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference,
+                                                                        executor, 'map', 'reduce'))
     }
 
     def 'bulkWrite should use MixedBulkWriteOperation correctly'() {

--- a/driver-core/src/main/com/mongodb/client/model/CreateCollectionOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/CreateCollectionOptions.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.client.model;
 
+import org.bson.conversions.Bson;
+
 /**
  * Options for creating a collection
  *
@@ -28,7 +30,7 @@ public class CreateCollectionOptions {
     private boolean capped;
     private long sizeInBytes;
     private Boolean usePowerOf2Sizes;
-    private Object storageEngineOptions;
+    private Bson storageEngineOptions;
 
     /**
      * Gets if auto-index is enabled
@@ -140,7 +142,7 @@ public class CreateCollectionOptions {
      * @return the storage engine options
      * @mongodb.server.release 3.0
      */
-    public Object getStorageEngineOptions() {
+    public Bson getStorageEngineOptions() {
         return storageEngineOptions;
     }
 
@@ -151,7 +153,7 @@ public class CreateCollectionOptions {
      * @return this
      * @mongodb.server.release 3.0
      */
-    public CreateCollectionOptions storageEngineOptions(final Object storageEngineOptions) {
+    public CreateCollectionOptions storageEngineOptions(final Bson storageEngineOptions) {
         this.storageEngineOptions = storageEngineOptions;
         return this;
     }

--- a/driver/src/main/com/mongodb/AggregateIterableImpl.java
+++ b/driver/src/main/com/mongodb/AggregateIterableImpl.java
@@ -36,27 +36,26 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-class AggregateIterableImpl<TResult, TDocument> implements AggregateIterable<TResult> {
+class AggregateIterableImpl<TDocument, TResult> implements AggregateIterable<TResult> {
     private final MongoNamespace namespace;
-    private final Class<TResult> clazz;
+    private final Class<TDocument> documentClass;
+    private final Class<TResult> resultClass;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final OperationExecutor executor;
     private final List<? extends Bson> pipeline;
-    private final Class<TDocument> collectionClass;
 
     private Boolean allowDiskUse;
     private Integer batchSize;
     private long maxTimeMS;
     private Boolean useCursor;
 
-    AggregateIterableImpl(final MongoNamespace namespace, final Class<TResult> clazz, final Class<TDocument> collectionClass,
-                          final CodecRegistry codecRegistry,
-                          final ReadPreference readPreference, final OperationExecutor executor,
+    AggregateIterableImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final Class<TResult> resultClass,
+                          final CodecRegistry codecRegistry, final ReadPreference readPreference, final OperationExecutor executor,
                           final List<? extends Bson> pipeline) {
         this.namespace = notNull("namespace", namespace);
-        this.clazz = notNull("clazz", clazz);
-        this.collectionClass = notNull("collectionClass", collectionClass);
+        this.documentClass = notNull("collectionClass", documentClass);
+        this.resultClass = notNull("resultClass", resultClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.executor = notNull("executor", executor);
@@ -123,12 +122,13 @@ class AggregateIterableImpl<TResult, TDocument> implements AggregateIterable<TRe
                     .maxTime(maxTimeMS, MILLISECONDS)
                     .allowDiskUse(allowDiskUse);
             executor.execute(operation);
-            return new FindIterableImpl<TResult, TDocument>(new MongoNamespace(namespace.getDatabaseName(),
+            return new FindIterableImpl<TDocument, TResult>(new MongoNamespace(namespace.getDatabaseName(),
                                                                                outCollection.asString().getValue()),
-                    clazz, collectionClass, codecRegistry, readPreference, executor, new BsonDocument(),
+                                                            documentClass, resultClass, codecRegistry, readPreference, executor,
+                                                            new BsonDocument(),
                     new FindOptions()).batchSize(batchSize);
         } else {
-            return new OperationIterable<TResult>(new AggregateOperation<TResult>(namespace, aggregateList, codecRegistry.get(clazz))
+            return new OperationIterable<TResult>(new AggregateOperation<TResult>(namespace, aggregateList, codecRegistry.get(resultClass))
                     .maxTime(maxTimeMS, MILLISECONDS)
                     .allowDiskUse(allowDiskUse)
                     .batchSize(batchSize)
@@ -140,7 +140,7 @@ class AggregateIterableImpl<TResult, TDocument> implements AggregateIterable<TRe
     private List<BsonDocument> createBsonDocumentList(final List<? extends Bson> pipeline) {
         List<BsonDocument> aggregateList = new ArrayList<BsonDocument>(pipeline.size());
         for (Bson obj : pipeline) {
-            aggregateList.add(obj.toBsonDocument(collectionClass, codecRegistry));
+            aggregateList.add(obj.toBsonDocument(documentClass, codecRegistry));
         }
         return aggregateList;
     }

--- a/driver/src/main/com/mongodb/DistinctIterableImpl.java
+++ b/driver/src/main/com/mongodb/DistinctIterableImpl.java
@@ -21,8 +21,8 @@ import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoIterable;
 import com.mongodb.operation.DistinctOperation;
 import com.mongodb.operation.OperationExecutor;
-import org.bson.BsonDocumentWrapper;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
@@ -30,22 +30,25 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-class DistinctIterableImpl<T> implements DistinctIterable<T> {
+class DistinctIterableImpl<TDocument, TResult> implements DistinctIterable<TResult> {
     private final MongoNamespace namespace;
-    private final Class<T> clazz;
+    private final Class<TDocument> documentClass;
+    private final Class<TResult> resultClass;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final OperationExecutor executor;
     private final String fieldName;
 
-    private Object filter;
+    private Bson filter;
     private long maxTimeMS;
 
 
-    DistinctIterableImpl(final MongoNamespace namespace, final Class<T> clazz, final CodecRegistry codecRegistry,
-                         final ReadPreference readPreference, final OperationExecutor executor, final String fieldName) {
+    DistinctIterableImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final Class<TResult> resultClass,
+                         final CodecRegistry codecRegistry, final ReadPreference readPreference, final OperationExecutor executor,
+                         final String fieldName) {
+        this.documentClass = documentClass;
         this.namespace = notNull("namespace", namespace);
-        this.clazz = notNull("clazz", clazz);
+        this.resultClass = notNull("clazz", resultClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.executor = notNull("executor", executor);
@@ -53,53 +56,53 @@ class DistinctIterableImpl<T> implements DistinctIterable<T> {
     }
 
     @Override
-    public DistinctIterable<T> filter(final Object filter) {
+    public DistinctIterable<TResult> filter(final Bson filter) {
         this.filter = filter;
         return this;
     }
 
     @Override
-    public DistinctIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public DistinctIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public DistinctIterable<T> batchSize(final int batchSize) {
+    public DistinctIterable<TResult> batchSize(final int batchSize) {
         // Noop - not supported by DistinctIterable
         return this;
     }
 
     @Override
-    public MongoCursor<T> iterator() {
+    public MongoCursor<TResult> iterator() {
         return execute().iterator();
     }
 
     @Override
-    public T first() {
+    public TResult first() {
         return execute().first();
     }
 
     @Override
-    public <U> MongoIterable<U> map(final Function<T, U> mapper) {
-        return new MappingIterable<T, U>(this, mapper);
+    public <U> MongoIterable<U> map(final Function<TResult, U> mapper) {
+        return new MappingIterable<TResult, U>(this, mapper);
     }
 
     @Override
-    public void forEach(final Block<? super T> block) {
+    public void forEach(final Block<? super TResult> block) {
         execute().forEach(block);
     }
 
     @Override
-    public <A extends Collection<? super T>> A into(final A target) {
+    public <A extends Collection<? super TResult>> A into(final A target) {
         return execute().into(target);
     }
 
-    private MongoIterable<T> execute() {
-        DistinctOperation<T> operation = new DistinctOperation<T>(namespace, fieldName, codecRegistry.get(clazz))
-                .filter(BsonDocumentWrapper.asBsonDocument(filter, codecRegistry))
+    private MongoIterable<TResult> execute() {
+        DistinctOperation<TResult> operation = new DistinctOperation<TResult>(namespace, fieldName, codecRegistry.get(resultClass))
+                .filter(filter == null ? null : filter.toBsonDocument(documentClass, codecRegistry))
                 .maxTime(maxTimeMS, MILLISECONDS);
-        return new OperationIterable<T>(operation, readPreference, executor);
+        return new OperationIterable<TResult>(operation, readPreference, executor);
     }
 }

--- a/driver/src/main/com/mongodb/ListCollectionsIterableImpl.java
+++ b/driver/src/main/com/mongodb/ListCollectionsIterableImpl.java
@@ -22,9 +22,9 @@ import com.mongodb.client.MongoIterable;
 import com.mongodb.operation.ListCollectionsOperation;
 import com.mongodb.operation.OperationExecutor;
 import org.bson.BsonDocument;
-import org.bson.BsonDocumentWrapper;
 import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
@@ -32,88 +32,88 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-final class ListCollectionsIterableImpl<T> implements ListCollectionsIterable<T> {
+final class ListCollectionsIterableImpl<TResult> implements ListCollectionsIterable<TResult> {
     private final String databaseName;
-    private final Class<T> clazz;
+    private final Class<TResult> resultClass;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final OperationExecutor executor;
 
-    private Object filter;
+    private Bson filter;
     private int batchSize;
     private long maxTimeMS;
 
-    ListCollectionsIterableImpl(final String databaseName, final Class<T> clazz, final CodecRegistry codecRegistry,
+    ListCollectionsIterableImpl(final String databaseName, final Class<TResult> resultClass, final CodecRegistry codecRegistry,
                                 final ReadPreference readPreference, final OperationExecutor executor) {
         this.databaseName = notNull("databaseName", databaseName);
-        this.clazz = notNull("clazz", clazz);
+        this.resultClass = notNull("resultClass", resultClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.executor = notNull("executor", executor);
     }
 
     @Override
-    public ListCollectionsIterable<T> filter(final Object filter) {
+    public ListCollectionsIterable<TResult> filter(final Bson filter) {
         notNull("filter", filter);
         this.filter = filter;
         return this;
     }
 
     @Override
-    public ListCollectionsIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public ListCollectionsIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         this.maxTimeMS = MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public ListCollectionsIterable<T> batchSize(final int batchSize) {
+    public ListCollectionsIterable<TResult> batchSize(final int batchSize) {
         this.batchSize = batchSize;
         return this;
     }
 
     @Override
-    public MongoCursor<T> iterator() {
+    public MongoCursor<TResult> iterator() {
         return execute().iterator();
     }
 
     @Override
-    public T first() {
+    public TResult first() {
         return execute().first();
     }
 
     @Override
-    public <U> MongoIterable<U> map(final Function<T, U> mapper) {
-        return new MappingIterable<T, U>(this, mapper);
+    public <U> MongoIterable<U> map(final Function<TResult, U> mapper) {
+        return new MappingIterable<TResult, U>(this, mapper);
     }
 
     @Override
-    public void forEach(final Block<? super T> block) {
+    public void forEach(final Block<? super TResult> block) {
         execute().forEach(block);
     }
 
     @Override
-    public <A extends Collection<? super T>> A into(final A target) {
+    public <A extends Collection<? super TResult>> A into(final A target) {
         return execute().into(target);
     }
 
-    private MongoIterable<T> execute() {
-        return new OperationIterable<T>(createListCollectionsOperation(), readPreference, executor);
+    private MongoIterable<TResult> execute() {
+        return new OperationIterable<TResult>(createListCollectionsOperation(), readPreference, executor);
     }
 
     private <C> Codec<C> getCodec(final Class<C> clazz) {
         return codecRegistry.get(clazz);
     }
 
-    private ListCollectionsOperation<T> createListCollectionsOperation() {
-        return new ListCollectionsOperation<T>(databaseName, getCodec(clazz))
-                .filter(asBson(filter))
+    private ListCollectionsOperation<TResult> createListCollectionsOperation() {
+        return new ListCollectionsOperation<TResult>(databaseName, getCodec(resultClass))
+                .filter(toBsonDocument(filter))
                 .batchSize(batchSize)
                 .maxTime(maxTimeMS, MILLISECONDS);
     }
 
-    private BsonDocument asBson(final Object document) {
-        return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
+    private BsonDocument toBsonDocument(final Bson document) {
+        return document == null ? null : document.toBsonDocument(BsonDocument.class, codecRegistry);
     }
 
 }

--- a/driver/src/main/com/mongodb/ListDatabasesIterableImpl.java
+++ b/driver/src/main/com/mongodb/ListDatabasesIterableImpl.java
@@ -20,8 +20,6 @@ import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoIterable;
 import com.mongodb.operation.ListDatabasesOperation;
 import com.mongodb.operation.OperationExecutor;
-import org.bson.BsonDocument;
-import org.bson.BsonDocumentWrapper;
 import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecRegistry;
 
@@ -32,15 +30,15 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 
-final class ListDatabasesIterableImpl<T> implements ListDatabasesIterable<T> {
-    private final Class<T> clazz;
+final class ListDatabasesIterableImpl<TResult> implements ListDatabasesIterable<TResult> {
+    private final Class<TResult> clazz;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final OperationExecutor executor;
 
     private long maxTimeMS;
 
-    ListDatabasesIterableImpl(final Class<T> clazz, final CodecRegistry codecRegistry,
+    ListDatabasesIterableImpl(final Class<TResult> clazz, final CodecRegistry codecRegistry,
                               final ReadPreference readPreference, final OperationExecutor executor) {
         this.clazz = notNull("clazz", clazz);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
@@ -49,57 +47,53 @@ final class ListDatabasesIterableImpl<T> implements ListDatabasesIterable<T> {
     }
 
     @Override
-    public ListDatabasesIterableImpl<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public ListDatabasesIterableImpl<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         this.maxTimeMS = MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public MongoCursor<T> iterator() {
+    public MongoCursor<TResult> iterator() {
         return execute().iterator();
     }
 
     @Override
-    public T first() {
+    public TResult first() {
         return execute().first();
     }
 
     @Override
-    public <U> MongoIterable<U> map(final Function<T, U> mapper) {
-        return new MappingIterable<T, U>(this, mapper);
+    public <U> MongoIterable<U> map(final Function<TResult, U> mapper) {
+        return new MappingIterable<TResult, U>(this, mapper);
     }
 
     @Override
-    public void forEach(final Block<? super T> block) {
+    public void forEach(final Block<? super TResult> block) {
         execute().forEach(block);
     }
 
     @Override
-    public <A extends Collection<? super T>> A into(final A target) {
+    public <A extends Collection<? super TResult>> A into(final A target) {
         return execute().into(target);
     }
 
     @Override
-    public ListDatabasesIterable<T> batchSize(final int batchSize) {
+    public ListDatabasesIterable<TResult> batchSize(final int batchSize) {
         // Noop - not supported by listDatabasesIterable
         return this;
     }
 
-    private MongoIterable<T> execute() {
-        return new OperationIterable<T>(createListCollectionsOperation(), readPreference, executor);
+    private MongoIterable<TResult> execute() {
+        return new OperationIterable<TResult>(createListCollectionsOperation(), readPreference, executor);
     }
 
     private <C> Codec<C> getCodec(final Class<C> clazz) {
         return codecRegistry.get(clazz);
     }
 
-    private ListDatabasesOperation<T> createListCollectionsOperation() {
-        return new ListDatabasesOperation<T>(getCodec(clazz)).maxTime(maxTimeMS, MILLISECONDS);
-    }
-
-    private BsonDocument asBson(final Object document) {
-        return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
+    private ListDatabasesOperation<TResult> createListCollectionsOperation() {
+        return new ListDatabasesOperation<TResult>(getCodec(clazz)).maxTime(maxTimeMS, MILLISECONDS);
     }
 
 }

--- a/driver/src/main/com/mongodb/ListIndexesIterableImpl.java
+++ b/driver/src/main/com/mongodb/ListIndexesIterableImpl.java
@@ -30,9 +30,9 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-final class ListIndexesIterableImpl<T> implements ListIndexesIterable<T> {
+final class ListIndexesIterableImpl<TResult> implements ListIndexesIterable<TResult> {
     private final MongoNamespace namespace;
-    private final Class<T> clazz;
+    private final Class<TResult> clazz;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final OperationExecutor executor;
@@ -40,7 +40,7 @@ final class ListIndexesIterableImpl<T> implements ListIndexesIterable<T> {
     private int batchSize;
     private long maxTimeMS;
 
-    ListIndexesIterableImpl(final MongoNamespace namespace, final Class<T> clazz, final CodecRegistry codecRegistry,
+    ListIndexesIterableImpl(final MongoNamespace namespace, final Class<TResult> clazz, final CodecRegistry codecRegistry,
                             final ReadPreference readPreference, final OperationExecutor executor) {
         this.namespace = notNull("namespace", namespace);
         this.clazz = notNull("clazz", clazz);
@@ -50,53 +50,53 @@ final class ListIndexesIterableImpl<T> implements ListIndexesIterable<T> {
     }
 
     @Override
-    public ListIndexesIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public ListIndexesIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         this.maxTimeMS = MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public ListIndexesIterable<T> batchSize(final int batchSize) {
+    public ListIndexesIterable<TResult> batchSize(final int batchSize) {
         this.batchSize = batchSize;
         return this;
     }
 
     @Override
-    public MongoCursor<T> iterator() {
+    public MongoCursor<TResult> iterator() {
         return execute().iterator();
     }
 
     @Override
-    public T first() {
+    public TResult first() {
         return execute().first();
     }
 
     @Override
-    public <U> MongoIterable<U> map(final Function<T, U> mapper) {
-        return new MappingIterable<T, U>(this, mapper);
+    public <U> MongoIterable<U> map(final Function<TResult, U> mapper) {
+        return new MappingIterable<TResult, U>(this, mapper);
     }
 
     @Override
-    public void forEach(final Block<? super T> block) {
+    public void forEach(final Block<? super TResult> block) {
         execute().forEach(block);
     }
 
     @Override
-    public <A extends Collection<? super T>> A into(final A target) {
+    public <A extends Collection<? super TResult>> A into(final A target) {
         return execute().into(target);
     }
 
-    private MongoIterable<T> execute() {
-        return new OperationIterable<T>(createListIndexesOperation(), readPreference, executor);
+    private MongoIterable<TResult> execute() {
+        return new OperationIterable<TResult>(createListIndexesOperation(), readPreference, executor);
     }
 
     private <C> Codec<C> getCodec(final Class<C> clazz) {
         return codecRegistry.get(clazz);
     }
 
-    private ListIndexesOperation<T> createListIndexesOperation() {
-        return new ListIndexesOperation<T>(namespace, getCodec(clazz))
+    private ListIndexesOperation<TResult> createListIndexesOperation() {
+        return new ListIndexesOperation<TResult>(namespace, getCodec(clazz))
                 .batchSize(batchSize)
                 .maxTime(maxTimeMS, MILLISECONDS);
     }

--- a/driver/src/main/com/mongodb/MapReduceIterableImpl.java
+++ b/driver/src/main/com/mongodb/MapReduceIterableImpl.java
@@ -25,9 +25,9 @@ import com.mongodb.operation.MapReduceToCollectionOperation;
 import com.mongodb.operation.MapReduceWithInlineResultsOperation;
 import com.mongodb.operation.OperationExecutor;
 import org.bson.BsonDocument;
-import org.bson.BsonDocumentWrapper;
 import org.bson.BsonJavaScript;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
@@ -36,22 +36,22 @@ import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-class MapReduceIterableImpl<TResult, TDocument> implements MapReduceIterable<TResult> {
+class MapReduceIterableImpl<TDocument, TResult> implements MapReduceIterable<TResult> {
     private final MongoNamespace namespace;
-    private final Class<TResult> clazz;
+    private final Class<TDocument> documentClass;
+    private final Class<TResult> resultClass;
     private final ReadPreference readPreference;
     private final CodecRegistry codecRegistry;
     private final OperationExecutor executor;
     private final String mapFunction;
     private final String reduceFunction;
-    private final Class<TDocument> collectionClass;
 
     private boolean inline = true;
     private String collectionName;
     private String finalizeFunction;
-    private Object scope;
-    private Object filter;
-    private Object sort;
+    private Bson scope;
+    private Bson filter;
+    private Bson sort;
     private int limit;
     private boolean jsMode;
     private boolean verbose = true;
@@ -62,13 +62,12 @@ class MapReduceIterableImpl<TResult, TDocument> implements MapReduceIterable<TRe
     private boolean nonAtomic;
     private int batchSize;
 
-    MapReduceIterableImpl(final MongoNamespace namespace, final Class<TResult> clazz, final Class<TDocument> collectionClass,
-                          final CodecRegistry codecRegistry,
-                          final ReadPreference readPreference, final OperationExecutor executor, final String mapFunction,
-                          final String reduceFunction) {
+    MapReduceIterableImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final Class<TResult> resultClass,
+                          final CodecRegistry codecRegistry, final ReadPreference readPreference, final OperationExecutor executor,
+                          final String mapFunction, final String reduceFunction) {
         this.namespace = notNull("namespace", namespace);
-        this.clazz = notNull("clazz", clazz);
-        this.collectionClass = notNull("collectionClass", collectionClass);
+        this.documentClass = notNull("collectionClass", documentClass);
+        this.resultClass = notNull("clazz", resultClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.executor = notNull("executor", executor);
@@ -90,19 +89,19 @@ class MapReduceIterableImpl<TResult, TDocument> implements MapReduceIterable<TRe
     }
 
     @Override
-    public MapReduceIterable<TResult> scope(final Object scope) {
+    public MapReduceIterable<TResult> scope(final Bson scope) {
         this.scope = scope;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> sort(final Object sort) {
+    public MapReduceIterable<TResult> sort(final Bson sort) {
         this.sort = sort;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> filter(final Object filter) {
+    public MapReduceIterable<TResult> filter(final Bson filter) {
         this.filter = filter;
         return this;
     }
@@ -193,13 +192,13 @@ class MapReduceIterableImpl<TResult, TDocument> implements MapReduceIterable<TRe
                     new MapReduceWithInlineResultsOperation<TResult>(namespace,
                             new BsonJavaScript(mapFunction),
                             new BsonJavaScript(reduceFunction),
-                            codecRegistry.get(clazz))
-                            .filter(asBson(filter))
+                            codecRegistry.get(resultClass))
+                            .filter(toBsonDocument(filter))
                             .limit(limit)
                             .maxTime(maxTimeMS, MILLISECONDS)
                             .jsMode(jsMode)
-                            .scope(asBson(scope))
-                            .sort(asBson(sort))
+                            .scope(toBsonDocument(scope))
+                            .sort(toBsonDocument(sort))
                             .verbose(verbose);
             if (finalizeFunction != null) {
                 operation.finalizeFunction(new BsonJavaScript(finalizeFunction));
@@ -209,12 +208,12 @@ class MapReduceIterableImpl<TResult, TDocument> implements MapReduceIterable<TRe
             MapReduceToCollectionOperation operation =
                     new MapReduceToCollectionOperation(namespace, new BsonJavaScript(mapFunction), new BsonJavaScript(reduceFunction),
                             collectionName)
-                            .filter(asBson(filter))
+                            .filter(toBsonDocument(filter))
                             .limit(limit)
                             .maxTime(maxTimeMS, MILLISECONDS)
                             .jsMode(jsMode)
-                            .scope(asBson(scope))
-                            .sort(asBson(sort))
+                            .scope(toBsonDocument(scope))
+                            .sort(toBsonDocument(sort))
                             .verbose(verbose)
                             .action(action.getValue())
                             .nonAtomic(nonAtomic)
@@ -227,14 +226,14 @@ class MapReduceIterableImpl<TResult, TDocument> implements MapReduceIterable<TRe
             executor.execute(operation);
 
             String dbName = databaseName != null ? databaseName : namespace.getDatabaseName();
-            return new FindIterableImpl<TResult, TDocument>(new MongoNamespace(dbName, collectionName), clazz, collectionClass,
+            return new FindIterableImpl<TDocument, TResult>(new MongoNamespace(dbName, collectionName), documentClass, resultClass,
                                                             codecRegistry, primary(), executor, new BsonDocument(),
                                                             new FindOptions()).batchSize(batchSize);
         }
     }
 
-    private BsonDocument asBson(final Object document) {
-        return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
+    private BsonDocument toBsonDocument(final Bson document) {
+        return document == null ? null : document.toBsonDocument(documentClass, codecRegistry);
     }
 
 }

--- a/driver/src/main/com/mongodb/MongoCollectionImpl.java
+++ b/driver/src/main/com/mongodb/MongoCollectionImpl.java
@@ -164,7 +164,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public <TResult> DistinctIterable<TResult> distinct(final String fieldName, final Class<TResult> clazz) {
-        return new DistinctIterableImpl<TResult>(namespace, clazz, codecRegistry, readPreference, executor, fieldName);
+        return new DistinctIterableImpl<TDocument, TResult>(namespace, documentClass, clazz, codecRegistry, readPreference, executor,
+                                                            fieldName);
     }
 
     @Override
@@ -184,7 +185,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public <TResult> FindIterable<TResult> find(final Bson filter, final Class<TResult> clazz) {
-        return new FindIterableImpl<TResult, TDocument>(namespace, clazz, this.documentClass, codecRegistry, readPreference, executor,
+        return new FindIterableImpl<TDocument, TResult>(namespace, this.documentClass, clazz, codecRegistry, readPreference, executor,
                                                         filter, new FindOptions());
     }
 
@@ -194,8 +195,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    public <TResult> AggregateIterable<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> clazz) {
-        return new AggregateIterableImpl<TResult, TDocument>(namespace, clazz, this.documentClass, codecRegistry, readPreference, executor,
+    public <TResult> AggregateIterable<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass) {
+        return new AggregateIterableImpl<TDocument, TResult>(namespace, documentClass, resultClass, codecRegistry, readPreference, executor,
                                                              pipeline);
     }
 
@@ -206,8 +207,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public <TResult> MapReduceIterable<TResult> mapReduce(final String mapFunction, final String reduceFunction,
-                                                          final Class<TResult> clazz) {
-        return new MapReduceIterableImpl<TResult, TDocument>(namespace, clazz, this.documentClass, codecRegistry, readPreference, executor,
+                                                          final Class<TResult> resultClass) {
+        return new MapReduceIterableImpl<TDocument, TResult>(namespace, documentClass, resultClass, codecRegistry, readPreference, executor,
                                                              mapFunction, reduceFunction);
     }
 
@@ -410,8 +411,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    public <TResult> ListIndexesIterable<TResult> listIndexes(final Class<TResult> clazz) {
-        return new ListIndexesIterableImpl<TResult>(getNamespace(), clazz, codecRegistry, ReadPreference.primary(), executor);
+    public <TResult> ListIndexesIterable<TResult> listIndexes(final Class<TResult> resultClass) {
+        return new ListIndexesIterableImpl<TResult>(getNamespace(), resultClass, codecRegistry, ReadPreference.primary(), executor);
     }
 
     @Override

--- a/driver/src/main/com/mongodb/MongoDatabaseImpl.java
+++ b/driver/src/main/com/mongodb/MongoDatabaseImpl.java
@@ -27,9 +27,9 @@ import com.mongodb.operation.CreateCollectionOperation;
 import com.mongodb.operation.DropDatabaseOperation;
 import com.mongodb.operation.OperationExecutor;
 import org.bson.BsonDocument;
-import org.bson.BsonDocumentWrapper;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import static com.mongodb.MongoClient.getDefaultCodecRegistry;
 import static com.mongodb.assertions.Assertions.notNull;
@@ -97,24 +97,24 @@ class MongoDatabaseImpl implements MongoDatabase {
     }
 
     @Override
-    public Document executeCommand(final Object command) {
+    public Document executeCommand(final Bson command) {
         return executeCommand(command, Document.class);
     }
 
     @Override
-    public Document executeCommand(final Object command, final ReadPreference readPreference) {
+    public Document executeCommand(final Bson command, final ReadPreference readPreference) {
         return executeCommand(command, readPreference, Document.class);
     }
 
     @Override
-    public <T> T executeCommand(final Object command, final Class<T> clazz) {
-        return executor.execute(new CommandWriteOperation<T>(getName(), asBson(command), codecRegistry.get(clazz)));
+    public <T> T executeCommand(final Bson command, final Class<T> clazz) {
+        return executor.execute(new CommandWriteOperation<T>(getName(), toBsonDocument(command), codecRegistry.get(clazz)));
     }
 
     @Override
-    public <T> T executeCommand(final Object command, final ReadPreference readPreference, final Class<T> clazz) {
+    public <T> T executeCommand(final Bson command, final ReadPreference readPreference, final Class<T> clazz) {
         notNull("readPreference", readPreference);
-        return executor.execute(new CommandReadOperation<T>(getName(), asBson(command), codecRegistry.get(clazz)),
+        return executor.execute(new CommandReadOperation<T>(getName(), toBsonDocument(command), codecRegistry.get(clazz)),
                 readPreference);
     }
 
@@ -157,10 +157,10 @@ class MongoDatabaseImpl implements MongoDatabase {
                 .autoIndex(createCollectionOptions.isAutoIndex())
                 .maxDocuments(createCollectionOptions.getMaxDocuments())
                 .usePowerOf2Sizes(createCollectionOptions.isUsePowerOf2Sizes())
-                .storageEngineOptions(asBson(createCollectionOptions.getStorageEngineOptions())));
+                .storageEngineOptions(toBsonDocument(createCollectionOptions.getStorageEngineOptions())));
     }
 
-    private BsonDocument asBson(final Object document) {
-        return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
+    private BsonDocument toBsonDocument(final Bson document) {
+        return document == null ? null : document.toBsonDocument(BsonDocument.class, codecRegistry);
     }
 }

--- a/driver/src/main/com/mongodb/client/AggregateIterable.java
+++ b/driver/src/main/com/mongodb/client/AggregateIterable.java
@@ -21,10 +21,10 @@ import java.util.concurrent.TimeUnit;
 /**
  * Iterable for aggregate.
  *
- * @param <T> The type of the result.
+ * @param <TResult> The type of the result.
  * @since 3.0
  */
-public interface AggregateIterable<T> extends MongoIterable<T> {
+public interface AggregateIterable<TResult> extends MongoIterable<TResult> {
 
     /**
      * Enables writing to temporary files. A null value indicates that it's unspecified.
@@ -34,7 +34,7 @@ public interface AggregateIterable<T> extends MongoIterable<T> {
      * @mongodb.driver.manual reference/command/aggregate/ Aggregation
      * @mongodb.server.release 2.6
      */
-    AggregateIterable<T> allowDiskUse(final Boolean allowDiskUse);
+    AggregateIterable<TResult> allowDiskUse(final Boolean allowDiskUse);
 
     /**
      * Sets the number of documents to return per batch.
@@ -43,7 +43,7 @@ public interface AggregateIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
-    AggregateIterable<T> batchSize(final int batchSize);
+    AggregateIterable<TResult> batchSize(final int batchSize);
 
     /**
      * Sets the maximum execution time on the server for this operation.
@@ -53,7 +53,7 @@ public interface AggregateIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.maxTimeMS/#cursor.maxTimeMS Max Time
      */
-    AggregateIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit);
+    AggregateIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit);
 
     /**
      * Sets whether the server should use a cursor to return results.
@@ -63,6 +63,6 @@ public interface AggregateIterable<T> extends MongoIterable<T> {
      * @mongodb.driver.manual reference/command/aggregate/ Aggregation
      * @mongodb.server.release 2.6
      */
-    AggregateIterable<T> useCursor(final Boolean useCursor);
+    AggregateIterable<TResult> useCursor(final Boolean useCursor);
 
 }

--- a/driver/src/main/com/mongodb/client/DistinctIterable.java
+++ b/driver/src/main/com/mongodb/client/DistinctIterable.java
@@ -16,15 +16,17 @@
 
 package com.mongodb.client;
 
+import org.bson.conversions.Bson;
+
 import java.util.concurrent.TimeUnit;
 
 /**
  * Iterable interface for distinct.
  *
- * @param <T> The type of the result.
+ * @param <TResult> The type of the result.
  * @since 3.0
  */
-public interface DistinctIterable<T> extends MongoIterable<T> {
+public interface DistinctIterable<TResult> extends MongoIterable<TResult> {
 
     /**
      * Sets the query filter to apply to the query.
@@ -33,7 +35,7 @@ public interface DistinctIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Filter
      */
-    DistinctIterable<T> filter(Object filter);
+    DistinctIterable<TResult> filter(Bson filter);
 
     /**
      * Sets the maximum execution time on the server for this operation.
@@ -42,7 +44,7 @@ public interface DistinctIterable<T> extends MongoIterable<T> {
      * @param timeUnit the time unit, which may not be null
      * @return this
      */
-    DistinctIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit);
+    DistinctIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit);
 
     /**
      * Sets the number of documents to return per batch.
@@ -51,5 +53,5 @@ public interface DistinctIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
-    DistinctIterable<T> batchSize(final int batchSize);
+    DistinctIterable<TResult> batchSize(final int batchSize);
 }

--- a/driver/src/main/com/mongodb/client/FindIterable.java
+++ b/driver/src/main/com/mongodb/client/FindIterable.java
@@ -24,10 +24,10 @@ import java.util.concurrent.TimeUnit;
 /**
  * Iterable for find.
  *
- * @param <T> The type of the result.
+ * @param <TResult> The type of the result.
  * @since 3.0
  */
-public interface FindIterable<T> extends MongoIterable<T> {
+public interface FindIterable<TResult> extends MongoIterable<TResult> {
 
     /**
      * Sets the query filter to apply to the query.
@@ -36,7 +36,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Filter
      */
-    FindIterable<T> filter(Bson filter);
+    FindIterable<TResult> filter(Bson filter);
 
     /**
      * Sets the limit to apply.
@@ -45,7 +45,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.limit/#cursor.limit Limit
      */
-    FindIterable<T> limit(int limit);
+    FindIterable<TResult> limit(int limit);
     /**
      * Sets the number of documents to skip.
      *
@@ -53,7 +53,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.skip/#cursor.skip Skip
      */
-    FindIterable<T> skip(int skip);
+    FindIterable<TResult> skip(int skip);
 
     /**
      * Sets the maximum execution time on the server for this operation.
@@ -63,7 +63,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.maxTimeMS/#cursor.maxTimeMS Max Time
      */
-    FindIterable<T> maxTime(long maxTime, TimeUnit timeUnit);
+    FindIterable<TResult> maxTime(long maxTime, TimeUnit timeUnit);
 
     /**
      * Sets the query modifiers to apply to this operation.
@@ -72,7 +72,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/operator/query-modifier/ Query Modifiers
      */
-    FindIterable<T> modifiers(Bson modifiers);
+    FindIterable<TResult> modifiers(Bson modifiers);
 
     /**
      * Sets a document describing the fields to return for all matching documents.
@@ -81,7 +81,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Projection
      */
-    FindIterable<T> projection(Bson projection);
+    FindIterable<TResult> projection(Bson projection);
     /**
      * Sets the sort criteria to apply to the query.
      *
@@ -89,7 +89,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.sort/ Sort
      */
-    FindIterable<T> sort(Bson sort);
+    FindIterable<TResult> sort(Bson sort);
 
     /**
      * The server normally times out idle cursors after an inactivity period (10 minutes)
@@ -98,7 +98,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @param noCursorTimeout true if cursor timeout is disabled
      * @return this
      */
-    FindIterable<T> noCursorTimeout(boolean noCursorTimeout);
+    FindIterable<TResult> noCursorTimeout(boolean noCursorTimeout);
 
     /**
      * Users should not set this under normal circumstances.
@@ -106,7 +106,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @param oplogReplay if oplog replay is enabled
      * @return this
      */
-    FindIterable<T> oplogReplay(boolean oplogReplay);
+    FindIterable<TResult> oplogReplay(boolean oplogReplay);
 
     /**
      * Get partial results from a sharded cluster if one or more shards are unreachable (instead of throwing an error).
@@ -114,7 +114,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @param partial if partial results for sharded clusters is enabled
      * @return this
      */
-    FindIterable<T> partial(boolean partial);
+    FindIterable<TResult> partial(boolean partial);
 
     /**
      * Sets the cursor type.
@@ -122,7 +122,7 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @param cursorType the cursor type
      * @return this
      */
-    FindIterable<T> cursorType(CursorType cursorType);
+    FindIterable<TResult> cursorType(CursorType cursorType);
 
     /**
      * Sets the number of documents to return per batch.
@@ -132,5 +132,5 @@ public interface FindIterable<T> extends MongoIterable<T> {
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
     @Override
-    FindIterable<T> batchSize(int batchSize);
+    FindIterable<TResult> batchSize(int batchSize);
 }

--- a/driver/src/main/com/mongodb/client/ListCollectionsIterable.java
+++ b/driver/src/main/com/mongodb/client/ListCollectionsIterable.java
@@ -16,15 +16,17 @@
 
 package com.mongodb.client;
 
+import org.bson.conversions.Bson;
+
 import java.util.concurrent.TimeUnit;
 
 /**
  * Iterable for ListCollections.
  *
- * @param <T> The type of the result.
+ * @param <TResult> The type of the result.
  * @since 3.0
  */
-public interface ListCollectionsIterable<T> extends MongoIterable<T> {
+public interface ListCollectionsIterable<TResult> extends MongoIterable<TResult> {
 
     /**
      * Sets the query filter to apply to the query.
@@ -33,7 +35,7 @@ public interface ListCollectionsIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Filter
      */
-    ListCollectionsIterable<T> filter(Object filter);
+    ListCollectionsIterable<TResult> filter(Bson filter);
 
     /**
      * Sets the maximum execution time on the server for this operation.
@@ -43,7 +45,7 @@ public interface ListCollectionsIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/operator/meta/maxTimeMS/ Max Time
      */
-    ListCollectionsIterable<T> maxTime(long maxTime, TimeUnit timeUnit);
+    ListCollectionsIterable<TResult> maxTime(long maxTime, TimeUnit timeUnit);
 
     /**
      * Sets the number of documents to return per batch.
@@ -53,5 +55,5 @@ public interface ListCollectionsIterable<T> extends MongoIterable<T> {
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
     @Override
-    ListCollectionsIterable<T> batchSize(int batchSize);
+    ListCollectionsIterable<TResult> batchSize(int batchSize);
 }

--- a/driver/src/main/com/mongodb/client/ListDatabasesIterable.java
+++ b/driver/src/main/com/mongodb/client/ListDatabasesIterable.java
@@ -21,10 +21,10 @@ import java.util.concurrent.TimeUnit;
 /**
  * Iterable for ListDatabases.
  *
- * @param <T> The type of the result.
+ * @param <TResult> The type of the result.
  * @since 3.0
  */
-public interface ListDatabasesIterable<T> extends MongoIterable<T> {
+public interface ListDatabasesIterable<TResult> extends MongoIterable<TResult> {
 
     /**
      * Sets the maximum execution time on the server for this operation.
@@ -34,7 +34,7 @@ public interface ListDatabasesIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/operator/meta/maxTimeMS/ Max Time
      */
-    ListDatabasesIterable<T> maxTime(long maxTime, TimeUnit timeUnit);
+    ListDatabasesIterable<TResult> maxTime(long maxTime, TimeUnit timeUnit);
 
     /**
      * Sets the number of documents to return per batch.
@@ -44,5 +44,5 @@ public interface ListDatabasesIterable<T> extends MongoIterable<T> {
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
     @Override
-    ListDatabasesIterable<T> batchSize(int batchSize);
+    ListDatabasesIterable<TResult> batchSize(int batchSize);
 }

--- a/driver/src/main/com/mongodb/client/ListIndexesIterable.java
+++ b/driver/src/main/com/mongodb/client/ListIndexesIterable.java
@@ -21,10 +21,10 @@ import java.util.concurrent.TimeUnit;
 /**
  * Iterable for ListIndexes.
  *
- * @param <T> The type of the result.
+ * @param <TResult> The type of the result.
  * @since 3.0
  */
-public interface ListIndexesIterable<T> extends MongoIterable<T> {
+public interface ListIndexesIterable<TResult> extends MongoIterable<TResult> {
 
     /**
      * Sets the maximum execution time on the server for this operation.
@@ -34,7 +34,7 @@ public interface ListIndexesIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/operator/meta/maxTimeMS/ Max Time
      */
-    ListIndexesIterable<T> maxTime(long maxTime, TimeUnit timeUnit);
+    ListIndexesIterable<TResult> maxTime(long maxTime, TimeUnit timeUnit);
 
     /**
      * Sets the number of documents to return per batch.
@@ -44,5 +44,5 @@ public interface ListIndexesIterable<T> extends MongoIterable<T> {
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
     @Override
-    ListIndexesIterable<T> batchSize(int batchSize);
+    ListIndexesIterable<TResult> batchSize(int batchSize);
 }

--- a/driver/src/main/com/mongodb/client/MapReduceIterable.java
+++ b/driver/src/main/com/mongodb/client/MapReduceIterable.java
@@ -17,16 +17,17 @@
 package com.mongodb.client;
 
 import com.mongodb.client.model.MapReduceAction;
+import org.bson.conversions.Bson;
 
 import java.util.concurrent.TimeUnit;
 
 /**
  * Iterable for map reduce.
  *
- * @param <T> The type of the result.
+ * @param <TResult> The type of the result.
  * @since 3.0
  */
-public interface MapReduceIterable<T> extends MongoIterable<T> {
+public interface MapReduceIterable<TResult> extends MongoIterable<TResult> {
 
     /**
      * Sets the collectionName for the output of the MapReduce
@@ -36,7 +37,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @param collectionName the name of the collection that you want the map-reduce operation to write its output.
      * @return this
      */
-    MapReduceIterable<T> collectionName(final String collectionName);
+    MapReduceIterable<TResult> collectionName(final String collectionName);
 
     /**
      * Sets the JavaScript function that follows the reduce method and modifies the output.
@@ -45,7 +46,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/command/mapReduce/#mapreduce-finalize-cmd Requirements for the finalize Function
      */
-    MapReduceIterable<T> finalizeFunction(final String finalizeFunction);
+    MapReduceIterable<TResult> finalizeFunction(final String finalizeFunction);
 
     /**
      * Sets the global variables that are accessible in the map, reduce and finalize functions.
@@ -54,7 +55,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/command/mapReduce mapReduce
      */
-    MapReduceIterable<T> scope(final Object scope);
+    MapReduceIterable<TResult> scope(final Bson scope);
 
     /**
      * Sets the sort criteria to apply to the query.
@@ -63,7 +64,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.sort/ Sort
      */
-    MapReduceIterable<T> sort(final Object sort);
+    MapReduceIterable<TResult> sort(final Bson sort);
 
     /**
      * Sets the query filter to apply to the query.
@@ -72,7 +73,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/db.collection.find/ Filter
      */
-    MapReduceIterable<T> filter(final Object filter);
+    MapReduceIterable<TResult> filter(final Bson filter);
 
     /**
      * Sets the limit to apply.
@@ -81,7 +82,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.limit/#cursor.limit Limit
      */
-    MapReduceIterable<T> limit(final int limit);
+    MapReduceIterable<TResult> limit(final int limit);
 
     /**
      * Sets the flag that specifies whether to convert intermediate data into BSON format between the execution of the map and reduce
@@ -92,7 +93,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return jsMode
      * @mongodb.driver.manual reference/command/mapReduce mapReduce
      */
-    MapReduceIterable<T> jsMode(final boolean jsMode);
+    MapReduceIterable<TResult> jsMode(final boolean jsMode);
 
     /**
      * Sets whether to include the timing information in the result information.
@@ -100,7 +101,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @param verbose whether to include the timing information in the result information.
      * @return this
      */
-    MapReduceIterable<T> verbose(final boolean verbose);
+    MapReduceIterable<TResult> verbose(final boolean verbose);
 
     /**
      * Sets the maximum execution time on the server for this operation.
@@ -110,7 +111,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.maxTimeMS/#cursor.maxTimeMS Max Time
      */
-    MapReduceIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit);
+    MapReduceIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit);
 
     /**
      * Specify the {@code MapReduceAction} to be used when writing to a collection.
@@ -118,7 +119,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @param action an {@link MapReduceAction} to perform on the collection
      * @return this
      */
-    MapReduceIterable<T> action(final MapReduceAction action);
+    MapReduceIterable<TResult> action(final MapReduceAction action);
 
     /**
      * Sets the name of the database to output into.
@@ -127,7 +128,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/command/mapReduce/#output-to-a-collection-with-an-action output with an action
      */
-    MapReduceIterable<T> databaseName(final String databaseName);
+    MapReduceIterable<TResult> databaseName(final String databaseName);
     /**
      * Sets if the output database is sharded
      *
@@ -135,7 +136,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/command/mapReduce/#output-to-a-collection-with-an-action output with an action
      */
-    MapReduceIterable<T> sharded(final boolean sharded);
+    MapReduceIterable<TResult> sharded(final boolean sharded);
 
     /**
      * Sets if the post-processing step will prevent MongoDB from locking the database.
@@ -146,7 +147,7 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @return this
      * @mongodb.driver.manual reference/command/mapReduce/#output-to-a-collection-with-an-action output with an action
      */
-    MapReduceIterable<T> nonAtomic(final boolean nonAtomic);
+    MapReduceIterable<TResult> nonAtomic(final boolean nonAtomic);
 
     /**
      * Sets the number of documents to return per batch.
@@ -156,5 +157,5 @@ public interface MapReduceIterable<T> extends MongoIterable<T> {
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
     @Override
-    MapReduceIterable<T> batchSize(int batchSize);
+    MapReduceIterable<TResult> batchSize(int batchSize);
 }

--- a/driver/src/main/com/mongodb/client/MongoCursor.java
+++ b/driver/src/main/com/mongodb/client/MongoCursor.java
@@ -27,10 +27,10 @@ import java.util.Iterator;
  * The Mongo Cursor interface implementing the iterator protocol
  *
  * @since 3.0
- * @param <T> The type of documents the cursor contains
+ * @param <TResult> The type of documents the cursor contains
  */
 @NotThreadSafe
-public interface MongoCursor<T> extends Iterator<T>, Closeable {
+public interface MongoCursor<TResult> extends Iterator<TResult>, Closeable {
     @Override
     void close();
 
@@ -38,7 +38,7 @@ public interface MongoCursor<T> extends Iterator<T>, Closeable {
     boolean hasNext();
 
     @Override
-    T next();
+    TResult next();
 
     /**
      * A special {@code next()} case that returns the next element in the iteration if available or null.
@@ -49,7 +49,7 @@ public interface MongoCursor<T> extends Iterator<T>, Closeable {
      * @return the next element in the iteration if available or null.
      * @mongodb.driver.manual reference/glossary/#term-tailable-cursor Tailable Cursor
      */
-    T tryNext();
+    TResult tryNext();
 
     /**
      * Returns the server cursor

--- a/driver/src/main/com/mongodb/client/MongoDatabase.java
+++ b/driver/src/main/com/mongodb/client/MongoDatabase.java
@@ -22,6 +22,7 @@ import com.mongodb.annotations.ThreadSafe;
 import com.mongodb.client.model.CreateCollectionOptions;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 /**
  * The MongoDatabase interface.
@@ -109,7 +110,7 @@ public interface MongoDatabase {
      * @param command the command to be run
      * @return the command result
      */
-    Document executeCommand(Object command);
+    Document executeCommand(Bson command);
 
     /**
      * Executes command in the context of the current database.
@@ -118,7 +119,7 @@ public interface MongoDatabase {
      * @param readPreference the {@link ReadPreference} to be used when executing the command
      * @return the command result
      */
-    Document executeCommand(Object command, ReadPreference readPreference);
+    Document executeCommand(Bson command, ReadPreference readPreference);
 
     /**
      * Executes command in the context of the current database.
@@ -128,7 +129,7 @@ public interface MongoDatabase {
      * @param <T>            the type of the class to use instead of {@code Document}.
      * @return the command result
      */
-    <T> T executeCommand(Object command, Class<T> clazz);
+    <T> T executeCommand(Bson command, Class<T> clazz);
 
     /**
      * Executes command in the context of the current database.
@@ -139,7 +140,7 @@ public interface MongoDatabase {
      * @param <T>            the type of the class to use instead of {@code Document}.
      * @return the command result
      */
-    <T> T executeCommand(Object command, ReadPreference readPreference, Class<T> clazz);
+    <T> T executeCommand(Bson command, ReadPreference readPreference, Class<T> clazz);
 
     /**
      * Drops this database.

--- a/driver/src/main/com/mongodb/client/MongoIterable.java
+++ b/driver/src/main/com/mongodb/client/MongoIterable.java
@@ -24,20 +24,20 @@ import java.util.Collection;
 /**
  *The MongoIterable is the results from an operation, such as a query.
  *
- * @param <T> The type that this iterable will decode documents to.
+ * @param <TResult> The type that this iterable will decode documents to.
  * @since 3.0
  */
-public interface MongoIterable<T> extends Iterable<T> {
+public interface MongoIterable<TResult> extends Iterable<TResult> {
 
     @Override
-    MongoCursor<T> iterator();
+    MongoCursor<TResult> iterator();
 
     /**
      * Helper to return the first item in the iterator or null.
      *
      * @return T the first item or null.
      */
-    T first();
+    TResult first();
 
     /**
      * Maps this iterable from the source document type to the target document type.
@@ -46,7 +46,7 @@ public interface MongoIterable<T> extends Iterable<T> {
      * @param <U> the target document type
      * @return an iterable which maps T to U
      */
-    <U> MongoIterable<U> map(Function<T, U> mapper);
+    <U> MongoIterable<U> map(Function<TResult, U> mapper);
 
     /**
      * Iterates over all documents in the view, applying the given block to each.
@@ -55,7 +55,7 @@ public interface MongoIterable<T> extends Iterable<T> {
      *
      * @param block the block to apply to each document of type T.
      */
-    void forEach(Block<? super T> block);
+    void forEach(Block<? super TResult> block);
 
     /**
      * Iterates over all the documents, adding each to the given target.
@@ -64,7 +64,7 @@ public interface MongoIterable<T> extends Iterable<T> {
      * @param <A> the collection type
      * @return the target
      */
-    <A extends Collection<? super T>> A into(A target);
+    <A extends Collection<? super TResult>> A into(A target);
 
     /**
      * Sets the number of documents to return per batch.
@@ -73,5 +73,5 @@ public interface MongoIterable<T> extends Iterable<T> {
      * @return this
      * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
-    MongoIterable<T> batchSize(int batchSize);
+    MongoIterable<TResult> batchSize(int batchSize);
 }

--- a/driver/src/test/unit/com/mongodb/AggregateIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/AggregateIterableSpecification.groovy
@@ -47,8 +47,9 @@ class AggregateIterableSpecification extends Specification {
         given:
         def executor = new TestOperationExecutor([null, null, null, null, null]);
         def pipeline = [new Document('$match', 1)]
-        def aggregationIterable = new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
-                pipeline)
+        def aggregationIterable = new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference,
+                                                            executor,
+                                                            pipeline)
 
         when: 'default input should be as expected'
         aggregationIterable.iterator()
@@ -83,7 +84,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'aggregation includes $out'
         new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
-                pipeline)
+                                  pipeline)
                 .batchSize(99)
                 .maxTime(999, MILLISECONDS)
                 .allowDiskUse(true)
@@ -110,8 +111,9 @@ class AggregateIterableSpecification extends Specification {
         def codecRegistry = fromProviders([new ValueCodecProvider(), new BsonValueCodecProvider()])
         def executor = new TestOperationExecutor([new MongoException('failure')])
         def pipeline = [new BsonDocument('$match', new BsonInt32(1))]
-        def aggregationIterable = new AggregateIterableImpl(namespace, BsonDocument, BsonDocument, codecRegistry, readPreference, executor,
-                pipeline)
+        def aggregationIterable = new AggregateIterableImpl(namespace, BsonDocument, BsonDocument, codecRegistry,
+                                                            readPreference, executor,
+                                                            pipeline)
 
         when: 'The operation fails with an exception'
         aggregationIterable.iterator()
@@ -121,7 +123,7 @@ class AggregateIterableSpecification extends Specification {
 
         when: 'a codec is missing'
         new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
-                pipeline).iterator()
+                                  pipeline).iterator()
 
         then:
         thrown(CodecConfigurationException)
@@ -150,7 +152,7 @@ class AggregateIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
         def mongoIterable = new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
-                [new Document('$match', 1)])
+                                                      [new Document('$match', 1)])
 
         when:
         def results = mongoIterable.first()

--- a/driver/src/test/unit/com/mongodb/DistinctIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/DistinctIterableSpecification.groovy
@@ -43,7 +43,7 @@ class DistinctIterableSpecification extends Specification {
     def 'should build the expected DistinctOperation'() {
         given:
         def executor = new TestOperationExecutor([null, null]);
-        def distinctIterable = new DistinctIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor, 'field')
+        def distinctIterable = new DistinctIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor, 'field')
 
         when: 'default input should be as expected'
         distinctIterable.iterator()
@@ -70,7 +70,7 @@ class DistinctIterableSpecification extends Specification {
         given:
         def codecRegistry = fromProviders([new ValueCodecProvider(), new BsonValueCodecProvider()])
         def executor = new TestOperationExecutor([new MongoException('failure')])
-        def distinctIterable = new DistinctIterableImpl(namespace, BsonDocument, codecRegistry, readPreference, executor, 'field')
+        def distinctIterable = new DistinctIterableImpl(namespace, Document, BsonDocument, codecRegistry, readPreference, executor, 'field')
 
         when: 'The operation fails with an exception'
         distinctIterable.iterator()
@@ -106,7 +106,7 @@ class DistinctIterableSpecification extends Specification {
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
-        def mongoIterable = new DistinctIterableImpl<Document>(namespace, Document, codecRegistry, readPreference, executor, 'field')
+        def mongoIterable = new DistinctIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor, 'field')
 
         when:
         def results = mongoIterable.first()

--- a/driver/src/test/unit/com/mongodb/FindIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/FindIterableSpecification.groovy
@@ -56,7 +56,7 @@ class FindIterableSpecification extends Specification {
                                            .noCursorTimeout(false)
                                            .partial(false)
         def findIterable = new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
-                                                          new Document('filter', 1), findOptions)
+                                                new Document('filter', 1), findOptions)
 
         when: 'default input should be as expected'
         findIterable.iterator()
@@ -163,7 +163,7 @@ class FindIterableSpecification extends Specification {
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
         def findOptions = new FindOptions()
         def mongoIterable = new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
-                                                           new Document(), findOptions)
+                                                 new Document(), findOptions)
 
         when:
         def results = mongoIterable.first()

--- a/driver/src/test/unit/com/mongodb/MapReduceIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MapReduceIterableSpecification.groovy
@@ -48,7 +48,7 @@ class MapReduceIterableSpecification extends Specification {
         given:
         def executor = new TestOperationExecutor([null, null]);
         def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
-                'map', 'reduce')
+                                                          'map', 'reduce')
 
         when: 'default input should be as expected'
         mapReduceIterable.iterator()
@@ -93,7 +93,7 @@ class MapReduceIterableSpecification extends Specification {
         when: 'mapReduce to a collection'
         def collectionNamespace = new MongoNamespace('dbName', 'collName')
         def mapReduceIterable = new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
-                'map', 'reduce')
+                                                          'map', 'reduce')
                 .collectionName(collectionNamespace.getCollectionName())
                 .databaseName(collectionNamespace.getDatabaseName())
                 .filter(new Document('filter', 1))
@@ -141,8 +141,9 @@ class MapReduceIterableSpecification extends Specification {
         given:
         def codecRegistry = fromProviders([new ValueCodecProvider(), new BsonValueCodecProvider()])
         def executor = new TestOperationExecutor([new MongoException('failure')])
-        def mapReduceIterable = new MapReduceIterableImpl(namespace, BsonDocument, BsonDocument, codecRegistry, readPreference, executor,
-                'map', 'reduce')
+        def mapReduceIterable = new MapReduceIterableImpl(namespace, BsonDocument, BsonDocument, codecRegistry,
+                                                          readPreference, executor,
+                                                          'map', 'reduce')
 
 
         when: 'The operation fails with an exception'
@@ -153,7 +154,7 @@ class MapReduceIterableSpecification extends Specification {
 
         when: 'a codec is missing'
         new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
-                'map', 'reduce').iterator()
+                                  'map', 'reduce').iterator()
 
         then:
         thrown(CodecConfigurationException)
@@ -182,8 +183,9 @@ class MapReduceIterableSpecification extends Specification {
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
-        def mongoIterable = new MapReduceIterableImpl(namespace, BsonDocument, BsonDocument, codecRegistry, readPreference, executor,
-                'map', 'reduce')
+        def mongoIterable = new MapReduceIterableImpl(namespace, BsonDocument, BsonDocument, codecRegistry, readPreference,
+                                                      executor,
+                                                      'map', 'reduce')
 
         when:
         def results = mongoIterable.first()

--- a/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
@@ -183,8 +183,8 @@ class MongoCollectionSpecification extends Specification {
         def distinctIterable = collection.distinct('field', String)
 
         then:
-        expect distinctIterable, isTheSameAs(new DistinctIterableImpl(namespace, String, codecRegistry, readPreference,
-                executor, 'field'))
+        expect distinctIterable, isTheSameAs(new DistinctIterableImpl(namespace, Document, String, codecRegistry, readPreference,
+                                                                      executor, 'field'))
     }
 
     def 'should create FindIterable correctly'() {
@@ -196,29 +196,31 @@ class MongoCollectionSpecification extends Specification {
         def findIterable = collection.find()
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference,
+                                                              executor,
                                                               new BsonDocument(), new FindOptions()))
 
         when:
         findIterable = collection.find(BsonDocument)
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, BsonDocument, Document, codecRegistry, readPreference, executor,
-                                                              new BsonDocument(), new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, BsonDocument, codecRegistry, readPreference,
+                                                              executor, new BsonDocument(), new FindOptions()))
 
         when:
         findIterable = collection.find(new Document())
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference, executor,
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, Document, codecRegistry, readPreference,
+                                                              executor,
                                                               new Document(), new FindOptions()))
 
         when:
         findIterable = collection.find(new Document(), BsonDocument)
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, BsonDocument, Document, codecRegistry, readPreference, executor,
-                                                              new Document(), new FindOptions()))
+        expect findIterable, isTheSameAs(new FindIterableImpl(namespace, Document, BsonDocument, codecRegistry, readPreference,
+                                                              executor, new Document(), new FindOptions()))
     }
 
     def 'should create AggregateIterable correctly'() {
@@ -230,16 +232,17 @@ class MongoCollectionSpecification extends Specification {
         def aggregateIterable = collection.aggregate([new Document('$match', 1)])
 
         then:
-        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, Document, Document, codecRegistry, readPreference,
+        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, Document, Document, codecRegistry,
+                                                                        readPreference,
                                                                         executor, [new Document('$match', 1)]))
 
         when:
         aggregateIterable = collection.aggregate([new Document('$match', 1)], BsonDocument)
 
         then:
-        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, BsonDocument, Document, codecRegistry, readPreference,
-                                                                        executor,
-                [new Document('$match', 1)]))
+        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(namespace, Document, BsonDocument, codecRegistry,
+                                                                        readPreference, executor,
+                                                                        [new Document('$match', 1)]))
     }
 
     def 'should create MapReduceIterable correctly'() {
@@ -251,7 +254,8 @@ class MongoCollectionSpecification extends Specification {
         def mapReduceIterable = collection.mapReduce('map', 'reduce')
 
         then:
-        expect mapReduceIterable, isTheSameAs(new MapReduceIterableImpl(namespace, Document, Document, codecRegistry, readPreference,
+        expect mapReduceIterable, isTheSameAs(new MapReduceIterableImpl(namespace, Document, Document, codecRegistry,
+                                                                        readPreference,
                                                                         executor, 'map', 'reduce'))
     }
 


### PR DESCRIPTION
Looks look I missed a bunch of places in the Iterable implementations where Object has to change to Bson.
Also normalized generic type names and variables names.