### PR TITLE
Docs: Added a link to the shared core

### DIFF
--- a/docs/reference/content/apidocs.md
+++ b/docs/reference/content/apidocs.md
@@ -17,3 +17,4 @@ The following API documentation is available:
   - [Java Reactive Streams Driver]({{< apiref "mongodb-driver-reactivestreams" "index.html" >}})
   - [Scala Driver]({{< apiref "mongo-scala-driver" "index.html" >}})
   - [Bson]({{< apiref "bson" "index.html" >}}) (The bson layer)
+  - [Core]({{< apiref ""mongodb-driver-core" "index.html" >}}) (The shared core classes)


### PR DESCRIPTION
JAVA-3803

http://rozza.github.io/mongo-java-driver/4.1/apidocs/

I opted not to merge the sources for each areas java docs, as that makes the index page very hard to read - losing the initial benefits of splitting out the docs. It also significantly increases the size of the docs - from 45mb to 110mb