### PR TITLE
fix url path for accumulators documentation

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/Accumulators.java
+++ b/driver-core/src/main/com/mongodb/client/model/Accumulators.java
@@ -20,7 +20,7 @@ package com.mongodb.client.model;
  * Builders for accumulators used in the group pipeline stage of an aggregation pipeline.
  *
  * @mongodb.driver.manual core/aggregation-pipeline/ Aggregation pipeline
- * @mongodb.driver.manual operator/aggregation/group/#accumulator-operator Accumulators
+ * @mongodb.driver.manual reference/operator/aggregation/group/#accumulator-operator Accumulators
  * @mongodb.driver.manual meta/aggregation-quick-reference/#aggregation-expressions Expressions
  * @mongodb.server.release 2.2
  * @since 3.1


### PR DESCRIPTION
Fix link to MongoDB documentation.

http://mongodb.github.io/mongo-java-driver/3.7/javadoc/?com/mongodb/client/model/Accumulators.html

I will do another fix for `%n` introduced by https://github.com/mongodb/mongo-java-driver/commit/8331079d529ea3df6b4f2f0d9c59d46d82965eb4