### PR TITLE
Log offensive document when exceeding maxDocumentSize

### DIFF
--- a/driver/src/main/com/mongodb/DBObjectCodec.java
+++ b/driver/src/main/com/mongodb/DBObjectCodec.java
@@ -23,6 +23,7 @@ import org.bson.BsonDbPointer;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;
 import org.bson.BsonReader;
+import org.bson.BsonSerializationException;
 import org.bson.BsonType;
 import org.bson.BsonValue;
 import org.bson.BsonWriter;
@@ -39,6 +40,9 @@ import org.bson.types.BSONTimestamp;
 import org.bson.types.Binary;
 import org.bson.types.CodeWScope;
 import org.bson.types.Symbol;
+
+import com.mongodb.diagnostics.logging.Logger;
+import com.mongodb.diagnostics.logging.Loggers;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -61,6 +65,8 @@ import static org.bson.BsonBinarySubType.UUID_STANDARD;
  */
 @SuppressWarnings("rawtypes")
 public class DBObjectCodec implements CollectibleCodec<DBObject> {
+	
+	public static final Logger LOGGER = Loggers.getLogger("coder");
 
     private static final BsonTypeClassMap DEFAULT_BSON_TYPE_CLASS_MAP = createDefaultBsonTypeClassMap();
     private static final String ID_FIELD_NAME = "_id";
@@ -119,18 +125,23 @@ public class DBObjectCodec implements CollectibleCodec<DBObject> {
 
     @Override
     public void encode(final BsonWriter writer, final DBObject document, final EncoderContext encoderContext) {
-        writer.writeStartDocument();
+        try {
+			writer.writeStartDocument();
 
-        beforeFields(writer, encoderContext, document);
+			beforeFields(writer, encoderContext, document);
 
-        for (final String key : document.keySet()) {
-            if (skipField(encoderContext, key)) {
-                continue;
-            }
-            writer.writeName(key);
-            writeValue(writer, encoderContext, document.get(key));
-        }
-        writer.writeEndDocument();
+			for (final String key : document.keySet()) {
+			    if (skipField(encoderContext, key)) {
+			        continue;
+			    }
+			    writer.writeName(key);
+			    writeValue(writer, encoderContext, document.get(key));
+			}
+			writer.writeEndDocument();
+		} catch (BsonSerializationException ex) {
+			LOGGER.error("Problem serializing document with id '"+document.get("_id")+"': "+ex.getMessage());
+			throw ex;
+		}
     }
 
     @Override


### PR DESCRIPTION
Please log the document id when exceeding the max document size when doing bulk updates to mongo with the java driver.  Otherwise it is almost impossible to know which is the offensive document. 

The only workaround to this is to split the bulk update (in my case of thousand documents), to do the update 1 by 1 and print the id when the exception is thrown.

I opened a ticket in JIRA to throw the requested information in the exception. But this pull is only for writing a message to file log. I have tested it with 3.2.0 version and it didn't break anything. This is the related ticket: [https://jira.mongodb.org/browse/JAVA-2180]

Thank you.
