### PR TITLE
JAVA-3238: Support reading extended JSON from an input stream

### DIFF
--- a/bson/src/main/org/bson/json/JsonBufferFactory.java
+++ b/bson/src/main/org/bson/json/JsonBufferFactory.java
@@ -16,21 +16,19 @@
 
 package org.bson.json;
 
-import java.io.Closeable;
+import java.io.InputStream;
 
-interface JsonBuffer extends Closeable {
+final class JsonBufferFactory {
 
-    int getPosition();
+    private JsonBufferFactory() {
 
-    int read();
+    }
 
-    void unread(int c);
+    static JsonBuffer createBuffer(final String json) {
+        return new JsonStringBuffer(json);
+    }
 
-    int mark();
-
-    void reset(int markPos);
-
-    void close();
-
-    void discard(int markPos);
+    static JsonBuffer createBuffer(final InputStream jsonStream) {
+        return new JsonStreamBuffer(jsonStream);
+    }
 }

--- a/bson/src/main/org/bson/json/JsonStreamBuffer.java
+++ b/bson/src/main/org/bson/json/JsonStreamBuffer.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.json;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+class JsonStreamBuffer implements JsonBuffer {
+
+    private final BufferedReader stream;
+    private int position;
+    private int lastChar;
+    private int bufferStartPos;
+    private boolean reuseLastChar;
+    private boolean eof;
+    private List<Integer> buffer;
+    private List<Integer> markedPoses;
+
+    JsonStreamBuffer(final InputStream stream) {
+        try {
+            this.stream = new BufferedReader(new InputStreamReader(stream, "UTF-8"));
+        } catch (final UnsupportedEncodingException e) {
+            throw new JsonParseException(e);
+        }
+        buffer = new ArrayList<Integer>();
+        markedPoses = new LinkedList<Integer>();
+        bufferStartPos = -1;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public int read() {
+        if (eof) {
+            throw new JsonParseException("Trying to read past EOF.");
+        }
+
+        // if we just unread, we need to use the last character read since it may not be in the
+        // buffer
+        if (reuseLastChar) {
+            reuseLastChar = false;
+            final int reusedChar = lastChar;
+            lastChar = -1;
+            position++;
+            return reusedChar;
+        }
+
+        // use the buffer until we catch up to the stream position
+        if (position >= bufferStartPos && position - bufferStartPos < buffer.size()) {
+            final int currChar = buffer.get(position - bufferStartPos);
+            lastChar = currChar;
+            position++;
+            return currChar;
+        }
+
+        // if there are no marked positions and we have caught up, we can clear the buffer
+        if (markedPoses.isEmpty()) {
+            bufferStartPos = -1;
+            buffer.clear();
+        }
+
+        // otherwise, try and read from the stream
+        final int currChar;
+        try {
+            currChar = stream.read();
+            lastChar = currChar;
+
+            // if the lowest mark is ahead of our position, we can safely
+            if (!markedPoses.isEmpty()) {
+                buffer.add(currChar);
+            }
+        } catch (final IOException e) {
+            throw new JsonParseException(e);
+        }
+        position++;
+        if (currChar == -1) {
+            eof = true;
+        }
+        return currChar;
+    }
+
+    public void unread(final int c) {
+        eof = false;
+        if (c != -1 && lastChar == c) {
+            reuseLastChar = true;
+            position--;
+        }
+    }
+
+    public int mark() {
+        if (buffer.isEmpty()) {
+            bufferStartPos = position;
+        }
+        markedPoses.add(position);
+        return position;
+    }
+
+    public void reset(final int markPos) {
+        if (markedPoses.isEmpty()) {
+            return;
+        }
+        final int idx = markedPoses.indexOf(markPos);
+        if (idx == -1) {
+            throw new IllegalArgumentException("mark invalidated");
+        }
+        if (markPos > position) {
+            throw new IllegalStateException("mark cannot reset ahead of position, only back");
+        }
+        final Iterator<Integer> markIter = markedPoses.iterator();
+        while (markIter.hasNext()) {
+            final Integer nextMark = markIter.next();
+            if (nextMark > markPos) {
+                markIter.remove();
+            }
+        }
+        if (reuseLastChar && markPos != position) {
+            reuseLastChar = false;
+        }
+        markedPoses.remove(idx);
+        position = markPos;
+    }
+
+    public void discard(final int markPos) {
+        if (markedPoses.isEmpty()) {
+            return;
+        }
+        final int idx = markedPoses.indexOf(markPos);
+        if (idx == -1) {
+            return;
+        }
+        markedPoses.remove(idx);
+    }
+
+    public void close() {
+        try {
+            stream.close();
+        } catch (IOException e) {
+            throw new JsonParseException(e);
+        }
+        buffer.clear();
+    }
+}

--- a/bson/src/main/org/bson/json/JsonStringBuffer.java
+++ b/bson/src/main/org/bson/json/JsonStringBuffer.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.json;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+class JsonStringBuffer implements JsonBuffer {
+
+    private final String buffer;
+    private int position;
+    private List<Integer> markedPoses;
+    private boolean eof;
+    private int lastChar;
+
+    JsonStringBuffer(final String buffer) {
+        this.buffer = buffer;
+        markedPoses = new ArrayList<Integer>();
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public int read() {
+        if (eof) {
+            throw new JsonParseException("Trying to read past EOF.");
+    } else if (position >= buffer.length()) {
+            eof = true;
+            return -1;
+        }  else {
+            final int currChar = buffer.charAt(position++);
+            lastChar = currChar;
+            return currChar;
+        }
+    }
+
+    public void unread(final int c) {
+        eof = false;
+        if (c != -1 && lastChar != -1 && lastChar == c) {
+            lastChar = -1;
+            position--;
+        }
+    }
+
+    public int mark() {
+        markedPoses.add(position);
+        return position;
+    }
+
+    public void reset(final int markPos) {
+        if (markedPoses.isEmpty()) {
+            return;
+        }
+        final int idx = markedPoses.indexOf(markPos);
+        if (idx == -1) {
+            throw new IllegalArgumentException("mark invalidated");
+        }
+        if (markPos > position) {
+            throw new IllegalStateException("mark cannot reset ahead of position, only back");
+        }
+        final Iterator<Integer> markIter = markedPoses.iterator();
+        while (markIter.hasNext()) {
+            final Integer nextMark = markIter.next();
+            if (nextMark > markPos) {
+                markIter.remove();
+            }
+        }
+        markedPoses.remove(idx);
+        position = markPos;
+    }
+
+    public void discard(final int markPos) {
+        final int idx = markedPoses.indexOf(markPos);
+        if (idx == -1) {
+            return;
+        }
+        markedPoses.remove(idx);
+    }
+
+    public void close() {
+
+    }
+}

--- a/bson/src/test/unit/org/bson/LimitedLookaheadMarkSpecification.groovy
+++ b/bson/src/test/unit/org/bson/LimitedLookaheadMarkSpecification.groovy
@@ -241,7 +241,7 @@ class LimitedLookaheadMarkSpecification extends Specification {
         ]
     }
 
-    def 'Lookahead should work at various states with Mark'(BsonWriter writer) {
+    def 'Lookahead should work at various states with Mark'(BsonWriter writer, boolean useAlternateReader) {
         given:
         writer.with {
             writeStartDocument()
@@ -274,7 +274,11 @@ class LimitedLookaheadMarkSpecification extends Specification {
             BasicOutputBuffer buffer = (BasicOutputBuffer) writer.getBsonOutput();
             reader = new BsonBinaryReader(new ByteBufferBsonInput(buffer.getByteBuffers().get(0)))
         } else if (writer instanceof JsonWriter) {
-            reader = new JsonReader(writer.writer.toString())
+            if (useAlternateReader) {
+                reader = new JsonReader(new ByteArrayInputStream(writer.writer.toString().getBytes()))
+            } else {
+                reader = new JsonReader(writer.writer.toString())
+            }
         }
 
         reader.readStartDocument()
@@ -420,11 +424,11 @@ class LimitedLookaheadMarkSpecification extends Specification {
         reader.readEndDocument()
 
         where:
-        writer << [
-                new BsonDocumentWriter(new BsonDocument()),
-                new BsonBinaryWriter(new BasicOutputBuffer()),
-                new JsonWriter(new StringWriter())
-        ]
+        writer | useAlternateReader
+        new BsonDocumentWriter(new BsonDocument()) | false
+        new BsonBinaryWriter(new BasicOutputBuffer()) | false
+        new JsonWriter(new StringWriter()) | false
+        new JsonWriter(new StringWriter()) | true
     }
 
     def 'should peek binary subtype and size'(BsonWriter writer) {

--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -27,6 +27,7 @@ import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -41,268 +42,416 @@ import static org.junit.Assert.fail;
 
 
 public class JsonReaderTest {
-    private AbstractBsonReader bsonReader;
+    interface Function<T, R> {
+        R apply(T t);
+    }
+
+    void testStringAndStream(
+            final String json,
+            final Function<AbstractBsonReader, Void> testFunc,
+            final Class<? extends RuntimeException> exClass) {
+        try {
+            testFunc.apply(new JsonReader(json));
+        } catch (final RuntimeException e) {
+            if (exClass == null) {
+                throw e;
+            }
+            assertEquals(exClass, e.getClass());
+        }
+        try {
+            testFunc.apply(new JsonReader(new ByteArrayInputStream(json.getBytes())));
+        } catch (final RuntimeException e) {
+            if (exClass == null) {
+                throw e;
+            }
+            assertEquals(exClass, e.getClass());
+        }
+    }
+
+    void testStringAndStream(final String json, final Function<AbstractBsonReader, Void> testFunc) {
+        testStringAndStream(json, testFunc, null);
+    }
 
     @Test
     public void testArrayEmpty() {
         String json = "[]";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.ARRAY, bsonReader.readBsonType());
-        bsonReader.readStartArray();
-        assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readEndArray();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.ARRAY, bsonReader.readBsonType());
+                bsonReader.readStartArray();
+                assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readEndArray();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testArrayOneElement() {
         String json = "[1]";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.ARRAY, bsonReader.readBsonType());
-        bsonReader.readStartArray();
-        assertEquals(BsonType.INT32, bsonReader.readBsonType());
-        assertEquals(1, bsonReader.readInt32());
-        assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readEndArray();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.ARRAY, bsonReader.readBsonType());
+                bsonReader.readStartArray();
+                assertEquals(BsonType.INT32, bsonReader.readBsonType());
+                assertEquals(1, bsonReader.readInt32());
+                assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readEndArray();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testArrayTwoElements() {
         String json = "[1, 2]";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.ARRAY, bsonReader.readBsonType());
-        bsonReader.readStartArray();
-        assertEquals(BsonType.INT32, bsonReader.readBsonType());
-        assertEquals(1, bsonReader.readInt32());
-        assertEquals(BsonType.INT32, bsonReader.readBsonType());
-        assertEquals(2, bsonReader.readInt32());
-        assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readEndArray();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.ARRAY, bsonReader.readBsonType());
+                bsonReader.readStartArray();
+                assertEquals(BsonType.INT32, bsonReader.readBsonType());
+                assertEquals(1, bsonReader.readInt32());
+                assertEquals(BsonType.INT32, bsonReader.readBsonType());
+                assertEquals(2, bsonReader.readInt32());
+                assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readEndArray();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testBooleanFalse() {
         String json = "false";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.BOOLEAN, bsonReader.readBsonType());
-        assertEquals(false, bsonReader.readBoolean());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.BOOLEAN, bsonReader.readBsonType());
+                assertEquals(false, bsonReader.readBoolean());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testBooleanTrue() {
         String json = "true";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.BOOLEAN, bsonReader.readBsonType());
-        assertEquals(true, bsonReader.readBoolean());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.BOOLEAN, bsonReader.readBsonType());
+                assertEquals(true, bsonReader.readBoolean());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDateTimeMinBson() {
         String json = "new Date(-9223372036854775808)";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
-        assertEquals(-9223372036854775808L, bsonReader.readDateTime());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+                assertEquals(-9223372036854775808L, bsonReader.readDateTime());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDateTimeMaxBson() {
         String json = "new Date(9223372036854775807)";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
-        long k = bsonReader.readDateTime();
-        assertEquals(9223372036854775807L, k);
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+                long k = bsonReader.readDateTime();
+                assertEquals(9223372036854775807L, k);
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDateTimeShell() {
         String json = "ISODate(\"1970-01-01T00:00:00Z\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
-        assertEquals(0, bsonReader.readDateTime());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+                assertEquals(0, bsonReader.readDateTime());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDateTimeShellWith24HourTimeSpecification() {
         String json = "ISODate(\"2013-10-04T12:07:30.443Z\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
-        assertEquals(1380888450443L, bsonReader.readDateTime());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+                assertEquals(1380888450443L, bsonReader.readDateTime());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDateTimeStrict() {
         String json = "{ \"$date\" : 0 }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
-        assertEquals(0, bsonReader.readDateTime());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+                assertEquals(0, bsonReader.readDateTime());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testNestedDateTimeStrict() {
         String json = "{d1 : { \"$date\" : 0 }, d2 : { \"$date\" : 1 } }";
-        bsonReader = new JsonReader(json);
-        bsonReader.readStartDocument();
-        assertEquals(0L, bsonReader.readDateTime("d1"));
-        assertEquals(1L, bsonReader.readDateTime("d2"));
-        bsonReader.readEndDocument();
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                bsonReader.readStartDocument();
+                assertEquals(0L, bsonReader.readDateTime("d1"));
+                assertEquals(1L, bsonReader.readDateTime("d2"));
+                bsonReader.readEndDocument();
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDateTimeISOString() {
         String json = "{ \"$date\" : \"2015-04-16T14:55:57.626Z\" }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
-        assertEquals(1429196157626L, bsonReader.readDateTime());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+                assertEquals(1429196157626L, bsonReader.readDateTime());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDateTimeISOStringWithTimeOffset() {
         String json = "{ \"$date\" : \"2015-04-16T16:55:57.626+02:00\" }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
-        assertEquals(1429196157626L, bsonReader.readDateTime());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+                assertEquals(1429196157626L, bsonReader.readDateTime());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDateTimeTengen() {
         String json = "new Date(0)";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
-        assertEquals(0, bsonReader.readDateTime());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+                assertEquals(0, bsonReader.readDateTime());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDocumentEmpty() {
         String json = "{ }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readEndDocument();
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readEndDocument();
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDocumentNested() {
         String json = "{ \"a\" : { \"x\" : 1 }, \"y\" : 2 }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
-        assertEquals("a", bsonReader.readName());
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.INT32, bsonReader.readBsonType());
-        assertEquals("x", bsonReader.readName());
-        assertEquals(1, bsonReader.readInt32());
-        assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readEndDocument();
-        assertEquals(BsonType.INT32, bsonReader.readBsonType());
-        assertEquals("y", bsonReader.readName());
-        assertEquals(2, bsonReader.readInt32());
-        assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readEndDocument();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
+                assertEquals("a", bsonReader.readName());
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.INT32, bsonReader.readBsonType());
+                assertEquals("x", bsonReader.readName());
+                assertEquals(1, bsonReader.readInt32());
+                assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readEndDocument();
+                assertEquals(BsonType.INT32, bsonReader.readBsonType());
+                assertEquals("y", bsonReader.readName());
+                assertEquals(2, bsonReader.readInt32());
+                assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readEndDocument();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDocumentOneElement() {
         String json = "{ \"x\" : 1 }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.INT32, bsonReader.readBsonType());
-        assertEquals("x", bsonReader.readName());
-        assertEquals(1, bsonReader.readInt32());
-        assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readEndDocument();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.INT32, bsonReader.readBsonType());
+                assertEquals("x", bsonReader.readName());
+                assertEquals(1, bsonReader.readInt32());
+                assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readEndDocument();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDocumentTwoElements() {
         String json = "{ \"x\" : 1, \"y\" : 2 }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.INT32, bsonReader.readBsonType());
-        assertEquals("x", bsonReader.readName());
-        assertEquals(1, bsonReader.readInt32());
-        assertEquals(BsonType.INT32, bsonReader.readBsonType());
-        assertEquals("y", bsonReader.readName());
-        assertEquals(2, bsonReader.readInt32());
-        assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readEndDocument();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.INT32, bsonReader.readBsonType());
+                assertEquals("x", bsonReader.readName());
+                assertEquals(1, bsonReader.readInt32());
+                assertEquals(BsonType.INT32, bsonReader.readBsonType());
+                assertEquals("y", bsonReader.readName());
+                assertEquals(2, bsonReader.readInt32());
+                assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readEndDocument();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDouble() {
         String json = "1.5";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DOUBLE, bsonReader.readBsonType());
-        assertEquals(1.5, bsonReader.readDouble(), 0);
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DOUBLE, bsonReader.readBsonType());
+                assertEquals(1.5, bsonReader.readDouble(), 0);
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testHexData() {
-        byte[] expectedBytes = new byte[]{0x01, 0x23};
+        final byte[] expectedBytes = new byte[]{0x01, 0x23};
         String json = "HexData(0, \"0123\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
-        BsonBinary binary = bsonReader.readBinaryData();
-        assertArrayEquals(expectedBytes, binary.getData());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                BsonBinary binary = bsonReader.readBinaryData();
+                assertArrayEquals(expectedBytes, binary.getData());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testHexDataWithNew() {
-        byte[] expectedBytes = new byte[]{0x01, 0x23};
+        final byte[] expectedBytes = new byte[]{0x01, 0x23};
         String json = "new HexData(0, \"0123\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
-        BsonBinary binary = bsonReader.readBinaryData();
-        assertArrayEquals(expectedBytes, binary.getData());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                BsonBinary binary = bsonReader.readBinaryData();
+                assertArrayEquals(expectedBytes, binary.getData());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testInt32() {
         String json = "123";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.INT32, bsonReader.readBsonType());
-        assertEquals(123, bsonReader.readInt32());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.INT32, bsonReader.readBsonType());
+                assertEquals(123, bsonReader.readInt32());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
 
     }
 
     @Test
     public void testInt64() {
         String json = String.valueOf(Long.MAX_VALUE);
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.INT64, bsonReader.readBsonType());
-        assertEquals(Long.MAX_VALUE, bsonReader.readInt64());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.INT64, bsonReader.readBsonType());
+                assertEquals(Long.MAX_VALUE, bsonReader.readInt64());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testNumberLongExtendedJson() {
         String json = "{\"$numberLong\":\"123\"}";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.INT64, bsonReader.readBsonType());
-        assertEquals(123, bsonReader.readInt64());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.INT64, bsonReader.readBsonType());
+                assertEquals(123, bsonReader.readInt64());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
@@ -313,10 +462,15 @@ public class JsonReaderTest {
                 "new NumberLong(123)",
                 "new NumberLong(\"123\")");
         for (String json : jsonTexts) {
-            bsonReader = new JsonReader(json);
-            assertEquals(BsonType.INT64, bsonReader.readBsonType());
-            assertEquals(123, bsonReader.readInt64());
-            assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+            testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+                @Override
+                public Void apply(final AbstractBsonReader bsonReader) {
+                    assertEquals(BsonType.INT64, bsonReader.readBsonType());
+                    assertEquals(123, bsonReader.readInt64());
+                    assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                    return null;
+                }
+            });
         }
     }
 
@@ -328,117 +482,171 @@ public class JsonReaderTest {
                 "new NumberInt(123)",
                 "new NumberInt(\"123\")");
         for (String json : jsonTexts) {
-            bsonReader = new JsonReader(json);
-            assertEquals(BsonType.INT32, bsonReader.readBsonType());
-            assertEquals(123, bsonReader.readInt32());
-            assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+            testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+                @Override
+                public Void apply(final AbstractBsonReader bsonReader) {
+                    assertEquals(BsonType.INT32, bsonReader.readBsonType());
+                    assertEquals(123, bsonReader.readInt32());
+                    assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                    return null;
+                }
+            });
         }
     }
 
     @Test
     public void testDecimal128StringConstructor() {
         String json = "NumberDecimal(\"314E-2\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DECIMAL128, bsonReader.readBsonType());
-        assertEquals(Decimal128.parse("314E-2"), bsonReader.readDecimal128());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DECIMAL128, bsonReader.readBsonType());
+                assertEquals(Decimal128.parse("314E-2"), bsonReader.readDecimal128());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDecimal128Int32Constructor() {
         String json = "NumberDecimal(" + Integer.MAX_VALUE + ")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DECIMAL128, bsonReader.readBsonType());
-        assertEquals(new Decimal128(Integer.MAX_VALUE), bsonReader.readDecimal128());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DECIMAL128, bsonReader.readBsonType());
+                assertEquals(new Decimal128(Integer.MAX_VALUE), bsonReader.readDecimal128());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDecimal128Int64Constructor() {
         String json = "NumberDecimal(" + Long.MAX_VALUE + ")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DECIMAL128, bsonReader.readBsonType());
-        assertEquals(new Decimal128(Long.MAX_VALUE), bsonReader.readDecimal128());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DECIMAL128, bsonReader.readBsonType());
+                assertEquals(new Decimal128(Long.MAX_VALUE), bsonReader.readDecimal128());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDecimal128DoubleConstructor() {
         String json = "NumberDecimal(" + 1.0 + ")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DECIMAL128, bsonReader.readBsonType());
-        assertEquals(Decimal128.parse("1"), bsonReader.readDecimal128());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DECIMAL128, bsonReader.readBsonType());
+                assertEquals(Decimal128.parse("1"), bsonReader.readDecimal128());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDecimal128BooleanConstructor() {
         String json = "NumberDecimal(true)";
-        bsonReader = new JsonReader(json);
-        try {
-            bsonReader.readBsonType();
-            fail("Should fail to parse NumberDecimal constructor with a string");
-        } catch (JsonParseException e) {
-            // all good
-        }
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                try {
+                    bsonReader.readBsonType();
+                    fail("Should fail to parse NumberDecimal constructor with a string");
+                } catch (JsonParseException e) {
+                    // all good
+                }
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDecimal128WithNew() {
         String json = "new NumberDecimal(\"314E-2\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DECIMAL128, bsonReader.readBsonType());
-        assertEquals(Decimal128.parse("314E-2"), bsonReader.readDecimal128());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DECIMAL128, bsonReader.readBsonType());
+                assertEquals(Decimal128.parse("314E-2"), bsonReader.readDecimal128());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDecimal128ExtendedJson() {
         String json = "{\"$numberDecimal\":\"314E-2\"}";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DECIMAL128, bsonReader.readBsonType());
-        assertEquals(Decimal128.parse("314E-2"), bsonReader.readDecimal128());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DECIMAL128, bsonReader.readBsonType());
+                assertEquals(Decimal128.parse("314E-2"), bsonReader.readDecimal128());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testJavaScript() {
         String json = "{ \"$code\" : \"function f() { return 1; }\" }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.JAVASCRIPT, bsonReader.readBsonType());
-        assertEquals("function f() { return 1; }", bsonReader.readJavaScript());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
-
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.JAVASCRIPT, bsonReader.readBsonType());
+                assertEquals("function f() { return 1; }", bsonReader.readJavaScript());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testJavaScriptWithScope() {
         String json = "{\"codeWithScope\": { \"$code\" : \"function f() { return n; }\", \"$scope\" : { \"n\" : 1 } } }";
-        bsonReader = new JsonReader(json);
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.JAVASCRIPT_WITH_SCOPE, bsonReader.readBsonType());
-        assertEquals("codeWithScope", bsonReader.readName());
-        assertEquals("function f() { return n; }", bsonReader.readJavaScriptWithScope());
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.INT32, bsonReader.readBsonType());
-        assertEquals("n", bsonReader.readName());
-        assertEquals(1, bsonReader.readInt32());
-        bsonReader.readEndDocument();
-        bsonReader.readEndDocument();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.JAVASCRIPT_WITH_SCOPE, bsonReader.readBsonType());
+                assertEquals("codeWithScope", bsonReader.readName());
+                assertEquals("function f() { return n; }", bsonReader.readJavaScriptWithScope());
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.INT32, bsonReader.readBsonType());
+                assertEquals("n", bsonReader.readName());
+                assertEquals(1, bsonReader.readInt32());
+                bsonReader.readEndDocument();
+                bsonReader.readEndDocument();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testMaxKey() {
         for (String maxKeyJson : asList("{ \"$maxKey\" : 1 }", "MaxKey", "MaxKey()", "new MaxKey", "new MaxKey()")) {
             String json = "{ maxKey : " + maxKeyJson + " }";
-            bsonReader = new JsonReader(json);
-            bsonReader.readStartDocument();
-            assertEquals("maxKey", bsonReader.readName());
-            assertEquals(BsonType.MAX_KEY, bsonReader.getCurrentBsonType());
-            bsonReader.readMaxKey();
-            bsonReader.readEndDocument();
-            assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+            testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+                @Override
+                public Void apply(final AbstractBsonReader bsonReader) {
+                    bsonReader.readStartDocument();
+                    assertEquals("maxKey", bsonReader.readName());
+                    assertEquals(BsonType.MAX_KEY, bsonReader.getCurrentBsonType());
+                    bsonReader.readMaxKey();
+                    bsonReader.readEndDocument();
+                    assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                    return null;
+                }
+            });
         }
     }
 
@@ -446,555 +654,810 @@ public class JsonReaderTest {
     public void testMinKey() {
         for (String minKeyJson : asList("{ \"$minKey\" : 1 }", "MinKey", "MinKey()", "new MinKey", "new MinKey()")) {
             String json = "{ minKey : " + minKeyJson + " }";
-            bsonReader = new JsonReader(json);
-            bsonReader.readStartDocument();
-            assertEquals("minKey", bsonReader.readName());
-            assertEquals(BsonType.MIN_KEY, bsonReader.getCurrentBsonType());
-            bsonReader.readMinKey();
-            bsonReader.readEndDocument();
-            assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+            testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+                @Override
+                public Void apply(final AbstractBsonReader bsonReader) {
+                    bsonReader.readStartDocument();
+                    assertEquals("minKey", bsonReader.readName());
+                    assertEquals(BsonType.MIN_KEY, bsonReader.getCurrentBsonType());
+                    bsonReader.readMinKey();
+                    bsonReader.readEndDocument();
+                    assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                    return null;
+                }
+            });
         }
     }
 
     @Test
     public void testNestedArray() {
         String json = "{ \"a\" : [1, 2] }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.ARRAY, bsonReader.readBsonType());
-        assertEquals("a", bsonReader.readName());
-        bsonReader.readStartArray();
-        assertEquals(1, bsonReader.readInt32());
-        assertEquals(2, bsonReader.readInt32());
-        bsonReader.readEndArray();
-        bsonReader.readEndDocument();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
-
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.ARRAY, bsonReader.readBsonType());
+                assertEquals("a", bsonReader.readName());
+                bsonReader.readStartArray();
+                assertEquals(1, bsonReader.readInt32());
+                assertEquals(2, bsonReader.readInt32());
+                bsonReader.readEndArray();
+                bsonReader.readEndDocument();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testNestedDocument() {
         String json = "{ \"a\" : { \"b\" : 1, \"c\" : 2 } }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
-        assertEquals("a", bsonReader.readName());
-        bsonReader.readStartDocument();
-        assertEquals("b", bsonReader.readName());
-        assertEquals(1, bsonReader.readInt32());
-        assertEquals("c", bsonReader.readName());
-        assertEquals(2, bsonReader.readInt32());
-        bsonReader.readEndDocument();
-        bsonReader.readEndDocument();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
-
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
+                assertEquals("a", bsonReader.readName());
+                bsonReader.readStartDocument();
+                assertEquals("b", bsonReader.readName());
+                assertEquals(1, bsonReader.readInt32());
+                assertEquals("c", bsonReader.readName());
+                assertEquals(2, bsonReader.readInt32());
+                bsonReader.readEndDocument();
+                bsonReader.readEndDocument();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testNull() {
         String json = "null";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.NULL, bsonReader.readBsonType());
-        bsonReader.readNull();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
-
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.NULL, bsonReader.readBsonType());
+                bsonReader.readNull();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testObjectIdShell() {
         String json = "ObjectId(\"4d0ce088e447ad08b4721a37\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.OBJECT_ID, bsonReader.readBsonType());
-        ObjectId objectId = bsonReader.readObjectId();
-        assertEquals("4d0ce088e447ad08b4721a37", objectId.toString());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.OBJECT_ID, bsonReader.readBsonType());
+                ObjectId objectId = bsonReader.readObjectId();
+                assertEquals("4d0ce088e447ad08b4721a37", objectId.toString());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testObjectIdWithNew() {
         String json = "new ObjectId(\"4d0ce088e447ad08b4721a37\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.OBJECT_ID, bsonReader.readBsonType());
-        ObjectId objectId = bsonReader.readObjectId();
-        assertEquals("4d0ce088e447ad08b4721a37", objectId.toString());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.OBJECT_ID, bsonReader.readBsonType());
+                ObjectId objectId = bsonReader.readObjectId();
+                assertEquals("4d0ce088e447ad08b4721a37", objectId.toString());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testObjectIdStrict() {
         String json = "{ \"$oid\" : \"4d0ce088e447ad08b4721a37\" }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.OBJECT_ID, bsonReader.readBsonType());
-        ObjectId objectId = bsonReader.readObjectId();
-        assertEquals("4d0ce088e447ad08b4721a37", objectId.toString());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.OBJECT_ID, bsonReader.readBsonType());
+                ObjectId objectId = bsonReader.readObjectId();
+                assertEquals("4d0ce088e447ad08b4721a37", objectId.toString());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testObjectIdTenGen() {
         String json = "ObjectId(\"4d0ce088e447ad08b4721a37\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.OBJECT_ID, bsonReader.readBsonType());
-        ObjectId objectId = bsonReader.readObjectId();
-        assertEquals("4d0ce088e447ad08b4721a37", objectId.toString());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.OBJECT_ID, bsonReader.readBsonType());
+                ObjectId objectId = bsonReader.readObjectId();
+                assertEquals("4d0ce088e447ad08b4721a37", objectId.toString());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testRegularExpressionShell() {
         String json = "/pattern/imxs";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.REGULAR_EXPRESSION, bsonReader.readBsonType());
-        BsonRegularExpression regex = bsonReader.readRegularExpression();
-        assertEquals("pattern", regex.getPattern());
-        assertEquals("imsx", regex.getOptions());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
-
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.REGULAR_EXPRESSION, bsonReader.readBsonType());
+                BsonRegularExpression regex = bsonReader.readRegularExpression();
+                assertEquals("pattern", regex.getPattern());
+                assertEquals("imsx", regex.getOptions());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testRegularExpressionStrict() {
         String json = "{ \"$regex\" : \"pattern\", \"$options\" : \"imxs\" }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.REGULAR_EXPRESSION, bsonReader.readBsonType());
-        BsonRegularExpression regex = bsonReader.readRegularExpression();
-        assertEquals("pattern", regex.getPattern());
-        assertEquals("imsx", regex.getOptions());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.REGULAR_EXPRESSION, bsonReader.readBsonType());
+                BsonRegularExpression regex = bsonReader.readRegularExpression();
+                assertEquals("pattern", regex.getPattern());
+                assertEquals("imsx", regex.getOptions());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testRegularExpressionCanonical() {
         String json = "{ \"$regularExpression\" : { \"pattern\" : \"pattern\", \"options\" : \"imxs\" }}";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.REGULAR_EXPRESSION, bsonReader.readBsonType());
-        BsonRegularExpression regex = bsonReader.readRegularExpression();
-        assertEquals("pattern", regex.getPattern());
-        assertEquals("imsx", regex.getOptions());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.REGULAR_EXPRESSION, bsonReader.readBsonType());
+                BsonRegularExpression regex = bsonReader.readRegularExpression();
+                assertEquals("pattern", regex.getPattern());
+                assertEquals("imsx", regex.getOptions());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testRegularExpressionQuery() {
         String json = "{ \"$regex\" : { \"$regularExpression\" : { \"pattern\" : \"pattern\", \"options\" : \"imxs\" }}}";
-        bsonReader = new JsonReader(json);
-        bsonReader.readStartDocument();
-        BsonRegularExpression regex = bsonReader.readRegularExpression("$regex");
-        assertEquals("pattern", regex.getPattern());
-        assertEquals("imsx", regex.getOptions());
-        bsonReader.readEndDocument();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                bsonReader.readStartDocument();
+                BsonRegularExpression regex = bsonReader.readRegularExpression("$regex");
+                assertEquals("pattern", regex.getPattern());
+                assertEquals("imsx", regex.getOptions());
+                bsonReader.readEndDocument();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testRegularExpressionQueryShell() {
         String json = "{ \"$regex\" : /pattern/imxs}";
-        bsonReader = new JsonReader(json);
-        bsonReader.readStartDocument();
-        BsonRegularExpression regex = bsonReader.readRegularExpression("$regex");
-        assertEquals("pattern", regex.getPattern());
-        assertEquals("imsx", regex.getOptions());
-        bsonReader.readEndDocument();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                bsonReader.readStartDocument();
+                BsonRegularExpression regex = bsonReader.readRegularExpression("$regex");
+                assertEquals("pattern", regex.getPattern());
+                assertEquals("imsx", regex.getOptions());
+                bsonReader.readEndDocument();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testString() {
-        String str = "abc";
-        String json = '"' + str + '"';
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.STRING, bsonReader.readBsonType());
-        assertEquals(str, bsonReader.readString());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        final String str = "abc";
+        final String json = '"' + str + '"';
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.STRING, bsonReader.readBsonType());
+                assertEquals(str, bsonReader.readString());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
 
-        str = "\ud806\udc5c";
-        json = '"' + str + '"';
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.STRING, bsonReader.readBsonType());
-        assertEquals(str, bsonReader.readString());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        final String str2 = "\ud806\udc5c";
+        final String json2 = '"' + str2 + '"';
+        testStringAndStream(json2, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.STRING, bsonReader.readBsonType());
+                assertEquals(str2, bsonReader.readString());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
 
-        str = "\\ud806\\udc5c";
-        json = '"' + str + '"';
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.STRING, bsonReader.readBsonType());
-        assertEquals("\ud806\udc5c", bsonReader.readString());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        final String str3 = "\\ud806\\udc5c";
+        final String json3 = '"' + str3 + '"';
+        testStringAndStream(json3, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.STRING, bsonReader.readBsonType());
+                assertEquals("\ud806\udc5c", bsonReader.readString());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
 
-        str = "꼢𑡜ᳫ鉠鮻罖᧭䆔瘉";
-        json = '"' + str + '"';
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.STRING, bsonReader.readBsonType());
-        assertEquals(str, bsonReader.readString());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        final String str4 = "꼢𑡜ᳫ鉠鮻罖᧭䆔瘉";
+        final String json4 = '"' + str4 + '"';
+        testStringAndStream(json4, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.STRING, bsonReader.readBsonType());
+                assertEquals(str4, bsonReader.readString());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testStringEmpty() {
         String json = "\"\"";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.STRING, bsonReader.readBsonType());
-        assertEquals("", bsonReader.readString());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.STRING, bsonReader.readBsonType());
+                assertEquals("", bsonReader.readString());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testSymbol() {
         String json = "{ \"$symbol\" : \"symbol\" }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.SYMBOL, bsonReader.readBsonType());
-        assertEquals("symbol", bsonReader.readSymbol());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.SYMBOL, bsonReader.readBsonType());
+                assertEquals("symbol", bsonReader.readSymbol());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testTimestampStrict() {
         String json = "{ \"$timestamp\" : { \"t\" : 1234, \"i\" : 1 } }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.TIMESTAMP, bsonReader.readBsonType());
-        assertEquals(new BsonTimestamp(1234, 1), bsonReader.readTimestamp());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.TIMESTAMP, bsonReader.readBsonType());
+                assertEquals(new BsonTimestamp(1234, 1), bsonReader.readTimestamp());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testTimestampStrictWithOutOfOrderFields() {
         String json = "{ \"$timestamp\" : { \"i\" : 1, \"t\" : 1234 } }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.TIMESTAMP, bsonReader.readBsonType());
-        assertEquals(new BsonTimestamp(1234, 1), bsonReader.readTimestamp());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.TIMESTAMP, bsonReader.readBsonType());
+                assertEquals(new BsonTimestamp(1234, 1), bsonReader.readTimestamp());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testTimestampShell() {
         String json = "Timestamp(1234, 1)";
-        bsonReader = new JsonReader(json);
-
-        assertEquals(BsonType.TIMESTAMP, bsonReader.readBsonType());
-        assertEquals(new BsonTimestamp(1234, 1), bsonReader.readTimestamp());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.TIMESTAMP, bsonReader.readBsonType());
+                assertEquals(new BsonTimestamp(1234, 1), bsonReader.readTimestamp());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testUndefined() {
         String json = "undefined";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.UNDEFINED, bsonReader.readBsonType());
-        bsonReader.readUndefined();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.UNDEFINED, bsonReader.readBsonType());
+                bsonReader.readUndefined();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testUndefinedExtended() {
         String json = "{ \"$undefined\" : true }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.UNDEFINED, bsonReader.readBsonType());
-        bsonReader.readUndefined();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.UNDEFINED, bsonReader.readBsonType());
+                bsonReader.readUndefined();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test(expected = IllegalStateException.class)
     public void testClosedState() {
-        bsonReader = new JsonReader("");
+        final AbstractBsonReader bsonReader = new JsonReader("");
         bsonReader.close();
         bsonReader.readBinaryData();
     }
 
-    @Test(expected = JsonParseException.class)
+    @Test
     public void testEndOfFile0() {
         String json = "{";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readStartDocument();
-        bsonReader.readBsonType();
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readStartDocument();
+                bsonReader.readBsonType();
+                return null;
+            }
+        }, JsonParseException.class);
     }
 
-    @Test(expected = JsonParseException.class)
+    @Test
     public void testEndOfFile1() {
         String json = "{ test : ";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readStartDocument();
-        bsonReader.readBsonType();
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readStartDocument();
+                bsonReader.readBsonType();
+                return null;
+            }
+        }, JsonParseException.class);
     }
 
     @Test
     public void testLegacyBinary() {
         String json = "{ \"$binary\" : \"AQID\", \"$type\" : \"0\" }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
-        BsonBinary binary = bsonReader.readBinaryData();
-        assertEquals(BsonBinarySubType.BINARY.getValue(), binary.getType());
-        assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                BsonBinary binary = bsonReader.readBinaryData();
+                assertEquals(BsonBinarySubType.BINARY.getValue(), binary.getType());
+                assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testLegacyBinaryWithNumericType() {
         String json = "{ \"$binary\" : \"AQID\", \"$type\" : 0 }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
-        BsonBinary binary = bsonReader.readBinaryData();
-        assertEquals(BsonBinarySubType.BINARY.getValue(), binary.getType());
-        assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                BsonBinary binary = bsonReader.readBinaryData();
+                assertEquals(BsonBinarySubType.BINARY.getValue(), binary.getType());
+                assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testLegacyUserDefinedBinary() {
         String json = "{ \"$binary\" : \"AQID\", \"$type\" : \"80\" }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
-        BsonBinary binary = bsonReader.readBinaryData();
-        assertEquals(BsonBinarySubType.USER_DEFINED.getValue(), binary.getType());
-        assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                BsonBinary binary = bsonReader.readBinaryData();
+                assertEquals(BsonBinarySubType.USER_DEFINED.getValue(), binary.getType());
+                assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testLegacyUserDefinedBinaryWithKeyOrderReversed() {
         String json = "{ \"$type\" : \"80\", \"$binary\" : \"AQID\" }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
-        BsonBinary binary = bsonReader.readBinaryData();
-        assertEquals(BsonBinarySubType.USER_DEFINED.getValue(), binary.getType());
-        assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                BsonBinary binary = bsonReader.readBinaryData();
+                assertEquals(BsonBinarySubType.USER_DEFINED.getValue(), binary.getType());
+                assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testLegacyUserDefinedBinaryWithNumericType() {
         String json = "{ \"$binary\" : \"AQID\", \"$type\" : 128 }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
-        BsonBinary binary = bsonReader.readBinaryData();
-        assertEquals(BsonBinarySubType.USER_DEFINED.getValue(), binary.getType());
-        assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                BsonBinary binary = bsonReader.readBinaryData();
+                assertEquals(BsonBinarySubType.USER_DEFINED.getValue(), binary.getType());
+                assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testCanonicalExtendedJsonBinary() {
         String json = "{ \"$binary\" : { \"base64\" : \"AQID\", \"subType\" : \"80\" } }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
-        BsonBinary binary = bsonReader.readBinaryData();
-        assertEquals(BsonBinarySubType.USER_DEFINED.getValue(), binary.getType());
-        assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                BsonBinary binary = bsonReader.readBinaryData();
+                assertEquals(BsonBinarySubType.USER_DEFINED.getValue(), binary.getType());
+                assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testCanonicalExtendedJsonBinaryWithKeysReversed() {
         String json = "{ \"$binary\" : { \"subType\" : \"80\", \"base64\" : \"AQID\" } }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
-        BsonBinary binary = bsonReader.readBinaryData();
-        assertEquals(BsonBinarySubType.USER_DEFINED.getValue(), binary.getType());
-        assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                BsonBinary binary = bsonReader.readBinaryData();
+                assertEquals(BsonBinarySubType.USER_DEFINED.getValue(), binary.getType());
+                assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
-    @Test(expected = JsonParseException.class)
+    @Test
     public void testCanonicalExtendedJsonBinaryWithIncorrectFirstKey() {
         String json = "{ \"$binary\" : { \"badKey\" : \"80\", \"base64\" : \"AQID\" } }";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                return null;
+            }
+        }, JsonParseException.class);
     }
 
     @Test
     public void testInfinity() {
         String json = "{ \"value\" : Infinity }";
-        bsonReader = new JsonReader(json);
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.DOUBLE, bsonReader.readBsonType());
-        bsonReader.readName();
-        assertEquals(Double.POSITIVE_INFINITY, bsonReader.readDouble(), 0.0001);
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.DOUBLE, bsonReader.readBsonType());
+                bsonReader.readName();
+                assertEquals(Double.POSITIVE_INFINITY, bsonReader.readDouble(), 0.0001);
+                return null;
+            }
+        });
     }
 
     @Test
     public void testNaN() {
         String json = "{ \"value\" : NaN }";
-        bsonReader = new JsonReader(json);
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.DOUBLE, bsonReader.readBsonType());
-        bsonReader.readName();
-        assertEquals(Double.NaN, bsonReader.readDouble(), 0.0001);
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.DOUBLE, bsonReader.readBsonType());
+                bsonReader.readName();
+                assertEquals(Double.NaN, bsonReader.readDouble(), 0.0001);
+                return null;
+            }
+        });
     }
 
     @Test
     public void testBinData() {
         String json = "{ \"a\" : BinData(3, AQID) }";
-        bsonReader = new JsonReader(json);
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
-        BsonBinary binary = bsonReader.readBinaryData();
-        assertEquals(3, binary.getType());
-        assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
-        bsonReader.readEndDocument();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                BsonBinary binary = bsonReader.readBinaryData();
+                assertEquals(3, binary.getType());
+                assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
+                bsonReader.readEndDocument();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testBinDataUserDefined() {
         String json = "{ \"a\" : BinData(128, AQID) }";
-        bsonReader = new JsonReader(json);
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
-        BsonBinary binary = bsonReader.readBinaryData();
-        assertEquals(BsonBinarySubType.USER_DEFINED.getValue(), binary.getType());
-        assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
-        bsonReader.readEndDocument();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                BsonBinary binary = bsonReader.readBinaryData();
+                assertEquals(BsonBinarySubType.USER_DEFINED.getValue(), binary.getType());
+                assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
+                bsonReader.readEndDocument();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testBinDataWithNew() {
         String json = "{ \"a\" : new BinData(3, AQID) }";
-        bsonReader = new JsonReader(json);
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
-        BsonBinary binary = bsonReader.readBinaryData();
-        assertEquals(3, binary.getType());
-        assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
-        bsonReader.readEndDocument();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                BsonBinary binary = bsonReader.readBinaryData();
+                assertEquals(3, binary.getType());
+                assertArrayEquals(new byte[]{1, 2, 3}, binary.getData());
+                bsonReader.readEndDocument();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testBinDataQuoted() {
         String json = "{ \"a\" : BinData(3, \"AQIDBA==\") }";
-        bsonReader = new JsonReader(json);
-        bsonReader.readStartDocument();
-        assertEquals(BsonType.BINARY, bsonReader.readBsonType());
-        BsonBinary binary = bsonReader.readBinaryData();
-        assertEquals(3, binary.getType());
-        assertArrayEquals(new byte[]{1, 2, 3, 4}, binary.getData());
-        bsonReader.readEndDocument();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                bsonReader.readStartDocument();
+                assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+                BsonBinary binary = bsonReader.readBinaryData();
+                assertEquals(3, binary.getType());
+                assertArrayEquals(new byte[]{1, 2, 3, 4}, binary.getData());
+                bsonReader.readEndDocument();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDateWithNumbers() {
         String json = "new Date(1988, 06, 13 , 22 , 1)";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
-        assertEquals(584834460000L, bsonReader.readDateTime());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+                assertEquals(584834460000L, bsonReader.readDateTime());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDateTimeConstructorWithNew() {
         String json = "new Date(\"Sat Jul 13 2013 11:10:05 UTC\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
-        assertEquals(1373713805000L, bsonReader.readDateTime());
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+                assertEquals(1373713805000L, bsonReader.readDateTime());
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testEmptyDateTimeConstructorWithNew() {
-        long currentTime = new Date().getTime();
+        final long currentTime = new Date().getTime();
         String json = "new Date()";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
-        assertTrue(bsonReader.readDateTime() >= currentTime);
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+                assertTrue(bsonReader.readDateTime() >= currentTime);
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDateTimeWithOutNew() {
-        long currentTime = currentTimeWithoutMillis();
+        final long currentTime = currentTimeWithoutMillis();
         String json = "Date()";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.STRING, bsonReader.readBsonType());
-        assertTrue(dateStringToTime(bsonReader.readString()) >= currentTime);
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.STRING, bsonReader.readBsonType());
+                assertTrue(dateStringToTime(bsonReader.readString()) >= currentTime);
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDateTimeWithOutNewContainingJunk() {
-        long currentTime = currentTimeWithoutMillis();
+        final long currentTime = currentTimeWithoutMillis();
         String json = "Date({ok: 1}, 1234)";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.STRING, bsonReader.readBsonType());
-        assertTrue(dateStringToTime(bsonReader.readString()) >= currentTime);
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.STRING, bsonReader.readBsonType());
+                assertTrue(dateStringToTime(bsonReader.readString()) >= currentTime);
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testEmptyISODateTimeConstructorWithNew() {
-        long currentTime = new Date().getTime();
+        final long currentTime = new Date().getTime();
         String json = "new ISODate()";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
-        assertTrue(bsonReader.readDateTime() >= currentTime);
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+                assertTrue(bsonReader.readDateTime() >= currentTime);
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testEmptyISODateTimeConstructor() {
-        long currentTime = new Date().getTime();
+        final long currentTime = new Date().getTime();
         String json = "ISODate()";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
-        assertTrue(bsonReader.readDateTime() >= currentTime);
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+                assertTrue(bsonReader.readDateTime() >= currentTime);
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testRegExp() {
         String json = "RegExp(\"abc\",\"im\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.REGULAR_EXPRESSION, bsonReader.readBsonType());
-        BsonRegularExpression regularExpression = bsonReader.readRegularExpression();
-        assertEquals("abc", regularExpression.getPattern());
-        assertEquals("im", regularExpression.getOptions());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.REGULAR_EXPRESSION, bsonReader.readBsonType());
+                BsonRegularExpression regularExpression = bsonReader.readRegularExpression();
+                assertEquals("abc", regularExpression.getPattern());
+                assertEquals("im", regularExpression.getOptions());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testRegExpWithNew() {
         String json = "new RegExp(\"abc\",\"im\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.REGULAR_EXPRESSION, bsonReader.readBsonType());
-        BsonRegularExpression regularExpression = bsonReader.readRegularExpression();
-        assertEquals("abc", regularExpression.getPattern());
-        assertEquals("im", regularExpression.getOptions());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.REGULAR_EXPRESSION, bsonReader.readBsonType());
+                BsonRegularExpression regularExpression = bsonReader.readRegularExpression();
+                assertEquals("abc", regularExpression.getPattern());
+                assertEquals("im", regularExpression.getOptions());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testSkip() {
         String json = "{ \"a\" : 2 }";
-        bsonReader = new JsonReader(json);
-        bsonReader.readStartDocument();
-        bsonReader.readBsonType();
-        bsonReader.skipName();
-        bsonReader.skipValue();
-        assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
-        bsonReader.readEndDocument();
-        assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                bsonReader.readStartDocument();
+                bsonReader.readBsonType();
+                bsonReader.skipName();
+                bsonReader.skipValue();
+                assertEquals(BsonType.END_OF_DOCUMENT, bsonReader.readBsonType());
+                bsonReader.readEndDocument();
+                assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDBPointer() {
         String json = "DBPointer(\"b\",\"5209296cd6c4e38cf96fffdc\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DB_POINTER, bsonReader.readBsonType());
-        BsonDbPointer dbPointer = bsonReader.readDBPointer();
-        assertEquals("b", dbPointer.getNamespace());
-        assertEquals(new ObjectId("5209296cd6c4e38cf96fffdc"), dbPointer.getId());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DB_POINTER, bsonReader.readBsonType());
+                BsonDbPointer dbPointer = bsonReader.readDBPointer();
+                assertEquals("b", dbPointer.getNamespace());
+                assertEquals(new ObjectId("5209296cd6c4e38cf96fffdc"), dbPointer.getId());
+                return null;
+            }
+        });
     }
 
     @Test
     public void testDBPointerWithNew() {
         String json = "new DBPointer(\"b\",\"5209296cd6c4e38cf96fffdc\")";
-        bsonReader = new JsonReader(json);
-        assertEquals(BsonType.DB_POINTER, bsonReader.readBsonType());
-        BsonDbPointer dbPointer = bsonReader.readDBPointer();
-        assertEquals("b", dbPointer.getNamespace());
-        assertEquals(new ObjectId("5209296cd6c4e38cf96fffdc"), dbPointer.getId());
+        testStringAndStream(json, new Function<AbstractBsonReader, Void>() {
+            @Override
+            public Void apply(final AbstractBsonReader bsonReader) {
+                assertEquals(BsonType.DB_POINTER, bsonReader.readBsonType());
+                BsonDbPointer dbPointer = bsonReader.readDBPointer();
+                assertEquals("b", dbPointer.getNamespace());
+                assertEquals(new ObjectId("5209296cd6c4e38cf96fffdc"), dbPointer.getId());
+                return null;
+            }
+        });
     }
 
     private long dateStringToTime(final String date) {

--- a/bson/src/test/unit/org/bson/json/JsonScannerTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonScannerTest.java
@@ -26,7 +26,7 @@ public class JsonScannerTest {
     @Test
     public void testEndOfFile() {
         String json = "\t ";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.END_OF_FILE, token.getType());
@@ -36,7 +36,7 @@ public class JsonScannerTest {
     @Test
     public void testBeginObject() {
         String json = "\t {x";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.BEGIN_OBJECT, token.getType());
@@ -47,7 +47,7 @@ public class JsonScannerTest {
     @Test
     public void testEndObject() {
         String json = "\t }x";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.END_OBJECT, token.getType());
@@ -58,7 +58,7 @@ public class JsonScannerTest {
     @Test
     public void testBeginArray() {
         String json = "\t [x";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.BEGIN_ARRAY, token.getType());
@@ -69,7 +69,7 @@ public class JsonScannerTest {
     @Test
     public void testEndArray() {
         String json = "\t ]x";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.END_ARRAY, token.getType());
@@ -80,7 +80,7 @@ public class JsonScannerTest {
     @Test
     public void testParentheses() {
         String json = "\t (jj)x";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.LEFT_PAREN, token.getType());
@@ -95,7 +95,7 @@ public class JsonScannerTest {
     @Test
     public void testNameSeparator() {
         String json = "\t :x";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.COLON, token.getType());
@@ -106,7 +106,7 @@ public class JsonScannerTest {
     @Test
     public void testValueSeparator() {
         String json = "\t ,x";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.COMMA, token.getType());
@@ -117,7 +117,7 @@ public class JsonScannerTest {
     @Test
     public void testEmptyString() {
         String json = "\t \"\"x";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.STRING, token.getType());
@@ -128,7 +128,7 @@ public class JsonScannerTest {
     @Test
     public void test1CharacterString() {
         String json = "\t \"1\"x";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.STRING, token.getType());
@@ -139,7 +139,7 @@ public class JsonScannerTest {
     @Test
     public void test2CharacterString() {
         String json = "\t \"12\"x";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.STRING, token.getType());
@@ -150,7 +150,7 @@ public class JsonScannerTest {
     @Test
     public void test3CharacterString() {
         String json = "\t \"123\"x";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.STRING, token.getType());
@@ -161,7 +161,7 @@ public class JsonScannerTest {
     @Test
     public void testEscapeSequences() {
         String json = "\t \"x\\\"\\\\\\/\\b\\f\\n\\r\\t\\u0030y\"x";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.STRING, token.getType());
@@ -173,7 +173,7 @@ public class JsonScannerTest {
     @Test
     public void testTrue() {
         String json = "\t true,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.UNQUOTED_STRING, token.getType());
@@ -184,7 +184,7 @@ public class JsonScannerTest {
     @Test
     public void testMinusInfinity() {
         String json = "\t -Infinity]";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.DOUBLE, token.getType());
@@ -195,7 +195,7 @@ public class JsonScannerTest {
     @Test
     public void testFalse() {
         String json = "\t false,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.UNQUOTED_STRING, token.getType());
@@ -206,7 +206,7 @@ public class JsonScannerTest {
     @Test
     public void testNull() {
         String json = "\t null,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.UNQUOTED_STRING, token.getType());
@@ -217,7 +217,7 @@ public class JsonScannerTest {
     @Test
     public void testUndefined() {
         String json = "\t undefined,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.UNQUOTED_STRING, token.getType());
@@ -228,7 +228,7 @@ public class JsonScannerTest {
     @Test
     public void testUnquotedStringWithSeparator() {
         String json = "\t name123:1";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.UNQUOTED_STRING, token.getType());
@@ -239,7 +239,7 @@ public class JsonScannerTest {
     @Test
     public void testUnquotedString() {
         String json = "name123";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.UNQUOTED_STRING, token.getType());
@@ -250,7 +250,7 @@ public class JsonScannerTest {
     @Test
     public void testZero() {
         String json = "\t 0,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.INT32, token.getType());
@@ -261,7 +261,7 @@ public class JsonScannerTest {
     @Test
     public void testMinusZero() {
         String json = "\t -0,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.INT32, token.getType());
@@ -272,7 +272,7 @@ public class JsonScannerTest {
     @Test
     public void testOne() {
         String json = "\t 1,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.INT32, token.getType());
@@ -283,7 +283,7 @@ public class JsonScannerTest {
     @Test
     public void testMinusOne() {
         String json = "\t -1,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.INT32, token.getType());
@@ -294,7 +294,7 @@ public class JsonScannerTest {
     @Test
     public void testTwelve() {
         String json = "\t 12,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.INT32, token.getType());
@@ -305,7 +305,7 @@ public class JsonScannerTest {
     @Test
     public void testMinusTwelve() {
         String json = "\t -12,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.INT32, token.getType());
@@ -316,7 +316,7 @@ public class JsonScannerTest {
     @Test
     public void testZeroPointZero() {
         String json = "\t 0.0,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.DOUBLE, token.getType());
@@ -327,7 +327,7 @@ public class JsonScannerTest {
     @Test
     public void testMinusZeroPointZero() {
         String json = "\t -0.0,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.DOUBLE, token.getType());
@@ -338,7 +338,7 @@ public class JsonScannerTest {
     @Test
     public void testZeroExponentOne() {
         String json = "\t 0e1,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.DOUBLE, token.getType());
@@ -349,7 +349,7 @@ public class JsonScannerTest {
     @Test
     public void testMinusZeroExponentOne() {
         String json = "\t -0e1,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.DOUBLE, token.getType());
@@ -360,7 +360,7 @@ public class JsonScannerTest {
     @Test
     public void testZeroExponentMinusOne() {
         String json = "\t 0e-1,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.DOUBLE, token.getType());
@@ -371,7 +371,7 @@ public class JsonScannerTest {
     @Test
     public void testMinusZeroExponentMinusOne() {
         String json = "\t -0e-1,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.DOUBLE, token.getType());
@@ -382,7 +382,7 @@ public class JsonScannerTest {
     @Test
     public void testOnePointTwo() {
         String json = "\t 1.2,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.DOUBLE, token.getType());
@@ -393,7 +393,7 @@ public class JsonScannerTest {
     @Test
     public void testMinusOnePointTwo() {
         String json = "\t -1.2,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.DOUBLE, token.getType());
@@ -404,7 +404,7 @@ public class JsonScannerTest {
     @Test
     public void testOneExponentTwelve() {
         String json = "\t 1e12,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.DOUBLE, token.getType());
@@ -415,7 +415,7 @@ public class JsonScannerTest {
     @Test
     public void testMinusZeroExponentTwelve() {
         String json = "\t -1e12,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.DOUBLE, token.getType());
@@ -426,7 +426,7 @@ public class JsonScannerTest {
     @Test
     public void testOneExponentMinuesTwelve() {
         String json = "\t 1e-12,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.DOUBLE, token.getType());
@@ -437,7 +437,7 @@ public class JsonScannerTest {
     @Test
     public void testMinusZeroExponentMinusTwelve() {
         String json = "\t -1e-12,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.DOUBLE, token.getType());
@@ -448,7 +448,7 @@ public class JsonScannerTest {
     @Test
     public void testRegularExpressionEmpty() {
         String json = "\t //,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.REGULAR_EXPRESSION, token.getType());
@@ -464,7 +464,7 @@ public class JsonScannerTest {
     public void testRegularExpressionPattern() {
         String json = "\t /pattern/,";
 
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.REGULAR_EXPRESSION, token.getType());
@@ -475,7 +475,7 @@ public class JsonScannerTest {
     @Test
     public void testRegularExpressionPatternAndOptions() {
         String json = "\t /pattern/im,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.REGULAR_EXPRESSION, token.getType());
@@ -489,7 +489,7 @@ public class JsonScannerTest {
     @Test
     public void testRegularExpressionPatternAndEscapeSequence() {
         String json = "\t /patte\\.n/,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         JsonToken token = scanner.nextToken();
         assertEquals(JsonTokenType.REGULAR_EXPRESSION, token.getType());
@@ -500,7 +500,7 @@ public class JsonScannerTest {
     @Test(expected = JsonParseException.class)
     public void testInvalidRegularExpression() {
         String json = "\t /pattern/nsk,";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         scanner.nextToken();
     }
@@ -508,7 +508,7 @@ public class JsonScannerTest {
     @Test(expected = JsonParseException.class)
     public void testInvalidRegularExpressionNoEnd() {
         String json = "/b";
-        JsonBuffer buffer = new JsonBuffer(json);
+        JsonBuffer buffer = JsonBufferFactory.createBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
         scanner.nextToken();
     }

--- a/bson/src/test/unit/org/bson/json/JsonStreamBufferTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonStreamBufferTest.java
@@ -18,13 +18,15 @@ package org.bson.json;
 
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+
 import static org.junit.Assert.assertEquals;
 
-public class JsonBufferTest {
+public class JsonStreamBufferTest {
 
     @Test
     public void testRead() {
-        JsonBuffer buffer = new JsonBuffer("ABC");
+        JsonStreamBuffer buffer = new JsonStreamBuffer(new ByteArrayInputStream("ABC".getBytes()));
         assertEquals('A', buffer.read());
         assertEquals('B', buffer.read());
         assertEquals('C', buffer.read());
@@ -33,7 +35,7 @@ public class JsonBufferTest {
 
     @Test
     public void testUnRead() {
-        JsonBuffer buffer = new JsonBuffer("A");
+        JsonStreamBuffer buffer = new JsonStreamBuffer(new ByteArrayInputStream("A".getBytes()));
         buffer.unread(buffer.read());
         assertEquals('A', buffer.read());
         assertEquals(-1, buffer.read());
@@ -41,15 +43,16 @@ public class JsonBufferTest {
 
     @Test
     public void testPosition() {
-        JsonBuffer buffer = new JsonBuffer("ABC");
+        JsonStreamBuffer buffer = new JsonStreamBuffer(new ByteArrayInputStream("ABC".getBytes()));
 
-        buffer.setPosition(2);
+        buffer.read();
+        buffer.read();
         assertEquals(2, buffer.getPosition());
     }
 
     @Test(expected = JsonParseException.class)
     public void testEOFCheck() {
-        JsonBuffer buffer = new JsonBuffer("");
+        JsonStreamBuffer buffer = new JsonStreamBuffer(new ByteArrayInputStream("".getBytes()));
 
         buffer.read();
         buffer.read();

--- a/bson/src/test/unit/org/bson/json/JsonStringBufferTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonStringBufferTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.json;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class JsonStringBufferTest {
+
+    @Test
+    public void testRead() {
+        JsonBuffer buffer = new JsonStringBuffer("ABC");
+        assertEquals('A', buffer.read());
+        assertEquals('B', buffer.read());
+        assertEquals('C', buffer.read());
+        assertEquals(-1, buffer.read());
+    }
+
+    @Test
+    public void testUnRead() {
+        JsonStringBuffer buffer = new JsonStringBuffer("A");
+        buffer.unread(buffer.read());
+        assertEquals('A', buffer.read());
+        assertEquals(-1, buffer.read());
+    }
+
+    @Test
+    public void testPosition() {
+        JsonStringBuffer buffer = new JsonStringBuffer("ABC");
+
+        buffer.read();
+        buffer.read();
+        assertEquals(2, buffer.getPosition());
+    }
+
+    @Test(expected = JsonParseException.class)
+    public void testEOFCheck() {
+        JsonStringBuffer buffer = new JsonStringBuffer("");
+
+        buffer.read();
+        buffer.read();
+    }
+}

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -73,6 +73,7 @@ allprojects {
             |     })();
             | }
             | </script>'''.stripMargin()
+                source '8'
             }
         }
     }


### PR DESCRIPTION
@jyemin This effectively allows one to parse extended JSON into BSON via an `InputStream`. I had to avoid a `BufferedReader`'s `mark` and `reset` methods because it allocates too much storage based on the read ahead limit once and 16 MiB would have been too large. The tests for `JsonReader` have been refactored to test both implementations of the buffer. `JsonScanner` also was slightly refactored to not use buffer's substring when it could just use builders. This in addition to a different way of tracking markers, allowed `getPosition` and `setPosition` to go away which were imposing constraints on the streamed version that were impossible to meet (i.e. random access).