### PR TITLE
Update server discovery monitoring tests with directConnection URI option

### DIFF
--- a/driver-core/src/test/resources/server-discovery-and-monitoring-monitoring/discovered_standalone.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring-monitoring/discovered_standalone.json
@@ -1,6 +1,6 @@
 {
-  "description": "Monitoring a direct connection",
-  "uri": "mongodb://a:27017/?directConnection=true",
+  "description": "Monitoring a discovered standalone connection",
+  "uri": "mongodb://a:27017/?directConnection=false",
   "phases": [
     {
       "responses": [
@@ -29,7 +29,7 @@
                 "servers": []
               },
               "newDescription": {
-                "topologyType": "Single",
+                "topologyType": "Unknown",
                 "servers": [
                   {
                     "address": "a:27017",
@@ -72,7 +72,7 @@
             "topology_description_changed_event": {
               "topologyId": "42",
               "previousDescription": {
-                "topologyType": "Single",
+                "topologyType": "Unknown",
                 "servers": [
                   {
                     "address": "a:27017",

--- a/driver-core/src/test/resources/server-discovery-and-monitoring-monitoring/standalone_suppress_equal_description_changes.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring-monitoring/standalone_suppress_equal_description_changes.json
@@ -1,6 +1,6 @@
 {
-  "description": "Monitoring a standalone connection - suppress update events for equal server descriptions",
-  "uri": "mongodb://a:27017",
+  "description": "Monitoring a direct connection - suppress update events for equal server descriptions",
+  "uri": "mongodb://a:27017/?directConnection=true",
   "phases": [
     {
       "responses": [

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractServerDiscoveryAndMonitoringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractServerDiscoveryAndMonitoringTest.java
@@ -186,6 +186,14 @@ public class AbstractServerDiscoveryAndMonitoringTest {
         return definition;
     }
 
+    protected boolean isSingleServerClusterExpected() {
+        ConnectionString connectionString = new ConnectionString(definition.getString("uri").getValue());
+        Boolean directConnection = connectionString.isDirectConnection();
+        return (directConnection != null && directConnection)
+                || (directConnection == null && connectionString.getHosts().size() == 1
+                && connectionString.getRequiredReplicaSetName() == null);
+    }
+
     protected DefaultTestClusterableServerFactory getFactory() {
         return factory;
     }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringMonitoringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringMonitoringTest.java
@@ -102,7 +102,7 @@ public class ServerDiscoveryAndMonitoringMonitoringTest extends AbstractServerDi
                 BsonDocument newDescription = topologyDescriptionChangedEventDocument.getDocument("newDescription");
                 assertEqualClusterDescriptions(createClusterDescriptionFromClusterDescriptionDocument(newDescription),
                         event.getNewDescription());
-                if (newDescription.getString("topologyType").getValue().equals("Single")) {
+                if (newDescription.getString("topologyType").getValue().equals("Single") && isSingleServerClusterExpected()) {
                     assertEquals(SingleServerCluster.class, getCluster().getClass());
                 } else {
                     assertEquals(MultiServerCluster.class, getCluster().getClass());


### PR DESCRIPTION
https://jira.mongodb.org/browse/JAVA-3824

No patch build since it's just a change to unit tests, which I ran locally.