### PR TITLE
JAVA-3815: Pojo Codec - Detect property models on extended interfaces

### DIFF
--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -30,6 +30,7 @@ import org.bson.codecs.pojo.entities.AbstractInterfaceModel;
 import org.bson.codecs.pojo.entities.AsymmetricalCreatorModel;
 import org.bson.codecs.pojo.entities.AsymmetricalIgnoreModel;
 import org.bson.codecs.pojo.entities.AsymmetricalModel;
+import org.bson.codecs.pojo.entities.ComposeInterfaceModel;
 import org.bson.codecs.pojo.entities.ConcreteAndNestedAbstractInterfaceModel;
 import org.bson.codecs.pojo.entities.ConcreteCollectionsModel;
 import org.bson.codecs.pojo.entities.ConcreteStandAloneAbstractInterfaceModel;
@@ -39,6 +40,8 @@ import org.bson.codecs.pojo.entities.ConverterModel;
 import org.bson.codecs.pojo.entities.CustomPropertyCodecOptionalModel;
 import org.bson.codecs.pojo.entities.GenericTreeModel;
 import org.bson.codecs.pojo.entities.InterfaceBasedModel;
+import org.bson.codecs.pojo.entities.InterfaceModelB;
+import org.bson.codecs.pojo.entities.InterfaceModelImpl;
 import org.bson.codecs.pojo.entities.InvalidCollectionModel;
 import org.bson.codecs.pojo.entities.InvalidGetterAndSetterModel;
 import org.bson.codecs.pojo.entities.InvalidMapModel;
@@ -65,6 +68,7 @@ import org.bson.codecs.pojo.entities.conventions.CollectionsGetterNullModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorConstructorPrimitivesModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorConstructorThrowsExceptionModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorMethodThrowsExceptionModel;
+import org.bson.codecs.pojo.entities.conventions.InterfaceModelBInstanceCreatorConvention;
 import org.bson.codecs.pojo.entities.conventions.MapGetterImmutableModel;
 import org.bson.codecs.pojo.entities.conventions.MapGetterMutableModel;
 import org.bson.codecs.pojo.entities.conventions.MapGetterNonEmptyModel;
@@ -499,7 +503,7 @@ public final class PojoCustomTest extends PojoTestCase {
     public void testEncodingInvalidCollectionModel() {
         try {
             encodesTo(getPojoCodecProviderBuilder(InvalidCollectionModel.class), new InvalidCollectionModel(asList(1, 2, 3)),
-                "{collectionField: [1, 2, 3]}");
+                    "{collectionField: [1, 2, 3]}");
         } catch (CodecConfigurationException e) {
             assertTrue(e.getMessage().startsWith("Failed to encode 'InvalidCollectionModel'. Encoding 'collectionField' errored with:"));
             throw e;
@@ -510,6 +514,17 @@ public final class PojoCustomTest extends PojoTestCase {
     public void testInvalidMapModelWithCustomPropertyCodecProvider() {
         encodesTo(getPojoCodecProviderBuilder(InvalidMapModel.class).register(new InvalidMapPropertyCodecProvider()), getInvalidMapModel(),
                 "{'invalidMap': {'1': 1, '2': 2}}");
+    }
+
+    @Test
+    public void testInterfaceModelCreatorMadeInConvention() {
+        roundTrip(
+                getPojoCodecProviderBuilder(ComposeInterfaceModel.class, InterfaceModelB.class, InterfaceModelImpl.class)
+                        .conventions(Collections.singletonList(new InterfaceModelBInstanceCreatorConvention())),
+                new ComposeInterfaceModel("someTitle",
+                        new InterfaceModelImpl("a", "b")),
+                "{'title': 'someTitle', 'nestedModel': {'propertyA': 'a', 'propertyB': 'b'}}"
+        );
     }
 
     @Test(expected = CodecConfigurationException.class)

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/ComposeInterfaceModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/ComposeInterfaceModel.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+import java.util.Objects;
+
+public class ComposeInterfaceModel {
+    private String title;
+    private InterfaceModelB nestedModel;
+
+    public ComposeInterfaceModel() {
+    }
+
+    public ComposeInterfaceModel(final String title, final InterfaceModelB nestedModel) {
+        this.title = title;
+        this.nestedModel = nestedModel;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(final String title) {
+        this.title = title;
+    }
+
+    public InterfaceModelB getNestedModel() {
+        return nestedModel;
+    }
+
+    public void setNestedModel(final InterfaceModelB nestedModel) {
+        this.nestedModel = nestedModel;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ComposeInterfaceModel that = (ComposeInterfaceModel) o;
+        return Objects.equals(title, that.title)
+                && Objects.equals(nestedModel, that.nestedModel);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(title, nestedModel);
+    }
+
+    @Override
+    public String toString() {
+        return "ComposeInterfaceModel{"
+                + "title='" + title + '\''
+                + ", nestedModel=" + nestedModel
+                + '}';
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceModelImpl.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/InterfaceModelImpl.java
@@ -63,7 +63,15 @@ public class InterfaceModelImpl extends InterfaceModelAbstract implements Interf
     @Override
     public int hashCode() {
         int result = getPropertyA() != null ? getPropertyA().hashCode() : 0;
-        result = 31 * result + getPropertyB() != null ? getPropertyB().hashCode() : 0;
+        result = 31 * result + (getPropertyB() != null ? getPropertyB().hashCode() : 0);
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return "InterfaceModelImpl{"
+                + "propertyA='" + getPropertyA() + "', "
+                + "propertyB='" + getPropertyB() + '\''
+                + '}';
     }
 }

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/InterfaceModelBInstanceCreatorConvention.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/InterfaceModelBInstanceCreatorConvention.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.conventions;
+
+import org.bson.codecs.pojo.ClassModelBuilder;
+import org.bson.codecs.pojo.Convention;
+import org.bson.codecs.pojo.InstanceCreator;
+import org.bson.codecs.pojo.PropertyModel;
+import org.bson.codecs.pojo.entities.InterfaceModelB;
+import org.bson.codecs.pojo.entities.InterfaceModelImpl;
+
+public class InterfaceModelBInstanceCreatorConvention implements Convention {
+    @Override
+    @SuppressWarnings("unchecked")
+    public void apply(final ClassModelBuilder<?> classModelBuilder) {
+        if (classModelBuilder.getType().equals(InterfaceModelB.class)) {
+            // Simulate a custom implementation of InstanceCreator factory
+            // (This one can be generated automatically, but, a real use case can have an advanced reflection based
+            // solution that the POJO Codec doesn't support out of the box)
+            ((ClassModelBuilder<InterfaceModelB>) classModelBuilder).instanceCreatorFactory(() -> {
+                InterfaceModelB interfaceModelB = new InterfaceModelImpl();
+                return new InstanceCreator<InterfaceModelB>() {
+                    @Override
+                    public <S> void set(final S value, final PropertyModel<S> propertyModel) {
+                        if (propertyModel.getName().equals("propertyA")) {
+                            interfaceModelB.setPropertyA((String) value);
+                        } else if (propertyModel.getName().equals("propertyB")) {
+                            interfaceModelB.setPropertyB((String) value);
+                        }
+                    }
+
+                    @Override
+                    public InterfaceModelB getInstance() {
+                        return interfaceModelB;
+                    }
+                };
+            });
+        }
+    }
+}


### PR DESCRIPTION
If we have an interface like:
```
public interface SampleInterface {
  int getFirst();
  String getSecond();
}
```

which is implemented as:
```
public abstract class SampleImplementor implements SampleInterface {
  public abstract boolean isThird();
}
```

and has a concrete implementation that's called `SampleImplementorImpl`. 
When `PojoBuilderHelper` goes to create the property models, it only checks
for methods on the current class and super classes - not interfaces. In
the above example, this means the property model will only have "third" entry -
no "first" or "second" property model. Today, you can manually get around that by
creating a @BsonCreator by hand:

```
public abstract class SampleImplementor implements SampleInterface {
  @BsonCreator
  public static SampleImplementor newInstance(
    @BsonProperty("first") int first,
    @BsonProperty("second") String second,
    @BsonProperty("third") boolean third) {
    return new SampleImplementorImpl(first, second, third);
  }

  public abstract boolean isThird();
}
```

The presence of the `@BsonProperty` on the `@BsonCreator` method will
create the property models. Conversely though, if you want to leverage a
`Convention` implementation to dynamically create a `InstanceCreator`
that knows how to find `SampleImplementorImpl` above, you won't be able
to. `InstanceCreator` is only provided properties for which
`PropertyModel` exists, so above, since `PojoBuilderHelper` didn't
discover the interface fields, and there is no exposed API to add
property models, your `InstanceCreator` will never be provided the
`first` and `second` fields present on the interface.

Simply put, if you provide the pojo codec a class that is not concrete,
extends an interface for methods, and does not have a `@BsonCreator`
annotation, there is no way to implement a `InstanceCreator`
implementation that works for the non concrete class. You get stuck in
a place where the class can serialize since the concrete implementation
`SampleImplementorImpl` is provided at runtime, but then you have no way
to deserialize it since usages in the code only reference `SampleImplementor`.

We've worked around this problem for years and created 700+ hand written 
`@BsonCreator` annotations, so at this point I want to fix actual the problem.

This fix is relatively straight forward: Update `PojoBuilderHelper` to
scan implementing classes and interfaces, which provides a fully
populated property model.