### PR TITLE
Named thread pools

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/thread/DaemonThreadFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/thread/DaemonThreadFactory.java
@@ -31,10 +31,6 @@ public class DaemonThreadFactory implements ThreadFactory {
     private final AtomicInteger threadNumber = new AtomicInteger(1);
     private final String namePrefix;
 
-    public DaemonThreadFactory() {
-        this("pool");
-    }
-
     public DaemonThreadFactory(final String prefix) {
         namePrefix = prefix + "-" + POOL_NUMBER.getAndIncrement() + "-thread-";
     }

--- a/driver/src/main/com/mongodb/Mongo.java
+++ b/driver/src/main/com/mongodb/Mongo.java
@@ -849,7 +849,7 @@ public class Mongo {
     }
 
     private ExecutorService createCursorCleaningService() {
-        ScheduledExecutorService newTimer = Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory());
+        ScheduledExecutorService newTimer = Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory("CleanCursors"));
         newTimer.scheduleAtFixedRate(new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
Make sure all threads created by driver have descriptive names, also not conflicting with JVM's built-in thread pools.