### PR TITLE
DOCSP-11515: fix typos

### DIFF
--- a/docs/reference/content/bson/codecs.md
+++ b/docs/reference/content/bson/codecs.md
@@ -88,7 +88,7 @@ public class DocumentCodecProvider implements CodecProvider {
             return (Codec<T>) new DocumentCodec(registry);           
         }                                                                                              
                                                                                                        
-        // CodecProvider returns null if it's not a provider for the requresed Class 
+        // CodecProvider returns null if it's not a provider for the requested Class 
         return null;                                          
     }                                                                                                  
 }

--- a/docs/reference/content/bson/pojos.md
+++ b/docs/reference/content/bson/pojos.md
@@ -60,7 +60,7 @@ encoded and decoded.
 Automatic POJO support can be provided by setting `PojoCodecProvider.Builder#automatic(true)`, once built the `PojoCodecProvider` will 
 automatically create a POJO `Codec` for any class that contains at least one serializable or deserializable property.
 
-The entry point for customisable POJO support is the `PojoCodecProvider`. New instances can be created via the
+The entry point for customizable POJO support is the `PojoCodecProvider`. New instances can be created via the
 [`PojoCodecProvider.builder()`]({{< apiref "bson" "org/bson/codecs/pojo/PojoCodecProvider.html#builder" >}}) method. The `builder` allows users to 
 register any combination of:
 

--- a/docs/reference/content/builders/filters.md
+++ b/docs/reference/content/builders/filters.md
@@ -67,7 +67,7 @@ The logical operator methods include:
  
 #### Examples
 
-This example creates a filter that selects all documents where ther value of the `qty` field is greater than `20` and the value of the 
+This example creates a filter that selects all documents where the value of the `qty` field is greater than `20` and the value of the 
 `user` field equals `"jdoe"`:
  
 ```java

--- a/docs/reference/content/builders/projections.md
+++ b/docs/reference/content/builders/projections.md
@@ -10,7 +10,7 @@ title = "Projections"
 ## Projections
 
 The [`Projections`]({{< apiref "mongodb-driver-core" "com/mongodb/client/model/Projections" >}}) class provides static factory methods for all the MongoDB 
-projection opererators.  Each method returns an instance of the [`Bson`]({{< relref "bson/documents.md#bson" >}}) type, which can in turn
+projection operators.  Each method returns an instance of the [`Bson`]({{< relref "bson/documents.md#bson" >}}) type, which can in turn
 be passed to any method that expects a projection.
 
 For brevity, you may choose to import the methods of the `Projections` class statically:

--- a/docs/reference/content/driver-scala/builders/filters.md
+++ b/docs/reference/content/driver-scala/builders/filters.md
@@ -69,7 +69,7 @@ The logical operator methods include:
  
 #### Examples
 
-This example creates a filter that selects all documents where ther value of the `qty` field is greater than `20` and the value of the 
+This example creates a filter that selects all documents where the value of the `qty` field is greater than `20` and the value of the 
 `user` field equals `"jdoe"`:
  
 ```scala

--- a/docs/reference/content/driver-scala/builders/projections.md
+++ b/docs/reference/content/driver-scala/builders/projections.md
@@ -11,7 +11,7 @@ title = "Projections"
 ## Projections
 
 The [`Projections`]({{< apiref "mongo-scala-driver" "org/mongodb/scala/model/Projections$" >}}) class provides static factory methods for all the MongoDB 
-projection opererators.  Each method returns an instance of the [`Bson`]({{< relref "bson/documents.md#bson" >}}) type, which can in turn
+projection operators.  Each method returns an instance of the [`Bson`]({{< relref "bson/documents.md#bson" >}}) type, which can in turn
 be passed to any method that expects a projection.
 
 For brevity, you may choose to import the methods of the `Projections` class statically:


### PR DESCRIPTION
JIRA: 
https://github.com/ccho-mongodb/mongo-java-driver/pull/new/DOCSP-11515-typo-fixes

Fixes to typos in current reference documents.