### PR TITLE
JAVA-3220 add convention for setting fields regardless of access level

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/ConventionSetAllFieldImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/ConventionSetAllFieldImpl.java
@@ -1,0 +1,60 @@
+package org.bson.codecs.pojo;
+
+import org.bson.codecs.configuration.CodecConfigurationException;
+
+import static java.lang.String.format;
+import static java.lang.reflect.Modifier.isPublic;
+
+public class ConventionSetAllFieldImpl implements Convention {
+    @Override
+    public void apply(final ClassModelBuilder<?> classModelBuilder) {
+        for (PropertyModelBuilder<?> propertyModelBuilder : classModelBuilder.getPropertyModelBuilders()) {
+            if (!(propertyModelBuilder.getPropertyAccessor() instanceof PropertyAccessorImpl)) {
+                throw new CodecConfigurationException(format("The SET_ALL_FIELDS_CONVENTION is not compatible with "
+                                + "propertyModelBuilder instance that have custom implementations of org.bson.codecs.pojo.PropertyAccessor: %s",
+                        propertyModelBuilder.getPropertyAccessor().getClass().getName()));
+            }
+            PropertyAccessorImpl<?> defaultAccessor = (PropertyAccessorImpl<?>) propertyModelBuilder.getPropertyAccessor();
+            PropertyMetadata<?> propertyMetaData = defaultAccessor.getPropertyMetadata();
+            if (!propertyMetaData.isDeserializable() && propertyMetaData.getField() != null
+                    && !isPublic(propertyMetaData.getField().getModifiers())) {
+                setPropertyAccessor(propertyModelBuilder);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> void setPropertyAccessor(final PropertyModelBuilder<T> propertyModelBuilder) {
+        propertyModelBuilder.propertyAccessor(new AnyPropertyAccessor<T>(
+                (PropertyAccessorImpl<T>) propertyModelBuilder.getPropertyAccessor()));
+    }
+
+    private static final class AnyPropertyAccessor<T> implements PropertyAccessor<T> {
+        private final PropertyAccessorImpl<T> wrapped;
+
+        private AnyPropertyAccessor(final PropertyAccessorImpl<T> wrapped) {
+            this.wrapped = wrapped;
+            try {
+                wrapped.getPropertyMetadata().getField().setAccessible(true);
+            } catch (Exception e) {
+                throw new CodecConfigurationException(format("Unable to make field accessible '%s' in %s",
+                        wrapped.getPropertyMetadata().getName(), wrapped.getPropertyMetadata().getDeclaringClassName()), e);
+            }
+        }
+
+        @Override
+        public <S> T get(final S instance) {
+            return wrapped.get(instance);
+        }
+
+        @Override
+        public <S> void set(final S instance, final T value) {
+            try {
+                wrapped.getPropertyMetadata().getField().set(instance, value);
+            } catch (Exception e) {
+                throw new CodecConfigurationException(format("Unable to set value for property '%s' in %s",
+                        wrapped.getPropertyMetadata().getName(), wrapped.getPropertyMetadata().getDeclaringClassName()), e);
+            }
+        }
+    }
+}

--- a/bson/src/main/org/bson/codecs/pojo/ConventionSetAllFieldImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/ConventionSetAllFieldImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bson.codecs.pojo;
 
 import org.bson.codecs.configuration.CodecConfigurationException;
@@ -5,13 +21,13 @@ import org.bson.codecs.configuration.CodecConfigurationException;
 import static java.lang.String.format;
 import static java.lang.reflect.Modifier.isPublic;
 
-public class ConventionSetAllFieldImpl implements Convention {
+final class ConventionSetAllFieldImpl implements Convention {
     @Override
     public void apply(final ClassModelBuilder<?> classModelBuilder) {
         for (PropertyModelBuilder<?> propertyModelBuilder : classModelBuilder.getPropertyModelBuilders()) {
             if (!(propertyModelBuilder.getPropertyAccessor() instanceof PropertyAccessorImpl)) {
                 throw new CodecConfigurationException(format("The SET_ALL_FIELDS_CONVENTION is not compatible with "
-                                + "propertyModelBuilder instance that have custom implementations of org.bson.codecs.pojo.PropertyAccessor: %s",
+                        + "propertyModelBuilder instance that have custom implementations of org.bson.codecs.pojo.PropertyAccessor: %s",
                         propertyModelBuilder.getPropertyAccessor().getClass().getName()));
             }
             PropertyAccessorImpl<?> defaultAccessor = (PropertyAccessorImpl<?>) propertyModelBuilder.getPropertyAccessor();

--- a/bson/src/main/org/bson/codecs/pojo/Conventions.java
+++ b/bson/src/main/org/bson/codecs/pojo/Conventions.java
@@ -60,6 +60,17 @@ public final class Conventions {
     public static final Convention SET_PRIVATE_FIELDS_CONVENTION = new ConventionSetPrivateFieldImpl();
 
     /**
+     * A convention that enables all fields to be set using reflection. Unlike {@link #SET_PRIVATE_FIELDS_CONVENTION},
+     * this will also enable package private and protected fields to be set using reflection.
+     *
+     * <p>This convention mimics how some other JSON libraries directly set a field when there is no setter.</p>
+     * <p>Note: This convention is not part of the {@code DEFAULT_CONVENTIONS} list and must explicitly be set.</p>
+     *
+     * @since 3.11
+     */
+    public static final Convention SET_ALL_FIELDS_CONVENTION = new ConventionSetAllFieldImpl();
+
+    /**
      * A convention that uses getter methods as setters for collections and maps if there is no setter.
      *
      * <p>This convention mimics how JAXB mutate collections and maps.</p>

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -26,6 +26,7 @@ import org.bson.codecs.LongCodec;
 import org.bson.codecs.MapCodec;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.entities.AnySetterFieldModel;
 import org.bson.codecs.pojo.entities.AsymmetricalCreatorModel;
 import org.bson.codecs.pojo.entities.AsymmetricalIgnoreModel;
 import org.bson.codecs.pojo.entities.AsymmetricalModel;
@@ -82,6 +83,7 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 import static org.bson.codecs.pojo.Conventions.DEFAULT_CONVENTIONS;
 import static org.bson.codecs.pojo.Conventions.NO_CONVENTIONS;
+import static org.bson.codecs.pojo.Conventions.SET_ALL_FIELDS_CONVENTION;
 import static org.bson.codecs.pojo.Conventions.SET_PRIVATE_FIELDS_CONVENTION;
 import static org.bson.codecs.pojo.Conventions.USE_GETTERS_FOR_SETTERS;
 import static org.junit.Assert.assertEquals;
@@ -241,6 +243,17 @@ public final class PojoCustomTest extends PojoTestCase {
         builder.conventions(conventions);
 
         roundTrip(builder, new PrivateSetterFieldModel(1, "2", asList("a", "b")),
+                "{'someMethod': 'some method', 'integerField': 1, 'stringField': '2', listField: ['a', 'b']}");
+    }
+
+    @Test
+    public void testSetFieldDirectlyConvention() {
+        PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(AnySetterFieldModel.class);
+        ArrayList<Convention> conventions = new ArrayList<Convention>(DEFAULT_CONVENTIONS);
+        conventions.add(SET_ALL_FIELDS_CONVENTION);
+        builder.conventions(conventions);
+
+        roundTrip(builder, new AnySetterFieldModel(1, "2", asList("a", "b")),
                 "{'someMethod': 'some method', 'integerField': 1, 'stringField': '2', listField: ['a', 'b']}");
     }
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/AnySetterFieldModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/AnySetterFieldModel.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+import java.util.List;
+
+public final class AnySetterFieldModel {
+
+    Integer integerField;
+    private String stringField;
+    protected List<String> listField;
+
+    public AnySetterFieldModel(){
+    }
+
+    public AnySetterFieldModel(final Integer integerField, final String stringField, final List<String> listField) {
+        this.integerField = integerField;
+        this.stringField = stringField;
+        this.listField = listField;
+    }
+
+    public String getSomeMethod() {
+        return "some method";
+    }
+
+    public Integer getIntegerField() {
+        return integerField;
+    }
+
+    public String getStringField() {
+        return stringField;
+    }
+
+    public List<String> getListField() {
+        return listField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AnySetterFieldModel that = (AnySetterFieldModel) o;
+
+        if (getIntegerField() != null ? !getIntegerField().equals(that.getIntegerField()) : that.getIntegerField() != null) {
+            return false;
+        }
+        if (getStringField() != null ? !getStringField().equals(that.getStringField()) : that.getStringField() != null) {
+            return false;
+        }
+        return getListField() != null ? getListField().equals(that.getListField()) : that.getListField() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getIntegerField() != null ? getIntegerField().hashCode() : 0;
+        result = 31 * result + (getStringField() != null ? getStringField().hashCode() : 0);
+        result = 31 * result + (getListField() != null ? getListField().hashCode() : 0);
+        return result;
+    }
+}


### PR DESCRIPTION
Added following convention: 
```
/**
 * A convention that enables all fields to be set using reflection. Unlike {@link #SET_PRIVATE_FIELDS_CONVENTION},
 * this will also enable package private and protected fields to be set using reflection.
 *
 * <p>This convention mimics how some other JSON libraries directly set a field when there is no setter.</p>
 * <p>Note: This convention is not part of the {@code DEFAULT_CONVENTIONS} list and must explicitly be set.</p>
 *
 * @since 3.11
 */
public static final Convention SET_ALL_FIELDS_CONVENTION = new ConventionSetAllFieldImpl();
```
not sure if the `@since 3.11` is accurate.

The `ConventionSetAllFieldImpl` is nearly identical to existing `ConventionSetPrivateFieldImpl` except for one change which is changing `isPrivate(<field modifiers>)` to `!isPublic(<field modifiers>)`.
I did consider modifying the existing class to take in accessors on which it works and use two differently configured instances in `Conventions`, but did not make the change as the class is public and may break compatibility.