### PR TITLE
link to centralized compatibility chart on ecosystem

### DIFF
--- a/docs/reference/content/upgrading.md
+++ b/docs/reference/content/upgrading.md
@@ -72,17 +72,5 @@ The minimum JVM is Java 8.
 
 # Compatibility
 
-The following table specifies the compatibility of the MongoDB Java driver for use with a specific version of MongoDB.
-
-|Java Driver Version|MongoDB 2.6|MongoDB 3.0 |MongoDB 3.2|MongoDB 3.4|MongoDB 3.6|MongoDB 4.0|
-|-------------------|-----------|------------|-----------|-----------|-----------|-----------|
-|Version 3.9        |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |
-|Version 3.8        |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |
-|Version 3.7        |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |     |
-|Version 3.6        |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |     |
-|Version 3.5        |  ✓  |  ✓  |  ✓  |  ✓  |     |     |
-|Version 3.4        |  ✓  |  ✓  |  ✓  |  ✓  |     |     |
-|Version 3.3        |  ✓  |  ✓  |  ✓  |     |     |     |
-|Version 3.2        |  ✓  |  ✓  |  ✓  |     |     |     |
-|Version 3.1        |  ✓  |  ✓  |     |     |     |     |
-|Version 3.0        |  ✓  |  ✓  |     |     |     |     |
+For information on compatibility of the MongoDB Java driver with specific
+versions of MongoDB, see the [compatibility chart](https://docs.mongodb.com/ecosystem/drivers/java/#compatibility).


### PR DESCRIPTION
In the "Upgrading" section, the MongoDB server and driver version compatibility chart was out of date. Rather than updating this in multiple places, let's link to the ecosystem driver page which is maintained by the Developer Education Team.