### PR TITLE
Fix a racing condition during cursor closing.

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
@@ -332,8 +332,9 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
         synchronized (lock) {
             localCursor = cursor.get();
             if (localCursor == null) {
-                isClosed.getAndSet(true);
-                connectionSource.release();
+                if (!isClosed.getAndSet(true)) {
+                    connectionSource.release();
+                }
             } else {
                 connectionSource.retain();
             }


### PR DESCRIPTION
This can happen if close and next are called on two different threads. It can result in IllegalStateException triggered by decrementing the reference count below 0.