### PR TITLE
Made CodecConfigurationException error message more explicit

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/CreatorExecutable.java
+++ b/bson/src/main/org/bson/codecs/pojo/CreatorExecutable.java
@@ -137,7 +137,9 @@ final class CreatorExecutable<T> {
 
     private void checkHasAnExecutable() {
         if (constructor == null && method == null) {
-            throw new CodecConfigurationException(format("Cannot find a public constructor for '%s'.", clazz.getSimpleName()));
+            throw new CodecConfigurationException(format("Cannot find a public constructor for '%s'.%n"
+                                                       + "Please ensure the class '%s' has a public, empty constructor with no arguments",
+                                                       clazz.getSimpleName()));
         }
     }
 


### PR DESCRIPTION
It just took me several hours to figure out the fact that the problem was not that no public constructor existed (because it did), but that the problem was that the BSON deserializer requires the class to have an *empty* constructor with *no arguments*. Once I figured that out, I was able to solve the problem within less than a minute. I hope that this more explicit error message helps other people who run into the same issue with their first time trying to deserialize BSON objects.