### PR TITLE
Fix typo in BulkWriteError.hashCode()

### DIFF
--- a/driver-core/src/main/com/mongodb/bulk/BulkWriteError.java
+++ b/driver-core/src/main/com/mongodb/bulk/BulkWriteError.java
@@ -69,8 +69,8 @@ public class BulkWriteError extends WriteError {
 
     @Override
     public int hashCode() {
-        int result = index;
-        result = 31 * super.hashCode();
+        int result = super.hashCode();
+        result = 31 * result + index;
         return result;
     }
 


### PR DESCRIPTION
This fixes small error in `com.mongodb.bulk.BulkWriteError.hashCode()` (`index` field was effectively not used in hash code), which was introduced during parent class extraction.
