### PR TITLE
Fix typo in enum code example

### DIFF
--- a/docs/reference/content/bson/pojos.md
+++ b/docs/reference/content/bson/pojos.md
@@ -289,7 +289,7 @@ public enum Membership {
 public class Person {
     private String firstName;
     private String lastName;
-    private Member membership = Member.UNREGISTERED;
+    private Membership membership = Membership.UNREGISTERED;
 
     public Person() { }
 


### PR DESCRIPTION
Currently, `enum Membership` is declared, and used as a constructor argument, but the field is of type `Member`.
Just changed the field to `Membership` to make it consistent.