### PR TITLE
Update to FloatCodec to support negative numbers

### DIFF
--- a/bson/src/main/org/bson/codecs/FloatCodec.java
+++ b/bson/src/main/org/bson/codecs/FloatCodec.java
@@ -36,7 +36,7 @@ public class FloatCodec implements Codec<Float> {
     @Override
     public Float decode(final BsonReader reader, final DecoderContext decoderContext) {
         double value = reader.readDouble();
-        if (value < Float.MIN_VALUE || value > Float.MAX_VALUE) {
+        if (value < -Float.MAX_VALUE || value > Float.MAX_VALUE) {
             throw new BsonInvalidOperationException(format("%s can not be converted into a Float.", value));
         }
         return (float) value;

--- a/bson/src/test/unit/org/bson/codecs/FloatCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/FloatCodecTest.java
@@ -36,9 +36,14 @@ public final class FloatCodecTest extends CodecTestCase {
         roundTrip(new Document("a", new Float(1)));
     }
 
+    @Test
+    public void shouldRoundTripNegativeFloatValues() {
+        roundTrip(new Document("a", new Float(-1)));
+    }
+
     @Test(expected = BsonInvalidOperationException.class)
     public void shouldErrorDecodingOutsideMinRange() {
-        roundTrip(new Document("a", Double.MIN_VALUE));
+        roundTrip(new Document("a", -Double.MAX_VALUE));
     }
 
     @Test(expected = BsonInvalidOperationException.class)


### PR DESCRIPTION
in Java, the most negative number for a float is  -Float.MAX_VALUE, not Float.MIN_VALUE.   The original code would not parse any negative numbers are smaller than Float.MIN_VALUE.   Float.MIN_VALUE is the smallest positive number.

I have also updated the unit test to properly check negative bounds using -Double.MAX_VALUE as opposed to Double.MIN_VALUE.   Added a test to check for passing of a negative number properly