### PR TITLE
Fix typo in POJOs doc

### DIFF
--- a/docs/reference/content/bson/pojos.md
+++ b/docs/reference/content/bson/pojos.md
@@ -473,7 +473,7 @@ public final class Person {
 ### Changing what is serialized
 
 By default `null` values aren't serialized. This is controlled by the default implementation of the 
-[`FieldSerialization`]({{< apiref "bson" "org/bson/codecs/pojo/FieldSerialization.html" >}}) interface. Custom implementations can be set on 
+[`PropertySerialization`]({{< apiref "bson" "org/bson/codecs/pojo/PropertySerialization.html" >}}) interface. Custom implementations can be set on
 the `PropertyModelBuilder` which is available from the `ClassModelBuilder`.
 
 The [`BsonIgnore`]({{< apiref "bson" "org/bson/codecs/pojo/annotations/BsonIgnore.html" >}}) can be used along with the `DEFAULT_CONVENTIONS` to mark


### PR DESCRIPTION
Currently, the hyperlink `FieldSerialization` redirect to 404 Not Found page.
It should be `PropertySerialization`.

Someone is suffering now by this. Check this out:
https://stackoverflow.com/q/61915336