### PR TITLE
JAVA-3085: Add the ability to configure the output format of StrictCharacterStreamJsonWriter

### DIFF
--- a/bson/src/main/org/bson/json/JsonWriter.java
+++ b/bson/src/main/org/bson/json/JsonWriter.java
@@ -56,12 +56,7 @@ public class JsonWriter extends AbstractBsonWriter {
         super(settings);
         this.settings = settings;
         setContext(new Context(null, BsonContextType.TOP_LEVEL));
-        strictJsonWriter = new StrictCharacterStreamJsonWriter(writer, StrictCharacterStreamJsonWriterSettings.builder()
-                                                                               .indent(settings.isIndent())
-                                                                               .newLineCharacters(settings.getNewLineCharacters())
-                                                                               .indentCharacters(settings.getIndentCharacters())
-                                                                               .maxLength(settings.getMaxLength())
-                                                                               .build());
+        strictJsonWriter = new StrictCharacterStreamJsonWriter(writer, settings.getWriterSettings());
     }
 
     /**
@@ -242,11 +237,12 @@ public class JsonWriter extends AbstractBsonWriter {
     }
 
     /**
-     * Return true if the output has been truncated due to exceeding the length specified in {@link JsonWriterSettings#maxLength}.
+     * Return true if the output has been truncated due to exceeding the length
+     * specified in {@link StrictCharacterStreamJsonWriterSettings#getMaxLength()}.
      *
      * @return true if the output has been truncated
      * @since 3.7
-     * @see JsonWriterSettings#maxLength
+     * @see StrictCharacterStreamJsonWriterSettings#getMaxLength()
      */
     public boolean isTruncated() {
         return strictJsonWriter.isTruncated();

--- a/bson/src/main/org/bson/json/StrictCharacterStreamJsonWriterSettings.java
+++ b/bson/src/main/org/bson/json/StrictCharacterStreamJsonWriterSettings.java
@@ -30,6 +30,8 @@ public final class StrictCharacterStreamJsonWriterSettings {
     private final String newLineCharacters;
     private final String indentCharacters;
     private final int maxLength;
+    private final boolean oneArrayElementPerLine;
+    private final PropertySeparator propertySeparator;
 
     /**
      * Create a builder for StrictCharacterStreamJsonWriterSettings, which are immutable.
@@ -45,6 +47,8 @@ public final class StrictCharacterStreamJsonWriterSettings {
         newLineCharacters = builder.newLineCharacters != null ? builder.newLineCharacters : System.getProperty("line.separator");
         indentCharacters = builder.indentCharacters;
         maxLength = builder.maxLength;
+        oneArrayElementPerLine = builder.oneArrayElementPerLine;
+        propertySeparator = builder.propertySeparator;
     }
 
     /**
@@ -86,6 +90,52 @@ public final class StrictCharacterStreamJsonWriterSettings {
     }
 
     /**
+     * If each array element should be formatted to have its own line when indent mode is enabled.  The default value is {@code false}.
+     *
+     * @return if each array element should have its own line
+     * @since 3.10
+     */
+    public boolean isOneArrayElementPerLine() {
+        return oneArrayElementPerLine;
+    }
+
+    /**
+     * The format of the separator between property name's and property value's.
+     *
+     * @return the property separator to use.
+     * @since 3.10
+     */
+    public PropertySeparator getPropertySeparator() {
+        return propertySeparator;
+    }
+
+    /**
+     * The format of the separator between property name's and property value's.
+     *
+     * @since 3.10
+     */
+    public enum PropertySeparator {
+        NO_SPACES(":"),
+        SPACE_BEFORE(" :"),
+        SPACE_AFTER(": "),
+        SPACE_BEFORE_AND_AFTER(" : ");
+
+        private String separator;
+
+        PropertySeparator(final String separator) {
+            this.separator = separator;
+        }
+
+        /**
+         * The character(s) to use as a separator between property name's and property value's.
+         * @return the separator character(s)
+         */
+        public String getSeparator() {
+            return separator;
+        }
+    }
+
+    /**
      * A builder for StrictCharacterStreamJsonWriterSettings
      *
      * @since 3.4
@@ -95,6 +145,8 @@ public final class StrictCharacterStreamJsonWriterSettings {
         private String newLineCharacters = System.getProperty("line.separator");
         private String indentCharacters = "  ";
         private int maxLength;
+        private boolean oneArrayElementPerLine;
+        private PropertySeparator propertySeparator = PropertySeparator.SPACE_BEFORE_AND_AFTER;
 
         /**
          * Build a JsonWriterSettings instance.
@@ -149,6 +201,31 @@ public final class StrictCharacterStreamJsonWriterSettings {
          */
         public Builder maxLength(final int maxLength) {
             this.maxLength = maxLength;
+            return this;
+        }
+
+        /**
+         * Sets if each array element should be formatted to have its own line if indent mode is enabled.
+         *
+         * @param oneArrayElementPerLine if each array element should be formatted to have its own line
+         * @return this
+         * @since 3.10
+         */
+        public Builder oneArrayElementPerLine(final boolean oneArrayElementPerLine) {
+            this.oneArrayElementPerLine = oneArrayElementPerLine;
+            return this;
+        }
+
+        /**
+         * Sets the format to use for the separator between property name's and property value's.
+         *
+         * @param propertySeparator the property separator type
+         * @return this
+         * @since 3.10
+         */
+        public Builder propertySeparator(final PropertySeparator propertySeparator) {
+            notNull("propertySeparator", propertySeparator);
+            this.propertySeparator = propertySeparator;
             return this;
         }
 

--- a/bson/src/test/unit/org/bson/json/StrictCharacterStreamJsonWriterSpecification.groovy
+++ b/bson/src/test/unit/org/bson/json/StrictCharacterStreamJsonWriterSpecification.groovy
@@ -227,6 +227,125 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         stringWriter.toString() == format('{%n  "doc" : {%n    "a" : 1,%n    "b" : 2%n  }%n}')
     }
 
+    def 'should indent embedded array'() {
+        given:
+        writer = new StrictCharacterStreamJsonWriter(stringWriter, StrictCharacterStreamJsonWriterSettings.builder().indent(true).build())
+
+        when:
+        writer.writeStartObject()
+        writer.writeStartArray('arr')
+        writer.writeNumber('1')
+        writer.writeNumber('2')
+        writer.writeEndArray()
+        writer.writeEndObject()
+
+        then:
+        stringWriter.toString() == format('{%n  "arr" : [1, 2]%n}')
+    }
+
+    def 'should indent embedded document in array'() {
+        given:
+        writer = new StrictCharacterStreamJsonWriter(stringWriter, StrictCharacterStreamJsonWriterSettings.builder().indent(true).build())
+
+        when:
+        writer.writeStartObject()
+        writer.writeStartArray('arr')
+        writer.writeStartObject()
+        writer.writeNumber('a', '1')
+        writer.writeNumber('b', '2')
+        writer.writeEndObject()
+        writer.writeStartObject()
+        writer.writeNumber('c', '3')
+        writer.writeNumber('d', '4')
+        writer.writeEndObject()
+        writer.writeEndArray()
+        writer.writeEndObject()
+
+        then:
+        stringWriter.toString() == format('{%n  "arr" : [{%n      "a" : 1,%n      "b" : 2%n    },' +
+                ' {%n      "c" : 3,%n      "d" : 4%n    }]%n}')
+    }
+
+    def 'should indent embedded document in array with one element per line'() {
+        given:
+        writer = new StrictCharacterStreamJsonWriter(stringWriter, StrictCharacterStreamJsonWriterSettings.builder()
+                .indent(true).oneArrayElementPerLine(true).build())
+
+        when:
+        writer.writeStartObject()
+        writer.writeStartArray('arr')
+        writer.writeStartObject()
+        writer.writeNumber('a', '1')
+        writer.writeNumber('b', '2')
+        writer.writeEndObject()
+        writer.writeStartObject()
+        writer.writeNumber('c', '3')
+        writer.writeNumber('d', '4')
+        writer.writeEndObject()
+        writer.writeEndArray()
+        writer.writeEndObject()
+
+        then:
+        stringWriter.toString() == format('{%n  "arr" : [%n    {%n      "a" : 1,%n      "b" : 2%n    },' +
+                '%n    {%n      "c" : 3,%n      "d" : 4%n    }%n  ]%n}')
+    }
+
+    def 'property separator with no spaces'() {
+        given:
+        writer = new StrictCharacterStreamJsonWriter(stringWriter, StrictCharacterStreamJsonWriterSettings.builder()
+                 .propertySeparator(StrictCharacterStreamJsonWriterSettings.PropertySeparator.NO_SPACES).build())
+
+        when:
+        writer.writeStartObject()
+        writer.writeString('name', 'value')
+        writer.writeEndObject()
+
+        then:
+        stringWriter.toString() == format('{ "name":"value" }')
+    }
+
+    def 'property separator with space after'() {
+        given:
+        writer = new StrictCharacterStreamJsonWriter(stringWriter, StrictCharacterStreamJsonWriterSettings.builder()
+                 .propertySeparator(StrictCharacterStreamJsonWriterSettings.PropertySeparator.SPACE_AFTER).build())
+
+        when:
+        writer.writeStartObject()
+        writer.writeString('name', 'value')
+        writer.writeEndObject()
+
+        then:
+        stringWriter.toString() == format('{ "name": "value" }')
+    }
+
+    def 'property separator with space before '() {
+        given:
+        writer = new StrictCharacterStreamJsonWriter(stringWriter, StrictCharacterStreamJsonWriterSettings.builder()
+                 .propertySeparator(StrictCharacterStreamJsonWriterSettings.PropertySeparator.SPACE_BEFORE).build())
+
+        when:
+        writer.writeStartObject()
+        writer.writeString('name', 'value')
+        writer.writeEndObject()
+
+        then:
+        stringWriter.toString() == format('{ "name" :"value" }')
+    }
+
+    def 'property separator with space before and after'() {
+        given:
+        writer = new StrictCharacterStreamJsonWriter(stringWriter, StrictCharacterStreamJsonWriterSettings.builder()
+                 .propertySeparator(StrictCharacterStreamJsonWriterSettings.PropertySeparator.SPACE_BEFORE_AND_AFTER).build())
+
+        when:
+        writer.writeStartObject()
+        writer.writeString('name', 'value')
+        writer.writeEndObject()
+
+        then:
+        stringWriter.toString() == format('{ "name" : "value" }')
+    }
+
     def shouldThrowExceptionForBooleanWhenWritingBeforeStartingDocument() {
         when:
         writer.writeBoolean('b1', true)


### PR DESCRIPTION
https://jira.mongodb.org/browse/JAVA-3085

- Adds the ability to configure `StrictCharacterStreamJsonWriter` with
 - A `PropertySeparator` setting to control the spacing between property key's and property value's.
 - A boolean setting for if each array value is to have its own line.
- Adds new unit tests for the new settings
- Removes the need to replicate builder settings from `StrictCharacterStreamJsonWriterSettings` to `JsonWriterSettings` by using the existing builder.


**Misc:**
- Removes unneeded varargs from `StrictCharacterStreamJsonWriter.checkPreconditions`
- Removes `notNull` check from non-nullable boolean argument in `StrictCharacterStreamJsonWriter.writeBoolean`

----

```
$ ./gradlew check
> Task :bson:test
--------------------------------------------------------------------------
Results: SUCCESS (2151 tests, 2146 passed, 0 failed, 5 skipped)
--------------------------------------------------------------------------
> Task :driver-async:test
--------------------------------------------------------------------------
Results: SUCCESS (762 tests, 531 passed, 0 failed, 231 skipped)
--------------------------------------------------------------------------
> Task :driver-core:test
--------------------------------------------------------------------------
Results: SUCCESS (2224 tests, 2173 passed, 0 failed, 51 skipped)
--------------------------------------------------------------------------
> Task :driver-legacy:test
--------------------------------------------------------------------------
Results: SUCCESS (725 tests, 677 passed, 0 failed, 48 skipped)
--------------------------------------------------------------------------
> Task :driver-sync:test
--------------------------------------------------------------------------
Results: SUCCESS (693 tests, 459 passed, 0 failed, 234 skipped)
--------------------------------------------------------------------------
```