### PR TITLE
Fix BSON decoder inconsistency in java-driver to workaround a bug in MongoDB.

### DIFF
--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -69,7 +69,10 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, C
      */
     public BsonDocument(final List<BsonElement> bsonElements) {
         for (BsonElement cur : bsonElements) {
-            put(cur.getName(), cur.getValue());
+            final String name = cur.getName();
+            if (!containsKey(name)) {
+                put(name, cur.getValue());
+            }
         }
     }
 

--- a/driver-core/src/test/functional/com/mongodb/operation/RolesInfoOperationsSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/RolesInfoOperationsSpecification.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.operation
+
+import com.mongodb.OperationFunctionalSpecification
+import org.bson.BsonBoolean
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.codecs.BsonDocumentCodec
+
+import static com.mongodb.ClusterFixture.getBinding
+
+class RolesInfoOperationsSpecification extends OperationFunctionalSpecification {
+
+    def '{rolesInfo:1, showBuiltinRoles: true} should return a document with a non-empty "roles" array.'() {
+        given:
+        def commandOperation = new CommandReadOperation<BsonDocument>(getNamespace().databaseName,
+                new BsonDocument("rolesInfo", new BsonInt32(1))
+                        .append("showBuiltinRoles", new BsonBoolean(true)),
+                new BsonDocumentCodec())
+        when:
+        def result = commandOperation.execute(getBinding())
+
+        then:
+        result.getArray('roles').size() > 0
+    }
+}


### PR DESCRIPTION
This is a hotfix to workaround a regression in MongoDB 3.4 (works fine with 3.2), which causes the "rolesInfo" command to return a document with a duplicate "roles" field.

Unfortunately, the first "roles" entry has the data, while the second one is empty. The java driver behaves differently compared to the C based drivers, since Map::put() will overwrite existing entries, thus making the last occurrence matter, while the C based drivers use a linear scan that will always return the first occurrence.

Further, I want to point out that this is NOT a bug in the java driver, but since the broken MongoDB has already been shipped to production, we still need a fix to deal with the broken MongoDBs that are in circulation.