### PR TITLE
JAVA-2186 Add the ability to parse/output a BasicDBList

### DIFF
--- a/bson/src/main/org/bson/AbstractBsonWriter.java
+++ b/bson/src/main/org/bson/AbstractBsonWriter.java
@@ -307,7 +307,11 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
 
     @Override
     public void writeStartArray() {
-        checkPreconditions("writeStartArray", State.VALUE);
+        if (supportsArrayAsInitial()) {
+            checkPreconditions("writeStartArray", State.VALUE, State.INITIAL);
+        } else {
+            checkPreconditions("writeStartArray", State.VALUE);
+        }
 
         if (context != null && context.name != null) {
             fieldNameValidatorStack.push(fieldNameValidatorStack.peek().getValidatorForField(getName()));
@@ -787,6 +791,17 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
             default:
                 throw new IllegalArgumentException("unhandled BSON type: " + reader.getCurrentBsonType());
         }
+    }
+
+    /**
+     * Indicates if the implementation supports writing array when in the INITIAL state.
+     *
+     * It is obviously false for writer producing documents so it defaults to false.
+     *
+     * @return true if this implementation supports writing an array when in the INITIAL state.
+     */
+    protected boolean supportsArrayAsInitial() {
+        return false;
     }
 
     /**

--- a/bson/src/main/org/bson/json/JsonWriter.java
+++ b/bson/src/main/org/bson/json/JsonWriter.java
@@ -414,6 +414,11 @@ public class JsonWriter extends AbstractBsonWriter {
         }
     }
 
+    @Override
+    protected boolean supportsArrayAsInitial() {
+        return true;
+    }
+
     private void writeNameHelper(final String name) throws IOException {
         switch (getContext().getContextType()) {
             case ARRAY:

--- a/config/checkstyle-exclude.xml
+++ b/config/checkstyle-exclude.xml
@@ -63,6 +63,7 @@
     <suppress checks="ConstantName" files="ReflectionDBObject"/>
 
     <suppress checks="JavadocMethod" files="BasicDBObject"/>
+    <suppress checks="JavadocMethod" files="BasicDBList"/>
 
     <suppress checks="MethodName" files="BasicBSONCallback"/>
     <suppress checks="MethodName" files="BasicBSONEncoder"/>

--- a/driver/src/main/com/mongodb/AbstractDBObjectCodec.java
+++ b/driver/src/main/com/mongodb/AbstractDBObjectCodec.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2008-2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb;
+
+import org.bson.BSON;
+import org.bson.BSONObject;
+import org.bson.BsonBinary;
+import org.bson.BsonDbPointer;
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+import org.bson.codecs.BsonTypeClassMap;
+import org.bson.codecs.BsonTypeCodecMap;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.types.BSONTimestamp;
+import org.bson.types.Binary;
+import org.bson.types.CodeWScope;
+import org.bson.types.Symbol;
+
+import java.lang.reflect.Array;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static org.bson.BsonBinarySubType.BINARY;
+import static org.bson.BsonBinarySubType.OLD_BINARY;
+import static org.bson.BsonBinarySubType.UUID_LEGACY;
+import static org.bson.BsonBinarySubType.UUID_STANDARD;
+
+@SuppressWarnings("rawtypes")
+abstract class AbstractDBObjectCodec {
+
+    protected static final BsonTypeClassMap DEFAULT_BSON_TYPE_CLASS_MAP = createDefaultBsonTypeClassMap();
+
+    private final CodecRegistry codecRegistry;
+    private final BsonTypeCodecMap bsonTypeCodecMap;
+    private final DBObjectFactory objectFactory;
+
+    static BsonTypeClassMap createDefaultBsonTypeClassMap() {
+        Map<BsonType, Class<?>> replacements = new HashMap<BsonType, Class<?>>();
+        replacements.put(BsonType.REGULAR_EXPRESSION, Pattern.class);
+        replacements.put(BsonType.SYMBOL, String.class);
+        replacements.put(BsonType.TIMESTAMP, BSONTimestamp.class);
+        replacements.put(BsonType.JAVASCRIPT_WITH_SCOPE, null);
+        replacements.put(BsonType.DOCUMENT, null);
+
+        return new BsonTypeClassMap(replacements);
+    }
+
+    static BsonTypeClassMap getDefaultBsonTypeClassMap() {
+        return DEFAULT_BSON_TYPE_CLASS_MAP;
+    }
+
+    protected AbstractDBObjectCodec(final CodecRegistry codecRegistry, final BsonTypeClassMap bsonTypeClassMap,
+            final DBObjectFactory objectFactory) {
+        this.objectFactory = notNull("objectFactory", objectFactory);
+        this.codecRegistry = notNull("codecRegistry", codecRegistry);
+        this.bsonTypeCodecMap = new BsonTypeCodecMap(notNull("bsonTypeClassMap", bsonTypeClassMap), codecRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void writeValue(final BsonWriter bsonWriter, final EncoderContext encoderContext, final Object initialValue) {
+        Object value = BSON.applyEncodingHooks(initialValue);
+        if (value == null) {
+            bsonWriter.writeNull();
+        } else if (value instanceof DBRef) {
+            encodeDBRef(bsonWriter, (DBRef) value);
+        } else if (value instanceof Map) {
+            encodeMap(bsonWriter, (Map<String, Object>) value);
+        } else if (value instanceof Iterable) {
+            encodeIterable(bsonWriter, (Iterable) value);
+        } else if (value instanceof BSONObject) {
+            encodeBsonObject(bsonWriter, ((BSONObject) value));
+        } else if (value instanceof CodeWScope) {
+            encodeCodeWScope(bsonWriter, (CodeWScope) value);
+        } else if (value instanceof byte[]) {
+            encodeByteArray(bsonWriter, (byte[]) value);
+        } else if (value.getClass().isArray()) {
+            encodeArray(bsonWriter, value);
+        } else if (value instanceof Symbol) {
+            bsonWriter.writeSymbol(((Symbol) value).getSymbol());
+        } else {
+            Codec codec = codecRegistry.get(value.getClass());
+            codec.encode(bsonWriter, value, encoderContext);
+        }
+    }
+
+    private void encodeMap(final BsonWriter bsonWriter, final Map<String, Object> document) {
+        bsonWriter.writeStartDocument();
+
+        for (final Map.Entry<String, Object> entry : document.entrySet()) {
+            bsonWriter.writeName(entry.getKey());
+            writeValue(bsonWriter, null, entry.getValue());
+        }
+        bsonWriter.writeEndDocument();
+    }
+
+    private void encodeBsonObject(final BsonWriter bsonWriter, final BSONObject document) {
+        bsonWriter.writeStartDocument();
+
+        for (String key : document.keySet()) {
+            bsonWriter.writeName(key);
+            writeValue(bsonWriter, null, document.get(key));
+        }
+        bsonWriter.writeEndDocument();
+    }
+
+    private void encodeByteArray(final BsonWriter bsonWriter, final byte[] value) {
+        bsonWriter.writeBinaryData(new BsonBinary(value));
+    }
+
+    private void encodeArray(final BsonWriter bsonWriter, final Object value) {
+        bsonWriter.writeStartArray();
+
+        int size = Array.getLength(value);
+        for (int i = 0; i < size; i++) {
+            writeValue(bsonWriter, null, Array.get(value, i));
+        }
+
+        bsonWriter.writeEndArray();
+    }
+
+    private void encodeDBRef(final BsonWriter bsonWriter, final DBRef dbRef) {
+        bsonWriter.writeStartDocument();
+
+        bsonWriter.writeString("$ref", dbRef.getCollectionName());
+        bsonWriter.writeName("$id");
+        writeValue(bsonWriter, null, dbRef.getId());
+
+        bsonWriter.writeEndDocument();
+    }
+
+    private void encodeCodeWScope(final BsonWriter bsonWriter, final CodeWScope value) {
+        bsonWriter.writeJavaScriptWithScope(value.getCode());
+        encodeBsonObject(bsonWriter, value.getScope());
+    }
+
+    private void encodeIterable(final BsonWriter bsonWriter, final Iterable iterable) {
+        bsonWriter.writeStartArray();
+        for (final Object cur : iterable) {
+            writeValue(bsonWriter, null, cur);
+        }
+        bsonWriter.writeEndArray();
+    }
+
+    protected Object readValue(final BsonReader reader, final DecoderContext decoderContext, final String fieldName,
+                             final List<String> path) {
+        Object initialRetVal;
+        BsonType bsonType = reader.getCurrentBsonType();
+
+        if (bsonType.isContainer() && fieldName != null) {
+            //if we got into some new context like nested document or array
+            path.add(fieldName);
+        }
+
+        switch (bsonType) {
+            case DOCUMENT:
+                initialRetVal = verifyForDBRef(readDocument(reader, decoderContext, path));
+                break;
+            case ARRAY:
+                initialRetVal = readArray(reader, decoderContext, path);
+                break;
+            case JAVASCRIPT_WITH_SCOPE: //custom for driver-compat types
+                initialRetVal = readCodeWScope(reader, decoderContext, path);
+                break;
+            case DB_POINTER: //custom for driver-compat types
+                BsonDbPointer dbPointer = reader.readDBPointer();
+                initialRetVal = new DBRef(dbPointer.getNamespace(), dbPointer.getId());
+                break;
+            case BINARY:
+                initialRetVal = readBinary(reader, decoderContext);
+                break;
+            case NULL:
+                reader.readNull();
+                initialRetVal = null;
+                break;
+            default:
+                initialRetVal = bsonTypeCodecMap.get(bsonType).decode(reader, decoderContext);
+        }
+
+        if (bsonType.isContainer() && fieldName != null) {
+            //step out of current context to a parent
+            path.remove(fieldName);
+        }
+
+        return BSON.applyDecodingHooks(initialRetVal);
+    }
+
+    private Object readBinary(final BsonReader reader, final DecoderContext decoderContext) {
+        byte bsonSubType = reader.peekBinarySubType();
+
+        if (bsonSubType == UUID_STANDARD.getValue() || bsonSubType == UUID_LEGACY.getValue()) {
+            return codecRegistry.get(UUID.class).decode(reader, decoderContext);
+        } else if (bsonSubType == BINARY.getValue() || bsonSubType == OLD_BINARY.getValue()) {
+            return codecRegistry.get(byte[].class).decode(reader, decoderContext);
+        } else {
+            return codecRegistry.get(Binary.class).decode(reader, decoderContext);
+        }
+    }
+
+    protected BasicDBList readArray(final BsonReader reader, final DecoderContext decoderContext, final List<String> path) {
+        reader.readStartArray();
+        BasicDBList list = new BasicDBList();
+        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+            list.add(readValue(reader, decoderContext, null, path));
+        }
+        reader.readEndArray();
+        return list;
+    }
+
+    protected DBObject readDocument(final BsonReader reader, final DecoderContext decoderContext, final List<String> path) {
+        DBObject document = objectFactory.getInstance(path);
+
+        reader.readStartDocument();
+        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+            String fieldName = reader.readName();
+            document.put(fieldName, readValue(reader, decoderContext, fieldName, path));
+        }
+
+        reader.readEndDocument();
+        return document;
+    }
+
+    private CodeWScope readCodeWScope(final BsonReader reader, final DecoderContext decoderContext, final List<String> path) {
+        return new CodeWScope(reader.readJavaScriptWithScope(), readDocument(reader, decoderContext, path));
+    }
+
+    private Object verifyForDBRef(final DBObject document) {
+        if (document.containsField("$ref") && document.containsField("$id")) {
+            return new DBRef((String) document.get("$ref"), document.get("$id"));
+        } else {
+            return document;
+        }
+    }
+
+}

--- a/driver/src/main/com/mongodb/BasicDBList.java
+++ b/driver/src/main/com/mongodb/BasicDBList.java
@@ -19,6 +19,18 @@
 package com.mongodb;
 
 import com.mongodb.util.JSON;
+
+import static com.mongodb.MongoClient.getDefaultCodecRegistry;
+
+import java.io.StringWriter;
+
+import org.bson.codecs.Decoder;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.Encoder;
+import org.bson.codecs.EncoderContext;
+import org.bson.json.JsonReader;
+import org.bson.json.JsonWriter;
+import org.bson.json.JsonWriterSettings;
 import org.bson.types.BasicBSONList;
 
 /**
@@ -27,6 +39,83 @@ import org.bson.types.BasicBSONList;
 public class BasicDBList extends BasicBSONList implements DBObject {
 
     private static final long serialVersionUID = -4415279469780082174L;
+
+    /**
+     * Parses a string in MongoDB Extended JSON format to a {@code BasicDBList}.
+     *
+     * @param json the JSON string
+     * @return a corresponding {@code BasicDBList} object
+     * @see org.bson.json.JsonReader
+     * @mongodb.driver.manual reference/mongodb-extended-json/ MongoDB Extended JSON
+     */
+    public static BasicDBList parse(final String json) {
+        return parse(json, getDefaultCodecRegistry().get(BasicDBList.class));
+    }
+
+    /**
+     * Parses a string in MongoDB Extended JSON format to a {@code BasicDBList}.
+     *
+     * @param json the JSON string
+     * @param decoder the decoder to use to decode the BasicDBList instance
+     * @return a corresponding {@code BasicDBList} object
+     * @see org.bson.json.JsonReader
+     * @mongodb.driver.manual reference/mongodb-extended-json/ MongoDB Extended JSON
+     */
+    public static BasicDBList parse(final String json, final Decoder<BasicDBList> decoder) {
+        return decoder.decode(new JsonReader(json), DecoderContext.builder().build());
+    }
+
+    /**
+     * Gets a JSON representation of this object
+     *
+     * <p>With the default {@link JsonWriterSettings} and {@link DBObjectCodec}.</p>
+     *
+     * @return a JSON representation of this document
+     * @throws org.bson.codecs.configuration.CodecConfigurationException if the document contains types not in the default registry
+     */
+    public String toJson() {
+        return toJson(new JsonWriterSettings());
+    }
+
+    /**
+     * Gets a JSON representation of this object
+     *
+     * <p>With the default {@link DBObjectCodec}.</p>
+     *
+     * @param writerSettings the json writer settings to use when encoding
+     * @return a JSON representation of this document
+     * @throws org.bson.codecs.configuration.CodecConfigurationException if the document contains types not in the default registry
+     */
+    public String toJson(final JsonWriterSettings writerSettings) {
+        return toJson(writerSettings, getDefaultCodecRegistry().get(BasicDBList.class));
+    }
+
+    /**
+     * Gets a JSON representation of this object
+     *
+     * <p>With the default {@link JsonWriterSettings}.</p>
+     *
+     * @param encoder the BasicDBList codec instance to encode the document with
+     * @return a JSON representation of this document
+     * @throws org.bson.codecs.configuration.CodecConfigurationException if the registry does not contain a codec for the document values.
+     */
+    public String toJson(final Encoder<BasicDBList> encoder) {
+        return toJson(new JsonWriterSettings(), encoder);
+    }
+
+    /**
+     * Gets a JSON representation of this object
+     *
+     * @param writerSettings the json writer settings to use when encoding
+     * @param encoder the BasicDBList codec instance to encode the document with
+     * @return a JSON representation of this document
+     * @throws org.bson.codecs.configuration.CodecConfigurationException if the registry does not contain a codec for the document values.
+     */
+    public String toJson(final JsonWriterSettings writerSettings, final Encoder<BasicDBList> encoder) {
+        JsonWriter writer = new JsonWriter(new StringWriter(), writerSettings);
+        encoder.encode(writer, this, EncoderContext.builder().isEncodingCollectibleDocument(false).build());
+        return writer.getWriter().toString();
+    }
 
     /**
      * Returns a JSON serialization of this object

--- a/driver/src/main/com/mongodb/BasicDBListCodec.java
+++ b/driver/src/main/com/mongodb/BasicDBListCodec.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2008-2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+import org.bson.BsonReader;
+import org.bson.BsonWriter;
+import org.bson.codecs.BsonTypeClassMap;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A codec for a BasicDBList.
+ *
+ * @since 3.3
+ */
+public class BasicDBListCodec extends AbstractDBObjectCodec implements Codec<BasicDBList> {
+
+    /**
+     * Construct an instance with the given codec registry.
+     *
+     * @param codecRegistry the non-null codec registry
+     */
+    public BasicDBListCodec(final CodecRegistry codecRegistry) {
+        this(codecRegistry, DEFAULT_BSON_TYPE_CLASS_MAP);
+    }
+
+    /**
+     * Construct an instance.
+     *
+     * @param codecRegistry the codec registry
+     * @param bsonTypeClassMap the non-null BsonTypeClassMap
+     */
+    public BasicDBListCodec(final CodecRegistry codecRegistry, final BsonTypeClassMap bsonTypeClassMap) {
+        this(codecRegistry, bsonTypeClassMap, new BasicDBObjectFactory());
+    }
+
+    /**
+     * Construct an instance.
+     *
+     * @param codecRegistry the non-null codec registry
+     * @param bsonTypeClassMap the non-null BsonTypeClassMap
+     * @param objectFactory the non-null object factory used to create empty DBObject instances when decoding
+     */
+    public BasicDBListCodec(final CodecRegistry codecRegistry, final BsonTypeClassMap bsonTypeClassMap,
+            final DBObjectFactory objectFactory) {
+        super(codecRegistry, bsonTypeClassMap, objectFactory);
+    }
+
+    @Override
+    public void encode(final BsonWriter writer, final BasicDBList list, final EncoderContext encoderContext) {
+        writer.writeStartArray();
+
+        for (Object element : list) {
+            writeValue(writer, encoderContext, element);
+        }
+
+        writer.writeEndArray();
+    }
+
+    @Override
+    public BasicDBList decode(final BsonReader reader, final DecoderContext decoderContext) {
+        List<String> path = new ArrayList<String>(10);
+        return readArray(reader, decoderContext, path);
+    }
+
+    @Override
+    public Class<BasicDBList> getEncoderClass() {
+        return BasicDBList.class;
+    }
+
+}
+

--- a/driver/src/main/com/mongodb/DBObjectCodec.java
+++ b/driver/src/main/com/mongodb/DBObjectCodec.java
@@ -16,74 +16,32 @@
 
 package com.mongodb;
 
-import org.bson.BSON;
-import org.bson.BSONObject;
-import org.bson.BsonBinary;
-import org.bson.BsonDbPointer;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;
 import org.bson.BsonReader;
-import org.bson.BsonType;
 import org.bson.BsonValue;
 import org.bson.BsonWriter;
 import org.bson.codecs.BsonTypeClassMap;
-import org.bson.codecs.BsonTypeCodecMap;
-import org.bson.codecs.Codec;
 import org.bson.codecs.CollectibleCodec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 import org.bson.codecs.IdGenerator;
 import org.bson.codecs.ObjectIdGenerator;
 import org.bson.codecs.configuration.CodecRegistry;
-import org.bson.types.BSONTimestamp;
-import org.bson.types.Binary;
-import org.bson.types.CodeWScope;
-import org.bson.types.Symbol;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.regex.Pattern;
-
-import static com.mongodb.assertions.Assertions.notNull;
-import static org.bson.BsonBinarySubType.BINARY;
-import static org.bson.BsonBinarySubType.OLD_BINARY;
-import static org.bson.BsonBinarySubType.UUID_LEGACY;
-import static org.bson.BsonBinarySubType.UUID_STANDARD;
 
 /**
  * A collectible codec for a DBObject.
  *
  * @since 3.0
  */
-@SuppressWarnings("rawtypes")
-public class DBObjectCodec implements CollectibleCodec<DBObject> {
+public class DBObjectCodec extends AbstractDBObjectCodec implements CollectibleCodec<DBObject> {
 
-    private static final BsonTypeClassMap DEFAULT_BSON_TYPE_CLASS_MAP = createDefaultBsonTypeClassMap();
     private static final String ID_FIELD_NAME = "_id";
 
-    private final CodecRegistry codecRegistry;
-    private final BsonTypeCodecMap bsonTypeCodecMap;
-    private final DBObjectFactory objectFactory;
     private final IdGenerator idGenerator = new ObjectIdGenerator();
-
-    static BsonTypeClassMap createDefaultBsonTypeClassMap() {
-        Map<BsonType, Class<?>> replacements = new HashMap<BsonType, Class<?>>();
-        replacements.put(BsonType.REGULAR_EXPRESSION, Pattern.class);
-        replacements.put(BsonType.SYMBOL, String.class);
-        replacements.put(BsonType.TIMESTAMP, BSONTimestamp.class);
-        replacements.put(BsonType.JAVASCRIPT_WITH_SCOPE, null);
-        replacements.put(BsonType.DOCUMENT, null);
-
-        return new BsonTypeClassMap(replacements);
-    }
-
-    static BsonTypeClassMap getDefaultBsonTypeClassMap() {
-        return DEFAULT_BSON_TYPE_CLASS_MAP;
-    }
 
     /**
      * Construct an instance with the given codec registry.
@@ -107,14 +65,12 @@ public class DBObjectCodec implements CollectibleCodec<DBObject> {
     /**
      * Construct an instance.
      *
-     *  @param codecRegistry the non-null codec registry
+     * @param codecRegistry the non-null codec registry
      * @param bsonTypeClassMap the non-null BsonTypeClassMap
      * @param objectFactory the non-null object factory used to create empty DBObject instances when decoding
      */
     public DBObjectCodec(final CodecRegistry codecRegistry, final BsonTypeClassMap bsonTypeClassMap, final DBObjectFactory objectFactory) {
-        this.objectFactory = notNull("objectFactory", objectFactory);
-        this.codecRegistry = notNull("codecRegistry", codecRegistry);
-        this.bsonTypeCodecMap = new BsonTypeCodecMap(notNull("bsonTypeClassMap", bsonTypeClassMap), codecRegistry);
+        super(codecRegistry, bsonTypeClassMap, objectFactory);
     }
 
     @Override
@@ -188,180 +144,5 @@ public class DBObjectCodec implements CollectibleCodec<DBObject> {
         return encoderContext.isEncodingCollectibleDocument() && key.equals(ID_FIELD_NAME);
     }
 
-    @SuppressWarnings("unchecked")
-    private void writeValue(final BsonWriter bsonWriter, final EncoderContext encoderContext, final Object initialValue) {
-        Object value = BSON.applyEncodingHooks(initialValue);
-        if (value == null) {
-            bsonWriter.writeNull();
-        } else if (value instanceof DBRef) {
-            encodeDBRef(bsonWriter, (DBRef) value);
-        } else if (value instanceof Map) {
-            encodeMap(bsonWriter, (Map<String, Object>) value);
-        } else if (value instanceof Iterable) {
-            encodeIterable(bsonWriter, (Iterable) value);
-        } else if (value instanceof BSONObject) {
-            encodeBsonObject(bsonWriter, ((BSONObject) value));
-        } else if (value instanceof CodeWScope) {
-            encodeCodeWScope(bsonWriter, (CodeWScope) value);
-        } else if (value instanceof byte[]) {
-            encodeByteArray(bsonWriter, (byte[]) value);
-        } else if (value.getClass().isArray()) {
-            encodeArray(bsonWriter, value);
-        } else if (value instanceof Symbol) {
-            bsonWriter.writeSymbol(((Symbol) value).getSymbol());
-        } else {
-            Codec codec = codecRegistry.get(value.getClass());
-            codec.encode(bsonWriter, value, encoderContext);
-        }
-    }
-
-    private void encodeMap(final BsonWriter bsonWriter, final Map<String, Object> document) {
-        bsonWriter.writeStartDocument();
-
-        for (final Map.Entry<String, Object> entry : document.entrySet()) {
-            bsonWriter.writeName(entry.getKey());
-            writeValue(bsonWriter, null, entry.getValue());
-        }
-        bsonWriter.writeEndDocument();
-    }
-
-    private void encodeBsonObject(final BsonWriter bsonWriter, final BSONObject document) {
-        bsonWriter.writeStartDocument();
-
-        for (String key : document.keySet()) {
-            bsonWriter.writeName(key);
-            writeValue(bsonWriter, null, document.get(key));
-        }
-        bsonWriter.writeEndDocument();
-    }
-
-    private void encodeByteArray(final BsonWriter bsonWriter, final byte[] value) {
-        bsonWriter.writeBinaryData(new BsonBinary(value));
-    }
-
-    private void encodeArray(final BsonWriter bsonWriter, final Object value) {
-        bsonWriter.writeStartArray();
-
-        int size = Array.getLength(value);
-        for (int i = 0; i < size; i++) {
-            writeValue(bsonWriter, null, Array.get(value, i));
-        }
-
-        bsonWriter.writeEndArray();
-    }
-
-    private void encodeDBRef(final BsonWriter bsonWriter, final DBRef dbRef) {
-        bsonWriter.writeStartDocument();
-
-        bsonWriter.writeString("$ref", dbRef.getCollectionName());
-        bsonWriter.writeName("$id");
-        writeValue(bsonWriter, null, dbRef.getId());
-
-        bsonWriter.writeEndDocument();
-    }
-
-    @SuppressWarnings("unchecked")
-    private void encodeCodeWScope(final BsonWriter bsonWriter, final CodeWScope value) {
-        bsonWriter.writeJavaScriptWithScope(value.getCode());
-        encodeBsonObject(bsonWriter, value.getScope());
-    }
-
-    private void encodeIterable(final BsonWriter bsonWriter, final Iterable iterable) {
-        bsonWriter.writeStartArray();
-        for (final Object cur : iterable) {
-            writeValue(bsonWriter, null, cur);
-        }
-        bsonWriter.writeEndArray();
-    }
-
-    private Object readValue(final BsonReader reader, final DecoderContext decoderContext, final String fieldName,
-                             final List<String> path) {
-        Object initialRetVal;
-        BsonType bsonType = reader.getCurrentBsonType();
-
-        if (bsonType.isContainer() && fieldName != null) {
-            //if we got into some new context like nested document or array
-            path.add(fieldName);
-        }
-
-        switch (bsonType) {
-            case DOCUMENT:
-                initialRetVal = verifyForDBRef(readDocument(reader, decoderContext, path));
-                break;
-            case ARRAY:
-                initialRetVal = readArray(reader, decoderContext, path);
-                break;
-            case JAVASCRIPT_WITH_SCOPE: //custom for driver-compat types
-                initialRetVal = readCodeWScope(reader, decoderContext, path);
-                break;
-            case DB_POINTER: //custom for driver-compat types
-                BsonDbPointer dbPointer = reader.readDBPointer();
-                initialRetVal = new DBRef(dbPointer.getNamespace(), dbPointer.getId());
-                break;
-            case BINARY:
-                initialRetVal = readBinary(reader, decoderContext);
-                break;
-            case NULL:
-                reader.readNull();
-                initialRetVal = null;
-                break;
-            default:
-                initialRetVal = bsonTypeCodecMap.get(bsonType).decode(reader, decoderContext);
-        }
-
-        if (bsonType.isContainer() && fieldName != null) {
-            //step out of current context to a parent
-            path.remove(fieldName);
-        }
-
-        return BSON.applyDecodingHooks(initialRetVal);
-    }
-
-    private Object readBinary(final BsonReader reader, final DecoderContext decoderContext) {
-        byte bsonSubType = reader.peekBinarySubType();
-
-        if (bsonSubType == UUID_STANDARD.getValue() || bsonSubType == UUID_LEGACY.getValue()) {
-            return codecRegistry.get(UUID.class).decode(reader, decoderContext);
-        } else if (bsonSubType == BINARY.getValue() || bsonSubType == OLD_BINARY.getValue()) {
-            return codecRegistry.get(byte[].class).decode(reader, decoderContext);
-        } else {
-            return codecRegistry.get(Binary.class).decode(reader, decoderContext);
-        }
-    }
-
-    private List readArray(final BsonReader reader, final DecoderContext decoderContext, final List<String> path) {
-        reader.readStartArray();
-        BasicDBList list = new BasicDBList();
-        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
-            list.add(readValue(reader, decoderContext, null, path));
-        }
-        reader.readEndArray();
-        return list;
-    }
-
-    private DBObject readDocument(final BsonReader reader, final DecoderContext decoderContext, final List<String> path) {
-        DBObject document = objectFactory.getInstance(path);
-
-        reader.readStartDocument();
-        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
-            String fieldName = reader.readName();
-            document.put(fieldName, readValue(reader, decoderContext, fieldName, path));
-        }
-
-        reader.readEndDocument();
-        return document;
-    }
-
-    private CodeWScope readCodeWScope(final BsonReader reader, final DecoderContext decoderContext, final List<String> path) {
-        return new CodeWScope(reader.readJavaScriptWithScope(), readDocument(reader, decoderContext, path));
-    }
-
-    private Object verifyForDBRef(final DBObject document) {
-        if (document.containsField("$ref") && document.containsField("$id")) {
-            return new DBRef((String) document.get("$ref"), document.get("$id"));
-        } else {
-            return document;
-        }
-    }
 }
 

--- a/driver/src/main/com/mongodb/DBObjectCodecProvider.java
+++ b/driver/src/main/com/mongodb/DBObjectCodecProvider.java
@@ -58,6 +58,10 @@ public class DBObjectCodecProvider implements CodecProvider {
             return (Codec<T>) new BSONTimestampCodec();
         }
 
+        if (BasicDBList.class.isAssignableFrom(clazz)) {
+            return (Codec<T>) new BasicDBListCodec(registry, bsonTypeClassMap);
+        }
+
         if (DBObject.class.isAssignableFrom(clazz)) {
             return (Codec<T>) new DBObjectCodec(registry, bsonTypeClassMap);
         }

--- a/driver/src/test/unit/com/mongodb/BasicDBListTest.java
+++ b/driver/src/test/unit/com/mongodb/BasicDBListTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+import static com.mongodb.MongoClient.getDefaultCodecRegistry;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+
+public class BasicDBListTest {
+
+    @Test
+    public void testParse() {
+        BasicDBList target = new BasicDBList();
+        target.addAll(Arrays.asList(1, 2));
+
+        BasicDBList document = BasicDBList.parse("[ 1, 2 ]");
+        assertEquals(target, document);
+
+        document = BasicDBList.parse("[ 1, 2 ]", getDefaultCodecRegistry().get(BasicDBList.class));
+        assertEquals(target, document);
+
+        target = new BasicDBList();
+        target.addAll(Arrays.asList("string1", "string2"));
+
+        document = BasicDBList.parse("[ 'string1', 'string2' ]");
+        assertEquals(target, document);
+
+        target = new BasicDBList();
+        target.add(123L);
+        target.add(new ObjectId("5522d5d12cf8fb556a991f45"));
+
+        document = BasicDBList.parse("[ NumberLong(123), ObjectId('5522d5d12cf8fb556a991f45') ]");
+        assertEquals(target, document);
+    }
+
+    @Test
+    public void testToJson() {
+        BasicDBList list = new BasicDBList();
+        list.add(new ObjectId("5522d5d12cf8fb556a991f45"));
+        list.add(3);
+        list.add("abc");
+
+        assertEquals("[{ \"$oid\" : \"5522d5d12cf8fb556a991f45\" }, 3, \"abc\"]", list.toJson());
+        assertEquals("[ObjectId(\"5522d5d12cf8fb556a991f45\"), 3, \"abc\"]",
+                     list.toJson(new JsonWriterSettings(JsonMode.SHELL)));
+
+        assertEquals("[{ \"$oid\" : \"5522d5d12cf8fb556a991f45\" }, 3, \"abc\"]",
+                     list.toJson(getDefaultCodecRegistry().get(BasicDBList.class)));
+
+        assertEquals("[ObjectId(\"5522d5d12cf8fb556a991f45\"), 3, \"abc\"]",
+                     list.toJson(new JsonWriterSettings(JsonMode.SHELL), getDefaultCodecRegistry().get(BasicDBList.class)));
+    }
+
+}


### PR DESCRIPTION
For now in Hibernate OGM, we only need the ability to decode a BasicDBList.

I also provided the ability to output a BasicDBList which needed some tweaking to AbstractBsonWriter. The other option might be to simply throw an unsupported exception when trying to encode a BasicDBList.

Comments welcome.
