### PR TITLE
JAVA-1354: JSON date parsing - support for timezones other than 'Z'

### DIFF
--- a/driver/src/test/unit/com/mongodb/util/JSONCallbackTest.java
+++ b/driver/src/test/unit/com/mongodb/util/JSONCallbackTest.java
@@ -36,6 +36,7 @@ import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class JSONCallbackTest {
 
@@ -62,6 +63,38 @@ public class JSONCallbackTest {
         parsedDate = (Date) JSON.parse("{ \"$date\" : \"" + format.format(rightNow) + "\"}");
         assertEquals(0, parsedDate.compareTo(format.parse(format.format(rightNow), new ParsePosition(0))));
 
+    }
+
+    private static final String[] TIMEZONED_DATES = {
+            "2000-01-01T00:00:00.000Z",
+            "2000-01-01T00:00:00.000+0000",
+            "2000-01-01T00:00:00.000+0100",
+            "2000-01-01T00:00:00.000-0100",
+            "2000-01-01T00:00:00.000+01",
+            "2000-01-01T00:00:00.000-01",
+            "2000-01-01T00:00:00Z",
+            "2000-01-01T00:00:00+0000",
+            "2000-01-01T00:00:00+0100",
+            "2000-01-01T00:00:00-0100",
+            "2000-01-01T00:00:00+01",
+            "2000-01-01T00:00:00-01"
+    };
+
+    @Test
+    public void timezonedDateParsing() {
+        for (String date : TIMEZONED_DATES) {
+            Date parsedDate = (Date) JSON.parse("{ \"$date\" : \"" + date + "\"}");
+            assertNotNull("Failed to parse date: " + date, parsedDate);
+        }
+    }
+
+    @Test
+    public void timezoneJava16FallbackDateParsing() {
+        JSONCallback callbackUnderTest = new JSONCallback();
+        for (String date : TIMEZONED_DATES) {
+            Date parsedDate = callbackUnderTest.fallbackDateParse(date);
+            assertNotNull(parsedDate);
+        }
     }
 
     @Test


### PR DESCRIPTION
This is an elaborated version of first fix (which only used 'X' in parsing pattern). Right now it works best on java 1.7+ but has some fallback code to support java 1.6 as well. Quick performance tests shows that on java 1.6 it is around 3 times slower than original version.