### PR TITLE
Add 2.14 reference documentation

### DIFF
--- a/docs/reference/content/getting-started/installation-guide.md
+++ b/docs/reference/content/getting-started/installation-guide.md
@@ -17,7 +17,7 @@ The recommended way to get started using one of the drivers in your project is w
 
 This jar that contains everything you need including the BSON library.
 
-{{< install artifactId="mongo-java-driver" version="2.14.0-SNAPSHOT" >}}
+{{< install artifactId="mongo-java-driver" version="2.14.0-rc0" >}}
 
 ## BSON
 
@@ -25,4 +25,4 @@ This library comprehensively supports [BSON](http://www.bsonspec.org),
 the data storage and network transfer format that MongoDB uses for "documents".
 BSON is short for Binary [JSON](http://json.org/), is a binary-encoded serialization of JSON-like documents.
 
-{{< install artifactId="bson" version="2.14.0-SNAPSHOT" >}}
+{{< install artifactId="bson" version="2.14.0-rc0" >}}

--- a/docs/reference/content/getting-started/quick-tour.md
+++ b/docs/reference/content/getting-started/quick-tour.md
@@ -97,7 +97,7 @@ for more information.
 
 To get a collection to use, just specify the name of the collection to
 the [getCollection(String
-collectionName)](http://api.mongodb.org/java/2.14/com/mongodb/DB.html#getCollection%28java.lang.String%29)
+collectionName)]({{< apiref "com/mongodb/DB.html#getCollection-java.lang.String-">}})
 method:
 
 ```java
@@ -110,7 +110,7 @@ data, query for data, etc
 ## Setting Write Concern
 
 As of version 2.10.0, the default write concern is
-[WriteConcern.ACKNOWLEDGED](http://api.mongodb.org/java/2.14/com/mongodb/WriteConcern.html#ACKNOWLEDGED),
+[WriteConcern.ACKNOWLEDGED]({{< apiref "com/mongodb/WriteConcern.html#ACKNOWLEDGED">}})
 but it can be easily changed:
 
 ```java
@@ -143,7 +143,7 @@ be represented as
 
 Notice that the above has an "inner" document embedded within it. To do
 this, we can use the
-[BasicDBObject](http://api.mongodb.org/java/2.14/com/mongodb/BasicDBObject.html)
+[BasicDBObject]({{< apiref "com/mongodb/BasicDBObject.html">}})
 class to create the document (including the inner document), and then
 just simply insert it into the collection using the `insert()` method.
 
@@ -159,10 +159,10 @@ coll.insert(doc);
 
 To show that the document we inserted in the previous step is there, we
 can do a simple
-[findOne()](http://api.mongodb.org/java/2.14/com/mongodb/DBCollection.html#findOne%28java.lang.Object%29)
+[findOne()]({{< apiref "com/mongodb/DBCollection.html#findOne">}})
 operation to get the first document in the collection. This method
-returns a single document (rather than the [DBCursor](http://api.mongodb.org/java/2.14/com/mongodb/DBCursor.html)
-that the [find()](http://api.mongodb.org/java/2.14/com/mongodb/DBCollection.html#find()')
+returns a single document (rather than the [DBCursor]({{< apiref "com/mongodb/DBCursor.html">}})
+that the [find()]({{< apiref "com/mongodb/DBCollection.html#find">}})
 operation returns), and it's useful for things where there only is one
 document, or you are only interested in the first. You don't have to
 deal with the cursor.

--- a/docs/reference/content/getting-started/quick-tour.md
+++ b/docs/reference/content/getting-started/quick-tour.md
@@ -97,7 +97,7 @@ for more information.
 
 To get a collection to use, just specify the name of the collection to
 the [getCollection(String
-collectionName)](http://api.mongodb.org/java/2.13/com/mongodb/DB.html#getCollection%28java.lang.String%29)
+collectionName)](http://api.mongodb.org/java/2.14/com/mongodb/DB.html#getCollection%28java.lang.String%29)
 method:
 
 ```java
@@ -110,7 +110,7 @@ data, query for data, etc
 ## Setting Write Concern
 
 As of version 2.10.0, the default write concern is
-[WriteConcern.ACKNOWLEDGED](http://api.mongodb.org/java/2.13/com/mongodb/WriteConcern.html#ACKNOWLEDGED),
+[WriteConcern.ACKNOWLEDGED](http://api.mongodb.org/java/2.14/com/mongodb/WriteConcern.html#ACKNOWLEDGED),
 but it can be easily changed:
 
 ```java
@@ -120,7 +120,7 @@ mongoClient.setWriteConcern(WriteConcern.JOURNALED);
 There are many options for write concern. Additionally, the default
 write concern can be overridden on the database, collection, and
 individual update operations. Please consult the [API
-Documentation](http://api.mongodb.org/java/2.13/index.html) for
+Documentation](http://api.mongodb.org/java/2.14/index.html) for
 details.
 
 ## Inserting a Document
@@ -143,7 +143,7 @@ be represented as
 
 Notice that the above has an "inner" document embedded within it. To do
 this, we can use the
-[BasicDBObject](http://api.mongodb.org/java/2.13/com/mongodb/BasicDBObject.html)
+[BasicDBObject](http://api.mongodb.org/java/2.14/com/mongodb/BasicDBObject.html)
 class to create the document (including the inner document), and then
 just simply insert it into the collection using the `insert()` method.
 
@@ -159,10 +159,10 @@ coll.insert(doc);
 
 To show that the document we inserted in the previous step is there, we
 can do a simple
-[findOne()](http://api.mongodb.org/java/2.13/com/mongodb/DBCollection.html#findOne%28java.lang.Object%29)
+[findOne()](http://api.mongodb.org/java/2.14/com/mongodb/DBCollection.html#findOne%28java.lang.Object%29)
 operation to get the first document in the collection. This method
-returns a single document (rather than the [DBCursor](http://api.mongodb.org/java/2.13/com/mongodb/DBCursor.html)
-that the [find()](http://api.mongodb.org/java/2.13/com/mongodb/DBCollection.html#find()')
+returns a single document (rather than the [DBCursor](http://api.mongodb.org/java/2.14/com/mongodb/DBCursor.html)
+that the [find()](http://api.mongodb.org/java/2.14/com/mongodb/DBCollection.html#find()')
 operation returns), and it's useful for things where there only is one
 document, or you are only interested in the first. You don't have to
 deal with the cursor.

--- a/docs/reference/content/index.md
+++ b/docs/reference/content/index.md
@@ -6,7 +6,7 @@ type = "index"
 
 ## MongoDB Java Driver Documentation
 
-Welcome to the MongoDB Java driver documentation hub for the 2.13 driver release.
+Welcome to the MongoDB Java driver documentation hub for the 2.14 driver release.
 
 ### Getting Started
 
@@ -15,4 +15,4 @@ and a simple tutorial to get up  and running quickly.
 
 ### API Documentation
 
-For more detailed API documentation, see the [Java Docs](http://api.mongodb.org/java/2.13/).
+For more detailed API documentation, see the [Java Docs](http://api.mongodb.org/java/2.14/).


### PR DESCRIPTION
Most of the links had already been updated to 2.13.

Note there is no What's New page yet, as there is with 3.x releases, but probably makes sense to add one.