### PR TITLE
Support parsing $uuid in JSON

### DIFF
--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -42,6 +42,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.UUID;
 
 import static java.lang.String.format;
 
@@ -608,6 +609,10 @@ public class JsonReader extends AbstractBsonReader {
                     setCurrentBsonType(BsonType.BINARY);
                     return;
                 }
+            } if ("$uuid".equals(value)) {
+                currentValue = visitUuidExtendedJson();
+                setCurrentBsonType(BsonType.BINARY);
+                return;
             } else if ("$regex".equals(value) || "$options".equals(value)) {
                 currentValue = visitRegularExpressionExtendedJson(value);
                 if (currentValue != null) {
@@ -1209,6 +1214,17 @@ public class JsonReader extends AbstractBsonReader {
             throw new JsonParseException("JSON reader expected an integer but found '%s'.", nextToken.getValue());
         }
         return value;
+    }
+
+    private BsonBinary visitUuidExtendedJson() {
+        verifyToken(JsonTokenType.COLON);
+        String uuidString = readStringFromExtendedJson();
+        verifyToken(JsonTokenType.END_OBJECT);
+        try {
+            return new BsonBinary(UUID.fromString(uuidString));
+        } catch (IllegalArgumentException e) {
+            throw new JsonParseException(e);
+        }
     }
 
     private void visitJavaScriptExtendedJson() {

--- a/bson/src/test/resources/bson/binary.json
+++ b/bson/src/test/resources/bson/binary.json
@@ -40,6 +40,12 @@
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}"
         },
         {
+            "description": "subtype 0x04 UUID",
+            "canonical_bson": "1D000000057800100000000473FFD26444B34C6990E8E7D1DFC035D400",
+            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}",
+            "degenerate_extjson": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}"
+        },
+        {
             "description": "subtype 0x05",
             "canonical_bson": "1D000000057800100000000573FFD26444B34C6990E8E7D1DFC035D400",
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"05\"}}}"
@@ -80,6 +86,16 @@
         {
             "description": "subtype 0x02 length negative one",
             "bson": "130000000578000600000002FFFFFFFFFFFF00"
+        }
+    ],
+    "parseErrors": [
+        {
+            "description": "$uuid wrong type",
+            "string": "{\"x\" : { \"$uuid\" : { \"data\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}}"
+        },
+        {
+            "description": "$uuid invalid value",
+            "string": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-90e8-e7d1dfc035d4\"}}"
         }
     ]
 }

--- a/bson/src/test/unit/org/bson/GenericBsonTest.java
+++ b/bson/src/test/unit/org/bson/GenericBsonTest.java
@@ -259,7 +259,7 @@ public class GenericBsonTest {
             } catch (NumberFormatException e) {
                 // all good
             }
-        } else if (testDefinitionDescription.startsWith("Top-level")) {
+        } else if (testDefinitionDescription.startsWith("Top-level") || testDefinitionDescription.startsWith("Binary type")) {
             try {
                 parse(str);
                 fail("Should fail to parse JSON '" + str + "' with description '" + description + "'");

--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -946,6 +946,18 @@ public class JsonReaderTest {
     }
 
     @Test
+    public void testUuid() {
+        String json = "{ \"$uuid\" : \"b5f21e0c-2a0d-42d6-ad03-d827008d8ab6\"}}";
+        testStringAndStream(json, bsonReader -> {
+            assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+            BsonBinary binary = bsonReader.readBinaryData();
+            assertEquals(BsonBinarySubType.UUID_STANDARD.getValue(), binary.getType());
+            assertArrayEquals(new byte[]{-75, -14, 30, 12, 42, 13, 66, -42, -83, 3, -40, 39, 0, -115, -118, -74}, binary.getData());
+            assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+            return null;
+        });
+    }
+    @Test
     public void testUuidConstructor() {
         String json = "UUID(\"b5f21e0c-2a0d-42d6-ad03-d827008d8ab6\")";
         testStringAndStream(json, bsonReader -> {


### PR DESCRIPTION
$uuid is a synonym for a subtype 4 $binary, and is typically found in MongoDB 4.4+ server logs

JAVA-3834