### PR TITLE
JAVA-2224 Support the /pattern/options syntax for regexps in JsonReader

### DIFF
--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -936,10 +936,19 @@ public class JsonReader extends AbstractBsonReader {
     private BsonRegularExpression visitRegularExpressionExtendedJson() {
         verifyToken(":");
         JsonToken patternToken = popToken();
-        if (patternToken.getType() != JsonTokenType.STRING) {
-            throw new JsonParseException("JSON reader expected a string but found '%s'.", patternToken.getValue());
-        }
+        String pattern;
         String options = "";
+
+        if (patternToken.getType() == JsonTokenType.REGULAR_EXPRESSION) {
+            BsonRegularExpression regularExpression = patternToken.getValue(BsonRegularExpression.class);
+            pattern = regularExpression.getPattern();
+            options = regularExpression.getOptions();
+        } else if (patternToken.getType() == JsonTokenType.STRING) {
+            pattern = patternToken.getValue(String.class);
+        } else {
+            throw new JsonParseException("JSON reader expected a string or a regular expression but found '%s'.", patternToken.getValue());
+        }
+
         JsonToken commaToken = popToken();
         if (commaToken.getType() == JsonTokenType.COMMA) {
             verifyString("$options");
@@ -953,7 +962,7 @@ public class JsonReader extends AbstractBsonReader {
             pushToken(commaToken);
         }
         verifyToken("}");
-        return new BsonRegularExpression(patternToken.getValue(String.class), options);
+        return new BsonRegularExpression(pattern, options);
     }
 
     private String visitSymbolExtendedJson() {

--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -475,6 +475,21 @@ public class JsonReaderTest {
         assertEquals("imxs", regex.getOptions());
         assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
 
+        json = "{ \"$regex\" : /pattern/imxs }";
+        bsonReader = new JsonReader(json);
+        assertEquals(BsonType.REGULAR_EXPRESSION, bsonReader.readBsonType());
+        regex = bsonReader.readRegularExpression();
+        assertEquals("pattern", regex.getPattern());
+        assertEquals("imxs", regex.getOptions());
+        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+
+        json = "{ \"$regex\" : /pattern/, $options : \"is\" }";
+        bsonReader = new JsonReader(json);
+        assertEquals(BsonType.REGULAR_EXPRESSION, bsonReader.readBsonType());
+        regex = bsonReader.readRegularExpression();
+        assertEquals("pattern", regex.getPattern());
+        assertEquals("is", regex.getOptions());
+        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
     }
 
     @Test


### PR DESCRIPTION
https://jira.mongodb.org/browse/JAVA-2224

It would be nice if it could get backported into 3.2.
