### PR TITLE
JAVA-2308: unable to start MongoClient

### DIFF
--- a/bson/build.gradle
+++ b/bson/build.gradle
@@ -28,6 +28,7 @@ clirr {
 
 jar {
     manifest {
+        instruction 'Build-Version', getGitVersion()
         instruction 'Import-Package',
                     'javax.xml.bind.*',
                     'org.slf4j;resolution:=optional'

--- a/build.gradle
+++ b/build.gradle
@@ -131,8 +131,6 @@ configure(subprojects.findAll { it.name != 'util' }) {
     task generateVersionPropertiesFile << {
         def directory = new File(project.ext.generatedResources)
         directory.mkdirs()
-        def propertiesFile = new File(directory, "version.properties")
-        propertiesFile.text = "version=${getGitVersion()}"
     }
 }
 

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
 jar {
     manifest {
+        instruction 'Build-Version', getGitVersion()
         instruction 'Import-Package',
                     'org.bson.*',                       // unfortunate that this is necessary, but if it's left out then it's not included
                     'javax.crypto.*',

--- a/mongo-java-driver/build.gradle
+++ b/mongo-java-driver/build.gradle
@@ -47,6 +47,7 @@ sourceSets {
 // copied from driver-core
 jar {
     manifest {
+        instruction 'Build-Version', getGitVersion()
         instruction 'Import-Package',
                     'javax.xml.bind.*',
                     'javax.crypto.*',


### PR DESCRIPTION
https://jira.mongodb.org/browse/JAVA-2308

Version: 3.4.0.SNAPSHOT
ClientMetadataHelper tries to get DriverVersion using
```
Class<InternalStreamConnectionInitializer> clazz = InternalStreamConnectionInitializer.class;
URL versionPropertiesFileURL = clazz.getResource("/version.properties");
```
but there is another **"version.properties"** file in classpath - it leads to **IllegalArgumentException("Value can not be null")** in BsonString constructor


Proposal: read version from jar MANIFEST.MF file 