### PR TITLE
Fix incorrect use of async driver in code sample creating CodecRegistry

### DIFF
--- a/docs/reference/content/driver-async/getting-started/quick-start-pojo.md
+++ b/docs/reference/content/driver-async/getting-started/quick-start-pojo.md
@@ -140,8 +140,8 @@ to handle the translation to and from [`bson`]({{< relref "bson/index.md" >}}) f
 
 The following example will combine the default codec registry, with the `PojoCodecProvider` configured to automatically create `PojoCodecs`:
 ```java
-CodecRegistry pojoCodecRegistry = fromRegistries(MongoClient.getDefaultCodecRegistry(),
-                                        fromProviders(PojoCodecProvider.builder().automatic().build()));
+CodecRegistry pojoCodecRegistry = fromRegistries(MongoClients.getDefaultCodecRegistry(),
+                                        fromProviders(PojoCodecProvider.builder().automatic(true).build()));
 ```
 
 ### Using the CodecRegistry


### PR DESCRIPTION
This commit changes MongoClient to MongoClients to call getgetDefaultCodecRegistry() and adds value 'true' to automatic().