### PR TITLE
Fix visit UUID constructor

### DIFF
--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -722,7 +722,7 @@ public class JsonReader extends AbstractBsonReader {
         verifyToken(JsonTokenType.RIGHT_PAREN);
         byte[] bytes = decodeHex(hexString);
         BsonBinarySubType subType = BsonBinarySubType.UUID_STANDARD;
-        if (!"UUID".equals(uuidConstructorName) || !"GUID".equals(uuidConstructorName)) {
+        if (!"UUID".equals(uuidConstructorName) && !"GUID".equals(uuidConstructorName)) {
             subType = BsonBinarySubType.UUID_LEGACY;
         }
         return new BsonBinary(subType, bytes);


### PR DESCRIPTION

The condition in visitUUIDConstructor is always true and make it return a UUID_LEGACY regardless of the uuidConstructorName
```
        BsonBinarySubType subType = BsonBinarySubType.UUID_STANDARD;
        if (!"UUID".equals(uuidConstructorName) || !"GUID".equals(uuidConstructorName)) {
            subType = BsonBinarySubType.UUID_LEGACY;
        }
```