### PR TITLE
In WriteCommandResult, the 'nModified' could be either Long or Integer

### DIFF
--- a/src/main/com/mongodb/WriteCommandResultHelper.java
+++ b/src/main/com/mongodb/WriteCommandResultHelper.java
@@ -88,7 +88,14 @@ final class WriteCommandResultHelper {
     }
 
     private static Integer getModifiedCount(final WriteRequest.Type type, final CommandResult commandResult) {
-        Integer modifiedCount =  (Integer) commandResult.get("nModified");
+        Object nModifiedValue = (Object) commandResult.get("nModified");
+        Integer modifiedCount = null;
+        if (nModifiedValue != null && nModifiedValue instanceof Long) {
+            Long modifiedCountLong = (Long) nModifiedValue;
+            modifiedCount = new Integer(modifiedCountLong.intValue());
+        } else if (nModifiedValue != null) {
+            modifiedCount = (Integer) nModifiedValue;
+        }
         if (modifiedCount == null && !(type == UPDATE || type == REPLACE)) {
             modifiedCount = 0;
         }


### PR DESCRIPTION
I have a GRAILS project based on the GRAILS 2.3.11 framework. This includes mongo-java-driver-2.14.2, and we can't easily upgrade to 3.x (where this issue seems to be fixed).

I'm build a proof-of-concept using Azure CosmosDB with MongoDB 3.2.0 API, and ran into a problem, 'java.lang.ClassCastException: java.lang.Long cannot be cast to java.lang.Integer' at getModifiedCount() in WriteResultCommandHelper.java.

This pull request fixes this particular problem. Please release java-mongo-driver-2.14.4 with this PR.

