### PR TITLE
Support Unix domain sockets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 
 def configDir = new File(rootDir, 'config')
+ext.jnrUnixsocketVersion = '0.18'
 ext.nettyVersion = '4.1.17.Final'
 ext.snappyVersion = '1.1.4'
 

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -29,6 +29,7 @@ clirr {
 dependencies {
     compile project(':bson')
 
+    compile "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
     compile "io.netty:netty-buffer:$nettyVersion", optional
     compile "io.netty:netty-transport:$nettyVersion", optional
     compile "io.netty:netty-handler:$nettyVersion", optional

--- a/driver-core/src/main/com/mongodb/ServerAddress.java
+++ b/driver-core/src/main/com/mongodb/ServerAddress.java
@@ -17,7 +17,9 @@
 package com.mongodb;
 
 import com.mongodb.annotations.Immutable;
+import jnr.unixsocket.UnixSocketAddress;
 
+import java.io.File;
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -86,6 +88,15 @@ public class ServerAddress implements Serializable {
      */
     public ServerAddress(final ServerAddress serverAddress) {
         this(serverAddress.host, serverAddress.port, serverAddress.address);
+    }
+
+    /**
+     * Creates a ServerAddress
+     *
+     * @param path the file used for the Unix domain socket
+     */
+    public ServerAddress(final File path) {
+        this(path.toString(), 0, new UnixSocketAddress(path));
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/ServerAddress.java
+++ b/driver-core/src/main/com/mongodb/ServerAddress.java
@@ -21,6 +21,7 @@ import com.mongodb.annotations.Immutable;
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.UnknownHostException;
 
 /**
@@ -32,7 +33,7 @@ public class ServerAddress implements Serializable {
 
     private final String host;
     private final int port;
-    private final InetSocketAddress address;
+    private final SocketAddress address;
 
     /**
      * Creates a ServerAddress with default host and port
@@ -94,7 +95,7 @@ public class ServerAddress implements Serializable {
      * @param port mongod port
      * @param address an instance of socket address or `null`
      */
-    protected ServerAddress(final String host, final int port, final InetSocketAddress address) {
+    protected ServerAddress(final String host, final int port, final SocketAddress address) {
         this.host = host;
         this.port = port;
         this.address = address;
@@ -205,7 +206,7 @@ public class ServerAddress implements Serializable {
      *
      * @return socket address
      */
-    public InetSocketAddress getSocketAddress() {
+    public SocketAddress getSocketAddress() {
         if (address != null) {
             return address;
         }

--- a/driver-core/src/main/com/mongodb/ServerAddress.java
+++ b/driver-core/src/main/com/mongodb/ServerAddress.java
@@ -32,6 +32,7 @@ public class ServerAddress implements Serializable {
 
     private final String host;
     private final int port;
+    private final InetSocketAddress address;
 
     /**
      * Creates a ServerAddress with default host and port
@@ -55,7 +56,7 @@ public class ServerAddress implements Serializable {
      * @param inetAddress host address
      */
     public ServerAddress(final InetAddress inetAddress) {
-        this(inetAddress.getHostName(), defaultPort());
+        this(inetAddress.getHostName(), defaultPort(), new InetSocketAddress(inetAddress, defaultPort()));
     }
 
     /**
@@ -65,7 +66,7 @@ public class ServerAddress implements Serializable {
      * @param port        mongod port
      */
     public ServerAddress(final InetAddress inetAddress, final int port) {
-        this(inetAddress.getHostName(), port);
+        this(inetAddress.getHostName(), port, new InetSocketAddress(inetAddress, port));
     }
 
     /**
@@ -74,7 +75,20 @@ public class ServerAddress implements Serializable {
      * @param inetSocketAddress inet socket address containing hostname and port
      */
     public ServerAddress(final InetSocketAddress inetSocketAddress) {
-        this(inetSocketAddress.getAddress(), inetSocketAddress.getPort());
+        this(inetSocketAddress.getHostName(), inetSocketAddress.getPort(), inetSocketAddress);
+    }
+
+    /**
+     * Creates a ServerAddress - intended for internal usage
+     *
+     * @param host hostname
+     * @param port mongod port
+     * @param address an instance of socket address or `null`
+     */
+    protected ServerAddress(final String host, final int port, final InetSocketAddress address) {
+        this.host = host;
+        this.port = port;
+        this.address = address;
     }
 
     /**
@@ -127,6 +141,7 @@ public class ServerAddress implements Serializable {
         }
         this.host = hostToUse.toLowerCase();
         this.port = portToUse;
+        this.address = null;
     }
 
     @Override
@@ -182,6 +197,9 @@ public class ServerAddress implements Serializable {
      * @return socket address
      */
     public InetSocketAddress getSocketAddress() {
+        if (address != null) {
+            return address;
+        }
         try {
             return new InetSocketAddress(InetAddress.getByName(host), port);
         } catch (UnknownHostException e) {

--- a/driver-core/src/main/com/mongodb/ServerAddress.java
+++ b/driver-core/src/main/com/mongodb/ServerAddress.java
@@ -79,6 +79,15 @@ public class ServerAddress implements Serializable {
     }
 
     /**
+     * Creates a ServerAddress
+     *
+     * @param serverAddress an instance to be shallow-copied
+     */
+    public ServerAddress(final ServerAddress serverAddress) {
+        this(serverAddress.host, serverAddress.port, serverAddress.address);
+    }
+
+    /**
      * Creates a ServerAddress - intended for internal usage
      *
      * @param host hostname

--- a/driver-core/src/main/com/mongodb/connection/ClusterSettings.java
+++ b/driver-core/src/main/com/mongodb/connection/ClusterSettings.java
@@ -127,7 +127,7 @@ public final class ClusterSettings {
             Set<ServerAddress> hostsSet = new LinkedHashSet<ServerAddress>(hosts.size());
             for (ServerAddress host : hosts) {
                 notNull("host", host);
-                hostsSet.add(new ServerAddress(host.getHost(), host.getPort()));
+                hostsSet.add(new ServerAddress(host));
             }
             this.hosts = unmodifiableList(new ArrayList<ServerAddress>(hostsSet));
             return this;

--- a/driver-core/src/main/com/mongodb/connection/SocketChannelStream.java
+++ b/driver-core/src/main/com/mongodb/connection/SocketChannelStream.java
@@ -19,6 +19,8 @@ package com.mongodb.connection;
 import com.mongodb.MongoSocketOpenException;
 import com.mongodb.MongoSocketReadException;
 import com.mongodb.ServerAddress;
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixSocketChannel;
 import org.bson.ByteBuf;
 
 import java.io.IOException;
@@ -48,8 +50,12 @@ class SocketChannelStream implements Stream {
     @Override
     public void open() throws IOException {
         try {
-            socketChannel = SocketChannel.open();
-            SocketStreamHelper.initialize(socketChannel.socket(), address, settings, sslSettings);
+            if (address.getSocketAddress() instanceof UnixSocketAddress) {
+                socketChannel = UnixSocketChannel.open((UnixSocketAddress) address.getSocketAddress());
+            } else {
+                socketChannel = SocketChannel.open();
+                SocketStreamHelper.initialize(socketChannel.socket(), address, settings, sslSettings);
+            }
         } catch (IOException e) {
             close();
             throw new MongoSocketOpenException("Exception opening socket", getAddress(), e);

--- a/driver-core/src/main/com/mongodb/connection/SocketStreamFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/SocketStreamFactory.java
@@ -24,6 +24,8 @@ import javax.net.SocketFactory;
 import javax.net.ssl.SSLContext;
 import java.security.NoSuchAlgorithmException;
 
+import jnr.unixsocket.UnixSocketAddress;
+
 import static com.mongodb.assertions.Assertions.notNull;
 
 /**
@@ -63,7 +65,9 @@ public class SocketStreamFactory implements StreamFactory {
     @Override
     public Stream create(final ServerAddress serverAddress) {
         Stream stream;
-        if (socketFactory != null) {
+        if (serverAddress.getSocketAddress() instanceof UnixSocketAddress) {
+            stream = new SocketChannelStream(serverAddress, settings, sslSettings, bufferProvider);
+        } else if (socketFactory != null) {
             stream = new SocketStream(serverAddress, settings, sslSettings, socketFactory, bufferProvider);
         } else if (sslSettings.isEnabled()) {
             stream = new SocketStream(serverAddress, settings, sslSettings, getSslContext().getSocketFactory(), bufferProvider);

--- a/mongo-java-driver/build.gradle
+++ b/mongo-java-driver/build.gradle
@@ -27,6 +27,7 @@ idea {
 
 // dependencies copied from driver-core
 dependencies {
+    compile "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
     compile "io.netty:netty-buffer:$nettyVersion", optional
     compile "io.netty:netty-transport:$nettyVersion", optional
     compile "io.netty:netty-handler:$nettyVersion", optional


### PR DESCRIPTION
I found this piece of code, which unfortunately does not work with the official Mongo driver:
http://www.allanbank.com/mongodb-async-driver/userguide/unix_domain_sockets.html

This pull request does a couple of things that should fix the incompatibilities that I observed that prevented `junixsocket` from working.

Unix sockets aside - I think these changes make sense on their own.