### PR TITLE
fix url path for documentation

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/Accumulators.java
+++ b/driver-core/src/main/com/mongodb/client/model/Accumulators.java
@@ -20,7 +20,7 @@ package com.mongodb.client.model;
  * Builders for accumulators used in the group pipeline stage of an aggregation pipeline.
  *
  * @mongodb.driver.manual core/aggregation-pipeline/ Aggregation pipeline
- * @mongodb.driver.manual operator/aggregation/group/#accumulator-operator Accumulators
+ * @mongodb.driver.manual reference/operator/aggregation/group/#accumulator-operator Accumulators
  * @mongodb.driver.manual meta/aggregation-quick-reference/#aggregation-expressions Expressions
  * @mongodb.server.release 2.2
  * @since 3.1

--- a/driver-legacy/src/main/com/mongodb/BulkWriteRequestBuilder.java
+++ b/driver-legacy/src/main/com/mongodb/BulkWriteRequestBuilder.java
@@ -26,9 +26,9 @@ import java.util.List;
  * A builder for a single write request.
  *
  * @mongodb.server.release 2.6
- * @mongodb.driver.manual /reference/command/delete/ Delete
- * @mongodb.driver.manual /reference/command/update/ Update
- * @mongodb.driver.manual /reference/command/insert/ Insert
+ * @mongodb.driver.manual reference/command/delete/ Delete
+ * @mongodb.driver.manual reference/command/update/ Update
+ * @mongodb.driver.manual reference/command/insert/ Insert
  * @since 2.12
  */
 public class BulkWriteRequestBuilder {


### PR DESCRIPTION
Replace #467 

Fix link to MongoDB documentation.

- http://mongodb.github.io/mongo-java-driver/3.7/javadoc/?com/mongodb/client/model/Accumulators.html

- http://mongodb.github.io/mongo-java-driver/3.7/javadoc/com/mongodb/BulkWriteRequestBuilder.html

I will do another fix for `%n` introduced by 8331079