### PR TITLE
Add "since" and "forRemoval" properties to @Deprecated in com.mongodb

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/MongoClientSettings.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoClientSettings.java
@@ -119,7 +119,7 @@ public final class MongoClientSettings {
          * @return this
          * @since 3.7
          */
-        @SuppressWarnings("deprecation")
+        @SuppressWarnings("removal")
         public Builder applyConnectionString(final ConnectionString connectionString) {
             credentialList = new ArrayList<MongoCredential>(connectionString.getCredentialList());
             wrappedBuilder.applyConnectionString(connectionString);

--- a/driver-core/src/main/com/mongodb/AuthenticationMechanism.java
+++ b/driver-core/src/main/com/mongodb/AuthenticationMechanism.java
@@ -45,7 +45,7 @@ public enum AuthenticationMechanism {
      *
      * @deprecated This mechanism was replaced by {@link #SCRAM_SHA_1} in MongoDB 3.0, and is now deprecated
      */
-    @Deprecated
+    @Deprecated(since = "3.7", forRemoval = true)
     MONGODB_CR("MONGODB-CR"),
 
     /**

--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -643,7 +643,7 @@ public class ConnectionString {
         return credential;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     private MongoCredential createMongoCredentialWithMechanism(final AuthenticationMechanism mechanism, final String userName,
                                                                @Nullable final char[] password,
                                                                @Nullable final String authSource,
@@ -790,7 +790,7 @@ public class ConnectionString {
         return null;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     @Nullable
     private WriteConcern buildWriteConcern(@Nullable final Boolean safe, @Nullable final String w,
                                            @Nullable final Integer wTimeout, @Nullable final Boolean fsync,
@@ -1001,7 +1001,7 @@ public class ConnectionString {
      * @return the connection string
      * deprecated use {@link #getConnectionString()}
      */
-    @Deprecated
+    @Deprecated(since = "3.1", forRemoval = true)
     public String getURI() {
         return getConnectionString();
     }
@@ -1023,7 +1023,7 @@ public class ConnectionString {
      * @return the credentials in an immutable list
      * @deprecated Prefer {@link #getCredential()}
      */
-    @Deprecated
+    @Deprecated(since = "3.6", forRemoval = true)
     public List<MongoCredential> getCredentialList() {
         return credential != null ? singletonList(credential) : Collections.<MongoCredential>emptyList();
     }

--- a/driver-core/src/main/com/mongodb/MongoCredential.java
+++ b/driver-core/src/main/com/mongodb/MongoCredential.java
@@ -52,7 +52,8 @@ public final class MongoCredential {
      * @mongodb.driver.manual core/authentication/#mongodb-cr-authentication MONGODB-CR
      * @deprecated This mechanism was replaced by {@link #SCRAM_SHA_1_MECHANISM} in MongoDB 3.0, and is now deprecated
      */
-    @Deprecated
+    @SuppressWarnings("removal")
+    @Deprecated(since = "3.7", forRemoval = true)
     public static final String MONGODB_CR_MECHANISM = AuthenticationMechanism.MONGODB_CR.getMechanismName();
 
     /**
@@ -221,7 +222,8 @@ public final class MongoCredential {
      * @deprecated MONGODB-CR was replaced by SCRAM-SHA-1 in MongoDB 3.0, and is now deprecated. Use
      * the {@link #createCredential(String, String, char[])} factory method instead.
      */
-    @Deprecated
+    @SuppressWarnings("removal")
+    @Deprecated(since = "3.5", forRemoval = true)
     public static MongoCredential createMongoCRCredential(final String userName, final String database, final char[] password) {
         return new MongoCredential(MONGODB_CR, userName, database, password);
     }
@@ -368,7 +370,7 @@ public final class MongoCredential {
         this.mechanismProperties = new HashMap<String, Object>(mechanismProperties);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     private boolean mechanismRequiresPassword(@Nullable final AuthenticationMechanism mechanism) {
         return mechanism == PLAIN || mechanism == MONGODB_CR || mechanism == SCRAM_SHA_1 || mechanism == SCRAM_SHA_256;
 

--- a/driver-core/src/main/com/mongodb/MongoNodeIsRecoveringException.java
+++ b/driver-core/src/main/com/mongodb/MongoNodeIsRecoveringException.java
@@ -44,7 +44,7 @@ public class MongoNodeIsRecoveringException extends MongoCommandException {
      * @param serverAddress the address of the server
      * @deprecated Prefer {@link #MongoNodeIsRecoveringException(BsonDocument, ServerAddress)}
      */
-    @Deprecated
+    @Deprecated(since = "3.8", forRemoval = true)
     public MongoNodeIsRecoveringException(final ServerAddress serverAddress) {
         super(new BsonDocument(), serverAddress);
     }

--- a/driver-core/src/main/com/mongodb/MongoNotPrimaryException.java
+++ b/driver-core/src/main/com/mongodb/MongoNotPrimaryException.java
@@ -44,7 +44,7 @@ public class MongoNotPrimaryException extends MongoCommandException {
      * @param serverAddress the address of the server
      * @deprecated Prefer {@link #MongoNotPrimaryException(BsonDocument, ServerAddress)}
      */
-    @Deprecated
+    @Deprecated(since = "3.8", forRemoval = true)
     public MongoNotPrimaryException(final ServerAddress serverAddress) {
         super(new BsonDocument(), serverAddress);
     }

--- a/driver-core/src/main/com/mongodb/ServerAddress.java
+++ b/driver-core/src/main/com/mongodb/ServerAddress.java
@@ -242,7 +242,7 @@ public class ServerAddress implements Serializable {
      * @return if they are the same
      * @deprecated use the {@link #equals(Object)} method instead
      */
-    @Deprecated
+    @Deprecated(since = "3.6", forRemoval = true)
     public boolean sameHost(final String hostName) {
         return equals(new ServerAddress(hostName));
     }

--- a/driver-core/src/main/com/mongodb/WriteConcern.java
+++ b/driver-core/src/main/com/mongodb/WriteConcern.java
@@ -126,7 +126,7 @@ public class WriteConcern implements Serializable {
      *
      * @deprecated Prefer {@link #JOURNALED}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public static final WriteConcern FSYNCED = ACKNOWLEDGED.withFsync(true);
 
     /**
@@ -140,7 +140,7 @@ public class WriteConcern implements Serializable {
      * Exceptions are raised for network issues, and server errors; waits for at least 2 servers for the write operation.
      * @deprecated Prefer WriteConcern#W2
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public static final WriteConcern REPLICA_ACKNOWLEDGED = new WriteConcern(2);
 
     /**
@@ -152,7 +152,7 @@ public class WriteConcern implements Serializable {
      * @see WriteConcern#UNACKNOWLEDGED
      * @deprecated Prefer {@link #UNACKNOWLEDGED}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public static final WriteConcern NORMAL = UNACKNOWLEDGED;
 
     /**
@@ -164,7 +164,7 @@ public class WriteConcern implements Serializable {
      * @see WriteConcern#ACKNOWLEDGED
      * @deprecated Prefer {@link #ACKNOWLEDGED}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public static final WriteConcern SAFE = ACKNOWLEDGED;
 
     /**
@@ -181,7 +181,7 @@ public class WriteConcern implements Serializable {
      * @see WriteConcern#FSYNCED
      * @deprecated Prefer {@link #JOURNALED}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public static final WriteConcern FSYNC_SAFE = FSYNCED;
 
     /**
@@ -192,7 +192,7 @@ public class WriteConcern implements Serializable {
      *
      * @deprecated Prefer {@link #JOURNALED}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public static final WriteConcern JOURNAL_SAFE = JOURNALED;
 
     /**
@@ -203,7 +203,7 @@ public class WriteConcern implements Serializable {
      * @see WriteConcern#W2
      * @deprecated Prefer {@link #W2}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public static final WriteConcern REPLICAS_SAFE = REPLICA_ACKNOWLEDGED;
 
     /**
@@ -213,7 +213,7 @@ public class WriteConcern implements Serializable {
      * @see WriteConcern#UNACKNOWLEDGED
      * @deprecated Prefer {@link #UNACKNOWLEDGED}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public WriteConcern() {
         this(0);
     }
@@ -259,7 +259,7 @@ public class WriteConcern implements Serializable {
      * @param fsync whether or not to fsync
      * @deprecated prefer {@link #JOURNALED} or {@link #withJournal(Boolean)}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public WriteConcern(final boolean fsync) {
         this(null, null, fsync, null);
     }
@@ -274,7 +274,7 @@ public class WriteConcern implements Serializable {
      * @mongodb.driver.manual reference/write-concern/#w-option w option
      * @mongodb.driver.manual reference/write-concern/#wtimeout wtimeout option
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public WriteConcern(final int w, final int wTimeoutMS, final boolean fsync) {
         this(w, wTimeoutMS, fsync, null);
     }
@@ -291,7 +291,7 @@ public class WriteConcern implements Serializable {
      * @mongodb.driver.manual reference/write-concern/#wtimeout wtimeout option
      * @mongodb.driver.manual reference/write-concern/#j-option j option
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public WriteConcern(final int w, final int wTimeoutMS, final boolean fsync, final boolean journal) {
         this((Object) w, wTimeoutMS, fsync, journal);
     }
@@ -305,7 +305,7 @@ public class WriteConcern implements Serializable {
      * @param journal    whether writes should wait for a journaling group commit
      * @deprecated Prefer {@link #withW(String)}, {@link #withWTimeout(long, TimeUnit)}, {@link #withJournal(Boolean)}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public WriteConcern(final String w, final int wTimeoutMS, final boolean fsync, final boolean journal) {
         this((Object) notNull("w", w), wTimeoutMS, fsync, journal);
     }
@@ -382,7 +382,7 @@ public class WriteConcern implements Serializable {
      * @deprecated Prefer {@link #getWTimeout(TimeUnit)}
      * @mongodb.driver.manual core/write-concern/#timeouts wTimeout
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public int getWtimeout() {
         return wTimeoutMS == null ? 0 : wTimeoutMS;
     }
@@ -405,7 +405,7 @@ public class WriteConcern implements Serializable {
      * @mongodb.driver.manual core/write-concern/#journaled Journaled
      * @deprecated Prefer {@link #getJournal()}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public boolean getJ() {
         return journal == null ? false : journal;
     }
@@ -416,7 +416,7 @@ public class WriteConcern implements Serializable {
      * @return true if fsync is true, false if it false or unspecified
      * @deprecated Prefer {@link #getJournal()}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public boolean getFsync() {
         return fsync == null ? false : fsync;
     }
@@ -427,7 +427,7 @@ public class WriteConcern implements Serializable {
      * @return true if fsync is true, false if it false or unspecified
      * @deprecated Prefer {@link #getJournal()}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public boolean fsync() {
         return getFsync();
     }
@@ -438,7 +438,7 @@ public class WriteConcern implements Serializable {
      * @return whether this write concern will result in an an acknowledged write
      * @deprecated Prefer {@link #isAcknowledged()}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public boolean callGetLastError() {
         return isAcknowledged();
     }
@@ -568,7 +568,7 @@ public class WriteConcern implements Serializable {
      * @return the new WriteConcern
      * @deprecated Prefer {@link #withJournal(Boolean)}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public WriteConcern withFsync(final boolean fsync) {
         return new WriteConcern(w, wTimeoutMS, fsync, journal);
     }
@@ -593,7 +593,7 @@ public class WriteConcern implements Serializable {
      * @deprecated Prefer {@link #withJournal(Boolean)}
      * @mongodb.driver.manual reference/write-concern/#j-option j option
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public WriteConcern withJ(final boolean journal) {
         return withJournal(journal);
     }
@@ -650,7 +650,7 @@ public class WriteConcern implements Serializable {
      * @return Majority, a subclass of WriteConcern that represents the write concern requiring most servers to acknowledge the write
      * @deprecated Prefer {@link #MAJORITY}, {@link #withWTimeout(long, TimeUnit)}, {@link #withJournal(Boolean)}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public static Majority majorityWriteConcern(final int wtimeout, final boolean fsync, final boolean j) {
         return new Majority(wtimeout, fsync, j);
     }
@@ -660,7 +660,7 @@ public class WriteConcern implements Serializable {
      *
      * @deprecated Prefer {@link #MAJORITY}, {@link #withWTimeout(long, TimeUnit)}, {@link #withJournal(Boolean)}
      */
-    @Deprecated
+    @Deprecated(since = "3.2", forRemoval = true)
     public static class Majority extends WriteConcern {
 
         private static final long serialVersionUID = -4128295115883875212L;

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -312,7 +312,7 @@ public final class ClusterFixture {
                 Collections.<MongoCompressor>emptyList());
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     private static Cluster createCluster(final ConnectionString connectionString, final StreamFactory streamFactory) {
         return new DefaultClusterFactory().createCluster(ClusterSettings.builder().applyConnectionString(connectionString).build(),
                 ServerSettings.builder().build(),
@@ -383,7 +383,7 @@ public final class ClusterFixture {
         return serverDescriptions.get(0).getAddress();
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     public static List<MongoCredential> getCredentialList() {
         return getConnectionString().getCredentialList();
     }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/NativeAuthenticatorUnitTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/NativeAuthenticatorUnitTest.java
@@ -39,7 +39,7 @@ public class NativeAuthenticatorUnitTest {
     private NativeAuthenticator subject;
     private ConnectionDescription connectionDescription;
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     @Before
     public void before() {
         connection = new TestInternalConnection(new ServerId(new ClusterId(), new ServerAddress("localhost", 27017)));

--- a/driver-legacy/src/main/com/mongodb/AggregationOptions.java
+++ b/driver-legacy/src/main/com/mongodb/AggregationOptions.java
@@ -45,7 +45,7 @@ public class AggregationOptions {
      * that support it (&gt;= 2.6).  The driver will ignore this as of MongoDB 3.6, which does not support inline results for the aggregate
      * command.
      */
-    @Deprecated
+    @Deprecated(since = "3.5", forRemoval = true)
     public enum OutputMode {
         /**
          * The output of the aggregate operation is returned inline.
@@ -99,7 +99,7 @@ public class AggregationOptions {
      * that support it (&gt;= 2.6).  The driver will ignore this as of MongoDB 3.6, which does not support inline results for the aggregate
      * command.
      */
-    @Deprecated
+    @Deprecated(since = "3.5", forRemoval = true)
     public OutputMode getOutputMode() {
         return outputMode;
     }
@@ -212,7 +212,7 @@ public class AggregationOptions {
          * that support it (&gt;= 2.6).  The driver will ignore this as of MongoDB 3.6, which does not support inline results for the
          * aggregate command.
          */
-        @Deprecated
+        @Deprecated(since = "3.5", forRemoval = true)
         public Builder outputMode(final OutputMode mode) {
             outputMode = mode;
             return this;

--- a/driver-legacy/src/main/com/mongodb/AggregationOutput.java
+++ b/driver-legacy/src/main/com/mongodb/AggregationOutput.java
@@ -26,7 +26,7 @@ import java.util.List;
  * @deprecated Replace with use of aggregate methods in {@link DBCollection} that return instances of {@link Cursor}.
  * @see DBCollection#aggregate(List, AggregationOptions)
  */
-@Deprecated
+@Deprecated(since = "3.5", forRemoval = true)
 public class AggregationOutput {
     private final List<DBObject> results;
 

--- a/driver-legacy/src/main/com/mongodb/Bytes.java
+++ b/driver-legacy/src/main/com/mongodb/Bytes.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * Class that hold definitions of the wire protocol
  * @deprecated there is no replacement for this class
  */
-@Deprecated
+@Deprecated(since = "3.9", forRemoval = true)
 @SuppressWarnings("deprecation")
 public class Bytes extends org.bson.BSON {
 

--- a/driver-legacy/src/main/com/mongodb/DB.java
+++ b/driver-legacy/src/main/com/mongodb/DB.java
@@ -70,7 +70,7 @@ import static java.util.Arrays.asList;
  * @see MongoClient
  */
 @ThreadSafe
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class DB {
     private final Mongo mongo;
     private final String name;
@@ -108,7 +108,7 @@ public class DB {
      * @return the mongo instance that this database was created from
      * @deprecated Use {@link #getMongoClient()} instead
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public Mongo getMongo() {
         return mongo;
     }
@@ -584,7 +584,7 @@ public class DB {
      * @mongodb.driver.manual reference/method/db.eval/ db.eval()
      * @deprecated The eval command was deprecated in MongoDB 3.0
      */
-    @Deprecated
+    @Deprecated(since = "3.6", forRemoval = true)
     public CommandResult doEval(final String code, final Object... args) {
         DBObject commandDocument = new BasicDBObject("$eval", code).append("args", asList(args));
         return executeCommand(wrap(commandDocument));
@@ -601,7 +601,7 @@ public class DB {
      * @mongodb.driver.manual reference/method/db.eval/ db.eval()
      * @deprecated The eval command was deprecated in MongoDB 3.0
      */
-    @Deprecated
+    @Deprecated(since = "3.6", forRemoval = true)
     public Object eval(final String code, final Object... args) {
         CommandResult result = doEval(code, args);
         result.throwOnError();
@@ -633,7 +633,7 @@ public class DB {
      * @mongodb.driver.manual reference/command/updateUser updateUser
      * @deprecated Use {@code DB.command} to call either the createUser or updateUser command
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public WriteResult addUser(final String userName, final char[] password) {
         return addUser(userName, password, false);
     }
@@ -652,7 +652,7 @@ public class DB {
      * @mongodb.driver.manual reference/command/updateUser updateUser
      * @deprecated Use {@code DB.command} to call either the createUser or updateUser command
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public WriteResult addUser(final String userName, final char[] password, final boolean readOnly) {
         MongoCredential credential = createCredential(userName, getName(), password);
         boolean userExists = false;
@@ -685,7 +685,7 @@ public class DB {
      * @mongodb.driver.manual administration/security-access-control/  Access Control
      * @deprecated Use {@code DB.command} to call the dropUser command
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public WriteResult removeUser(final String userName) {
         try {
             executor.execute(new com.mongodb.operation.DropUserOperation(getName(), userName, getWriteConcern()), getReadConcern());
@@ -701,7 +701,7 @@ public class DB {
      * @see ReadPreference#secondaryPreferred()
      * @deprecated Replaced with {@code ReadPreference.secondaryPreferred()}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public void slaveOk() {
         addOption(Bytes.QUERYOPTION_SLAVEOK);
     }
@@ -713,7 +713,7 @@ public class DB {
      * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query Query Flags
      * @deprecated Replaced with {@link DBCursor#addOption(int)}
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public void addOption(final int option) {
         optionHolder.add(option);
     }
@@ -725,7 +725,7 @@ public class DB {
      * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query Query Flags
      * @deprecated Replaced with {@link DBCursor#setOptions(int)}
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public void setOptions(final int options) {
         optionHolder.set(options);
     }
@@ -735,7 +735,7 @@ public class DB {
      * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query Query Flags
      * @deprecated Replaced with {@link DBCursor#resetOptions()}
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public void resetOptions() {
         optionHolder.reset();
     }
@@ -747,7 +747,7 @@ public class DB {
      * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query Query Flags
      * @deprecated Replaced with {@link DBCursor#getOptions()}
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public int getOptions() {
         return optionHolder.get();
     }

--- a/driver-legacy/src/main/com/mongodb/DBAddress.java
+++ b/driver-legacy/src/main/com/mongodb/DBAddress.java
@@ -29,7 +29,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  * @mongodb.driver.manual reference/connection-string/ MongoDB Connection String
  * @deprecated This class is no longer needed, as the driver does not rely on it for anything anymore.  Use {@link ServerAddress} instead.
  */
-@Deprecated
+@Deprecated(since = "3.1", forRemoval = true)
 public class DBAddress extends ServerAddress {
     private static final long serialVersionUID = -813211264765778133L;
     private final String _db;

--- a/driver-legacy/src/main/com/mongodb/DBCollection.java
+++ b/driver-legacy/src/main/com/mongodb/DBCollection.java
@@ -122,7 +122,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * @mongodb.driver.manual reference/glossary/#term-collection Collection
  */
 @ThreadSafe
-@SuppressWarnings({"rawtypes", "deprecation"})
+@SuppressWarnings({"rawtypes", "removal"})
 public class DBCollection {
     public static final String ID_FIELD_NAME = "_id";
     private final String name;
@@ -652,7 +652,7 @@ public class DBCollection {
      * com.mongodb.DBCursor#setOptions(int)} on the {@code DBCursor} returned from {@link com.mongodb.DBCollection#find(DBObject,
      * DBObject)}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public DBCursor find(final DBObject query, final DBObject projection, final int numToSkip, final int batchSize,
                          final int options) {
         return new DBCursor(this, query, projection, getReadPreference()).batchSize(batchSize).skip(numToSkip).setOptions(options);
@@ -671,7 +671,7 @@ public class DBCollection {
      * @deprecated use {@link com.mongodb.DBCursor#skip(int)} and {@link com.mongodb.DBCursor#batchSize(int)} on the {@code DBCursor}
      * returned from {@link com.mongodb.DBCollection#find(DBObject, DBObject)}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public DBCursor find(final DBObject query, final DBObject projection, final int numToSkip, final int batchSize) {
         return new DBCursor(this, query, projection, getReadPreference()).batchSize(batchSize).skip(numToSkip);
     }
@@ -1068,7 +1068,7 @@ public class DBCollection {
      * @mongodb.driver.manual reference/command/group/ Group Command
      * @deprecated The group command was deprecated in MongoDB 3.4
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public DBObject group(final DBObject key, final DBObject cond, final DBObject initial, final String reduce) {
         return group(key, cond, initial, reduce, null);
     }
@@ -1086,7 +1086,7 @@ public class DBCollection {
      * @mongodb.driver.manual reference/command/group/ Group Command
      * @deprecated The group command was deprecated in MongoDB 3.4
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public DBObject group(final DBObject key, final DBObject cond, final DBObject initial, final String reduce,
                           @Nullable final String finalize) {
         return group(key, cond, initial, reduce, finalize, getReadPreference());
@@ -1106,7 +1106,7 @@ public class DBCollection {
      * @mongodb.driver.manual reference/command/group/ Group Command
      * @deprecated The group command was deprecated in MongoDB 3.4
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public DBObject group(final DBObject key, final DBObject cond, final DBObject initial, final String reduce,
                           @Nullable final String finalize, final ReadPreference readPreference) {
         return group(new GroupCommand(this, key, cond, initial, reduce, finalize), readPreference);
@@ -1121,7 +1121,7 @@ public class DBCollection {
      * @mongodb.driver.manual reference/command/group/ Group Command
      * @deprecated The group command was deprecated in MongoDB 3.4
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public DBObject group(final GroupCommand cmd) {
         return group(cmd, getReadPreference());
     }
@@ -1136,7 +1136,7 @@ public class DBCollection {
      * @mongodb.driver.manual reference/command/group/ Group Command
      * @deprecated The group command was deprecated in MongoDB 3.4
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public DBObject group(final GroupCommand cmd, final ReadPreference readPreference) {
         return toDBList(executor.execute(cmd.toOperation(getNamespace(), getDefaultDBObjectCodec()), readPreference, getReadConcern()));
     }
@@ -1377,7 +1377,7 @@ public class DBCollection {
      * @mongodb.server.release 2.2
      * @deprecated Use {@link #aggregate(List, AggregationOptions)} instead
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     @SuppressWarnings("unchecked")
     public AggregationOutput aggregate(final DBObject firstOp, final DBObject... additionalOps) {
         List<DBObject> pipeline = new ArrayList<DBObject>();
@@ -1395,7 +1395,7 @@ public class DBCollection {
      * @mongodb.server.release 2.2
      * @deprecated Use {@link #aggregate(List, AggregationOptions)} instead
      */
-    @Deprecated
+    @Deprecated(since = "3.5", forRemoval = true)
     public AggregationOutput aggregate(final List<? extends DBObject> pipeline) {
         return aggregate(pipeline, getReadPreference());
     }
@@ -1410,7 +1410,7 @@ public class DBCollection {
      * @mongodb.server.release 2.2
      * @deprecated Use {@link #aggregate(List, AggregationOptions, ReadPreference)} )} instead
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     @SuppressWarnings("unchecked")
     public AggregationOutput aggregate(final List<? extends DBObject> pipeline, final ReadPreference readPreference) {
         Cursor cursor = aggregate(pipeline, AggregationOptions.builder().build(), readPreference, false);
@@ -1538,7 +1538,7 @@ public class DBCollection {
      * @since 2.12
      * @deprecated the parallelCollectionScan command will be removed in MongoDB 4.2
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public List<Cursor> parallelScan(final ParallelScanOptions options) {
         List<Cursor> cursors = new ArrayList<Cursor>();
         ParallelCollectionScanOperation<DBObject> operation = new ParallelCollectionScanOperation<DBObject>(getNamespace(),
@@ -2078,7 +2078,7 @@ public class DBCollection {
      *
      * @deprecated Replaced with {@link ReadPreference#secondaryPreferred()}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public void slaveOk() {
         addOption(Bytes.QUERYOPTION_SLAVEOK);
     }
@@ -2090,7 +2090,7 @@ public class DBCollection {
      * @mongodb.driver.manual reference/method/cursor.addOption/#flags Query Flags
      * @deprecated Replaced with {@link DBCursor#addOption(int)}
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public void addOption(final int option) {
         optionHolder.add(option);
     }
@@ -2101,7 +2101,7 @@ public class DBCollection {
      * @mongodb.driver.manual reference/method/cursor.addOption/#flags Query Flags
      * @deprecated Replaced with {@link DBCursor#resetOptions()}
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public void resetOptions() {
         optionHolder.reset();
     }
@@ -2113,7 +2113,7 @@ public class DBCollection {
      * @mongodb.driver.manual reference/method/cursor.addOption/#flags Query Flags
      * @deprecated Replaced with {@link DBCursor#getOptions()}
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public int getOptions() {
         return optionHolder.get();
     }
@@ -2125,7 +2125,7 @@ public class DBCollection {
      * @mongodb.driver.manual reference/method/cursor.addOption/#flags Query Flags
      * @deprecated Replaced with {@link DBCursor#setOptions(int)}
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public void setOptions(final int options) {
         optionHolder.set(options);
     }

--- a/driver-legacy/src/main/com/mongodb/DBCollectionObjectFactory.java
+++ b/driver-legacy/src/main/com/mongodb/DBCollectionObjectFactory.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 @Immutable
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 final class DBCollectionObjectFactory implements DBObjectFactory {
 
     private final Map<List<String>, Class<? extends DBObject>> pathToClassMap;

--- a/driver-legacy/src/main/com/mongodb/DBCursor.java
+++ b/driver-legacy/src/main/com/mongodb/DBCursor.java
@@ -65,7 +65,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * @mongodb.driver.manual core/read-operations Read Operations
  */
 @NotThreadSafe
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class DBCursor implements Cursor, Iterable<DBObject> {
     private final DBCollection collection;
     private final DBObject filter;
@@ -356,7 +356,7 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
      * @since 2.12
      * @deprecated Deprecated as of MongoDB 4.0 release
      */
-    @Deprecated
+    @Deprecated(since = "3.8", forRemoval = true)
     public DBCursor maxScan(final int max) {
         findOptions.getModifiers().put("$maxScan", max);
         return this;
@@ -465,7 +465,7 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
      * @mongodb.driver.manual reference/operator/meta/snapshot/ $snapshot
      * @deprecated Deprecated in MongoDB 3.6 release and removed in MongoDB 4.0 release
      */
-    @Deprecated
+    @Deprecated(since = "3.8", forRemoval = true)
     public DBCursor snapshot() {
         findOptions.getModifiers().put("$snapshot", true);
         return this;
@@ -629,7 +629,7 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
      * @see ReadPreference#secondaryPreferred()
      * @deprecated Replaced with {@link com.mongodb.ReadPreference#secondaryPreferred()}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public DBCursor slaveOk() {
         return addOption(Bytes.QUERYOPTION_SLAVEOK);
     }

--- a/driver-legacy/src/main/com/mongodb/GroupCommand.java
+++ b/driver-legacy/src/main/com/mongodb/GroupCommand.java
@@ -30,7 +30,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  * @mongodb.driver.manual reference/command/group/ Group
  * @deprecated the group command was deprecated in MongoDB 3.4
  */
-@Deprecated
+@Deprecated(since = "3.9", forRemoval = true)
 public class GroupCommand {
     private final String collectionName;
     private final DBObject keys;

--- a/driver-legacy/src/main/com/mongodb/Mongo.java
+++ b/driver-legacy/src/main/com/mongodb/Mongo.java
@@ -80,7 +80,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * with this class.
  */
 @ThreadSafe
-@Deprecated
+@Deprecated(since = "3.9", forRemoval = true)
 public class Mongo {
     static final String ADMIN_DATABASE_NAME = "admin";
 
@@ -93,6 +93,7 @@ public class Mongo {
     private final MongoClientOptions options;
     private final List<MongoCredential> credentialsList;
 
+    @SuppressWarnings("removal")
     private final Bytes.OptionHolder optionHolder;
 
     private final BufferProvider bufferProvider = new PowerOfTwoBufferPool();
@@ -107,7 +108,7 @@ public class Mongo {
      * @throws MongoException if there's a failure
      * @deprecated Replaced by {@link MongoClient#MongoClient()})
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public Mongo() {
         this(new ServerAddress(), createLegacyOptions());
     }
@@ -118,7 +119,7 @@ public class Mongo {
      * @param host server to connect to
      * @deprecated Replaced by {@link MongoClient#MongoClient(String)}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public Mongo(final String host) {
         this(new ServerAddress(host), createLegacyOptions());
     }
@@ -131,9 +132,9 @@ public class Mongo {
      * @param options default query options
      * @deprecated Replaced by {@link MongoClient#MongoClient(String, MongoClientOptions)}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public Mongo(final String host,
-                 @SuppressWarnings("deprecation")
+                 @SuppressWarnings("removal")
                  final MongoOptions options) {
         this(new ServerAddress(host), options.toClientOptions());
     }
@@ -145,7 +146,7 @@ public class Mongo {
      * @param port the port on which the database is running
      * @deprecated Replaced by {@link MongoClient#MongoClient(String, int)}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public Mongo(final String host, final int port) {
         this(new ServerAddress(host, port), createLegacyOptions());
     }
@@ -157,7 +158,7 @@ public class Mongo {
      * @see com.mongodb.ServerAddress
      * @deprecated Replaced by {@link MongoClient#MongoClient(ServerAddress)}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public Mongo(final ServerAddress address) {
         this(address, createLegacyOptions());
     }
@@ -170,9 +171,9 @@ public class Mongo {
      * @see com.mongodb.ServerAddress
      * @deprecated Replaced by {@link MongoClient#MongoClient(ServerAddress, MongoClientOptions)}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public Mongo(final ServerAddress address,
-                 @SuppressWarnings("deprecation")
+                 @SuppressWarnings("removal")
                  final MongoOptions options) {
         this(address, options.toClientOptions());
     }
@@ -187,7 +188,7 @@ public class Mongo {
      * @see com.mongodb.ServerAddress
      * @deprecated Please use {@link MongoClient#MongoClient(java.util.List)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public Mongo(final ServerAddress left, final ServerAddress right) {
         this(asList(left, right), createLegacyOptions());
     }
@@ -203,9 +204,9 @@ public class Mongo {
      * @see com.mongodb.ServerAddress
      * @deprecated Please use {@link MongoClient#MongoClient(java.util.List, MongoClientOptions)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public Mongo(final ServerAddress left, final ServerAddress right,
-                 @SuppressWarnings("deprecation")
+                 @SuppressWarnings("removal")
                  final MongoOptions options) {
         this(asList(left, right), options.toClientOptions());
     }
@@ -225,7 +226,7 @@ public class Mongo {
      * @see MongoClientOptions#getLocalThreshold()
      * @deprecated Replaced by {@link MongoClient#MongoClient(java.util.List)}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public Mongo(final List<ServerAddress> seeds) {
         this(seeds, createLegacyOptions());
     }
@@ -247,9 +248,9 @@ public class Mongo {
      * @see MongoClientOptions#getLocalThreshold()
      * @deprecated Replaced by {@link MongoClient#MongoClient(java.util.List, MongoClientOptions)}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public Mongo(final List<ServerAddress> seeds,
-                 @SuppressWarnings("deprecation")
+                 @SuppressWarnings("removal")
                  final MongoOptions options) {
         this(seeds, options.toClientOptions());
     }
@@ -270,9 +271,9 @@ public class Mongo {
      * @see MongoURI
      * @deprecated Replaced by {@link MongoClient#MongoClient(MongoClientURI)}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public Mongo(
-                @SuppressWarnings("deprecation")
+                @SuppressWarnings("removal")
                 final MongoURI uri) {
         this(uri.toClientURI());
     }
@@ -312,6 +313,7 @@ public class Mongo {
                 mongoURI.getCredentials() != null ? asList(mongoURI.getCredentials()) : Collections.<MongoCredential>emptyList());
     }
 
+    @SuppressWarnings("removal")
     Mongo(final Cluster cluster, final MongoClientOptions options, final List<MongoCredential> credentialsList) {
         this.options = options;
         this.readPreference = options.getReadPreference();
@@ -335,7 +337,7 @@ public class Mongo {
      * @param writeConcern write concern to use
      * @deprecated Set the default write concern with either {@link MongoClientURI} or {@link MongoClientOptions}
      */
-    @Deprecated
+    @Deprecated(since = "3.3", forRemoval = true)
     public void setWriteConcern(final WriteConcern writeConcern) {
         this.writeConcern = writeConcern;
     }
@@ -370,7 +372,7 @@ public class Mongo {
      * @param readPreference Read Preference to use
      * @deprecated Set the default read preference with either {@link MongoClientURI} or {@link MongoClientOptions}
      */
-    @Deprecated
+    @Deprecated(since = "3.3", forRemoval = true)
     public void setReadPreference(final ReadPreference readPreference) {
         this.readPreference = readPreference;
     }
@@ -390,7 +392,7 @@ public class Mongo {
      * @return list of server addresses
      * @throws MongoException if there's a failure
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public List<ServerAddress> getAllAddress() {
         return delegate.getCluster().getSettings().getHosts();
     }
@@ -401,7 +403,7 @@ public class Mongo {
      * @return list of server addresses
      * @throws MongoException if there's a failure
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public List<ServerAddress> getServerAddressList() {
         return delegate.getServerAddressList();
     }
@@ -415,8 +417,8 @@ public class Mongo {
      *
      * @return the address
      */
-    @Deprecated
-    @SuppressWarnings("deprecation")
+    @Deprecated(since = "3.9", forRemoval = true)
+    @SuppressWarnings("removal")
     @Nullable
     public ServerAddress getAddress() {
         ClusterDescription description = getClusterDescription();
@@ -435,7 +437,8 @@ public class Mongo {
      * @deprecated Please use {@link MongoClient} class to connect to server and corresponding {@link
      * com.mongodb.MongoClient#getMongoClientOptions()}
      */
-    @Deprecated
+    @SuppressWarnings("removal")
+    @Deprecated(since = "3.0", forRemoval = true)
     public MongoOptions getMongoOptions() {
         return new MongoOptions(getMongoClientOptions());
     }
@@ -445,7 +448,8 @@ public class Mongo {
      *
      * @return replica set status information
      */
-    @Deprecated
+    @SuppressWarnings("removal")
+    @Deprecated(since = "3.9", forRemoval = true)
     @Nullable
     public ReplicaSetStatus getReplicaSetStatus() {
         ClusterDescription clusterDescription = getClusterDescription();
@@ -461,7 +465,7 @@ public class Mongo {
      * @throws MongoException  if the operation fails
      * @deprecated Replaced with {@link com.mongodb.MongoClient#listDatabaseNames()}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public List<String> getDatabaseNames() {
         return new MongoIterableImpl<DBObject>(null, createOperationExecutor(), ReadConcern.DEFAULT, primary()) {
             @Override
@@ -492,7 +496,7 @@ public class Mongo {
      * @see MongoNamespace#checkDatabaseNameValidity(String)
      * @deprecated use {@link com.mongodb.MongoClient#getDatabase(String)}
      */
-    @Deprecated
+    @Deprecated(since = "3.0")
     public DB getDB(final String dbName) {
         DB db = dbCache.get(dbName);
         if (db != null) {
@@ -513,7 +517,7 @@ public class Mongo {
      *
      * @return a collection of database objects
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public Collection<DB> getUsedDatabases() {
         return dbCache.values();
     }
@@ -546,7 +550,8 @@ public class Mongo {
      * @see ReadPreference#secondaryPreferred()
      * @deprecated Replaced with {@code ReadPreference.secondaryPreferred()}
      */
-    @Deprecated
+    @SuppressWarnings("removal")
+    @Deprecated(since = "3.0", forRemoval = true)
     public void slaveOk() {
         addOption(Bytes.QUERYOPTION_SLAVEOK);
     }
@@ -563,7 +568,7 @@ public class Mongo {
      * @param options value to be set
      * @deprecated Set options on instances of {@link DBCursor}
      */
-    @Deprecated
+    @Deprecated(since = "3.3", forRemoval = true)
     public void setOptions(final int options) {
         optionHolder.set(options);
     }
@@ -574,7 +579,7 @@ public class Mongo {
      *
      * @deprecated Reset options instead on instances of {@link DBCursor}
      */
-    @Deprecated
+    @Deprecated(since = "3.3", forRemoval = true)
     public void resetOptions() {
         optionHolder.reset();
     }
@@ -591,7 +596,7 @@ public class Mongo {
      * @param option value to be added to current options
      * @deprecated Add options instead on instances of {@link DBCursor}
      */
-    @Deprecated
+    @Deprecated(since = "3.3", forRemoval = true)
     public void addOption(final int option) {
         optionHolder.add(option);
     }
@@ -603,7 +608,7 @@ public class Mongo {
      * @return an int representing the options to be used by queries
      * @deprecated Get options instead from instances of {@link DBCursor}
      */
-    @Deprecated
+    @Deprecated(since = "3.3", forRemoval = true)
     public int getOptions() {
         return optionHolder.get();
     }
@@ -617,7 +622,7 @@ public class Mongo {
      * @throws MongoException if there's a failure
      * @mongodb.driver.manual reference/command/fsync/ fsync command
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public CommandResult fsync(final boolean async) {
         DBObject command = new BasicDBObject("fsync", 1);
         if (async) {
@@ -634,7 +639,7 @@ public class Mongo {
      * @throws MongoException if there's a failure
      * @mongodb.driver.manual reference/command/fsync/ fsync command
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public CommandResult fsyncAndLock() {
         DBObject command = new BasicDBObject("fsync", 1);
         command.put("lock", 1);
@@ -649,7 +654,7 @@ public class Mongo {
      * @throws MongoException if there's a failure
      * @mongodb.driver.manual reference/command/fsync/ fsync command
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public DBObject unlock() {
         return DBObjects.toDBObject(createOperationExecutor().execute(new FsyncUnlockOperation(), readPreference, readConcern));
     }
@@ -661,7 +666,7 @@ public class Mongo {
      * @throws MongoException if the operation fails
      * @mongodb.driver.manual reference/command/fsync/ fsync command
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public boolean isLocked() {
         return createOperationExecutor().execute(new CurrentOpOperation(), ReadPreference.primary(), readConcern)
                        .getBoolean("fsyncLock", BsonBoolean.FALSE).getValue();
@@ -681,8 +686,8 @@ public class Mongo {
      * @return the maximum size, or 0 if not obtained from servers yet.
      * @throws MongoException if there's a failure
      */
-    @Deprecated
-    @SuppressWarnings("deprecation")
+    @Deprecated(since = "3.9", forRemoval = true)
+    @SuppressWarnings("removal")
     public int getMaxBsonObjectSize() {
         List<ServerDescription> primaries = getClusterDescription().getPrimaries();
         return primaries.isEmpty() ? ServerDescription.getDefaultMaxDocumentSize() : primaries.get(0).getMaxDocumentSize();
@@ -693,7 +698,7 @@ public class Mongo {
      *
      * @return server address in a host:port form
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     @Nullable
     public String getConnectPoint() {
         ServerAddress master = getAddress();
@@ -780,6 +785,7 @@ public class Mongo {
         return delegate.getServerSessionPool();
     }
 
+    @SuppressWarnings("removal")
     Bytes.OptionHolder getOptionHolder() {
         return optionHolder;
     }
@@ -864,7 +870,7 @@ public class Mongo {
      * Mongo.Holder can be used as a static place to hold several instances of Mongo. Security is not enforced at this level, and needs to
      * be done on the application side.
      */
-    @Deprecated
+    @Deprecated(since = "3.9", forRemoval = true)
     public static class Holder {
 
         private static final Holder INSTANCE = new Holder();
@@ -888,7 +894,8 @@ public class Mongo {
          * @throws MongoException if there's a failure
          * @deprecated Please use {@link #connect(MongoClientURI)} instead.
          */
-        @Deprecated
+        @SuppressWarnings("removal")
+        @Deprecated(since = "3.9", forRemoval = true)
         public Mongo connect(final MongoURI uri) {
             return connect(uri.toClientURI());
         }

--- a/driver-legacy/src/main/com/mongodb/MongoClient.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClient.java
@@ -83,7 +83,7 @@ import static java.util.Collections.singletonList;
  * @see MongoClientURI
  * @since 2.10.0
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class MongoClient extends Mongo implements Closeable {
 
     /**
@@ -165,7 +165,7 @@ public class MongoClient extends Mongo implements Closeable {
      * @since 2.11.0
      * @deprecated Prefer {@link #MongoClient(ServerAddress, MongoCredential, MongoClientOptions)}
      */
-    @Deprecated
+    @Deprecated(since = "3.6", forRemoval = true)
     public MongoClient(final ServerAddress addr, final List<MongoCredential> credentialsList) {
         this(addr, credentialsList, MongoClientOptions.builder().build());
     }
@@ -191,7 +191,7 @@ public class MongoClient extends Mongo implements Closeable {
      * @since 2.11.0
      * @deprecated Prefer {@link #MongoClient(ServerAddress, MongoCredential, MongoClientOptions)}
      */
-    @Deprecated
+    @Deprecated(since = "3.6", forRemoval = true)
     public MongoClient(final ServerAddress addr, final List<MongoCredential> credentialsList, final MongoClientOptions options) {
         super(addr, credentialsList, options);
     }
@@ -245,7 +245,7 @@ public class MongoClient extends Mongo implements Closeable {
      * @since 2.11.0
      * @deprecated Prefer {@link #MongoClient(List, MongoCredential, MongoClientOptions)}
      */
-    @Deprecated
+    @Deprecated(since = "3.6", forRemoval = true)
     public MongoClient(final List<ServerAddress> seeds, final List<MongoCredential> credentialsList) {
         this(seeds, credentialsList, new MongoClientOptions.Builder().build());
     }
@@ -289,7 +289,7 @@ public class MongoClient extends Mongo implements Closeable {
      * @since 2.11.0
      * @deprecated Prefer {@link #MongoClient(List, MongoCredential, MongoClientOptions)}
      */
-    @Deprecated
+    @Deprecated(since = "3.6", forRemoval = true)
     public MongoClient(final List<ServerAddress> seeds, final List<MongoCredential> credentialsList, final MongoClientOptions options) {
         super(seeds, credentialsList, options);
     }
@@ -354,7 +354,7 @@ public class MongoClient extends Mongo implements Closeable {
      * @since 3.4
      * @deprecated Prefer {@link #MongoClient(ServerAddress, MongoCredential, MongoClientOptions, MongoDriverInformation)}
      */
-    @Deprecated
+    @Deprecated(since = "3.6", forRemoval = true)
     public MongoClient(final ServerAddress addr, final List<MongoCredential> credentialsList, final MongoClientOptions options,
                        final MongoDriverInformation mongoDriverInformation) {
         super(addr, credentialsList, options, mongoDriverInformation);
@@ -390,7 +390,7 @@ public class MongoClient extends Mongo implements Closeable {
      * @since 3.4
      * @deprecated Prefer {@link #MongoClient(List, MongoCredential, MongoClientOptions, MongoDriverInformation)}
      */
-    @Deprecated
+    @Deprecated(since = "3.6", forRemoval = true)
     public MongoClient(final List<ServerAddress> seeds, final List<MongoCredential> credentialsList, final MongoClientOptions options,
                        final MongoDriverInformation mongoDriverInformation) {
         super(seeds, credentialsList, options, mongoDriverInformation);

--- a/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
@@ -379,7 +379,7 @@ public class MongoClientOptions {
      * @see <a href="https://docs.mongodb.com/manual/faq/diagnostics/#does-tcp-keepalive-time-affect-mongodb-deployments">
      *     Does TCP keep-alive time affect MongoDB Deployments?</a>
      */
-    @Deprecated
+    @Deprecated(since = "3.5", forRemoval = true)
     public boolean isSocketKeepAlive() {
         return socketKeepAlive;
     }
@@ -1232,7 +1232,7 @@ public class MongoClientOptions {
          * @see <a href="https://docs.mongodb.com/manual/faq/diagnostics/#does-tcp-keepalive-time-affect-mongodb-deployments">
          *     Does TCP keep-alive time affect MongoDB Deployments?</a>
          */
-        @Deprecated
+        @Deprecated(since = "3.5", forRemoval = true)
         public Builder socketKeepAlive(final boolean socketKeepAlive) {
             this.socketKeepAlive = socketKeepAlive;
             return this;

--- a/driver-legacy/src/main/com/mongodb/MongoOptions.java
+++ b/driver-legacy/src/main/com/mongodb/MongoOptions.java
@@ -31,7 +31,7 @@ import static com.mongodb.MongoClientOptions.Builder;
  * @see MongoClient
  * @deprecated Please use {@link MongoClientOptions} instead.
  */
-@Deprecated
+@Deprecated(since = "3.0", forRemoval = true)
 public class MongoOptions {
 
     /**
@@ -160,7 +160,7 @@ public class MongoOptions {
      *
      * @deprecated use {@link com.mongodb.MongoClientOptions}
      */
-    @Deprecated
+    @Deprecated(since = "3.0", forRemoval = true)
     public MongoOptions() {
         reset();
     }
@@ -171,7 +171,8 @@ public class MongoOptions {
      * @param options the MongoClientOptions to copy values from into the new MongoOptions.
      * @deprecated use {@link com.mongodb.MongoClientOptions}
      */
-    @Deprecated
+    @SuppressWarnings("removal")
+    @Deprecated(since = "3.0", forRemoval = true)
     public MongoOptions(final MongoClientOptions options) {
         connectionsPerHost = options.getConnectionsPerHost();
         threadsAllowedToBlockForConnectionMultiplier = options.getThreadsAllowedToBlockForConnectionMultiplier();
@@ -245,6 +246,7 @@ public class MongoOptions {
         return m;
     }
 
+    @SuppressWarnings("removal")
     MongoClientOptions toClientOptions() {
         Builder builder = MongoClientOptions.builder()
                                             .requiredReplicaSetName(requiredReplicaSetName)
@@ -274,6 +276,7 @@ public class MongoOptions {
      *
      * @return a WriteConcern for the current MongoOptions.
      */
+    @SuppressWarnings("removal")
     public WriteConcern getWriteConcern() {
         WriteConcern retVal;
 

--- a/driver-legacy/src/main/com/mongodb/MongoURI.java
+++ b/driver-legacy/src/main/com/mongodb/MongoURI.java
@@ -30,7 +30,7 @@ import java.util.List;
  * @see MongoClientURI
  * @deprecated Replaced by {@link MongoClientURI}
  */
-@Deprecated
+@Deprecated(since = "3.0", forRemoval = true)
 public class MongoURI {
 
     /**
@@ -39,6 +39,7 @@ public class MongoURI {
     public static final String MONGODB_PREFIX = "mongodb://";
     private final MongoClientURI proxied;
 
+    @SuppressWarnings("removal")
     private final MongoOptions options;
 
     /**
@@ -48,7 +49,8 @@ public class MongoURI {
      * @mongodb.driver.manual reference/connection-string Connection String URI Format
      * @deprecated Replaced by {@link MongoClientURI#MongoClientURI(String)}
      */
-    @Deprecated
+    @SuppressWarnings("removal")
+    @Deprecated(since = "3.0", forRemoval = true)
     public MongoURI(final String uri) {
         this.proxied = new MongoClientURI(uri, MongoClientOptions.builder()
                                                                  .connectionsPerHost(10)
@@ -62,7 +64,8 @@ public class MongoURI {
      *
      * @param proxied the MongoClientURI to wrap with this deprecated class. * @deprecated Replaced by {@link MongoClientURI})
      */
-    @Deprecated
+    @SuppressWarnings("removal")
+    @Deprecated(since = "3.0", forRemoval = true)
     public MongoURI(final MongoClientURI proxied) {
         this.proxied = proxied;
         options = new MongoOptions(proxied.getOptions());
@@ -136,7 +139,7 @@ public class MongoURI {
      *
      * @return the mongo options
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     public MongoOptions getOptions() {
         return options;
     }
@@ -147,7 +150,7 @@ public class MongoURI {
      * @return a new Mongo instance.  There is no caching, so each call will create a new instance, each of which must be closed manually.
      * @throws MongoException if there's a failure
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     public Mongo connect() {
         // Note: we can't change this to new MongoClient(this) as that would silently change the default write concern.
         return new Mongo(this);
@@ -169,6 +172,7 @@ public class MongoURI {
      * @param mongo the Mongo instance to get the database from.
      * @return the database specified in this URI
      */
+    @SuppressWarnings("removal")
     public DB connectDB(final Mongo mongo) {
         return mongo.getDB(getDatabaseNonNull());
     }
@@ -189,6 +193,7 @@ public class MongoURI {
      * @param mongo the mongo instance to get the collection from
      * @return the collection specified in this URI
      */
+    @SuppressWarnings("removal")
     public DBCollection connectCollection(final Mongo mongo) {
         return connectDB(mongo).getCollection(getCollectionNonNull());
     }

--- a/driver-legacy/src/main/com/mongodb/ParallelScanOptions.java
+++ b/driver-legacy/src/main/com/mongodb/ParallelScanOptions.java
@@ -30,7 +30,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  * @since 2.12
  * @deprecated the parallelCollectionScan command will be removed in MongoDB 4.2
  */
-@Deprecated
+@Deprecated(since = "3.9", forRemoval = true)
 @Immutable
 public final class ParallelScanOptions {
     private final int numCursors;

--- a/driver-legacy/src/main/com/mongodb/ReflectionDBObject.java
+++ b/driver-legacy/src/main/com/mongodb/ReflectionDBObject.java
@@ -36,7 +36,7 @@ import static java.util.Collections.synchronizedMap;
  * @deprecated Replaced by {@link org.bson.codecs.pojo.PojoCodecProvider}
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
-@Deprecated
+@Deprecated(since = "3.9", forRemoval = true)
 public abstract class ReflectionDBObject implements DBObject {
 
     @Override
@@ -50,7 +50,7 @@ public abstract class ReflectionDBObject implements DBObject {
         return getWrapper().keySet();
     }
 
-    @Deprecated
+    @Deprecated(since = "3.8", forRemoval = true)
     @Override
     public boolean containsKey(final String key) {
         return containsField(key);

--- a/driver-legacy/src/main/com/mongodb/ReplicaSetStatus.java
+++ b/driver-legacy/src/main/com/mongodb/ReplicaSetStatus.java
@@ -30,7 +30,7 @@ import java.util.List;
  *
  * @deprecated Prefer {@link MongoClientOptions.Builder#addClusterListener(ClusterListener)}
  */
-@Deprecated
+@Deprecated(since = "3.9", forRemoval = true)
 public class ReplicaSetStatus {
 
     private final Cluster cluster;

--- a/driver-legacy/src/main/com/mongodb/gridfs/CLI.java
+++ b/driver-legacy/src/main/com/mongodb/gridfs/CLI.java
@@ -31,6 +31,7 @@ import java.security.MessageDigest;
  *
  * @deprecated there is no replacement for this class
  */
+@SuppressWarnings("removal")
 @Deprecated
 public class CLI {
 

--- a/driver-legacy/src/main/com/mongodb/util/ClassMapBasedObjectSerializer.java
+++ b/driver-legacy/src/main/com/mongodb/util/ClassMapBasedObjectSerializer.java
@@ -25,7 +25,7 @@ import java.util.List;
  *
  * @author breinero
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "removal"})
 class ClassMapBasedObjectSerializer extends AbstractObjectSerializer {
 
     /**

--- a/driver-legacy/src/main/com/mongodb/util/JSONSerializers.java
+++ b/driver-legacy/src/main/com/mongodb/util/JSONSerializers.java
@@ -52,7 +52,7 @@ import java.util.regex.Pattern;
  * @deprecated This class has been superseded by to toJson and parse methods on BasicDBObject
  */
 @Deprecated
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class JSONSerializers {
 
     private JSONSerializers() {

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionAggregationTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionAggregationTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class DBCollectionAggregationTest extends DatabaseTestCase {
 
     @Test

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionTest.java
@@ -69,7 +69,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class DBCollectionTest extends DatabaseTestCase {
 
     @Test

--- a/driver-legacy/src/test/functional/com/mongodb/DBCursorOldTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCursorOldTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class DBCursorOldTest extends DatabaseTestCase {
 
     @Test

--- a/driver-legacy/src/test/functional/com/mongodb/DBCursorTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCursorTest.java
@@ -228,7 +228,7 @@ public class DBCursorTest extends DatabaseTestCase {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     @Test
     public void testGetServerAddress() {
         DBCursor cursor = collection.find().limit(2);
@@ -311,7 +311,7 @@ public class DBCursorTest extends DatabaseTestCase {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     public void testMaxScan() {
         assumeFalse(serverVersionAtLeast(4, 1));
         countResults(new DBCursor(collection, new BasicDBObject(), new BasicDBObject(), ReadPreference.primary())
@@ -545,7 +545,7 @@ public class DBCursorTest extends DatabaseTestCase {
         }
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("removal")
     @Test(expected = UnsupportedOperationException.class)
     public void exhaustOptionShouldThrowUnsupportedOperationException() {
         DBCursor cursor = new DBCursor(collection, new BasicDBObject("x", 1), new BasicDBObject(), ReadPreference.primary());

--- a/driver-legacy/src/test/functional/com/mongodb/DBObjectCodecReflectionTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBObjectCodecReflectionTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class DBObjectCodecReflectionTest extends DatabaseTestCase {
 
     @Test

--- a/driver-legacy/src/test/functional/com/mongodb/DBTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBTest.java
@@ -56,7 +56,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "removal"})
 public class DBTest extends DatabaseTestCase {
     @Test
     public void shouldGetDefaultWriteConcern() {

--- a/driver-legacy/src/test/functional/com/mongodb/MongoMethodsTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/MongoMethodsTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class MongoMethodsTest extends DatabaseTestCase {
     @Test
     @SuppressWarnings("deprecation") // This is for testing the old API, so it will use deprecated methods

--- a/driver-legacy/src/test/unit/com/mongodb/DBAddressTest.java
+++ b/driver-legacy/src/test/unit/com/mongodb/DBAddressTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @Ignore("Doesn't work offline")
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class DBAddressTest {
 
     @Test

--- a/driver-legacy/src/test/unit/com/mongodb/DBCollectionObjectFactoryTest.java
+++ b/driver-legacy/src/test/unit/com/mongodb/DBCollectionObjectFactoryTest.java
@@ -27,7 +27,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class DBCollectionObjectFactoryTest {
 
     private DBCollectionObjectFactory factory;

--- a/driver-legacy/src/test/unit/com/mongodb/MongoConstructorsTest.java
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoConstructorsTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings("removal")
 public class MongoConstructorsTest {
 
     @Test

--- a/driver-legacy/src/test/unit/com/mongodb/MongoOptionsTest.java
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoOptionsTest.java
@@ -29,10 +29,10 @@ import static org.junit.Assert.assertTrue;
 /**
  * The mongo options test.
  */
+@SuppressWarnings({"deprecation", "removal"})
 public class MongoOptionsTest {
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testCopy() throws Exception {
 
         MongoOptions options = new MongoOptions();
@@ -79,7 +79,6 @@ public class MongoOptionsTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testGetterSetters() throws Exception {
 
         MongoOptions options = new MongoOptions();
@@ -126,7 +125,6 @@ public class MongoOptionsTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testGetWriteConcern() {
         MongoOptions options = new MongoOptions();
         assertEquals(WriteConcern.NORMAL, options.getWriteConcern());
@@ -153,7 +151,6 @@ public class MongoOptionsTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testToClientOptions() throws UnknownHostException {
         MongoOptions options = new MongoOptions();
         options.description = "my client";


### PR DESCRIPTION
This is the first stage of JAVA-3013, just covering com.mongodb package.  This takes care of 120 of the 312 total deprecated API elements in the whole driver, and is a good stopping point to get feedback.  

All deprecated API elements in com.mongodb that are intended for removal
in the next major release now have the forRemoval property on the
Deprecated annotation.

SuppressWarnings annotations are updated to specify "removal" instead of
"deprecation"

JAVA-3013