### PR TITLE
Adding BsonArray constructor that allocates an ArrayList with known capacity

### DIFF
--- a/bson/src/main/org/bson/BsonArray.java
+++ b/bson/src/main/org/bson/BsonArray.java
@@ -242,7 +242,7 @@ public class BsonArray extends BsonValue implements List<BsonValue>, Cloneable {
 
     @Override
     public BsonArray clone() {
-        BsonArray to = new BsonArray();
+        BsonArray to = new BsonArray(this.size());
         for (BsonValue cur : this) {
             switch (cur.getBsonType()) {
                 case DOCUMENT:

--- a/bson/src/main/org/bson/BsonArray.java
+++ b/bson/src/main/org/bson/BsonArray.java
@@ -59,7 +59,7 @@ public class BsonArray extends BsonValue implements List<BsonValue>, Cloneable {
      * @throws IllegalArgumentException if the specified initial capacity
      *         is negative
      */
-    public BsonArray(int initialCapacity) {
+    public BsonArray(final int initialCapacity) {
         this(new ArrayList<BsonValue>(initialCapacity), false);
     }
 

--- a/bson/src/main/org/bson/BsonArray.java
+++ b/bson/src/main/org/bson/BsonArray.java
@@ -52,6 +52,17 @@ public class BsonArray extends BsonValue implements List<BsonValue>, Cloneable {
         this(new ArrayList<BsonValue>(), false);
     }
 
+    /**
+     * Construct an empty BsonArray with the specified initial capacity.
+     *
+     * @param  initialCapacity  the initial capacity of the BsonArray
+     * @throws IllegalArgumentException if the specified initial capacity
+     *         is negative
+     */
+    public BsonArray(int initialCapacity) {
+        this(new ArrayList<BsonValue>(initialCapacity), false);
+    }
+
     @SuppressWarnings("unchecked")
     BsonArray(final List<? extends BsonValue> values, final boolean copy) {
         if (copy) {

--- a/driver-core/src/main/com/mongodb/TaggableReadPreference.java
+++ b/driver-core/src/main/com/mongodb/TaggableReadPreference.java
@@ -401,7 +401,7 @@ public abstract class TaggableReadPreference extends ReadPreference {
     }
 
     private BsonArray tagsListToBsonArray() {
-        BsonArray bsonArray = new BsonArray();
+        BsonArray bsonArray = new BsonArray(tagSetList.size());
         for (TagSet tagSet : tagSetList) {
             bsonArray.add(toDocument(tagSet));
         }

--- a/driver-core/src/main/com/mongodb/client/model/Filters.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filters.java
@@ -655,7 +655,7 @@ public final class Filters {
      * @since 3.1
      */
     public static Bson geoWithinPolygon(final String fieldName, final List<List<Double>> points) {
-        BsonArray pointsArray = new BsonArray();
+        BsonArray pointsArray = new BsonArray(points.size());
         for (List<Double> point : points) {
             pointsArray.add(new BsonArray(asList(new BsonDouble(point.get(0)), new BsonDouble(point.get(1)))));
         }
@@ -1227,7 +1227,7 @@ public final class Filters {
                 Map.Entry<String, BsonValue> entry = filterDocument.entrySet().iterator().next();
                 return createFilter(entry.getKey(), entry.getValue());
             } else {
-                BsonArray values = new BsonArray();
+                BsonArray values = new BsonArray(filterDocument.size());
                 for (Map.Entry<String, BsonValue> docs : filterDocument.entrySet()) {
                     values.add(new BsonDocument(docs.getKey(), docs.getValue()));
                 }

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
@@ -121,7 +121,7 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
             isMasterCommandDocument.append("client", clientMetadataDocument);
         }
         if (!requestedCompressors.isEmpty()) {
-            BsonArray compressors = new BsonArray();
+            BsonArray compressors = new BsonArray(this.requestedCompressors.size());
             for (MongoCompressor cur : this.requestedCompressors) {
                 compressors.add(new BsonString(cur.getName()));
             }

--- a/driver-core/src/main/com/mongodb/internal/connection/KillCursorProtocol.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/KillCursorProtocol.java
@@ -140,7 +140,7 @@ class KillCursorProtocol implements LegacyProtocol<Void> {
     }
 
     private BsonDocument asCommandDocument() {
-        BsonArray array = new BsonArray();
+        BsonArray array = new BsonArray(cursors.size());
         for (long cursor : cursors) {
             array.add(new BsonInt64(cursor));
         }
@@ -149,7 +149,7 @@ class KillCursorProtocol implements LegacyProtocol<Void> {
     }
 
     private BsonDocument asCommandResponseDocument() {
-        BsonArray cursorIdArray = new BsonArray();
+        BsonArray cursorIdArray = new BsonArray(cursors.size());
         for (long cursorId : cursors) {
             cursorIdArray.add(new BsonInt64(cursorId));
         }


### PR DESCRIPTION
This probably does not need much additional explanations. I could not find a way in the current `BsonArray` implementation to specify the capacity.

From https://dzone.com/articles/performance-evaluation-of-java-arraylist

> It is clear from the from the results (considering the add operation of ArrayList) that if the required maximum capacity of the ArrayList is known, we can get the optimal performance (both average latency and throughput) by specifying the initial capacity to the required capacity.

> In doing so, we can get 24% to 34% improvement in average latency and 30% to 50% improvement in throughput.

JAVA-3613 