### PR TITLE
Correct class level javadoc

### DIFF
--- a/driver/src/main/com/mongodb/client/model/DBCollectionDistinctOptions.java
+++ b/driver/src/main/com/mongodb/client/model/DBCollectionDistinctOptions.java
@@ -21,7 +21,7 @@ import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 
 /**
- * The options for a count operation.
+ * The options for a distinct operation.
  *
  * @since 3.4
  * @mongodb.driver.manual reference/command/count/ Count


### PR DESCRIPTION
Updated class level javadoc for DBCollectionDistinctOptions.java
Previously stated it was for count operations, which applies to a different class: DBCollectionCountOptions.java