### PR TITLE
JAVA-3132 package-info declaration

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/package-info.java
+++ b/driver-core/src/main/com/mongodb/connection/package-info.java
@@ -17,4 +17,4 @@
 /**
  * Contains classes that manage connecting to MongoDB servers.
  */
-package com.mongodb.internal.connection;
+package com.mongodb.connection;

--- a/driver-sync/src/main/com/mongodb/client/package-info.java
+++ b/driver-sync/src/main/com/mongodb/client/package-info.java
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/**
+ * This package contains the synchronous CRUD API.
+ */
 @NonNullApi
 package com.mongodb.client;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1149149/47270647-43c6fa80-d56f-11e8-879e-0e09509e5fa3.png)

description is missing for package `com.mongodb.client`. Any suggestion ?