### PR TITLE
JAVA-2560 : Use jdk.javadoc.doclet package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_script:
 script:
   - ./gradlew -q assemble
   - ./gradlew check -Ptravistest=true
+  - ./gradlew docs
 
 after_script:
   - pkill mongod

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: true
 language: java
 jdk:
-- oraclejdk8
+- oraclejdk9
 
 notifications:
   email:

--- a/build.gradle
+++ b/build.gradle
@@ -277,7 +277,7 @@ task docs(type: Javadoc) {
 def setJavaDocOptions(MinimalJavadocOptions options) {
     options.author = true
     options.version = true
-    options.links 'http://docs.oracle.com/javase/7/docs/api/'
+    options.links 'https://docs.oracle.com/javase/9/docs/api/'
     options.tagletPath single(project(':util').sourceSets.main.output.classesDirs)
     options.taglets 'ManualTaglet'
     options.taglets 'DochubTaglet'

--- a/build.gradle
+++ b/build.gradle
@@ -286,6 +286,7 @@ def setJavaDocOptions(MinimalJavadocOptions options) {
     options.charSet 'UTF-8'
     options.docEncoding 'UTF-8'
     options.addBooleanOption("html4", true)
+    options.addBooleanOption("-allow-script-in-comments", true)
     options.header = '''
             <script type="text/javascript">
             <!-- Set the location hash in the classFrame -->
@@ -308,15 +309,6 @@ def setJavaDocOptions(MinimalJavadocOptions options) {
             }
             </script>
         '''
-
-    // Add --allow-script-in-comments if available (since 1.8.0_121)
-    try {
-        if (Class.forName('com.sun.tools.doclets.formats.html.ConfigurationImpl')
-                .newInstance().optionLength('--allow-script-in-comments') > 0) {
-            options.addBooleanOption("-allow-script-in-comments", true)
-        }
-    } catch (ignored) {
-    }
 }
 
 //////////////////////////////////////////
@@ -327,8 +319,8 @@ task wrapper(type: Wrapper) {
 }
 
 gradle.buildFinished { BuildResult result ->
-    if (result.failure && !JavaVersion.current().isJava8Compatible()) {
-        gradle.rootProject.logger.error("\nWARNING:\nJDK ${JavaVersion.VERSION_1_8} is required to build the driver: " +
+    if (result.failure && !JavaVersion.current().isJava9Compatible()) {
+        gradle.rootProject.logger.error("\nWARNING:\nJDK ${JavaVersion.VERSION_1_9} is required to build the driver: " +
                 "you are using JDK ${JavaVersion.current()}.")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -285,6 +285,7 @@ def setJavaDocOptions(MinimalJavadocOptions options) {
     options.encoding = 'UTF-8'
     options.charSet 'UTF-8'
     options.docEncoding 'UTF-8'
+    options.addBooleanOption("html4", true)
     options.header = '''
             <script type="text/javascript">
             <!-- Set the location hash in the classFrame -->

--- a/driver-core/src/main/com/mongodb/client/model/Projections.java
+++ b/driver-core/src/main/com/mongodb/client/model/Projections.java
@@ -185,7 +185,6 @@ public final class Projections {
      *
      * @param projections the list of projections to combine
      * @return the combined projection
-     * @mongodb.driver.manual
      */
     public static Bson fields(final List<? extends Bson> projections) {
         notNull("sorts", projections);

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -16,12 +16,8 @@
 
 apply plugin: 'java'
 
-sourceCompatibility = '1.6'
-targetCompatibility = '1.6'
-
-dependencies {
-    compile files("${System.getProperty('java.home')}/../lib/tools.jar")
-}
+sourceCompatibility = JavaVersion.VERSION_1_6
+targetCompatibility = JavaVersion.VERSION_1_6
 
 sourceSets {
     main { java.srcDirs = ['src/main'] }

--- a/util/src/main/DocTaglet.java
+++ b/util/src/main/DocTaglet.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import static java.util.Arrays.asList;
 import static jdk.javadoc.doclet.Taglet.Location.*;
 
-
 public abstract class DocTaglet implements Taglet {
 
     @Override
@@ -43,9 +42,10 @@ public abstract class DocTaglet implements Taglet {
         if (tags.size() == 0) {
             return null;
         }
+
         StringBuilder buf = new StringBuilder(String.format("<dl><dt><span class=\"strong\">%s</span></dt>", getHeader()));
-        for (DocTree t : tags) {
-            String text = ((UnknownBlockTagTree) t).getContent().get(0).toString();
+        for (DocTree tag : tags) {
+            String text = ((UnknownBlockTagTree) tag).getContent().get(0).toString();
             buf.append("<dd>").append(genLink(text)).append("</dd>");
         }
         return buf.toString();
@@ -65,6 +65,6 @@ public abstract class DocTaglet implements Taglet {
     }
 
     protected abstract String getHeader();
-    
+
     protected abstract String getBaseDocURI();
 }

--- a/util/src/main/DocTaglet.java
+++ b/util/src/main/DocTaglet.java
@@ -14,55 +14,41 @@
  * limitations under the License.
  */
 
-import com.sun.javadoc.Tag;
-import com.sun.tools.doclets.Taglet;
+import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.UnknownBlockTagTree;
+import jdk.javadoc.doclet.Taglet;
+import javax.lang.model.element.Element;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static jdk.javadoc.doclet.Taglet.Location.*;
+
 
 public abstract class DocTaglet implements Taglet {
 
-    public boolean inConstructor() {
-        return true;
+    @Override
+    public Set<Location> getAllowedLocations() {
+        return new HashSet<Location>(asList(CONSTRUCTOR, METHOD, FIELD, OVERVIEW, PACKAGE, TYPE));
     }
 
-    public boolean inField() {
-        return true;
-    }
-
-    public boolean inMethod() {
-        return true;
-    }
-
-    public boolean inOverview() {
-        return true;
-    }
-
-    public boolean inPackage() {
-        return true;
-    }
-
-    public boolean inType() {
-        return true;
-    }
-
+    @Override
     public boolean isInlineTag() {
         return false;
     }
 
-    public String toString(final Tag[] tags) {
-        if (tags.length == 0) {
+    @Override
+    public String toString(List<? extends DocTree> tags, Element element) {
+        if (tags.size() == 0) {
             return null;
         }
-
         StringBuilder buf = new StringBuilder(String.format("<dl><dt><span class=\"strong\">%s</span></dt>", getHeader()));
-        for (Tag t : tags) {
-            buf.append("<dd>").append(genLink(t.text())).append("</dd>");
+        for (DocTree t : tags) {
+            String text = ((UnknownBlockTagTree) t).getContent().get(0).toString();
+            buf.append("<dd>").append(genLink(text)).append("</dd>");
         }
         return buf.toString();
-    }
-
-    protected abstract String getHeader();
-
-    public String toString(final Tag tag) {
-        return toString(new Tag[]{tag});
     }
 
     protected String genLink(final String text) {
@@ -78,5 +64,7 @@ public abstract class DocTaglet implements Taglet {
         return String.format("<a href='%s%s'>%s</a>", getBaseDocURI(), relativePath, display);
     }
 
+    protected abstract String getHeader();
+    
     protected abstract String getBaseDocURI();
 }

--- a/util/src/main/DochubTaglet.java
+++ b/util/src/main/DochubTaglet.java
@@ -14,17 +14,11 @@
  * limitations under the License.
  */
 
-import com.sun.tools.doclets.Taglet;
-
-import java.util.Map;
-
 public class DochubTaglet extends DocTaglet {
 
-    public static void register(final Map<String, Taglet> tagletMap) {
-        DochubTaglet t = new DochubTaglet();
-        tagletMap.put(t.getName(), t);
-    }
+    public DochubTaglet() { }
 
+    @Override
     public String getName() {
         return "mongodb.driver.dochub";
     }

--- a/util/src/main/DochubTaglet.java
+++ b/util/src/main/DochubTaglet.java
@@ -16,8 +16,6 @@
 
 public class DochubTaglet extends DocTaglet {
 
-    public DochubTaglet() { }
-
     @Override
     public String getName() {
         return "mongodb.driver.dochub";

--- a/util/src/main/ManualTaglet.java
+++ b/util/src/main/ManualTaglet.java
@@ -16,8 +16,6 @@
 
 public class ManualTaglet extends DocTaglet {
 
-    public ManualTaglet() { }
-
     @Override
     public String getName() {
         return "mongodb.driver.manual";

--- a/util/src/main/ManualTaglet.java
+++ b/util/src/main/ManualTaglet.java
@@ -14,17 +14,11 @@
  * limitations under the License.
  */
 
-import com.sun.tools.doclets.Taglet;
-
-import java.util.Map;
-
 public class ManualTaglet extends DocTaglet {
 
-    public static void register(final Map<String, Taglet> tagletMap) {
-        ManualTaglet t = new ManualTaglet();
-        tagletMap.put(t.getName(), t);
-    }
+    public ManualTaglet() { }
 
+    @Override
     public String getName() {
         return "mongodb.driver.manual";
     }

--- a/util/src/main/ServerReleaseTaglet.java
+++ b/util/src/main/ServerReleaseTaglet.java
@@ -16,11 +16,14 @@
 
 public class ServerReleaseTaglet extends DocTaglet {
 
-    public ServerReleaseTaglet() { }
-
     @Override
     public String getName() {
         return "mongodb.server.release";
+    }
+
+    @Override
+    protected String getHeader() {
+        return "Since server release";
     }
 
     @Override
@@ -28,8 +31,4 @@ public class ServerReleaseTaglet extends DocTaglet {
         return "http://docs.mongodb.org/manual/release-notes/";
     }
 
-    @Override
-    protected String getHeader() {
-        return "Since server release";
-    }
 }

--- a/util/src/main/ServerReleaseTaglet.java
+++ b/util/src/main/ServerReleaseTaglet.java
@@ -14,16 +14,9 @@
  * limitations under the License.
  */
 
-import com.sun.tools.doclets.Taglet;
-
-import java.util.Map;
-
 public class ServerReleaseTaglet extends DocTaglet {
 
-    public static void register(final Map<String, Taglet> tagletMap) {
-        Taglet t = new ServerReleaseTaglet();
-        tagletMap.put(t.getName(), t);
-    }
+    public ServerReleaseTaglet() { }
 
     @Override
     public String getName() {


### PR DESCRIPTION


 
**Migration guide :** 

- https://docs.oracle.com/javase/9/docs/api/jdk/javadoc/doclet/package-summary.html#migration 

**Generated API documention on my machine :**

![image](https://user-images.githubusercontent.com/1149149/39385989-cac1f856-4a72-11e8-81cf-c87bf587b062.png)

URLs are correctly generated.

**Javadoc Search**

[JEP 225](http://openjdk.java.net/jeps/225) added a search box : 

![image](https://user-images.githubusercontent.com/1149149/39386171-9774c040-4a73-11e8-8ba2-9c915448b412.png)

**Javadoc and HTML**

Javadoc tools currently generates pages in HTML 4.01 : 
![image](https://user-images.githubusercontent.com/1149149/39386454-f7ecd92a-4a74-11e8-8278-0292f4eb1476.png)

[JEP 224](http://openjdk.java.net/jeps/224) added an option to generate HTML5.
I have tried this option and it's not working. I need to convert documentation comments written using HTML 4 to HTML5. And there are others rendering issue (with frame). 
There is a lot of issue about javadoc tools :  [JIRA](https://bugs.openjdk.java.net/issues/?jql=project+in+%28JDK%29+AND+component+in+%28tools%29+AND+Subcomponent+in+%28%22javadoc%28tool%29%22%29)

**Build with :** 

```
------------------------------------------------------------
Gradle 4.5.1
------------------------------------------------------------

Build time:   2018-02-05 13:22:49 UTC
Revision:     37007e1c012001ff09973e0bd095139239ecd3b3

Groovy:       2.4.12
Ant:          Apache Ant(TM) version 1.9.9 compiled on February 2 2017
JVM:          9.0.4 (Oracle Corporation 9.0.4+11)
OS:           Linux 3.13.0-137-generic amd64
```

Gradle docs task is not working on Windows : [GRADLE-3099]( https://issues.gradle.org/browse/GRADLE-3099)

 Farès