### PR TITLE
Added ulimit with command to start mongod when building; removed lega…

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,17 @@ $ ./gradlew check
 ```
 
 The test suite requires mongod to be running with [`enableTestCommands`](http://docs.mongodb.org/manual/reference/parameters/#param.enableTestCommands), which may be set with the `--setParameter enableTestCommands=1`
-command-line parameter.
+command-line parameter:
+```
+$ mongod --dbpath ./data/db --logpath ./data/mongod.log --port 27017 --logappend --fork --setParameter enableTestCommands=1
+```
 
+If you encounter `"Too many open files"` errors when running the tests then you will need to increase 
+the number of available file descriptors prior to starting mongod as described in [https://docs.mongodb.com/manual/reference/ulimit/](https://docs.mongodb.com/manual/reference/ulimit/)
 
 ### Build status:
 
-[![Build Status](https://travis-ci.org/mongodb/mongo-java-driver.svg?branch=master)](https://travis-ci.org/mongodb/mongo-java-driver) | [![Build Status](https://jenkins.10gen.com/job/mongo-java-driver-3.x/badge/icon)](https://jenkins.10gen.com/job/mongo-java-driver/)
+[![Build Status](https://travis-ci.org/mongodb/mongo-java-driver.svg?branch=master)](https://travis-ci.org/mongodb/mongo-java-driver)
 
 ## Maintainers
 
@@ -141,6 +146,5 @@ YourKit is supporting this open source project with its [YourKit Java Profiler](
 
 JetBrains is supporting this open source project with:
 
-[![Intellij IDEA](http://www.jetbrains.com/img/logos/logo_intellij_idea.png)]
-(http://www.jetbrains.com/idea/)
+[![Intellij IDEA](http://www.jetbrains.com/img/logos/logo_intellij_idea.png)](http://www.jetbrains.com/idea/)
 


### PR DESCRIPTION
When first checking out the project + running the commands to build and test the driver several tests fail with "Too many open files" errors causing the suite to hang and server to crash.

This pull request helps new users get up and running quickly by stating a `ulimit` command that can be used. I also provided the subsequent command to start a local `mongod` using this limit.

There was a broken build status image/link pointing to 10gen which looks old/legacy so I removed it.

Also fixed intellij image showing extra braces due to an extra line break