### PR TITLE
JAVA-1796 accept hexadecimal string for value of $type in binary data

### DIFF
--- a/driver/src/main/com/mongodb/util/JSONCallback.java
+++ b/driver/src/main/com/mongodb/util/JSONCallback.java
@@ -125,7 +125,7 @@ public class JSONCallback extends BasicBSONCallback {
         } else if (b.containsField("$uuid")) {
             o = UUID.fromString((String) b.get("$uuid"));
         } else if (b.containsField("$binary")) {
-            int type = (b.get("$type") instanceof String) ? Integer.decode((String) b.get("$type")) : (Integer) b.get("$type");
+            int type = (b.get("$type") instanceof String) ? Integer.valueOf((String) b.get("$type"), 16) : (Integer) b.get("$type");
             byte[] bytes = DatatypeConverter.parseBase64Binary((String) b.get("$binary"));
             o = new Binary((byte) type, bytes);
         } else if (b.containsField("$undefined") && b.get("$undefined").equals(true)) {

--- a/driver/src/main/com/mongodb/util/JSONCallback.java
+++ b/driver/src/main/com/mongodb/util/JSONCallback.java
@@ -125,12 +125,7 @@ public class JSONCallback extends BasicBSONCallback {
         } else if (b.containsField("$uuid")) {
             o = UUID.fromString((String) b.get("$uuid"));
         } else if (b.containsField("$binary")) {
-            int type;
-            if (b.get("$type") instanceof String) {
-                type = Integer.decode((String) b.get("$type"));
-            } else {
-                type = (Integer) b.get("$type");
-            }
+            int type = (b.get("$type") instanceof String) ? Integer.decode((String) b.get("$type")) : (Integer) b.get("$type");
             byte[] bytes = DatatypeConverter.parseBase64Binary((String) b.get("$binary"));
             o = new Binary((byte) type, bytes);
         } else if (b.containsField("$undefined") && b.get("$undefined").equals(true)) {

--- a/driver/src/main/com/mongodb/util/JSONCallback.java
+++ b/driver/src/main/com/mongodb/util/JSONCallback.java
@@ -125,7 +125,12 @@ public class JSONCallback extends BasicBSONCallback {
         } else if (b.containsField("$uuid")) {
             o = UUID.fromString((String) b.get("$uuid"));
         } else if (b.containsField("$binary")) {
-            int type = (Integer) b.get("$type");
+            int type;
+            if (b.get("$type") instanceof String) {
+                type = Integer.decode((String) b.get("$type"));
+            } else {
+                type = (Integer) b.get("$type");
+            }
             byte[] bytes = DatatypeConverter.parseBase64Binary((String) b.get("$binary"));
             o = new Binary((byte) type, bytes);
         } else if (b.containsField("$undefined") && b.get("$undefined").equals(true)) {

--- a/driver/src/test/unit/com/mongodb/util/JSONCallbackTest.java
+++ b/driver/src/test/unit/com/mongodb/util/JSONCallbackTest.java
@@ -19,8 +19,6 @@ package com.mongodb.util;
 import com.mongodb.DBObject;
 import com.mongodb.DBRef;
 import org.bson.BSON;
-import org.bson.BSONCallback;
-import org.bson.BasicBSONObject;
 import org.bson.BsonUndefined;
 import org.bson.Transformer;
 import org.bson.types.BSONTimestamp;
@@ -29,7 +27,6 @@ import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 import org.junit.Test;
 
-import javax.xml.bind.DatatypeConverter;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Date;

--- a/driver/src/test/unit/com/mongodb/util/JSONCallbackTest.java
+++ b/driver/src/test/unit/com/mongodb/util/JSONCallbackTest.java
@@ -94,6 +94,10 @@ public class JSONCallbackTest {
         Binary parsedBinary = (Binary) JSON.parse(("{ \"$binary\" : \"YWJjZA==\", \"$type\" : 0 }"));
         assertEquals(0, parsedBinary.getType());
         assertArrayEquals(new byte[]{97, 98, 99, 100}, parsedBinary.getData());
+
+        Binary parsedBinaryWithHexType = (Binary) JSON.parse(("{ \"$binary\" : \"YWJjZA==\", \"$type\" : \"80\" }"));
+        assertEquals(128, parsedBinaryWithHexType.getType());
+        assertArrayEquals(new byte[]{97, 98, 99, 100}, parsedBinaryWithHexType.getData());
     }
 
     @Test
@@ -141,46 +145,5 @@ public class JSONCallbackTest {
     public void numberDecimalParsing() {
         Decimal128 number = (Decimal128) JSON.parse(("{\"$numberDecimal\" : \"314E-2\"}"));
         assertEquals(number, Decimal128.parse("314E-2"));
-    }
-
-    private Object objectDoneTestHelper(final String jsonString, final String rootName) {
-        JSONParser jsonParser = new JSONParser(jsonString);
-        BSONCallback callback = jsonParser._callback;
-        callback.objectStart();
-        jsonParser.parseObject(rootName);
-        return ((BasicBSONObject) ((BasicBSONObject) callback.get()).get(rootName)).get(rootName);
-    }
-
-    @Test
-    public void objectDoneIntTypeTest() throws Exception {
-        String rootName = "testObj";
-        String binaryString = "H4sIAAAAAA";
-        int type = 0;
-        final String jsonString = "{\"" + rootName + "\":{\"$binary\":\"" + binaryString + "\",\"$type\":" + type + "}}";
-
-        Object o1 = objectDoneTestHelper(jsonString, rootName);
-
-        byte[] bytes = DatatypeConverter.parseBase64Binary(binaryString);
-        Object o2 = new Binary((byte) type, bytes);
-
-        assertEquals(o1, o2);
-
-    }
-
-    @Test
-    public void objectDoneHexTypeTest() throws Exception {
-        String rootName = "testObj";
-        String binaryString = "H4sIAAAAAA";
-        String typeHex = "00";
-        final String jsonString = "{\"" + rootName + "\":{\"$binary\":\"" + binaryString + "\",\"$type\":\"" + typeHex + "\"}}";
-
-        Object o1 = objectDoneTestHelper(jsonString, rootName);
-
-        int type = Integer.decode(typeHex);
-        byte[] bytes = DatatypeConverter.parseBase64Binary(binaryString);
-        Object o2 = new Binary((byte) type, bytes);
-
-        assertEquals(o1, o2);
-
     }
 }

--- a/driver/src/test/unit/com/mongodb/util/JSONCallbackTest.java
+++ b/driver/src/test/unit/com/mongodb/util/JSONCallbackTest.java
@@ -96,7 +96,7 @@ public class JSONCallbackTest {
         assertArrayEquals(new byte[]{97, 98, 99, 100}, parsedBinary.getData());
 
         Binary parsedBinaryWithHexType = (Binary) JSON.parse(("{ \"$binary\" : \"YWJjZA==\", \"$type\" : \"80\" }"));
-        assertEquals(128, parsedBinaryWithHexType.getType());
+        assertEquals((byte) 128, parsedBinaryWithHexType.getType());
         assertArrayEquals(new byte[]{97, 98, 99, 100}, parsedBinaryWithHexType.getData());
     }
 

--- a/driver/src/test/unit/com/mongodb/util/JSONCallbackTest.java
+++ b/driver/src/test/unit/com/mongodb/util/JSONCallbackTest.java
@@ -143,12 +143,12 @@ public class JSONCallbackTest {
         assertEquals(number, Decimal128.parse("314E-2"));
     }
 
-    private Object objectDoneTestHelper(String jsonString, String rootName) {
+    private Object objectDoneTestHelper(final String jsonString, final String rootName) {
         JSONParser jsonParser = new JSONParser(jsonString);
         BSONCallback callback = jsonParser._callback;
         callback.objectStart();
         jsonParser.parseObject(rootName);
-        return ((BasicBSONObject)((BasicBSONObject) callback.get()).get(rootName)).get(rootName);
+        return ((BasicBSONObject) ((BasicBSONObject) callback.get()).get(rootName)).get(rootName);
     }
 
     @Test
@@ -156,7 +156,7 @@ public class JSONCallbackTest {
         String rootName = "testObj";
         String binaryString = "H4sIAAAAAA";
         int type = 0;
-        String jsonString = "{\"" + rootName + "\":{\"$binary\":\"" + binaryString + "\",\"$type\":" + type + "}}";
+        final String jsonString = "{\"" + rootName + "\":{\"$binary\":\"" + binaryString + "\",\"$type\":" + type + "}}";
 
         Object o1 = objectDoneTestHelper(jsonString, rootName);
 
@@ -172,7 +172,7 @@ public class JSONCallbackTest {
         String rootName = "testObj";
         String binaryString = "H4sIAAAAAA";
         String typeHex = "00";
-        String jsonString = "{\"" + rootName + "\":{\"$binary\":\"" + binaryString + "\",\"$type\":\"" + typeHex + "\"}}";
+        final String jsonString = "{\"" + rootName + "\":{\"$binary\":\"" + binaryString + "\",\"$type\":\"" + typeHex + "\"}}";
 
         Object o1 = objectDoneTestHelper(jsonString, rootName);
 


### PR DESCRIPTION
Fixed jira issue [JAVA-1796](https://jira.mongodb.org/browse/JAVA-1796).

I had the same problem as in this ticket, where the value for $type for $binary data was in a hexadecimal string. This specification can be found [here](https://docs.mongodb.com/v3.2/reference/mongodb-extended-json/#data_binary).