### PR TITLE
JAVA-2724 : Remove %n in String.format call in DocTaglet

### DIFF
--- a/util/src/main/DocTaglet.java
+++ b/util/src/main/DocTaglet.java
@@ -52,9 +52,9 @@ public abstract class DocTaglet implements Taglet {
             return null;
         }
 
-        StringBuilder buf = new StringBuilder(String.format("%n<dl><dt><span class=\"strong\">%s</span></dt>%n", getHeader()));
+        StringBuilder buf = new StringBuilder(String.format("<dl><dt><span class=\"strong\">%s</span></dt>", getHeader()));
         for (Tag t : tags) {
-            buf.append("   <dd>").append(genLink(t.text())).append("</dd>%n");
+            buf.append("<dd>").append(genLink(t.text())).append("</dd>");
         }
         return buf.toString();
     }


### PR DESCRIPTION
The `<dd>` element is block level element : https://www.w3.org/TR/html401/struct/lists.html#edef-DD
So, we don't need `\n` or `%`, or `<br/>`  : 

With `%n`:
- http://mongodb.github.io/mongo-java-driver/3.7/javadoc/?com/mongodb/client/model/Accumulators.html 

Without  `%n`:
![image](https://user-images.githubusercontent.com/1149149/39332825-f2747312-49a8-11e8-8b1e-4adb979ea730.png)
