### PR TITLE
Fix getDefaultCodecRegistry() example

### DIFF
--- a/docs/reference/content/driver/getting-started/quick-start-pojo.md
+++ b/docs/reference/content/driver/getting-started/quick-start-pojo.md
@@ -138,7 +138,7 @@ to handle the translation to and from [`bson`]({{< relref "bson/index.md" >}}) f
 
 The following example will combine the default codec registry, with the `PojoCodecProvider` configured to automatically create `PojoCodecs`:
 ```java
-CodecRegistry pojoCodecRegistry = fromRegistries(MongoClient.getDefaultCodecRegistry(),
+CodecRegistry pojoCodecRegistry = fromRegistries(MongoClientSettings.getDefaultCodecRegistry(),
                 fromProviders(PojoCodecProvider.builder().automatic(true).build()));
 ```
 


### PR DESCRIPTION
MongoClient.getDefaultCodecRegistry() no longer seems to exist