### PR TITLE
Fix scala publishing

### DIFF
--- a/.evergreen/publish.sh
+++ b/.evergreen/publish.sh
@@ -34,4 +34,5 @@ SYSTEM_PROPERTIES="-Dorg.gradle.internal.publish.checksums.insecure=true -Dorg.g
 
 ./gradlew -version
 ./gradlew ${SYSTEM_PROPERTIES} --stacktrace --info  ${TASK}
-./gradlew ${SYSTEM_PROPERTIES} --stacktrace --info :bson-scala:${TASK} :driver-scala:${TASK} -PdefaultScalaVersions=2.11.12,2.12.10
+./gradlew ${SYSTEM_PROPERTIES} --stacktrace --info :bson-scala:${TASK} :driver-scala:${TASK} -PdefaultScalaVersions=2.12.12
+./gradlew ${SYSTEM_PROPERTIES} --stacktrace --info :bson-scala:${TASK} :driver-scala:${TASK} -PdefaultScalaVersions=2.11.12

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
         classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:5.1.2'
         
         // Scala plugins
-        classpath "com.adtran:scala-multiversion-plugin:1.+"
+        classpath "com.adtran:scala-multiversion-plugin:1.0.36"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:3.27.1"
 
         // Test logging plugin

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
         classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:5.1.2'
         
         // Scala plugins
-        classpath "com.adtran:scala-multiversion-plugin:1.0.35"
+        classpath "com.adtran:scala-multiversion-plugin:1.+"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:3.27.1"
 
         // Test logging plugin


### PR DESCRIPTION
Use the latest scala multiversion plugin
Split out the publishing steps

JAVA-3843

Patch: https://spruce.mongodb.com/version/5f6b310a1e2d17450be4b41e/tasks
Snapshots: https://oss.sonatype.org/content/repositories/snapshots/org/mongodb/scala/