### PR TITLE
java-1529 JSON parser allows unmatched trailing quote on field names

### DIFF
--- a/driver/src/main/com/mongodb/util/JSON.java
+++ b/driver/src/main/com/mongodb/util/JSON.java
@@ -391,6 +391,9 @@ class JSONParser {
                 if (current == ':' || current == ' ') {
                     break;
                 }
+                if (current == '\"') {
+                    throw new JSONParseException(s, pos);
+                }
             }
 
             if (current == '\\') {

--- a/driver/src/test/unit/com/mongodb/util/JSONTest.java
+++ b/driver/src/test/unit/com/mongodb/util/JSONTest.java
@@ -172,6 +172,13 @@ public class JSONTest {
         }
         assertEquals(true, threw);
         threw = false;
+        try {
+            JSON.parse("{ a\": 1 }");
+        } catch (JSONParseException e) {
+            threw = true;
+        }
+        assertEquals(threw, true);
+        threw = false;
     }
 
     @Test


### PR DESCRIPTION
This change detects unmatched trailing quotes by checking if the current quote char has a corresponding opening quote and throws and exception if not.