### PR TITLE
Update ErrorHandlingResultCallback#onResult log level

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/ErrorHandlingResultCallback.java
+++ b/driver-core/src/main/com/mongodb/internal/async/ErrorHandlingResultCallback.java
@@ -48,7 +48,7 @@ public class ErrorHandlingResultCallback<T> implements SingleResultCallback<T> {
         try {
             wrapped.onResult(result, t);
         } catch (Throwable e) {
-            logger.warn("Callback onResult call produced an error", e);
+            logger.error("Callback onResult call produced an error", e);
         }
     }
 


### PR DESCRIPTION
When the log appender to the "org.mongodb" package is configured with ERROR level.

```xml
<logger name="org.mongodb" level="ERROR"/>
```

And some exception is thrown inside the callback lambda expression body.

```java
...
mongoCollection.insertOne(document, (result, error) -> {
        if (null == error) {
          // do something that throws some runtime exception.
          throw new RuntimeException("some exception!!!");
        }
      });
```

Nothing is written to the log, shadowing the error that occurred. Because internally the driver writes as warning and not error. ErrorHandlingResultCallback#onResult

```java
public void onResult(final T result, final Throwable t) {
    try {
        wrapped.onResult(result, t);
    } catch (Throwable e) {
        logger.warn("Callback onResult call produced an error", e);
    }
}
```
