### PR TITLE
Argument for validation method changed according to the conventions

### DIFF
--- a/driver/src/main/com/mongodb/MongoCollectionImpl.java
+++ b/driver/src/main/com/mongodb/MongoCollectionImpl.java
@@ -90,7 +90,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     MongoCollectionImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final CodecRegistry codecRegistry,
                         final ReadPreference readPreference, final WriteConcern writeConcern, final OperationExecutor executor) {
         this.namespace = notNull("namespace", namespace);
-        this.documentClass = notNull("clazz", documentClass);
+        this.documentClass = notNull("documentClass", documentClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.readPreference = notNull("readPreference", readPreference);
         this.writeConcern = notNull("writeConcern", writeConcern);


### PR DESCRIPTION
A minor thing I noticed during reading the code.
All parameters are passed to the validation accompanied with their actual name as a string.