### PR TITLE
Fix NaN handling

### DIFF
--- a/driver/src/main/com/mongodb/DBObjectCodec.java
+++ b/driver/src/main/com/mongodb/DBObjectCodec.java
@@ -209,6 +209,8 @@ public class DBObjectCodec implements CollectibleCodec<DBObject> {
             encodeArray(bsonWriter, value);
         } else if (value instanceof Symbol) {
             bsonWriter.writeSymbol(((Symbol) value).getSymbol());
+		} else if (value.equals(Float.NaN) || value.equals(Double.NaN)) {
+			 bsonWriter.writeString("NaN");
         } else {
             Codec codec = codecRegistry.get(value.getClass());
             codec.encode(bsonWriter, value, encoderContext);

--- a/driver/src/main/com/mongodb/util/JSONSerializers.java
+++ b/driver/src/main/com/mongodb/util/JSONSerializers.java
@@ -101,7 +101,7 @@ public class JSONSerializers {
         serializer.addObjectSerializer(Map.class, new MapSerializer(serializer));
         serializer.addObjectSerializer(MaxKey.class, new MaxKeySerializer(serializer));
         serializer.addObjectSerializer(MinKey.class, new MinKeySerializer(serializer));
-        serializer.addObjectSerializer(Number.class, new ToStringSerializer());
+        serializer.addObjectSerializer(Number.class, new NumberSerializer());
         serializer.addObjectSerializer(ObjectId.class, new ObjectIdSerializer(serializer));
         serializer.addObjectSerializer(Pattern.class, new PatternSerializer(serializer));
         serializer.addObjectSerializer(String.class, new StringSerializer());
@@ -157,6 +157,17 @@ public class JSONSerializers {
         }
 
     }
+
+	private static class NumberSerializer extends AbstractObjectSerializer {
+		@Override
+		public void serialize(final Object obj, final StringBuilder buf) {
+			if (obj.equals(Float.NaN) || obj.equals(Double.NaN)) {
+				buf.append("\"NaN\"");
+			} else {
+				buf.append(obj.toString());
+			}
+		}
+	}
 
     private static class LegacyBSONTimestampSerializer extends CompoundObjectSerializer {
 

--- a/driver/src/test/unit/com/mongodb/BasicDBObjectTest.java
+++ b/driver/src/test/unit/com/mongodb/BasicDBObjectTest.java
@@ -63,6 +63,9 @@ public class BasicDBObjectTest {
 
         assertEquals("{ \"_id\" : ObjectId(\"5522d5d12cf8fb556a991f45\"), \"int\" : 1, \"string\" : \"abc\" }",
                      doc.toJson(new JsonWriterSettings(JsonMode.SHELL), getDefaultCodecRegistry().get(BasicDBObject.class)));
+
+		doc = new BasicDBObject("_id", new ObjectId("5522d5d12cf8fb556a991f45")).append("x", new BasicDBObject("z", Double.NaN));
+		assertEquals("{ \"_id\" : { \"$oid\" : \"5522d5d12cf8fb556a991f45\" }, \"x\" : { \"z\" : \"NaN\" } }", doc.toJson());
     }
 
     @Test

--- a/driver/src/test/unit/com/mongodb/util/JSONTest.java
+++ b/driver/src/test/unit/com/mongodb/util/JSONTest.java
@@ -63,6 +63,7 @@ public class JSONTest {
         assertEquals("{ \"x\" : 5.0}", JSON.serialize(JSON.parse("{'x' : 5. }")));
         assertEquals("{ \"x\" : 50.0}", JSON.serialize(JSON.parse("{'x' : 5.0e+1 }")));
         assertEquals("{ \"x\" : 0.5}", JSON.serialize(JSON.parse("{'x' : 5.0E-1 }")));
+        assertEquals("{ \"x\" : \"NaN\"}", JSON.serialize(JSON.parse("{'x' : NaN }")));
     }
 
     @Test


### PR DESCRIPTION
Currently if BasicDBObject conatins Double.NaN toString() and toJSON() methods produce invalid json - NaN isn't escaped with quotes. This PR fixes it.
