### PR TITLE
When checking the presence of slf4j, ClassNotFoundException isn't enough

### DIFF
--- a/driver-core/src/main/com/mongodb/diagnostics/logging/Loggers.java
+++ b/driver-core/src/main/com/mongodb/diagnostics/logging/Loggers.java
@@ -64,6 +64,8 @@ public final class Loggers {
             return true;
         } catch (ClassNotFoundException e) {
             return false;
+        } catch (NoClassDefFoundError e) {
+            return false;
         }
     }
 }


### PR DESCRIPTION
I'm getting a java.lang.NoClassDefFoundError: org/apache/log4j/Level
because I use org.apache.logging.log4j.Level