### PR TITLE
Fixed wrong static imports in builders documentation

### DIFF
--- a/docs/reference/content/builders/aggregation.md
+++ b/docs/reference/content/builders/aggregation.md
@@ -17,7 +17,7 @@ pipeline operators]({{< docsref "reference/operator/aggregation/" >}}).  Each me
 For brevity, you may choose to import the methods of the `Aggregates` class statically:
 
 ```java
-import com.mongodb.client.model.Aggregates.*;
+import static com.mongodb.client.model.Aggregates.*;
 ```
 
 All the examples below assume this static import.

--- a/docs/reference/content/builders/filters.md
+++ b/docs/reference/content/builders/filters.md
@@ -16,7 +16,7 @@ any method that expects a query filter.
 For brevity, you may choose to import the methods of the `Filters` class statically:
 
 ```java
-import com.mongodb.client.model.Filters.*;
+import static com.mongodb.client.model.Filters.*;
 ```
   
 All the examples below assume this static import.

--- a/docs/reference/content/builders/indexes.md
+++ b/docs/reference/content/builders/indexes.md
@@ -16,7 +16,7 @@ methods.
 For brevity, you may choose to import the methods of the `Indexes` class statically:
 
 ```java
-import com.mongodb.client.model.Indexes.*;
+import static com.mongodb.client.model.Indexes.*;
 ```
 
 All the examples below assume this static import.

--- a/docs/reference/content/builders/sorts.md
+++ b/docs/reference/content/builders/sorts.md
@@ -16,7 +16,7 @@ any method that expects sort criteria.
 For brevity, you may choose to import the methods of the `Sorts` class statically:
 
 ```java
-import com.mongodb.client.model.Sorts.*;
+import static com.mongodb.client.model.Sorts.*;
 ```
   
 All the examples below assume this static import.

--- a/docs/reference/content/builders/updates.md
+++ b/docs/reference/content/builders/updates.md
@@ -16,7 +16,7 @@ any method that expects an update.
 For brevity, you may choose to import the methods of the `Updates` class statically:
 
 ```java
-import com.mongodb.client.model.Updates.*;
+import static com.mongodb.client.model.Updates.*;
 ```
   
 All the examples below assume this static import.


### PR DESCRIPTION
This PR fixes wrong import statements in the following builder documentation pages:

* aggregation
* filters
* indexes
* sorts
* updates