### PR TITLE
JAVA-1980: Add hook for monitoring the performance of MongoDB calls.

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/AggregateOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateOperation.java
@@ -59,7 +59,7 @@ import static com.mongodb.operation.OperationHelper.withConnection;
  * @mongodb.server.release 2.2
  * @since 3.0
  */
-public class AggregateOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
+public class AggregateOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>>, NamespacedOperation {
     private static final String RESULT = "result";
     private static final String FIRST_BATCH = "firstBatch";
 
@@ -82,6 +82,15 @@ public class AggregateOperation<T> implements AsyncReadOperation<AsyncBatchCurso
         this.namespace = notNull("namespace", namespace);
         this.pipeline = notNull("pipeline", pipeline);
         this.decoder = notNull("decoder", decoder);
+    }
+
+    /**
+     * Gets the namespace.
+     *
+     * @return the namespace
+     */
+    public MongoNamespace getNamespace() {
+        return namespace;
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/operation/BaseWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/BaseWriteOperation.java
@@ -55,7 +55,8 @@ import static com.mongodb.operation.OperationHelper.withConnection;
  *
  * @since 3.0
  */
-public abstract class BaseWriteOperation implements AsyncWriteOperation<WriteConcernResult>, WriteOperation<WriteConcernResult> {
+public abstract class BaseWriteOperation implements AsyncWriteOperation<WriteConcernResult>, WriteOperation<WriteConcernResult>,
+        NamespacedOperation {
 
     private final WriteConcern writeConcern;
     private final MongoNamespace namespace;

--- a/driver-core/src/main/com/mongodb/operation/CountOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CountOperation.java
@@ -40,7 +40,7 @@ import static com.mongodb.operation.DocumentHelper.putIfNotZero;
  *
  * @since 3.0
  */
-public class CountOperation implements AsyncReadOperation<Long>, ReadOperation<Long> {
+public class CountOperation implements AsyncReadOperation<Long>, ReadOperation<Long>, NamespacedOperation {
     private final MongoNamespace namespace;
     private BsonDocument filter;
     private BsonValue hint;
@@ -55,6 +55,15 @@ public class CountOperation implements AsyncReadOperation<Long>, ReadOperation<L
      */
     public CountOperation(final MongoNamespace namespace) {
         this.namespace = notNull("namespace", namespace);
+    }
+
+    /**
+     * Gets the namespace.
+     *
+     * @return the namespace
+     */
+    public MongoNamespace getNamespace() {
+        return namespace;
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/operation/DistinctOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DistinctOperation.java
@@ -53,7 +53,7 @@ import static com.mongodb.operation.OperationHelper.withConnection;
  * @mongodb.driver.manual reference/command/distinct Distinct Command
  * @since 3.0
  */
-public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
+public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>>, NamespacedOperation {
     private static final String VALUES = "values";
 
     private final MongoNamespace namespace;
@@ -73,6 +73,15 @@ public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor
         this.namespace = notNull("namespace", namespace);
         this.fieldName = notNull("fieldName", fieldName);
         this.decoder = notNull("decoder", decoder);
+    }
+
+    /**
+     * Gets the namespace.
+     *
+     * @return the namespace
+     */
+    public MongoNamespace getNamespace() {
+        return namespace;
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/operation/FindAndDeleteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindAndDeleteOperation.java
@@ -40,7 +40,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * @param <T> the operations result type.
  * @since 3.0
  */
-public class FindAndDeleteOperation<T> implements AsyncWriteOperation<T>, WriteOperation<T> {
+public class FindAndDeleteOperation<T> implements AsyncWriteOperation<T>, WriteOperation<T>, NamespacedOperation {
     private final MongoNamespace namespace;
     private final Decoder<T> decoder;
     private BsonDocument filter;

--- a/driver-core/src/main/com/mongodb/operation/FindAndReplaceOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindAndReplaceOperation.java
@@ -46,7 +46,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * @param <T> the operations result type.
  * @since 3.0
  */
-public class FindAndReplaceOperation<T> implements AsyncWriteOperation<T>, WriteOperation<T> {
+public class FindAndReplaceOperation<T> implements AsyncWriteOperation<T>, WriteOperation<T>, NamespacedOperation {
     private final MongoNamespace namespace;
     private final Decoder<T> decoder;
     private final BsonDocument replacement;

--- a/driver-core/src/main/com/mongodb/operation/FindAndUpdateOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindAndUpdateOperation.java
@@ -46,7 +46,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * @param <T> the operations result type.
  * @since 3.0
  */
-public class FindAndUpdateOperation<T> implements AsyncWriteOperation<T>, WriteOperation<T> {
+public class FindAndUpdateOperation<T> implements AsyncWriteOperation<T>, WriteOperation<T>, NamespacedOperation {
     private final MongoNamespace namespace;
     private final Decoder<T> decoder;
     private final BsonDocument update;

--- a/driver-core/src/main/com/mongodb/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindOperation.java
@@ -54,7 +54,7 @@ import static com.mongodb.operation.OperationHelper.withConnection;
  * @param <T> the operations result type.
  * @since 3.0
  */
-public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
+public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>>, NamespacedOperation {
     private final MongoNamespace namespace;
     private final Decoder<T> decoder;
     private BsonDocument filter;

--- a/driver-core/src/main/com/mongodb/operation/GroupOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/GroupOperation.java
@@ -49,7 +49,7 @@ import static com.mongodb.operation.OperationHelper.withConnection;
  * @mongodb.driver.manual reference/command/group Group Command
  * @since 3.0
  */
-public class GroupOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
+public class GroupOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>>, NamespacedOperation {
     private final MongoNamespace namespace;
     private final Decoder<T> decoder;
     private final BsonJavaScript reduceFunction;
@@ -74,6 +74,15 @@ public class GroupOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>
         this.reduceFunction = notNull("reduceFunction", reduceFunction);
         this.initial = notNull("initial", initial);
         this.decoder = notNull("decoder", decoder);
+    }
+
+    /**
+     * Gets the namespace.
+     *
+     * @return the namespace
+     */
+    public MongoNamespace getNamespace() {
+        return namespace;
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/operation/NamespacedOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/NamespacedOperation.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.operation;
+
+import com.mongodb.MongoNamespace;
+
+/**
+ * An operation which uses a {@code MongoNamespace}.
+ *
+ * @since 3.1
+ */
+public interface NamespacedOperation {
+    /**
+     * Gets the namespace.
+     *
+     * @return the namespace
+     */
+    MongoNamespace getNamespace();
+}

--- a/driver/src/main/com/mongodb/IMongoPerformanceMonitor.java
+++ b/driver/src/main/com/mongodb/IMongoPerformanceMonitor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2014 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+import com.mongodb.operation.ReadOperation;
+import com.mongodb.operation.WriteOperation;
+
+/**
+ * A performance monitor to track execution times.
+ *
+ * @since 3.1
+ */
+public interface IMongoPerformanceMonitor {
+    /**
+     * Tracks execution time from startTime until now for operation.
+     *
+     * @param <T> the operations result type.
+     * @param operation to track execution time of
+     * @param startTime of operation in nanoseconds
+     */
+    <T> void track(ReadOperation<T> operation, long startTime);
+
+    /**
+     * Tracks execution time from startTime until now for operation.
+     *
+     * @param <T> the operations result type.
+     * @param operation to track execution time of
+     * @param startTime of operation in nanoseconds
+     */
+    <T> void track(WriteOperation<T> operation, long startTime);
+}

--- a/driver/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver/src/main/com/mongodb/MongoClientOptions.java
@@ -83,6 +83,7 @@ public class MongoClientOptions {
     private final SocketSettings heartbeatSocketSettings;
     private final SslSettings sslSettings;
     private final List<CommandListener> commandListeners;
+    private final IMongoPerformanceMonitor performanceMonitor;
 
     private MongoClientOptions(final Builder builder) {
         description = builder.description;
@@ -113,6 +114,7 @@ public class MongoClientOptions {
         socketFactory = builder.socketFactory;
         cursorFinalizerEnabled = builder.cursorFinalizerEnabled;
         commandListeners = builder.commandListeners;
+        performanceMonitor = builder.performanceMonitor;
 
         connectionPoolSettings = ConnectionPoolSettings.builder()
                                                        .minSize(getMinConnectionsPerHost())
@@ -456,6 +458,16 @@ public class MongoClientOptions {
     }
 
     /**
+     * Gets the {@code IMongoPerformanceMonitor}. The default is null.
+     *
+     * @return the performance monitor
+     * @since 3.1
+     */
+    public IMongoPerformanceMonitor getPerformanceMonitor() {
+        return performanceMonitor;
+    }
+
+    /**
      * Override the decoder factory. Default is for the standard Mongo Java driver configuration.
      *
      * @return the decoder factory
@@ -616,6 +628,10 @@ public class MongoClientOptions {
         if (!commandListeners.equals(that.commandListeners)) {
             return false;
         }
+        if (performanceMonitor != null ? !performanceMonitor.equals(that.performanceMonitor)
+                                       : that.performanceMonitor != null) {
+            return false;
+        }
         if (requiredReplicaSetName != null ? !requiredReplicaSetName.equals(that.requiredReplicaSetName)
                                            : that.requiredReplicaSetName != null) {
             return false;
@@ -634,6 +650,7 @@ public class MongoClientOptions {
         result = 31 * result + writeConcern.hashCode();
         result = 31 * result + codecRegistry.hashCode();
         result = 31 * result + commandListeners.hashCode();
+        result = 31 * result + (performanceMonitor != null ? performanceMonitor.hashCode() : 0);
         result = 31 * result + minConnectionsPerHost;
         result = 31 * result + maxConnectionsPerHost;
         result = 31 * result + threadsAllowedToBlockForConnectionMultiplier;
@@ -668,6 +685,7 @@ public class MongoClientOptions {
                + ", writeConcern=" + writeConcern
                + ", codecRegistry=" + codecRegistry
                + ", commandListeners=" + commandListeners
+               + ", performanceMonitor=" + performanceMonitor
                + ", minConnectionsPerHost=" + minConnectionsPerHost
                + ", maxConnectionsPerHost=" + maxConnectionsPerHost
                + ", threadsAllowedToBlockForConnectionMultiplier=" + threadsAllowedToBlockForConnectionMultiplier
@@ -737,6 +755,8 @@ public class MongoClientOptions {
         private SocketFactory socketFactory = SocketFactory.getDefault();
         private boolean cursorFinalizerEnabled = true;
 
+        private IMongoPerformanceMonitor performanceMonitor = null;
+
         /**
          * Creates a Builder for MongoClientOptions, getting the appropriate system properties for initialization.
          */
@@ -782,6 +802,7 @@ public class MongoClientOptions {
             socketFactory = options.getSocketFactory();
             cursorFinalizerEnabled = options.isCursorFinalizerEnabled();
             commandListeners = options.commandListeners;
+            performanceMonitor = options.performanceMonitor;
         }
 
         /**
@@ -1011,6 +1032,19 @@ public class MongoClientOptions {
         public Builder addCommandListener(final CommandListener commandListener) {
             notNull("commandListener", commandListener);
             commandListeners.add(commandListener);
+            return this;
+        }
+
+        /**
+         * Sets the performance monitor.
+         *
+         * @param performanceMonitor the performance monitor
+         * @return {@code this}
+         * @see {@code IMongoPerformanceMonitor}
+         * @since 3.1
+         */
+        public Builder performanceMonitor(final IMongoPerformanceMonitor performanceMonitor) {
+            this.performanceMonitor = performanceMonitor;
             return this;
         }
 

--- a/driver/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
@@ -66,6 +66,7 @@ class MongoClientOptionsSpecification extends Specification {
                                                 .minHeartbeatFrequency(500, MILLISECONDS)
                                                 .build()
         options.sslSettings == SslSettings.builder().build();
+        options.performanceMonitor == null;
     }
 
     @SuppressWarnings('UnnecessaryObjectReferences')
@@ -248,6 +249,7 @@ class MongoClientOptionsSpecification extends Specification {
                 .cursorFinalizerEnabled(false)
                 .dbEncoderFactory(new MyDBEncoderFactory())
                 .addCommandListener(Mock(CommandListener))
+                .performanceMonitor(Mock(IMongoPerformanceMonitor))
                 .build()
 
         then:
@@ -313,6 +315,26 @@ class MongoClientOptionsSpecification extends Specification {
         options.commandListeners[2].is commandListenerThree
     }
 
+    def 'should set performance monitor'() {
+        given:
+        IMongoPerformanceMonitor performanceMonitor = Mock(IMongoPerformanceMonitor)
+
+        when:
+        def options = MongoClientOptions.builder()
+                                        .build()
+
+        then:
+        options.performanceMonitor == null
+
+        when:
+        options = MongoClientOptions.builder()
+                                    .performanceMonitor(performanceMonitor)
+                                    .build()
+
+        then:
+        options.performanceMonitor.is performanceMonitor
+    }
+
     def 'should copy all methods from the existing MongoClientOptions'() {
         given:
         def options = Mock(MongoClientOptions)
@@ -360,9 +382,10 @@ class MongoClientOptionsSpecification extends Specification {
         def expected = ['alwaysUseMBeans', 'codecRegistry', 'commandListeners', 'connectTimeout', 'cursorFinalizerEnabled',
                         'dbDecoderFactory', 'dbEncoderFactory', 'description', 'heartbeatConnectTimeout', 'heartbeatFrequency',
                         'heartbeatSocketTimeout', 'localThreshold', 'maxConnectionIdleTime', 'maxConnectionLifeTime',
-                        'maxConnectionsPerHost', 'maxWaitTime', 'minConnectionsPerHost', 'minHeartbeatFrequency', 'readPreference',
-                        'requiredReplicaSetName', 'serverSelectionTimeout', 'socketFactory', 'socketKeepAlive', 'socketTimeout',
-                        'sslEnabled', 'sslInvalidHostNameAllowed', 'threadsAllowedToBlockForConnectionMultiplier', 'writeConcern']
+                        'maxConnectionsPerHost', 'maxWaitTime', 'minConnectionsPerHost', 'minHeartbeatFrequency', 'performanceMonitor',
+                        'readPreference', 'requiredReplicaSetName', 'serverSelectionTimeout', 'socketFactory', 'socketKeepAlive',
+                        'socketTimeout', 'sslEnabled', 'sslInvalidHostNameAllowed', 'threadsAllowedToBlockForConnectionMultiplier',
+                        'writeConcern']
 
         then:
         actual == expected


### PR DESCRIPTION
An implementation of the hook will allow an app to record performance metrics for every call that is made to mongodb. The additional interface will also provide access to the specific database and collection that the operation is performed against for more granular metric gathering.