### PR TITLE
Fix for https://jira.mongodb.org/browse/JAVA-2648

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/PropertyAccessorImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/PropertyAccessorImpl.java
@@ -19,6 +19,7 @@ package org.bson.codecs.pojo;
 import org.bson.codecs.configuration.CodecConfigurationException;
 
 import static java.lang.String.format;
+import java.util.Collection;
 
 final class PropertyAccessorImpl<T> implements PropertyAccessor<T> {
 
@@ -47,6 +48,7 @@ final class PropertyAccessorImpl<T> implements PropertyAccessor<T> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <S> void set(final S instance, final T value) {
         try {
             if (propertyMetadata.isDeserializable()) {
@@ -54,6 +56,16 @@ final class PropertyAccessorImpl<T> implements PropertyAccessor<T> {
                     propertyMetadata.getSetter().invoke(instance, value);
                 } else {
                     propertyMetadata.getField().set(instance, value);
+                }
+            } else if (propertyMetadata.getGetter() != null
+                    && value instanceof Collection) {
+                // PCB : https://jira.mongodb.org/browse/JAVA-2648
+                // If a type is a collection and there is no setter then use the getter and addAll to it from the value
+                // Also check that the collection is currently empty. Without this check some test cases fail.
+                T collection = (T) propertyMetadata.getGetter().invoke(instance);
+                Collection<?> col = ((Collection<?>) collection);
+                if (col != null && col.isEmpty()) {
+                    col.addAll((Collection) value);
                 }
             }
         } catch (final Exception e) {

--- a/bson/src/main/org/bson/codecs/pojo/PropertyAccessorImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/PropertyAccessorImpl.java
@@ -57,12 +57,16 @@ final class PropertyAccessorImpl<T> implements PropertyAccessor<T> {
                 } else {
                     propertyMetadata.getField().set(instance, value);
                 }
-            } else if (propertyMetadata.getGetter() != null
-                    && value instanceof Collection) {
+            } else if (propertyMetadata.isSerializable() && value instanceof Collection) {
                 // PCB : https://jira.mongodb.org/browse/JAVA-2648
                 // If a type is a collection and there is no setter then use the getter and addAll to it from the value
                 // Also check that the collection is currently empty. Without this check some test cases fail.
-                T collection = (T) propertyMetadata.getGetter().invoke(instance);
+                T collection;
+                if (propertyMetadata.getGetter() != null) {
+                    collection = (T) propertyMetadata.getGetter().invoke(instance);
+                } else {
+                    collection = (T) propertyMetadata.getField().get(instance);
+                }
                 Collection<?> col = ((Collection<?>) collection);
                 if (col != null && col.isEmpty()) {
                     col.addAll((Collection) value);


### PR DESCRIPTION
Allow a POJO without a setter for a collection to have the collection
populated via the getter and addAll()