### PR TITLE
Fix read concern/preference propagation from connection uri for async…

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/MongoClients.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoClients.java
@@ -122,6 +122,15 @@ public final class MongoClients {
                                          .socketSettings(SocketSettings.builder()
                                                                        .applyConnectionString(connectionString)
                                                                        .build());
+
+        if (connectionString.getReadPreference() != null) {
+            builder = builder.readPreference(connectionString.getReadPreference());
+        }
+
+        if (connectionString.getReadConcern() != null) {
+            builder = builder.readConcern(connectionString.getReadConcern());
+        }
+
         if (connectionString.getStreamType() != null) {
             if (connectionString.getStreamType().toLowerCase().equals("netty")) {
                 builder.streamFactoryFactory(NettyStreamFactoryFactory.builder().build());


### PR DESCRIPTION
…-driver

For async driver, the primary method of configuring the client is to specify the options
in the connection string. However, not all options are honored during client creation.

The expectation is that what was set in the connection uri should be the default...