### PR TITLE
TypeData getNestedTypeData function should check for WildcardType

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/TypeData.java
+++ b/bson/src/main/org/bson/codecs/pojo/TypeData.java
@@ -19,6 +19,7 @@ package org.bson.codecs.pojo;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.WildcardType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
@@ -78,6 +79,10 @@ final class TypeData<T> implements TypeWithTypeParameters<T> {
             for (Type argType : pType.getActualTypeArguments()) {
                 getNestedTypeData(paramBuilder, argType);
             }
+            builder.addTypeParameter(paramBuilder.build());
+        } else if (type instanceof WildcardType) {
+            WildcardType wType = (WildcardType) type;
+            TypeData.Builder paramBuilder = TypeData.builder((Class) wType.getUpperBounds()[0]);
             builder.addTypeParameter(paramBuilder.build());
         } else if (type instanceof TypeVariable) {
             builder.addTypeParameter(TypeData.builder(Object.class).build());


### PR DESCRIPTION
Hi,

I'm using the Mongo Java driver with Kotlin (through KMongo).
I've created a sealed class Account (it could also be an interface) and concrete classes InternalAccount and GoogleAccount which implement Account.

Then I've created a User model which has a list of accounts so List<Account> in Kotlin. The signature of this List in Kotlin is List<out T> so at runtime it gives the following signature in Java List<? extends Account>.
? extends Account is a WildcardType and getNestedTypeData don't recognize it so the list of accounts recovered from the database will be a list of Document. When I tried to get my user, I get an invalid cast exception with Document can't be cast to Account.
This pull request add the required conditional branch for WildcardType and solve the bug.

Best,
JB