### PR TITLE
JAVA-2169: update the connection release order in pool

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
@@ -93,7 +93,7 @@ public class ConcurrentPool<T> implements Pool<T> {
         if (prune) {
             close(t);
         } else {
-            available.addLast(t);
+            available.addFirst(t);
         }
 
         releasePermit();

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ConcurrentPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ConcurrentPoolTest.java
@@ -23,11 +23,7 @@ import org.junit.Test;
 import java.io.Closeable;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class ConcurrentPoolTest {
     private ConcurrentPool<TestCloseable> pool;
@@ -55,6 +51,23 @@ public class ConcurrentPoolTest {
         pool.get();
         pool.release(pool.get());
         assertNotNull(pool.get());
+    }
+
+    @Test
+    public void testThatReleaseAndGetPickDifferently() {
+        pool = new ConcurrentPool<TestCloseable>(3, new TestItemFactory());
+
+        //Create two items
+        TestCloseable first = pool.get();
+        TestCloseable second = pool.get();
+        pool.release(first);
+        pool.release(second);
+
+        //Get the first item an release it , make sure that get doesn't return the same item back
+        first = pool.get();
+        pool.release(first);
+        second = pool.get();
+        assertNotEquals(first,second);
     }
 
     @Test

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ConcurrentPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ConcurrentPoolTest.java
@@ -23,7 +23,12 @@ import org.junit.Test;
 import java.io.Closeable;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotEquals;
 
 public class ConcurrentPoolTest {
     private ConcurrentPool<TestCloseable> pool;
@@ -63,11 +68,11 @@ public class ConcurrentPoolTest {
         pool.release(first);
         pool.release(second);
 
-        //Get the first item an release it , make sure that get doesn't return the same item back
+        //Get the first item an release it, make sure that get doesn't return the same item back
         first = pool.get();
         pool.release(first);
         second = pool.get();
-        assertNotEquals(first,second);
+        assertNotEquals(first, second);
     }
 
     @Test

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ConcurrentPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ConcurrentPoolTest.java
@@ -68,7 +68,7 @@ public class ConcurrentPoolTest {
         pool.release(first);
         pool.release(second);
 
-        //Get the first item an release it, make sure that get doesn't return the same item back
+        //Get the first item, release it and make sure that `get` doesn't return the same item back
         first = pool.get();
         pool.release(first);
         second = pool.get();


### PR DESCRIPTION
Release the connection to the pool in a different order to how it is picked. Helps avoid using the same buffer again and again
