### PR TITLE
[JAVA-3402] Override provider URL when initializing DNS context in case it is def…

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/dns/DefaultDnsResolver.java
+++ b/driver-core/src/main/com/mongodb/internal/dns/DefaultDnsResolver.java
@@ -146,6 +146,7 @@ public final class DefaultDnsResolver implements DnsResolver {
     private static InitialDirContext createDnsDirContext() {
         Hashtable<String, String> envProps = new Hashtable<String, String>();
         envProps.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+        envProps.put(Context.PROVIDER_URL, "dns:");
         try {
             return new InitialDirContext(envProps);
         } catch (NamingException e) {


### PR DESCRIPTION
When a jndi.properties is added on the classpath and `java.naming.provider.url` is set to a value other than `dns:`, connecting via mongodb+srv scheme fails with error `javax.naming.ConfigurationException: Invalid URI`.

This PR ensures that provider url is always set to `dns:`.

The error can be reproduced by adding jndi.properties file with content `java.naming.provider.url=SomeProvider` to test resources then running SRV connection tests.