### PR TITLE
Notify listener about wait queue enter before throwing an exception if the queue is full (JAVA-1873)

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014 MongoDB, Inc.
+ * Copyright (c) 2008-2015 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,10 +83,10 @@ class DefaultConnectionPool implements ConnectionPool {
     @Override
     public InternalConnection get(final long timeout, final TimeUnit timeUnit) {
         try {
+            connectionPoolListener.waitQueueEntered(new ConnectionPoolWaitQueueEvent(serverId, currentThread().getId()));
             if (waitQueueSize.incrementAndGet() > settings.getMaxWaitQueueSize()) {
                 throw createWaitQueueFullException();
             }
-            connectionPoolListener.waitQueueEntered(new ConnectionPoolWaitQueueEvent(serverId, currentThread().getId()));
             PooledConnection pooledConnection = getPooledConnection(timeout, timeUnit);
             if (!pooledConnection.opened()) {
                 try {

--- a/driver-core/src/test/functional/com/mongodb/connection/QueueEventsConnectionPoolListener.java
+++ b/driver-core/src/test/functional/com/mongodb/connection/QueueEventsConnectionPoolListener.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection;
+
+import com.mongodb.event.ConnectionPoolListenerAdapter;
+import com.mongodb.event.ConnectionPoolWaitQueueEvent;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+class QueueEventsConnectionPoolListener extends ConnectionPoolListenerAdapter {
+    private final AtomicInteger waitQueueSize = new AtomicInteger();
+
+    @Override
+    public void waitQueueExited(ConnectionPoolWaitQueueEvent event) {
+        waitQueueSize.decrementAndGet();
+    }
+
+    @Override
+    public void waitQueueEntered(ConnectionPoolWaitQueueEvent event) {
+        waitQueueSize.incrementAndGet();
+    }
+
+    public int getWaitQueueSize() {
+        return waitQueueSize.get();
+    }
+}


### PR DESCRIPTION
Without this fix DefaultConnectionPool::get throws exception about a full queue first and then notify listener about wait queue exit in finally clause.
As a result, wait queue size reported by the ConnectionPoolStatistics may become negative.