### PR TITLE
JAVA-3253: Require retryable writes network error tests to run on mongos 4.2+

### DIFF
--- a/driver-core/src/test/resources/retryable-writes/bulkWrite-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/bulkWrite-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "BulkWrite succeeds after PrimarySteppedDown",
@@ -165,6 +178,81 @@
             {
               "_id": 2,
               "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite fails with a RetryableWriteError label after two connection failures",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "update"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
               "_id": 3,

--- a/driver-core/src/test/resources/retryable-writes/bulkWrite.json
+++ b/driver-core/src/test/resources/retryable-writes/bulkWrite.json
@@ -1,11 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
       "x": 11
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "First command is retried",

--- a/driver-core/src/test/resources/retryable-writes/deleteMany.json
+++ b/driver-core/src/test/resources/retryable-writes/deleteMany.json
@@ -1,4 +1,13 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,10 +18,10 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "DeleteMany ignores retryWrites",
+      "useMultipleMongoses": true,
       "operation": {
         "name": "deleteMany",
         "arguments": {

--- a/driver-core/src/test/resources/retryable-writes/deleteOne-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/deleteOne-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "DeleteOne succeeds after PrimarySteppedDown",
@@ -78,6 +91,49 @@
         },
         "collection": {
           "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "DeleteOne fails with RetryableWriteError label after two connection failures",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "delete"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operation": {
+        "name": "deleteOne",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
             {
               "_id": 2,
               "x": 22

--- a/driver-core/src/test/resources/retryable-writes/deleteOne.json
+++ b/driver-core/src/test/resources/retryable-writes/deleteOne.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "DeleteOne is committed on first attempt",

--- a/driver-core/src/test/resources/retryable-writes/findOneAndDelete-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/findOneAndDelete-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "FindOneAndDelete succeeds after PrimarySteppedDown",
@@ -90,6 +103,54 @@
         },
         "collection": {
           "data": [
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndDelete fails with a RetryableWriteError label after two connection failures",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operation": {
+        "name": "findOneAndDelete",
+        "arguments": {
+          "filter": {
+            "x": {
+              "$gte": 11
+            }
+          },
+          "sort": {
+            "x": 1
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
             {
               "_id": 2,
               "x": 22

--- a/driver-core/src/test/resources/retryable-writes/findOneAndDelete.json
+++ b/driver-core/src/test/resources/retryable-writes/findOneAndDelete.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "FindOneAndDelete is committed on first attempt",

--- a/driver-core/src/test/resources/retryable-writes/findOneAndReplace-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/findOneAndReplace-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "FindOneAndReplace succeeds after PrimarySteppedDown",
@@ -97,6 +110,54 @@
             {
               "_id": 1,
               "x": 111
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndReplace fails with a RetryableWriteError label after two connection failures",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operation": {
+        "name": "findOneAndReplace",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "replacement": {
+            "_id": 1,
+            "x": 111
+          },
+          "returnDocument": "Before"
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
             },
             {
               "_id": 2,

--- a/driver-core/src/test/resources/retryable-writes/findOneAndReplace.json
+++ b/driver-core/src/test/resources/retryable-writes/findOneAndReplace.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "FindOneAndReplace is committed on first attempt",

--- a/driver-core/src/test/resources/retryable-writes/findOneAndUpdate-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/findOneAndUpdate-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "FindOneAndUpdate succeeds after PrimarySteppedDown",
@@ -99,6 +112,55 @@
             {
               "_id": 1,
               "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndUpdate fails with a RetryableWriteError label after two connection failures",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operation": {
+        "name": "findOneAndUpdate",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "update": {
+            "$inc": {
+              "x": 1
+            }
+          },
+          "returnDocument": "Before"
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
             },
             {
               "_id": 2,

--- a/driver-core/src/test/resources/retryable-writes/findOneAndUpdate.json
+++ b/driver-core/src/test/resources/retryable-writes/findOneAndUpdate.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "FindOneAndUpdate is committed on first attempt",

--- a/driver-core/src/test/resources/retryable-writes/insertMany-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/insertMany-serverErrors.json
@@ -1,11 +1,24 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
       "x": 11
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "InsertMany succeeds after PrimarySteppedDown",
@@ -119,6 +132,55 @@
             {
               "_id": 3,
               "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "InsertMany fails with a RetryableWriteError label after two connection failures",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operation": {
+        "name": "insertMany",
+        "arguments": {
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
             }
           ]
         }

--- a/driver-core/src/test/resources/retryable-writes/insertMany.json
+++ b/driver-core/src/test/resources/retryable-writes/insertMany.json
@@ -1,11 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
       "x": 11
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "InsertMany succeeds after one network error",

--- a/driver-core/src/test/resources/retryable-writes/insertOne-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/insertOne-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "InsertOne succeeds after connection failure",
@@ -195,7 +208,7 @@
       }
     },
     {
-      "description": "InsertOne succeeds after InterruptedDueToStepDown",
+      "description": "InsertOne succeeds after InterruptedDueToReplStateChange",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -588,6 +601,11 @@
       },
       "outcome": {
         "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
         "collection": {
           "data": [
             {
@@ -651,7 +669,7 @@
       }
     },
     {
-      "description": "InsertOne succeeds after WriteConcernError InterruptedDueToStepDown",
+      "description": "InsertOne succeeds after WriteConcernError InterruptedDueToReplStateChange",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -822,6 +840,11 @@
       },
       "outcome": {
         "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
         "collection": {
           "data": [
             {
@@ -868,6 +891,11 @@
       },
       "outcome": {
         "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
         "collection": {
           "data": [
             {
@@ -918,6 +946,11 @@
       },
       "outcome": {
         "error": true,
+        "result": {
+          "errorLabelsOmit": [
+            "RetryableWriteError"
+          ]
+        },
         "collection": {
           "data": [
             {
@@ -931,6 +964,50 @@
             {
               "_id": 3,
               "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "InsertOne fails with a RetryableWriteError label after two connection failures",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operation": {
+        "name": "insertOne",
+        "arguments": {
+          "document": {
+            "_id": 3,
+            "x": 33
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
             }
           ]
         }

--- a/driver-core/src/test/resources/retryable-writes/insertOne.json
+++ b/driver-core/src/test/resources/retryable-writes/insertOne.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "InsertOne is committed on first attempt",

--- a/driver-core/src/test/resources/retryable-writes/replaceOne-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/replaceOne-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "ReplaceOne succeeds after PrimarySteppedDown",
@@ -97,6 +110,53 @@
             {
               "_id": 1,
               "x": 111
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "ReplaceOne fails with a RetryableWriteError label after two connection failures",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "update"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operation": {
+        "name": "replaceOne",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "replacement": {
+            "_id": 1,
+            "x": 111
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
             },
             {
               "_id": 2,

--- a/driver-core/src/test/resources/retryable-writes/replaceOne.json
+++ b/driver-core/src/test/resources/retryable-writes/replaceOne.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "ReplaceOne is committed on first attempt",

--- a/driver-core/src/test/resources/retryable-writes/updateMany.json
+++ b/driver-core/src/test/resources/retryable-writes/updateMany.json
@@ -1,4 +1,13 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,10 +18,10 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "UpdateMany ignores retryWrites",
+      "useMultipleMongoses": true,
       "operation": {
         "name": "updateMany",
         "arguments": {

--- a/driver-core/src/test/resources/retryable-writes/updateOne-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/updateOne-serverErrors.json
@@ -1,4 +1,18 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +23,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.99",
   "tests": [
     {
       "description": "UpdateOne succeeds after PrimarySteppedDown",
@@ -99,6 +112,54 @@
             {
               "_id": 1,
               "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateOne fails with a RetryableWriteError label after two connection failures",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "update"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operation": {
+        "name": "updateOne",
+        "arguments": {
+          "filter": {
+            "_id": 1
+          },
+          "update": {
+            "$inc": {
+              "x": 1
+            }
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "errorLabelsContain": [
+            "RetryableWriteError"
+          ]
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
             },
             {
               "_id": 2,

--- a/driver-core/src/test/resources/retryable-writes/updateOne.json
+++ b/driver-core/src/test/resources/retryable-writes/updateOne.json
@@ -1,4 +1,12 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -9,7 +17,6 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "UpdateOne is committed on first attempt",


### PR DESCRIPTION
Evergreen patch: https://evergreen.mongodb.com/version/5ddd48dbd6d80a564c65a077