### PR TITLE
JAVA-2703

### DIFF
--- a/bson/src/test/unit/org/bson/BsonDocumentWriterSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BsonDocumentWriterSpecification.groovy
@@ -46,4 +46,22 @@ class BsonDocumentWriterSpecification extends Specification {
         then:
         document == documentWithValuesOfEveryType()
     }
+
+    def 'should pipe all types with extra elements'() {
+        given:
+        def document = new BsonDocument()
+        def reader = new BsonDocumentReader(new BsonDocument())
+        def writer = new BsonDocumentWriter(document)
+
+        def extraElements = []
+        for (def entry : documentWithValuesOfEveryType()) {
+            extraElements.add(new BsonElement(entry.getKey(), entry.getValue()))
+        }
+
+        when:
+        writer.pipe(reader, extraElements)
+
+        then:
+        document == documentWithValuesOfEveryType()
+    }
 }

--- a/bson/src/test/unit/org/bson/BsonHelper.java
+++ b/bson/src/test/unit/org/bson/BsonHelper.java
@@ -31,36 +31,41 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
 public final class BsonHelper {
-    private static final List<BsonValue> BSON_VALUES = asList(
-            new BsonNull(),
-            new BsonInt32(42),
-            new BsonInt64(52L),
-            new BsonDecimal128(Decimal128.parse("4.00")),
-            new BsonBoolean(true),
-            new BsonDateTime(new Date().getTime()),
-            new BsonDouble(62.0),
-            new BsonString("the fox ..."),
-            new BsonMinKey(),
-            new BsonMaxKey(),
-            new BsonDbPointer("test.test", new ObjectId()),
-            new BsonJavaScript("int i = 0;"),
-            new BsonJavaScriptWithScope("x", new BsonDocument("x", new BsonInt32(1))),
-            new BsonObjectId(new ObjectId()),
-            new BsonRegularExpression("^test.*regex.*xyz$", "i"),
-            new BsonSymbol("ruby stuff"),
-            new BsonTimestamp(0x12345678, 5),
-            new BsonUndefined(),
-            new BsonBinary((byte) 80, new byte[]{5, 4, 3, 2, 1}),
-            new BsonArray(asList(new BsonInt32(1), new BsonInt64(2L), new BsonBoolean(true),
-                    new BsonArray(asList(new BsonInt32(1), new BsonInt32(2), new BsonInt32(3), new BsonDocument("a", new BsonInt64(2L)))))),
-            new BsonDocument("a", new BsonInt32(1)));
 
-    private static final BsonDocument BSON_DOCUMENT = new BsonDocument();
+    private static final Date DATE = new Date();
+    private static final ObjectId OBJECT_ID = new ObjectId();
 
-    static {
-        for (int i = 0; i < BSON_VALUES.size(); i++) {
-            BSON_DOCUMENT.append(Integer.toString(i), BSON_VALUES.get(i));
-        }
+    private static List<BsonValue> getBsonValues() {
+        return asList(
+                new BsonNull(),
+                new BsonInt32(42),
+                new BsonInt64(52L),
+                new BsonDecimal128(Decimal128.parse("4.00")),
+                new BsonBoolean(true),
+                new BsonDateTime(DATE.getTime()),
+                new BsonDouble(62.0),
+                new BsonString("the fox ..."),
+                new BsonMinKey(),
+                new BsonMaxKey(),
+                new BsonDbPointer("test.test", OBJECT_ID),
+                new BsonJavaScript("int i = 0;"),
+                new BsonJavaScriptWithScope("x", new BsonDocument("x", new BsonInt32(1))),
+                new BsonObjectId(OBJECT_ID),
+                new BsonRegularExpression("^test.*regex.*xyz$", "i"),
+                new BsonSymbol("ruby stuff"),
+                new BsonTimestamp(0x12345678, 5),
+                new BsonUndefined(),
+                new BsonBinary((byte) 80, new byte[]{5, 4, 3, 2, 1}),
+                new BsonArray(asList(
+                        new BsonInt32(1),
+                        new BsonInt64(2L),
+                        new BsonBoolean(true),
+                        new BsonArray(asList(
+                                new BsonInt32(1),
+                                new BsonInt32(2),
+                                new BsonInt32(3),
+                                new BsonDocument("a", new BsonInt64(2L)))))),
+                new BsonDocument("a", new BsonInt32(1)));
     }
 
     // fail class loading if any BSON types are not represented in BSON_VALUES.
@@ -71,7 +76,7 @@ public final class BsonHelper {
             }
 
             boolean found = false;
-            for (BsonValue curBsonValue : BSON_VALUES) {
+            for (BsonValue curBsonValue : getBsonValues()) {
                 if (curBsonValue.getBsonType() == curBsonType) {
                     found = true;
                     break;
@@ -85,11 +90,16 @@ public final class BsonHelper {
     }
 
     public static List<BsonValue> valuesOfEveryType() {
-        return BSON_VALUES;
+        return getBsonValues();
     }
 
     public static BsonDocument documentWithValuesOfEveryType() {
-        return BSON_DOCUMENT;
+        BsonDocument document = new BsonDocument();
+        List<BsonValue> bsonValues = getBsonValues();
+        for (int i = 0; i < bsonValues.size(); i++) {
+            document.append(Integer.toString(i), bsonValues.get(i));
+        }
+        return document;
     }
 
     public static ByteBuffer toBson(final BsonDocument document) {

--- a/driver-core/src/main/com/mongodb/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandMessage.java
@@ -158,12 +158,12 @@ final class CommandMessage extends RequestMessage {
     }
 
     private void addDocumentWithPayload(final BsonOutput bsonOutput) {
-        BsonWriter writer = new BsonBinaryWriter(bsonOutput, getPayloadArrayFieldNameValidator());
-        if (payload != null) {
-            writer =  new SplittablePayloadBsonWriter(writer, bsonOutput, getSettings(), payload);
-        }
+        BsonBinaryWriter bsonBinaryWriter = new BsonBinaryWriter(bsonOutput, getPayloadArrayFieldNameValidator());
+        BsonWriter bsonWriter = payload == null
+                ? bsonBinaryWriter
+                : new SplittablePayloadBsonWriter(bsonBinaryWriter, bsonOutput, getSettings(), payload);
         BsonDocument commandToEncode = getCommandToEncode();
-        getCodec(commandToEncode).encode(writer, commandToEncode, EncoderContext.builder().build());
+        getCodec(commandToEncode).encode(bsonWriter, commandToEncode, EncoderContext.builder().build());
     }
 
     private int getFlagBits() {

--- a/driver-core/src/main/com/mongodb/connection/ElementExtendingBsonWriter.java
+++ b/driver-core/src/main/com/mongodb/connection/ElementExtendingBsonWriter.java
@@ -16,8 +16,9 @@
 
 package com.mongodb.connection;
 
+import org.bson.BsonBinaryWriter;
 import org.bson.BsonElement;
-import org.bson.BsonWriter;
+import org.bson.BsonReader;
 
 import java.util.List;
 
@@ -26,7 +27,7 @@ import static com.mongodb.connection.BsonWriterHelper.writeElements;
 class ElementExtendingBsonWriter extends LevelCountingBsonWriter {
     private final List<BsonElement> extraElements;
 
-    ElementExtendingBsonWriter(final BsonWriter writer, final List<BsonElement> extraElements) {
+    ElementExtendingBsonWriter(final BsonBinaryWriter writer, final List<BsonElement> extraElements) {
         super(writer);
         this.extraElements = extraElements;
     }
@@ -34,9 +35,17 @@ class ElementExtendingBsonWriter extends LevelCountingBsonWriter {
     @Override
     public void writeEndDocument() {
         if (getCurrentLevel() == 0) {
-            writeElements(getBsonWriter(), extraElements);
+            writeElements(getBsonBinaryWriter(), extraElements);
         }
         super.writeEndDocument();
     }
 
+    @Override
+    public void pipe(final BsonReader reader) {
+        if (getCurrentLevel() == -1) {
+            getBsonBinaryWriter().pipe(reader, extraElements);
+        } else {
+            getBsonBinaryWriter().pipe(reader);
+        }
+    }
 }

--- a/driver-core/src/main/com/mongodb/connection/LevelCountingBsonWriter.java
+++ b/driver-core/src/main/com/mongodb/connection/LevelCountingBsonWriter.java
@@ -17,6 +17,7 @@
 package com.mongodb.connection;
 
 import org.bson.BsonBinary;
+import org.bson.BsonBinaryWriter;
 import org.bson.BsonDbPointer;
 import org.bson.BsonReader;
 import org.bson.BsonRegularExpression;
@@ -29,256 +30,256 @@ import static org.bson.assertions.Assertions.notNull;
 
 
 abstract class LevelCountingBsonWriter implements BsonWriter {
-    private final BsonWriter bsonWriter;
+    private final BsonBinaryWriter bsonBinaryWriter;
     private int level = -1;
 
-    LevelCountingBsonWriter(final BsonWriter bsonWriter) {
-        this.bsonWriter = notNull("bsonWriter", bsonWriter);
+    LevelCountingBsonWriter(final BsonBinaryWriter bsonBinaryWriter) {
+        this.bsonBinaryWriter = notNull("bsonBinaryWriter", bsonBinaryWriter);
     }
 
     public int getCurrentLevel() {
         return level;
     }
 
-    public BsonWriter getBsonWriter() {
-        return bsonWriter;
+    public BsonBinaryWriter getBsonBinaryWriter() {
+        return bsonBinaryWriter;
     }
 
     @Override
     public void writeStartDocument(final String name) {
         level++;
-        bsonWriter.writeStartDocument(name);
+        bsonBinaryWriter.writeStartDocument(name);
     }
 
     @Override
     public void writeStartDocument() {
         level++;
-        bsonWriter.writeStartDocument();
+        bsonBinaryWriter.writeStartDocument();
     }
 
     @Override
     public void writeEndDocument() {
         level--;
-        bsonWriter.writeEndDocument();
+        bsonBinaryWriter.writeEndDocument();
     }
 
     @Override
     public void writeStartArray(final String name) {
-        bsonWriter.writeStartArray(name);
+        bsonBinaryWriter.writeStartArray(name);
     }
 
     @Override
     public void writeStartArray() {
-        bsonWriter.writeStartArray();
+        bsonBinaryWriter.writeStartArray();
     }
 
     @Override
     public void writeEndArray() {
-        bsonWriter.writeEndArray();
+        bsonBinaryWriter.writeEndArray();
     }
 
     @Override
     public void writeBinaryData(final String name, final BsonBinary binary) {
-        bsonWriter.writeBinaryData(name, binary);
+        bsonBinaryWriter.writeBinaryData(name, binary);
     }
 
     @Override
     public void writeBinaryData(final BsonBinary binary) {
-        bsonWriter.writeBinaryData(binary);
+        bsonBinaryWriter.writeBinaryData(binary);
     }
 
     @Override
     public void writeBoolean(final String name, final boolean value) {
-        bsonWriter.writeBoolean(name, value);
+        bsonBinaryWriter.writeBoolean(name, value);
     }
 
     @Override
     public void writeBoolean(final boolean value) {
-        bsonWriter.writeBoolean(value);
+        bsonBinaryWriter.writeBoolean(value);
     }
 
     @Override
     public void writeDateTime(final String name, final long value) {
-        bsonWriter.writeDateTime(name, value);
+        bsonBinaryWriter.writeDateTime(name, value);
     }
 
     @Override
     public void writeDateTime(final long value) {
-        bsonWriter.writeDateTime(value);
+        bsonBinaryWriter.writeDateTime(value);
     }
 
     @Override
     public void writeDBPointer(final String name, final BsonDbPointer value) {
-        bsonWriter.writeDBPointer(name, value);
+        bsonBinaryWriter.writeDBPointer(name, value);
     }
 
     @Override
     public void writeDBPointer(final BsonDbPointer value) {
-        bsonWriter.writeDBPointer(value);
+        bsonBinaryWriter.writeDBPointer(value);
     }
 
     @Override
     public void writeDouble(final String name, final double value) {
-        bsonWriter.writeDouble(name, value);
+        bsonBinaryWriter.writeDouble(name, value);
     }
 
     @Override
     public void writeDouble(final double value) {
-        bsonWriter.writeDouble(value);
+        bsonBinaryWriter.writeDouble(value);
     }
 
     @Override
     public void writeInt32(final String name, final int value) {
-        bsonWriter.writeInt32(name, value);
+        bsonBinaryWriter.writeInt32(name, value);
     }
 
     @Override
     public void writeInt32(final int value) {
-        bsonWriter.writeInt32(value);
+        bsonBinaryWriter.writeInt32(value);
     }
 
     @Override
     public void writeInt64(final String name, final long value) {
-        bsonWriter.writeInt64(name, value);
+        bsonBinaryWriter.writeInt64(name, value);
     }
 
     @Override
     public void writeInt64(final long value) {
-        bsonWriter.writeInt64(value);
+        bsonBinaryWriter.writeInt64(value);
     }
 
     @Override
     public void writeDecimal128(final Decimal128 value) {
-        bsonWriter.writeDecimal128(value);
+        bsonBinaryWriter.writeDecimal128(value);
     }
 
     @Override
     public void writeDecimal128(final String name, final Decimal128 value) {
-        bsonWriter.writeDecimal128(name, value);
+        bsonBinaryWriter.writeDecimal128(name, value);
     }
 
     @Override
     public void writeJavaScript(final String name, final String code) {
-        bsonWriter.writeJavaScript(name, code);
+        bsonBinaryWriter.writeJavaScript(name, code);
     }
 
     @Override
     public void writeJavaScript(final String code) {
-        bsonWriter.writeJavaScript(code);
+        bsonBinaryWriter.writeJavaScript(code);
     }
 
     @Override
     public void writeJavaScriptWithScope(final String name, final String code) {
-        bsonWriter.writeJavaScriptWithScope(name, code);
+        bsonBinaryWriter.writeJavaScriptWithScope(name, code);
     }
 
     @Override
     public void writeJavaScriptWithScope(final String code) {
-        bsonWriter.writeJavaScriptWithScope(code);
+        bsonBinaryWriter.writeJavaScriptWithScope(code);
     }
 
     @Override
     public void writeMaxKey(final String name) {
-        bsonWriter.writeMaxKey(name);
+        bsonBinaryWriter.writeMaxKey(name);
     }
 
     @Override
     public void writeMaxKey() {
-        bsonWriter.writeMaxKey();
+        bsonBinaryWriter.writeMaxKey();
     }
 
     @Override
     public void writeMinKey(final String name) {
-        bsonWriter.writeMinKey(name);
+        bsonBinaryWriter.writeMinKey(name);
     }
 
     @Override
     public void writeMinKey() {
-        bsonWriter.writeMinKey();
+        bsonBinaryWriter.writeMinKey();
     }
 
     @Override
     public void writeName(final String name) {
-        bsonWriter.writeName(name);
+        bsonBinaryWriter.writeName(name);
     }
 
     @Override
     public void writeNull(final String name) {
-        bsonWriter.writeNull(name);
+        bsonBinaryWriter.writeNull(name);
     }
 
     @Override
     public void writeNull() {
-        bsonWriter.writeNull();
+        bsonBinaryWriter.writeNull();
     }
 
     @Override
     public void writeObjectId(final String name, final ObjectId objectId) {
-        bsonWriter.writeObjectId(name, objectId);
+        bsonBinaryWriter.writeObjectId(name, objectId);
     }
 
     @Override
     public void writeObjectId(final ObjectId objectId) {
-        bsonWriter.writeObjectId(objectId);
+        bsonBinaryWriter.writeObjectId(objectId);
     }
 
     @Override
     public void writeRegularExpression(final String name, final BsonRegularExpression regularExpression) {
-        bsonWriter.writeRegularExpression(name, regularExpression);
+        bsonBinaryWriter.writeRegularExpression(name, regularExpression);
     }
 
     @Override
     public void writeRegularExpression(final BsonRegularExpression regularExpression) {
-        bsonWriter.writeRegularExpression(regularExpression);
+        bsonBinaryWriter.writeRegularExpression(regularExpression);
     }
 
     @Override
     public void writeString(final String name, final String value) {
-        bsonWriter.writeString(name, value);
+        bsonBinaryWriter.writeString(name, value);
     }
 
     @Override
     public void writeString(final String value) {
-        bsonWriter.writeString(value);
+        bsonBinaryWriter.writeString(value);
     }
 
     @Override
     public void writeSymbol(final String name, final String value) {
-        bsonWriter.writeSymbol(name, value);
+        bsonBinaryWriter.writeSymbol(name, value);
     }
 
     @Override
     public void writeSymbol(final String value) {
-        bsonWriter.writeSymbol(value);
+        bsonBinaryWriter.writeSymbol(value);
     }
 
     @Override
     public void writeTimestamp(final String name, final BsonTimestamp value) {
-        bsonWriter.writeTimestamp(name, value);
+        bsonBinaryWriter.writeTimestamp(name, value);
     }
 
     @Override
     public void writeTimestamp(final BsonTimestamp value) {
-        bsonWriter.writeTimestamp(value);
+        bsonBinaryWriter.writeTimestamp(value);
     }
 
     @Override
     public void writeUndefined(final String name) {
-        bsonWriter.writeUndefined(name);
+        bsonBinaryWriter.writeUndefined(name);
     }
 
     @Override
     public void writeUndefined() {
-        bsonWriter.writeUndefined();
+        bsonBinaryWriter.writeUndefined();
     }
 
     @Override
     public void pipe(final BsonReader reader) {
-        bsonWriter.pipe(reader);
+        bsonBinaryWriter.pipe(reader);
     }
 
     @Override
     public void flush() {
-        bsonWriter.flush();
+        bsonBinaryWriter.flush();
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/RequestMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/RequestMessage.java
@@ -237,11 +237,11 @@ abstract class RequestMessage {
     private <T> void addDocument(final T obj, final Encoder<T> encoder, final EncoderContext encoderContext,
                                  final BsonOutput bsonOutput, final FieldNameValidator validator, final int maxDocumentSize,
                                  final List<BsonElement> extraElements) {
-        BsonWriter writer = new BsonBinaryWriter(new BsonWriterSettings(), new BsonBinaryWriterSettings(maxDocumentSize), bsonOutput,
-                validator);
-        if (extraElements != null) {
-            writer = new ElementExtendingBsonWriter((BsonBinaryWriter) writer, extraElements);
-        }
-        encoder.encode(writer, obj, encoderContext);
+        BsonBinaryWriter bsonBinaryWriter = new BsonBinaryWriter(new BsonWriterSettings(), new BsonBinaryWriterSettings(maxDocumentSize),
+                bsonOutput, validator);
+        BsonWriter bsonWriter = extraElements == null
+                ? bsonBinaryWriter
+                : new ElementExtendingBsonWriter(bsonBinaryWriter, extraElements);
+        encoder.encode(bsonWriter, obj, encoderContext);
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/SplittablePayloadBsonWriter.java
+++ b/driver-core/src/main/com/mongodb/connection/SplittablePayloadBsonWriter.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.connection;
 
+import org.bson.BsonBinaryWriter;
 import org.bson.BsonWriter;
 import org.bson.io.BsonOutput;
 
@@ -29,7 +30,7 @@ class SplittablePayloadBsonWriter extends LevelCountingBsonWriter {
     private final MessageSettings settings;
     private int commandStartPosition;
 
-    SplittablePayloadBsonWriter(final BsonWriter writer, final BsonOutput bsonOutput, final MessageSettings settings,
+    SplittablePayloadBsonWriter(final BsonBinaryWriter writer, final BsonOutput bsonOutput, final MessageSettings settings,
                                 final SplittablePayload payload) {
         super(writer);
         this.writer = writer;

--- a/driver/src/test/functional/com/mongodb/DBFunctionalSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/DBFunctionalSpecification.groovy
@@ -172,7 +172,7 @@ class DBFunctionalSpecification extends FunctionalSpecification {
     @Test
     def 'should execute command with customer encoder'() {
         when:
-        CommandResult commandResult = database.command(new BasicDBObject("isMaster", 1), DefaultDBEncoder.FACTORY.create());
+        CommandResult commandResult = database.command(new BasicDBObject('isMaster', 1), DefaultDBEncoder.FACTORY.create());
 
         then:
         commandResult.ok()

--- a/driver/src/test/functional/com/mongodb/DBFunctionalSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/DBFunctionalSpecification.groovy
@@ -20,6 +20,7 @@ import org.bson.BsonDocument
 import org.bson.BsonDouble
 import org.bson.BsonInt32
 import org.bson.BsonString
+import org.junit.Test
 import spock.lang.IgnoreIf
 
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
@@ -166,5 +167,14 @@ class DBFunctionalSpecification extends FunctionalSpecification {
 
         cleanup:
         database.setWriteConcern(null)
+    }
+
+    @Test
+    def 'should execute command with customer encoder'() {
+        when:
+        CommandResult commandResult = database.command(new BasicDBObject("isMaster", 1), DefaultDBEncoder.FACTORY.create());
+
+        then:
+        commandResult.ok()
     }
 }


### PR DESCRIPTION
Ensure that the ElementExtendingBsonWriter appends the extra elements when a reader is piped into the writer at the top level.

The fix is largely restoring the original code which we mistakenly thought was no longer needed.

The bug wasn't caught because of a poorly written test, which was also hiding a bug in the original implementation.

Patch build: https://evergreen.mongodb.com/version/5a34454ce3c3316221004284