### PR TITLE
Avoid interruption exception in tryAcquire when there is no wait.

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
@@ -176,7 +176,9 @@ public class ConcurrentPool<T> implements Pool<T> {
         try {
             if (closed) {
                 return false;
-            } else if (timeout >= 0) {
+            } else if (timeout == 0) {
+                return permits.tryAcquire();
+            } else if (timeout > 0) {
                 return permits.tryAcquire(timeout, timeUnit);
             } else {
                 permits.acquire();


### PR DESCRIPTION
When using the mongo-java-driver-reactivestream with RxJava2, sometimes the driver throws MongoInterruptedException due to RxJava2 interrupts the thread when disposed. See discussion on the RxJava2 side: https://github.com/ReactiveX/RxJava/issues/5711

RxJava developers recommend the callbacks should not be interrupt sensitive. By changing the tryAcquire(0, TimeUnit) to tryAcquire(), it would not throw InterruptedException.