### PR TITLE
JAVA-3328: Excessive memory allocation due to unwrapping of updates in bulk ops

### DIFF
--- a/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/BenchmarkSuite.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/BenchmarkSuite.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -22,6 +22,7 @@ import com.mongodb.benchmark.framework.BenchmarkResult;
 import com.mongodb.benchmark.framework.BenchmarkResultWriter;
 import com.mongodb.benchmark.framework.BenchmarkRunner;
 import com.mongodb.benchmark.framework.EvergreenBenchmarkResultWriter;
+import com.mongodb.benchmark.framework.TextBasedBenchmarkResultWriter;
 import org.bson.Document;
 import org.bson.codecs.Codec;
 
@@ -40,14 +41,14 @@ public class BenchmarkSuite {
 
     private static final Class DOCUMENT_CLASS = Document.class;
     private static final IdRemover<Document> ID_REMOVER = new IdRemover<Document>() {
-        public void removeId(final Document document) {
-            document.remove("_id");
+        public Object removeId(final Document document) {
+            return document.remove("_id");
         }
     };
     private static final Codec<Document> DOCUMENT_CODEC = getDefaultCodecRegistry().get(DOCUMENT_CLASS);
 
     private static final List<BenchmarkResultWriter> WRITERS = Arrays.<BenchmarkResultWriter>asList(
-            new EvergreenBenchmarkResultWriter());
+            new EvergreenBenchmarkResultWriter(), new TextBasedBenchmarkResultWriter(System.err));
 
     public static void main(String[] args) throws Exception {
         runBenchmarks();
@@ -75,6 +76,9 @@ public class BenchmarkSuite {
                 DOCUMENT_CLASS, ID_REMOVER));
         runBenchmark(new InsertOneBenchmark<Document>("Large", "./single_and_multi_document/large_doc.json", 10,
                 DOCUMENT_CLASS, ID_REMOVER));
+
+        runBenchmark(new UpsertOneBenchmark<Document>("Large", "./single_and_multi_document/large_doc.json", 10,
+                                                      DOCUMENT_CLASS, ID_REMOVER));
 
         runBenchmark(new FindManyBenchmark<Document>("single_and_multi_document/tweet.json", BenchmarkSuite.DOCUMENT_CLASS));
         runBenchmark(new InsertManyBenchmark<Document>("Small", "./single_and_multi_document/small_doc.json", 10000,

--- a/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/IdRemover.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/IdRemover.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -18,5 +18,5 @@
 package com.mongodb.benchmark.benchmarks;
 
 public interface IdRemover<T> {
-    void removeId(T document);
+    Object removeId(T document);
 }

--- a/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/UpsertOneBenchmark.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/UpsertOneBenchmark.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.benchmark.benchmarks;
+
+import com.mongodb.client.model.UpdateOptions;
+import org.bson.BsonDocumentWrapper;
+import org.bson.Document;
+
+public class UpsertOneBenchmark<T> extends AbstractInsertBenchmark<T> {
+    private final int numIterations;
+    private final IdRemover<T> idRemover;
+
+    public UpsertOneBenchmark(final String name, final String resourcePath, final int numIterations, final Class<T> clazz,
+                              final IdRemover<T> idRemover) {
+        super(name + " doc upsertOne", resourcePath, clazz);
+        this.numIterations = numIterations;
+        this.idRemover = idRemover;
+    }
+
+    @Override
+    public void run() {
+        for (int i = 0; i < numIterations; i++) {
+            Object id = idRemover.removeId(document);
+            collection.updateOne(new Document("_id", id),
+                                 BsonDocumentWrapper.asBsonDocument(new Document("$set", document), collection.getCodecRegistry()),
+                                 new UpdateOptions().upsert(true));
+        }
+    }
+
+    @Override
+    public int getBytesPerRun() {
+        return fileLength * numIterations;
+    }
+
+}

--- a/driver-core/src/main/com/mongodb/operation/BulkWriteBatch.java
+++ b/driver-core/src/main/com/mongodb/operation/BulkWriteBatch.java
@@ -40,12 +40,17 @@ import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.internal.validator.UpdateFieldNameValidator;
 import com.mongodb.session.SessionContext;
 import org.bson.BsonArray;
+import org.bson.BsonBinary;
 import org.bson.BsonBoolean;
+import org.bson.BsonDbPointer;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWrapper;
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
+import org.bson.BsonReader;
+import org.bson.BsonRegularExpression;
 import org.bson.BsonString;
+import org.bson.BsonTimestamp;
 import org.bson.BsonValue;
 import org.bson.BsonWriter;
 import org.bson.FieldNameValidator;
@@ -55,6 +60,8 @@ import org.bson.codecs.Decoder;
 import org.bson.codecs.Encoder;
 import org.bson.codecs.EncoderContext;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -389,10 +396,9 @@ final class BulkWriteBatch {
                 getCodec(update.getFilter()).encode(writer, update.getFilter(), EncoderContext.builder().build());
                 writer.writeName("u");
 
-                if (update.getType() == WriteRequest.Type.UPDATE && update.getUpdate().isEmpty()) {
-                    throw new IllegalArgumentException("Invalid BSON document for an update");
-                }
-                getCodec(update.getUpdate()).encode(writer, update.getUpdate(), EncoderContext.builder().build());
+                BsonWriter updateWriter = maybeWrapWriterForUpdate(writer, update);
+                getCodec(update.getUpdate()).encode(updateWriter, update.getUpdate(), EncoderContext.builder().build());
+                verifyNoEmptyUpdate(updateWriter);
 
                 if (update.isMulti()) {
                     writer.writeBoolean("multi", update.isMulti());
@@ -428,6 +434,22 @@ final class BulkWriteBatch {
             }
         }
 
+        private BsonWriter maybeWrapWriterForUpdate(BsonWriter writer, UpdateRequest update) {
+            BsonWriter updateWriter = writer;
+
+            if (update.getType() == WriteRequest.Type.UPDATE) {
+                updateWriter = new NonEmptyObjectWriterSpy(writer);
+            }
+            return updateWriter;
+        }
+
+        private void verifyNoEmptyUpdate(BsonWriter updateWriter) {
+            if (updateWriter instanceof NonEmptyObjectWriterSpy &&
+                    !((NonEmptyObjectWriterSpy) updateWriter).hasANonEmptyObject()) {
+                throw new IllegalArgumentException("Invalid BSON document for an update");
+            }
+        }
+
         @Override
         public Class<WriteRequest> getEncoderClass() {
             return WriteRequest.class;
@@ -445,6 +467,256 @@ final class BulkWriteBatch {
 
         WriteRequest.Type getType() {
             return writeRequest.getType();
+        }
+    }
+
+    static class NonEmptyObjectWriterSpy implements BsonWriter {
+        @Override
+        public void flush() {
+            bsonWriter.flush();
+        }
+
+        @Override
+        public void writeBinaryData(BsonBinary binary) {
+            bsonWriter.writeBinaryData(binary);
+        }
+
+        @Override
+        public void writeBinaryData(String name, BsonBinary binary) {
+            bsonWriter.writeBinaryData(name, binary);
+        }
+
+        @Override
+        public void writeBoolean(boolean value) {
+            bsonWriter.writeBoolean(value);
+        }
+
+        @Override
+        public void writeBoolean(String name, boolean value) {
+            bsonWriter.writeBoolean(name, value);
+        }
+
+        @Override
+        public void writeDateTime(long value) {
+            bsonWriter.writeDateTime(value);
+        }
+
+        @Override
+        public void writeDateTime(String name, long value) {
+            bsonWriter.writeDateTime(name, value);
+        }
+
+        @Override
+        public void writeDBPointer(BsonDbPointer value) {
+            bsonWriter.writeDBPointer(value);
+        }
+
+        @Override
+        public void writeDBPointer(String name, BsonDbPointer value) {
+            bsonWriter.writeDBPointer(name, value);
+        }
+
+        @Override
+        public void writeDouble(double value) {
+            bsonWriter.writeDouble(value);
+        }
+
+        @Override
+        public void writeDouble(String name, double value) {
+            bsonWriter.writeDouble(name, value);
+        }
+
+        @Override
+        public void writeEndArray() {
+            bsonWriter.writeEndArray();
+        }
+
+        @Override
+        public void writeEndDocument() {
+            bsonWriter.writeEndDocument();
+        }
+
+        @Override
+        public void writeInt32(int value) {
+            bsonWriter.writeInt32(value);
+        }
+
+        @Override
+        public void writeInt32(String name, int value) {
+            bsonWriter.writeInt32(name, value);
+        }
+
+        @Override
+        public void writeInt64(long value) {
+            bsonWriter.writeInt64(value);
+        }
+
+        @Override
+        public void writeInt64(String name, long value) {
+            bsonWriter.writeInt64(name, value);
+        }
+
+        @Override
+        public void writeDecimal128(Decimal128 value) {
+            bsonWriter.writeDecimal128(value);
+        }
+
+        @Override
+        public void writeDecimal128(String name, Decimal128 value) {
+            bsonWriter.writeDecimal128(name, value);
+        }
+
+        @Override
+        public void writeJavaScript(String code) {
+            bsonWriter.writeJavaScript(code);
+        }
+
+        @Override
+        public void writeJavaScript(String name, String code) {
+            bsonWriter.writeJavaScript(name, code);
+        }
+
+        @Override
+        public void writeJavaScriptWithScope(String code) {
+            bsonWriter.writeJavaScriptWithScope(code);
+        }
+
+        @Override
+        public void writeJavaScriptWithScope(String name, String code) {
+            bsonWriter.writeJavaScriptWithScope(name, code);
+        }
+
+        @Override
+        public void writeMaxKey() {
+            bsonWriter.writeMaxKey();
+        }
+
+        @Override
+        public void writeMaxKey(String name) {
+            bsonWriter.writeMaxKey(name);
+        }
+
+        @Override
+        public void writeMinKey() {
+            bsonWriter.writeMinKey();
+        }
+
+        @Override
+        public void writeMinKey(String name) {
+            bsonWriter.writeMinKey(name);
+        }
+
+        @Override
+        public void writeName(String name) {
+            hasANonEmptyObject = true;
+            bsonWriter.writeName(name);
+        }
+
+        @Override
+        public void writeNull() {
+            bsonWriter.writeNull();
+        }
+
+        @Override
+        public void writeNull(String name) {
+            bsonWriter.writeNull(name);
+        }
+
+        @Override
+        public void writeObjectId(ObjectId objectId) {
+            bsonWriter.writeObjectId(objectId);
+        }
+
+        @Override
+        public void writeObjectId(String name, ObjectId objectId) {
+            bsonWriter.writeObjectId(name, objectId);
+        }
+
+        @Override
+        public void writeRegularExpression(BsonRegularExpression regularExpression) {
+            bsonWriter.writeRegularExpression(regularExpression);
+        }
+
+        @Override
+        public void writeRegularExpression(String name, BsonRegularExpression regularExpression) {
+            bsonWriter.writeRegularExpression(name, regularExpression);
+        }
+
+        @Override
+        public void writeStartArray() {
+            bsonWriter.writeStartArray();
+        }
+
+        @Override
+        public void writeStartArray(String name) {
+            bsonWriter.writeStartArray(name);
+        }
+
+        @Override
+        public void writeStartDocument() {
+            bsonWriter.writeStartDocument();
+        }
+
+        @Override
+        public void writeStartDocument(String name) {
+            bsonWriter.writeStartDocument(name);
+        }
+
+        @Override
+        public void writeString(String value) {
+            bsonWriter.writeString(value);
+        }
+
+        @Override
+        public void writeString(String name, String value) {
+            bsonWriter.writeString(name, value);
+        }
+
+        @Override
+        public void writeSymbol(String value) {
+            bsonWriter.writeSymbol(value);
+        }
+
+        @Override
+        public void writeSymbol(String name, String value) {
+            bsonWriter.writeSymbol(name, value);
+        }
+
+        @Override
+        public void writeTimestamp(BsonTimestamp value) {
+            bsonWriter.writeTimestamp(value);
+        }
+
+        @Override
+        public void writeTimestamp(String name, BsonTimestamp value) {
+            bsonWriter.writeTimestamp(name, value);
+        }
+
+        @Override
+        public void writeUndefined() {
+            bsonWriter.writeUndefined();
+        }
+
+        @Override
+        public void writeUndefined(String name) {
+            bsonWriter.writeUndefined(name);
+        }
+
+        @Override
+        public void pipe(BsonReader reader) {
+            bsonWriter.pipe(reader);
+        }
+
+        private final BsonWriter bsonWriter;
+
+        private boolean hasANonEmptyObject = false;
+
+        public NonEmptyObjectWriterSpy(BsonWriter bsonWriter) {
+            this.bsonWriter = bsonWriter;
+        }
+
+        public boolean hasANonEmptyObject() {
+            return hasANonEmptyObject;
         }
     }
 

--- a/driver-core/src/test/functional/com/mongodb/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/MixedBulkWriteOperationSpecification.groovy
@@ -286,7 +286,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         [async, ordered] << [[true, false], [true, false]].combinations()
     }
 
-    def 'when updating with an empty document, update should throw IllegalArgumentException'() {
+    def 'when updating with an empty document, update should fail'() {
         given:
         def id = new ObjectId()
         def operation = new MixedBulkWriteOperation(getNamespace(),
@@ -297,7 +297,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         execute(operation, async)
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(RuntimeException)
 
         where:
         [async, ordered] << [[true, false], [true, false]].combinations()

--- a/driver-core/src/test/unit/com/mongodb/operation/BulkWriteBatchSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/BulkWriteBatchSpecification.groovy
@@ -286,23 +286,6 @@ class BulkWriteBatchSpecification extends Specification {
         !bulkWriteBatch.shouldProcessBatch()
     }
 
-    def 'should reject empty update documents'() {
-        given:
-        def bulkWriteBatch = BulkWriteBatch.createBulkWriteBatch(namespace, serverDescription, connectionDescription, false,
-                                                                 WriteConcern.MAJORITY, true, false, [
-                                                                         new UpdateRequest(toBsonDocument('{ _id: 3}'),
-                                                                                           toBsonDocument('{}'), UPDATE)],
-                                                                 sessionContext)
-        def payload = bulkWriteBatch.getPayload()
-
-        when:
-        payload.setPosition(payload.getPayload().size())
-        payload.getPayload().iterator().next().getFirstKey()
-
-        then:
-        thrown IllegalArgumentException
-    }
-
     private static List<WriteRequest> getWriteRequests() {
         [new InsertRequest(toBsonDocument('{_id: 1, x: 1}')),
          new UpdateRequest(toBsonDocument('{ _id: 2}'), toBsonDocument('{$set: {x : 2}}'), UPDATE).upsert(true),

--- a/driver-core/src/test/unit/com/mongodb/operation/BulkWriteBatchSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/BulkWriteBatchSpecification.groovy
@@ -286,6 +286,23 @@ class BulkWriteBatchSpecification extends Specification {
         !bulkWriteBatch.shouldProcessBatch()
     }
 
+    def 'should reject empty update documents'() {
+        given:
+        def bulkWriteBatch = BulkWriteBatch.createBulkWriteBatch(namespace, serverDescription, connectionDescription, false,
+                                                                 WriteConcern.MAJORITY, true, false, [
+                                                                         new UpdateRequest(toBsonDocument('{ _id: 3}'),
+                                                                                           toBsonDocument('{}'), UPDATE)],
+                                                                 sessionContext)
+        def payload = bulkWriteBatch.getPayload()
+
+        when:
+        payload.setPosition(payload.getPayload().size())
+        payload.getPayload().iterator().next().getFirstKey()
+
+        then:
+        thrown IllegalArgumentException
+    }
+
     private static List<WriteRequest> getWriteRequests() {
         [new InsertRequest(toBsonDocument('{_id: 1, x: 1}')),
          new UpdateRequest(toBsonDocument('{ _id: 2}'), toBsonDocument('{$set: {x : 2}}'), UPDATE).upsert(true),


### PR DESCRIPTION
Change removes check and call to isEmpty() which causes an unnecessary unwrapping.

IT has been relaxed to allow for server-side failure for this case.