### PR TITLE
[JAVA-3644] Аdd to call of callback if error raise on decoding of document

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncChangeStreamBatchCursor.java
@@ -166,16 +166,19 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
                     callback.onResult(null, t);
                 } else if (rawDocuments != null) {
                     List<T> results = new ArrayList<T>();
-                    try {
-                        for (RawBsonDocument rawDocument : rawDocuments) {
-                            if (!rawDocument.containsKey("_id")) {
-                                callback.onResult(null,
-                                        new MongoChangeStreamException("Cannot provide resume functionality when the resume token is missing.")
-                                );
-                                return;
-                            }
-                            results.add(rawDocument.decode(changeStreamOperation.getDecoder()));
+                    for (RawBsonDocument rawDocument : rawDocuments) {
+                        if (!rawDocument.containsKey("_id")) {
+                            callback.onResult(
+                                null,
+                                new MongoChangeStreamException(
+                                    "Cannot provide resume functionality when the resume token is missing."
+                                )
+                            );
+                            return;
                         }
+                        results.add(rawDocument.decode(changeStreamOperation.getDecoder()));
+                    }
+                    try {
                         resumeToken = rawDocuments.get(rawDocuments.size() - 1).getDocument("_id");
                         callback.onResult(results, null);
                     } catch (Exception e) {

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncChangeStreamBatchCursor.java
@@ -166,17 +166,21 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
                     callback.onResult(null, t);
                 } else if (rawDocuments != null) {
                     List<T> results = new ArrayList<T>();
-                    for (RawBsonDocument rawDocument : rawDocuments) {
-                        if (!rawDocument.containsKey("_id")) {
-                            callback.onResult(null,
-                                    new MongoChangeStreamException("Cannot provide resume functionality when the resume token is missing.")
-                            );
-                            return;
+                    try {
+                        for (RawBsonDocument rawDocument : rawDocuments) {
+                            if (!rawDocument.containsKey("_id")) {
+                                callback.onResult(null,
+                                        new MongoChangeStreamException("Cannot provide resume functionality when the resume token is missing.")
+                                );
+                                return;
+                            }
+                            results.add(rawDocument.decode(changeStreamOperation.getDecoder()));
                         }
-                        results.add(rawDocument.decode(changeStreamOperation.getDecoder()));
+                        resumeToken = rawDocuments.get(rawDocuments.size() - 1).getDocument("_id");
+                        callback.onResult(results, null);
+                    } catch (Exception e) {
+                        callback.onResult(null, e);
                     }
-                    resumeToken = rawDocuments.get(rawDocuments.size() - 1).getDocument("_id");
-                    callback.onResult(results, null);
                 } else {
                     callback.onResult(null, null);
                 }

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncChangeStreamBatchCursor.java
@@ -166,19 +166,19 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
                     callback.onResult(null, t);
                 } else if (rawDocuments != null) {
                     List<T> results = new ArrayList<T>();
-                    for (RawBsonDocument rawDocument : rawDocuments) {
-                        if (!rawDocument.containsKey("_id")) {
-                            callback.onResult(
-                                null,
-                                new MongoChangeStreamException(
-                                    "Cannot provide resume functionality when the resume token is missing."
-                                )
-                            );
-                            return;
-                        }
-                        results.add(rawDocument.decode(changeStreamOperation.getDecoder()));
-                    }
                     try {
+                        for (RawBsonDocument rawDocument : rawDocuments) {
+                            if (!rawDocument.containsKey("_id")) {
+                                callback.onResult(
+                                    null,
+                                    new MongoChangeStreamException(
+                                        "Cannot provide resume functionality when the resume token is missing."
+                                    )
+                                );
+                                return;
+                            }
+                            results.add(rawDocument.decode(changeStreamOperation.getDecoder()));
+                        }
                         resumeToken = rawDocuments.get(rawDocuments.size() - 1).getDocument("_id");
                         callback.onResult(results, null);
                     } catch (Exception e) {


### PR DESCRIPTION
If some error raise on decoding of document, watch stream is stumping on error and never close or receive other documents
So add catching an error on decoding and if it raise - call callback with error.

https://jira.mongodb.org/browse/JAVA-3644