### PR TITLE
JAVA-2523: Remove use of methods deprecated in Java 9

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/CollectionPropertyCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/pojo/CollectionPropertyCodecProvider.java
@@ -95,7 +95,7 @@ final class CollectionPropertyCodecProvider implements PropertyCodecProvider {
             }
 
             try {
-                return encoderClass.newInstance();
+                return encoderClass.getDeclaredConstructor().newInstance();
             } catch (final Exception e) {
                 throw new CodecConfigurationException(e.getMessage(), e);
             }

--- a/bson/src/main/org/bson/codecs/pojo/MapPropertyCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/pojo/MapPropertyCodecProvider.java
@@ -106,7 +106,7 @@ final class MapPropertyCodecProvider implements PropertyCodecProvider {
                 return new HashMap<String, T>();
             }
             try {
-                return encoderClass.newInstance();
+                return encoderClass.getDeclaredConstructor().newInstance();
             } catch (final Exception e) {
                 throw new CodecConfigurationException(e.getMessage(), e);
             }


### PR DESCRIPTION
There is 1 warning i haven't fixed when i build with Oracle JDK 9 : 

D:\github\mongo-java-driver\driver-legacy\src\main\com\mongodb\DBCursor.java:980: warning: [deprecation] finalize() in Object has been deprecated
        protected void finalize() {
                       ^
1 warning

Use close() method...