### PR TITLE
Support username containing ',' comma

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/ScramSha1Authenticator.java
+++ b/driver-core/src/main/com/mongodb/connection/ScramSha1Authenticator.java
@@ -281,7 +281,7 @@ class ScramSha1Authenticator extends SaslAuthenticator {
         }
 
         private String prepUserName(final String userName) {
-            return userName.replace("=", "=3D").replace(",", "=2D");
+            return userName.replace("=", "=3D").replace(",", "=2C");
         }
 
         private byte[] xor(final byte[] a, final byte[] b) {


### PR DESCRIPTION
When a username contains ',' comma character, it raises authentication exception. According to [RFC 5801](https://tools.ietf.org/html/rfc5801) , comma should be replace by =2C.

> The server MUST replace any "," (comma) in the string with "=2C".
The server MUST replace any "=" (equals) in the string with "=3D".

EDIT: change the reference to [RFC 5802](https://tools.ietf.org/html/rfc5802)
>The characters ',' or '=' in usernames are sent as '=2C' and
         '=3D' respectively.  If the server receives a username that
         contains '=' not followed by either '2C' or '3D', then the
         server MUST fail the authentication.