### PR TITLE
Fix FLE tests

### DIFF
--- a/driver-core/src/test/resources/client-side-encryption-corpus/corpus-schema.json
+++ b/driver-core/src/test/resources/client-side-encryption-corpus/corpus-schema.json
@@ -98,18 +98,6 @@
         }
       }
     },
-    "aws_string_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_aws",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "string"
-          }
-        }
-      }
-    },
     "aws_string_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -254,18 +242,6 @@
         }
       }
     },
-    "aws_binData=00_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_aws",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "binData"
-          }
-        }
-      }
-    },
     "aws_binData=00_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -332,18 +308,6 @@
         }
       }
     },
-    "aws_binData=04_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_aws",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "binData"
-          }
-        }
-      }
-    },
     "aws_binData=04_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -404,18 +368,6 @@
                 }
               }
             ],
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "objectId"
-          }
-        }
-      }
-    },
-    "aws_objectId_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_aws",
             "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
             "bsonType": "objectId"
           }
@@ -527,18 +479,6 @@
         }
       }
     },
-    "aws_date_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_aws",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "date"
-          }
-        }
-      }
-    },
     "aws_date_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -599,18 +539,6 @@
                 }
               }
             ],
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "regex"
-          }
-        }
-      }
-    },
-    "aws_regex_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_aws",
             "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
             "bsonType": "regex"
           }
@@ -683,18 +611,6 @@
         }
       }
     },
-    "aws_dbPointer_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_aws",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "dbPointer"
-          }
-        }
-      }
-    },
     "aws_dbPointer_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -761,18 +677,6 @@
         }
       }
     },
-    "aws_javascript_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_aws",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "javascript"
-          }
-        }
-      }
-    },
     "aws_javascript_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -833,18 +737,6 @@
                 }
               }
             ],
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "symbol"
-          }
-        }
-      }
-    },
-    "aws_symbol_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_aws",
             "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
             "bsonType": "symbol"
           }
@@ -956,18 +848,6 @@
         }
       }
     },
-    "aws_int_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_aws",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "int"
-          }
-        }
-      }
-    },
     "aws_int_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -1034,18 +914,6 @@
         }
       }
     },
-    "aws_timestamp_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_aws",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "timestamp"
-          }
-        }
-      }
-    },
     "aws_timestamp_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -1106,18 +974,6 @@
                 }
               }
             ],
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "long"
-          }
-        }
-      }
-    },
-    "aws_long_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_aws",
             "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
             "bsonType": "long"
           }
@@ -1268,18 +1124,6 @@
         }
       }
     },
-    "local_string_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_local",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "string"
-          }
-        }
-      }
-    },
     "local_string_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -1424,18 +1268,6 @@
         }
       }
     },
-    "local_binData=00_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_local",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "binData"
-          }
-        }
-      }
-    },
     "local_binData=00_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -1502,18 +1334,6 @@
         }
       }
     },
-    "local_binData=04_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_local",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "binData"
-          }
-        }
-      }
-    },
     "local_binData=04_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -1574,18 +1394,6 @@
                 }
               }
             ],
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "objectId"
-          }
-        }
-      }
-    },
-    "local_objectId_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_local",
             "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
             "bsonType": "objectId"
           }
@@ -1697,18 +1505,6 @@
         }
       }
     },
-    "local_date_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_local",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "date"
-          }
-        }
-      }
-    },
     "local_date_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -1769,18 +1565,6 @@
                 }
               }
             ],
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "regex"
-          }
-        }
-      }
-    },
-    "local_regex_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_local",
             "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
             "bsonType": "regex"
           }
@@ -1853,18 +1637,6 @@
         }
       }
     },
-    "local_dbPointer_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_local",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "dbPointer"
-          }
-        }
-      }
-    },
     "local_dbPointer_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -1931,18 +1703,6 @@
         }
       }
     },
-    "local_javascript_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_local",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "javascript"
-          }
-        }
-      }
-    },
     "local_javascript_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -2003,18 +1763,6 @@
                 }
               }
             ],
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "symbol"
-          }
-        }
-      }
-    },
-    "local_symbol_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_local",
             "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
             "bsonType": "symbol"
           }
@@ -2126,18 +1874,6 @@
         }
       }
     },
-    "local_int_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_local",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "int"
-          }
-        }
-      }
-    },
     "local_int_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -2204,18 +1940,6 @@
         }
       }
     },
-    "local_timestamp_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_local",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "timestamp"
-          }
-        }
-      }
-    },
     "local_timestamp_det_explicit_id": {
       "bsonType": "object",
       "properties": { "value": { "bsonType": "binData" } }
@@ -2276,18 +2000,6 @@
                 }
               }
             ],
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-            "bsonType": "long"
-          }
-        }
-      }
-    },
-    "local_long_det_auto_altname": {
-      "bsonType": "object",
-      "properties": {
-        "value": {
-          "encrypt": {
-            "keyId": "/altname_local",
             "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
             "bsonType": "long"
           }

--- a/driver-core/src/test/resources/client-side-encryption-corpus/corpus.json
+++ b/driver-core/src/test/resources/client-side-encryption-corpus/corpus.json
@@ -101,15 +101,6 @@
     "allowed": true,
     "value": "mongodb"
   },
-  "aws_string_det_auto_altname": {
-    "kms": "aws",
-    "type": "string",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": "mongodb"
-  },
   "aws_string_det_explicit_id": {
     "kms": "aws",
     "type": "string",
@@ -305,15 +296,6 @@
     "allowed": true,
     "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
   },
-  "aws_binData=00_det_auto_altname": {
-    "kms": "aws",
-    "type": "binData=00",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
-  },
   "aws_binData=00_det_explicit_id": {
     "kms": "aws",
     "type": "binData=00",
@@ -382,17 +364,6 @@
     "algo": "det",
     "method": "auto",
     "identifier": "id",
-    "allowed": true,
-    "value": {
-      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-    }
-  },
-  "aws_binData=04_det_auto_altname": {
-    "kms": "aws",
-    "type": "binData=04",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
     "allowed": true,
     "value": {
       "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
@@ -498,15 +469,6 @@
     "algo": "det",
     "method": "auto",
     "identifier": "id",
-    "allowed": true,
-    "value": { "$oid": "01234567890abcdef0123456" }
-  },
-  "aws_objectId_det_auto_altname": {
-    "kms": "aws",
-    "type": "objectId",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
     "allowed": true,
     "value": { "$oid": "01234567890abcdef0123456" }
   },
@@ -627,15 +589,6 @@
     "allowed": true,
     "value": { "$date": { "$numberLong": "12345" } }
   },
-  "aws_date_det_auto_altname": {
-    "kms": "aws",
-    "type": "date",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": { "$date": { "$numberLong": "12345" } }
-  },
   "aws_date_det_explicit_id": {
     "kms": "aws",
     "type": "date",
@@ -735,15 +688,6 @@
     "allowed": true,
     "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
   },
-  "aws_regex_det_auto_altname": {
-    "kms": "aws",
-    "type": "regex",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
-  },
   "aws_regex_det_explicit_id": {
     "kms": "aws",
     "type": "regex",
@@ -832,20 +776,6 @@
       }
     }
   },
-  "aws_dbPointer_det_auto_altname": {
-    "kms": "aws",
-    "type": "dbPointer",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": {
-      "$dbPointer": {
-        "$ref": "db.example",
-        "$id": { "$oid": "01234567890abcdef0123456" }
-      }
-    }
-  },
   "aws_dbPointer_det_explicit_id": {
     "kms": "aws",
     "type": "dbPointer",
@@ -919,15 +849,6 @@
     "allowed": true,
     "value": { "$code": "x=1" }
   },
-  "aws_javascript_det_auto_altname": {
-    "kms": "aws",
-    "type": "javascript",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": { "$code": "x=1" }
-  },
   "aws_javascript_det_explicit_id": {
     "kms": "aws",
     "type": "javascript",
@@ -988,15 +909,6 @@
     "algo": "det",
     "method": "auto",
     "identifier": "id",
-    "allowed": true,
-    "value": { "$symbol": "mongodb-symbol" }
-  },
-  "aws_symbol_det_auto_altname": {
-    "kms": "aws",
-    "type": "symbol",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
     "allowed": true,
     "value": { "$symbol": "mongodb-symbol" }
   },
@@ -1117,15 +1029,6 @@
     "allowed": true,
     "value": { "$numberInt": "123" }
   },
-  "aws_int_det_auto_altname": {
-    "kms": "aws",
-    "type": "int",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": { "$numberInt": "123" }
-  },
   "aws_int_det_explicit_id": {
     "kms": "aws",
     "type": "int",
@@ -1189,15 +1092,6 @@
     "allowed": true,
     "value": { "$timestamp": { "t": 0, "i": 12345 } }
   },
-  "aws_timestamp_det_auto_altname": {
-    "kms": "aws",
-    "type": "timestamp",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": { "$timestamp": { "t": 0, "i": 12345 } }
-  },
   "aws_timestamp_det_explicit_id": {
     "kms": "aws",
     "type": "timestamp",
@@ -1258,15 +1152,6 @@
     "algo": "det",
     "method": "auto",
     "identifier": "id",
-    "allowed": true,
-    "value": { "$numberLong": "456" }
-  },
-  "aws_long_det_auto_altname": {
-    "kms": "aws",
-    "type": "long",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
     "allowed": true,
     "value": { "$numberLong": "456" }
   },
@@ -1513,15 +1398,6 @@
     "allowed": true,
     "value": "mongodb"
   },
-  "local_string_det_auto_altname": {
-    "kms": "local",
-    "type": "string",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": "mongodb"
-  },
   "local_string_det_explicit_id": {
     "kms": "local",
     "type": "string",
@@ -1717,15 +1593,6 @@
     "allowed": true,
     "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
   },
-  "local_binData=00_det_auto_altname": {
-    "kms": "local",
-    "type": "binData=00",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
-  },
   "local_binData=00_det_explicit_id": {
     "kms": "local",
     "type": "binData=00",
@@ -1794,17 +1661,6 @@
     "algo": "det",
     "method": "auto",
     "identifier": "id",
-    "allowed": true,
-    "value": {
-      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-    }
-  },
-  "local_binData=04_det_auto_altname": {
-    "kms": "local",
-    "type": "binData=04",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
     "allowed": true,
     "value": {
       "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
@@ -1910,15 +1766,6 @@
     "algo": "det",
     "method": "auto",
     "identifier": "id",
-    "allowed": true,
-    "value": { "$oid": "01234567890abcdef0123456" }
-  },
-  "local_objectId_det_auto_altname": {
-    "kms": "local",
-    "type": "objectId",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
     "allowed": true,
     "value": { "$oid": "01234567890abcdef0123456" }
   },
@@ -2039,15 +1886,6 @@
     "allowed": true,
     "value": { "$date": { "$numberLong": "12345" } }
   },
-  "local_date_det_auto_altname": {
-    "kms": "local",
-    "type": "date",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": { "$date": { "$numberLong": "12345" } }
-  },
   "local_date_det_explicit_id": {
     "kms": "local",
     "type": "date",
@@ -2147,15 +1985,6 @@
     "allowed": true,
     "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
   },
-  "local_regex_det_auto_altname": {
-    "kms": "local",
-    "type": "regex",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
-  },
   "local_regex_det_explicit_id": {
     "kms": "local",
     "type": "regex",
@@ -2244,20 +2073,6 @@
       }
     }
   },
-  "local_dbPointer_det_auto_altname": {
-    "kms": "local",
-    "type": "dbPointer",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": {
-      "$dbPointer": {
-        "$ref": "db.example",
-        "$id": { "$oid": "01234567890abcdef0123456" }
-      }
-    }
-  },
   "local_dbPointer_det_explicit_id": {
     "kms": "local",
     "type": "dbPointer",
@@ -2331,15 +2146,6 @@
     "allowed": true,
     "value": { "$code": "x=1" }
   },
-  "local_javascript_det_auto_altname": {
-    "kms": "local",
-    "type": "javascript",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": { "$code": "x=1" }
-  },
   "local_javascript_det_explicit_id": {
     "kms": "local",
     "type": "javascript",
@@ -2400,15 +2206,6 @@
     "algo": "det",
     "method": "auto",
     "identifier": "id",
-    "allowed": true,
-    "value": { "$symbol": "mongodb-symbol" }
-  },
-  "local_symbol_det_auto_altname": {
-    "kms": "local",
-    "type": "symbol",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
     "allowed": true,
     "value": { "$symbol": "mongodb-symbol" }
   },
@@ -2529,15 +2326,6 @@
     "allowed": true,
     "value": { "$numberInt": "123" }
   },
-  "local_int_det_auto_altname": {
-    "kms": "local",
-    "type": "int",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": { "$numberInt": "123" }
-  },
   "local_int_det_explicit_id": {
     "kms": "local",
     "type": "int",
@@ -2601,15 +2389,6 @@
     "allowed": true,
     "value": { "$timestamp": { "t": 0, "i": 12345 } }
   },
-  "local_timestamp_det_auto_altname": {
-    "kms": "local",
-    "type": "timestamp",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
-    "allowed": true,
-    "value": { "$timestamp": { "t": 0, "i": 12345 } }
-  },
   "local_timestamp_det_explicit_id": {
     "kms": "local",
     "type": "timestamp",
@@ -2670,15 +2449,6 @@
     "algo": "det",
     "method": "auto",
     "identifier": "id",
-    "allowed": true,
-    "value": { "$numberLong": "456" }
-  },
-  "local_long_det_auto_altname": {
-    "kms": "local",
-    "type": "long",
-    "algo": "det",
-    "method": "auto",
-    "identifier": "altname",
     "allowed": true,
     "value": { "$numberLong": "456" }
   },

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionProseTestSpecification.groovy
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionProseTestSpecification.groovy
@@ -84,7 +84,7 @@ class ClientSideEncryptionProseTestSpecification extends FunctionalSpecification
           "encrypt": {
             "keyId": "/placeholder",
             "bsonType": "string",
-            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
           }
         }
       }


### PR DESCRIPTION
I think I got tripped up before because updating the JSON files in:

```
driver-core/src/test/resources/client-side-encryption
```

Didn't update the ones that the test runner seemed to use:

```
driver-core/out/test/resources/client-side-encryption/
```

I think this is the correct fix, but I'm can't fully run the prose test – creating a data key isn't adding the key alt name, and I think I'm not picking up the fix from [keyAltName fix](https://github.com/mongodb/libmongocrypt/commit/feceb84e0ef4305d3ab6b7d3e3552955491c6f67) though I'm publishing to maven local after that commit. I must be doing something wrong locally.

@jyemin would you be able to validate this fix works? If so, I'll make the corresponding change in the specifications repo.