### PR TITLE
JAVA-2961 ObjectId generation with number of bytes > 12 should throw expection

### DIFF
--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -246,7 +246,12 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
      * @throws IllegalArgumentException if array is null or not of length 12
      */
     public ObjectId(final byte[] bytes) {
-        this(ByteBuffer.wrap(notNull("bytes", bytes)));
+        notNull("bytes", bytes);
+        isTrueArgument("buffer.remaining() == 12", bytes.length == 12);
+        this.timestamp = makeInt(bytes[0], bytes[1], bytes[2], bytes[3]);
+        this.machineIdentifier = makeInt((byte) 0, bytes[4], bytes[5], bytes[6]);
+        this.processIdentifier = (short) makeInt((byte) 0, (byte) 0, bytes[7], bytes[8]);
+        this.counter = makeInt((byte) 0, bytes[9], bytes[10], bytes[11]);
     }
 
     /**

--- a/bson/src/test/unit/org/bson/types/ObjectIdTest.java
+++ b/bson/src/test/unit/org/bson/types/ObjectIdTest.java
@@ -56,6 +56,12 @@ public class ObjectIdTest {
         assertEquals(0x0036D289, objectId2.getCounter());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromInvalidBytes() {
+        byte[] bytes = new byte[]{81, 6, -4, -102, -68, -126, 55, 85, -127, 54, -46, -119, -120, -4};
+        new ObjectId(bytes);
+    }
+
     @Test
     public void testBytesRoundtrip() {
         ObjectId expected = new ObjectId();


### PR DESCRIPTION
As per documentation of getting ObjectId from bytes, IllegalArgumentException should be thrown if bytes is null or bytes.length!= 12 . But presently for bytes.length > 12, it returns ObjectId using first 12 bytes.

https://jira.mongodb.org/browse/JAVA-2961