### PR TITLE
Cloudp 42881

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ def javaCodeCheckedProjects = subprojects.findAll { !['util', 'mongo-java-driver
 configure(coreProjects) {
     evaluationDependsOn(':util')
     group = 'org.mongodb'
-    version = '3.11.0-SNAPSHOT'
+    version = '3.11.0-mongot'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ def javaCodeCheckedProjects = subprojects.findAll { !['util', 'mongo-java-driver
 configure(coreProjects) {
     evaluationDependsOn(':util')
     group = 'org.mongodb'
-    version = '3.11.0-mongot'
+    version = '3.11.0-mongot-SNAPSHOT'
 
     repositories {
         google()

--- a/driver-core/src/main/com/mongodb/operation/ChangeStreamOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ChangeStreamOperation.java
@@ -327,7 +327,6 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
      *
      * @param showMigrationEvents true if chunk migrations events should be shown.
      * @return this
-     * @since 3.10.3-mongot
      */
     public ChangeStreamOperation<T> showMigrationEvents(final boolean showMigrationEvents) {
         this.showMigrationEvents = showMigrationEvents;
@@ -340,7 +339,6 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
      * <p>Returns true if this operation will create a change stream that will show chunk migrations.</p>
      *
      * @return if this change stream will show chunk migrations.
-     * @since 3.10.3-mongot
      */
     public boolean getShowMigrationEvents() {
         return showMigrationEvents;

--- a/driver-core/src/main/com/mongodb/operation/ChangeStreamOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ChangeStreamOperation.java
@@ -319,13 +319,15 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
     }
 
     /**
-     * <b>This functionality is for internal use only. It is not supported.</b>
+     * <p>This option is NOT part of the public API.  It may change at any time without notification.</p>
      *
      * <p>Configures this change stream to show chunk migration CRUD events.</p>
+     * <p>This option is only allowed to be true when passed to a change stream opened directly with a shard.</p>
+     * <p>Using this option with a change stream opened against a mongos is an error.</p>
      *
      * @param showMigrationEvents true if chunk migrations events should be shown.
      * @return this
-     * @since 3.10.3-SNAPSHOT
+     * @since 3.10.3-mongot
      */
     public ChangeStreamOperation<T> showMigrationEvents(final boolean showMigrationEvents) {
         this.showMigrationEvents = showMigrationEvents;
@@ -333,12 +335,12 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
     }
 
     /**
-     * <b>This functionality is for internal use only. It is not supported.</b>
+     * <p>This option is NOT part of the public API.  It may change at any time without notification.</p>
      *
      * <p>Returns true if this operation will create a change stream that will show chunk migrations.</p>
      *
      * @return if this change stream will show chunk migrations.
-     * @since 3.10.3-SNAPSHOT
+     * @since 3.10.3-mongot
      */
     public boolean getShowMigrationEvents() {
         return showMigrationEvents;

--- a/driver-core/src/main/com/mongodb/operation/ChangeStreamOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ChangeStreamOperation.java
@@ -60,6 +60,7 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
     private final Decoder<T> decoder;
     private final ChangeStreamLevel changeStreamLevel;
 
+    private boolean showMigrationEvents;
     private BsonDocument resumeToken;
     private BsonDocument startAfter;
     private BsonTimestamp startAtOperationTime;
@@ -317,6 +318,32 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
         return wrapped.getRetryReads();
     }
 
+    /**
+     * <b>This functionality is for internal use only. It is not supported.</b>
+     *
+     * <p>Configures this change stream to show chunk migration CRUD events.</p>
+     *
+     * @param showMigrationEvents true if chunk migrations events should be shown.
+     * @return this
+     * @since 3.10.3-SNAPSHOT
+     */
+    public ChangeStreamOperation<T> showMigrationEvents(final boolean showMigrationEvents) {
+        this.showMigrationEvents = showMigrationEvents;
+        return this;
+    }
+
+    /**
+     * <b>This functionality is for internal use only. It is not supported.</b>
+     *
+     * <p>Returns true if this operation will create a change stream that will show chunk migrations.</p>
+     *
+     * @return if this change stream will show chunk migrations.
+     * @since 3.10.3-SNAPSHOT
+     */
+    public boolean getShowMigrationEvents() {
+        return showMigrationEvents;
+    }
+
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
         return new ChangeStreamBatchCursor<T>(ChangeStreamOperation.this, wrapped.execute(binding), binding);
@@ -373,6 +400,10 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
 
                 if (!hasResumeSetting && startAtOperationTimeForResume != null && serverIsAtLeastVersionFourDotZero(description)) {
                     changeStream.append("startAtOperationTime", startAtOperationTimeForResume);
+                }
+
+                if (showMigrationEvents) {
+                    changeStream.append("showMigrationEvents", BsonBoolean.TRUE);
                 }
 
                 changeStreamPipeline.add(new BsonDocument("$changeStream", changeStream));

--- a/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
@@ -625,6 +625,23 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         waitForLastRelease(getCluster())
     }
 
+    def 'should support showMigrationEvents on the sync API'() {
+        given:
+        def helper = getHelper()
+
+        when:
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, [], CODEC)
+
+        then:
+        operation.getShowMigrationEvents().equals(false)
+
+        when:
+        operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, [], CODEC).showMigrationEvents(true)
+
+        then:
+        operation.getShowMigrationEvents().equals(true)
+    }
+
     def 'should set the startAtOperationTime on the sync cursor'() {
         given:
         def changeStream

--- a/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
@@ -625,21 +625,22 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         waitForLastRelease(getCluster())
     }
 
-    def 'should support showMigrationEvents on the sync API'() {
+    def 'should set and unset showMigrationEvents'() {
         given:
         def helper = getHelper()
 
         when:
         def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, [], CODEC)
-
-        then:
-        operation.getShowMigrationEvents().equals(false)
-
-        when:
-        operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, [], CODEC).showMigrationEvents(true)
+                .showMigrationEvents(true)
 
         then:
         operation.getShowMigrationEvents().equals(true)
+
+        when:
+        operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, [], CODEC)
+
+        then:
+        operation.getShowMigrationEvents().equals(false)
     }
 
     def 'should set the startAtOperationTime on the sync cursor'() {

--- a/driver-sync/src/main/com/mongodb/client/ChangeStreamIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/ChangeStreamIterable.java
@@ -120,4 +120,16 @@ public interface ChangeStreamIterable<TResult> extends MongoIterable<ChangeStrea
      * @mongodb.driver.manual changeStreams/#change-stream-start-after
      */
     ChangeStreamIterable<TResult> startAfter(BsonDocument startAfter);
+
+    /**
+     * <b>This functionality is for internal use only. It is not supported.</b>
+     *
+     * <p>Configures this change stream to show chunk migration CRUD events.</p>
+     *
+     * @param showMigrationEvents the showMigrationEvents boolean
+     * @return this
+     * @since never
+     * @mongodb.server.release 4.2
+     */
+    ChangeStreamIterable<TResult> showMigrationEvents(boolean showMigrationEvents);
 }

--- a/driver-sync/src/main/com/mongodb/client/ChangeStreamIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/ChangeStreamIterable.java
@@ -122,9 +122,11 @@ public interface ChangeStreamIterable<TResult> extends MongoIterable<ChangeStrea
     ChangeStreamIterable<TResult> startAfter(BsonDocument startAfter);
 
     /**
-     * <b>This functionality is for internal use only. It is not supported.</b>
+     * <p>This option is NOT part of the public API.  It may change at any time without notification.</p>
      *
      * <p>Configures this change stream to show chunk migration CRUD events.</p>
+     * <p>This option is only allowed to be true when passed to a change stream opened directly with a shard.</p>
+     * <p>Using this option with a change stream opened against a mongos is an error.</p>
      *
      * @param showMigrationEvents the showMigrationEvents boolean
      * @return this

--- a/driver-sync/src/main/com/mongodb/client/ChangeStreamIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/ChangeStreamIterable.java
@@ -130,7 +130,6 @@ public interface ChangeStreamIterable<TResult> extends MongoIterable<ChangeStrea
      *
      * @param showMigrationEvents the showMigrationEvents boolean
      * @return this
-     * @since never
      * @mongodb.server.release 4.2
      */
     ChangeStreamIterable<TResult> showMigrationEvents(boolean showMigrationEvents);

--- a/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
@@ -101,7 +101,7 @@ class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeStreamDo
 
     @Override
     public ChangeStreamIterable<TResult> showMigrationEvents(final boolean showMigrationEvents) {
-        this.showMigrationEvents = notNull("showMigrationEvents", showMigrationEvents);
+        this.showMigrationEvents = showMigrationEvents;
         return this;
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
@@ -59,6 +59,7 @@ class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeStreamDo
     private long maxAwaitTimeMS;
     private Collation collation;
     private BsonTimestamp startAtOperationTime;
+    private boolean showMigrationEvents;
 
     ChangeStreamIterableImpl(@Nullable final ClientSession clientSession, final String databaseName,
                              final CodecRegistry codecRegistry, final ReadPreference readPreference, final ReadConcern readConcern,
@@ -95,6 +96,12 @@ class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeStreamDo
     @Override
     public ChangeStreamIterable<TResult> batchSize(final int batchSize) {
         super.batchSize(batchSize);
+        return this;
+    }
+
+    @Override
+    public ChangeStreamIterable<TResult> showMigrationEvents(final boolean showMigrationEvents) {
+        this.showMigrationEvents = notNull("showMigrationEvents", showMigrationEvents);
         return this;
     }
 
@@ -148,7 +155,8 @@ class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeStreamDo
                         .resumeAfter(resumeToken)
                         .startAtOperationTime(startAtOperationTime)
                         .startAfter(startAfter)
-                        .retryReads(getRetryReads());
+                        .retryReads(getRetryReads())
+                        .showMigrationEvents(showMigrationEvents);
     }
 
     private List<BsonDocument> createBsonDocumentList(final List<? extends Bson> pipeline) {

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ChangeStreamIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ChangeStreamIterableSpecification.groovy
@@ -54,6 +54,7 @@ class ChangeStreamIterableSpecification extends Specification {
     def readConcern = ReadConcern.MAJORITY
     def writeConcern = WriteConcern.MAJORITY
     def collation = Collation.builder().locale('en').build()
+    def showMigrationEvents = true
 
     def 'should build the expected ChangeStreamOperation'() {
         given:
@@ -79,7 +80,7 @@ class ChangeStreamIterableSpecification extends Specification {
         def startAtOperationTime = new BsonTimestamp(99)
         changeStreamIterable.collation(collation).maxAwaitTime(99, MILLISECONDS)
                 .fullDocument(FullDocument.UPDATE_LOOKUP).resumeAfter(resumeToken).startAtOperationTime(startAtOperationTime)
-                .startAfter(resumeToken).iterator()
+                .startAfter(resumeToken).showMigrationEvents(showMigrationEvents).iterator()
 
         operation = executor.getReadOperation() as ChangeStreamOperation<Document>
 
@@ -88,7 +89,7 @@ class ChangeStreamIterableSpecification extends Specification {
                 [BsonDocument.parse('{$match: 1}')], codec, ChangeStreamLevel.COLLECTION)
                 .retryReads(true)
                 .collation(collation).maxAwaitTime(99, MILLISECONDS)
-                .resumeAfter(resumeToken).startAtOperationTime(startAtOperationTime).startAfter(resumeToken))
+                .resumeAfter(resumeToken).startAtOperationTime(startAtOperationTime).startAfter(resumeToken).showMigrationEvents(showMigrationEvents))
     }
 
     def 'should use ClientSession'() {

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ChangeStreamIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ChangeStreamIterableSpecification.groovy
@@ -54,7 +54,6 @@ class ChangeStreamIterableSpecification extends Specification {
     def readConcern = ReadConcern.MAJORITY
     def writeConcern = WriteConcern.MAJORITY
     def collation = Collation.builder().locale('en').build()
-    def showMigrationEvents = true
 
     def 'should build the expected ChangeStreamOperation'() {
         given:
@@ -78,9 +77,14 @@ class ChangeStreamIterableSpecification extends Specification {
         when: 'overriding initial options'
         def resumeToken = RawBsonDocument.parse('{_id: {a: 1}}')
         def startAtOperationTime = new BsonTimestamp(99)
-        changeStreamIterable.collation(collation).maxAwaitTime(99, MILLISECONDS)
-                .fullDocument(FullDocument.UPDATE_LOOKUP).resumeAfter(resumeToken).startAtOperationTime(startAtOperationTime)
-                .startAfter(resumeToken).showMigrationEvents(showMigrationEvents).iterator()
+        changeStreamIterable.collation(collation)
+                .maxAwaitTime(99, MILLISECONDS)
+                .fullDocument(FullDocument.UPDATE_LOOKUP)
+                .resumeAfter(resumeToken)
+                .startAtOperationTime(startAtOperationTime)
+                .startAfter(resumeToken)
+                .showMigrationEvents(true)
+                .iterator()
 
         operation = executor.getReadOperation() as ChangeStreamOperation<Document>
 
@@ -88,8 +92,12 @@ class ChangeStreamIterableSpecification extends Specification {
         expect operation, isTheSameAs(new ChangeStreamOperation<Document>(namespace, FullDocument.UPDATE_LOOKUP,
                 [BsonDocument.parse('{$match: 1}')], codec, ChangeStreamLevel.COLLECTION)
                 .retryReads(true)
-                .collation(collation).maxAwaitTime(99, MILLISECONDS)
-                .resumeAfter(resumeToken).startAtOperationTime(startAtOperationTime).startAfter(resumeToken).showMigrationEvents(showMigrationEvents))
+                .collation(collation)
+                .maxAwaitTime(99, MILLISECONDS)
+                .resumeAfter(resumeToken)
+                .startAtOperationTime(startAtOperationTime)
+                .startAfter(resumeToken)
+                .showMigrationEvents(true))
     }
 
     def 'should use ClientSession'() {


### PR DESCRIPTION
This exposes the new internal `showMigrationEvents` option that may be passed to change streams. Setting this option to true will make change streams show insert, update, and delete events generated by chunk migrations. This option may only be used for a change stream opened against a mongod.