### PR TITLE
JAVA-3485: Suppress firing of duplicate cluster events

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
@@ -26,7 +26,6 @@ import com.mongodb.connection.ClusterType;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
-import com.mongodb.event.ClusterDescriptionChangedEvent;
 import com.mongodb.event.ServerDescriptionChangedEvent;
 import org.bson.types.ObjectId;
 
@@ -100,7 +99,7 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
             }
             newDescription = updateDescription();
         }
-        fireChangeEvent(new ClusterDescriptionChangedEvent(getClusterId(), newDescription, currentDescription));
+        fireChangeEvent(newDescription, currentDescription);
     }
 
     @Override
@@ -165,7 +164,7 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
             ClusterDescription oldClusterDescription = getCurrentDescription();
             ClusterDescription newClusterDescription = updateDescription();
 
-            fireChangeEvent(new ClusterDescriptionChangedEvent(getClusterId(), newClusterDescription, oldClusterDescription));
+            fireChangeEvent(newClusterDescription, oldClusterDescription);
         }
     }
 
@@ -224,7 +223,7 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
             }
         }
         if (shouldUpdateDescription) {
-            fireChangeEvent(new ClusterDescriptionChangedEvent(getClusterId(), newClusterDescription, oldClusterDescription));
+            fireChangeEvent(newClusterDescription, oldClusterDescription);
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
@@ -28,7 +28,6 @@ import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.event.ClusterDescriptionChangedEvent;
 import com.mongodb.event.ServerDescriptionChangedEvent;
-import com.mongodb.event.ServerListener;
 import org.bson.types.ObjectId;
 
 import java.util.ArrayList;
@@ -135,7 +134,7 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
     }
 
 
-    private final class DefaultServerStateListener implements ServerListener {
+    private final class DefaultServerDescriptionChangedListener implements ServerDescriptionChangedListener {
         @Override
         public void serverDescriptionChanged(final ServerDescriptionChangedEvent event) {
             onChange(event);
@@ -350,7 +349,7 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info(format("Adding discovered server %s to client view of cluster", serverAddress));
             }
-            ClusterableServer server = createServer(serverAddress, new DefaultServerStateListener());
+            ClusterableServer server = createServer(serverAddress, new DefaultServerDescriptionChangedListener());
             addressToServerTupleMap.put(serverAddress, new ServerTuple(server, getConnectingServerDescription(serverAddress)));
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -21,7 +21,6 @@ import com.mongodb.MongoIncompatibleDriverException;
 import com.mongodb.MongoInterruptedException;
 import com.mongodb.MongoTimeoutException;
 import com.mongodb.ServerAddress;
-import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.connection.ClusterDescription;
 import com.mongodb.connection.ClusterId;
 import com.mongodb.connection.ClusterSettings;
@@ -33,7 +32,7 @@ import com.mongodb.event.ClusterClosedEvent;
 import com.mongodb.event.ClusterDescriptionChangedEvent;
 import com.mongodb.event.ClusterListener;
 import com.mongodb.event.ClusterOpeningEvent;
-import com.mongodb.event.ServerListener;
+import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.selector.CompositeServerSelector;
 import com.mongodb.selector.ServerSelector;
 import org.bson.BsonTimestamp;
@@ -374,8 +373,10 @@ abstract class BaseCluster implements Cluster {
         return result;
     }
 
-    protected ClusterableServer createServer(final ServerAddress serverAddress, final ServerListener serverListener) {
-        return serverFactory.create(serverAddress, createServerListener(serverFactory.getSettings(), serverListener), clusterClock);
+    protected ClusterableServer createServer(final ServerAddress serverAddress,
+                                             final ServerDescriptionChangedListener serverDescriptionChangedListener) {
+        return serverFactory.create(serverAddress, serverDescriptionChangedListener, createServerListener(serverFactory.getSettings()),
+                clusterClock);
     }
 
     private void throwIfIncompatible(final ClusterDescription curDescription) {

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -51,7 +51,7 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.connection.ServerDescription.MAX_DRIVER_WIRE_VERSION;
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_SERVER_VERSION;
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
-import static com.mongodb.internal.connection.EventHelper.equivalentEvent;
+import static com.mongodb.internal.connection.EventHelper.wouldDescriptionsGenerateEquivalentEvents;
 import static com.mongodb.internal.event.EventListenerHelper.createServerListener;
 import static com.mongodb.internal.event.EventListenerHelper.getClusterListener;
 import static java.lang.String.format;
@@ -254,7 +254,7 @@ abstract class BaseCluster implements Cluster {
     }
 
     protected void fireChangeEvent(final ClusterDescription newDescription, final ClusterDescription previousDescription) {
-        if (!equivalentEvent(newDescription, previousDescription)) {
+        if (!wouldDescriptionsGenerateEquivalentEvents(newDescription, previousDescription)) {
              clusterListener.clusterDescriptionChanged(
                      new ClusterDescriptionChangedEvent(getClusterId(), newDescription, previousDescription));
         }

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -51,6 +51,7 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.connection.ServerDescription.MAX_DRIVER_WIRE_VERSION;
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_SERVER_VERSION;
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
+import static com.mongodb.internal.connection.EventHelper.equivalentEvent;
 import static com.mongodb.internal.event.EventListenerHelper.createServerListener;
 import static com.mongodb.internal.event.EventListenerHelper.getClusterListener;
 import static java.lang.String.format;
@@ -252,8 +253,11 @@ abstract class BaseCluster implements Cluster {
         updatePhase();
     }
 
-    protected void fireChangeEvent(final ClusterDescriptionChangedEvent event) {
-        clusterListener.clusterDescriptionChanged(event);
+    protected void fireChangeEvent(final ClusterDescription newDescription, final ClusterDescription previousDescription) {
+        if (!equivalentEvent(newDescription, previousDescription)) {
+             clusterListener.clusterDescriptionChanged(
+                     new ClusterDescriptionChangedEvent(getClusterId(), newDescription, previousDescription));
+        }
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
@@ -65,7 +65,9 @@ public class DefaultClusterableServerFactory implements ClusterableServerFactory
     }
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress, final ServerListener serverListener,
+    public ClusterableServer create(final ServerAddress serverAddress,
+                                    final ServerDescriptionChangedListener serverDescriptionChangedListener,
+                                    final ServerListener serverListener,
                                     final ClusterClock clusterClock) {
         ConnectionPool connectionPool = new DefaultConnectionPool(new ServerId(clusterId, serverAddress),
                 new InternalStreamConnectionFactory(streamFactory, credential, applicationName,
@@ -80,7 +82,8 @@ public class DefaultClusterableServerFactory implements ClusterableServerFactory
                             applicationName, mongoDriverInformation, Collections.<MongoCompressor>emptyList(), null), connectionPool);
 
         return new DefaultServer(new ServerId(clusterId, serverAddress), clusterSettings.getMode(), connectionPool,
-                new DefaultConnectionFactory(), serverMonitorFactory, serverListener, commandListener, clusterClock);
+                new DefaultConnectionFactory(), serverMonitorFactory, serverDescriptionChangedListener, serverListener, commandListener,
+                clusterClock);
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServer.java
@@ -205,8 +205,7 @@ class DefaultServer implements ClusterableServer {
             connectionPool.close();
             serverMonitor.close();
             isClosed = true;
-            ServerClosedEvent event = new ServerClosedEvent(serverId);
-            serverListener.serverClosed(event);
+            serverListener.serverClosed(new ServerClosedEvent(serverId));
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServer.java
@@ -45,6 +45,7 @@ import static com.mongodb.connection.ServerConnectionState.CONNECTING;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.connection.ClusterableServer.ConnectionState.AFTER_HANDSHAKE;
 import static com.mongodb.internal.connection.ClusterableServer.ConnectionState.BEFORE_HANDSHAKE;
+import static com.mongodb.internal.connection.EventHelper.equivalentEvent;
 import static com.mongodb.internal.operation.ServerVersionHelper.FOUR_DOT_TWO_WIRE_VERSION;
 import static java.util.Arrays.asList;
 
@@ -305,7 +306,9 @@ class DefaultServer implements ClusterableServer {
                 ServerDescriptionChangedEvent serverDescriptionChangedEvent =
                         new ServerDescriptionChangedEvent(serverId, description, oldDescription);
                 serverDescriptionChangedListener.serverDescriptionChanged(serverDescriptionChangedEvent);
-                serverListener.serverDescriptionChanged(serverDescriptionChangedEvent);
+                if (!equivalentEvent(description, oldDescription)) {
+                    serverListener.serverDescriptionChanged(serverDescriptionChangedEvent);
+                }
             }
         }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServer.java
@@ -45,7 +45,7 @@ import static com.mongodb.connection.ServerConnectionState.CONNECTING;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.connection.ClusterableServer.ConnectionState.AFTER_HANDSHAKE;
 import static com.mongodb.internal.connection.ClusterableServer.ConnectionState.BEFORE_HANDSHAKE;
-import static com.mongodb.internal.connection.EventHelper.equivalentEvent;
+import static com.mongodb.internal.connection.EventHelper.wouldDescriptionsGenerateEquivalentEvents;
 import static com.mongodb.internal.operation.ServerVersionHelper.FOUR_DOT_TWO_WIRE_VERSION;
 import static java.util.Arrays.asList;
 
@@ -305,7 +305,7 @@ class DefaultServer implements ClusterableServer {
                 ServerDescriptionChangedEvent serverDescriptionChangedEvent =
                         new ServerDescriptionChangedEvent(serverId, description, oldDescription);
                 serverDescriptionChangedListener.serverDescriptionChanged(serverDescriptionChangedEvent);
-                if (!equivalentEvent(description, oldDescription)) {
+                if (!wouldDescriptionsGenerateEquivalentEvents(description, oldDescription)) {
                     serverListener.serverDescriptionChanged(serverDescriptionChangedEvent);
                 }
             }

--- a/driver-core/src/main/com/mongodb/internal/connection/EventHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/EventHelper.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.connection;
+
+import com.mongodb.connection.ClusterDescription;
+import com.mongodb.connection.ServerDescription;
+
+import java.util.Objects;
+
+final class EventHelper {
+
+    static boolean equivalentEvent(final ClusterDescription current, final ClusterDescription previous) {
+        if (!exceptionsEquals(current.getSrvResolutionException(), previous.getSrvResolutionException())) {
+            return false;
+        }
+        if (current.getServerDescriptions().size() != previous.getServerDescriptions().size()) {
+            return false;
+        }
+        for (ServerDescription curNew: current.getServerDescriptions()) {
+            ServerDescription matchingPrev = null;
+            for (ServerDescription curPrev: previous.getServerDescriptions()) {
+                if (curNew.getAddress().equals(curPrev.getAddress())) {
+                    matchingPrev = curPrev;
+                    break;
+                }
+            }
+            if (!equivalentEvent(curNew, matchingPrev)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static boolean equivalentEvent(final ServerDescription current, final ServerDescription previous) {
+        if (current == previous) {
+            return true;
+        }
+        if (previous == null || current == null) {
+            return false;
+        }
+        if (current.isOk() != previous.isOk()) {
+            return false;
+        }
+        if (current.getState() != previous.getState()) {
+            return false;
+        }
+        if (current.getType() != previous.getType()) {
+            return false;
+        }
+        if (current.getMinWireVersion() != previous.getMinWireVersion()) {
+            return false;
+        }
+        if (current.getMaxWireVersion() != previous.getMaxWireVersion()) {
+            return false;
+        }
+        if (!Objects.equals(current.getCanonicalAddress(), previous.getCanonicalAddress())) {
+            return false;
+        }
+        if (!current.getHosts().equals(previous.getHosts())) {
+            return false;
+        }
+        if (!current.getPassives().equals(previous.getPassives())) {
+            return false;
+        }
+        if (!current.getArbiters().equals(previous.getArbiters())) {
+            return false;
+        }
+        if (!current.getTagSet().equals(previous.getTagSet())) {
+            return false;
+        }
+        if (!Objects.equals(current.getSetName(), previous.getSetName())) {
+            return false;
+        }
+        if (!Objects.equals(current.getSetVersion(), previous.getSetVersion())) {
+            return false;
+        }
+        if (!Objects.equals(current.getElectionId(), previous.getElectionId())) {
+            return false;
+        }
+        if (!Objects.equals(current.getPrimary(), previous.getPrimary())) {
+            return false;
+        }
+        if (!Objects.equals(current.getLogicalSessionTimeoutMinutes(), previous.getLogicalSessionTimeoutMinutes())) {
+            return false;
+        }
+        if (!Objects.equals(current.getTopologyVersion(), previous.getTopologyVersion())) {
+            return false;
+        }
+        if (!exceptionsEquals(current.getException(), previous.getException())) {
+            return false;
+        }
+        return true;
+    }
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    private static boolean exceptionsEquals(final Throwable current, final Throwable previous) {
+        // Compare class equality and message as exceptions rarely override equals
+        Class<?> thisExceptionClass = current != null ? current.getClass() : null;
+        Class<?> thatExceptionClass = previous != null ? previous.getClass() : null;
+        if (!Objects.equals(thisExceptionClass, thatExceptionClass)) {
+            return false;
+        }
+
+        String thisExceptionMessage = current != null ? current.getMessage() : null;
+        String thatExceptionMessage = previous != null ? previous.getMessage() : null;
+        if (!Objects.equals(thisExceptionMessage, thatExceptionMessage)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    private EventHelper() {}
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/EventHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/EventHelper.java
@@ -108,16 +108,15 @@ final class EventHelper {
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     private static boolean exceptionsEquals(final Throwable current, final Throwable previous) {
+        if (current == null || previous == null) {
+            return current == previous;
+        }
         // Compare class equality and message as exceptions rarely override equals
-        Class<?> thisExceptionClass = current != null ? current.getClass() : null;
-        Class<?> thatExceptionClass = previous != null ? previous.getClass() : null;
-        if (!Objects.equals(thisExceptionClass, thatExceptionClass)) {
+        if (!Objects.equals(current.getClass(), previous.getClass())) {
             return false;
         }
 
-        String thisExceptionMessage = current != null ? current.getMessage() : null;
-        String thatExceptionMessage = previous != null ? previous.getMessage() : null;
-        if (!Objects.equals(thisExceptionMessage, thatExceptionMessage)) {
+        if (!Objects.equals(current.getMessage(), previous.getMessage())) {
             return false;
         }
         return true;

--- a/driver-core/src/main/com/mongodb/internal/connection/EventHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/EventHelper.java
@@ -23,7 +23,12 @@ import java.util.Objects;
 
 final class EventHelper {
 
-    static boolean equivalentEvent(final ClusterDescription current, final ClusterDescription previous) {
+    /**
+     * Determine whether the two cluster descriptions are effectively equivalent for the purpose of cluster event
+     * generation, according to the equality rules enumerated in the Server Discovery and Monitoring specification.
+     */
+    static boolean wouldDescriptionsGenerateEquivalentEvents(final ClusterDescription current,
+                                                             final ClusterDescription previous) {
         if (!exceptionsEquals(current.getSrvResolutionException(), previous.getSrvResolutionException())) {
             return false;
         }
@@ -38,14 +43,19 @@ final class EventHelper {
                     break;
                 }
             }
-            if (!equivalentEvent(curNew, matchingPrev)) {
+            if (!wouldDescriptionsGenerateEquivalentEvents(curNew, matchingPrev)) {
                 return false;
             }
         }
         return true;
     }
 
-    static boolean equivalentEvent(final ServerDescription current, final ServerDescription previous) {
+    /**
+     * Determine whether the two server descriptions are effectively equivalent for the purpose of server event
+     * generation, according to the equality rules enumerated in the Server Discovery and Monitoring specification.
+     */
+    static boolean wouldDescriptionsGenerateEquivalentEvents(final ServerDescription current,
+                                                             final ServerDescription previous) {
         if (current == previous) {
             return true;
         }

--- a/driver-core/src/main/com/mongodb/internal/connection/ServerDescriptionChangedListener.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ServerDescriptionChangedListener.java
@@ -16,13 +16,11 @@
 
 package com.mongodb.internal.connection;
 
-import com.mongodb.ServerAddress;
-import com.mongodb.connection.ServerSettings;
-import com.mongodb.event.ServerListener;
+import com.mongodb.event.ServerDescriptionChangedEvent;
 
-public interface ClusterableServerFactory {
-    ClusterableServer create(ServerAddress serverAddress, ServerDescriptionChangedListener serverDescriptionChangedListener,
-                             ServerListener serverListener, ClusterClock clusterClock);
-
-    ServerSettings getSettings();
+// internal interface that Cluster implementations register with Server implementations in order be notified of changes in server state.
+// Server implementations should fire this event even if the state has not changed according to the rules of topology change event
+// notification in the SDAM specification.
+interface ServerDescriptionChangedListener {
+    void serverDescriptionChanged(ServerDescriptionChangedEvent event);
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/ServerDescriptionChangedListener.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ServerDescriptionChangedListener.java
@@ -18,9 +18,11 @@ package com.mongodb.internal.connection;
 
 import com.mongodb.event.ServerDescriptionChangedEvent;
 
-// internal interface that Cluster implementations register with Server implementations in order be notified of changes in server state.
-// Server implementations should fire this event even if the state has not changed according to the rules of topology change event
-// notification in the SDAM specification.
+/*
+ internal interface that Cluster implementations register with Server implementations in order be notified of changes in
+ server state. Server implementations should fire this event even if the state has not changed according to the rules of
+ topology change event notification in the SDAM specification.
+*/
 interface ServerDescriptionChangedListener {
     void serverDescriptionChanged(ServerDescriptionChangedEvent event);
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
@@ -29,7 +29,6 @@ import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.event.ClusterDescriptionChangedEvent;
 import com.mongodb.event.ServerDescriptionChangedEvent;
-import com.mongodb.event.ServerListener;
 
 import static com.mongodb.assertions.Assertions.isTrue;
 import static java.lang.String.format;
@@ -56,7 +55,7 @@ public final class SingleServerCluster extends BaseCluster {
         // synchronized in the constructor because the change listener is re-entrant to this instance.
         // In other words, we are leaking a reference to "this" from the constructor.
         synchronized (this) {
-            this.server = createServer(settings.getHosts().get(0), new DefaultServerStateListener());
+            this.server = createServer(settings.getHosts().get(0), new DefaultServerDescriptionChangedListener());
             publishDescription(server.getDescription());
         }
     }
@@ -80,7 +79,7 @@ public final class SingleServerCluster extends BaseCluster {
         }
     }
 
-    private class DefaultServerStateListener implements ServerListener {
+    private class DefaultServerDescriptionChangedListener implements ServerDescriptionChangedListener {
         @Override
         public void serverDescriptionChanged(final ServerDescriptionChangedEvent event) {
             ServerDescription newDescription = event.getNewDescription();

--- a/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
@@ -27,7 +27,6 @@ import com.mongodb.connection.ServerDescription;
 import com.mongodb.connection.ServerType;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
-import com.mongodb.event.ClusterDescriptionChangedEvent;
 import com.mongodb.event.ServerDescriptionChangedEvent;
 
 import static com.mongodb.assertions.Assertions.isTrue;
@@ -122,6 +121,6 @@ public final class SingleServerCluster extends BaseCluster {
                 getServerFactory().getSettings());
 
         updateDescription(description);
-        fireChangeEvent(new ClusterDescriptionChangedEvent(getClusterId(), description, currentDescription));
+        fireChangeEvent(description, currentDescription);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/event/EventListenerHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/event/EventListenerHelper.java
@@ -25,7 +25,6 @@ import com.mongodb.event.ConnectionPoolListener;
 import com.mongodb.event.ServerListener;
 import com.mongodb.event.ServerMonitorListener;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public final class EventListenerHelper {
@@ -74,20 +73,14 @@ public final class EventListenerHelper {
         }
     }
 
-    public static ServerListener createServerListener(final ServerSettings serverSettings, final ServerListener additionalServerListener) {
-        List<ServerListener> mergedServerListeners = new ArrayList<ServerListener>();
-        if (additionalServerListener != null) {
-            mergedServerListeners.add(additionalServerListener);
-        }
-        mergedServerListeners.addAll(serverSettings.getServerListeners());
-
-        switch (mergedServerListeners.size()) {
+    public static ServerListener createServerListener(final ServerSettings serverSettings) {
+        switch (serverSettings.getServerListeners().size()) {
             case 0:
                 return NO_OP_SERVER_LISTENER;
             case 1:
-                return mergedServerListeners.get(0);
+                return serverSettings.getServerListeners().get(0);
             default:
-                return new ServerListenerMulticaster(mergedServerListeners);
+                return new ServerListenerMulticaster(serverSettings.getServerListeners());
         }
     }
 

--- a/driver-core/src/test/resources/server-discovery-and-monitoring-monitoring/standalone_suppress_equal_description_changes.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring-monitoring/standalone_suppress_equal_description_changes.json
@@ -1,0 +1,113 @@
+{
+  "description": "Monitoring a standalone connection - suppress update events for equal server descriptions",
+  "uri": "mongodb://a:27017",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 4
+          }
+        ],
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 4
+          }
+        ]
+      ],
+      "outcome": {
+        "events": [
+          {
+            "topology_opening_event": {
+              "topologyId": "42"
+            }
+          },
+          {
+            "topology_description_changed_event": {
+              "topologyId": "42",
+              "previousDescription": {
+                "topologyType": "Unknown",
+                "servers": []
+              },
+              "newDescription": {
+                "topologyType": "Single",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "Unknown"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "server_opening_event": {
+              "topologyId": "42",
+              "address": "a:27017"
+            }
+          },
+          {
+            "server_description_changed_event": {
+              "topologyId": "42",
+              "address": "a:27017",
+              "previousDescription": {
+                "address": "a:27017",
+                "arbiters": [],
+                "hosts": [],
+                "passives": [],
+                "type": "Unknown"
+              },
+              "newDescription": {
+                "address": "a:27017",
+                "arbiters": [],
+                "hosts": [],
+                "passives": [],
+                "type": "Standalone"
+              }
+            }
+          },
+          {
+            "topology_description_changed_event": {
+              "topologyId": "42",
+              "previousDescription": {
+                "topologyType": "Single",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "Unknown"
+                  }
+                ]
+              },
+              "newDescription": {
+                "topologyType": "Single",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "Standalone"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultTestClusterableServerFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultTestClusterableServerFactory.java
@@ -27,8 +27,6 @@ import com.mongodb.event.ServerListener;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.mongodb.internal.event.EventListenerHelper.createServerListener;
-
 public class DefaultTestClusterableServerFactory implements ClusterableServerFactory {
     private final ServerSettings settings = ServerSettings.builder().build();
     private final ClusterId clusterId;
@@ -45,15 +43,15 @@ public class DefaultTestClusterableServerFactory implements ClusterableServerFac
     }
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress, final ServerListener serverListener,
-                                    final ClusterClock clusterClock) {
+    public ClusterableServer create(final ServerAddress serverAddress,
+                                    final ServerDescriptionChangedListener serverDescriptionChangedListener,
+                                    final ServerListener serverListener, final ClusterClock clusterClock) {
         TestServerMonitorFactory serverMonitorFactory = new TestServerMonitorFactory(new ServerId(clusterId, serverAddress));
         serverAddressToServerMonitorFactoryMap.put(serverAddress, serverMonitorFactory);
 
         return new DefaultServer(new ServerId(clusterId, serverAddress), clusterConnectionMode, new TestConnectionPool(),
-                new TestConnectionFactory(), serverMonitorFactory,
-                createServerListener(ServerSettings.builder().addServerListener(serverListener).build(),
-                        serverListenerFactory.create(serverAddress)), null, clusterClock);
+                new TestConnectionFactory(), serverMonitorFactory, serverDescriptionChangedListener,
+                serverListenerFactory.create(serverAddress), null, clusterClock);
     }
 
     @Override

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DnsMultiServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DnsMultiServerClusterSpecification.groovy
@@ -115,7 +115,7 @@ class DnsMultiServerClusterSpecification extends Specification {
         clusterDescription = cluster.getDescription()
 
         then: 'events are generated, description is updated, and the removed server is closed'
-        2 * clusterListener.clusterDescriptionChanged(_)
+        1 * clusterListener.clusterDescriptionChanged(_)
         clusterDescription.getType() == SHARDED
         ClusterDescriptionHelper.getAll(clusterDescription) == factory.getDescriptions(secondServer, thirdServer)
         clusterDescription.getSrvResolutionException() == null

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/EventHelperTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/EventHelperTest.java
@@ -39,7 +39,7 @@ import static com.mongodb.connection.ClusterType.STANDALONE;
 import static com.mongodb.connection.ServerConnectionState.CONNECTED;
 import static com.mongodb.connection.ServerConnectionState.CONNECTING;
 import static com.mongodb.connection.ServerDescription.builder;
-import static com.mongodb.internal.connection.EventHelper.equivalentEvent;
+import static com.mongodb.internal.connection.EventHelper.wouldDescriptionsGenerateEquivalentEvents;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -51,91 +51,97 @@ public class EventHelperTest {
     @Test
     public void testServerDescriptionEventEquivalence() {
         ServerDescription serverDescription = createBuilder().build();
-        assertTrue(equivalentEvent(serverDescription, serverDescription));
-        assertTrue(equivalentEvent((ServerDescription) null, null));
-        assertFalse(equivalentEvent(serverDescription, null));
-        assertFalse(equivalentEvent(null, serverDescription));
+        assertTrue(wouldDescriptionsGenerateEquivalentEvents(serverDescription, serverDescription));
+        assertTrue(wouldDescriptionsGenerateEquivalentEvents((ServerDescription) null, null));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, null));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(null, serverDescription));
 
-        assertTrue(equivalentEvent(createBuilder().build(), createBuilder().build()));
+        assertTrue(wouldDescriptionsGenerateEquivalentEvents(createBuilder().build(), createBuilder().build()));
 
-        assertFalse(equivalentEvent(serverDescription, createBuilder().ok(false).build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder().state(CONNECTING).build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder().type(ServerType.STANDALONE).build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder().minWireVersion(2).build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder().maxWireVersion(3).build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder().canonicalAddress("host:27017").build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder()
-                .hosts(new HashSet<String>(asList("localhost:27017", "localhost:27018", "localhost:27019"))).build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder()
-                .passives(new HashSet<String>(singletonList("localhost:27018"))).build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder()
-                .arbiters(new HashSet<String>(singletonList("localhost:27018"))).build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder().tagSet(new TagSet()).build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder().setName("test2").build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder().setVersion(3).build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder().electionId(new ObjectId()).build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder().primary("localhost:27018").build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder().logicalSessionTimeoutMinutes(26).build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder().topologyVersion(
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().ok(false).build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().state(CONNECTING).build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().type(ServerType.STANDALONE).build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().minWireVersion(2).build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().maxWireVersion(3).build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().canonicalAddress("host:27017").build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder()
+                .hosts(new HashSet<>(asList("localhost:27017", "localhost:27018", "localhost:27019"))).build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder()
+                .passives(new HashSet<>(singletonList("localhost:27018"))).build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder()
+                .arbiters(new HashSet<>(singletonList("localhost:27018"))).build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().tagSet(new TagSet()).build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().setName("test2").build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().setVersion(3).build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().electionId(new ObjectId()).build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().primary("localhost:27018").build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().logicalSessionTimeoutMinutes(26).build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().topologyVersion(
                 new TopologyVersion(new ObjectId("5e47699e32e4571020a96f07"), 43)).build()));
 
-        assertTrue(equivalentEvent(createBuilder().exception(new MongoException("msg1")).build(),
+        assertTrue(wouldDescriptionsGenerateEquivalentEvents(createBuilder().exception(new MongoException("msg1")).build(),
                 createBuilder().exception(new MongoException("msg1")).build()));
-        assertFalse(equivalentEvent(serverDescription, createBuilder().exception(new MongoException("msg1")).build()));
-        assertFalse(equivalentEvent(createBuilder().exception(new MongoException("msg1")).build(),
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(serverDescription,
+                createBuilder().exception(new MongoException("msg1")).build()));
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(createBuilder().exception(new MongoException("msg1")).build(),
                 createBuilder().exception(new MongoException("msg2")).build()));
-        assertFalse(equivalentEvent(createBuilder().exception(new MongoException("msg1")).build(),
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(createBuilder().exception(new MongoException("msg1")).build(),
                 createBuilder().exception(new IOException("msg1")).build()));
 
-        assertTrue(equivalentEvent(serverDescription, createBuilder().lastWriteDate(new Date(100)).build()));
+        assertTrue(wouldDescriptionsGenerateEquivalentEvents(serverDescription, createBuilder().lastWriteDate(new Date(100)).build()));
     }
 
     @Test
     public void testClusterDescriptionEquivalence() {
-        assertTrue(equivalentEvent(new ClusterDescription(SINGLE, STANDALONE, singletonList(createBuilder().build())),
+        assertTrue(wouldDescriptionsGenerateEquivalentEvents(
+                new ClusterDescription(SINGLE, STANDALONE, singletonList(createBuilder().build())),
                 new ClusterDescription(SINGLE, STANDALONE, singletonList(createBuilder().build()))));
-        assertTrue(equivalentEvent(new ClusterDescription(MULTIPLE, REPLICA_SET,
+        assertTrue(wouldDescriptionsGenerateEquivalentEvents(new ClusterDescription(MULTIPLE, REPLICA_SET,
                         asList(createBuilder("localhost:27017").build(),
                                 createBuilder("localhost:27018").build())),
                 new ClusterDescription(MULTIPLE, REPLICA_SET,
                         asList(createBuilder("localhost:27017").build(),
                                 createBuilder("localhost:27018").build()))));
-        assertTrue(equivalentEvent(new ClusterDescription(MULTIPLE, REPLICA_SET,
+        assertTrue(wouldDescriptionsGenerateEquivalentEvents(new ClusterDescription(MULTIPLE, REPLICA_SET,
                         asList(createBuilder("localhost:27017").build(),
                                 createBuilder("localhost:27018").build())),
                 new ClusterDescription(MULTIPLE, REPLICA_SET,
                         asList(createBuilder("localhost:27018").build(),
                                 createBuilder("localhost:27017").build()))));
 
-        assertFalse(equivalentEvent(new ClusterDescription(SINGLE, STANDALONE, singletonList(createBuilder().build())),
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(
+                new ClusterDescription(SINGLE, STANDALONE, singletonList(createBuilder().build())),
                 new ClusterDescription(SINGLE, STANDALONE, singletonList(createBuilder().maxWireVersion(4).build()))));
-        assertFalse(equivalentEvent(new ClusterDescription(MULTIPLE, REPLICA_SET,
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(new ClusterDescription(MULTIPLE, REPLICA_SET,
                         asList(createBuilder("localhost:27017").build(),
                                 createBuilder("localhost:27018").build())),
                 new ClusterDescription(MULTIPLE, REPLICA_SET,
                         singletonList(createBuilder("localhost:27017").build()))));
-        assertFalse(equivalentEvent(new ClusterDescription(MULTIPLE, REPLICA_SET,
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(new ClusterDescription(MULTIPLE, REPLICA_SET,
                         asList(createBuilder("localhost:27017").build(),
                                 createBuilder("localhost:27018").build())),
                 new ClusterDescription(MULTIPLE, REPLICA_SET,
                         asList(createBuilder("localhost:27017").build(),
                                 createBuilder("localhost:27018").maxWireVersion(4).build()))));
-        assertFalse(equivalentEvent(new ClusterDescription(MULTIPLE, REPLICA_SET,
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(new ClusterDescription(MULTIPLE, REPLICA_SET,
                         asList(createBuilder("localhost:27017").build(),
                                 createBuilder("localhost:27018").build())),
                 new ClusterDescription(MULTIPLE, REPLICA_SET,
                         asList(createBuilder("localhost:27018").build(),
                                 createBuilder("localhost:27017").maxWireVersion(4).build()))));
 
-        assertTrue(equivalentEvent(new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null),
+        assertTrue(wouldDescriptionsGenerateEquivalentEvents(
+                new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null),
                 new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null)));
-        assertFalse(equivalentEvent(new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null),
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(
+                new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null),
                 new ClusterDescription(SINGLE, STANDALONE, null, emptyList(), null, null)));
-        assertFalse(equivalentEvent(new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null),
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(
+                new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null),
                 new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg2"), emptyList(), null, null)));
-        assertFalse(equivalentEvent(new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null),
+        assertFalse(wouldDescriptionsGenerateEquivalentEvents(
+                new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null),
                 new ClusterDescription(SINGLE, STANDALONE, new MongoClientException("msg1"), emptyList(), null, null)));
-
     }
 
     private ServerDescription.Builder createBuilder() {
@@ -150,9 +156,9 @@ public class EventHelperTest {
                 .minWireVersion(1)
                 .maxWireVersion(2)
                 .canonicalAddress(address)
-                .hosts(new HashSet<String>(asList("localhost:27017", "localhost:27018")))
-                .passives(new HashSet<String>(singletonList("localhost:27019")))
-                .arbiters(new HashSet<String>(singletonList("localhost:27020")))
+                .hosts(new HashSet<>(asList("localhost:27017", "localhost:27018")))
+                .passives(new HashSet<>(singletonList("localhost:27019")))
+                .arbiters(new HashSet<>(singletonList("localhost:27020")))
                 .tagSet(new TagSet(singletonList(new Tag("dc", "ny"))))
                 .setName("test")
                 .setVersion(2)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/EventHelperTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/EventHelperTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.connection;
+
+import com.mongodb.MongoClientException;
+import com.mongodb.MongoException;
+import com.mongodb.ServerAddress;
+import com.mongodb.Tag;
+import com.mongodb.TagSet;
+import com.mongodb.connection.ClusterDescription;
+import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.ServerType;
+import com.mongodb.connection.TopologyVersion;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashSet;
+
+import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE;
+import static com.mongodb.connection.ClusterConnectionMode.SINGLE;
+import static com.mongodb.connection.ClusterType.REPLICA_SET;
+import static com.mongodb.connection.ClusterType.STANDALONE;
+import static com.mongodb.connection.ServerConnectionState.CONNECTED;
+import static com.mongodb.connection.ServerConnectionState.CONNECTING;
+import static com.mongodb.connection.ServerDescription.builder;
+import static com.mongodb.internal.connection.EventHelper.equivalentEvent;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class EventHelperTest {
+
+    @Test
+    public void testServerDescriptionEventEquivalence() {
+        ServerDescription serverDescription = createBuilder().build();
+        assertTrue(equivalentEvent(serverDescription, serverDescription));
+        assertTrue(equivalentEvent((ServerDescription) null, null));
+        assertFalse(equivalentEvent(serverDescription, null));
+        assertFalse(equivalentEvent(null, serverDescription));
+
+        assertTrue(equivalentEvent(createBuilder().build(), createBuilder().build()));
+
+        assertFalse(equivalentEvent(serverDescription, createBuilder().ok(false).build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder().state(CONNECTING).build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder().type(ServerType.STANDALONE).build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder().minWireVersion(2).build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder().maxWireVersion(3).build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder().canonicalAddress("host:27017").build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder()
+                .hosts(new HashSet<String>(asList("localhost:27017", "localhost:27018", "localhost:27019"))).build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder()
+                .passives(new HashSet<String>(singletonList("localhost:27018"))).build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder()
+                .arbiters(new HashSet<String>(singletonList("localhost:27018"))).build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder().tagSet(new TagSet()).build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder().setName("test2").build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder().setVersion(3).build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder().electionId(new ObjectId()).build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder().primary("localhost:27018").build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder().logicalSessionTimeoutMinutes(26).build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder().topologyVersion(
+                new TopologyVersion(new ObjectId("5e47699e32e4571020a96f07"), 43)).build()));
+
+        assertTrue(equivalentEvent(createBuilder().exception(new MongoException("msg1")).build(),
+                createBuilder().exception(new MongoException("msg1")).build()));
+        assertFalse(equivalentEvent(serverDescription, createBuilder().exception(new MongoException("msg1")).build()));
+        assertFalse(equivalentEvent(createBuilder().exception(new MongoException("msg1")).build(),
+                createBuilder().exception(new MongoException("msg2")).build()));
+        assertFalse(equivalentEvent(createBuilder().exception(new MongoException("msg1")).build(),
+                createBuilder().exception(new IOException("msg1")).build()));
+
+        assertTrue(equivalentEvent(serverDescription, createBuilder().lastWriteDate(new Date(100)).build()));
+    }
+
+    @Test
+    public void testClusterDescriptionEquivalence() {
+        assertTrue(equivalentEvent(new ClusterDescription(SINGLE, STANDALONE, singletonList(createBuilder().build())),
+                new ClusterDescription(SINGLE, STANDALONE, singletonList(createBuilder().build()))));
+        assertTrue(equivalentEvent(new ClusterDescription(MULTIPLE, REPLICA_SET,
+                        asList(createBuilder("localhost:27017").build(),
+                                createBuilder("localhost:27018").build())),
+                new ClusterDescription(MULTIPLE, REPLICA_SET,
+                        asList(createBuilder("localhost:27017").build(),
+                                createBuilder("localhost:27018").build()))));
+        assertTrue(equivalentEvent(new ClusterDescription(MULTIPLE, REPLICA_SET,
+                        asList(createBuilder("localhost:27017").build(),
+                                createBuilder("localhost:27018").build())),
+                new ClusterDescription(MULTIPLE, REPLICA_SET,
+                        asList(createBuilder("localhost:27018").build(),
+                                createBuilder("localhost:27017").build()))));
+
+        assertFalse(equivalentEvent(new ClusterDescription(SINGLE, STANDALONE, singletonList(createBuilder().build())),
+                new ClusterDescription(SINGLE, STANDALONE, singletonList(createBuilder().maxWireVersion(4).build()))));
+        assertFalse(equivalentEvent(new ClusterDescription(MULTIPLE, REPLICA_SET,
+                        asList(createBuilder("localhost:27017").build(),
+                                createBuilder("localhost:27018").build())),
+                new ClusterDescription(MULTIPLE, REPLICA_SET,
+                        singletonList(createBuilder("localhost:27017").build()))));
+        assertFalse(equivalentEvent(new ClusterDescription(MULTIPLE, REPLICA_SET,
+                        asList(createBuilder("localhost:27017").build(),
+                                createBuilder("localhost:27018").build())),
+                new ClusterDescription(MULTIPLE, REPLICA_SET,
+                        asList(createBuilder("localhost:27017").build(),
+                                createBuilder("localhost:27018").maxWireVersion(4).build()))));
+        assertFalse(equivalentEvent(new ClusterDescription(MULTIPLE, REPLICA_SET,
+                        asList(createBuilder("localhost:27017").build(),
+                                createBuilder("localhost:27018").build())),
+                new ClusterDescription(MULTIPLE, REPLICA_SET,
+                        asList(createBuilder("localhost:27018").build(),
+                                createBuilder("localhost:27017").maxWireVersion(4).build()))));
+
+        assertTrue(equivalentEvent(new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null),
+                new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null)));
+        assertFalse(equivalentEvent(new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null),
+                new ClusterDescription(SINGLE, STANDALONE, null, emptyList(), null, null)));
+        assertFalse(equivalentEvent(new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null),
+                new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg2"), emptyList(), null, null)));
+        assertFalse(equivalentEvent(new ClusterDescription(SINGLE, STANDALONE, new MongoException("msg1"), emptyList(), null, null),
+                new ClusterDescription(SINGLE, STANDALONE, new MongoClientException("msg1"), emptyList(), null, null)));
+
+    }
+
+    private ServerDescription.Builder createBuilder() {
+        return createBuilder("localhost:27017");
+    }
+
+    private ServerDescription.Builder createBuilder(final String address) {
+        return builder().address(new ServerAddress(address))
+                .ok(true)
+                .state(CONNECTED)
+                .type(ServerType.REPLICA_SET_PRIMARY)
+                .minWireVersion(1)
+                .maxWireVersion(2)
+                .canonicalAddress(address)
+                .hosts(new HashSet<String>(asList("localhost:27017", "localhost:27018")))
+                .passives(new HashSet<String>(singletonList("localhost:27019")))
+                .arbiters(new HashSet<String>(singletonList("localhost:27020")))
+                .tagSet(new TagSet(singletonList(new Tag("dc", "ny"))))
+                .setName("test")
+                .setVersion(2)
+                .electionId(new ObjectId("abcdabcdabcdabcdabcdabcd"))
+                .primary("localhost:27017")
+                .logicalSessionTimeoutMinutes(25)
+                .topologyVersion(new TopologyVersion(new ObjectId("5e47699e32e4571020a96f07"), 42))
+                .lastWriteDate(new Date(99));
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestClusterableServerFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestClusterableServerFactory.java
@@ -37,9 +37,11 @@ public class TestClusterableServerFactory implements ClusterableServerFactory {
     private final Map<ServerAddress, TestServer> addressToServerMap = new HashMap<ServerAddress, TestServer>();
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress, final ServerListener serverListener,
+    public ClusterableServer create(final ServerAddress serverAddress,
+                                    final ServerDescriptionChangedListener serverDescriptionChangedListener,
+                                    final ServerListener serverListener,
                                     final ClusterClock clusterClock) {
-        addressToServerMap.put(serverAddress, new TestServer(serverAddress, serverListener));
+        addressToServerMap.put(serverAddress, new TestServer(serverAddress, serverDescriptionChangedListener, serverListener));
         return addressToServerMap.get(serverAddress);
     }
 

--- a/driver-sync/src/test/functional/com/mongodb/client/ServerDiscoveryAndMonitoringProseTests.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ServerDiscoveryAndMonitoringProseTests.java
@@ -92,7 +92,7 @@ public class ServerDiscoveryAndMonitoringProseTests {
         try (MongoClient client = MongoClients.create(settings)) {
             client.getDatabase("admin").runCommand(new Document("ping", 1));
             Thread.sleep(250);
-            assertTrue(events.size() > 1);
+            assertTrue(events.size() >= 1);
             events.forEach(event ->
                            assertTrue(event.getNewDescription().getRoundTripTimeNanos() > 0));
 


### PR DESCRIPTION
The design problem presented by this requirement is that currently we combine the ServerListener registered by Cluster implementations to be informed of server changes with any ServerListeners registered by an application.  This turns out to be incorrect, because different rules apply.  The Cluster needs to be informed of all changes to server descriptions, e.g. including changes to RTT.  But the spec requires that server events are only delivered to applications under certain rules of equality.  So to implement this, in the first commit I refactored Server and Cluster implementations to separate the two types of listeners (adding a new private interface for the former).  In the second commit I implemented the event suppression rules required by the specification.

* https://jira.mongodb.org/browse/JAVA-3485
* https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#server-description-equality
* https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#server-description-equality

https://spruce.mongodb.com/version/5f4ab0a92a60ed0c9dcaac25/tasks