### PR TITLE
fix isoDate hour date formatter from hh to HH (hour 0-23)

### DIFF
--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -733,7 +733,7 @@ public class JsonReader extends AbstractBsonReader {
             throw new JsonParseException("JSON reader expected a string but found '%s'.", valueToken.getValue());
         }
         verifyToken(")");
-        String[] patterns = {"yyyy-MM-dd", "yyyy-MM-dd'T'hh:mm:ssz", "yyyy-MM-dd'T'hh:mm:ss.SSSz"};
+        String[] patterns = {"yyyy-MM-dd", "yyyy-MM-dd'T'HH:mm:ssz", "yyyy-MM-dd'T'HH:mm:ss.SSSz"};
 
         SimpleDateFormat format = new SimpleDateFormat(patterns[0], Locale.ENGLISH);
         ParsePosition pos = new ParsePosition(0);

--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -119,6 +119,15 @@ public class JsonReaderTest {
     }
 
     @Test
+    public void testDateTimeISOString2() {
+        String json = "ISODate(\"2013-10-04T12:07:30.443Z\")";
+        bsonReader = new JsonReader(json);
+        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+        assertEquals(1380888450443L, bsonReader.readDateTime());
+        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+    }
+
+    @Test
     public void testDateTimeStrict() {
         String json = "{ \"$date\" : 0 }";
         bsonReader = new JsonReader(json);


### PR DESCRIPTION
Added a test which fails for an ISODate, then fixed.  This was the failure output:

```
org.bson.json.JsonReaderTest > testDateTimeISOString2 FAILED
    java.lang.AssertionError: expected:<1380888450443> but was:<1380845250443>
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:645)
        at org.junit.Assert.assertEquals(Assert.java:631)
        at org.bson.json.JsonReaderTest.testDateTimeISOString2(JsonReaderTest.java:126)

373 tests completed, 1 failed
```
ref:
https://groups.google.com/forum/#!topic/mongodb-dev/t0Z7iZsSbGw