### PR TITLE
Allow discriminators to be used in a collection.

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/PojoCodecImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/PojoCodecImpl.java
@@ -67,29 +67,34 @@ final class PojoCodecImpl<T> extends PojoCodec<T> {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void encode(final BsonWriter writer, final T value, final EncoderContext encoderContext) {
         if (!specialized) {
             throw new CodecConfigurationException(format("%s contains generic types that have not been specialised.%n"
                             + "Top level classes with generic types are not supported by the PojoCodec.", classModel.getName()));
         }
-        writer.writeStartDocument();
-        PropertyModel<?> idPropertyModel = classModel.getIdPropertyModel();
-        if (idPropertyModel != null) {
-            encodeProperty(writer, value, encoderContext, idPropertyModel);
-        }
-
-        if (classModel.useDiscriminator()) {
-            writer.writeString(classModel.getDiscriminatorKey(), classModel.getDiscriminator());
-        }
-
-        for (PropertyModel<?> propertyModel : classModel.getPropertyModels()) {
-            if (propertyModel.equals(classModel.getIdPropertyModel())) {
-                continue;
+        if (areEquivalentTypes(value.getClass(), classModel.getType())) {
+            writer.writeStartDocument();
+            PropertyModel<?> idPropertyModel = classModel.getIdPropertyModel();
+            if (idPropertyModel != null) {
+                encodeProperty(writer, value, encoderContext, idPropertyModel);
             }
-            encodeProperty(writer, value, encoderContext, propertyModel);
+
+            if (classModel.useDiscriminator()) {
+                writer.writeString(classModel.getDiscriminatorKey(), classModel.getDiscriminator());
+            }
+
+            for (PropertyModel<?> propertyModel : classModel.getPropertyModels()) {
+                if (propertyModel.equals(classModel.getIdPropertyModel())) {
+                    continue;
+                }
+                encodeProperty(writer, value, encoderContext, propertyModel);
+            }
+            writer.writeEndDocument();
+        } else {
+            ((Codec<T>) registry.get(value.getClass())).encode(writer, value, encoderContext);
         }
-        writer.writeEndDocument();
     }
 
     @Override
@@ -132,7 +137,7 @@ final class PojoCodecImpl<T> extends PojoCodec<T> {
                 if (propertyValue == null) {
                     writer.writeNull();
                 } else {
-                    getInstanceCodec(propertyModel, propertyValue.getClass()).encode(writer, propertyValue, encoderContext);
+                    propertyModel.getCachedCodec().encode(writer, propertyValue, encoderContext);
                 }
             }
         }
@@ -205,15 +210,6 @@ final class PojoCodecImpl<T> extends PojoCodec<T> {
             codec = getCodecFromClass(head);
         }
 
-        return codec;
-    }
-
-    @SuppressWarnings("unchecked")
-    private <S, V> Codec<S> getInstanceCodec(final PropertyModel<S> propertyModel, final Class<V> instanceType) {
-        Codec<S> codec = propertyModel.getCachedCodec();
-        if (!areEquivalentTypes(codec.getEncoderClass(), instanceType)) {
-            codec = (Codec<S>) registry.get(instanceType);
-        }
         return codec;
     }
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
@@ -54,17 +54,23 @@ import org.bson.codecs.pojo.entities.SimpleGenericsModel;
 import org.bson.codecs.pojo.entities.SimpleModel;
 import org.bson.codecs.pojo.entities.SimpleNestedPojoModel;
 import org.bson.codecs.pojo.entities.UpperBoundsConcreteModel;
+import org.bson.codecs.pojo.entities.conventions.CollectionDiscriminatorModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorAllFinalFieldsModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorConstructorModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorMethodModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorNoArgsConstructorModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorNoArgsMethodModel;
+import org.bson.codecs.pojo.entities.conventions.Subclass1Model;
+import org.bson.codecs.pojo.entities.conventions.Subclass2Model;
+import org.bson.codecs.pojo.entities.conventions.SuperClassModel;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import static java.lang.String.format;
@@ -155,7 +161,8 @@ public final class PojoRoundTripTest extends PojoTestCase {
         data.add(new TestData("Nested generic holder map", getNestedGenericHolderMapModel(),
                 getPojoCodecProviderBuilder(NestedGenericHolderMapModel.class,
                         GenericHolderModel.class, SimpleGenericsModel.class, SimpleModel.class),
-                "{ 'nested': { 'myGenericField': {'s': " + SIMPLE_MODEL_JSON + "}, 'myLongField': {'$numberLong': '1'}}}"));
+                "{ 'nested': { 'myGenericField': {'s': " + SIMPLE_MODEL_JSON
+                        + "}, 'myLongField': {'$numberLong': '1'}}}"));
 
         data.add(new TestData("Nested reused generic", getNestedReusedGenericsModel(),
                 getPojoCodecProviderBuilder(NestedReusedGenericsModel.class, ReusedGenericsModel.class, SimpleModel.class),
@@ -260,6 +267,16 @@ public final class PojoRoundTripTest extends PojoTestCase {
                 new ContainsAlternativeMapAndCollectionModel(BsonDocument.parse("{customList: [1,2,3], customMap: {'field': 'value'}}")),
                 getPojoCodecProviderBuilder(ContainsAlternativeMapAndCollectionModel.class),
                 "{customList: [1,2,3], customMap: {'field': 'value'}}"));
+
+        data.add(new TestData("Collection of discriminators", new CollectionDiscriminatorModel().setList(Arrays
+                .asList(new Subclass1Model().setName("abc").setValue(true),
+                        new Subclass2Model().setInteger(234).setValue(false))).setMap(
+                Collections.singletonMap("key", new Subclass2Model().setInteger(123).setValue(true))),
+                getPojoCodecProviderBuilder(CollectionDiscriminatorModel.class, SuperClassModel.class, Subclass1Model.class,
+                        Subclass2Model.class),
+                "{list: [{_t:'org.bson.codecs.pojo.entities.conventions.Subclass1Model',value:true,name:'abc'},"
+                        + "{_t:'org.bson.codecs.pojo.entities.conventions.Subclass2Model',value:false,integer:234}],"
+                        + "map:{key:{_t:'org.bson.codecs.pojo.entities.conventions.Subclass2Model',value:true,integer:123}}}"));
 
         return data;
     }

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CollectionDiscriminatorModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CollectionDiscriminatorModel.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import java.util.List;
+import java.util.Map;
+
+public class CollectionDiscriminatorModel {
+    private List<SuperClassModel> list;
+    private Map<String, SuperClassModel> map;
+
+    public List<SuperClassModel> getList() {
+        return list;
+    }
+
+    public CollectionDiscriminatorModel setList(final List<SuperClassModel> list) {
+        this.list = list;
+        return this;
+    }
+
+    public Map<String, SuperClassModel> getMap() {
+        return map;
+    }
+
+    public CollectionDiscriminatorModel setMap(final Map<String, SuperClassModel> map) {
+        this.map = map;
+        return this;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CollectionDiscriminatorModel that = (CollectionDiscriminatorModel) o;
+
+        if (getList() != null ? !getList().equals(that.getList()) : that.getList() != null) {
+            return false;
+        }
+        return getMap() != null ? getMap().equals(that.getMap()) : that.getMap() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getList() != null ? getList().hashCode() : 0;
+        result = 31 * result + (getMap() != null ? getMap().hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "CollectionDiscriminatorModel{"
+                + "list=" + list
+                + ", map=" + map
+                + '}';
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/Subclass1Model.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/Subclass1Model.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+@BsonDiscriminator
+public class Subclass1Model extends SuperClassModel {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public Subclass1Model setName(final String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        Subclass1Model that = (Subclass1Model) o;
+
+        return getName() != null ? getName().equals(that.getName()) : that.getName() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (getName() != null ? getName().hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Subclass1Model{"
+                + "name='" + name + '\''
+                + "} " + super.toString();
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/Subclass2Model.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/Subclass2Model.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+@BsonDiscriminator
+public class Subclass2Model extends SuperClassModel {
+    private int integer;
+
+    public int getInteger() {
+        return integer;
+    }
+
+    public Subclass2Model setInteger(final int integer) {
+        this.integer = integer;
+        return this;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        Subclass2Model that = (Subclass2Model) o;
+
+        return getInteger() == that.getInteger();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + getInteger();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Subclass2Model{"
+                + "integer=" + integer
+                + "} " + super.toString();
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/SuperClassModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/SuperClassModel.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+@BsonDiscriminator
+public abstract class SuperClassModel {
+    private boolean value;
+
+    public boolean isValue() {
+        return value;
+    }
+
+    public SuperClassModel setValue(final boolean value) {
+        this.value = value;
+        return this;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SuperClassModel that = (SuperClassModel) o;
+
+        return isValue() == that.isValue();
+    }
+
+    @Override
+    public int hashCode() {
+        return (isValue() ? 1 : 0);
+    }
+
+    @Override
+    public String toString() {
+        return "SuperClassModel{"
+                + "value=" + value
+                + '}';
+    }
+}


### PR DESCRIPTION
Right now, there is no way to serialize/deserialize a collection of abstract class or interface correctly, even though BsonDiscriminator annotation is added to all relevant classes (i.e. both parent class and all sub-classes). See the added unit test.
This patch fixes this problem by using the codec of the actual class of the value during encoding instead of the declared class. The decoding already uses a similar process.