### PR TITLE
JAVA-2683: Don't include a session identifier for unacknowledged write commands

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandMessage.java
@@ -200,7 +200,7 @@ final class CommandMessage extends RequestMessage {
         if (sessionContext.getClusterTime() != null) {
             extraElements.add(new BsonElement("$clusterTime", sessionContext.getClusterTime()));
         }
-        if (sessionContext.hasSession()) {
+        if (sessionContext.hasSession() && responseExpected) {
             extraElements.add(new BsonElement("lsid", sessionContext.getSessionId()));
         }
         if (!isDefaultReadPreference(getReadPreference())) {


### PR DESCRIPTION
Doing this at the lowest level, as in practice the only commands for which a response is not expected is an unacknowledged write.  I expect though that if the driver ever send other commands without expecting a response (e.g. killCursors), then those also shouldn't include a session id.