### PR TITLE
JAVA-2589 : Quoting the Keys within extended JSON are now not compulsory anymore

### DIFF
--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -1091,8 +1091,7 @@ public class JsonReader extends AbstractBsonReader {
 
         String pattern;
         String options = "";
-
-        String firstKey = readStringFromExtendedJson();
+        String firstKey = readStringKeyFromExtendedJson();
         if (firstKey.equals("pattern")) {
             verifyToken(JsonTokenType.COLON);
             pattern = readStringFromExtendedJson();
@@ -1108,7 +1107,7 @@ public class JsonReader extends AbstractBsonReader {
             verifyToken(JsonTokenType.COLON);
             pattern = readStringFromExtendedJson();
         } else {
-            throw new JsonParseException("Expected 't' and 'i' fields in $timestamp document but found " + firstKey);
+            throw new JsonParseException("Expected 'pattern' and 'options' fields in $regularExpression document but found " + firstKey);
         }
 
         verifyToken(JsonTokenType.END_OBJECT);
@@ -1168,7 +1167,7 @@ public class JsonReader extends AbstractBsonReader {
         int time;
         int increment;
 
-        String firstKey = readStringFromExtendedJson();
+        String firstKey = readStringKeyFromExtendedJson();
         if (firstKey.equals("t")) {
             verifyToken(JsonTokenType.COLON);
             time = readIntFromExtendedJson();
@@ -1411,6 +1410,19 @@ public class JsonReader extends AbstractBsonReader {
         }
 
         return out;
+    }
+
+    /**
+     * Read an extended json key and verify its type.
+     * Throws a org.bson.json.JsonParseException if the key is not an unquoted string or a simple string.
+     * @return the key string value
+     */
+    private String readStringKeyFromExtendedJson() {
+        JsonToken patternToken = popToken();
+        if (patternToken.getType() != JsonTokenType.STRING && patternToken.getType() != JsonTokenType.UNQUOTED_STRING) {
+            throw new JsonParseException("JSON reader expected a string but found '%s'.", patternToken.getValue());
+        }
+        return patternToken.getValue(String.class);
     }
 }
 

--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -600,6 +600,33 @@ public class JsonReaderTest {
         assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
     }
 
+    /**
+     * Test a $regularExpression extended json with unquoted keys
+     */
+    @Test
+    public void testRegularExpressionCanonicalWithUnquotedKeys() {
+        String json = "{$regularExpression: {pattern: \"[a-z]\", options: \"imxs\"}}";
+        bsonReader = new JsonReader(json);
+        assertEquals(BsonType.REGULAR_EXPRESSION, bsonReader.readBsonType());
+        assertEquals(new BsonRegularExpression("[a-z]", "imxs"), bsonReader.readRegularExpression());
+        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+    }
+
+    /**
+     * Test a $regex extended json query version with unquoted keys
+     */
+    @Test
+    public void testRegularExpressionQueryWithUnquotedKeys() {
+        String json = "{$regex : { $regularExpression : { pattern : \"[a-z]\", options : \"imxs\" }}}";
+        bsonReader = new JsonReader(json);
+        bsonReader.readStartDocument();
+        BsonRegularExpression regex = bsonReader.readRegularExpression("$regex");
+        assertEquals("[a-z]", regex.getPattern());
+        assertEquals("imsx", regex.getOptions());
+        bsonReader.readEndDocument();
+        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+    }
+
     @Test
     public void testString() {
         String str = "abc";
@@ -672,6 +699,18 @@ public class JsonReaderTest {
         String json = "Timestamp(1234, 1)";
         bsonReader = new JsonReader(json);
 
+        assertEquals(BsonType.TIMESTAMP, bsonReader.readBsonType());
+        assertEquals(new BsonTimestamp(1234, 1), bsonReader.readTimestamp());
+        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+    }
+
+    /**
+     * Test a $timestamp extended json with unquoted keys
+     */
+    @Test
+    public void testTimestampStrictWithUnquotedKeys() {
+        String json = "{$timestamp : { t : 1234, i : 1 }}";
+        bsonReader = new JsonReader(json);
         assertEquals(BsonType.TIMESTAMP, bsonReader.readBsonType());
         assertEquals(new BsonTimestamp(1234, 1), bsonReader.readTimestamp());
         assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());


### PR DESCRIPTION
@jyemin : Hi, this is my fix for the JIRA ticket for the issue JAVA-2589.
I hope I won't get checkstyle error again. :-)
The ticket on JIRA will be updated in order to point to this actual pull request.