### PR TITLE
[JAVA-3759] Fix for BsonBinary subtype v4 conversion to UUID

### DIFF
--- a/bson/src/main/org/bson/BSONCallbackAdapter.java
+++ b/bson/src/main/org/bson/BSONCallbackAdapter.java
@@ -18,6 +18,7 @@ package org.bson;
 
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
+import org.bson.internal.UuidHelper;
 
 import static org.bson.Bits.readLong;
 
@@ -87,6 +88,10 @@ class BSONCallbackAdapter extends AbstractBsonWriter {
             bsonCallback.gotUUID(getName(),
                     readLong(value.getData(), 0),
                     readLong(value.getData(), 8));
+        } else if (value.getType() == BsonBinarySubType.UUID_STANDARD.getValue()) {
+            bsonCallback.gotUUID(getName(),
+                UuidHelper.readLongFromArrayBigEndian(value.getData(), 0),
+                UuidHelper.readLongFromArrayBigEndian(value.getData(), 8));
         } else {
             bsonCallback.gotBinary(getName(), value.getType(), value.getData());
         }

--- a/bson/src/main/org/bson/internal/UuidHelper.java
+++ b/bson/src/main/org/bson/internal/UuidHelper.java
@@ -39,7 +39,7 @@ public final class UuidHelper {
         bytes[offset] = (byte) (0xFFL & (x >> 56));
     }
 
-    private static long readLongFromArrayBigEndian(final byte[] bytes, final int offset) {
+    public static long readLongFromArrayBigEndian(final byte[] bytes, final int offset) {
         long x = 0;
         x |= (0xFFL & bytes[offset + 7]);
         x |= (0xFFL & bytes[offset + 6]) << 8;


### PR DESCRIPTION
https://jira.mongodb.org/browse/JAVA-3759
Bug: BsonBinary subtype v4 (UUID Standard) gets converted back to Binary instead of UUID

On reading UUID subtype V4 from MongoDB using mongo-java-driver 3.12.5, BsonBinary subtype v4 (STANDARD Uuid) gets converted back to Binary and not UUID.

Line of code where this bug occurs:
https://github.com/mongodb/mongo-java-driver/blob/master/bson/src/main/org/bson/BSONCallbackAdapter.java#L86

Which throws mapping exception only in case of UUID v4 (and not in V3) : Causing: dev.morphia.mapping.MappingException: Could not map Entity with ID: org.bson.types.Binary@e1123829

As a result, calling client is forced to add a decoding hook transformer for Binary to UUID

Options