### PR TITLE
update documentation for running tests to explicitly mention required mongod parameter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,9 @@ Pull requests should generally be made against the master (default) branch and i
 
 Code should compile and tests should pass under all Java versions which the driver currently supports.  Currently the Java driver 
 supports a minimum version of Java 6.  Please run './gradlew test' to confirm.   By default, running the tests requires that you started a 
-mongod server on localhost, listening on the default port.   At minimum, please test against the latest release version of the MongoDB 
+mongod server on localhost, listening on the default port and configured to run with
+[`enableTestCommands`](http://docs.mongodb.org/manual/reference/parameters/#param.enableTestCommands), which may be set with the 
+`--setParameter enableTestCommands=1` command-line parameter.   At minimum, please test against the latest release version of the MongoDB 
 server.
 
 The results of pull request testing will be appended to the request. If any tests do not pass, or relevant tests are not included, the 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ $ cd mongo-java-driver
 $ ./gradlew check
 ```
 
-The test suite requires mongod to be running with [`enableTestCommands`](http://docs.mongodb.org/manual/reference/parameters/#param.enableTestCommands).
+The test suite requires mongod to be running with [`enableTestCommands`](http://docs.mongodb.org/manual/reference/parameters/#param.enableTestCommands), which may be set with the `--setParameter enableTestCommands=1`
+command-line parameter.
 
 
 ### Build status:


### PR DESCRIPTION
Update the documentation to explicitly mention the mongod parameter that must be for the mongod used for test runs to be properly configured. (CONTRIBUTING.md did not mention the requirement.)