### PR TITLE
Support BsonCreator with BsonProperty renaming

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/ClassModelBuilder.java
+++ b/bson/src/main/org/bson/codecs/pojo/ClassModelBuilder.java
@@ -43,7 +43,7 @@ import static org.bson.codecs.pojo.PojoBuilderHelper.stateNotNull;
  * @see ClassModel
  */
 public class ClassModelBuilder<T> {
-    private static final String ID_PROPERTY_NAME = "_id";
+    static final String ID_PROPERTY_NAME = "_id";
     private final List<PropertyModelBuilder<?>> propertyModelBuilders = new ArrayList<PropertyModelBuilder<?>>();
     private InstanceCreatorFactory<T> instanceCreatorFactory;
     private Class<T> type;

--- a/bson/src/main/org/bson/codecs/pojo/ConventionAnnotationImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/ConventionAnnotationImpl.java
@@ -170,7 +170,8 @@ final class ConventionAnnotationImpl implements Convention {
                     }
 
                     if (propertyModelBuilder == null) {
-                        propertyModelBuilder = addCreatorPropertyToClassModelBuilder(classModelBuilder, bsonProperty.value(), parameterType);
+                        propertyModelBuilder = addCreatorPropertyToClassModelBuilder(classModelBuilder, bsonProperty.value(),
+                            parameterType);
                     } else {
                         // An existing property is found, set its write name
                         propertyModelBuilder.writeName(bsonProperty.value());
@@ -186,10 +187,11 @@ final class ConventionAnnotationImpl implements Convention {
         }
     }
 
-    private <T, S> PropertyModelBuilder<S> addCreatorPropertyToClassModelBuilder(final ClassModelBuilder<T> classModelBuilder, final String name,
-                                                              final Class<S> clazz) {
-        PropertyModelBuilder<S> propertyModelBuilder = createPropertyModelBuilder(new PropertyMetadata<S>(name, classModelBuilder.getType().getSimpleName(),
-            TypeData.builder(clazz).build())).readName(null).writeName(name);
+    private <T, S> PropertyModelBuilder<S> addCreatorPropertyToClassModelBuilder(final ClassModelBuilder<T> classModelBuilder,
+                                                                                 final String name,
+                                                                                 final Class<S> clazz) {
+        PropertyModelBuilder<S> propertyModelBuilder = createPropertyModelBuilder(new PropertyMetadata<S>(name,
+            classModelBuilder.getType().getSimpleName(), TypeData.builder(clazz).build())).readName(null).writeName(name);
         classModelBuilder.addProperty(propertyModelBuilder);
         return propertyModelBuilder;
     }

--- a/bson/src/main/org/bson/codecs/pojo/ConventionAnnotationImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/ConventionAnnotationImpl.java
@@ -138,26 +138,34 @@ final class ConventionAnnotationImpl implements Convention {
             for (int i = 0; i < properties.size(); i++) {
                 BsonProperty bsonProperty = properties.get(i);
                 Class<?> parameterType = parameterTypes.get(i);
-                PropertyModelBuilder<?> propertyModelBuilder = null;
-                if ("_id".equals(bsonProperty.value())) {
-                    // Special case for ID properties
-                    propertyModelBuilder = classModelBuilder.getProperty(classModelBuilder.getIdPropertyName());
-                } else {
-                    // Find the property using write name and falls back to read name
-                    for (PropertyModelBuilder<?> builder : classModelBuilder.getPropertyModelBuilders()) {
-                        if (builder.getWriteName().equals(bsonProperty.value())) {
-                            // When there is a property that matches the write name of the parameter, use it and stop looking
-                            propertyModelBuilder = builder;
-                            break;
-                        }
+                // BsonProperty value should be the BSON property name (write name). However, in legacy, when BsonProperty is used
+                // in BsonCreator parameters, it is mapped to the actual POJO property name (e.g. method name or field name).
+                // To support it, we still need to look it up.
+                PropertyModelBuilder<?> propertyModelBuilder = classModelBuilder.getProperty(bsonProperty.value());
 
-                        if (builder.getReadName().equals(bsonProperty.value())) {
-                            // When there is a property that matches the read name of the parameter, save it but continue to look
-                            // This is so just in case there is another property that matches the write name.
-                            propertyModelBuilder = builder;
+                if (propertyModelBuilder == null) {
+                    // When the property cannot be found in the legacy way
+                    if ("_id".equals(bsonProperty.value())) {
+                        // Special case for ID properties
+                        propertyModelBuilder = classModelBuilder.getProperty(classModelBuilder.getIdPropertyName());
+                    } else {
+                        // Find the property using write name and falls back to read name
+                        for (PropertyModelBuilder<?> builder : classModelBuilder.getPropertyModelBuilders()) {
+                            if (bsonProperty.value().equals(builder.getWriteName())) {
+                                // When there is a property that matches the write name of the parameter, use it and stop looking
+                                propertyModelBuilder = builder;
+                                break;
+                            }
+
+                            if (bsonProperty.value().equals(builder.getReadName())) {
+                                // When there is a property that matches the read name of the parameter, save it but continue to look
+                                // This is so just in case there is another property that matches the write name.
+                                propertyModelBuilder = builder;
+                            }
                         }
                     }
                 }
+
                 if (propertyModelBuilder == null) {
                     addCreatorPropertyToClassModelBuilder(classModelBuilder, bsonProperty.value(), parameterType);
                 } else if (!propertyModelBuilder.getTypeData().isAssignableFrom(parameterType)) {

--- a/bson/src/main/org/bson/codecs/pojo/InstanceCreatorImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/InstanceCreatorImpl.java
@@ -54,11 +54,20 @@ final class InstanceCreatorImpl<T> implements InstanceCreator<T> {
             propertyModel.getPropertyAccessor().set(newInstance, value);
         } else {
             if (!properties.isEmpty()) {
-                Integer index = properties.get(propertyModel.getName());
+                String propertyName = propertyModel.getWriteName();
+
+                if (!properties.containsKey(propertyName)) {
+                    // If the property name cannot be found using write name, falls back to the property name
+                    // This is to provide backward compatibility with the legacy BsonProperty annotation on
+                    // BsonCreator parameters
+                    propertyName = propertyModel.getName();
+                }
+
+                Integer index = properties.get(propertyName);
                 if (index != null) {
                     params[index] = value;
                 }
-                properties.remove(propertyModel.getName());
+                properties.remove(propertyName);
             }
 
             if (properties.isEmpty()) {

--- a/bson/src/main/org/bson/codecs/pojo/InstanceCreatorImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/InstanceCreatorImpl.java
@@ -17,7 +17,6 @@
 package org.bson.codecs.pojo;
 
 import org.bson.codecs.configuration.CodecConfigurationException;
-import org.bson.codecs.pojo.annotations.BsonProperty;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/bson/src/main/org/bson/codecs/pojo/InstanceCreatorImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/InstanceCreatorImpl.java
@@ -17,6 +17,7 @@
 package org.bson.codecs.pojo;
 
 import org.bson.codecs.configuration.CodecConfigurationException;
+import org.bson.codecs.pojo.annotations.BsonProperty;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -41,9 +42,18 @@ final class InstanceCreatorImpl<T> implements InstanceCreator<T> {
         } else {
             this.cachedValues = new HashMap<PropertyModel<?>, Object>();
             this.properties = new HashMap<String, Integer>();
-            for (int i = 0; i < creatorExecutable.getProperties().size(); i++) {
-                this.properties.put(creatorExecutable.getProperties().get(i).value(), i);
+
+            if (creatorExecutable.getIdPropertyIndex() != null) {
+              this.properties.put(ClassModelBuilder.ID_PROPERTY_NAME, creatorExecutable.getIdPropertyIndex());
             }
+
+            for (int i = 0; i < creatorExecutable.getProperties().size(); i++) {
+                if (!Integer.valueOf(i).equals(creatorExecutable.getIdPropertyIndex())) {
+                    // Skip the ID property
+                    this.properties.put(creatorExecutable.getProperties().get(i).value(), i);
+                }
+            }
+
             this.params = new Object[properties.size()];
         }
     }

--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonId.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonId.java
@@ -32,6 +32,6 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD, ElementType.METHOD})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
 public @interface BsonId {
 }

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
@@ -55,7 +55,9 @@ import org.bson.codecs.pojo.entities.SimpleModel;
 import org.bson.codecs.pojo.entities.SimpleNestedPojoModel;
 import org.bson.codecs.pojo.entities.UpperBoundsConcreteModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorAllFinalFieldsModel;
+import org.bson.codecs.pojo.entities.conventions.CreatorConstructorIdModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorConstructorModel;
+import org.bson.codecs.pojo.entities.conventions.CreatorConstructorRenameModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorMethodModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorNoArgsConstructorModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorNoArgsMethodModel;
@@ -230,6 +232,14 @@ public final class PojoRoundTripTest extends PojoTestCase {
         data.add(new TestData("Creator constructor", new CreatorConstructorModel(asList(10, 11), "twelve", 13),
                 getPojoCodecProviderBuilder(CreatorConstructorModel.class),
                 "{'integersField': [10, 11], 'stringField': 'twelve', 'longField': {$numberLong: '13'}}"));
+
+        data.add(new TestData("Creator constructor with rename", new CreatorConstructorRenameModel(asList(10, 11), "twelve", 13),
+            getPojoCodecProviderBuilder(CreatorConstructorRenameModel.class),
+            "{'integerList': [10, 11], 'stringField': 'twelve', 'longField': {$numberLong: '13'}}"));
+
+        data.add(new TestData("Creator constructor with ID", new CreatorConstructorIdModel("1234-34567-890", asList(10, 11), "twelve", 13),
+            getPojoCodecProviderBuilder(CreatorConstructorIdModel.class),
+            "{'_id': '1234-34567-890', integersField': [10, 11], 'stringField': 'twelve', 'longField': {$numberLong: '13'}}"));
 
         data.add(new TestData("Creator no-args constructor", new CreatorNoArgsConstructorModel(40, "one", 42),
                 getPojoCodecProviderBuilder(CreatorNoArgsConstructorModel.class),

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
@@ -239,7 +239,7 @@ public final class PojoRoundTripTest extends PojoTestCase {
 
         data.add(new TestData("Creator constructor with ID", new CreatorConstructorIdModel("1234-34567-890", asList(10, 11), "twelve", 13),
             getPojoCodecProviderBuilder(CreatorConstructorIdModel.class),
-            "{'_id': '1234-34567-890', integersField': [10, 11], 'stringField': 'twelve', 'longField': {$numberLong: '13'}}"));
+            "{'_id': '1234-34567-890', 'integersField': [10, 11], 'stringField': 'twelve', 'longField': {$numberLong: '13'}}"));
 
         data.add(new TestData("Creator no-args constructor", new CreatorNoArgsConstructorModel(40, "one", 42),
                 getPojoCodecProviderBuilder(CreatorNoArgsConstructorModel.class),

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorConstructorIdModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorConstructorIdModel.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bson.codecs.pojo.entities.conventions;
 
 import org.bson.codecs.pojo.annotations.BsonCreator;
@@ -13,7 +29,7 @@ public class CreatorConstructorIdModel {
   public long longField;
 
   @BsonCreator
-  public CreatorConstructorIdModel(@BsonId String id, @BsonProperty("integersField") final List<Integer> integerField,
+  public CreatorConstructorIdModel(final @BsonId String id, @BsonProperty("integersField") final List<Integer> integerField,
       @BsonProperty("longField") final long longField) {
     this.id = id;
     this.integersField = integerField;
@@ -52,7 +68,7 @@ public class CreatorConstructorIdModel {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
@@ -68,8 +84,8 @@ public class CreatorConstructorIdModel {
     if (getId() != null ? !getId().equals(that.getId()) : that.getId() != null) {
       return false;
     }
-    if (getIntegersField() != null ? !getIntegersField().equals(that.getIntegersField()) :
-        that.getIntegersField() != null) {
+    if (getIntegersField() != null ? !getIntegersField().equals(that.getIntegersField())
+        : that.getIntegersField() != null) {
       return false;
     }
     return getStringField() != null ? getStringField().equals(that.getStringField()) : that.getStringField() == null;
@@ -86,11 +102,11 @@ public class CreatorConstructorIdModel {
 
   @Override
   public String toString() {
-    return "CreatorConstructorIdModel{" +
-        "id='" + id + '\'' +
-        ", integersField=" + integersField +
-        ", stringField='" + stringField + '\'' +
-        ", longField=" + longField +
-        '}';
+    return "CreatorConstructorIdModel{"
+        + "id='" + id + '\''
+        + ", integersField=" + integersField
+        + ", stringField='" + stringField + '\''
+        + ", longField=" + longField
+        + '}';
   }
 }

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorConstructorIdModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorConstructorIdModel.java
@@ -13,7 +13,7 @@ public class CreatorConstructorIdModel {
   public long longField;
 
   @BsonCreator
-  public CreatorConstructorIdModel(@BsonProperty("_id") String id, @BsonProperty("integersField") final List<Integer> integerField,
+  public CreatorConstructorIdModel(@BsonId String id, @BsonProperty("integersField") final List<Integer> integerField,
       @BsonProperty("longField") final long longField) {
     this.id = id;
     this.integersField = integerField;

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorConstructorIdModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorConstructorIdModel.java
@@ -1,0 +1,96 @@
+package org.bson.codecs.pojo.entities.conventions;
+
+import org.bson.codecs.pojo.annotations.BsonCreator;
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+import java.util.List;
+
+public class CreatorConstructorIdModel {
+  private final String id;
+  private final List<Integer> integersField;
+  private String stringField;
+  public long longField;
+
+  @BsonCreator
+  public CreatorConstructorIdModel(@BsonProperty("_id") String id, @BsonProperty("integersField") final List<Integer> integerField,
+      @BsonProperty("longField") final long longField) {
+    this.id = id;
+    this.integersField = integerField;
+    this.longField = longField;
+  }
+
+  public CreatorConstructorIdModel(final String id, final List<Integer> integersField, final String stringField, final long longField) {
+    this.id = id;
+    this.integersField = integersField;
+    this.stringField = stringField;
+    this.longField = longField;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public List<Integer> getIntegersField() {
+    return integersField;
+  }
+
+  public String getStringField() {
+    return stringField;
+  }
+
+  public void setStringField(final String stringField) {
+    this.stringField = stringField;
+  }
+
+  public long getLongField() {
+    return longField;
+  }
+
+  public void setLongField(final long longField) {
+    this.longField = longField;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    CreatorConstructorIdModel that = (CreatorConstructorIdModel) o;
+
+    if (getLongField() != that.getLongField()) {
+      return false;
+    }
+    if (getId() != null ? !getId().equals(that.getId()) : that.getId() != null) {
+      return false;
+    }
+    if (getIntegersField() != null ? !getIntegersField().equals(that.getIntegersField()) :
+        that.getIntegersField() != null) {
+      return false;
+    }
+    return getStringField() != null ? getStringField().equals(that.getStringField()) : that.getStringField() == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getId() != null ? getId().hashCode() : 0;
+    result = 31 * result + (getIntegersField() != null ? getIntegersField().hashCode() : 0);
+    result = 31 * result + (getStringField() != null ? getStringField().hashCode() : 0);
+    result = 31 * result + (int) (getLongField() ^ (getLongField() >>> 32));
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "CreatorConstructorIdModel{" +
+        "id='" + id + '\'' +
+        ", integersField=" + integersField +
+        ", stringField='" + stringField + '\'' +
+        ", longField=" + longField +
+        '}';
+  }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorConstructorRenameModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorConstructorRenameModel.java
@@ -1,0 +1,87 @@
+package org.bson.codecs.pojo.entities.conventions;
+
+import org.bson.codecs.pojo.annotations.BsonCreator;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+import java.util.List;
+
+public class CreatorConstructorRenameModel {
+  private final List<Integer> integersField;
+  private String stringField;
+  public long longField;
+
+  @BsonCreator
+  public CreatorConstructorRenameModel(@BsonProperty("integerList") final List<Integer> integerField,
+      @BsonProperty("longField") final long longField) {
+    this.integersField = integerField;
+    this.longField = longField;
+  }
+
+  public CreatorConstructorRenameModel(final List<Integer> integersField, final String stringField, final long longField) {
+    this.integersField = integersField;
+    this.stringField = stringField;
+    this.longField = longField;
+  }
+
+  @BsonProperty("integerList")
+  public List<Integer> getIntegersField() {
+    return integersField;
+  }
+
+  public String getStringField() {
+    return stringField;
+  }
+
+  public void setStringField(final String stringField) {
+    this.stringField = stringField;
+  }
+
+  public long getLongField() {
+    return longField;
+  }
+
+  public void setLongField(final long longField) {
+    this.longField = longField;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    CreatorConstructorRenameModel that = (CreatorConstructorRenameModel) o;
+
+    if (getLongField() != that.getLongField()) {
+      return false;
+    }
+    if (getIntegersField() != null ? !getIntegersField().equals(that.getIntegersField()) : that.getIntegersField() != null) {
+      return false;
+    }
+    if (getStringField() != null ? !getStringField().equals(that.getStringField()) : that.getStringField() != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getIntegersField() != null ? getIntegersField().hashCode() : 0;
+    result = 31 * result + (getStringField() != null ? getStringField().hashCode() : 0);
+    result = 31 * result + (int) (getLongField() ^ (getLongField() >>> 32));
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "CreatorConstructorRenameModel{"
+        + "integersField=" + integersField
+        + ", stringField='" + stringField + "'"
+        + ", longField=" + longField
+        + "}";
+  }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorConstructorRenameModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorConstructorRenameModel.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bson.codecs.pojo.entities.conventions;
 
 import org.bson.codecs.pojo.annotations.BsonCreator;


### PR DESCRIPTION
The existing POJO codec does not work if a property is renamed using @BsonProperty("newName") on the property getter and a @BsonCreator with property @BsonProperty annotations to the parameter.

Also added support of @BsonId annotation to the @BsonCreator's parameter.

To my opinion, the value of @BsonProperty should be mapped to the property name in BSON, regardless where it is annotated. Right now, @BsonProperty value on a @BsonCreator maps to a property getter name. For example, if there is a getter @BsonId getPersonId(), the corresponding constructor parameter annotation should be @BsonId or @BsonProperty("_id) (since '_id' is the property name in BSON), not @BsonProperty("personId") ('personId' does not exist in BSON data). This patch corrects the behavior, but falls back to the old behavior if the new behavior cannot find the right property.