### PR TITLE
JAVA-1674: Simplified locking in InternalStreamConnection

### DIFF
--- a/driver-async/src/test/resources/logback-test.xml
+++ b/driver-async/src/test/resources/logback-test.xml
@@ -11,7 +11,7 @@
     <!--<logger name="org.mongodb.driver.protocol" level="TRACE" additivity="true"/>-->
     <!--<logger name="org.mongodb.driver.operation" level="TRACE" additivity="true"/>-->
 
-    <root level="INFO">
+    <root level="TRACE">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/driver-core/src/main/com/mongodb/binding/AsyncClusterBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncClusterBinding.java
@@ -18,8 +18,8 @@ package com.mongodb.binding;
 
 import com.mongodb.ReadPreference;
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Cluster;
-import com.mongodb.connection.Connection;
 import com.mongodb.connection.Server;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.selector.PrimaryServerSelector;
@@ -98,7 +98,7 @@ public class AsyncClusterBinding extends AbstractReferenceCounted implements Asy
         }
 
         @Override
-        public void getConnection(final SingleResultCallback<Connection> callback) {
+        public void getConnection(final SingleResultCallback<AsyncConnection> callback) {
             server.getConnectionAsync(callback);
         }
 

--- a/driver-core/src/main/com/mongodb/binding/AsyncConnectionSource.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncConnectionSource.java
@@ -17,7 +17,7 @@
 package com.mongodb.binding;
 
 import com.mongodb.async.SingleResultCallback;
-import com.mongodb.connection.Connection;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.ServerDescription;
 
 /**
@@ -39,7 +39,7 @@ public interface AsyncConnectionSource extends ReferenceCounted {
      *
      * @param callback the to be passed the connection
      */
-    void getConnection(SingleResultCallback<Connection> callback);
+    void getConnection(SingleResultCallback<AsyncConnection> callback);
 
     @Override
     AsyncConnectionSource retain();

--- a/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteConcernResult;
 import com.mongodb.annotations.ThreadSafe;
+import com.mongodb.async.SingleResultCallback;
 import com.mongodb.binding.ReferenceCounted;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.bulk.DeleteRequest;
@@ -31,8 +32,8 @@ import org.bson.codecs.Decoder;
 
 import java.util.List;
 
-
 /**
+ *
  * A synchronous connection to a MongoDB server with blocking and non-blocking operations.
  *
  * <p> Implementations of this class are thread safe.  </p>
@@ -40,10 +41,10 @@ import java.util.List;
  * @since 3.0
  */
 @ThreadSafe
-public interface Connection extends ReferenceCounted {
+public interface AsyncConnection extends ReferenceCounted {
 
     @Override
-    Connection retain();
+    AsyncConnection retain();
 
     /**
      * Gets the description of the connection.
@@ -53,89 +54,93 @@ public interface Connection extends ReferenceCounted {
     ConnectionDescription getDescription();
 
     /**
-     * Insert the documents using the insert wire protocol and apply the write concern.
+     * Insert the documents using the insert wire protocol and apply the write concern asynchronously.
      *
      * @param namespace    the namespace
      * @param ordered      whether the writes are ordered
      * @param writeConcern the write concern
      * @param inserts      the inserts
-     * @return the write concern result
+     * @param callback     the callback to be passed the write result
      */
-    WriteConcernResult insert(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<InsertRequest> inserts);
+    void insertAsync(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern,
+                                                List<InsertRequest> inserts, SingleResultCallback<WriteConcernResult> callback);
 
     /**
-     * Update the documents using the update wire protocol and apply the write concern.
+     * Update the documents using the update wire protocol and apply the write concern asynchronously.
      *
      * @param namespace    the namespace
      * @param ordered      whether the writes are ordered
      * @param writeConcern the write concern
      * @param updates      the updates
-     * @return the write concern result
+     * @param callback     the callback to be passed the write result
      */
-    WriteConcernResult update(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern,
-                              List<UpdateRequest> updates);
+    void updateAsync(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<UpdateRequest> updates,
+                     SingleResultCallback<WriteConcernResult> callback);
 
     /**
-     * Delete the documents using the delete wire protocol and apply the write concern.
+     * Delete the documents using the delete wire protocol and apply the write concern asynchronously.
      *
      * @param namespace    the namespace
      * @param ordered      whether the writes are ordered
      * @param writeConcern the write concern
      * @param deletes      the deletes
-     * @return the write concern result
+     * @param callback     the callback to be passed the write result
      */
-    WriteConcernResult delete(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern,
-                              List<DeleteRequest> deletes);
+    void deleteAsync(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<DeleteRequest> deletes,
+                     SingleResultCallback<WriteConcernResult> callback);
 
     /**
-     * Insert the documents using the insert command.
+     * Insert the documents using the insert command asynchronously.
      *
      * @param namespace    the namespace
      * @param ordered      whether the writes are ordered
      * @param writeConcern the write concern
      * @param inserts      the inserts
-     * @return the bulk write result
+     * @param callback     the callback to be passed the bulk write result
      */
-    BulkWriteResult insertCommand(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<InsertRequest> inserts);
+    void insertCommandAsync(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<InsertRequest> inserts,
+                            SingleResultCallback<BulkWriteResult> callback);
 
     /**
-     * Update the documents using the update command.
+     * Update the documents using the update command asynchronously.
      *
      * @param namespace    the namespace
      * @param ordered      whether the writes are ordered
      * @param writeConcern the write concern
      * @param updates      the updates
-     * @return the bulk write result
+     * @param callback     the callback to be passed the BulkWriteResult
      */
-    BulkWriteResult updateCommand(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<UpdateRequest> updates);
+    void updateCommandAsync(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<UpdateRequest> updates,
+                            SingleResultCallback<BulkWriteResult> callback);
 
     /**
-     * Delete the documents using the delete command.
+     * Delete the documents using the delete command asynchronously.
      *
      * @param namespace    the namespace
      * @param ordered      whether the writes are ordered
      * @param writeConcern the write concern
      * @param deletes      the deletes
-     * @return the bulk write result
+     * @param callback     the callback to be passed the BulkWriteResult
      */
-    BulkWriteResult deleteCommand(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<DeleteRequest> deletes);
+    void deleteCommandAsync(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<DeleteRequest> deletes,
+                            SingleResultCallback<BulkWriteResult> callback);
 
     /**
-     * Execute the command.
+     * Execute the command asynchronously.
      *
      * @param database             the database to execute the command in
      * @param command              the command document
      * @param slaveOk              whether the command can run on a secondary
      * @param fieldNameValidator   the field name validator for the command document
      * @param commandResultDecoder the decoder for the result
+     * @param callback             the callback to be passed the command result
      * @param <T>                  the type of the result
-     * @return the command result
      */
-    <T> T command(String database, BsonDocument command, boolean slaveOk, FieldNameValidator fieldNameValidator,
-                  Decoder<T> commandResultDecoder);
+    <T> void commandAsync(String database, BsonDocument command, boolean slaveOk, FieldNameValidator fieldNameValidator,
+                                    Decoder<T> commandResultDecoder, SingleResultCallback<T> callback);
 
     /**
-     * Execute the query.
+     * Execute the query asynchronously.
      *
      * @param namespace       the namespace to query
      * @param queryDocument   the query document
@@ -150,30 +155,30 @@ public interface Connection extends ReferenceCounted {
      * @param oplogReplay     whether to replay the oplog
      * @param resultDecoder   the decoder for the query result documents
      * @param <T>             the query result document type
-     * @return the query results
+     * @param callback     the callback to be passed the write result
      */
-    <T> QueryResult<T> query(MongoNamespace namespace, BsonDocument queryDocument, BsonDocument fields,
-                             int numberToReturn, int skip,
-                             boolean slaveOk, boolean tailableCursor, boolean awaitData, boolean noCursorTimeout,
-                             boolean partial, boolean oplogReplay,
-                             Decoder<T> resultDecoder);
+    <T> void queryAsync(MongoNamespace namespace, BsonDocument queryDocument, BsonDocument fields,
+                        int numberToReturn, int skip, boolean slaveOk, boolean tailableCursor, boolean awaitData, boolean noCursorTimeout,
+                        boolean partial, boolean oplogReplay, Decoder<T> resultDecoder, SingleResultCallback<QueryResult<T>> callback);
 
     /**
-     * Get more result documents from a cursor.
+     * Get more result documents from a cursor asynchronously.
      *
      * @param namespace      the namespace to get more documents from
      * @param cursorId       the cursor id
      * @param numberToReturn the number of documents to return
-     * @param resultDecoder  the decoder for the query results
+     * @param resultDecoder  the decoder for the query result documents
+     * @param callback       the callback to be passed the query result
      * @param <T>            the type of the query result documents
-     * @return the query results
      */
-    <T> QueryResult<T> getMore(MongoNamespace namespace, long cursorId, int numberToReturn, Decoder<T> resultDecoder);
+    <T> void getMoreAsync(MongoNamespace namespace, long cursorId, int numberToReturn, Decoder<T> resultDecoder,
+                                                 SingleResultCallback<QueryResult<T>> callback);
 
     /**
-     * Kills the given list of cursors.
+     * Asynchronously Kills the given list of cursors.
      *
-     * @param cursors the cursors
+     * @param cursors   the cursors
+     * @param callback  the callback that is called once the cursors have been killed
      */
-    void killCursor(List<Long> cursors);
+    void killCursorAsync(List<Long> cursors, SingleResultCallback<Void> callback);
 }

--- a/driver-core/src/main/com/mongodb/connection/ConnectionFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/ConnectionFactory.java
@@ -18,4 +18,7 @@ package com.mongodb.connection;
 
 interface ConnectionFactory {
     Connection create(InternalConnection internalConnection, ProtocolExecutor executor, ClusterConnectionMode clusterConnectionMode);
+
+    AsyncConnection createAsync(InternalConnection internalConnection, ProtocolExecutor executor,
+                                ClusterConnectionMode clusterConnectionMode);
 }

--- a/driver-core/src/main/com/mongodb/connection/DefaultConnectionFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultConnectionFactory.java
@@ -19,7 +19,13 @@ package com.mongodb.connection;
 class DefaultConnectionFactory implements ConnectionFactory {
     @Override
     public Connection create(final InternalConnection internalConnection, final ProtocolExecutor executor,
-                             final ClusterConnectionMode clusterConnectionMode) {
+                                 final ClusterConnectionMode clusterConnectionMode) {
+        return new DefaultServerConnection(internalConnection, executor, clusterConnectionMode);
+    }
+
+    @Override
+    public AsyncConnection createAsync(final InternalConnection internalConnection, final ProtocolExecutor executor,
+                                       final ClusterConnectionMode clusterConnectionMode) {
         return new DefaultServerConnection(internalConnection, executor, clusterConnectionMode);
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/DefaultServer.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultServer.java
@@ -31,8 +31,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.connection.ServerConnectionState.CONNECTING;
+import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 
 class DefaultServer implements ClusterableServer {
     private final ServerAddress serverAddress;
@@ -74,7 +74,7 @@ class DefaultServer implements ClusterableServer {
     }
 
     @Override
-    public void getConnectionAsync(final SingleResultCallback<Connection> callback) {
+    public void getConnectionAsync(final SingleResultCallback<AsyncConnection> callback) {
         isTrue("open", !isClosed());
         connectionPool.getAsync(new SingleResultCallback<InternalConnection>() {
             @Override
@@ -85,7 +85,8 @@ class DefaultServer implements ClusterableServer {
                 if (t != null) {
                     callback.onResult(null, t);
                 } else {
-                    callback.onResult(connectionFactory.create(result, new DefaultServerProtocolExecutor(), clusterConnectionMode), null);
+                    callback.onResult(connectionFactory.createAsync(result, new DefaultServerProtocolExecutor(), clusterConnectionMode),
+                                      null);
                 }
             }
         });

--- a/driver-core/src/main/com/mongodb/connection/DefaultServerConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultServerConnection.java
@@ -31,10 +31,10 @@ import org.bson.codecs.Decoder;
 import java.util.List;
 
 import static com.mongodb.assertions.Assertions.isTrue;
-import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.connection.ServerType.SHARD_ROUTER;
+import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 
-class DefaultServerConnection extends AbstractReferenceCounted implements Connection {
+class DefaultServerConnection extends AbstractReferenceCounted implements Connection, AsyncConnection {
     private final InternalConnection wrapped;
     private final ProtocolExecutor protocolExecutor;
     private final ClusterConnectionMode clusterConnectionMode;

--- a/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
@@ -273,11 +273,12 @@ class InternalStreamConnection implements InternalConnection {
             callback.onResult(null, new MongoSocketClosedException("Can not read from a closed socket", getServerAddress()));
         }
 
+        Response response = null;
         readerLock.lock();
 
-        Response response = messages.get(responseTo);
-
         try {
+            response = messages.get(responseTo);
+
             if (response == null) {
                 readQueue.put(responseTo, callback);
             }

--- a/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014 MongoDB, Inc.
+ * Copyright 2013-2015 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/driver-core/src/main/com/mongodb/connection/Server.java
+++ b/driver-core/src/main/com/mongodb/connection/Server.java
@@ -54,5 +54,5 @@ public interface Server {
      *
      * @param callback the callback to execute when the connection is available or an error occurs
      */
-    void getConnectionAsync(SingleResultCallback<Connection> callback);
+    void getConnectionAsync(SingleResultCallback<AsyncConnection> callback);
 }

--- a/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
@@ -21,7 +21,7 @@ import com.mongodb.ServerCursor;
 import com.mongodb.async.AsyncBatchCursor;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.binding.AsyncConnectionSource;
-import com.mongodb.connection.Connection;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.QueryResult;
 import org.bson.codecs.Decoder;
 
@@ -120,9 +120,9 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
     }
 
     private void getMore(final SingleResultCallback<List<T>> callback) {
-        connectionSource.getConnection(new SingleResultCallback<Connection>() {
+        connectionSource.getConnection(new SingleResultCallback<AsyncConnection>() {
             @Override
-            public void onResult(final Connection connection, final Throwable t) {
+            public void onResult(final AsyncConnection connection, final Throwable t) {
                 if (t != null) {
                     callback.onResult(null, t);
                 } else {
@@ -137,9 +137,9 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
         if (cursor != null) {
             final ServerCursor localCursor = cursor;
             cursor = null;
-            connectionSource.getConnection(new SingleResultCallback<Connection>() {
+            connectionSource.getConnection(new SingleResultCallback<AsyncConnection>() {
                 @Override
-                public void onResult(final Connection connection, final Throwable connectionException) {
+                public void onResult(final AsyncConnection connection, final Throwable connectionException) {
                     connection.killCursorAsync(asList(localCursor.getId()), new SingleResultCallback<Void>() {
                                   @Override
                                   public void onResult(final Void result, final Throwable t) {
@@ -157,10 +157,10 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
     }
 
     private class QueryResultSingleResultCallback implements SingleResultCallback<QueryResult<T>> {
-        private final Connection connection;
+        private final AsyncConnection connection;
         private final SingleResultCallback<List<T>> callback;
 
-        public QueryResultSingleResultCallback(final Connection connection, final SingleResultCallback<List<T>> callback) {
+        public QueryResultSingleResultCallback(final AsyncConnection connection, final SingleResultCallback<List<T>> callback) {
             this.connection = connection;
             this.callback = errorHandlingCallback(callback);
         }

--- a/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
@@ -26,6 +26,7 @@ import com.mongodb.binding.AsyncWriteBinding;
 import com.mongodb.binding.ConnectionSource;
 import com.mongodb.binding.ReadBinding;
 import com.mongodb.binding.WriteBinding;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
@@ -35,8 +36,8 @@ import org.bson.codecs.BsonDocumentCodec;
 import org.bson.codecs.Decoder;
 
 import static com.mongodb.ReadPreference.primary;
-import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.connection.ServerType.SHARD_ROUTER;
+import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.operation.OperationHelper.IdentityTransformer;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 
@@ -261,13 +262,13 @@ final class CommandOperationHelper {
 
     static void executeWrappedCommandProtocolAsync(final String database,
                                                    final BsonDocument command,
-                                                   final Connection connection,
+                                                   final AsyncConnection connection,
                                                    final SingleResultCallback<BsonDocument> callback) {
         executeWrappedCommandProtocolAsync(database, command, new BsonDocumentCodec(), connection, callback);
     }
 
     static <T> void executeWrappedCommandProtocolAsync(final String database, final BsonDocument command,
-                                                       final Connection connection,
+                                                       final AsyncConnection connection,
                                                        final Function<BsonDocument, T> transformer,
                                                        final SingleResultCallback<T> callback) {
         executeWrappedCommandProtocolAsync(database, command, new BsonDocumentCodec(), connection, primary(), transformer, callback);
@@ -276,14 +277,14 @@ final class CommandOperationHelper {
     static <T> void executeWrappedCommandProtocolAsync(final String database,
                                                        final BsonDocument command,
                                                        final Decoder<T> decoder,
-                                                       final Connection connection,
+                                                       final AsyncConnection connection,
                                                        final SingleResultCallback<T> callback) {
         executeWrappedCommandProtocolAsync(database, command, decoder, connection, primary(), new IdentityTransformer<T>(), callback);
     }
 
     static <D, T> void executeWrappedCommandProtocolAsync(final String database, final BsonDocument command,
                                                           final Decoder<D> decoder,
-                                                          final Connection connection,
+                                                          final AsyncConnection connection,
                                                           final ReadPreference readPreference,
                                                           final Function<D, T> transformer,
                                                           final SingleResultCallback<T> callback) {
@@ -365,9 +366,9 @@ final class CommandOperationHelper {
             if (t != null) {
                 callback.onResult(null, t);
             } else {
-                source.getConnection(new SingleResultCallback<Connection>() {
+                source.getConnection(new SingleResultCallback<AsyncConnection>() {
                     @Override
-                    public void onResult(final Connection connection, final Throwable t) {
+                    public void onResult(final AsyncConnection connection, final Throwable t) {
                         if (t != null) {
                             callback.onResult(null, t);
                         } else {

--- a/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
@@ -29,6 +29,7 @@ import com.mongodb.binding.AsyncWriteBinding;
 import com.mongodb.binding.WriteBinding;
 import com.mongodb.bulk.IndexRequest;
 import com.mongodb.bulk.InsertRequest;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
@@ -93,7 +94,7 @@ public class CreateIndexesOperation implements AsyncWriteOperation<Void>, WriteO
         return withConnection(binding, new CallableWithConnection<Void>() {
             @Override
             public Void call(final Connection connection) {
-                if (serverIsAtLeastVersionTwoDotSix(connection)) {
+                if (serverIsAtLeastVersionTwoDotSix(connection.getDescription())) {
                     try {
                         executeWrappedCommandProtocol(namespace.getDatabaseName(), getCommand(), connection);
                     } catch (MongoCommandException e) {
@@ -114,12 +115,12 @@ public class CreateIndexesOperation implements AsyncWriteOperation<Void>, WriteO
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
         withConnection(binding, new AsyncCallableWithConnection() {
             @Override
-            public void call(final Connection connection, final Throwable t) {
+            public void call(final AsyncConnection connection, final Throwable t) {
                 if (t != null) {
                     errorHandlingCallback(callback).onResult(null, t);
                 } else {
                     final SingleResultCallback<Void> wrappedCallback = releasingCallback(errorHandlingCallback(callback), connection);
-                    if (serverIsAtLeastVersionTwoDotSix(connection)) {
+                    if (serverIsAtLeastVersionTwoDotSix(connection.getDescription())) {
                         executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), getCommand(), connection,
                                                            new SingleResultCallback<BsonDocument>() {
                                                                @Override

--- a/driver-core/src/main/com/mongodb/operation/DeleteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DeleteOperation.java
@@ -23,6 +23,7 @@ import com.mongodb.async.SingleResultCallback;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.bulk.DeleteRequest;
 import com.mongodb.bulk.WriteRequest;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 
 import java.util.List;
@@ -66,7 +67,7 @@ public class DeleteOperation extends BaseWriteOperation {
     }
 
     @Override
-    protected void executeProtocolAsync(final Connection connection,
+    protected void executeProtocolAsync(final AsyncConnection connection,
                                         final SingleResultCallback<WriteConcernResult> callback) {
         connection.deleteAsync(getNamespace(), isOrdered(), getWriteConcern(), deleteRequests, callback);
     }
@@ -77,7 +78,7 @@ public class DeleteOperation extends BaseWriteOperation {
     }
 
     @Override
-    protected void executeCommandProtocolAsync(final Connection connection, final SingleResultCallback<BulkWriteResult> callback) {
+    protected void executeCommandProtocolAsync(final AsyncConnection connection, final SingleResultCallback<BulkWriteResult> callback) {
         connection.deleteCommandAsync(getNamespace(), isOrdered(), getWriteConcern(), deleteRequests, callback);
     }
 

--- a/driver-core/src/main/com/mongodb/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindOperation.java
@@ -27,6 +27,7 @@ import com.mongodb.binding.AsyncConnectionSource;
 import com.mongodb.binding.AsyncReadBinding;
 import com.mongodb.binding.ConnectionSource;
 import com.mongodb.binding.ReadBinding;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.QueryResult;
@@ -41,8 +42,8 @@ import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.connection.ServerType.SHARD_ROUTER;
+import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.operation.OperationHelper.AsyncCallableWithConnectionAndSource;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
@@ -414,7 +415,7 @@ public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
         withConnection(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
-            public void call(final AsyncConnectionSource source, final Connection connection, final Throwable t) {
+            public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 if (t != null) {
                     errorHandlingCallback(callback).onResult(null, t);
                 } else {

--- a/driver-core/src/main/com/mongodb/operation/InsertOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/InsertOperation.java
@@ -23,6 +23,7 @@ import com.mongodb.async.SingleResultCallback;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.bulk.InsertRequest;
 import com.mongodb.bulk.WriteRequest;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 
 import java.util.List;
@@ -66,7 +67,7 @@ public class InsertOperation extends BaseWriteOperation {
     }
 
     @Override
-    protected void executeProtocolAsync(final Connection connection, final SingleResultCallback<WriteConcernResult> callback) {
+    protected void executeProtocolAsync(final AsyncConnection connection, final SingleResultCallback<WriteConcernResult> callback) {
         connection.insertAsync(getNamespace(), isOrdered(), getWriteConcern(), insertRequests, callback);
     }
 
@@ -76,7 +77,7 @@ public class InsertOperation extends BaseWriteOperation {
     }
 
     @Override
-    protected void executeCommandProtocolAsync(final Connection connection, final SingleResultCallback<BulkWriteResult> callback) {
+    protected void executeCommandProtocolAsync(final AsyncConnection connection, final SingleResultCallback<BulkWriteResult> callback) {
         connection.insertCommandAsync(getNamespace(), isOrdered(), getWriteConcern(), insertRequests, callback);
     }
 

--- a/driver-core/src/main/com/mongodb/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListCollectionsOperation.java
@@ -28,6 +28,7 @@ import com.mongodb.binding.AsyncConnectionSource;
 import com.mongodb.binding.AsyncReadBinding;
 import com.mongodb.binding.ConnectionSource;
 import com.mongodb.binding.ReadBinding;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.QueryResult;
@@ -171,7 +172,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
         return withConnection(binding, new CallableWithConnectionAndSource<BatchCursor<T>>() {
             @Override
             public BatchCursor<T> call(final ConnectionSource source, final Connection connection) {
-                if (serverIsAtLeastVersionThreeDotZero(connection)) {
+                if (serverIsAtLeastVersionThreeDotZero(connection.getDescription())) {
                     try {
                         return executeWrappedCommandProtocol(databaseName, getCommand(), createCommandDecoder(), connection,
                                                              commandTransformer(source));
@@ -193,13 +194,13 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
         withConnection(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
-            public void call(final AsyncConnectionSource source, final Connection connection, final Throwable t) {
+            public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 if (t != null) {
                     errorHandlingCallback(callback).onResult(null, t);
                 } else {
                     final SingleResultCallback<AsyncBatchCursor<T>> wrappedCallback = releasingCallback(errorHandlingCallback(callback),
                                                                                                         source, connection);
-                    if (serverIsAtLeastVersionThreeDotZero(connection)) {
+                    if (serverIsAtLeastVersionThreeDotZero(connection.getDescription())) {
                         executeWrappedCommandProtocolAsync(databaseName, getCommand(), createCommandDecoder(), connection,
                                 binding.getReadPreference(), asyncTransformer(source),
                                 new SingleResultCallback<AsyncBatchCursor<T>>() {

--- a/driver-core/src/main/com/mongodb/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListIndexesOperation.java
@@ -26,6 +26,7 @@ import com.mongodb.binding.AsyncConnectionSource;
 import com.mongodb.binding.AsyncReadBinding;
 import com.mongodb.binding.ConnectionSource;
 import com.mongodb.binding.ReadBinding;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.QueryResult;
@@ -135,7 +136,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
         return withConnection(binding, new OperationHelper.CallableWithConnectionAndSource<BatchCursor<T>>() {
             @Override
             public BatchCursor<T> call(final ConnectionSource source, final Connection connection) {
-                if (serverIsAtLeastVersionThreeDotZero(connection)) {
+                if (serverIsAtLeastVersionThreeDotZero(connection.getDescription())) {
                     try {
                         return executeWrappedCommandProtocol(namespace.getDatabaseName(), getCommand(), createCommandDecoder(), connection,
                                                              transformer(source));
@@ -157,13 +158,13 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
         withConnection(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
-            public void call(final AsyncConnectionSource source, final Connection connection, final Throwable t) {
+            public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 if (t != null) {
                     errorHandlingCallback(callback).onResult(null, t);
                 } else {
                     final SingleResultCallback<AsyncBatchCursor<T>> wrappedCallback = releasingCallback(errorHandlingCallback(callback),
                                                                                                         source, connection);
-                    if (serverIsAtLeastVersionThreeDotZero(connection)) {
+                    if (serverIsAtLeastVersionThreeDotZero(connection.getDescription())) {
                         executeWrappedCommandProtocolAsync(namespace.getDatabaseName(), getCommand(), createCommandDecoder(),
                                                            connection, binding.getReadPreference(), asyncTransformer(source),
                                                            new SingleResultCallback<AsyncBatchCursor<T>>() {

--- a/driver-core/src/main/com/mongodb/operation/ParallelCollectionScanOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ParallelCollectionScanOperation.java
@@ -25,6 +25,7 @@ import com.mongodb.binding.AsyncConnectionSource;
 import com.mongodb.binding.AsyncReadBinding;
 import com.mongodb.binding.ConnectionSource;
 import com.mongodb.binding.ReadBinding;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.QueryResult;
 import org.bson.BsonArray;
@@ -128,7 +129,7 @@ public class ParallelCollectionScanOperation<T> implements AsyncReadOperation<Li
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<List<AsyncBatchCursor<T>>> callback) {
         withConnection(binding, new AsyncCallableWithConnectionAndSource() {
             @Override
-            public void call(final AsyncConnectionSource source, final Connection connection, final Throwable t) {
+            public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                 if (t != null) {
                     errorHandlingCallback(callback).onResult(null, t);
                 } else {

--- a/driver-core/src/main/com/mongodb/operation/UpdateOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/UpdateOperation.java
@@ -23,6 +23,7 @@ import com.mongodb.async.SingleResultCallback;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.bulk.UpdateRequest;
 import com.mongodb.bulk.WriteRequest;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 
 import java.util.List;
@@ -66,7 +67,7 @@ public class UpdateOperation extends BaseWriteOperation {
     }
 
     @Override
-    protected void executeProtocolAsync(final Connection connection, final SingleResultCallback<WriteConcernResult> callback) {
+    protected void executeProtocolAsync(final AsyncConnection connection, final SingleResultCallback<WriteConcernResult> callback) {
         connection.updateAsync(getNamespace(), isOrdered(), getWriteConcern(), updates, callback);
     }
 
@@ -76,7 +77,7 @@ public class UpdateOperation extends BaseWriteOperation {
     }
 
     @Override
-    protected void executeCommandProtocolAsync(final Connection connection, final SingleResultCallback<BulkWriteResult> callback) {
+    protected void executeCommandProtocolAsync(final AsyncConnection connection, final SingleResultCallback<BulkWriteResult> callback) {
         connection.updateCommandAsync(getNamespace(), isOrdered(), getWriteConcern(), updates, callback);
     }
 

--- a/driver-core/src/main/com/mongodb/operation/UserExistsOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/UserExistsOperation.java
@@ -21,6 +21,7 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.binding.AsyncReadBinding;
 import com.mongodb.binding.ReadBinding;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.QueryResult;
 import org.bson.BsonDocument;
@@ -62,7 +63,7 @@ public class UserExistsOperation implements AsyncReadOperation<Boolean>, ReadOpe
         return withConnection(binding, new CallableWithConnection<Boolean>() {
             @Override
             public Boolean call(final Connection connection) {
-                if (serverIsAtLeastVersionTwoDotSix(connection)) {
+                if (serverIsAtLeastVersionTwoDotSix(connection.getDescription())) {
                     return executeWrappedCommandProtocol(databaseName, getCommand(), connection, binding.getReadPreference(),
                                                          transformer());
                 } else {
@@ -80,12 +81,12 @@ public class UserExistsOperation implements AsyncReadOperation<Boolean>, ReadOpe
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<Boolean> callback) {
         withConnection(binding, new AsyncCallableWithConnection() {
             @Override
-            public void call(final Connection connection, final Throwable t) {
+            public void call(final AsyncConnection connection, final Throwable t) {
                 if (t != null) {
                     errorHandlingCallback(callback).onResult(null, t);
                 } else {
                     final SingleResultCallback<Boolean> wrappedCallback = releasingCallback(errorHandlingCallback(callback), connection);
-                    if (serverIsAtLeastVersionTwoDotSix(connection)) {
+                    if (serverIsAtLeastVersionTwoDotSix(connection.getDescription())) {
                         executeWrappedCommandProtocolAsync(databaseName, getCommand(), connection, transformer(), wrappedCallback);
                     } else {
                         connection.queryAsync(new MongoNamespace(databaseName, "system.users"),

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -26,12 +26,12 @@ import com.mongodb.binding.AsyncSingleConnectionBinding;
 import com.mongodb.binding.ClusterBinding;
 import com.mongodb.binding.ReadWriteBinding;
 import com.mongodb.binding.SingleConnectionBinding;
+import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.AsynchronousSocketChannelStreamFactory;
 import com.mongodb.connection.Cluster;
 import com.mongodb.connection.ClusterDescription;
 import com.mongodb.connection.ClusterSettings;
 import com.mongodb.connection.ClusterType;
-import com.mongodb.connection.Connection;
 import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.connection.DefaultClusterFactory;
 import com.mongodb.connection.ServerDescription;
@@ -331,8 +331,8 @@ public final class ClusterFixture {
         return futureResultCallback.get(60, SECONDS);
     }
 
-    public static Connection getConnection(final AsyncConnectionSource source) throws Throwable {
-        final FutureResultCallback<Connection> futureResultCallback = new FutureResultCallback<Connection>();
+    public static AsyncConnection getConnection(final AsyncConnectionSource source) throws Throwable {
+        final FutureResultCallback<AsyncConnection> futureResultCallback = new FutureResultCallback<AsyncConnection>();
         source.getConnection(futureResultCallback);
         return futureResultCallback.get(60, SECONDS);
     }

--- a/driver-core/src/test/functional/com/mongodb/binding/AsyncSingleConnectionBindingTest.java
+++ b/driver-core/src/test/functional/com/mongodb/binding/AsyncSingleConnectionBindingTest.java
@@ -18,7 +18,7 @@ package com.mongodb.binding;
 
 import category.ReplicaSet;
 import com.mongodb.async.SingleResultCallback;
-import com.mongodb.connection.Connection;
+import com.mongodb.connection.AsyncConnection;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,12 +52,12 @@ public class AsyncSingleConnectionBindingTest  {
     @Test
     public void shouldReturnTheSameConnection() throws Throwable {
         AsyncConnectionSource asyncConnectionSource = getReadConnectionSource(binding);
-        Connection asyncConnection = getConnection(asyncConnectionSource);
+        AsyncConnection asyncConnection = getConnection(asyncConnectionSource);
 
         // Check we get the same connection
         for (int i = 0; i < 100; i++) {
             AsyncConnectionSource connectionSource = getReadConnectionSource(binding);
-            Connection connection = getConnection(connectionSource);
+            AsyncConnection connection = getConnection(connectionSource);
             assertEquals(connection.getDescription().getConnectionId(), asyncConnection.getDescription().getConnectionId());
             connection.release();
             connectionSource.release();
@@ -70,10 +70,10 @@ public class AsyncSingleConnectionBindingTest  {
     @Test
     public void shouldHaveTheSameConnectionForReadsAndWritesWithPrimaryReadPreference() throws Throwable {
         AsyncConnectionSource writeSource = getWriteConnectionSource(binding);
-        Connection writeConnection = getConnection(writeSource);
+        AsyncConnection writeConnection = getConnection(writeSource);
 
         AsyncConnectionSource readSource = getReadConnectionSource(binding);
-        Connection readConnection = getConnection(readSource);
+        AsyncConnection readConnection = getConnection(readSource);
         assertEquals(writeConnection.getDescription().getConnectionId(), readConnection.getDescription().getConnectionId());
 
         writeConnection.release();
@@ -100,10 +100,10 @@ public class AsyncSingleConnectionBindingTest  {
     public void shouldHaveTheDifferentConnectionForReadsAndWritesWithNonPrimaryReadPreference() throws Throwable {
         AsyncSingleConnectionBinding binding = new AsyncSingleConnectionBinding(getAsyncCluster(), secondary(), 1, SECONDS);
         AsyncConnectionSource writeSource = getWriteConnectionSource(binding);
-        Connection writeConnection = getConnection(writeSource);
+        AsyncConnection writeConnection = getConnection(writeSource);
 
         AsyncConnectionSource readSource = getReadConnectionSource(binding);
-        Connection readConnection = getConnection(readSource);
+        AsyncConnection readConnection = getConnection(readSource);
         assertThat(writeConnection.getDescription().getConnectionId(), is(not(readConnection.getDescription().getConnectionId())));
 
         writeConnection.release();
@@ -128,9 +128,9 @@ public class AsyncSingleConnectionBindingTest  {
     }
 
     private void getAndReleaseConnectionSourceAndConnection(final AsyncConnectionSource connectionSource) {
-        connectionSource.getConnection(new SingleResultCallback<Connection>() {
+        connectionSource.getConnection(new SingleResultCallback<AsyncConnection>() {
             @Override
-            public void onResult(final Connection connection, final Throwable t) {
+            public void onResult(final AsyncConnection connection, final Throwable t) {
                 connection.release();
                 connectionSource.release();
             }

--- a/driver-core/src/test/resources/logback-test.xml
+++ b/driver-core/src/test/resources/logback-test.xml
@@ -11,7 +11,7 @@
     <!--<logger name="org.mongodb.driver.protocol" level="TRACE" additivity="true"/>-->
     <!--<logger name="org.mongodb.driver.operation" level="TRACE" additivity="true"/>-->
 
-    <root level="INFO">
+    <root level="TRACE">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/driver-core/src/test/unit/com/mongodb/connection/DefaultServerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/DefaultServerSpecification.groovy
@@ -73,7 +73,7 @@ class DefaultServerSpecification extends Specification {
         def serverMonitorFactory = Stub(ServerMonitorFactory)
         def serverMonitor = Stub(ServerMonitor)
         def internalConnection = Stub(InternalConnection)
-        def connection = Stub(Connection)
+        def connection = Stub(AsyncConnection)
 
         connectionPool.getAsync(_) >> {
             it[0].onResult(internalConnection, null)
@@ -92,7 +92,7 @@ class DefaultServerSpecification extends Specification {
         then:
         receivedConnection
         !receivedThrowable
-        1 * connectionFactory.create(_, _, mode) >> connection
+        1 * connectionFactory.createAsync(_, _, mode) >> connection
 
         where:
         mode << [SINGLE, MULTIPLE]

--- a/driver-core/src/test/unit/com/mongodb/connection/TestConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestConnection.java
@@ -31,7 +31,7 @@ import org.bson.codecs.Decoder;
 import java.util.List;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
-class TestConnection implements Connection {
+class TestConnection implements Connection, AsyncConnection {
     private final InternalConnection internalConnection;
     private final ProtocolExecutor executor;
     private Protocol enqueuedProtocol;
@@ -47,7 +47,7 @@ class TestConnection implements Connection {
     }
 
     @Override
-    public Connection retain() {
+    public TestConnection retain() {
         return this;
     }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/TestConnectionFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestConnectionFactory.java
@@ -19,7 +19,13 @@ package com.mongodb.connection;
 class TestConnectionFactory implements ConnectionFactory {
     @Override
     public Connection create(final InternalConnection internalConnection, final ProtocolExecutor executor,
-                             final ClusterConnectionMode clusterConnectionMode) {
+                                 final ClusterConnectionMode clusterConnectionMode) {
+        return new TestConnection(internalConnection, executor);
+    }
+
+    @Override
+    public AsyncConnection createAsync(final InternalConnection internalConnection, final ProtocolExecutor executor,
+                                       final ClusterConnectionMode clusterConnectionMode) {
         return new TestConnection(internalConnection, executor);
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/connection/TestServer.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestServer.java
@@ -81,7 +81,7 @@ public class TestServer implements ClusterableServer {
     }
 
     @Override
-    public void getConnectionAsync(final SingleResultCallback<Connection> callback) {
+    public void getConnectionAsync(final SingleResultCallback<AsyncConnection> callback) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
I took a walk this evening and came up with this design.  The basic insight is that we don't have to hold the reading lock while waiting for IO.  It's enough just to hold it while setting the state.

Ross, maybe this is what you were saying earlier today and I just didn't understand until now.

More comments in line.

The main problem still is that I haven't figured out how to support concurrent async and sync readers together.  With this design, the sync readers are using the reading lock in a way that is not compatible with the async readers.  

One possibility is to not allow sync and async readers to be combined.  In practice, I can't see that they would be.  But not sure how to actually prevent it at compile time without creating a parallel AsyncCluster/AsyncServer/AsyncConnection set of interfaces.
