### PR TITLE
Add toString() for com.mongodb.BulkWriteError

### DIFF
--- a/driver/src/main/com/mongodb/BulkWriteError.java
+++ b/driver/src/main/com/mongodb/BulkWriteError.java
@@ -117,4 +117,14 @@ public class BulkWriteError {
         result = 31 * result + details.hashCode();
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "BulkWriteError{"
+               + "index=" + index
+               + ", code=" + code
+               + ", message='" + message + '\''
+               + ", details=" + details
+               + '}';
+    }
 }


### PR DESCRIPTION
This adds `toString()` implementation for `com.mongodb.BulkWriteError` (similar to the one in `driver-core/src/main/com/mongodb/bulk/BulkWriteError.java`). I suspect that this class is some sort of "old" API, but it is used by mongo-hadoop. And other similar Errors have string representations, so this one should too.
I believe this closes https://jira.mongodb.org/browse/JAVA-1903 and https://jira.mongodb.org/browse/HADOOP-214.