### PR TITLE
Fix for NPE in POJO codec when a POJO has a nested collection property and one of the nested values is null

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/CollectionPropertyCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/pojo/CollectionPropertyCodecProvider.java
@@ -53,7 +53,11 @@ final class CollectionPropertyCodecProvider implements PropertyCodecProvider {
         public void encode(final BsonWriter writer, final Collection<T> collection, final EncoderContext encoderContext) {
             writer.writeStartArray();
             for (final T value : collection) {
-                codec.encode(writer, value, encoderContext);
+                if (value == null) {
+                    writer.writeNull();
+                } else {
+                    codec.encode(writer, value, encoderContext);
+                }
             }
             writer.writeEndArray();
         }


### PR DESCRIPTION
Currently if the top-level collection property is null it will be handled gracefully, but if a collection of collections contains a null element it currently causes an NPE on the inner CollectionCodec.encode call while attempting to loop through the null collection's values.