### PR TITLE
Hide mechanism properties in MongoCredential#toString

### DIFF
--- a/driver-core/src/main/com/mongodb/MongoCredential.java
+++ b/driver-core/src/main/com/mongodb/MongoCredential.java
@@ -514,7 +514,7 @@ public final class MongoCredential {
                 + ", userName='" + userName + '\''
                 + ", source='" + source + '\''
                 + ", password=<hidden>"
-                + ", mechanismProperties=" + mechanismProperties
+                + ", mechanismProperties=<hidden>"
                 + '}';
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/MongoCredentialSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/MongoCredentialSpecification.groovy
@@ -296,6 +296,11 @@ class MongoCredentialSpecification extends Specification {
         credentialOne.hashCode() != credentialTwo.hashCode()
 
         !credentialOne.toString().contains(password)
+        credentialOne.toString().contains('password=<hidden>')
+
+        !credentialTwo.toString().contains(propertyKey.toLowerCase())
+        !credentialTwo.toString().contains(propertyValue)
+        credentialTwo.toString().contains('mechanismProperties=<hidden>')
     }
 
     def 'testEqualsAndHashCode'() {


### PR DESCRIPTION
In some cases a mechanism property value can contain sensitive
information, so the toString method should be conservative and not
include any of them.

JAVA-3381