### PR TITLE
Added `collection` back to `MongoClientURI` and `ConnectionString` javadocs

### DIFF
--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -46,7 +46,7 @@ import static java.util.Collections.singletonList;
  *
  * <p>The format of the Connection String is:</p>
  * <pre>
- *   mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+ *   mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database.collection][?options]]
  * </pre>
  * <ul>
  * <li>{@code mongodb://} is a required prefix to identify that this is a string in the standard connection format.</li>

--- a/driver/src/main/com/mongodb/MongoClientURI.java
+++ b/driver/src/main/com/mongodb/MongoClientURI.java
@@ -26,7 +26,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  * be used and options.
  * <p>The format of the URI is:
  * <pre>
- *   mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+ *   mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database.collection][?options]]
  * </pre>
  * <ul>
  * <li>{@code mongodb://} is a required prefix to identify that this is a string in the standard connection format.</li>


### PR DESCRIPTION
Both `MongoClientURI` and `ConnectionString` support `/database.collection` format in uri but it's not in javadoc (previously fixed by #116)