### PR TITLE
JAVA-2734 : Upgrade codenarc to version 1.1

### DIFF
--- a/bson/src/test/unit/org/bson/RawBsonDocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/RawBsonDocumentSpecification.groovy
@@ -408,7 +408,6 @@ class RawBsonDocumentSpecification extends Specification {
 
         where:
         localRawDocument << createRawDocumentVariants()
-
     }
 
     private static List<RawBsonDocument> createRawDocumentVariants() {

--- a/bson/src/test/unit/org/bson/codecs/BigDecimalCodecSpecification.groovy
+++ b/bson/src/test/unit/org/bson/codecs/BigDecimalCodecSpecification.groovy
@@ -63,6 +63,5 @@ class BigDecimalCodecSpecification extends Specification {
                 new BigDecimal(Long.MIN_VALUE),
                 new BigDecimal(0),
         ]
-
     }
 }

--- a/bson/src/test/unit/org/bson/codecs/UuidCodecSpecification.groovy
+++ b/bson/src/test/unit/org/bson/codecs/UuidCodecSpecification.groovy
@@ -43,7 +43,6 @@ class UuidCodecSpecification extends Specification {
     }
 
     def 'should decode different types of UUID'(UuidCodec codec, byte[] list) throws IOException {
-
         given:
 
         ByteBufferBsonInput inputBuffer = new ByteBufferBsonInput(new ByteBufNIO(ByteBuffer.wrap(list)))
@@ -104,7 +103,6 @@ class UuidCodecSpecification extends Specification {
                  5, 6, 7, 8, 3, 4, 1, 2,
                  16, 15, 14, 13, 12, 11, 10, 9], //8 bytes for long, 2 longs for UUID, Big Endian
         ]
-
     }
 
     def 'should encode different types of UUIDs'(Byte bsonSubType,

--- a/bson/src/test/unit/org/bson/io/ByteBufferBsonInputSpecification.groovy
+++ b/bson/src/test/unit/org/bson/io/ByteBufferBsonInputSpecification.groovy
@@ -60,7 +60,6 @@ class ByteBufferBsonInputSpecification extends Specification {
         expect:
         bytesRead == bytes
         stream.position == 3
-
     }
 
     def 'should read into a byte array at offset until length'() {

--- a/bson/src/test/unit/org/bson/json/JsonWriterSettingsSpecification.groovy
+++ b/bson/src/test/unit/org/bson/json/JsonWriterSettingsSpecification.groovy
@@ -120,7 +120,6 @@ class JsonWriterSettingsSpecification extends Specification {
         settings.isIndent()
         settings.getIndentCharacters() == '\t'
         settings.getNewLineCharacters() == '\r'
-
     }
 
     def 'should use legacy extended json converters for strict mode'() {

--- a/bson/src/test/unit/org/bson/json/StrictCharacterStreamJsonWriterSpecification.groovy
+++ b/bson/src/test/unit/org/bson/json/StrictCharacterStreamJsonWriterSpecification.groovy
@@ -383,7 +383,6 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
 
         then:
         thrown(IllegalArgumentException)
-
     }
 
     def shouldThrowAnExceptionWhenWritingNullValue() {
@@ -478,7 +477,6 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
 
         then:
         thrown(IllegalArgumentException)
-
     }
 
     def shouldStopAtMaxLength() {

--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,7 @@ configure(subprojects.findAll { it.name != 'util' && it.name != 'mongo-java-driv
     }
 
     codenarc {
-        toolVersion = '1.0'
+        toolVersion = '1.1'
         reportFormat = project.buildingWith('xmlReports.enabled') ? 'xml' : 'html'
     }
 

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -34,6 +34,11 @@
         <exclude name="TrailingComma"/>
         <exclude name="CouldBeSwitchStatement"/>
         <exclude name="NoDef"/>
+        <exclude name='InvertedCondition'/>
+        <exclude name='MethodReturnTypeRequired'/>
+        <exclude name='MethodParameterTypeRequired'/>
+        <exclude name='FieldTypeRequired '/>
+        <exclude name="VariableTypeRequired"/>
     </ruleset-ref>
     <ruleset-ref path='rulesets/design.xml'>
         <rule-config name='BuilderMethodWithSideEffects'>
@@ -64,6 +69,7 @@
         <exclude name='BlankLineBeforePackage'/>
         <exclude name='ConsecutiveBlankLines'/>
         <exclude name='FileEndsWithoutNewline'/>
+        <exclude name='Indentation'/>
     </ruleset-ref>
     <ruleset-ref path='rulesets/generic.xml'/>
     <ruleset-ref path='rulesets/groovyism.xml'>

--- a/driver-async/src/test/functional/com/mongodb/async/client/NettyStreamFactoryFactorySmokeTestSpecification.groovy
+++ b/driver-async/src/test/functional/com/mongodb/async/client/NettyStreamFactoryFactorySmokeTestSpecification.groovy
@@ -50,7 +50,6 @@ class NettyStreamFactoryFactorySmokeTestSpecification extends FunctionalSpecific
 
         cleanup:
         mongoClient?.close()
-
     }
 
     def run(operation, ... args) {

--- a/driver-async/src/test/functional/com/mongodb/async/client/gridfs/helpers/AsyncStreamHelperTestSpecification.groovy
+++ b/driver-async/src/test/functional/com/mongodb/async/client/gridfs/helpers/AsyncStreamHelperTestSpecification.groovy
@@ -87,7 +87,6 @@ class AsyncStreamHelperTestSpecification extends FunctionalSpecification {
         content                             | new byte[content.length]
         ByteBuffer.wrap(content)            | ByteBuffer.allocate(content.length)
         new ByteArrayInputStream(content)   | new ByteArrayOutputStream(content.length)
-
     }
 
     def 'should accept data bigger than the chunkSize'() {

--- a/driver-async/src/test/unit/com/mongodb/async/client/ChangeStreamIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/ChangeStreamIterableSpecification.groovy
@@ -132,7 +132,6 @@ class ChangeStreamIterableSpecification extends Specification {
         def count = 0
         def cannedResults = ['{_id: 1}', '{_id: 2}', '{_id: 3}'].collect {
             new ChangeStreamDocument(RawBsonDocument.parse(it), null, Document.parse(it), BsonDocument.parse(it), null, null)
-
         }
         def executor = new TestOperationExecutor([cursor(cannedResults), cursor(cannedResults), cursor(cannedResults),
                                                   cursor(cannedResults), cursor(cannedResults)])

--- a/driver-async/src/test/unit/com/mongodb/async/client/MappingAsyncBatchCursorSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MappingAsyncBatchCursorSpecification.groovy
@@ -66,7 +66,6 @@ class MappingAsyncBatchCursorSpecification extends Specification {
         then:
         results.get() == null
         mappingAsyncBatchCursor.isClosed()
-
     }
 
     def 'should capture mapping errors'() {

--- a/driver-async/src/test/unit/com/mongodb/async/client/gridfs/GridFSIndexCheckSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/gridfs/GridFSIndexCheckSpecification.groovy
@@ -155,7 +155,6 @@ class GridFSIndexCheckSpecification extends Specification {
         if (clientSession != null) {
             1 * chunksCollection.createIndex(clientSession, { index -> index == Document.parse('{"files_id": 1, "n": 1}') },
                     { indexOptions -> indexOptions.isUnique() }, _) >> { it.last().onResult('files_id_1', null) }
-
         } else {
             1 * chunksCollection.createIndex({ index -> index == Document.parse('{"files_id": 1, "n": 1}') },
                     { indexOptions -> indexOptions.isUnique() }, _) >> { it.last().onResult('files_id_1', null) }
@@ -270,7 +269,6 @@ class GridFSIndexCheckSpecification extends Specification {
         if (clientSession != null) {
             1 * chunksCollection.createIndex(clientSession, { index -> index == Document.parse('{"files_id": 1, "n": 1}') },
                     { indexOptions -> indexOptions.isUnique() }, _) >> { it.last().onResult('files_id_1', null) }
-
         } else {
             1 * chunksCollection.createIndex({ index -> index == Document.parse('{"files_id": 1, "n": 1}') },
                     { indexOptions -> indexOptions.isUnique() }, _) >> { it.last().onResult('files_id_1', null) }

--- a/driver-core/src/test/functional/com/mongodb/client/model/ArrayUpdatesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/ArrayUpdatesFunctionalSpecification.groovy
@@ -86,7 +86,6 @@ class ArrayUpdatesFunctionalSpecification extends OperationFunctionalSpecificati
 
         then:
         find() == [new Document('_id', 1).append('x', [1, 2, 3, 4, 4])]
-
     }
 
     def 'push with each'() {

--- a/driver-core/src/test/functional/com/mongodb/client/model/FieldSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/FieldSpecification.groovy
@@ -25,7 +25,6 @@ class FieldSpecification extends Specification {
 
         then:
         thrown(IllegalArgumentException)
-
     }
 
     def 'should accept null values'() {

--- a/driver-core/src/test/functional/com/mongodb/connection/GSSAPIAuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/GSSAPIAuthenticationSpecification.groovy
@@ -197,7 +197,6 @@ class GSSAPIAuthenticationSpecification extends Specification {
             FutureResultCallback<Void> futureResultCallback = new FutureResultCallback<Void>();
             connection.openAsync(futureResultCallback)
             futureResultCallback.get(ClusterFixture.TIMEOUT, SECONDS);
-
         } else {
             connection.open()
         }

--- a/driver-core/src/test/functional/com/mongodb/connection/PlainAuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/PlainAuthenticationSpecification.groovy
@@ -110,7 +110,6 @@ class PlainAuthenticationSpecification extends Specification {
             FutureResultCallback<Void> futureResultCallback = new FutureResultCallback<Void>();
             connection.openAsync(futureResultCallback)
             futureResultCallback.get(ClusterFixture.TIMEOUT, SECONDS);
-
         } else {
             connection.open()
         }

--- a/driver-core/src/test/functional/com/mongodb/connection/ReplyHeaderSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/ReplyHeaderSpecification.groovy
@@ -60,7 +60,6 @@ class ReplyHeaderSpecification extends Specification {
     }
 
     def 'should parse reply header with compressed header'() {
-
         def outputBuffer = new BasicOutputBuffer();
         outputBuffer.with {
             writeInt(186)
@@ -187,7 +186,6 @@ class ReplyHeaderSpecification extends Specification {
     }
 
     def 'should throw MongoInternalException on num documents < 0 with compressed header'() {
-
         def outputBuffer = new BasicOutputBuffer();
         outputBuffer.with {
             writeInt(186)

--- a/driver-core/src/test/functional/com/mongodb/operation/AggregateToCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AggregateToCollectionOperationSpecification.groovy
@@ -254,7 +254,6 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         [3, 2, 0]     | true                    | false               | false            | false  | false
         [3, 0, 0]     | false                   | false               | false            | true   | false
         [3, 0, 0]     | false                   | false               | false            | false  | false
-
     }
 
     def 'should throw an exception when passing an unsupported collation'() {

--- a/driver-core/src/test/functional/com/mongodb/operation/CommandOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/CommandOperationSpecification.groovy
@@ -59,7 +59,6 @@ class CommandOperationSpecification extends OperationFunctionalSpecification {
 
         then:
         result.getNumber('n').intValue() == 0
-
     }
 
     def 'should execute write command'() {

--- a/driver-core/src/test/functional/com/mongodb/operation/DeleteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/DeleteOperationSpecification.groovy
@@ -59,7 +59,6 @@ class DeleteOperationSpecification extends OperationFunctionalSpecification {
 
         where:
         async << [true, false]
-
     }
 
     @Category(Slow)

--- a/driver-core/src/test/functional/com/mongodb/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/MixedBulkWriteOperationSpecification.groovy
@@ -763,7 +763,6 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     }
 
     def 'should throw IllegalArgumentException when passed an empty bulk operation'() {
-
         when:
         new MixedBulkWriteOperation(getNamespace(), [], ordered, UNACKNOWLEDGED, false)
 

--- a/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
@@ -294,13 +294,11 @@ class ConnectionStringSpecification extends Specification {
     def 'should ignore authSource if there is no credential'() {
         expect:
         new ConnectionString('mongodb://localhost/?authSource=test').credentialList == []
-
     }
 
     def 'should ignore authMechanismProperties if there is no credential'() {
         expect:
         new ConnectionString('mongodb://localhost/?&authMechanismProperties=SERVICE_REALM:AWESOME').credentialList == []
-
     }
 
     @Unroll
@@ -397,7 +395,6 @@ class ConnectionStringSpecification extends Specification {
         new ConnectionString('mongodb://localhost/?compressors=zlib') | createZlibCompressor()
         new ConnectionString('mongodb://localhost/?compressors=zlib' +
                 '&zlibCompressionLevel=5')                                           | createZlibCompressor().withProperty(LEVEL, 5)
-
     }
 
     def 'should be equal to another instance with the same string values'() {

--- a/driver-core/src/test/unit/com/mongodb/binding/SingleServerBindingSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/binding/SingleServerBindingSpecification.groovy
@@ -94,6 +94,5 @@ class SingleServerBindingSpecification extends Specification {
 
         then:
         binding.count == 0
-
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/gridfs/codecs/GridFSFileCodecSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/gridfs/codecs/GridFSFileCodecSpecification.groovy
@@ -68,7 +68,6 @@ class GridFSFileCodecSpecification extends Specification {
             new GridFSFile(ID, FILENAME, LENGTH, CHUNKSIZE, UPLOADDATE, MD5, null, EXTRAELEMENTS),
             new GridFSFile(ID, FILENAME, LENGTH, CHUNKSIZE, UPLOADDATE, MD5, METADATA, EXTRAELEMENTS)
         ]
-
     }
 
     def 'it should decode extra elements'() {

--- a/driver-core/src/test/unit/com/mongodb/client/model/IndexOptionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/IndexOptionsSpecification.groovy
@@ -116,6 +116,5 @@ class IndexOptionsSpecification extends Specification {
 
         then:
         options.getExpireAfter(TimeUnit.SECONDS) == 1
-
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/changestream/ChangeStreamDocumentCodecSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/changestream/ChangeStreamDocumentCodecSpecification.groovy
@@ -35,7 +35,6 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders
 class ChangeStreamDocumentCodecSpecification extends Specification {
 
     def 'should round trip ChangeStreamDocument successfully'() {
-
         given:
         def codecRegistry = fromProviders([new DocumentCodecProvider(), new BsonValueCodecProvider(), new ValueCodecProvider()])
         def codec = new ChangeStreamDocumentCodec(clazz, codecRegistry)

--- a/driver-core/src/test/unit/com/mongodb/client/model/changestream/OperationTypeCodecSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/changestream/OperationTypeCodecSpecification.groovy
@@ -27,7 +27,6 @@ import spock.lang.Specification
 class OperationTypeCodecSpecification extends Specification {
 
     def 'should round trip OperationType successfully'() {
-
         when:
         def codec = new OperationTypeCodec()
 
@@ -61,6 +60,5 @@ class OperationTypeCodecSpecification extends Specification {
                 OperationType.REPLACE,
                 OperationType.UPDATE
         ]
-
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/changestream/OperationTypeSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/changestream/OperationTypeSpecification.groovy
@@ -31,7 +31,6 @@ class OperationTypeSpecification extends Specification {
         OperationType.INVALIDATE | 'invalidate'
         OperationType.REPLACE    | 'replace'
         OperationType.UPDATE     | 'update'
-
     }
 
     def 'should support valid string representations'() {

--- a/driver-core/src/test/unit/com/mongodb/client/model/geojson/GeometryCollectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/geojson/GeometryCollectionSpecification.groovy
@@ -57,6 +57,5 @@ class GeometryCollectionSpecification extends Specification {
         new GeometryCollection(geometries).hashCode() == new GeometryCollection(geometries).hashCode()
         new GeometryCollection(geometries).toString() ==
         'GeometryCollection{geometries=[Point{coordinate=Position{values=[1.0, 2.0]}}, Point{coordinate=Position{values=[2.0, 2.0]}}]}'
-
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/geojson/MultiLineStringSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/geojson/MultiLineStringSpecification.groovy
@@ -67,6 +67,5 @@ class MultiLineStringSpecification extends Specification {
         'MultiLineString{coordinates=[' +
         '[Position{values=[1.0, 1.0]}, Position{values=[2.0, 2.0]}, Position{values=[3.0, 4.0]}], ' +
         '[Position{values=[2.0, 3.0]}, Position{values=[3.0, 2.0]}, Position{values=[4.0, 4.0]}]]}'
-
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/geojson/codecs/PolygonCodecSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/geojson/codecs/PolygonCodecSpecification.groovy
@@ -55,7 +55,6 @@ class PolygonCodecSpecification extends Specification {
 
         then:
         polygon == decodedPolygon
-
     }
 
     def 'should round trip with coordinate reference system'() {

--- a/driver-core/src/test/unit/com/mongodb/connection/ByteBufBsonDocumentSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ByteBufBsonDocumentSpecification.groovy
@@ -65,7 +65,6 @@ class ByteBufBsonDocumentSpecification extends Specification {
         byteBufDocument.get('z') == null
         byteBufDocument.get('a') == new BsonInt32(1)
         byteBufDocument.get('b') == new BsonInt32(2)
-
     }
 
     def 'get should throw if the key is null'() {

--- a/driver-core/src/test/unit/com/mongodb/connection/ByteBufSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ByteBufSpecification.groovy
@@ -233,6 +233,5 @@ class ByteBufSpecification extends Specification {
 
         where:
         provider << [new NettyBufferProvider(), new SimpleBufferProvider()]
-
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/connection/ClusterSettingsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ClusterSettingsSpecification.groovy
@@ -170,7 +170,6 @@ class ClusterSettingsSpecification extends Specification {
         ClusterSettings.builder().hosts([new ServerAddress(), new ServerAddress('other')]).mode(ClusterConnectionMode.SINGLE).build();
         then:
         thrown(IllegalArgumentException)
-
     }
 
     def 'when cluster type is Standalone and multiple hosts are specified, should throw'() {

--- a/driver-core/src/test/unit/com/mongodb/connection/CompositeByteBufSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/CompositeByteBufSpecification.groovy
@@ -76,7 +76,6 @@ class CompositeByteBufSpecification extends Specification {
 
         then:
         thrown(IllegalStateException)
-
     }
 
     def 'order should throw if not little endian'() {
@@ -500,7 +499,6 @@ class CompositeByteBufSpecification extends Specification {
         def bytes = new byte[5]
         nio.get(bytes)
         bytes == [2, 3, 4, 5, 6] as byte[]
-
     }
 
     def 'should throw IndexOutOfBoundsException if reading out of bounds'() {

--- a/driver-core/src/test/unit/com/mongodb/connection/DefaultServerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/DefaultServerSpecification.groovy
@@ -381,7 +381,6 @@ class DefaultServerSpecification extends Specification {
                 BsonDocument result, Throwable t -> latch.countDown()
             }
             latch.await()
-
         } else {
             testConnection.killCursor(new MongoNamespace('test.test'), [])
         }

--- a/driver-core/src/test/unit/com/mongodb/connection/DescriptionHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/DescriptionHelperSpecification.groovy
@@ -130,7 +130,6 @@ class DescriptionHelperSpecification extends Specification {
         expect:
         createServerDescription(serverAddress,
                 parse('{ ok : 1 }'), serverVersion, roundTripTime).getLastUpdateTime(TimeUnit.NANOSECONDS) == Time.CONSTANT_TIME
-
     }
 
     def 'server description should reflect roundTripNanos'() {

--- a/driver-core/src/test/unit/com/mongodb/connection/InternalStreamConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/InternalStreamConnectionSpecification.groovy
@@ -103,7 +103,6 @@ class InternalStreamConnectionSpecification extends Specification {
         connection.opened()
         connection.getDescription().getServerType() == ServerType.STANDALONE
         connection.getDescription().getConnectionId().getServerValue() == 1
-
     }
 
     @Category(Async)
@@ -125,7 +124,6 @@ class InternalStreamConnectionSpecification extends Specification {
         connection.opened()
         connection.getDescription().getServerType() == ServerType.STANDALONE
         connection.getDescription().getConnectionId().getServerValue() == 1
-
     }
 
     def 'should close the stream when initialization throws an exception'() {

--- a/driver-core/src/test/unit/com/mongodb/connection/MultiServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/MultiServerClusterSpecification.groovy
@@ -90,7 +90,6 @@ class MultiServerClusterSpecification extends Specification {
         then:
         cluster.getDescription().type == REPLICA_SET
         cluster.getDescription().connectionMode == MULTIPLE
-
     }
 
     def 'should not get server when closed'() {

--- a/driver-core/src/test/unit/com/mongodb/connection/SslSettingsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/SslSettingsSpecification.groovy
@@ -119,7 +119,6 @@ class SslSettingsSpecification extends Specification {
                 .context(SSLContext.getDefault()).build().hashCode() ==
                 builder().enabled(true).invalidHostNameAllowed(true)
                         .context(SSLContext.getDefault()).build().hashCode()
-
     }
 
     @IgnoreIf({ isNotAtLeastJava7() })

--- a/driver-core/src/test/unit/com/mongodb/connection/WriteCommandHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/WriteCommandHelperSpecification.groovy
@@ -127,7 +127,6 @@ class WriteCommandHelperSpecification extends Specification {
                                                   new BsonString('id1')))])),
                               new ServerAddress())
                 .writeErrors
-
     }
 
     def 'should get write concern error from writeConcernError field'() {

--- a/driver-core/src/test/unit/com/mongodb/connection/WriteResultProtocolHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/WriteResultProtocolHelperSpecification.groovy
@@ -41,7 +41,6 @@ class WriteResultProtocolHelperSpecification extends Specification {
 
         then:
         writeResult == WriteConcernResult.acknowledged(0, false, null)
-
     }
 
     def 'should return a write result for an upsert'() {
@@ -55,7 +54,6 @@ class WriteResultProtocolHelperSpecification extends Specification {
 
         then:
         writeResult == WriteConcernResult.acknowledged(1, false, new BsonObjectId(id))
-
     }
 
     def 'should throw command failure if result is not ok'() {

--- a/driver-core/src/test/unit/com/mongodb/event/CommandEventMulticasterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/event/CommandEventMulticasterSpecification.groovy
@@ -34,7 +34,6 @@ class CommandEventMulticasterSpecification extends Specification {
 
         expect:
         multicaster.commandListeners == [first, second]
-
     }
 
     def 'should multicast command started event'() {

--- a/driver-core/src/test/unit/com/mongodb/event/CommandListenerMulticasterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/event/CommandListenerMulticasterSpecification.groovy
@@ -35,7 +35,6 @@ class CommandListenerMulticasterSpecification extends Specification {
 
         expect:
         multicaster.commandListeners == [first, second]
-
     }
 
     def 'should multicast command started event'() {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/IndexMapSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/IndexMapSpecification.groovy
@@ -50,7 +50,6 @@ class IndexMapSpecification extends Specification {
     }
 
     def 'should throw on unmapped index'() {
-
         when:
         indexMap.map(-1)
 

--- a/driver-core/src/test/unit/com/mongodb/internal/session/ServerSessionPoolSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/session/ServerSessionPoolSpecification.groovy
@@ -91,7 +91,6 @@ class ServerSessionPoolSpecification extends Specification {
 
         then:
         thrown(IllegalStateException)
-
     }
 
     def 'should pool session'() {
@@ -201,7 +200,6 @@ class ServerSessionPoolSpecification extends Specification {
 
         then:
         session == newSession
-
     }
 
     def 'should initialize session'() {

--- a/driver-core/src/test/unit/com/mongodb/operation/AsyncQueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/AsyncQueryBatchCursorSpecification.groovy
@@ -426,7 +426,6 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         serverVersion                | commandAsync         | response
         new ServerVersion([3, 2, 0]) | true                 | documentResponse(SECOND_BATCH)
         new ServerVersion([3, 0, 0]) | false                | queryResult(SECOND_BATCH)
-
     }
 
     def 'should kill the cursor in the getMore callback if it was closed before getMore returned'() {
@@ -480,7 +479,6 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         serverVersion                | commandAsync         | response
         new ServerVersion([3, 2, 0]) | true                 | documentResponse([])
         new ServerVersion([3, 0, 0]) | false                | new QueryResult(NAMESPACE, [], 42, SERVER_ADDRESS)
-
     }
 
     def 'should handle errors when calling close'() {

--- a/driver-core/src/test/unit/com/mongodb/operation/BulkWriteBatchSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/BulkWriteBatchSpecification.groovy
@@ -183,7 +183,6 @@ class BulkWriteBatchSpecification extends Specification {
         !bulkWriteBatch.hasAnotherBatch()
         bulkWriteBatch.getCommand() == toBsonDocument('''{"delete": "coll", "ordered": false,
                 "writeConcern": {"w" : "majority"}, "bypassDocumentValidation" : true }''')
-
     }
 
     def 'should split payloads if only payload partially processed'() {

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionFunctionalSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionFunctionalSpecification.groovy
@@ -122,7 +122,6 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
 
         then:
         document instanceof ClassA
-
     }
 
     def 'should use internal classes for findAndModify'() {
@@ -578,7 +577,6 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         new BasicDBObject()                       | [x: -1] as BasicDBObject      | 2
         [x: 1] as BasicDBObject                   | [x: 1, y: 1] as BasicDBObject | 3
         QueryBuilder.start('x').lessThan(2).get() | [y: -1] as BasicDBObject      | 5
-
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
@@ -526,7 +526,6 @@ class DBCollectionSpecification extends Specification {
                 new BsonDocument(), collection.getDefaultDBObjectCodec()).key(BsonDocument.parse('{name: 1}')).collation(collation)
                 .filter(new BsonDocument())
         )
-
     }
 
     def 'mapReduce should create the correct MapReduceInlineResultsOperation'() {

--- a/driver-legacy/src/test/unit/com/mongodb/MapReduceCommandSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MapReduceCommandSpecification.groovy
@@ -44,7 +44,6 @@ class MapReduceCommandSpecification extends Specification {
 
     @Unroll
     def 'should have the correct default for #field'() throws Exception {
-
         expect:
         value == expected
 
@@ -69,7 +68,6 @@ class MapReduceCommandSpecification extends Specification {
 
     @Unroll
     def 'should be able to change the default for #field'() throws Exception {
-
         expect:
         value == expected
 

--- a/driver-legacy/src/test/unit/com/mongodb/MongoSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoSpecification.groovy
@@ -115,7 +115,6 @@ class MongoSpecification extends Specification {
                         new BsonDocument('ok', new BsonInt32(1))
                     }
                 }
-
             }
         }
 

--- a/driver-legacy/src/test/unit/com/mongodb/client/model/DBCollectionCountOptionsSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/client/model/DBCollectionCountOptionsSpecification.groovy
@@ -38,7 +38,6 @@ class DBCollectionCountOptionsSpecification extends Specification {
         options.getReadConcern() == null
         options.getReadPreference() == null
         options.getSkip() == 0
-
     }
 
     def 'should set and return the expected values'() {

--- a/driver-legacy/src/test/unit/org/bson/LazyBSONObjectSpecification.groovy
+++ b/driver-legacy/src/test/unit/org/bson/LazyBSONObjectSpecification.groovy
@@ -159,7 +159,6 @@ class LazyBSONObjectSpecification extends Specification {
         then:
         document.get('f') instanceof LazyBSONObject
         document.get('f').keySet() == ['$ref', '$id'] as Set
-
     }
 
     def 'should retain fields order'() {
@@ -362,8 +361,5 @@ class LazyBSONObjectSpecification extends Specification {
 
         then:
         bytes == baos.toByteArray()
-
     }
-
-
 }

--- a/driver/src/test/unit/com/mongodb/client/gridfs/GridFSFindIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/gridfs/GridFSFindIterableSpecification.groovy
@@ -144,7 +144,6 @@ class GridFSFindIterableSpecification extends Specification {
                 hasNext() >> {
                     count == 0
                 }
-
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
@@ -189,7 +188,6 @@ class GridFSFindIterableSpecification extends Specification {
 
         then:
         target == cannedResults*.getFilename()
-
     }
 
 }

--- a/driver/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
@@ -269,7 +269,6 @@ class AggregateIterableSpecification extends Specification {
                 hasNext() >> {
                     count == 0
                 }
-
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()])

--- a/driver/src/test/unit/com/mongodb/client/internal/ChangeStreamIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/internal/ChangeStreamIterableSpecification.groovy
@@ -146,7 +146,6 @@ class ChangeStreamIterableSpecification extends Specification {
         def count = 0
         def cannedResults = ['{_id: 1}', '{_id: 2}', '{_id: 3}'].collect {
             new ChangeStreamDocument(RawBsonDocument.parse(it), null, Document.parse(it), BsonDocument.parse(it), null, null)
-
         }
         def executor = new TestOperationExecutor([cursor(cannedResults), cursor(cannedResults), cursor(cannedResults),
                                                   cursor(cannedResults)])

--- a/driver/src/test/unit/com/mongodb/client/internal/DistinctIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/internal/DistinctIterableSpecification.groovy
@@ -141,7 +141,6 @@ class DistinctIterableSpecification extends Specification {
                 hasNext() >> {
                     count == 0
                 }
-
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);

--- a/driver/src/test/unit/com/mongodb/client/internal/FindIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/internal/FindIterableSpecification.groovy
@@ -233,7 +233,6 @@ class FindIterableSpecification extends Specification {
                 hasNext() >> {
                     count == 0
                 }
-
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()])

--- a/driver/src/test/unit/com/mongodb/client/internal/ListCollectionsIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/internal/ListCollectionsIterableSpecification.groovy
@@ -115,7 +115,6 @@ class ListCollectionsIterableSpecification extends Specification {
                 hasNext() >> {
                     count == 0
                 }
-
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);

--- a/driver/src/test/unit/com/mongodb/client/internal/ListDatabasesIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/internal/ListDatabasesIterableSpecification.groovy
@@ -84,7 +84,6 @@ class ListDatabasesIterableSpecification extends Specification {
                 hasNext() >> {
                     count == 0
                 }
-
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);

--- a/driver/src/test/unit/com/mongodb/client/internal/ListIndexesIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/internal/ListIndexesIterableSpecification.groovy
@@ -115,7 +115,6 @@ class ListIndexesIterableSpecification extends Specification {
                 hasNext() >> {
                     count == 0
                 }
-
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);

--- a/driver/src/test/unit/com/mongodb/client/internal/MapReduceIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/internal/MapReduceIterableSpecification.groovy
@@ -273,7 +273,6 @@ class MapReduceIterableSpecification extends Specification {
                 hasNext() >> {
                     count == 0
                 }
-
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);


### PR DESCRIPTION
New rules in 1.1: https://github.com/CodeNarc/CodeNarc/blob/master/CHANGELOG.md
The new rules excluded (see codenarc.xml) :

- Indentation
- InvertedCondition
- MethodReturnTypeRequired 
- MethodParameterTypeRequired 
- FieldTypeRequired
- VariableTypeRequired 

The new rules included :
- MissingOverrideAnnotation 
- BlockStartsWithBlankLine
- BlockEndsWithBlankLine 

(This is a very exciting contribution) 