### PR TITLE
JAVA-2852: Log failure to get machine or process id at debug

### DIFF
--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -516,9 +516,9 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
             }
             machinePiece = sb.toString().hashCode();
         } catch (Throwable t) {
-            // exception sometimes happens with IBM JVM, use random
+            // exception sometimes happens with IBM JVM, use SecureRandom instead
             machinePiece = (new SecureRandom().nextInt());
-            LOGGER.warn("Failed to get machine identifier from network interface, using random number instead", t);
+            LOGGER.debug("Failed to get machine identifier from network interface, using SecureRandom instead");
         }
         machinePiece = machinePiece & LOW_ORDER_THREE_BYTES;
         return machinePiece;
@@ -537,8 +537,9 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
             }
 
         } catch (Throwable t) {
+            // JMX not available on Android, use SecureRandom instead
             processId = (short) new SecureRandom().nextInt();
-            LOGGER.warn("Failed to get process identifier from JMX, using random number instead", t);
+            LOGGER.debug("Failed to get process identifier from JMX, using SecureRandom instead");
         }
 
         return processId;


### PR DESCRIPTION
The ObjectId class logs its failure to get either the machine identifer,
from NetworkInterface#getNetworkInterfaces, or the process
identifier, from JMX, at warning level, and includes the stack trace.

This is annoying for applications running on platforms where this occurs
(e.g. IBM JRE or Android's Dalvik), as it appears in the logs on every
application startup, there's no workaround, and the fallback behavior of
using SecureRandom is not a cause for concern.

This commit removes the stack trace from the log message and changes the
level from warn to debug