### PR TITLE
Typo : missing quote in toString method's result

### DIFF
--- a/driver-core/src/main/com/mongodb/DBRef.java
+++ b/driver-core/src/main/com/mongodb/DBRef.java
@@ -123,7 +123,7 @@ public class DBRef implements Serializable {
     @Override
     public String toString() {
         return "{ "
-                       + "\"$ref\" : \"" + collectionName + "\", \"$id\" : \"" + id + ""
+                       + "\"$ref\" : \"" + collectionName + "\", \"$id\" : \"" + id + "\""
                        + (databaseName == null ? "" : ", \"$db\" : \"" + databaseName + "\"")
                        + " }";
     }


### PR DESCRIPTION
No bug here, jus a typo : a missing quote for the id value in the toString method.