### PR TITLE
JAVA-2301 add read preferences to schema read operations list DB,DBna…

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/MongoClient.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoClient.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.async.client;
 
+import com.mongodb.ReadPreference;
 import com.mongodb.annotations.Immutable;
 import org.bson.Document;
 
@@ -56,7 +57,7 @@ public interface MongoClient extends Closeable {
     MongoClientSettings getSettings();
 
     /**
-     * Get a list of the database names
+     * Get a list of the database names from primary
      *
      * @mongodb.driver.manual reference/command/listDatabases List Databases
      * @return an iterable containing all the names of all the databases
@@ -64,7 +65,16 @@ public interface MongoClient extends Closeable {
     MongoIterable<String> listDatabaseNames();
 
     /**
-     * Gets the list of databases
+     * Get a list of the database names
+     *
+     * @param readPreference read preference used to get the list of database names
+     * @mongodb.driver.manual reference/command/listDatabases List Databases
+     * @return an iterable containing all the names of all the databases
+     */
+    MongoIterable<String> listDatabaseNames(ReadPreference readPreference);
+
+    /**
+     * Gets the list of databases from primary
      *
      * @return the list databases iterable interface
      */
@@ -73,10 +83,28 @@ public interface MongoClient extends Closeable {
     /**
      * Gets the list of databases
      *
+     * @param readPreference read preference used to get the list of databases
+     * @return the list databases iterable interface
+     */
+    ListDatabasesIterable<Document> listDatabases(ReadPreference readPreference);
+
+    /**
+     * Gets the list of databases from primary
+     *
      * @param resultClass the class to cast the database documents to
      * @param <TResult>   the type of the class to use instead of {@code Document}.
      * @return the list databases iterable interface
      */
     <TResult> ListDatabasesIterable<TResult> listDatabases(Class<TResult> resultClass);
+
+    /**
+     * Gets the list of databases
+     *
+     * @param resultClass the class to cast the database documents to
+     * @param readPreference read preference used to get the list of databases
+     * @param <TResult>   the type of the class to use instead of {@code Document}.
+     * @return the list databases iterable interface
+     */
+    <TResult> ListDatabasesIterable<TResult> listDatabases(Class<TResult> resultClass, ReadPreference readPreference);
 
 }

--- a/driver-async/src/main/com/mongodb/async/client/MongoClientImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoClientImpl.java
@@ -69,8 +69,13 @@ class MongoClientImpl implements MongoClient {
 
     @Override
     public MongoIterable<String> listDatabaseNames() {
+        return listDatabaseNames(ReadPreference.primary());
+    }
+
+    @Override
+    public MongoIterable<String> listDatabaseNames(final ReadPreference readPreference) {
         return new ListDatabasesIterableImpl<BsonDocument>(BsonDocument.class, MongoClients.getDefaultCodecRegistry(),
-                                                           ReadPreference.primary(), executor).map(new Function<BsonDocument, String>() {
+                readPreference, executor).map(new Function<BsonDocument, String>() {
             @Override
             public String apply(final BsonDocument document) {
                 return document.getString("name").getValue();
@@ -80,12 +85,22 @@ class MongoClientImpl implements MongoClient {
 
     @Override
     public ListDatabasesIterable<Document> listDatabases() {
-        return listDatabases(Document.class);
+        return listDatabases(Document.class, ReadPreference.primary());
+    }
+
+    @Override
+    public ListDatabasesIterable<Document> listDatabases(final ReadPreference readPreference) {
+        return listDatabases(Document.class, readPreference);
     }
 
     @Override
     public <T> ListDatabasesIterable<T> listDatabases(final Class<T> resultClass) {
-        return new ListDatabasesIterableImpl<T>(resultClass, settings.getCodecRegistry(), ReadPreference.primary(), executor);
+        return listDatabases(resultClass, ReadPreference.primary());
+    }
+
+    @Override
+    public <T> ListDatabasesIterable<T> listDatabases(final Class<T> resultClass, final ReadPreference readPreference) {
+        return new ListDatabasesIterableImpl<T>(resultClass, settings.getCodecRegistry(), readPreference, executor);
     }
 
     Cluster getCluster() {

--- a/driver-async/src/main/com/mongodb/async/client/MongoDatabase.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoDatabase.java
@@ -178,11 +178,19 @@ public interface MongoDatabase {
     void drop(SingleResultCallback<Void> callback);
 
     /**
-     * Gets the names of all the collections in this database.
+     * Gets the names of all the collections in this database from primary.
      *
      * @return an iterable containing all the names of all the collections in this database
      */
     MongoIterable<String> listCollectionNames();
+
+    /**
+     * Gets the names of all the collections in this database.
+     *
+     * @param readPreference the read preference used to get all collection names
+     * @return an iterable containing all the names of all the collections in this database
+     */
+    MongoIterable<String> listCollectionNames(ReadPreference readPreference);
 
     /**
      * Finds all the collections in this database.
@@ -195,12 +203,32 @@ public interface MongoDatabase {
     /**
      * Finds all the collections in this database.
      *
+     * @param readPreference the read preference used to get all collections
+     * @return the list collections iterable interface
+     * @mongodb.driver.manual reference/command/listCollections listCollections
+     */
+    ListCollectionsIterable<Document> listCollections(ReadPreference readPreference);
+
+    /**
+     * Finds all the collections in this database.
+     *
      * @param resultClass the class to decode each document into
      * @param <TResult>   the target document type of the iterable.
      * @return the list collections iterable interface
      * @mongodb.driver.manual reference/command/listCollections listCollections
      */
     <TResult> ListCollectionsIterable<TResult> listCollections(Class<TResult> resultClass);
+
+    /**
+     * Finds all the collections in this database.
+     *
+     * @param resultClass the class to decode each document into
+     * @param readPreference the read preference used to get all collections
+     * @param <TResult>   the target document type of the iterable.
+     * @return the list collections iterable interface
+     * @mongodb.driver.manual reference/command/listCollections listCollections
+     */
+    <TResult> ListCollectionsIterable<TResult> listCollections(Class<TResult> resultClass, ReadPreference readPreference);
 
     /**
      * Create a new collection with the given name.

--- a/driver-async/src/main/com/mongodb/async/client/MongoDatabaseImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoDatabaseImpl.java
@@ -106,8 +106,13 @@ class MongoDatabaseImpl implements MongoDatabase {
 
     @Override
     public MongoIterable<String> listCollectionNames() {
+        return listCollectionNames(ReadPreference.primary());
+    }
+
+    @Override
+    public MongoIterable<String> listCollectionNames(final ReadPreference readPreference) {
         return new ListCollectionsIterableImpl<BsonDocument>(name, BsonDocument.class, MongoClients.getDefaultCodecRegistry(),
-                                                             ReadPreference.primary(), executor).map(new Function<BsonDocument, String>() {
+                readPreference, executor).map(new Function<BsonDocument, String>() {
             @Override
             public String apply(final BsonDocument result) {
                 return result.getString("name").getValue();
@@ -117,11 +122,22 @@ class MongoDatabaseImpl implements MongoDatabase {
 
     @Override
     public ListCollectionsIterable<Document> listCollections() {
-        return listCollections(Document.class);
+        return listCollections(Document.class, ReadPreference.primary());
+    }
+
+    @Override
+    public ListCollectionsIterable<Document> listCollections(final ReadPreference readPreference) {
+        return listCollections(Document.class, readPreference);
     }
 
     @Override
     public <TResult> ListCollectionsIterable<TResult> listCollections(final Class<TResult> resultClass) {
+        return listCollections(resultClass, ReadPreference.primary());
+    }
+
+    @Override
+    public <TResult> ListCollectionsIterable<TResult> listCollections(final Class<TResult> resultClass,
+                                                                      final ReadPreference readPreference) {
         return new ListCollectionsIterableImpl<TResult>(name, resultClass, codecRegistry, ReadPreference.primary(), executor);
     }
 

--- a/driver/src/main/com/mongodb/DB.java
+++ b/driver/src/main/com/mongodb/DB.java
@@ -246,21 +246,33 @@ public class DB {
     }
 
     /**
-     * Returns a set containing the names of all collections in this database.
+     * Returns a set containing the names of all collections in this database from primary.
      *
      * @return the names of collections in this database
      * @throws MongoException if the operation failed
      * @mongodb.driver.manual reference/method/db.getCollectionNames/ getCollectionNames()
      */
     public Set<String> getCollectionNames() {
+        return getCollectionNames(primary());
+    }
+
+    /**
+     * Returns a set containing the names of all collections in this database.
+     *
+     * @param readPreference the read preference to get the collection names
+     * @return the names of collections in this database
+     * @throws MongoException if the operation failed
+     * @mongodb.driver.manual reference/method/db.getCollectionNames/ getCollectionNames()
+     */
+    public Set<String> getCollectionNames(final ReadPreference readPreference) {
         List<String> collectionNames = new OperationIterable<DBObject>(new ListCollectionsOperation<DBObject>(name, commandCodec),
-                                                                       primary(), executor)
-                                       .map(new Function<DBObject, String>() {
-                                           @Override
-                                           public String apply(final DBObject result) {
-                                               return (String) result.get("name");
-                                           }
-                                       }).into(new ArrayList<String>());
+                readPreference, executor)
+                .map(new Function<DBObject, String>() {
+                    @Override
+                    public String apply(final DBObject result) {
+                        return (String) result.get("name");
+                    }
+                }).into(new ArrayList<String>());
         Collections.sort(collectionNames);
         return new LinkedHashSet<String>(collectionNames);
     }

--- a/driver/src/main/com/mongodb/DBCollection.java
+++ b/driver/src/main/com/mongodb/DBCollection.java
@@ -2125,16 +2125,29 @@ public class DBCollection {
     }
 
     /**
-     * Return a list of the indexes for this collection.  Each object in the list is the "info document" from MongoDB
+     * Return a list of the indexes for this collection from primary.  Each object in the list is the "info document" from MongoDB
      *
      * @return list of index documents
      * @throws MongoException if the operation failed
      * @mongodb.driver.manual core/indexes/ Indexes
      */
     public List<DBObject> getIndexInfo() {
-        return new OperationIterable<DBObject>(new ListIndexesOperation<DBObject>(getNamespace(), getDefaultDBObjectCodec()),
-                                               primary(), executor).into(new ArrayList<DBObject>());
+        return getIndexInfo(primary());
     }
+
+    /**
+     * Return a list of the indexes for this collection.  Each object in the list is the "info document" from MongoDB
+     *
+     * @param readPreference the read preference used to get index documents
+     * @return list of index documents
+     * @throws MongoException if the operation failed
+     * @mongodb.driver.manual core/indexes/ Indexes
+     */
+    public List<DBObject> getIndexInfo(final ReadPreference readPreference) {
+        return new OperationIterable<DBObject>(new ListIndexesOperation<DBObject>(getNamespace(), getDefaultDBObjectCodec()),
+                readPreference, executor).into(new ArrayList<DBObject>());
+    }
+
 
     /**
      * Drops an index from this collection.  The DBObject index parameter must match the specification of the index to drop, i.e. correct

--- a/driver/src/main/com/mongodb/MongoClient.java
+++ b/driver/src/main/com/mongodb/MongoClient.java
@@ -305,15 +305,27 @@ public class MongoClient extends Mongo implements Closeable {
     }
 
     /**
-     * Get a list of the database names
+     * Get a list of the database names from primary
      *
      * @mongodb.driver.manual reference/command/listDatabases List Databases
      * @return an iterable containing all the names of all the databases
      * @since 3.0
      */
     public MongoIterable<String> listDatabaseNames() {
+        return listDatabaseNames(ReadPreference.primary());
+    }
+
+    /**
+     * Get a list of the database names
+     *
+     * @mongodb.driver.manual reference/command/listDatabases List Databases
+     * @param readPreference the read preference used to get the list of databases
+     * @return an iterable containing all the names of all the databases
+     * @since 3.0
+     */
+    public MongoIterable<String> listDatabaseNames(final ReadPreference readPreference) {
         return new ListDatabasesIterableImpl<BsonDocument>(BsonDocument.class, getDefaultCodecRegistry(),
-                ReadPreference.primary(), createOperationExecutor()).map(new Function<BsonDocument, String>() {
+                readPreference, createOperationExecutor()).map(new Function<BsonDocument, String>() {
             @Override
             public String apply(final BsonDocument result) {
                 return result.getString("name").getValue();
@@ -321,18 +333,30 @@ public class MongoClient extends Mongo implements Closeable {
         });
     }
 
+
     /**
-     * Gets the list of databases
+     * Gets the list of databases from primary
      *
      * @return the list of databases
      * @since 3.0
      */
     public ListDatabasesIterable<Document> listDatabases() {
-        return listDatabases(Document.class);
+        return listDatabases(Document.class, ReadPreference.primary());
     }
 
     /**
      * Gets the list of databases
+     *
+     * @param readPreference the read preference used to get the list of databases
+     * @return the list of databases
+     * @since 3.4
+     */
+    public ListDatabasesIterable<Document> listDatabases(final ReadPreference readPreference) {
+        return listDatabases(Document.class, readPreference);
+    }
+
+    /**
+     * Gets the list of databases from primary
      *
      * @param clazz the class to cast the database documents to
      * @param <T>   the type of the class to use instead of {@code Document}.
@@ -340,8 +364,21 @@ public class MongoClient extends Mongo implements Closeable {
      * @since 3.0
      */
     public <T> ListDatabasesIterable<T> listDatabases(final Class<T> clazz) {
+        return listDatabases(clazz, ReadPreference.primary());
+    }
+
+    /**
+     * Gets the list of databases
+     *
+     * @param clazz the class to cast the database documents to
+     * @param readPreference  the read preference used to get the list of database
+     * @param <T>   the type of the class to use instead of {@code Document}.
+     * @return the list of databases
+     * @since 3.4
+     */
+    public <T> ListDatabasesIterable<T> listDatabases(final Class<T> clazz, final ReadPreference readPreference) {
         return new ListDatabasesIterableImpl<T>(clazz, getMongoClientOptions().getCodecRegistry(),
-                ReadPreference.primary(), createOperationExecutor());
+                readPreference, createOperationExecutor());
     }
 
     /**

--- a/driver/src/main/com/mongodb/MongoCollectionImpl.java
+++ b/driver/src/main/com/mongodb/MongoCollectionImpl.java
@@ -484,12 +484,22 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public ListIndexesIterable<Document> listIndexes() {
-        return listIndexes(Document.class);
+        return listIndexes(Document.class, ReadPreference.primary());
+    }
+
+    @Override
+    public ListIndexesIterable<Document> listIndexes(final ReadPreference readPreference) {
+        return listIndexes(Document.class, readPreference);
     }
 
     @Override
     public <TResult> ListIndexesIterable<TResult> listIndexes(final Class<TResult> resultClass) {
-        return new ListIndexesIterableImpl<TResult>(getNamespace(), resultClass, codecRegistry, ReadPreference.primary(), executor);
+        return listIndexes(resultClass, ReadPreference.primary());
+    }
+
+    @Override
+    public <TResult> ListIndexesIterable<TResult> listIndexes(final Class<TResult> resultClass, final  ReadPreference readPreference) {
+        return new ListIndexesIterableImpl<TResult>(getNamespace(), resultClass, codecRegistry, readPreference, executor);
     }
 
     @Override

--- a/driver/src/main/com/mongodb/MongoDatabaseImpl.java
+++ b/driver/src/main/com/mongodb/MongoDatabaseImpl.java
@@ -143,7 +143,12 @@ class MongoDatabaseImpl implements MongoDatabase {
 
     @Override
     public MongoIterable<String> listCollectionNames() {
-        return new ListCollectionsIterableImpl<BsonDocument>(name, BsonDocument.class, getDefaultCodecRegistry(), ReadPreference.primary(),
+        return listCollectionNames(ReadPreference.primary());
+    }
+
+    @Override
+    public MongoIterable<String> listCollectionNames(final ReadPreference readPreference) {
+        return new ListCollectionsIterableImpl<BsonDocument>(name, BsonDocument.class, getDefaultCodecRegistry(), readPreference,
                 executor).map(new Function<BsonDocument, String>() {
             @Override
             public String apply(final BsonDocument result) {
@@ -154,12 +159,23 @@ class MongoDatabaseImpl implements MongoDatabase {
 
     @Override
     public ListCollectionsIterable<Document> listCollections() {
-        return listCollections(Document.class);
+        return listCollections(Document.class, ReadPreference.primary());
+    }
+
+    @Override
+    public ListCollectionsIterable<Document> listCollections(final ReadPreference readPreference) {
+        return listCollections(Document.class, readPreference);
     }
 
     @Override
     public <TResult> ListCollectionsIterable<TResult> listCollections(final Class<TResult> resultClass) {
-        return new ListCollectionsIterableImpl<TResult>(name, resultClass, codecRegistry, ReadPreference.primary(), executor);
+        return listCollections(resultClass, ReadPreference.primary());
+    }
+
+    @Override
+    public <TResult> ListCollectionsIterable<TResult> listCollections(final Class<TResult> resultClass,
+                                                                      final ReadPreference readPreference) {
+        return new ListCollectionsIterableImpl<TResult>(name, resultClass, codecRegistry, readPreference, executor);
     }
 
     @Override

--- a/driver/src/main/com/mongodb/client/MongoCollection.java
+++ b/driver/src/main/com/mongodb/client/MongoCollection.java
@@ -576,7 +576,7 @@ public interface MongoCollection<TDocument> {
     List<String> createIndexes(List<IndexModel> indexes);
 
     /**
-     * Get all the indexes in this collection.
+     * Get all the indexes in this collection from primary.
      *
      * @return the list indexes iterable interface
      * @mongodb.driver.manual reference/command/listIndexes/ List indexes
@@ -586,12 +586,33 @@ public interface MongoCollection<TDocument> {
     /**
      * Get all the indexes in this collection.
      *
+     * @param readPreference the read preference used to get the list of indexes
+     * @return the list indexes iterable interface
+     * @mongodb.driver.manual reference/command/listIndexes/ List indexes
+    */
+    ListIndexesIterable<Document> listIndexes(ReadPreference readPreference);
+
+    /**
+     * Get all the indexes in this collection from primary.
+     *
      * @param resultClass the class to decode each document into
      * @param <TResult>   the target document type of the iterable.
      * @return the list indexes iterable interface
      * @mongodb.driver.manual reference/command/listIndexes/ List indexes
      */
     <TResult> ListIndexesIterable<TResult> listIndexes(Class<TResult> resultClass);
+
+    /**
+     * Get all the indexes in this collection.
+     *
+     * @param resultClass the class to decode each document into
+     * @param readPreference the read preference use to get the list of indexes
+     * @param <TResult>   the target document type of the iterable.
+     * @return the list indexes iterable interface
+     * @mongodb.driver.manual reference/command/listIndexes/ List indexes
+     */
+    <TResult> ListIndexesIterable<TResult> listIndexes(Class<TResult> resultClass, ReadPreference readPreference);
+
 
     /**
      * Drops the index given its name.

--- a/driver/src/main/com/mongodb/client/MongoDatabase.java
+++ b/driver/src/main/com/mongodb/client/MongoDatabase.java
@@ -175,14 +175,22 @@ public interface MongoDatabase {
     void drop();
 
     /**
-     * Gets the names of all the collections in this database.
+     * Gets the names of all the collections in this database from primary.
      *
      * @return an iterable containing all the names of all the collections in this database
      */
     MongoIterable<String> listCollectionNames();
 
     /**
-     * Finds all the collections in this database.
+     * Gets the names of all the collections in this database.
+     *
+     * @param readPreference the read preference used to get all connection
+     * @return an iterable containing all the names of all the collections in this database
+     */
+     MongoIterable<String> listCollectionNames(ReadPreference readPreference);
+
+    /**
+     * Finds all the collections in this database from primary.
      *
      * @return the list collections iterable interface
      * @mongodb.driver.manual reference/command/listCollections listCollections
@@ -192,12 +200,32 @@ public interface MongoDatabase {
     /**
      * Finds all the collections in this database.
      *
+     * @param readPreference the read preference used to get all connection
+     * @return the list collections iterable interface
+     * @mongodb.driver.manual reference/command/listCollections listCollections
+     */
+    ListCollectionsIterable<Document> listCollections(ReadPreference readPreference);
+
+    /**
+     * Finds all the collections in this database from primary.
+     *
      * @param resultClass the class to decode each document into
      * @param <TResult>   the target document type of the iterable.
      * @return the list collections iterable interface
      * @mongodb.driver.manual reference/command/listCollections listCollections
      */
     <TResult> ListCollectionsIterable<TResult> listCollections(Class<TResult> resultClass);
+
+    /**
+     * Finds all the collections in this database.
+     *
+     * @param resultClass the class to decode each document into
+     * @param readPreference the read preference used to get all connection
+     * @param <TResult>   the target document type of the iterable.
+     * @return the list collections iterable interface
+     * @mongodb.driver.manual reference/command/listCollections listCollections
+     */
+    <TResult> ListCollectionsIterable<TResult> listCollections(Class<TResult> resultClass, ReadPreference readPreference);
 
     /**
      * Create a new collection with the given name.

--- a/driver/src/test/acceptance/com/mongodb/acceptancetest/core/ClientAcceptanceTest.java
+++ b/driver/src/test/acceptance/com/mongodb/acceptancetest/core/ClientAcceptanceTest.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.acceptancetest.core;
 
+import com.mongodb.ReadPreference;
 import com.mongodb.client.DatabaseTestCase;
 import com.mongodb.client.MongoDatabase;
 import org.bson.Document;
@@ -41,6 +42,14 @@ public class ClientAcceptanceTest extends DatabaseTestCase {
     public void shouldListDatabaseNamesFromDatabase() {
         database.createCollection(getCollectionName());
         List<String> names = client.listDatabaseNames().into(new ArrayList<String>());
+
+        assertThat(names.contains(getDatabaseName()), is(true));
+    }
+
+    @Test
+    public void shouldListDatabaseNamesFromDatabaseWithReadPreference() {
+        database.createCollection(getCollectionName());
+        List<String> names = client.listDatabaseNames(ReadPreference.primaryPreferred()).into(new ArrayList<String>());
 
         assertThat(names.contains(getDatabaseName()), is(true));
     }
@@ -75,6 +84,15 @@ public class ClientAcceptanceTest extends DatabaseTestCase {
 
         database.createCollection(getCollectionName());
         databases = client.listDatabases().into(new ArrayList<Document>());
+        assertThat(databases, new DatabaseNameMatcher(getDatabaseName()));
+    }
+
+    @Test
+    public void shouldListDatabaseWithReadPreference() {
+        List<Document> databases = client.listDatabases().into(new ArrayList<Document>());
+
+        database.createCollection(getCollectionName());
+        databases = client.listDatabases(ReadPreference.primaryPreferred()).into(new ArrayList<Document>());
         assertThat(databases, new DatabaseNameMatcher(getDatabaseName()));
     }
 

--- a/driver/src/test/functional/com/mongodb/DBTest.java
+++ b/driver/src/test/functional/com/mongodb/DBTest.java
@@ -105,6 +105,9 @@ public class DBTest extends DatabaseTestCase {
         }
 
         assertThat(database.getCollectionNames(), hasItems(collectionNames));
+
+        assertThat(database.getCollectionNames(ReadPreference.secondary()), hasItems(collectionNames));
+
     }
 
     @Test


### PR DESCRIPTION
Add read preferences to schema read operations list DB,DBname, Collection, Index

Test:
- All existing code is running with the new methods (using the new code path)
- Added few path with a ReadPreference.primaryPreferred

Functional Testing:
 I have encountered the bug while using MongoDB & Apache Drill in a context where Drill does not have access at all to primary.
- Tested with these patch and it is running as expected (get the schema information from secondary without no access to the primary - different network)
