### PR TITLE
Pojo Codec fixes with sub-classes and bson creator

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/CollectionCodec.java
+++ b/bson/src/main/org/bson/codecs/pojo/CollectionCodec.java
@@ -69,7 +69,7 @@ final class CollectionCodec<T> implements Codec<Collection<T>> {
         if (encoderClass.isInterface()) {
             if (encoderClass.isAssignableFrom(ArrayList.class)) {
                 return new ArrayList<T>();
-            } else if (encoderClass.isAssignableFrom(HashSet.class) ){
+            } else if (encoderClass.isAssignableFrom(HashSet.class)) {
                 return new HashSet<T>();
             } else {
                 throw new CodecConfigurationException(format("Unsupported Collection interface of %s!", encoderClass.getName()));

--- a/bson/src/main/org/bson/codecs/pojo/CollectionCodec.java
+++ b/bson/src/main/org/bson/codecs/pojo/CollectionCodec.java
@@ -24,7 +24,11 @@ import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 import org.bson.codecs.configuration.CodecConfigurationException;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+
+import static java.lang.String.format;
 
 
 final class CollectionCodec<T> implements Codec<Collection<T>> {
@@ -62,6 +66,16 @@ final class CollectionCodec<T> implements Codec<Collection<T>> {
     }
 
     private Collection<T> getInstance() {
+        if (encoderClass.isInterface()) {
+            if (encoderClass.isAssignableFrom(ArrayList.class)) {
+                return new ArrayList<T>();
+            } else if (encoderClass.isAssignableFrom(HashSet.class) ){
+                return new HashSet<T>();
+            } else {
+                throw new CodecConfigurationException(format("Unsupported Collection interface of %s!", encoderClass.getName()));
+            }
+        }
+
         try {
             return encoderClass.getDeclaredConstructor().newInstance();
         } catch (final Exception e) {

--- a/bson/src/main/org/bson/codecs/pojo/ConventionAnnotationImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/ConventionAnnotationImpl.java
@@ -123,8 +123,8 @@ final class ConventionAnnotationImpl implements Convention {
                                 throw new CodecConfigurationException("Found multiple constructors / methods annotated with @BsonCreator");
                             } else if (!bsonCreatorClass.isAssignableFrom(method.getReturnType())) {
                                 throw new CodecConfigurationException(
-                                        format("Invalid method annotated with @BsonCreator. Returns '%s', expected %s", method.getReturnType(),
-                                                bsonCreatorClass));
+                                        format("Invalid method annotated with @BsonCreator. Returns '%s', expected %s",
+                                                method.getReturnType(), bsonCreatorClass));
                             }
                             creatorExecutable = new CreatorExecutable<T>(clazz, method);
                             foundStaticBsonCreatorMethod = true;
@@ -149,7 +149,7 @@ final class ConventionAnnotationImpl implements Convention {
                 Class<?> parameterType = parameterTypes.get(i);
                 Type genericType = parameterGenericTypes.get(i);
                 PropertyModelBuilder<Object> propertyModelBuilder =
-                        (PropertyModelBuilder<Object>)classModelBuilder.getProperty(bsonProperty.value());
+                        (PropertyModelBuilder<Object>) classModelBuilder.getProperty(bsonProperty.value());
                 if (propertyModelBuilder == null) {
                     addCreatorPropertyToClassModelBuilder(classModelBuilder, bsonProperty.value(), parameterType);
                 } else if (parameterType.isAssignableFrom(propertyModelBuilder.getTypeData().getType())) {
@@ -169,7 +169,7 @@ final class ConventionAnnotationImpl implements Convention {
 
     @SuppressWarnings("unchecked")
     private static <T> TypeData<T> newTypeData(final Type genericType, final Class<?> clazz) {
-        return TypeData.newInstance(genericType, (Class<T>)clazz);
+        return TypeData.newInstance(genericType, (Class<T>) clazz);
     }
 
     private <T, S> void addCreatorPropertyToClassModelBuilder(final ClassModelBuilder<T> classModelBuilder, final String name,

--- a/bson/src/main/org/bson/codecs/pojo/ConventionAnnotationImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/ConventionAnnotationImpl.java
@@ -27,6 +27,7 @@ import org.bson.codecs.pojo.annotations.BsonProperty;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -111,36 +112,52 @@ final class ConventionAnnotationImpl implements Convention {
             }
         }
 
-        for (Method method : clazz.getDeclaredMethods()) {
-            if (isStatic(method.getModifiers())) {
-                for (Annotation annotation : method.getDeclaredAnnotations()) {
-                    if (annotation.annotationType().equals(BsonCreator.class)) {
-                        if (creatorExecutable != null) {
-                            throw new CodecConfigurationException("Found multiple constructors / methods annotated with @BsonCreator");
-                        } else if (!clazz.isAssignableFrom(method.getReturnType())) {
-                            throw new CodecConfigurationException(
-                                    format("Invalid method annotated with @BsonCreator. Returns '%s', expected %s", method.getReturnType(),
-                                            clazz));
+        Class<?> bsonCreatorClass = clazz;
+        boolean foundStaticBsonCreatorMethod = false;
+        while (bsonCreatorClass != null && !foundStaticBsonCreatorMethod) {
+            for (Method method : bsonCreatorClass.getDeclaredMethods()) {
+                if (isStatic(method.getModifiers())) {
+                    for (Annotation annotation : method.getDeclaredAnnotations()) {
+                        if (annotation.annotationType().equals(BsonCreator.class)) {
+                            if (creatorExecutable != null) {
+                                throw new CodecConfigurationException("Found multiple constructors / methods annotated with @BsonCreator");
+                            } else if (!bsonCreatorClass.isAssignableFrom(method.getReturnType())) {
+                                throw new CodecConfigurationException(
+                                        format("Invalid method annotated with @BsonCreator. Returns '%s', expected %s", method.getReturnType(),
+                                                bsonCreatorClass));
+                            }
+                            creatorExecutable = new CreatorExecutable<T>(clazz, method);
+                            foundStaticBsonCreatorMethod = true;
+                            break;
                         }
-                        creatorExecutable = new CreatorExecutable<T>(clazz, method);
-                        break;
                     }
                 }
             }
+
+            bsonCreatorClass = bsonCreatorClass.getSuperclass();
         }
 
         if (creatorExecutable != null) {
             List<BsonProperty> properties = creatorExecutable.getProperties();
             List<Class<?>> parameterTypes = creatorExecutable.getParameterTypes();
+            List<Type> parameterGenericTypes = creatorExecutable.getParameterGenericTypes();
             if (properties.size() != parameterTypes.size()) {
                 throw creatorExecutable.getError(clazz, "All parameters must be annotated with a @BsonProperty in %s");
             }
             for (int i = 0; i < properties.size(); i++) {
                 BsonProperty bsonProperty = properties.get(i);
                 Class<?> parameterType = parameterTypes.get(i);
-                PropertyModelBuilder<?> propertyModelBuilder = classModelBuilder.getProperty(bsonProperty.value());
+                Type genericType = parameterGenericTypes.get(i);
+                PropertyModelBuilder<Object> propertyModelBuilder =
+                        (PropertyModelBuilder<Object>)classModelBuilder.getProperty(bsonProperty.value());
                 if (propertyModelBuilder == null) {
                     addCreatorPropertyToClassModelBuilder(classModelBuilder, bsonProperty.value(), parameterType);
+                } else if (parameterType.isAssignableFrom(propertyModelBuilder.getTypeData().getType())) {
+                    // The existing getter for this field returns a more specific type than what the constructor accepts
+                    // This is typical when the getter returns a specific subtype, but the constructor accepts a more
+                    // general one (e.g.: getter returns ImmutableList<T>, while constructor just accepts List<T>)
+                    propertyModelBuilder.writeName(bsonProperty.value());
+                    propertyModelBuilder.typeData(newTypeData(genericType, parameterType));
                 } else if (!propertyModelBuilder.getTypeData().isAssignableFrom(parameterType)) {
                     throw creatorExecutable.getError(clazz, format("Invalid Property type for '%s'. Expected %s, found %s.",
                             bsonProperty.value(), propertyModelBuilder.getTypeData().getType(), parameterType));
@@ -148,6 +165,11 @@ final class ConventionAnnotationImpl implements Convention {
             }
             classModelBuilder.instanceCreatorFactory(new InstanceCreatorFactoryImpl<T>(creatorExecutable));
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> TypeData<T> newTypeData(final Type genericType, final Class<?> clazz) {
+        return TypeData.newInstance(genericType, (Class<T>)clazz);
     }
 
     private <T, S> void addCreatorPropertyToClassModelBuilder(final ClassModelBuilder<T> classModelBuilder, final String name,

--- a/bson/src/main/org/bson/codecs/pojo/ConventionAnnotationImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/ConventionAnnotationImpl.java
@@ -156,7 +156,6 @@ final class ConventionAnnotationImpl implements Convention {
                     // The existing getter for this field returns a more specific type than what the constructor accepts
                     // This is typical when the getter returns a specific subtype, but the constructor accepts a more
                     // general one (e.g.: getter returns ImmutableList<T>, while constructor just accepts List<T>)
-                    propertyModelBuilder.writeName(bsonProperty.value());
                     propertyModelBuilder.typeData(newTypeData(genericType, parameterType));
                 } else if (!propertyModelBuilder.getTypeData().isAssignableFrom(parameterType)) {
                     throw creatorExecutable.getError(clazz, format("Invalid Property type for '%s'. Expected %s, found %s.",

--- a/bson/src/main/org/bson/codecs/pojo/CreatorExecutable.java
+++ b/bson/src/main/org/bson/codecs/pojo/CreatorExecutable.java
@@ -22,6 +22,7 @@ import org.bson.codecs.pojo.annotations.BsonProperty;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,6 +35,7 @@ final class CreatorExecutable<T> {
     private final Method method;
     private final List<BsonProperty> properties = new ArrayList<BsonProperty>();
     private final List<Class<?>> parameterTypes = new ArrayList<Class<?>>();
+    private final List<Type> parameterGenericTypes = new ArrayList<Type>();
 
     CreatorExecutable(final Class<T> clazz, final Constructor<T> constructor) {
         this(clazz, constructor, null);
@@ -49,7 +51,10 @@ final class CreatorExecutable<T> {
         this.method = method;
 
         if (constructor != null || method != null) {
-            parameterTypes.addAll(asList(constructor != null ? constructor.getParameterTypes() : method.getParameterTypes()));
+            Class<?>[] paramTypes = constructor != null ? constructor.getParameterTypes() : method.getParameterTypes();
+            Type[] genericParamTypes = constructor != null ? constructor.getGenericParameterTypes() : method.getGenericParameterTypes();
+            parameterTypes.addAll(asList(paramTypes));
+            parameterGenericTypes.addAll(asList(genericParamTypes));
             Annotation[][] parameterAnnotations = constructor != null ? constructor.getParameterAnnotations()
                     : method.getParameterAnnotations();
 
@@ -74,6 +79,10 @@ final class CreatorExecutable<T> {
 
     public List<Class<?>> getParameterTypes() {
         return parameterTypes;
+    }
+
+    public List<Type> getParameterGenericTypes() {
+        return parameterGenericTypes;
     }
 
     @SuppressWarnings("unchecked")

--- a/bson/src/main/org/bson/codecs/pojo/MapCodec.java
+++ b/bson/src/main/org/bson/codecs/pojo/MapCodec.java
@@ -24,6 +24,7 @@ import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 import org.bson.codecs.configuration.CodecConfigurationException;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -64,11 +65,13 @@ final class MapCodec<T> implements Codec<Map<String, T>> {
     }
 
     private Map<String, T> getInstance() {
+        if (encoderClass.isInterface()) {
+            return new HashMap<String, T>();
+        }
         try {
             return encoderClass.getDeclaredConstructor().newInstance();
         } catch (final Exception e) {
             throw new CodecConfigurationException(e.getMessage(), e);
         }
     }
-
 }

--- a/bson/src/main/org/bson/codecs/pojo/PojoBuilderHelper.java
+++ b/bson/src/main/org/bson/codecs/pojo/PojoBuilderHelper.java
@@ -38,9 +38,11 @@ import static java.lang.reflect.Modifier.isPublic;
 import static java.util.Arrays.asList;
 import static java.util.Collections.reverse;
 import static org.bson.assertions.Assertions.notNull;
+import static org.bson.codecs.pojo.PropertyReflectionUtils.isGetter;
+import static org.bson.codecs.pojo.PropertyReflectionUtils.getPropertyMethods;
+import static org.bson.codecs.pojo.PropertyReflectionUtils.toPropertyName;
 
 final class PojoBuilderHelper {
-
     @SuppressWarnings("unchecked")
     static <T> void configureClassModelBuilder(final ClassModelBuilder<T> classModelBuilder, final Class<T> clazz) {
         classModelBuilder.type(notNull("clazz", clazz));
@@ -60,23 +62,34 @@ final class PojoBuilderHelper {
                 genericTypeNames.add(classTypeVariable.getName());
             }
 
-            for (Method method : currentClass.getDeclaredMethods()) {
-                String methodName = method.getName();
-                if (isPropertyMethod(method) && isPublic(method.getModifiers())) {
-                    String propertyName = toPropertyName(methodName);
-                    propertyNames.add(propertyName);
-                    PropertyMetadata<?> propertyMetadata = getOrCreateProperty(propertyName, declaringClassName, propertyNameMap,
-                            getTypeData(method), propertyTypeParameterMap, parentClassTypeData, genericTypeNames, getGenericType(method));
-                    if (isGetter(method) && propertyMetadata.getGetter() == null) {
-                        propertyMetadata.setGetter(method);
-                        for (Annotation annotation : method.getDeclaredAnnotations()) {
-                            propertyMetadata.addReadAnnotation(annotation);
-                        }
-                    } else if (propertyMetadata.getSetter() == null) {
-                        propertyMetadata.setSetter(method);
-                        for (Annotation annotation : method.getDeclaredAnnotations()) {
-                            propertyMetadata.addWriteAnnotation(annotation);
-                        }
+            PropertyReflectionUtils.PropertyMethods propertyMethods = getPropertyMethods(currentClass);
+
+            // Note that we're processing setters before getters. It's typical for setters to have more general types
+            // than getters (e.g.: getter returning ImmutableList, but setter accepting Collection), so by evaluating
+            // setters first, we'll initialize the PropertyMetadata with the more general type
+            for (Method method : propertyMethods.getSetterMethods()) {
+                String propertyName = toPropertyName(method);
+                propertyNames.add(propertyName);
+                PropertyMetadata<?> propertyMetadata = getOrCreateProperty(propertyName, declaringClassName, propertyNameMap,
+                        TypeData.newInstance(method), propertyTypeParameterMap, parentClassTypeData, genericTypeNames, getGenericType(method));
+                if (propertyMetadata.getSetter() == null) {
+                    propertyMetadata.setSetter(method);
+                    for (Annotation annotation : method.getDeclaredAnnotations()) {
+                        propertyMetadata.addWriteAnnotation(annotation);
+                    }
+                }
+            }
+
+            for (Method method : propertyMethods.getGetterMethods()) {
+                String propertyName = toPropertyName(method);
+                propertyNames.add(propertyName);
+                PropertyMetadata<?> propertyMetadata = getOrCreateProperty(propertyName, declaringClassName, propertyNameMap,
+                        TypeData.newInstance(method), propertyTypeParameterMap, parentClassTypeData, genericTypeNames, getGenericType(method));
+
+                if (propertyMetadata.getGetter() == null) {
+                    propertyMetadata.setGetter(method);
+                    for (Annotation annotation : method.getDeclaredAnnotations()) {
+                        propertyMetadata.addReadAnnotation(annotation);
                     }
                 }
             }
@@ -84,7 +97,7 @@ final class PojoBuilderHelper {
             for (Field field : currentClass.getDeclaredFields()) {
                 propertyNames.add(field.getName());
                 PropertyMetadata<?> propertyMetadata = getOrCreateProperty(field.getName(), declaringClassName, propertyNameMap,
-                        getTypeData(field.getGenericType(), field.getType()), propertyTypeParameterMap, parentClassTypeData,
+                        TypeData.newInstance(field), propertyTypeParameterMap, parentClassTypeData,
                         genericTypeNames, field.getGenericType());
                 if (propertyMetadata.getField() == null) {
                     propertyMetadata.field(field);
@@ -95,7 +108,7 @@ final class PojoBuilderHelper {
                 }
             }
 
-            parentClassTypeData = getTypeData(currentClass.getGenericSuperclass(), currentClass);
+            parentClassTypeData = TypeData.newInstance(currentClass.getGenericSuperclass(), currentClass);
             currentClass = currentClass.getSuperclass();
         }
 
@@ -136,7 +149,11 @@ final class PojoBuilderHelper {
             propertyMetadata = new PropertyMetadata<T>(propertyName, declaringClassName, typeData);
             propertyNameMap.put(propertyName, propertyMetadata);
         }
-        if (!propertyMetadata.getTypeData().equals(typeData)) {
+
+        // This allows subsequent invocations for the same property to provide more specific types
+        // (Collection -> ImmutableList). The patterns this method is called in ensures that ordering by evaluating
+        // setters (often accept more general types) before getters (often returns more specific types)
+        if (!propertyMetadata.getTypeData().getType().isAssignableFrom(typeData.getType())) {
             throw new CodecConfigurationException(format("Property '%s' in %s, has differing data types: %s and %s", propertyName,
                     declaringClassName, propertyMetadata.getTypeData(), typeData));
         }
@@ -144,42 +161,6 @@ final class PojoBuilderHelper {
         propertyTypeParameterMap.put(propertyMetadata.getName(), typeParameterMap);
         propertyMetadata.typeParameterInfo(typeParameterMap, parentClassTypeData);
         return propertyMetadata;
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private static <T> TypeData<T> getTypeData(final Type genericType, final Class<T> clazz) {
-        TypeData.Builder<T> builder = TypeData.builder(clazz);
-        if (genericType instanceof ParameterizedType) {
-            ParameterizedType pType = (ParameterizedType) genericType;
-            for (Type argType : pType.getActualTypeArguments()) {
-                getNestedTypeData(builder, argType);
-            }
-        }
-        return builder.build();
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private static <T> void getNestedTypeData(final TypeData.Builder<T> builder, final Type type) {
-        if (type instanceof ParameterizedType) {
-            ParameterizedType pType = (ParameterizedType) type;
-            TypeData.Builder paramBuilder = TypeData.builder((Class) pType.getRawType());
-            for (Type argType : pType.getActualTypeArguments()) {
-                getNestedTypeData(paramBuilder, argType);
-            }
-            builder.addTypeParameter(paramBuilder.build());
-        } else if (type instanceof TypeVariable) {
-            builder.addTypeParameter(TypeData.builder(Object.class).build());
-        } else if (type instanceof Class) {
-            builder.addTypeParameter(TypeData.builder((Class) type).build());
-        }
-    }
-
-    private static TypeData<?> getTypeData(final Method method) {
-        if (isGetter(method)) {
-            return getTypeData(method.getGenericReturnType(), method.getReturnType());
-        } else {
-            return getTypeData(method.getGenericParameterTypes()[0], method.getParameterTypes()[0]);
-        }
     }
 
     private static Type getGenericType(final Method method) {
@@ -227,7 +208,7 @@ final class PojoBuilderHelper {
     private static <V> void specializePropertyModelBuilder(final PropertyModelBuilder<V> propertyModelBuilder,
                                                            final PropertyMetadata<V> propertyMetadata) {
         if (propertyMetadata.getTypeParameterMap().hasTypeParameters() && !propertyMetadata.getTypeParameters().isEmpty()) {
-            TypeData<V> specializedFieldType = propertyModelBuilder.getTypeData();
+            TypeData<V> specializedFieldType;
             Map<Integer, Integer> fieldToClassParamIndexMap = propertyMetadata.getTypeParameterMap().getPropertyToClassParamIndexMap();
             Integer classTypeParamRepresentsWholeField = fieldToClassParamIndexMap.get(-1);
             if (classTypeParamRepresentsWholeField != null) {
@@ -254,42 +235,6 @@ final class PojoBuilderHelper {
             throw new IllegalStateException(format("%s cannot be null", property));
         }
         return value;
-    }
-
-    private static final String IS_PREFIX = "is";
-
-    private static final String GET_PREFIX = "get";
-
-    private static final String SET_PREFIX = "set";
-
-    static boolean isSetter(final Method method) {
-        if (method.getName().startsWith(SET_PREFIX) && method.getName().length() > SET_PREFIX.length()
-            && method.getParameterTypes().length == 1) {
-            return Character.isUpperCase(method.getName().charAt(SET_PREFIX.length()));
-        }
-        return false;
-    }
-
-    static boolean isGetter(final Method method) {
-        if (method.getParameterTypes().length > 0) {
-            return false;
-        } else if (method.getName().startsWith(GET_PREFIX) && method.getName().length() > GET_PREFIX.length()) {
-            return Character.isUpperCase(method.getName().charAt(GET_PREFIX.length()));
-        } else if (method.getName().startsWith(IS_PREFIX) && method.getName().length() > IS_PREFIX.length()) {
-            return Character.isUpperCase(method.getName().charAt(IS_PREFIX.length()));
-        }
-        return false;
-    }
-
-    static boolean isPropertyMethod(final Method method) {
-        return isGetter(method) || isSetter(method);
-    }
-
-    static String toPropertyName(final String name) {
-        String propertyName = name.substring(name.startsWith(IS_PREFIX) ? 2 : 3, name.length());
-        char[] chars = propertyName.toCharArray();
-        chars[0] = Character.toLowerCase(chars[0]);
-        return new String(chars);
     }
 
     private PojoBuilderHelper() {

--- a/bson/src/main/org/bson/codecs/pojo/PojoBuilderHelper.java
+++ b/bson/src/main/org/bson/codecs/pojo/PojoBuilderHelper.java
@@ -84,7 +84,13 @@ final class PojoBuilderHelper {
             for (Method method : propertyMethods.getGetterMethods()) {
                 String propertyName = toPropertyName(method);
                 propertyNames.add(propertyName);
-                PropertyMetadata<?> propertyMetadata = getOrCreateProperty(propertyName, declaringClassName, propertyNameMap,
+                // If the getter is overridden in a subclass, we only want to process that property, and ignore
+                // potentially less specific methods from super classes
+                PropertyMetadata<?> propertyMetadata = propertyNameMap.get(propertyName);
+                if (propertyMetadata != null && propertyMetadata.getGetter() != null) {
+                    continue;
+                }
+                propertyMetadata = getOrCreateProperty(propertyName, declaringClassName, propertyNameMap,
                         TypeData.newInstance(method), propertyTypeParameterMap, parentClassTypeData, genericTypeNames,
                         getGenericType(method));
 

--- a/bson/src/main/org/bson/codecs/pojo/PojoBuilderHelper.java
+++ b/bson/src/main/org/bson/codecs/pojo/PojoBuilderHelper.java
@@ -71,7 +71,8 @@ final class PojoBuilderHelper {
                 String propertyName = toPropertyName(method);
                 propertyNames.add(propertyName);
                 PropertyMetadata<?> propertyMetadata = getOrCreateProperty(propertyName, declaringClassName, propertyNameMap,
-                        TypeData.newInstance(method), propertyTypeParameterMap, parentClassTypeData, genericTypeNames, getGenericType(method));
+                        TypeData.newInstance(method), propertyTypeParameterMap, parentClassTypeData, genericTypeNames,
+                        getGenericType(method));
                 if (propertyMetadata.getSetter() == null) {
                     propertyMetadata.setSetter(method);
                     for (Annotation annotation : method.getDeclaredAnnotations()) {
@@ -84,7 +85,8 @@ final class PojoBuilderHelper {
                 String propertyName = toPropertyName(method);
                 propertyNames.add(propertyName);
                 PropertyMetadata<?> propertyMetadata = getOrCreateProperty(propertyName, declaringClassName, propertyNameMap,
-                        TypeData.newInstance(method), propertyTypeParameterMap, parentClassTypeData, genericTypeNames, getGenericType(method));
+                        TypeData.newInstance(method), propertyTypeParameterMap, parentClassTypeData, genericTypeNames,
+                        getGenericType(method));
 
                 if (propertyMetadata.getGetter() == null) {
                     propertyMetadata.setGetter(method);

--- a/bson/src/main/org/bson/codecs/pojo/PropertyReflectionUtils.java
+++ b/bson/src/main/org/bson/codecs/pojo/PropertyReflectionUtils.java
@@ -1,0 +1,88 @@
+package org.bson.codecs.pojo;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.reflect.Modifier.isPublic;
+
+public class PropertyReflectionUtils {
+    private PropertyReflectionUtils() {}
+
+    private static final String IS_PREFIX = "is";
+    private static final String GET_PREFIX = "get";
+    private static final String SET_PREFIX = "set";
+
+    static boolean isGetter(final Method method) {
+        if (method.getParameterTypes().length > 0) {
+            return false;
+        } else if (method.getName().startsWith(GET_PREFIX) && method.getName().length() > GET_PREFIX.length()) {
+            return Character.isUpperCase(method.getName().charAt(GET_PREFIX.length()));
+        } else if (method.getName().startsWith(IS_PREFIX) && method.getName().length() > IS_PREFIX.length()) {
+            return Character.isUpperCase(method.getName().charAt(IS_PREFIX.length()));
+        }
+        return false;
+    }
+
+    static boolean isSetter(final Method method) {
+        if (method.getName().startsWith(SET_PREFIX) && method.getName().length() > SET_PREFIX.length()
+                && method.getParameterTypes().length == 1) {
+            return Character.isUpperCase(method.getName().charAt(SET_PREFIX.length()));
+        }
+        return false;
+    }
+
+    static boolean isPropertyMethod(final Method method) {
+        return isGetter(method) || isSetter(method);
+    }
+
+    static String toPropertyName(final Method method) {
+        String name = method.getName();
+        String propertyName = name.substring(name.startsWith(IS_PREFIX) ? 2 : 3, name.length());
+        char[] chars = propertyName.toCharArray();
+        chars[0] = Character.toLowerCase(chars[0]);
+        return new String(chars);
+    }
+
+    static PropertyMethods getPropertyMethods(Class<?> clazz) {
+        List<Method> setters = new ArrayList<Method>();
+        List<Method> getters = new ArrayList<Method>();
+        for (Method method : clazz.getDeclaredMethods()) {
+            // Note that if you override a getter to provide a more specific return type, getting the declared methods
+            // on the subclass will return the overridden method as well as the method that was overridden from
+            // the super class. This original method is copied over into the subclass as a bridge method, so we're
+            // excluding them here to avoid multiple getters of the same property with different return types
+            if (isPublic(method.getModifiers()) && !method.isBridge()) {
+                if (isGetter(method)) {
+                    getters.add(method);
+                } else if (isSetter(method)) {
+                    // Setters are a bit more tricky - don't do anything fancy here
+                    setters.add(method);
+                }
+            }
+        }
+
+        return new PropertyMethods(getters, setters);
+    }
+
+    public static class PropertyMethods {
+        private final Collection<Method> getterMethods;
+        private final Collection<Method> setterMethods;
+
+        public PropertyMethods(Collection<Method> getterMethods, Collection<Method> setterMethods) {
+            this.getterMethods = getterMethods;
+            this.setterMethods = setterMethods;
+        }
+
+        public Collection<Method> getGetterMethods() {
+            return getterMethods;
+        }
+
+        public Collection<Method> getSetterMethods() {
+            return setterMethods;
+        }
+    }
+}

--- a/bson/src/main/org/bson/codecs/pojo/PropertyReflectionUtils.java
+++ b/bson/src/main/org/bson/codecs/pojo/PropertyReflectionUtils.java
@@ -1,15 +1,29 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bson.codecs.pojo;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static java.lang.reflect.Modifier.isPublic;
 
-public class PropertyReflectionUtils {
+final class PropertyReflectionUtils {
     private PropertyReflectionUtils() {}
 
     private static final String IS_PREFIX = "is";
@@ -35,10 +49,6 @@ public class PropertyReflectionUtils {
         return false;
     }
 
-    static boolean isPropertyMethod(final Method method) {
-        return isGetter(method) || isSetter(method);
-    }
-
     static String toPropertyName(final Method method) {
         String name = method.getName();
         String propertyName = name.substring(name.startsWith(IS_PREFIX) ? 2 : 3, name.length());
@@ -47,7 +57,7 @@ public class PropertyReflectionUtils {
         return new String(chars);
     }
 
-    static PropertyMethods getPropertyMethods(Class<?> clazz) {
+    static PropertyMethods getPropertyMethods(final Class<?> clazz) {
         List<Method> setters = new ArrayList<Method>();
         List<Method> getters = new ArrayList<Method>();
         for (Method method : clazz.getDeclaredMethods()) {
@@ -68,20 +78,20 @@ public class PropertyReflectionUtils {
         return new PropertyMethods(getters, setters);
     }
 
-    public static class PropertyMethods {
+    static class PropertyMethods {
         private final Collection<Method> getterMethods;
         private final Collection<Method> setterMethods;
 
-        public PropertyMethods(Collection<Method> getterMethods, Collection<Method> setterMethods) {
+        PropertyMethods(final Collection<Method> getterMethods, final Collection<Method> setterMethods) {
             this.getterMethods = getterMethods;
             this.setterMethods = setterMethods;
         }
 
-        public Collection<Method> getGetterMethods() {
+        Collection<Method> getGetterMethods() {
             return getterMethods;
         }
 
-        public Collection<Method> getSetterMethods() {
+        Collection<Method> getSetterMethods() {
             return setterMethods;
         }
     }

--- a/bson/src/main/org/bson/codecs/pojo/TypeData.java
+++ b/bson/src/main/org/bson/codecs/pojo/TypeData.java
@@ -16,19 +16,21 @@
 
 package org.bson.codecs.pojo;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static java.lang.String.format;
 import static org.bson.assertions.Assertions.notNull;
+import static org.bson.codecs.pojo.PropertyReflectionUtils.isGetter;
 
 
 final class TypeData<T> {
@@ -44,6 +46,45 @@ final class TypeData<T> {
      */
     public static <T> Builder<T> builder(final Class<T> type) {
         return new Builder<T>(notNull("type", type));
+    }
+
+    public static TypeData<?> newInstance(final Method method) {
+        if (isGetter(method)) {
+            return newInstance(method.getGenericReturnType(), method.getReturnType());
+        } else {
+            return newInstance(method.getGenericParameterTypes()[0], method.getParameterTypes()[0]);
+        }
+    }
+
+    public static TypeData<?> newInstance(final Field field) {
+        return newInstance(field.getGenericType(), field.getType());
+    }
+
+    public static <T> TypeData<T> newInstance(final Type genericType, final Class<T> clazz) {
+        TypeData.Builder<T> builder = TypeData.builder(clazz);
+        if (genericType instanceof ParameterizedType) {
+            ParameterizedType pType = (ParameterizedType) genericType;
+            for (Type argType : pType.getActualTypeArguments()) {
+                getNestedTypeData(builder, argType);
+            }
+        }
+        return builder.build();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <T> void getNestedTypeData(final TypeData.Builder<T> builder, final Type type) {
+        if (type instanceof ParameterizedType) {
+            ParameterizedType pType = (ParameterizedType) type;
+            TypeData.Builder paramBuilder = TypeData.builder((Class) pType.getRawType());
+            for (Type argType : pType.getActualTypeArguments()) {
+                getNestedTypeData(paramBuilder, argType);
+            }
+            builder.addTypeParameter(paramBuilder.build());
+        } else if (type instanceof TypeVariable) {
+            builder.addTypeParameter(TypeData.builder(Object.class).build());
+        } else if (type instanceof Class) {
+            builder.addTypeParameter(TypeData.builder((Class) type).build());
+        }
     }
 
     /**
@@ -207,25 +248,12 @@ final class TypeData<T> {
     }
 
     private TypeData(final Class<T> type, final List<TypeData<?>> typeParameters) {
-        this.type = getTypeClass(type);
+        this.type = boxType(type);
         this.typeParameters = typeParameters;
     }
 
     boolean isAssignableFrom(final Class<?> cls) {
-        return type.isAssignableFrom(getTypeClass(cls));
-    }
-
-    @SuppressWarnings("unchecked")
-    private <S> Class<S> getTypeClass(final Class<S> type) {
-        Class<S> instanceType = boxType(type);
-        if (type.equals(Map.class)) {
-            instanceType = (Class<S>) HashMap.class;
-        } else if (type.equals(List.class) || type.equals(Collection.class)) {
-            instanceType = (Class<S>) ArrayList.class;
-        } else if (type.equals(Set.class)) {
-            instanceType = (Class<S>) HashSet.class;
-        }
-        return instanceType;
+        return type.isAssignableFrom(boxType(cls));
     }
 
     @SuppressWarnings("unchecked")

--- a/bson/src/test/unit/org/bson/codecs/pojo/ClassModelBuilderTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/ClassModelBuilderTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;

--- a/bson/src/test/unit/org/bson/codecs/pojo/ClassModelBuilderTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/ClassModelBuilderTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -107,10 +108,10 @@ public final class ClassModelBuilderTest {
         ClassModelBuilder<ConcreteCollectionsModel> builder =
                 ClassModel.builder(ConcreteCollectionsModel.class);
 
-        assertEquals(ArrayList.class, builder.getProperty("collection").getTypeData().getType());
-        assertEquals(ArrayList.class, builder.getProperty("list").getTypeData().getType());
+        assertEquals(Collection.class, builder.getProperty("collection").getTypeData().getType());
+        assertEquals(List.class, builder.getProperty("list").getTypeData().getType());
         assertEquals(LinkedList.class, builder.getProperty("linked").getTypeData().getType());
-        assertEquals(HashMap.class, builder.getProperty("map").getTypeData().getType());
+        assertEquals(Map.class, builder.getProperty("map").getTypeData().getType());
         assertEquals(ConcurrentHashMap.class, builder.getProperty("concurrent").getTypeData().getType());
     }
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/ClassModelTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/ClassModelTest.java
@@ -26,9 +26,6 @@ import org.bson.codecs.pojo.entities.conventions.AnnotationInheritedModel;
 import org.bson.codecs.pojo.entities.conventions.AnnotationModel;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/bson/src/test/unit/org/bson/codecs/pojo/ClassModelTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/ClassModelTest.java
@@ -29,6 +29,9 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -58,18 +61,18 @@ public final class ClassModelTest {
     public void testCollectionNestedPojoModelPropertyTypes() {
         TypeData<String> string = TypeData.builder(String.class).build();
         TypeData<SimpleModel> simple = TypeData.builder(SimpleModel.class).build();
-        TypeData<ArrayList> list = TypeData.builder(ArrayList.class).addTypeParameter(simple).build();
-        TypeData<ArrayList> listList = TypeData.builder(ArrayList.class).addTypeParameter(list).build();
-        TypeData<HashSet> set = TypeData.builder(HashSet.class).addTypeParameter(simple).build();
-        TypeData<HashSet> setSet = TypeData.builder(HashSet.class).addTypeParameter(set).build();
-        TypeData<HashMap> map = TypeData.builder(HashMap.class).addTypeParameter(string).addTypeParameter(simple).build();
-        TypeData<ArrayList> listMap = TypeData.builder(ArrayList.class).addTypeParameter(map).build();
-        TypeData<HashMap> mapMap = TypeData.builder(HashMap.class).addTypeParameter(string).addTypeParameter(map).build();
-        TypeData<HashMap> mapList = TypeData.builder(HashMap.class).addTypeParameter(string).addTypeParameter(list).build();
-        TypeData<HashMap> mapListMap = TypeData.builder(HashMap.class).addTypeParameter(string).addTypeParameter(listMap).build();
-        TypeData<HashMap> mapSet = TypeData.builder(HashMap.class).addTypeParameter(string).addTypeParameter(set).build();
-        TypeData<ArrayList> listMapList = TypeData.builder(ArrayList.class).addTypeParameter(mapList).build();
-        TypeData<ArrayList> listMapSet = TypeData.builder(ArrayList.class).addTypeParameter(mapSet).build();
+        TypeData<List> list = TypeData.builder(List.class).addTypeParameter(simple).build();
+        TypeData<List> listList = TypeData.builder(List.class).addTypeParameter(list).build();
+        TypeData<Set> set = TypeData.builder(Set.class).addTypeParameter(simple).build();
+        TypeData<Set> setSet = TypeData.builder(Set.class).addTypeParameter(set).build();
+        TypeData<Map> map = TypeData.builder(Map.class).addTypeParameter(string).addTypeParameter(simple).build();
+        TypeData<List> listMap = TypeData.builder(List.class).addTypeParameter(map).build();
+        TypeData<Map> mapMap = TypeData.builder(Map.class).addTypeParameter(string).addTypeParameter(map).build();
+        TypeData<Map> mapList = TypeData.builder(Map.class).addTypeParameter(string).addTypeParameter(list).build();
+        TypeData<Map> mapListMap = TypeData.builder(Map.class).addTypeParameter(string).addTypeParameter(listMap).build();
+        TypeData<Map> mapSet = TypeData.builder(Map.class).addTypeParameter(string).addTypeParameter(set).build();
+        TypeData<List> listMapList = TypeData.builder(List.class).addTypeParameter(mapList).build();
+        TypeData<List> listMapSet = TypeData.builder(List.class).addTypeParameter(mapSet).build();
 
         ClassModel<?> classModel = ClassModel.builder(CollectionNestedPojoModel.class).build();
         assertEquals(list, classModel.getPropertyModel("listSimple").getTypeData());
@@ -104,7 +107,7 @@ public final class ClassModelTest {
     public void testMappingConcreteGenericTypes() {
         TypeData<String> string = TypeData.builder(String.class).build();
         TypeData<SimpleModel> simple = TypeData.builder(SimpleModel.class).build();
-        TypeData<HashMap> map = TypeData.builder(HashMap.class).addTypeParameter(string).addTypeParameter(simple).build();
+        TypeData<Map> map = TypeData.builder(Map.class).addTypeParameter(string).addTypeParameter(simple).build();
         TypeData<GenericHolderModel> genericHolder = TypeData.builder(GenericHolderModel.class).addTypeParameter(map).build();
 
         ClassModel<?> classModel = ClassModel.builder(NestedGenericHolderMapModel.class).build();
@@ -117,8 +120,8 @@ public final class ClassModelTest {
         TypeData<Object> object = TypeData.builder(Object.class).build();
         TypeData<Integer> integer = TypeData.builder(Integer.class).build();
         TypeData<String> string = TypeData.builder(String.class).build();
-        TypeData<ArrayList> list = TypeData.builder(ArrayList.class).addTypeParameter(object).build();
-        TypeData<HashMap> map = TypeData.builder(HashMap.class).addTypeParameter(string).addTypeParameter(object).build();
+        TypeData<List> list = TypeData.builder(List.class).addTypeParameter(object).build();
+        TypeData<Map> map = TypeData.builder(Map.class).addTypeParameter(string).addTypeParameter(object).build();
 
         ClassModel<?> classModel = ClassModel.builder(SimpleGenericsModel.class).build();
         assertEquals(integer, classModel.getPropertyModel("myIntegerField").getTypeData());

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
@@ -19,6 +19,8 @@ package org.bson.codecs.pojo;
 import org.bson.BsonDocument;
 import org.bson.codecs.pojo.entities.AbstractInterfaceModel;
 import org.bson.codecs.pojo.entities.CollectionNestedPojoModel;
+import org.bson.codecs.pojo.entities.CollectionSpecificReturnTypeCreatorModel;
+import org.bson.codecs.pojo.entities.CollectionSpecificReturnTypeModel;
 import org.bson.codecs.pojo.entities.ConcreteAndNestedAbstractInterfaceModel;
 import org.bson.codecs.pojo.entities.ConcreteCollectionsModel;
 import org.bson.codecs.pojo.entities.ConcreteStandAloneAbstractInterfaceModel;
@@ -28,6 +30,7 @@ import org.bson.codecs.pojo.entities.GenericHolderModel;
 import org.bson.codecs.pojo.entities.GenericTreeModel;
 import org.bson.codecs.pojo.entities.InterfaceBasedModel;
 import org.bson.codecs.pojo.entities.InterfaceModelImpl;
+import org.bson.codecs.pojo.entities.InterfaceUpperBoundsModelAbstractImpl;
 import org.bson.codecs.pojo.entities.MultipleBoundsModel;
 import org.bson.codecs.pojo.entities.MultipleLevelGenericModel;
 import org.bson.codecs.pojo.entities.NestedFieldReusingClassTypeParameter;
@@ -56,6 +59,8 @@ import org.bson.codecs.pojo.entities.SimpleNestedPojoModel;
 import org.bson.codecs.pojo.entities.UpperBoundsConcreteModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorAllFinalFieldsModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorConstructorModel;
+import org.bson.codecs.pojo.entities.conventions.CreatorInSuperClassModel;
+import org.bson.codecs.pojo.entities.conventions.CreatorInSuperClassModelImpl;
 import org.bson.codecs.pojo.entities.conventions.CreatorMethodModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorNoArgsConstructorModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorNoArgsMethodModel;
@@ -64,6 +69,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -109,6 +115,11 @@ public final class PojoRoundTripTest extends PojoTestCase {
                 getPojoCodecProviderBuilder(InterfaceModelImpl.class),
                 "{'propertyA': 'a', 'propertyB': 'b'}"));
 
+        data.add(new TestData("Interfaced based model with bound", new InterfaceUpperBoundsModelAbstractImpl("someName",
+                new InterfaceModelImpl("a", "b")),
+                getPojoCodecProviderBuilder(InterfaceUpperBoundsModelAbstractImpl.class, InterfaceModelImpl.class),
+                "{'name': 'someName', 'nestedModel': {'propertyA': 'a', 'propertyB': 'b'}}"));
+
         data.add(new TestData("Interface concrete and abstract model",
                 new ConcreteAndNestedAbstractInterfaceModel("A", new ConcreteAndNestedAbstractInterfaceModel("B",
                         new ConcreteStandAloneAbstractInterfaceModel("C"))),
@@ -124,6 +135,21 @@ public final class PojoRoundTripTest extends PojoTestCase {
                         + "'myLong': { '$numberLong': '5' }, 'myShort': 6}"));
 
         data.add(new TestData("Concrete collections model", getConcreteCollectionsModel(),
+                getPojoCodecProviderBuilder(ConcreteCollectionsModel.class),
+                "{'collection': [1, 2, 3], 'list': [4, 5, 6], 'linked': [7, 8, 9], 'map': {'A': 1.1, 'B': 2.2, 'C': 3.3},"
+                        + "'concurrent': {'D': 4.4, 'E': 5.5, 'F': 6.6}}"));
+
+        data.add(new TestData("Concrete specific return collection type model through BsonCreator",
+                new CollectionSpecificReturnTypeCreatorModel(Arrays.asList("foo", "bar")),
+                getPojoCodecProviderBuilder(CollectionSpecificReturnTypeCreatorModel.class),
+                "{'properties': ['foo', 'bar']}"));
+
+        data.add(new TestData("Concrete specific return collection type model through getter and setter",
+                new CollectionSpecificReturnTypeModel(Arrays.asList("foo", "bar")),
+                getPojoCodecProviderBuilder(CollectionSpecificReturnTypeModel.class),
+                "{'properties': ['foo', 'bar']}"));
+
+        data.add(new TestData("Concrete specific return collection type model", getConcreteCollectionsModel(),
                 getPojoCodecProviderBuilder(ConcreteCollectionsModel.class),
                 "{'collection': [1, 2, 3], 'list': [4, 5, 6], 'linked': [7, 8, 9], 'map': {'A': 1.1, 'B': 2.2, 'C': 3.3},"
                         + "'concurrent': {'D': 4.4, 'E': 5.5, 'F': 6.6}}"));
@@ -261,6 +287,11 @@ public final class PojoRoundTripTest extends PojoTestCase {
                 getPojoCodecProviderBuilder(ContainsAlternativeMapAndCollectionModel.class),
                 "{customList: [1,2,3], customMap: {'field': 'value'}}"));
 
+        data.add(new TestData("Creator in super class factory method",
+                CreatorInSuperClassModel.newInstance("a", "b"),
+                getPojoCodecProviderBuilder(CreatorInSuperClassModelImpl.class),
+                "{'propertyA': 'a', 'propertyB': 'b'}"));
+
         return data;
     }
 
@@ -306,6 +337,4 @@ public final class PojoRoundTripTest extends PojoTestCase {
             return json;
         }
     }
-
-
 }

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
@@ -26,6 +26,7 @@ import org.bson.codecs.pojo.entities.ConcreteCollectionsModel;
 import org.bson.codecs.pojo.entities.ConcreteStandAloneAbstractInterfaceModel;
 import org.bson.codecs.pojo.entities.ContainsAlternativeMapAndCollectionModel;
 import org.bson.codecs.pojo.entities.ConventionModel;
+import org.bson.codecs.pojo.entities.FieldAndPropertyTypeMismatchModel;
 import org.bson.codecs.pojo.entities.GenericHolderModel;
 import org.bson.codecs.pojo.entities.GenericTreeModel;
 import org.bson.codecs.pojo.entities.InterfaceBasedModel;
@@ -292,6 +293,10 @@ public final class PojoRoundTripTest extends PojoTestCase {
                 getPojoCodecProviderBuilder(CreatorInSuperClassModelImpl.class),
                 "{'propertyA': 'a', 'propertyB': 'b'}"));
 
+        data.add(new TestData("Primitive field type doesn't match private property",
+                new FieldAndPropertyTypeMismatchModel("foo"),
+                getPojoCodecProviderBuilder(FieldAndPropertyTypeMismatchModel.class),
+                "{'stringField': 'foo'}"));
         return data;
     }
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/TypeDataTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/TypeDataTest.java
@@ -19,9 +19,7 @@ package org.bson.codecs.pojo;
 import org.bson.codecs.pojo.entities.GenericHolderModel;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/TypeDataTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/TypeDataTest.java
@@ -45,7 +45,7 @@ public final class TypeDataTest {
         TypeData<String> subTypeData = TypeData.builder(String.class).build();
         TypeData<List> typeData = TypeData.builder(List.class).addTypeParameter(subTypeData).build();
 
-        assertEquals(ArrayList.class, typeData.getType());
+        assertEquals(List.class, typeData.getType());
         assertEquals(singletonList(subTypeData), typeData.getTypeParameters());
     }
 
@@ -55,7 +55,7 @@ public final class TypeDataTest {
         TypeData<Integer> valueTypeData = TypeData.builder(Integer.class).build();
         TypeData<Map> typeData = TypeData.builder(Map.class).addTypeParameter(keyTypeData).addTypeParameter(valueTypeData).build();
 
-        assertEquals(HashMap.class, typeData.getType());
+        assertEquals(Map.class, typeData.getType());
         assertEquals(Arrays.<TypeData<?>>asList(keyTypeData, valueTypeData), typeData.getTypeParameters());
     }
 
@@ -68,7 +68,7 @@ public final class TypeDataTest {
                 .build();
 
         assertEquals("TypeData{type=String}", stringType.toString());
-        assertEquals("TypeData{type=HashMap, typeParameters=[String, HashMap<String, String>]}", mapTypeData.toString());
+        assertEquals("TypeData{type=Map, typeParameters=[String, Map<String, String>]}", mapTypeData.toString());
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/AbstractCollectionSpecificReturnTypeCreatorModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/AbstractCollectionSpecificReturnTypeCreatorModel.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+import java.util.List;
+
+public abstract class AbstractCollectionSpecificReturnTypeCreatorModel {
+    public abstract List<String> getProperties();
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/CollectionSpecificReturnTypeCreatorModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/CollectionSpecificReturnTypeCreatorModel.java
@@ -1,0 +1,35 @@
+package org.bson.codecs.pojo.entities;
+
+import com.google.common.collect.ImmutableList;
+import org.bson.codecs.pojo.annotations.BsonCreator;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+import java.util.List;
+
+public class CollectionSpecificReturnTypeCreatorModel {
+    private final ImmutableList<String> properties;
+
+    @BsonCreator
+    public CollectionSpecificReturnTypeCreatorModel(@BsonProperty("properties") List<String> properties) {
+        this.properties = ImmutableList.copyOf(properties);
+    }
+
+    public ImmutableList<String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CollectionSpecificReturnTypeCreatorModel that = (CollectionSpecificReturnTypeCreatorModel) o;
+
+        return properties != null ? properties.equals(that.properties) : that.properties == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return properties != null ? properties.hashCode() : 0;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/CollectionSpecificReturnTypeCreatorModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/CollectionSpecificReturnTypeCreatorModel.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bson.codecs.pojo.entities;
 
 import com.google.common.collect.ImmutableList;
@@ -10,7 +26,7 @@ public class CollectionSpecificReturnTypeCreatorModel {
     private final ImmutableList<String> properties;
 
     @BsonCreator
-    public CollectionSpecificReturnTypeCreatorModel(@BsonProperty("properties") List<String> properties) {
+    public CollectionSpecificReturnTypeCreatorModel(@BsonProperty("properties") final List<String> properties) {
         this.properties = ImmutableList.copyOf(properties);
     }
 
@@ -19,9 +35,13 @@ public class CollectionSpecificReturnTypeCreatorModel {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         CollectionSpecificReturnTypeCreatorModel that = (CollectionSpecificReturnTypeCreatorModel) o;
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/CollectionSpecificReturnTypeCreatorModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/CollectionSpecificReturnTypeCreatorModel.java
@@ -22,7 +22,7 @@ import org.bson.codecs.pojo.annotations.BsonProperty;
 
 import java.util.List;
 
-public class CollectionSpecificReturnTypeCreatorModel {
+public class CollectionSpecificReturnTypeCreatorModel extends AbstractCollectionSpecificReturnTypeCreatorModel {
     private final ImmutableList<String> properties;
 
     @BsonCreator

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/CollectionSpecificReturnTypeModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/CollectionSpecificReturnTypeModel.java
@@ -1,8 +1,22 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bson.codecs.pojo.entities;
 
 import com.google.common.collect.ImmutableList;
-import org.bson.codecs.pojo.annotations.BsonCreator;
-import org.bson.codecs.pojo.annotations.BsonProperty;
 
 import java.util.List;
 
@@ -12,7 +26,7 @@ public class CollectionSpecificReturnTypeModel {
     public CollectionSpecificReturnTypeModel() {
     }
 
-    public CollectionSpecificReturnTypeModel(List<String> properties) {
+    public CollectionSpecificReturnTypeModel(final List<String> properties) {
         this.properties = ImmutableList.copyOf(properties);
     }
 
@@ -20,14 +34,18 @@ public class CollectionSpecificReturnTypeModel {
         return properties;
     }
 
-    public void setProperties(List<String> properties) {
+    public void setProperties(final List<String> properties) {
         this.properties = ImmutableList.copyOf(properties);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         CollectionSpecificReturnTypeModel that = (CollectionSpecificReturnTypeModel) o;
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/CollectionSpecificReturnTypeModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/CollectionSpecificReturnTypeModel.java
@@ -1,0 +1,41 @@
+package org.bson.codecs.pojo.entities;
+
+import com.google.common.collect.ImmutableList;
+import org.bson.codecs.pojo.annotations.BsonCreator;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+import java.util.List;
+
+public class CollectionSpecificReturnTypeModel {
+    private ImmutableList<String> properties;
+
+    public CollectionSpecificReturnTypeModel() {
+    }
+
+    public CollectionSpecificReturnTypeModel(List<String> properties) {
+        this.properties = ImmutableList.copyOf(properties);
+    }
+
+    public ImmutableList<String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<String> properties) {
+        this.properties = ImmutableList.copyOf(properties);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CollectionSpecificReturnTypeModel that = (CollectionSpecificReturnTypeModel) o;
+
+        return properties != null ? properties.equals(that.properties) : that.properties == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return properties != null ? properties.hashCode() : 0;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/FieldAndPropertyTypeMismatchModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/FieldAndPropertyTypeMismatchModel.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+import java.util.Arrays;
+
+public class FieldAndPropertyTypeMismatchModel {
+    private byte[] stringField;
+
+    public FieldAndPropertyTypeMismatchModel() {
+    }
+
+    public FieldAndPropertyTypeMismatchModel(final String stringField) {
+        this.stringField = stringField.getBytes();
+    }
+
+    public String getStringField() {
+        return new String(stringField);
+    }
+
+    public void setStringField(final String stringField) {
+        this.stringField = stringField.getBytes();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FieldAndPropertyTypeMismatchModel that = (FieldAndPropertyTypeMismatchModel) o;
+
+        return Arrays.equals(stringField, that.stringField);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(stringField);
+    }
+
+    @Override
+    public String toString() {
+        return "FieldAndPropertyTypeMismatchModel{"
+                + "stringField=" + new String(stringField)
+                + '}';
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceUpperBoundsModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceUpperBoundsModel.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bson.codecs.pojo.entities;
 
 public interface InterfaceUpperBoundsModel<T extends InterfaceModelA> {

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceUpperBoundsModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceUpperBoundsModel.java
@@ -1,0 +1,5 @@
+package org.bson.codecs.pojo.entities;
+
+public interface InterfaceUpperBoundsModel<T extends InterfaceModelA> {
+    T getNestedModel();
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceUpperBoundsModelAbstract.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceUpperBoundsModelAbstract.java
@@ -1,0 +1,5 @@
+package org.bson.codecs.pojo.entities;
+
+abstract class InterfaceUpperBoundsModelAbstract implements InterfaceUpperBoundsModel<InterfaceModelImpl> {
+    public abstract String getName();
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceUpperBoundsModelAbstract.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceUpperBoundsModelAbstract.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bson.codecs.pojo.entities;
 
 abstract class InterfaceUpperBoundsModelAbstract implements InterfaceUpperBoundsModel<InterfaceModelImpl> {

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceUpperBoundsModelAbstractImpl.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceUpperBoundsModelAbstractImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bson.codecs.pojo.entities;
 
 public class InterfaceUpperBoundsModelAbstractImpl extends InterfaceUpperBoundsModelAbstract {
@@ -7,7 +23,7 @@ public class InterfaceUpperBoundsModelAbstractImpl extends InterfaceUpperBoundsM
     public InterfaceUpperBoundsModelAbstractImpl() {
     }
 
-    public InterfaceUpperBoundsModelAbstractImpl(String name, InterfaceModelImpl nestedModel) {
+    public InterfaceUpperBoundsModelAbstractImpl(final String name, final InterfaceModelImpl nestedModel) {
         this.name = name;
         this.nestedModel = nestedModel;
     }
@@ -22,22 +38,28 @@ public class InterfaceUpperBoundsModelAbstractImpl extends InterfaceUpperBoundsM
         return nestedModel;
     }
 
-    public void setName(String name) {
+    public void setName(final String name) {
         this.name = name;
     }
 
-    public void setNestedModel(InterfaceModelImpl nestedModel) {
+    public void setNestedModel(final InterfaceModelImpl nestedModel) {
         this.nestedModel = nestedModel;
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         InterfaceUpperBoundsModelAbstractImpl that = (InterfaceUpperBoundsModelAbstractImpl) o;
 
-        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) {
+            return false;
+        }
         return nestedModel != null ? nestedModel.equals(that.nestedModel) : that.nestedModel == null;
     }
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceUpperBoundsModelAbstractImpl.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceUpperBoundsModelAbstractImpl.java
@@ -1,0 +1,50 @@
+package org.bson.codecs.pojo.entities;
+
+public class InterfaceUpperBoundsModelAbstractImpl extends InterfaceUpperBoundsModelAbstract {
+    private String name;
+    private InterfaceModelImpl nestedModel;
+
+    public InterfaceUpperBoundsModelAbstractImpl() {
+    }
+
+    public InterfaceUpperBoundsModelAbstractImpl(String name, InterfaceModelImpl nestedModel) {
+        this.name = name;
+        this.nestedModel = nestedModel;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public InterfaceModelImpl getNestedModel() {
+        return nestedModel;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setNestedModel(InterfaceModelImpl nestedModel) {
+        this.nestedModel = nestedModel;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        InterfaceUpperBoundsModelAbstractImpl that = (InterfaceUpperBoundsModelAbstractImpl) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        return nestedModel != null ? nestedModel.equals(that.nestedModel) : that.nestedModel == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (nestedModel != null ? nestedModel.hashCode() : 0);
+        return result;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorInSuperClassModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorInSuperClassModel.java
@@ -1,0 +1,14 @@
+package org.bson.codecs.pojo.entities.conventions;
+
+import org.bson.codecs.pojo.annotations.BsonCreator;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+public abstract class CreatorInSuperClassModel {
+    @BsonCreator
+    public static CreatorInSuperClassModel newInstance(@BsonProperty("propertyA") String propertyA,
+                                                       @BsonProperty("propertyB") String propertyB) {
+        return new CreatorInSuperClassModelImpl(propertyA, propertyB);
+    }
+    public abstract String getPropertyA();
+    public abstract String getPropertyB();
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorInSuperClassModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorInSuperClassModel.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bson.codecs.pojo.entities.conventions;
 
 import org.bson.codecs.pojo.annotations.BsonCreator;
@@ -5,8 +21,8 @@ import org.bson.codecs.pojo.annotations.BsonProperty;
 
 public abstract class CreatorInSuperClassModel {
     @BsonCreator
-    public static CreatorInSuperClassModel newInstance(@BsonProperty("propertyA") String propertyA,
-                                                       @BsonProperty("propertyB") String propertyB) {
+    public static CreatorInSuperClassModel newInstance(@BsonProperty("propertyA") final String propertyA,
+                                                       @BsonProperty("propertyB") final String propertyB) {
         return new CreatorInSuperClassModelImpl(propertyA, propertyB);
     }
     public abstract String getPropertyA();

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorInSuperClassModelImpl.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorInSuperClassModelImpl.java
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bson.codecs.pojo.entities.conventions;
 
 public class CreatorInSuperClassModelImpl extends CreatorInSuperClassModel {
     private final String propertyA;
     private final String propertyB;
 
-    CreatorInSuperClassModelImpl(String propertyA, String propertyB) {
+    CreatorInSuperClassModelImpl(final String propertyA, final String propertyB) {
         this.propertyA = propertyA;
         this.propertyB = propertyB;
     }
@@ -20,13 +36,19 @@ public class CreatorInSuperClassModelImpl extends CreatorInSuperClassModel {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         CreatorInSuperClassModelImpl that = (CreatorInSuperClassModelImpl) o;
 
-        if (propertyA != null ? !propertyA.equals(that.propertyA) : that.propertyA != null) return false;
+        if (propertyA != null ? !propertyA.equals(that.propertyA) : that.propertyA != null) {
+            return false;
+        }
         return propertyB != null ? propertyB.equals(that.propertyB) : that.propertyB == null;
     }
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorInSuperClassModelImpl.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/CreatorInSuperClassModelImpl.java
@@ -1,0 +1,39 @@
+package org.bson.codecs.pojo.entities.conventions;
+
+public class CreatorInSuperClassModelImpl extends CreatorInSuperClassModel {
+    private final String propertyA;
+    private final String propertyB;
+
+    CreatorInSuperClassModelImpl(String propertyA, String propertyB) {
+        this.propertyA = propertyA;
+        this.propertyB = propertyB;
+    }
+
+    @Override
+    public String getPropertyA() {
+        return propertyA;
+    }
+
+    @Override
+    public String getPropertyB() {
+        return propertyB;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CreatorInSuperClassModelImpl that = (CreatorInSuperClassModelImpl) o;
+
+        if (propertyA != null ? !propertyA.equals(that.propertyA) : that.propertyA != null) return false;
+        return propertyB != null ? propertyB.equals(that.propertyB) : that.propertyB == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = propertyA != null ? propertyA.hashCode() : 0;
+        result = 31 * result + (propertyB != null ? propertyB.hashCode() : 0);
+        return result;
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,7 @@ configure(subprojects.findAll { it.name != 'util' && it.name != 'mongo-java-driv
         testCompile 'org.objenesis:objenesis:1.3'
         testCompile 'org.hamcrest:hamcrest-all:1.3'
         testCompile 'ch.qos.logback:logback-classic:1.1.1'
+        testCompile 'com.google.guava:guava:22.0'
         testCompile project(':util') //Adding categories to classpath
     }
 


### PR DESCRIPTION
The changes below should help in many scenarios, but my particular use case is generating my POJOs with [Immutables](https://immutables.github.io/). With the changes below I can do something like:

```
@Value.Immutable
public abstract class User {
  @BsonCreator
  public static ImmutableUser newInstance(@BsonProperty("id") String id,
      @BsonProperty("firstName") String firstName,
      @BsonProperty("lastName") String lastName,
      @BsonProperty("friends") List<String> friends {
    return ImmutableUser.builder()
        .id(id)
        .firstName(firstName)
        .lastName(lastName)
        .friends(friends)
        .build();
  }

  public abstract String getId();
  public abstract String getFirstName();
  public abstract String getLastName();
  // Generated ImmutableUser class automatically
  // overrides this to ImmutableList<String>
  public abstract List<String> getFriends();
}
```

With that context, this commit tries to fix a few issues:

- It was not possible to overload a getter in a sub-class and make the
type more specific (covariant overload). For example, attempting to
serialize Bar would fail:

```
  // Assume there are setters here as well...
  class Foo {
    public Number getNumber() { /*...*/ }
  }

  class Bar extends Foo {
    @Override
    public Long getNumber() { /*...*/ }
  }
```

This was due to bridge methods not being accounted for, so even though
Method#getDeclaredMethods is documented to return methods only from the
super class, the Java compiler inserts a bridge method in the sub-class
(Bar in this case) for these covariant overrides for legacy interop. The existing
code produced a "has differing data types" exception.

- It was not possible to use a more specific type in a getter, but a
more general type in the setter/constructor/static factory method. For example:

```
class Foo {
  public ImmutableList<String> getNames() { /*...*/ }
  // Mutable class
  public void setNames(List<String> names) { /*...*/ }
  // or immutable class (both didn't work)
  @BsonCreator
  public Foo(@BsonProperty("names") List<String> names) { /*...*/ }
}
```

The first issue was that strict type equality was enforced. This is a
pretty common pattern that should be allowed though - it's typically a
bad idea to accept such a specific class in your constructor/setter.
In my case, I'm creating my domain models with Immutables, so the
geneerated immutable class will override my getter that returns
`List<T>` to return a more specific `ImmutableList<T>`.

The second issue was that various collections were boxed to specific
implementations like ArrayList/HashMap/HashSet. Doing this in TypeData
caused quite a few problems. The main one being that it was no longer possible to
understand the type hierarchy (ImmutableList does not extend ArrayList,
but it safely implements List). The ArrayList/HashMap/etc selection now
happens in collection codec at the last minute as a sensible default implementation.
I think this is a bit cleaner.

- It was not possible to use immutable collections like Guava's
ImmutableList. By fixing the above issues, it works now. Note that we
still can't use ImmutableList as a parameter that's accepted, which is 
a reasonable constraint.

- @BsonCreator annotations were only searched for in the target class,
but not any super classes. It's relatively common to have an abstract
base class host all of the static factory methods for the concrete
subtypes, so this allows for that pattern. I do the above, but in
addition, my domain models generated through Immutables don't
give me the ability to inject annotated static factory methods.

-----

I moved code around a bit for better locality and some re-usability. In
particular with PropertyReflectionUtils, and TypeData having a few
methods of extracting the types out of methods/fields/etc.

The new test cases exercise the above scenarios which failed
prior to these modifications. All other existing bson tests pass. I also
added guava to the test compile class path so we can have an actual test
case with immutable collections.