### PR TITLE
JAVA-2257 Handle autoIndexId without capped option enabled

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
@@ -317,10 +317,10 @@ public class CreateCollectionOperation implements AsyncWriteOperation<Void>, Wri
 
     private BsonDocument asDocument() {
         BsonDocument document = new BsonDocument("create", new BsonString(collectionName));
+        document.put("autoIndexId", BsonBoolean.valueOf(autoIndex));
         document.put("capped", BsonBoolean.valueOf(capped));
         if (capped) {
             putIfNotZero(document, "size", sizeInBytes);
-            document.put("autoIndexId", BsonBoolean.valueOf(autoIndex));
             putIfNotZero(document, "max", maxDocuments);
         }
         if (usePowerOf2Sizes != null) {

--- a/driver-core/src/test/functional/com/mongodb/operation/CreateCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/CreateCollectionOperationSpecification.groovy
@@ -185,6 +185,29 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         }
     }
 
+    def 'should create collection in respect to the autoIndex option'() {
+        given:
+        assert !collectionNameExists(getCollectionName())
+
+        when:
+        new CreateCollectionOperation(getDatabaseName(), getCollectionName())
+                .autoIndex(autoIndex)
+                .execute(getBinding())
+
+        then:
+        def stats = new CommandWriteOperation<Document>(getDatabaseName(),
+                new BsonDocument('collStats', new BsonString(getCollectionName())),
+                new DocumentCodec()).execute(getBinding())
+
+        expect:
+        stats.getInteger('nindexes') == expectedNumberOfIndexes
+
+        where:
+        autoIndex | expectedNumberOfIndexes
+        true | 1
+        false | 0
+    }
+
     @IgnoreIf({ !serverVersionAtLeast(asList(3, 1, 8)) })
     def 'should allow indexOptionDefaults'() {
         given:


### PR DESCRIPTION
It's seems that autoIndexId can't be activated without enabling capped option when creating a collection.
Since it is possible using the mongo shell, why blocking this action on the java driver.

Thanks,