### PR TITLE
JAVA-3567: Add support for records

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/ClassModelBuilder.java
+++ b/bson/src/main/org/bson/codecs/pojo/ClassModelBuilder.java
@@ -55,6 +55,7 @@ public class ClassModelBuilder<T> {
     private String discriminator;
     private String discriminatorKey;
     private String idPropertyName;
+    private boolean isRecord;
 
     ClassModelBuilder(final Class<T> type) {
         configureClassModelBuilder(this, notNull("type", type));
@@ -234,6 +235,23 @@ public class ClassModelBuilder<T> {
      */
     public boolean removeProperty(final String propertyName) {
         return propertyModelBuilders.remove(getProperty(notNull("propertyName", propertyName)));
+    }
+
+    /**
+     * @return returns true if the ClassModelBuilder represents a record
+     */
+    public boolean getIsRecord() {
+        return isRecord;
+    }
+
+    /**
+     * Sets whether or not the ClassModelBuilder represents a record
+     * @param isRecord whether or not the ClassModelBuilder represents a record
+     * @return this
+     */
+    public ClassModelBuilder<T> isRecord(boolean isRecord) {
+        this.isRecord = isRecord;
+        return this;
     }
 
     /**

--- a/bson/src/main/org/bson/codecs/pojo/ConstructorCreatorExecutable.java
+++ b/bson/src/main/org/bson/codecs/pojo/ConstructorCreatorExecutable.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo;
+
+import org.bson.codecs.configuration.CodecConfigurationException;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+
+final class ConstructorCreatorExecutable<T> implements CreatorExecutable<T> {
+    private final Class<T> clazz;
+    private final Constructor<T> constructor;
+    private final List<String> properties = new ArrayList<>();
+    private final Integer idPropertyIndex;
+    private final List<Class<?>> parameterTypes = new ArrayList<Class<?>>();
+    private final List<Type> parameterGenericTypes = new ArrayList<Type>();
+
+    ConstructorCreatorExecutable(final Class<T> clazz, final Constructor<T> constructor) {
+        this.clazz = clazz;
+        this.constructor = constructor;
+        Integer idPropertyIndex = null;
+
+        if (constructor != null) {
+            Class<?>[] paramTypes = constructor.getParameterTypes();
+            Type[] genericParamTypes = constructor.getGenericParameterTypes();
+            parameterTypes.addAll(asList(paramTypes));
+            parameterGenericTypes.addAll(asList(genericParamTypes));
+
+            Annotation[][] parameterAnnotations = constructor.getParameterAnnotations();
+            idPropertyIndex = CreatorExecutable.initializeDataFromAnnotations(parameterAnnotations, properties);
+        }
+
+        this.idPropertyIndex = idPropertyIndex;
+    }
+
+    @Override
+    public Class<T> getType() {
+        return clazz;
+    }
+
+    @Override
+    public List<String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public Integer getIdPropertyIndex() {
+        return idPropertyIndex;
+    }
+
+    @Override
+    public List<Class<?>> getParameterTypes() {
+        return parameterTypes;
+    }
+
+    @Override
+    public List<Type> getParameterGenericTypes() {
+        return parameterGenericTypes;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T getInstance(final Object... params) {
+        checkHasAnExecutable();
+        try {
+            return constructor.newInstance(params);
+        } catch (Exception e) {
+            throw new CodecConfigurationException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CodecConfigurationException getError(final Class<?> clazz, final String msg) {
+        return new CodecConfigurationException(format("Invalid @BsonCreator constructor in %s. %s",
+                clazz.getSimpleName(), msg));    }
+
+    private void checkHasAnExecutable() {
+        if (constructor == null) {
+            throw new CodecConfigurationException(format("Cannot find a public constructor for '%s'.", clazz.getSimpleName()));
+        }
+    }
+}

--- a/bson/src/main/org/bson/codecs/pojo/CreatorExecutable.java
+++ b/bson/src/main/org/bson/codecs/pojo/CreatorExecutable.java
@@ -21,129 +21,43 @@ import org.bson.codecs.pojo.annotations.BsonId;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.List;
+import java.lang.reflect.Type;
 
-import static java.lang.String.format;
-import static java.util.Arrays.asList;
+interface CreatorExecutable<T> {
+    Class<T> getType();
 
-final class CreatorExecutable<T> {
-    private final Class<T> clazz;
-    private final Constructor<T> constructor;
-    private final Method method;
-    private final List<BsonProperty> properties = new ArrayList<BsonProperty>();
-    private final Integer idPropertyIndex;
-    private final List<Class<?>> parameterTypes = new ArrayList<Class<?>>();
-    private final List<Type> parameterGenericTypes = new ArrayList<Type>();
+    List<String> getProperties();
 
-    CreatorExecutable(final Class<T> clazz, final Constructor<T> constructor) {
-        this(clazz, constructor, null);
-    }
+    Integer getIdPropertyIndex();
 
-    CreatorExecutable(final Class<T> clazz, final Method method) {
-        this(clazz, null, method);
-    }
+    List<Class<?>> getParameterTypes();
 
-    private CreatorExecutable(final Class<T> clazz, final Constructor<T> constructor, final Method method) {
-        this.clazz = clazz;
-        this.constructor = constructor;
-        this.method = method;
+    List<Type> getParameterGenericTypes();
+
+    T getInstance(Object... params);
+
+    CodecConfigurationException getError(Class<?> clazz, String msg);
+
+    static Integer initializeDataFromAnnotations(Annotation[][] parameterAnnotations, List<String> properties) {
         Integer idPropertyIndex = null;
+        for (int i = 0; i < parameterAnnotations.length; ++i) {
+            Annotation[] parameterAnnotation = parameterAnnotations[i];
 
-        if (constructor != null || method != null) {
-            Class<?>[] paramTypes = constructor != null ? constructor.getParameterTypes() : method.getParameterTypes();
-            Type[] genericParamTypes = constructor != null ? constructor.getGenericParameterTypes() : method.getGenericParameterTypes();
-            parameterTypes.addAll(asList(paramTypes));
-            parameterGenericTypes.addAll(asList(genericParamTypes));
-            Annotation[][] parameterAnnotations = constructor != null ? constructor.getParameterAnnotations()
-                    : method.getParameterAnnotations();
+            for (Annotation annotation : parameterAnnotation) {
+                if (annotation.annotationType().equals(BsonProperty.class)) {
+                    properties.add(((BsonProperty) annotation).value());
+                    break;
+                }
 
-            for (int i = 0; i < parameterAnnotations.length; ++i) {
-                Annotation[] parameterAnnotation = parameterAnnotations[i];
-
-                for (Annotation annotation : parameterAnnotation) {
-                    if (annotation.annotationType().equals(BsonProperty.class)) {
-                        properties.add((BsonProperty) annotation);
-                        break;
-                    }
-
-                    if (annotation.annotationType().equals(BsonId.class)) {
-                        properties.add(null);
-                        idPropertyIndex = i;
-                        break;
-                    }
+                if (annotation.annotationType().equals(BsonId.class)) {
+                    properties.add(null);
+                    idPropertyIndex = i;
+                    break;
                 }
             }
         }
-
-        this.idPropertyIndex = idPropertyIndex;
-    }
-
-    Class<T> getType() {
-        return clazz;
-    }
-
-    List<BsonProperty> getProperties() {
-        return properties;
-    }
-
-    Integer getIdPropertyIndex() {
         return idPropertyIndex;
-    }
-
-    List<Class<?>> getParameterTypes() {
-        return parameterTypes;
-    }
-
-    List<Type> getParameterGenericTypes() {
-        return parameterGenericTypes;
-    }
-
-    @SuppressWarnings("unchecked")
-    T getInstance() {
-        checkHasAnExecutable();
-        try {
-            if (constructor != null) {
-                return constructor.newInstance();
-            } else {
-                return (T) method.invoke(clazz);
-            }
-        } catch (Exception e) {
-            throw new CodecConfigurationException(e.getMessage(), e);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    T getInstance(final Object[] params) {
-        checkHasAnExecutable();
-        try {
-            if (constructor != null) {
-                return constructor.newInstance(params);
-            } else {
-                return (T) method.invoke(clazz, params);
-            }
-        } catch (Exception e) {
-            throw new CodecConfigurationException(e.getMessage(), e);
-        }
-    }
-
-
-    CodecConfigurationException getError(final Class<?> clazz, final String msg) {
-        return getError(clazz, constructor != null, msg);
-    }
-
-    private void checkHasAnExecutable() {
-        if (constructor == null && method == null) {
-            throw new CodecConfigurationException(format("Cannot find a public constructor for '%s'.", clazz.getSimpleName()));
-        }
-    }
-
-    private static CodecConfigurationException getError(final Class<?> clazz, final boolean isConstructor, final String msg) {
-        return new CodecConfigurationException(format("Invalid @BsonCreator %s in %s. %s", isConstructor ? "constructor" : "method",
-                clazz.getSimpleName(), msg));
     }
 
 }

--- a/bson/src/main/org/bson/codecs/pojo/InstanceCreatorImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/InstanceCreatorImpl.java
@@ -46,7 +46,7 @@ final class InstanceCreatorImpl<T> implements InstanceCreator<T> {
                 if (creatorExecutable.getIdPropertyIndex() != null && creatorExecutable.getIdPropertyIndex() == i) {
                     this.properties.put(ClassModelBuilder.ID_PROPERTY_NAME, creatorExecutable.getIdPropertyIndex());
                 } else {
-                    this.properties.put(creatorExecutable.getProperties().get(i).value(), i);
+                    this.properties.put(creatorExecutable.getProperties().get(i), i);
                 }
             }
 

--- a/bson/src/main/org/bson/codecs/pojo/MethodCreatorExecutable.java
+++ b/bson/src/main/org/bson/codecs/pojo/MethodCreatorExecutable.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo;
+
+import org.bson.codecs.configuration.CodecConfigurationException;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+
+final class MethodCreatorExecutable<T> implements CreatorExecutable<T> {
+    private final Class<T> clazz;
+    private final Method method;
+    private final List<String> properties = new ArrayList<>();
+    private final Integer idPropertyIndex;
+    private final List<Class<?>> parameterTypes = new ArrayList<Class<?>>();
+    private final List<Type> parameterGenericTypes = new ArrayList<Type>();
+
+    MethodCreatorExecutable(final Class<T> clazz, final Method method) {
+        this.clazz = clazz;
+        this.method = method;
+        Integer idPropertyIndex = null;
+
+        if (method != null) {
+            Class<?>[] paramTypes = method.getParameterTypes();
+            Type[] genericParamTypes = method.getGenericParameterTypes();
+            parameterTypes.addAll(asList(paramTypes));
+            parameterGenericTypes.addAll(asList(genericParamTypes));
+
+            Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+            CreatorExecutable.initializeDataFromAnnotations(parameterAnnotations, properties);
+        }
+
+        this.idPropertyIndex = idPropertyIndex;
+    }
+
+    @Override
+    public Class<T> getType() {
+        return clazz;
+    }
+
+    @Override
+    public List<String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public Integer getIdPropertyIndex() {
+        return idPropertyIndex;
+    }
+
+    @Override
+    public List<Class<?>> getParameterTypes() {
+        return parameterTypes;
+    }
+
+    @Override
+    public List<Type> getParameterGenericTypes() {
+        return parameterGenericTypes;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T getInstance(final Object... params) {
+        checkHasAnExecutable();
+        try {
+            return (T) method.invoke(clazz, params);
+        } catch (Exception e) {
+            throw new CodecConfigurationException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CodecConfigurationException getError(final Class<?> clazz, final String msg) {
+        return new CodecConfigurationException(format("Invalid @BsonCreator method in %s. %s",
+                clazz.getSimpleName(), msg));
+    }
+
+    private void checkHasAnExecutable() {
+        if (method == null) {
+            throw new CodecConfigurationException(format("Cannot find a public method to construct"
+                   + " the object with for '%s'.", clazz.getSimpleName()));
+        }
+    }
+}

--- a/bson/src/main/org/bson/codecs/pojo/RecordCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/pojo/RecordCodecProvider.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo;
+
+import org.bson.codecs.Codec;
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.diagnostics.Logger;
+import org.bson.diagnostics.Loggers;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static org.bson.assertions.Assertions.notNull;
+
+/**
+ * Provides Codecs for registered Records via the ClassModel abstractions.
+ *
+ * @since TODO
+ */
+public final class RecordCodecProvider implements CodecProvider {
+    static final Logger LOGGER = Loggers.getLogger("codecs.record");
+    private final boolean automatic;
+    private final Map<Class<?>, ClassModel<?>> classModels;
+    private final Set<String> packages;
+    private final DiscriminatorLookup discriminatorLookup;
+    private final List<PropertyCodecProvider> propertyCodecProviders;
+
+    private RecordCodecProvider(final boolean automatic, final Map<Class<?>, ClassModel<?>> classModels, final Set<String> packages,
+                              final List<PropertyCodecProvider> propertyCodecProviders) {
+        this.automatic = automatic;
+        this.classModels = classModels;
+        this.packages = packages;
+        this.discriminatorLookup = new DiscriminatorLookup(classModels, packages);
+        this.propertyCodecProviders = propertyCodecProviders;
+    }
+
+    /**
+     * Creates a Builder so classes or packages can be registered and configured before creating an immutable CodecProvider.
+     *
+     * @return the Builder
+     * @see RecordCodecProvider.Builder#register(Class[])
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
+        if (!PojoBuilderHelper.isRecord(clazz)) {
+            return null;
+        }
+
+        ClassModel<T> classModel = (ClassModel<T>) classModels.get(clazz);
+        if (classModel != null) {
+            return new PojoCodecImpl<T>(classModel, registry, propertyCodecProviders, discriminatorLookup);
+        } else if (automatic || (clazz.getPackage() != null && packages.contains(clazz.getPackage().getName()))) {
+            try {
+                classModel = createClassModel(clazz);
+                if (clazz.isInterface() || !classModel.getPropertyModels().isEmpty()) {
+                    discriminatorLookup.addClassModel(classModel);
+                    return new AutomaticPojoCodec<T>(new PojoCodecImpl<T>(classModel, registry, propertyCodecProviders,
+                            discriminatorLookup));
+                }
+            } catch (Exception e) {
+                LOGGER.warn(format("Cannot use '%s' with the PojoCodec for records.", clazz.getSimpleName()), e);
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * A Builder for the RecordCodecProvider
+     */
+    public static final class Builder {
+        private final Set<String> packages = new HashSet<String>();
+        private final Map<Class<?>, ClassModel<?>> classModels = new HashMap<Class<?>, ClassModel<?>>();
+        private final List<Class<?>> clazzes = new ArrayList<Class<?>>();
+        private List<Convention> conventions = null;
+        private final List<PropertyCodecProvider> propertyCodecProviders = new ArrayList<PropertyCodecProvider>();
+        private boolean automatic;
+
+        /**
+         * Sets whether the provider should automatically try to wrap a {@link ClassModel} for any class that is requested.
+         *
+         * @param automatic whether to automatically wrap {@code ClassModels} or not.
+         * @return this
+         */
+        public Builder automatic(final boolean automatic) {
+            this.automatic = automatic;
+            return this;
+        }
+
+        /**
+         * Registers a classes with the builder for inclusion in the Provider.
+         *
+         * <p>Note: Uses reflection for the property mapping.
+         *
+         * @param classes the classes to register
+         * @return this
+         */
+        public Builder register(final Class<?>... classes) {
+            clazzes.addAll(asList(classes));
+            return this;
+        }
+
+        /**
+         * Registers classModels for inclusion in the Provider.
+         *
+         * @param classModels the classModels to register
+         * @return this
+         */
+        public Builder register(final ClassModel<?>... classModels) {
+            notNull("classModels", classModels);
+            for (ClassModel<?> classModel : classModels) {
+                this.classModels.put(classModel.getType(), classModel);
+            }
+            return this;
+        }
+
+        /**
+         * Registers the packages of the given classes with the builder for inclusion in the Provider. This will allow records in the
+         * given packages to mapped for use with RecordCodecProvider.
+         *
+         * <p>Note: Uses reflection for the field mapping.
+         *
+         * @param packageNames the package names to register
+         * @return this
+         */
+        public Builder register(final String... packageNames) {
+            packages.addAll(asList(notNull("packageNames", packageNames)));
+            return this;
+        }
+
+        /**
+         * Registers codec providers that receive the type parameters of properties for instances encoded and decoded
+         * by a {@link PojoCodec} for records, handled by this provider.
+         *
+         * <p>Note that you should prefer working with the {@link CodecRegistry}/{@link CodecProvider} hierarchy. Providers
+         * should only be registered here if a codec needs to be created for custom container types like optionals and
+         * collections. Support for types {@link Map} and {@link java.util.Collection} are built-in so explicitly handling
+         * them is not necessary.
+         * @param providers property codec providers to register
+         * @return this
+         */
+        public Builder register(final PropertyCodecProvider... providers) {
+            propertyCodecProviders.addAll(asList(notNull("providers", providers)));
+            return this;
+        }
+
+        private Builder() {}
+
+        /**
+         * Creates the RecordCodecProvider for records with the classes or packages that configured and registered.
+         *
+         * @return the Provider
+         * @see #register(Class...)
+         */
+        public RecordCodecProvider build() {
+            for (Class<?> clazz : clazzes) {
+                if (!classModels.containsKey(clazz)) {
+                    register(createClassModel(clazz));
+                }
+            }
+            return new RecordCodecProvider(automatic, classModels, packages, propertyCodecProviders);
+        }
+    }
+
+    private static <T> ClassModel<T> createClassModel(final Class<T> clazz) {
+        return ClassModel.builder(clazz).build();
+    }
+}

--- a/bson/src/main/org/bson/codecs/pojo/RecordCreatorExecutable.java
+++ b/bson/src/main/org/bson/codecs/pojo/RecordCreatorExecutable.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo;
+
+import org.bson.codecs.configuration.CodecConfigurationException;
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.RecordComponent;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+
+final class RecordCreatorExecutable<T> implements CreatorExecutable<T> {
+    private final Class<T> clazz;
+    private final Constructor<T> constructor;
+    private final List<String> properties = new ArrayList<>();
+    private final Integer idPropertyIndex;
+    private final List<Class<?>> parameterTypes = new ArrayList<>();
+    private final List<Type> parameterGenericTypes = new ArrayList<>();
+
+    RecordCreatorExecutable(final Class<T> clazz, final Constructor<T> constructor) {
+        this.clazz = clazz;
+        this.constructor = constructor;
+        Integer idPropertyIndex = null;
+        parameterTypes.addAll(asList(constructor.getParameterTypes()));
+        parameterGenericTypes.addAll(asList(constructor.getGenericParameterTypes()));
+
+        RecordComponent[] recordComponents = clazz.getRecordComponents();
+        for (int i = 0; i < recordComponents.length; i++) {
+            RecordComponent recordComponent = recordComponents[i];
+            String name = recordComponent.getName();
+
+            boolean isId = name.equals("id") || name.equals("_id");
+            for (Annotation a : recordComponent.getAnnotations()) {
+                if (a instanceof BsonId) {
+                    isId = true;
+                }
+                else if (a instanceof BsonProperty) {
+                    isId = ((BsonProperty) a).value().equals("_id");
+                }
+            }
+
+            if (isId) {
+                properties.add(null);
+                idPropertyIndex = i;
+            } else {
+                properties.add(name);
+            }
+        }
+        this.idPropertyIndex = idPropertyIndex;
+    }
+
+    @Override
+    public Class<T> getType() {
+        return clazz;
+    }
+
+    @Override
+    public List<String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public Integer getIdPropertyIndex() {
+        return idPropertyIndex;
+    }
+
+    @Override
+    public List<Class<?>> getParameterTypes() {
+        return parameterTypes;
+    }
+
+    @Override
+    public List<Type> getParameterGenericTypes() {
+        return parameterGenericTypes;
+    }
+
+    @Override
+    public CodecConfigurationException getError(final Class<?> clazz, final String msg) {
+        return new CodecConfigurationException(format("Invalid @BsonCrator constructor in %s. %s", clazz.getSimpleName(), msg));
+    }
+
+    @Override
+    public T getInstance(final Object... params) {
+        try {
+            return constructor.newInstance(params);
+        } catch (Exception e) {
+            throw new CodecConfigurationException(e.getMessage(), e);
+        }
+    }
+}

--- a/bson/src/main/org/bson/codecs/pojo/TypeData.java
+++ b/bson/src/main/org/bson/codecs/pojo/TypeData.java
@@ -49,7 +49,11 @@ final class TypeData<T> implements TypeWithTypeParameters<T> {
     }
 
     public static TypeData<?> newInstance(final Method method) {
-        if (isGetter(method)) {
+        return newInstance(method, isGetter(method));
+    }
+
+    public static TypeData<?> newInstance(final Method method, final boolean isGetterMethod) {
+        if (isGetterMethod) {
             return newInstance(method.getGenericReturnType(), method.getReturnType());
         } else {
             return newInstance(method.getGenericParameterTypes()[0], method.getParameterTypes()[0]);

--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonId.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonId.java
@@ -32,6 +32,6 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.RECORD_COMPONENT})
 public @interface BsonId {
 }

--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonIgnore.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonIgnore.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * @see org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION
  */
 @Documented
-@Target({ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.RECORD_COMPONENT})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface BsonIgnore {
 }

--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonProperty.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonProperty.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
  * @see org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION
  */
 @Documented
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.RECORD_COMPONENT})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface BsonProperty {
     /**

--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonRepresentation.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonRepresentation.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD, ElementType.METHOD})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.RECORD_COMPONENT})
 public @interface BsonRepresentation {
     /**
      * The type that the property is stored as in the database.

--- a/bson/src/test/unit/org/bson/codecs/pojo/ClassModelTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/ClassModelTest.java
@@ -37,6 +37,8 @@ import org.bson.codecs.pojo.entities.SimpleGenericsModel;
 import org.bson.codecs.pojo.entities.SimpleModel;
 import org.bson.codecs.pojo.entities.conventions.AnnotationInheritedModel;
 import org.bson.codecs.pojo.entities.conventions.AnnotationModel;
+import org.bson.codecs.pojo.entities.records.NestedSimpleIdRecord;
+import org.bson.codecs.pojo.entities.records.SimpleIdRecord;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -269,6 +271,23 @@ public final class ClassModelTest {
 
     <T> TypeData<T> createTypeData(final Class<T> clazz, final Class<?>... types) {
         return createBuilder(clazz, types).build();
+    }
+
+    @Test
+    public void testRecordBuilder() {
+        ClassModel<NestedSimpleIdRecord> classModel = ClassModel.builder(NestedSimpleIdRecord.class).build();
+
+        assertEquals(classModel.getType(), NestedSimpleIdRecord.class);
+        assertEquals(classModel.getName(), "NestedSimpleIdRecord");
+        assertTrue(classModel.getInstanceCreatorFactory() instanceof InstanceCreatorFactoryImpl);
+        assertFalse(classModel.useDiscriminator());
+        assertEquals(classModel.getDiscriminatorKey(), "_t");
+        assertEquals(classModel.getDiscriminator(), "org.bson.codecs.pojo.entities.records.NestedSimpleIdRecord");
+
+        assertEquals(2, classModel.getPropertyModels().size());
+        assertEquals(classModel.getPropertyModel("id").getTypeData(), createTypeData(String.class));
+        assertEquals(classModel.getPropertyModel("nestedSimpleIdRecord").getTypeData(), createTypeData(SimpleIdRecord.class));
+        assertEquals(classModel.getPropertyModel("id"), classModel.getIdPropertyModel());
     }
 
 }

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -633,7 +633,7 @@ public final class PojoCustomTest extends PojoTestCase {
         return conventions;
     }
 
-    class ObjectCodec implements Codec<Object> {
+    static class ObjectCodec implements Codec<Object> {
 
         @Override
         public Object decode(final BsonReader reader, final DecoderContext decoderContext) {

--- a/bson/src/test/unit/org/bson/codecs/pojo/RecordCodecProviderTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/RecordCodecProviderTest.java
@@ -1,0 +1,72 @@
+package org.bson.codecs.pojo;
+
+import org.bson.codecs.Codec;
+import org.bson.codecs.ValueCodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.entities.SimpleModel;
+import org.bson.codecs.pojo.entities.records.BsonCreatorRecord;
+import org.bson.codecs.pojo.entities.records.SimpleRecord;
+import org.junit.Test;
+
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class RecordCodecProviderTest {
+    @Test
+    public void testClassNotFound() {
+        RecordCodecProvider provider = RecordCodecProvider.builder().build();
+        CodecRegistry registry = fromProviders(provider, new ValueCodecProvider());
+        Codec<SimpleRecord> codec = provider.get(SimpleRecord.class, registry);
+        assertNull(codec);
+    }
+
+    @Test
+    public void testAutomatic() {
+        RecordCodecProvider provider = RecordCodecProvider.builder().automatic(true).build();
+        CodecRegistry registry = fromProviders(provider, new ValueCodecProvider());
+        Codec<SimpleRecord> codec = provider.get(SimpleRecord.class, registry);
+        assertNotNull(codec);
+    }
+
+    @Test
+    public void testAutomaticNotRecord() {
+        RecordCodecProvider provider = RecordCodecProvider.builder().automatic(true).build();
+        CodecRegistry registry = fromProviders(provider);
+        Codec<SimpleModel> codec = provider.get(SimpleModel.class, registry);
+        assertNull(codec);
+    }
+
+    @Test
+    public void testAutomaticInvalidRecord() {
+        RecordCodecProvider provider = RecordCodecProvider.builder().automatic(true).build();
+        CodecRegistry registry = fromProviders(provider, new ValueCodecProvider());
+        Codec<BsonCreatorRecord> codec = provider.get(BsonCreatorRecord.class, registry);
+        assertNull(codec);
+    }
+
+    @Test
+    public void testRegisterClass() {
+        RecordCodecProvider provider = RecordCodecProvider.builder().register(SimpleRecord.class).build();
+        CodecRegistry registry = fromProviders(provider, new ValueCodecProvider());
+        Codec<SimpleRecord> codec = provider.get(SimpleRecord.class, registry);
+        assertNotNull(codec);
+    }
+
+    @Test
+    public void testRegisterClassModel() {
+        ClassModel<SimpleRecord> simpleRecordClassModel = ClassModel.builder(SimpleRecord.class).build();
+        RecordCodecProvider provider = RecordCodecProvider.builder().register(simpleRecordClassModel).build();
+        CodecRegistry registry = fromProviders(provider, new ValueCodecProvider());
+        Codec<SimpleRecord> codec = provider.get(SimpleRecord.class, registry);
+        assertNotNull(codec);
+    }
+
+    @Test
+    public void testRegisterPackageName() {
+        RecordCodecProvider provider = RecordCodecProvider.builder().register("org.bson.codecs.pojo.entities.records").build();
+        CodecRegistry registry = fromProviders(provider, new ValueCodecProvider());
+        Codec<SimpleRecord> codec = provider.get(SimpleRecord.class, registry);
+        assertNotNull(codec);
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/RecordCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/RecordCustomTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo;
+
+import org.bson.Document;
+import org.bson.codecs.BsonValueCodecProvider;
+import org.bson.codecs.Codec;
+import org.bson.codecs.LongCodec;
+import org.bson.codecs.MapCodec;
+import org.bson.codecs.ValueCodecProvider;
+import org.bson.codecs.configuration.CodecConfigurationException;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.entities.InvalidMapPropertyCodecProvider;
+import org.bson.codecs.pojo.entities.Optional;
+import org.bson.codecs.pojo.entities.OptionalPropertyCodecProvider;
+import org.bson.codecs.pojo.entities.SimpleEnum;
+import org.bson.codecs.pojo.entities.records.BsonRepresentationRecord;
+import org.bson.codecs.pojo.entities.records.BsonRepresentationUnsupportedIntRecord;
+import org.bson.codecs.pojo.entities.records.BsonRepresentationUnsupportedStringRecord;
+import org.bson.codecs.pojo.entities.records.ConverterRecord;
+import org.bson.codecs.pojo.entities.records.CustomPropertyCodecOptionalRecord;
+import org.bson.codecs.pojo.entities.records.GenericHolderRecord;
+import org.bson.codecs.pojo.entities.records.GenericTreeRecord;
+import org.bson.codecs.pojo.entities.records.InvalidCollectionRecord;
+import org.bson.codecs.pojo.entities.records.InvalidMapRecord;
+import org.bson.codecs.pojo.entities.records.MapStringObjectRecord;
+import org.bson.codecs.pojo.entities.records.PrimitivesRecord;
+import org.bson.codecs.pojo.entities.records.SimpleEnumRecord;
+import org.bson.codecs.pojo.entities.records.SimpleNestedRecord;
+import org.bson.codecs.pojo.entities.records.SimpleRecord;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static org.bson.codecs.configuration.CodecRegistries.fromCodecs;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+import static org.junit.Assert.assertTrue;
+
+public class RecordCustomTest extends PojoTestCase {
+
+    @Test
+    public void testEnumSupportWithCustomCodec() {
+        CodecRegistry registry = fromRegistries(getRecordCodecRegistry(SimpleEnumRecord.class), fromCodecs(new SimpleEnumCodec()));
+        roundTrip(registry, new SimpleEnumRecord(SimpleEnum.BRAVO), "{ 'myEnum': 1 }");
+    }
+
+    @Test
+    public void testCustomCodec() {
+        ObjectId id = new ObjectId();
+        ConverterRecord record = new ConverterRecord(id.toHexString(), "myName");
+
+        ClassModelBuilder<ConverterRecord> classModel = ClassModel.builder(ConverterRecord.class);
+        PropertyModelBuilder<String> idPropertyModelBuilder = (PropertyModelBuilder<String>) classModel.getProperty("id");
+        idPropertyModelBuilder.codec(new StringToObjectIdCodec());
+
+        roundTrip(getRecordCodecRegistry(classModel), record,
+                format("{'_id': {'$oid': '%s'}, 'name': 'myName'}", id.toHexString()));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCustomPropertySerializer() {
+        SimpleRecord record = new SimpleRecord(null, "myString");
+        ClassModelBuilder<SimpleRecord> classModel = ClassModel.builder(SimpleRecord.class);
+        ((PropertyModelBuilder<Integer>) classModel.getProperty("integerField"))
+                .propertySerialization(new PropertySerialization<Integer>() {
+                    @Override
+                    public boolean shouldSerialize(final Integer value) {
+                        return true;
+                    }
+                });
+
+        roundTrip(getRecordCodecRegistry(classModel), record, "{'integerField': null, 'stringField': 'myString'}");
+    }
+
+    @Test
+    public void testCanHandleExtraData() {
+        decodesTo(getRecordCodecRegistry(SimpleRecord.class), "{'integerField': 42,  'stringField': 'myString', 'extraFieldA': 1, 'extraFieldB': 2}",
+                RecordRoundTripTest.getSimpleRecord());
+    }
+
+    @Test
+    public void testDataCanHandleMissingData() {
+        SimpleRecord record = new SimpleRecord(null, "myString");
+
+        decodesTo(getRecordCodecRegistry(SimpleRecord.class), "{'_t': 'SimpleRecord', 'stringField': 'myString'}", record);
+    }
+
+    @Test
+    public void testCanHandleTopLevelGenericIfHasCodec() {
+        GenericHolderRecord<Long> record = new GenericHolderRecord<>(1L, 2L);
+
+        ClassModelBuilder<GenericHolderRecord> classModelBuilder = ClassModel.builder(GenericHolderRecord.class);
+        ((PropertyModelBuilder<Long>) classModelBuilder.getProperty("myGenericField")).codec(new LongCodec());
+        RecordCodecProvider provider = RecordCodecProvider.builder().register(classModelBuilder.build()).build();
+
+        roundTrip(RecordRoundTripTest.getRegistryFromProvider(provider), record,
+                "{'myGenericField': {'$numberLong': '1'}, 'myLongField': {'$numberLong': '2'}}");
+    }
+
+    @Test
+    public void testCustomRegisteredPropertyCodecWithValue() {
+        CustomPropertyCodecOptionalRecord record = new CustomPropertyCodecOptionalRecord(Optional.of("foo"));
+        ClassModelBuilder<CustomPropertyCodecOptionalRecord> classModelBuilder = ClassModel.builder(CustomPropertyCodecOptionalRecord.class);
+        RecordCodecProvider.Builder provider = RecordCodecProvider.builder();
+        provider.register(classModelBuilder.build());
+        provider.register(new OptionalPropertyCodecProvider());
+
+        roundTrip(RecordRoundTripTest.getRegistryFromProvider(provider.build()), record,
+                "{'optionalField': 'foo'}");
+    }
+
+    @Test
+    public void testMapStringObjectRecord() {
+        MapStringObjectRecord record = new MapStringObjectRecord(new HashMap<String, Object>(Document.parse("{a : 1, b: 'b', c: [1, 2, 3]}")));
+        CodecRegistry registry = fromRegistries(fromCodecs(new MapCodec()),
+                getRecordCodecRegistry(MapStringObjectRecord.class));
+        roundTrip(registry, record, "{ map: {a : 1, b: 'b', c: [1, 2, 3]}}");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testMapStringObjectRecordWithObjectCodec() {
+        MapStringObjectRecord record = new MapStringObjectRecord(new HashMap<String, Object>(Document.parse("{a : 1, b: 'b', c: [1, 2, 3]}")));
+        CodecRegistry registry = fromRegistries(fromCodecs(new MapCodec()), fromCodecs(new PojoCustomTest.ObjectCodec()), getRecordCodecRegistry(MapStringObjectRecord.class));
+        roundTrip(registry, record, "{ map: {a : 1, b: 'b', c: [1, 2, 3]}}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testEncodingInvalidMapRecord() {
+        Map<Integer, Integer> map = new HashMap<Integer, Integer>();
+        map.put(1, 1);
+        map.put(2, 2);
+       InvalidMapRecord record = new InvalidMapRecord(map);
+
+        encodesTo(getRecordCodecRegistry(InvalidMapRecord.class), record, "{'invalidMap': {'1': 1, '2': 2}}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testDecodingInvalidMapRecord() {
+        try {
+            decodingShouldFail(getRecordCodec(InvalidMapRecord.class), "{'invalidMap': {'1': 1, '2': 2}}");
+        } catch (CodecConfigurationException e) {
+            e.printStackTrace();
+            assertTrue(e.getMessage().startsWith("Failed to decode 'InvalidMapRecord'. Decoding 'invalidMap' errored with:"));
+            throw e;
+        }
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testEncodingInvalidCollectionRecord() {
+        try {
+            encodesTo(getRecordCodecRegistry(InvalidCollectionRecord.class), new InvalidCollectionRecord(asList(1, 2, 3)),
+                    "{collectionField: [1, 2, 3]}");
+        } catch (CodecConfigurationException e) {
+            assertTrue(e.getMessage().startsWith("Failed to encode 'InvalidCollectionRecord'. Encoding 'collectionField' errored with:"));
+            throw e;
+        }
+    }
+
+    @Test
+    public void testInvalidMapRecordWithCustomPropertyCodecProvider() {
+        Map<Integer, Integer> map = new HashMap<>();
+        map.put(1, 1);
+        map.put(2, 2);
+        InvalidMapRecord record = new InvalidMapRecord(map);
+        ClassModelBuilder builder = ClassModel.builder(InvalidMapRecord.class);
+        RecordCodecProvider.Builder provider = RecordCodecProvider.builder();
+        provider.register(InvalidMapRecord.class);
+        provider.register(new InvalidMapPropertyCodecProvider());
+        encodesTo(RecordRoundTripTest.getRegistryFromProvider(provider.build()), record,
+                "{'invalidMap': {'1': 1, '2': 2}}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testDataUnknownClass() {
+        ClassModel<SimpleRecord> classModel = ClassModel.builder(SimpleRecord.class).enableDiscriminator(true).build();
+        try {
+            RecordCodecProvider provider = RecordCodecProvider.builder().register(classModel).build();
+            decodingShouldFail(RecordRoundTripTest.getRegistryFromProvider(provider).get(SimpleRecord.class), "{'_t': 'FakeRecord'}");
+        } catch (CodecConfigurationException e) {
+            assertTrue(e.getMessage().startsWith("Failed to decode 'SimpleRecord'. Decoding errored with:"));
+            throw e;
+        }
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testInvalidTypeForField() {
+        decodingShouldFail(getRecordCodec(SimpleRecord.class), "{'_t': 'SimpleRecord', 'stringField': 123}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testInvalidTypeForPrimitiveField() {
+        decodingShouldFail(getRecordCodec(PrimitivesRecord.class), "{ '_t': 'PrimitivesRecord', 'myBoolean': null}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testInvalidTypeForRecordField() {
+        decodingShouldFail(getRecordCodec(SimpleNestedRecord.class), "{ '_t': 'SimpleNestedRecord', 'simple': 123}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testInvalidDiscriminatorInNestedRecord() {
+        decodingShouldFail(getRecordCodec(SimpleNestedRecord.class), "{ '_t': 'SimpleNestedRecord',"
+                + "'simple': {'_t': 'FakeRecord', 'integerField': 42, 'stringField': 'myString'}}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testCannotEncodeUnspecializedClasses() {
+        ClassModelBuilder<GenericTreeRecord> builder = ClassModel.builder(GenericTreeRecord.class);
+        CodecRegistry registry = fromProviders(getRecordProviderFromClassModel(builder));
+        encode(registry.get(GenericTreeRecord.class), RecordRoundTripTest.getGenericTreeRecord(), false);
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testCannotDecodeUnspecializedClasses() {
+        decodingShouldFail(getRecordCodec(GenericTreeRecord.class),
+                "{'field1': 'top', 'field2': 1, "
+                        + "'left': {'field1': 'left', 'field2': 2, 'left': {'field1': 'left', 'field2': 3}}, "
+                        + "'right': {'field1': 'right', 'field2': 4, 'left': {'field1': 'left', 'field2': 5}}}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testInvalidBsonRepresentationStringDecoding() {
+        decodingShouldFail(getRecordCodec(BsonRepresentationUnsupportedStringRecord.class), "{'id': 'hello', s: 3}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testInvalidBsonRepresentationStringEncoding() {
+        encodesTo(getRecordCodecRegistry(BsonRepresentationUnsupportedStringRecord.class),
+                new BsonRepresentationUnsupportedStringRecord("1", "1"), "");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testInvalidBsonRepresentationIntDecoding() {
+        decodingShouldFail(getRecordCodec(BsonRepresentationUnsupportedIntRecord.class), "{'id': 'hello', s: '3'}");
+    }
+
+    @Test(expected = CodecConfigurationException.class)
+    public void testStringIdIsNotObjectId() {
+        encodesTo(getRecordCodecRegistry(BsonRepresentationUnsupportedIntRecord.class), new BsonRepresentationRecord("notanobjectid", 1), null);
+    }
+
+    private static <T> RecordCodecProvider getRecordProviderFromClassModel(ClassModelBuilder<T> classModelBuilder) {
+        return RecordCodecProvider.builder().register(classModelBuilder.build()).build();
+    }
+
+    private static <T> CodecRegistry getRecordCodecRegistry(ClassModelBuilder<T> classModelBuilder) {
+        return fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider(), getRecordProviderFromClassModel(classModelBuilder));
+    }
+
+    private static CodecRegistry getRecordCodecRegistry(Class<?> clazz) {
+        ClassModelBuilder<?> builder = ClassModel.builder(clazz);
+        return getRecordCodecRegistry(builder);
+    }
+
+    private static Codec<?> getRecordCodec(Class<?> clazz) {
+        return getRecordCodecRegistry(clazz).get(clazz);
+    }
+
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/RecordPojoIntegrationTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/RecordPojoIntegrationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo;
+
+import org.bson.codecs.BsonValueCodecProvider;
+import org.bson.codecs.ValueCodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.entities.GenericHolderModel;
+import org.bson.codecs.pojo.entities.records.GenericHolderRecord;
+import org.bson.codecs.pojo.entities.records.NestedRecordsAndPojos;
+import org.bson.codecs.pojo.entities.records.PojoContainsGenericRecord;
+import org.bson.codecs.pojo.entities.records.PojoContainsRecord;
+import org.bson.codecs.pojo.entities.records.RecordContainsGenericPojo;
+import org.bson.codecs.pojo.entities.records.RecordContainsPojo;
+import org.junit.Test;
+
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+
+public class RecordPojoIntegrationTest extends PojoTestCase {
+    public static CodecRegistry registry = fromProviders(
+            new BsonValueCodecProvider(),
+            new ValueCodecProvider(),
+            RecordCodecProvider.builder().automatic(true).build(),
+            PojoCodecProvider.builder().automatic(true).build());
+
+    private final static String RECORD_CONTAINS_POJO_JSON = "{'stringField': 'stringField', 'simpleModel': " + SIMPLE_MODEL_JSON + "}";
+    private final static String POJO_CONTAINS_RECORD_JSON = "{'stringField': 'stringField', 'simpleRecord': " + SIMPLE_MODEL_JSON + "}";
+
+    @Test
+    public void RecordContainsPojo() {
+        roundTrip(registry, new RecordContainsPojo("stringField", getSimpleModel()), RECORD_CONTAINS_POJO_JSON);
+    }
+
+    @Test
+    public void PojoContainsRecord() {
+        roundTrip(registry, new PojoContainsRecord("stringField", RecordRoundTripTest.getSimpleRecord()), POJO_CONTAINS_RECORD_JSON);
+    }
+
+    @Test
+    public void RecordContainsGenericPojo() {
+        roundTrip(registry, new RecordContainsGenericPojo("stringField", new GenericHolderModel<>("stringGeneric", 1L)),
+                "{'stringField': 'stringField', 'genericField': {'myGenericField': 'stringGeneric', 'myLongField': {'$numberLong': '1'}}}");
+    }
+
+    @Test
+    public void PojoContainsGenericRecord() {
+        roundTrip(registry, new PojoContainsGenericRecord("stringField", new GenericHolderRecord<>("myGenericField", 1L)),
+                "{'stringField': 'stringField', 'genericRecord': {'myGenericField': 'myGenericField', 'myLongField': {'$numberLong': '1'}}}");
+    }
+
+    @Test
+    public void RecordContainsNestedPojosAndRecords() {
+        roundTrip(registry, new NestedRecordsAndPojos("stringField", getSimpleModel(), RecordRoundTripTest.getSimpleRecord(),
+                        new PojoContainsRecord("stringField", RecordRoundTripTest.getSimpleRecord()), new RecordContainsPojo("stringField", getSimpleModel())),
+                "{'stringField': 'stringField', 'simpleModel': " + SIMPLE_MODEL_JSON + "'simpleRecord':" + SIMPLE_MODEL_JSON + "'pojoContainer':" + POJO_CONTAINS_RECORD_JSON +
+                "'recordContainer':" + RECORD_CONTAINS_POJO_JSON + "}");
+    }
+
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/RecordRoundTripTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/RecordRoundTripTest.java
@@ -1,0 +1,499 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo;
+
+import org.bson.BsonDocument;
+import org.bson.codecs.BsonValueCodecProvider;
+import org.bson.codecs.ValueCodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.entities.SimpleEnum;
+import org.bson.codecs.pojo.entities.records.AnnotationBsonPropertyIdRecord;
+import org.bson.codecs.pojo.entities.records.BsonIgnoreInvalidMapRecord;
+import org.bson.codecs.pojo.entities.records.BsonPropUnderscoreId;
+import org.bson.codecs.pojo.entities.records.BsonPropUnderscoreIdNonIdName;
+import org.bson.codecs.pojo.entities.records.BsonRepresentationRecord;
+import org.bson.codecs.pojo.entities.records.CollectionNestedRecord;
+import org.bson.codecs.pojo.entities.records.ConcreteCollectionsRecord;
+import org.bson.codecs.pojo.entities.records.ConcreteInterfaceGenericRecord;
+import org.bson.codecs.pojo.entities.records.ContainsAlternativeMapAndCollectionRecord;
+import org.bson.codecs.pojo.entities.records.ConventionRecord;
+import org.bson.codecs.pojo.entities.records.GenericHolderRecord;
+import org.bson.codecs.pojo.entities.records.GenericTreeRecord;
+import org.bson.codecs.pojo.entities.records.MultipleLevelGenericRecord;
+import org.bson.codecs.pojo.entities.records.NestedFieldReusingClassTypeParameterRecord;
+import org.bson.codecs.pojo.entities.records.NestedGenericHolderFieldWithMultipleTypeParamsRecord;
+import org.bson.codecs.pojo.entities.records.NestedGenericHolderMapRecord;
+import org.bson.codecs.pojo.entities.records.NestedGenericHolderRecord;
+import org.bson.codecs.pojo.entities.records.NestedGenericHolderSimpleGenericsRecord;
+import org.bson.codecs.pojo.entities.records.NestedGenericTreeRecord;
+import org.bson.codecs.pojo.entities.records.NestedMultipleLevelGenericRecord;
+import org.bson.codecs.pojo.entities.records.NestedReusedGenericsRecord;
+import org.bson.codecs.pojo.entities.records.NestedSelfReferentialGenericHolderRecord;
+import org.bson.codecs.pojo.entities.records.NestedSelfReferentialGenericRecord;
+import org.bson.codecs.pojo.entities.records.NestedSimpleIdRecord;
+import org.bson.codecs.pojo.entities.records.PrimitivesRecord;
+import org.bson.codecs.pojo.entities.records.PropertyReusingClassTypeParameterRecord;
+import org.bson.codecs.pojo.entities.records.PropertySelectionRecord;
+import org.bson.codecs.pojo.entities.records.PropertyWithMultipleTypeParamsRecord;
+import org.bson.codecs.pojo.entities.records.ReusedGenericsRecord;
+import org.bson.codecs.pojo.entities.records.SelfReferentialGenericRecord;
+import org.bson.codecs.pojo.entities.records.SimpleEnumRecord;
+import org.bson.codecs.pojo.entities.records.SimpleGenericsRecord;
+import org.bson.codecs.pojo.entities.records.SimpleIdRecord;
+import org.bson.codecs.pojo.entities.records.SimpleNestedRecord;
+import org.bson.codecs.pojo.entities.records.SimpleRecord;
+import org.bson.codecs.pojo.entities.records.TreeWithIdRecord;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+
+@RunWith(Parameterized.class)
+public class RecordRoundTripTest extends PojoTestCase {
+    private final String name;
+    private final Record record;
+    private final CodecRegistry registry;
+    private final String json;
+
+    public RecordRoundTripTest(final String name, final Record record, final CodecRegistry registry, final String json) {
+        this.name = name;
+        this.record = record;
+        this.registry = registry;
+        this.json = json;
+    }
+
+    @Test
+    public void test() { roundTrip(registry, record, json); }
+
+    private static List<TestData> testCases() {
+        List<TestData> data = new ArrayList<>();
+        data.add(new TestData("Simple record", getSimpleRecord(),
+                getRecordRegistryFromClasses(SimpleRecord.class), SIMPLE_RECORD_JSON));
+
+        data.add(new TestData("Property selection record", new PropertySelectionRecord("stringField"),
+                getRecordRegistryFromClasses(PropertySelectionRecord.class), "{'stringField': 'stringField'}"));
+
+        data.add(new TestData("Conventions default", getConventionRecord(),
+                getRecordRegistryFromClasses(ConventionRecord.class, SimpleRecord.class),
+                "{'_id': 'id', '_cls': 'AnnotatedConventionRecord', "
+                        + "'child': {'_id': 'child',"
+                        + "'record': {'integerField': 42, 'stringField': 'myString'}}}"));
+
+        data.add(new TestData("BsonIgnore invalid map", new BsonIgnoreInvalidMapRecord("stringField", null),
+                getRecordRegistryFromClasses(BsonIgnoreInvalidMapRecord.class), "{'stringField': 'stringField'}"));
+
+        data.add(new TestData("Concrete generic interface record", new ConcreteInterfaceGenericRecord("someValue"),
+                getRecordRegistryFromClasses(ConcreteInterfaceGenericRecord.class), "{propertyA: 'someValue'}"));
+
+        data.add(new TestData("Primitives Record", getPrimitivesRecord(),
+                getRecordRegistryFromClasses(PrimitivesRecord.class),
+                "{ 'myBoolean': true, 'myByte': 1, 'myCharacter': '1', 'myDouble': 1.0, 'myFloat': 2.0," +
+                        " 'myInteger': 3, 'myLong': { '$numberLong': '5' }, 'myShort': 6}"));
+
+        data.add(new TestData("Concrete collections record", getConcreteCollectionsRecord(),
+                getRecordRegistryFromClasses(ConcreteCollectionsRecord.class),
+                "{'collection': [1, 2, 3], 'list': [4, 5, 6], 'linked': [7, 8, 9], 'map': {'A': 1.1, 'B': 2.2, 'C': 3.3},"
+                        + "'concurrent': {'D': 4.4, 'E': 5.5, 'F': 6.6}}"));
+
+        data.add(new TestData("Handling of nulls inside collections", getConcreteCollectionsRecordWithNulls(),
+                getRecordRegistryFromClasses(ConcreteCollectionsRecord.class),
+                "{'collection': [1, null, 3], 'list': [4, null, 6], 'linked': [null, 8, 9], 'map': {'A': 1.1, 'B': null, 'C': 3.3}}"));
+
+        data.add(new TestData("Nested simple", getSimpleNestedRecord(),
+                getRecordRegistryFromClasses(SimpleNestedRecord.class, SimpleRecord.class),
+                "{'simple': " + SIMPLE_RECORD_JSON + "}"));
+
+        data.add(new TestData("Nested collection", getCollectionNestedRecord(),
+                getRecordRegistryFromClasses(CollectionNestedRecord.class, SimpleRecord.class),
+                "{ 'listSimple': [" + SIMPLE_RECORD_JSON + "],"
+                        + "'listListSimple': [[" + SIMPLE_RECORD_JSON + "]],"
+                        + "'setSimple': [" + SIMPLE_RECORD_JSON + "],"
+                        + "'setSetSimple': [[" + SIMPLE_RECORD_JSON + "]],"
+                        + "'mapSimple': {'s': " + SIMPLE_RECORD_JSON + "},"
+                        + "'mapMapSimple': {'ms': {'s': " + SIMPLE_RECORD_JSON + "}},"
+                        + "'mapListSimple': {'ls': [" + SIMPLE_RECORD_JSON + "]},"
+                        + "'mapListMapSimple': {'lm': [{'s': " + SIMPLE_RECORD_JSON + "}]},"
+                        + "'mapSetSimple': {'s': [" + SIMPLE_RECORD_JSON + "]},"
+                        + "'listMapSimple': [{'s': " + SIMPLE_RECORD_JSON + "}],"
+                        + "'listMapListSimple': [{'ls': [" + SIMPLE_RECORD_JSON + "]}],"
+                        + "'listMapSetSimple': [{'s': [" + SIMPLE_RECORD_JSON + "]}],"
+                        + "}"));
+
+        data.add(new TestData("Nested collection with nulls", getCollectionNestedRecordWithNulls(),
+                getRecordRegistryFromClasses(CollectionNestedRecord.class, SimpleRecord.class),
+                "{ 'listListSimple': [ null ],"
+                        + "'setSetSimple': [ null ],"
+                        + "'mapMapSimple': {'ms': null},"
+                        + "'mapListSimple': {'ls': null},"
+                        + "'mapListMapSimple': {'lm': [null]},"
+                        + "'mapSetSimple': {'s': null},"
+                        + "'listMapSimple': [null],"
+                        + "'listMapListSimple': [{'ls': null}],"
+                        + "'listMapSetSimple': [{'s': null}],"
+                        + "}"));
+
+        data.add(new TestData("Nested generic holder", getNestedGenericHolderRecord(),
+                getRecordRegistryFromClasses(NestedGenericHolderRecord.class, GenericHolderRecord.class),
+                "{'nested': {'myGenericField': 'generic', 'myLongField': {'$numberLong': '1'}}}"));
+
+        data.add(new TestData("Nested generic holder map", getNestedGenericHolderMapRecord(),
+                getRecordRegistryFromClasses(NestedGenericHolderMapRecord.class, GenericHolderRecord.class, SimpleRecord.class),
+                "{ 'nested': { 'myGenericField': {'s': " + SIMPLE_RECORD_JSON + "}, 'myLongField': {'$numberLong': '1'}}}"));
+
+        data.add(new TestData("Nested reused generic", getNestedReusedGenericsRecord(),
+                getRecordRegistryFromClasses(NestedReusedGenericsRecord.class, SimpleRecord.class, NestedReusedGenericsRecord.class,
+                        ReusedGenericsRecord.class, GenericHolderRecord.class),
+                "{ 'nested':{ 'field1':{ '$numberLong':'1' }, 'field2':[" + SIMPLE_RECORD_JSON + "], "
+                        + "'field3':'field3', 'field4':42, 'field5':'field5', 'field6':[" + SIMPLE_RECORD_JSON + ", "
+                        + SIMPLE_RECORD_JSON + "], 'field7':{ '$numberLong':'2' }, 'field8':'field8' } }"));
+
+        data.add(new TestData("Nested generic holder with multiple types", getNestedGenericHolderFieldWithMultipleTypeParamsRecord(),
+                getRecordRegistryFromClasses(NestedGenericHolderFieldWithMultipleTypeParamsRecord.class, SimpleGenericsRecord.class,
+                        GenericHolderRecord.class, PropertyWithMultipleTypeParamsRecord.class),
+                "{'nested': {'myGenericField': {_t: 'PropertyWithMultipleTypeParamsRecord', "
+                        + "'simpleGenericsRecord': {_t: 'org.bson.codecs.pojo.entities.records.SimpleGenericsRecord', 'myIntegerField': 42, "
+                        + "'myGenericField': {'$numberLong': '101'}, 'myListField': ['B', 'C'], 'myMapField': {'D': 2, 'E': 3, 'F': 4 }}},"
+                        + "'myLongField': {'$numberLong': '42'}}}"));
+
+        data.add(new TestData("Nested generic tree", new NestedGenericTreeRecord(42, getGenericTreeRecord()),
+                getRecordRegistryFromClasses(NestedGenericTreeRecord.class, GenericTreeRecord.class),
+                "{'intField': 42, 'nested': {'field1': 'top', 'field2': 1, "
+                        + "'left': {'field1': 'left', 'field2': 2, 'left': {'field1': 'left', 'field2': 3}}, "
+                        + "'right': {'field1': 'right', 'field2': 4, 'left': {'field1': 'left', 'field2': 5}}}}"));
+
+        data.add(new TestData("Nested multiple level",
+                new NestedMultipleLevelGenericRecord(42, new MultipleLevelGenericRecord<String>("string", getGenericTreeRecord())),
+                getRecordRegistryFromClasses(NestedMultipleLevelGenericRecord.class, MultipleLevelGenericRecord.class, GenericTreeRecord.class),
+                "{'intField': 42, 'nested': {'stringField': 'string', 'nested': {'field1': 'top', 'field2': 1, "
+                        + "'left': {'field1': 'left', 'field2': 2, 'left': {'field1': 'left', 'field2': 3}}, "
+                        + "'right': {'field1': 'right', 'field2': 4, 'left': {'field1': 'left', 'field2': 5}}}}}"));
+
+        data.add(new TestData("Nested Generics holder", getNestedGenericHolderSimpleGenericsRecord(),
+                getRecordRegistryFromClasses(NestedGenericHolderSimpleGenericsRecord.class, GenericHolderRecord.class, SimpleGenericsRecord.class, SimpleRecord.class),
+                "{'nested': {'myGenericField': {'myIntegerField': 42, 'myGenericField': 42,"
+                        + "                           'myListField': [[" + SIMPLE_RECORD_JSON + "]], "
+                        + "                           'myMapField': {'A': {'A': " + SIMPLE_RECORD_JSON + "}}},"
+                        + "         'myLongField': {'$numberLong': '42' }}}"));
+
+        data.add(new TestData("Nested property reusing type parameter",
+                new NestedFieldReusingClassTypeParameterRecord(new PropertyReusingClassTypeParameterRecord<String>(getGenericTreeRecordStrings())),
+                getRecordRegistryFromClasses(NestedFieldReusingClassTypeParameterRecord.class, PropertyReusingClassTypeParameterRecord.class,
+                        GenericTreeRecord.class),
+                "{'nested': {'tree': {'field1': 'top', 'field2': '1', "
+                        + "'left': {'field1': 'left', 'field2': '2', 'left': {'field1': 'left', 'field2': '3'}}, "
+                        + "'right': {'field1': 'right', 'field2': '4', 'left': {'field1': 'left', 'field2': '5'}}}}}"));
+
+        data.add(new TestData("Self referential", getNestedSelfReferentialGenericHolderRecord(),
+                getRecordRegistryFromClasses(NestedSelfReferentialGenericHolderRecord.class, NestedSelfReferentialGenericRecord.class,
+                        SelfReferentialGenericRecord.class),
+                "{'nested': { 't': true, 'v': {'$numberLong': '42'}, 'z': 44.0, "
+                        + "'selfRef1': {'t': true, 'v': {'$numberLong': '33'}, 'child': {'t': {'$numberLong': '44'}, 'v': false}}, "
+                        + "'selfRef2': {'t': true, 'v': 3.14, 'child': {'t': 3.42, 'v': true}}}}"));
+
+        BsonDocument document = BsonDocument.parse("{customList: [1,2,3], customMap: {'field': 'value'}}");
+
+        data.add(new TestData("Can handle custom Maps and Collections",
+                new ContainsAlternativeMapAndCollectionRecord(document.getArray("customList"), document.getDocument("customMap")),
+                getRecordRegistryFromClasses(ContainsAlternativeMapAndCollectionRecord.class),
+                "{customList: [1,2,3], customMap: {'field': 'value'}}"));
+
+        data.add(new TestData("Enums support",
+                new SimpleEnumRecord(SimpleEnum.BRAVO),
+                getRecordRegistryFromClasses(SimpleEnumRecord.class),
+                "{ 'myEnum': 'BRAVO' }"));
+
+        data.add(new TestData("AnnotationBsonPropertyIdRecord", new AnnotationBsonPropertyIdRecord(99L),
+                getRecordRegistryFromClasses(AnnotationBsonPropertyIdRecord.class),
+                "{'id': {'$numberLong': '99' }}"));
+
+        data.add(new TestData("SimpleIdRecord with existing id",
+                new SimpleIdRecord(new ObjectId("123412341234123412341234"), 42, "myString"),
+                getRecordRegistryFromClasses(SimpleIdRecord.class),
+                "{'_id': {'$oid': '123412341234123412341234'}, 'integerField': 42, 'stringField': 'myString'}"));
+
+        data.add(new TestData("NestedSimpleIdRecord",
+                new NestedSimpleIdRecord(null, new SimpleIdRecord(null,42, "myString")),
+                getRecordRegistryFromClasses(NestedSimpleIdRecord.class, SimpleIdRecord.class),
+                "{'nestedSimpleIdRecord': {'integerField': 42, 'stringField': 'myString'}}"));
+
+        data.add(new TestData("TreeWithIdRecord",
+                new TreeWithIdRecord(new ObjectId("123412341234123412341234"), "top",
+                        new TreeWithIdRecord(null, "left-1", new TreeWithIdRecord(null,"left-2", null, null), null), new TreeWithIdRecord(null,"right-1", null, null)),
+                getRecordRegistryFromClasses(TreeWithIdRecord.class),
+                "{'_id': {'$oid': '123412341234123412341234'}, 'level': 'top',"
+                        + "'left': {'level': 'left-1', 'left': {'level': 'left-2'}},"
+                        + "'right': {'level': 'right-1'}}"));
+
+        data.add(new TestData("BsonRepresentation is encoded and decoded correctly", new BsonRepresentationRecord(new ObjectId("111111111111111111111111").toHexString(),1),
+                getRecordRegistryFromClasses(BsonRepresentationRecord.class),
+                "{'_id': {'$oid': '111111111111111111111111'}, 'age': 1}"));
+
+        data.add(new TestData("BsonProperty is _id", new BsonPropUnderscoreId("123123"), getRecordRegistryFromClasses(BsonPropUnderscoreId.class),
+                "{'_id': '123123'}"));
+
+        data.add(new TestData("BsonProperty is _id and the field is not id or _id", new BsonPropUnderscoreIdNonIdName("123123"), getRecordRegistryFromClasses(BsonPropUnderscoreIdNonIdName.class),
+                "{'_id': '123123'}"));
+
+        return data;
+    }
+
+    private static final String SIMPLE_RECORD_JSON = "{'integerField': 42, 'stringField': 'myString'}";
+
+    static CodecRegistry getRegistryFromProvider(RecordCodecProvider provider) {
+        return fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider(), provider);
+    }
+
+    static SimpleRecord getSimpleRecord() {
+        return new SimpleRecord(42, "myString");
+    }
+
+    static GenericTreeRecord<String, Integer> getGenericTreeRecord() {
+        return new GenericTreeRecord<String, Integer>("top", 1,
+                new GenericTreeRecord<String, Integer>("left", 2,
+                        new GenericTreeRecord<String, Integer>("left", 3, null, null), null),
+                new GenericTreeRecord<String, Integer>("right", 4,
+                        new GenericTreeRecord<String, Integer>("left", 5, null, null), null));
+    }
+
+    private static CodecRegistry getRecordRegistryFromClasses(Class<?>... classes) {
+        RecordCodecProvider.Builder builder = RecordCodecProvider.builder();
+        for (Class<?> clazz : classes) {
+            builder.register(clazz);
+        }
+        RecordCodecProvider recordCodecProvider = builder.build();
+        return getRegistryFromProvider(recordCodecProvider);
+    }
+
+    private static ConventionRecord getConventionRecord() {
+        SimpleRecord simpleRecord = getSimpleRecord();
+        ConventionRecord child = new ConventionRecord("child", null, simpleRecord);
+        return new ConventionRecord("id", child, null);
+    }
+
+    private static PrimitivesRecord getPrimitivesRecord() {
+        return new PrimitivesRecord(true, Byte.parseByte("1", 2), '1', 1.0, 2f, 3, 5L, (short) 6);
+    }
+
+    private static ConcreteCollectionsRecord getConcreteCollectionsRecord() {
+        Collection<Integer> collection = asList(1, 2, 3);
+        List<Integer> list = asList(4, 5, 6);
+        LinkedList<Integer> linked = new LinkedList<Integer>(asList(7, 8, 9));
+        Map<String, Double> map = new HashMap<String, Double>();
+        map.put("A", 1.1);
+        map.put("B", 2.2);
+        map.put("C", 3.3);
+        ConcurrentHashMap<String, Double> concurrent = new ConcurrentHashMap<String, Double>();
+        concurrent.put("D", 4.4);
+        concurrent.put("E", 5.5);
+        concurrent.put("F", 6.6);
+
+        return new ConcreteCollectionsRecord(collection, list, linked, map, concurrent);
+    }
+
+    private static ConcreteCollectionsRecord getConcreteCollectionsRecordWithNulls() {
+        Collection<Integer> collection = asList(1, null, 3);
+        List<Integer> list = asList(4, null, 6);
+        LinkedList<Integer> linked = new LinkedList<Integer>(asList(null, 8, 9));
+        Map<String, Double> map = new HashMap<String, Double>();
+        map.put("A", 1.1);
+        map.put("B", null);
+        map.put("C", 3.3);
+
+        return new ConcreteCollectionsRecord(collection, list, linked, map, null);
+    }
+
+    private static SimpleNestedRecord getSimpleNestedRecord() {
+        SimpleRecord simpleRecord = getSimpleRecord();
+        return new SimpleNestedRecord(simpleRecord);
+    }
+
+    private static CollectionNestedRecord getCollectionNestedRecord() {
+        return getCollectionNestedRecord(false);
+    }
+    private static CollectionNestedRecord getCollectionNestedRecordWithNulls() {
+        return getCollectionNestedRecord(true);
+    }
+
+    private static CollectionNestedRecord getCollectionNestedRecord (final boolean useNulls) {
+        List<SimpleRecord> listSimple;
+        Set<SimpleRecord> setSimple;
+        Map<String, SimpleRecord> mapSimple;
+
+        if (useNulls) {
+            listSimple = null;
+            setSimple = null;
+            mapSimple = null;
+        } else {
+            SimpleRecord SimpleRecord = getSimpleRecord();
+            listSimple = singletonList(SimpleRecord);
+            setSimple = new HashSet<SimpleRecord>(listSimple);
+            mapSimple = new HashMap<String, SimpleRecord>();
+            mapSimple.put("s", SimpleRecord);
+        }
+
+        List<List<SimpleRecord>> listListSimple = singletonList(listSimple);
+        Set<Set<SimpleRecord>> setSetSimple = new HashSet<Set<SimpleRecord>>(singletonList(setSimple));
+
+        Map<String, Map<String, SimpleRecord>> mapMapSimple = new HashMap<String, Map<String, SimpleRecord>>();
+        mapMapSimple.put("ms", mapSimple);
+
+        Map<String, List<SimpleRecord>> mapListSimple = new HashMap<String, List<SimpleRecord>>();
+        mapListSimple.put("ls", listSimple);
+
+        Map<String, List<Map<String, SimpleRecord>>> mapListMapSimple = new HashMap<String, List<Map<String, SimpleRecord>>>();
+        mapListMapSimple.put("lm", singletonList(mapSimple));
+
+        Map<String, Set<SimpleRecord>> mapSetSimple = new HashMap<String, Set<SimpleRecord>>();
+        mapSetSimple.put("s", setSimple);
+
+        List<Map<String, SimpleRecord>> listMapSimple = singletonList(mapSimple);
+        List<Map<String, List<SimpleRecord>>> listMapListSimple = singletonList(mapListSimple);
+        List<Map<String, Set<SimpleRecord>>> listMapSetSimple = singletonList(mapSetSimple);
+
+        return new CollectionNestedRecord(listSimple, listListSimple, setSimple, setSetSimple, mapSimple, mapMapSimple, mapListSimple,
+                mapListMapSimple, mapSetSimple, listMapSimple, listMapListSimple, listMapSetSimple);
+    }
+
+    private static NestedGenericHolderRecord getNestedGenericHolderRecord() {
+        return new NestedGenericHolderRecord(new GenericHolderRecord<String>("generic", 1L));
+    }
+
+    private static NestedGenericHolderMapRecord getNestedGenericHolderMapRecord() {
+        Map<String, SimpleRecord> mapSimple = new HashMap<>();
+        mapSimple.put("s", getSimpleRecord());
+        return new NestedGenericHolderMapRecord(new GenericHolderRecord<Map<String, SimpleRecord>>(mapSimple, 1L));
+    }
+
+    private static NestedReusedGenericsRecord getNestedReusedGenericsRecord() {
+        return new NestedReusedGenericsRecord(new ReusedGenericsRecord<Long, List<SimpleRecord>, String>(1L,
+                singletonList(getSimpleRecord()), "field3", 42, "field5", asList(getSimpleRecord(), getSimpleRecord()), 2L, "field8"));
+    }
+
+    private static SimpleGenericsRecord<Long, String, Integer> getSimpleGenericsRecordAlt() {
+        HashMap<String, Integer> map = new HashMap<String, Integer>();
+        map.put("D", 2);
+        map.put("E", 3);
+        map.put("F", 4);
+
+        return new SimpleGenericsRecord<Long, String, Integer>(42, 101L, asList("B", "C"), map);
+    }
+
+    private static NestedGenericHolderFieldWithMultipleTypeParamsRecord getNestedGenericHolderFieldWithMultipleTypeParamsRecord() {
+        SimpleGenericsRecord<Long, String, Integer> simple = getSimpleGenericsRecordAlt();
+        PropertyWithMultipleTypeParamsRecord<Integer, Long, String> field =
+                new PropertyWithMultipleTypeParamsRecord<>(simple);
+        GenericHolderRecord<PropertyWithMultipleTypeParamsRecord<Integer, Long, String>> nested = new
+                GenericHolderRecord<>(field, 42L);
+        return new NestedGenericHolderFieldWithMultipleTypeParamsRecord(nested);
+    }
+
+    private static NestedGenericHolderSimpleGenericsRecord getNestedGenericHolderSimpleGenericsRecord() {
+        SimpleRecord simpleRecord = getSimpleRecord();
+        Map<String, SimpleRecord> map = new HashMap<String, SimpleRecord>();
+        map.put("A", simpleRecord);
+        Map<String, Map<String, SimpleRecord>> mapB = new HashMap<String, Map<String, SimpleRecord>>();
+        mapB.put("A", map);
+        SimpleGenericsRecord<Integer, List<SimpleRecord>, Map<String, SimpleRecord>> simpleGenericsRecord =
+                new SimpleGenericsRecord<Integer, List<SimpleRecord>, Map<String, SimpleRecord>>(42, 42,
+                        singletonList(singletonList(simpleRecord)), mapB);
+        GenericHolderRecord<SimpleGenericsRecord<Integer, List<SimpleRecord>, Map<String, SimpleRecord>>> nested =
+                new GenericHolderRecord<SimpleGenericsRecord<Integer, List<SimpleRecord>, Map<String, SimpleRecord>>>(simpleGenericsRecord, 42L);
+
+        return new NestedGenericHolderSimpleGenericsRecord(nested);
+    }
+
+    private static GenericTreeRecord<String, String> getGenericTreeRecordStrings() {
+        return new GenericTreeRecord<String, String>("top", "1",
+                new GenericTreeRecord<String, String>("left", "2",
+                        new GenericTreeRecord<String, String>("left", "3", null, null), null),
+                new GenericTreeRecord<String, String>("right", "4",
+                        new GenericTreeRecord<String, String>("left", "5", null, null), null));
+    }
+
+    private static NestedSelfReferentialGenericHolderRecord getNestedSelfReferentialGenericHolderRecord() {
+        SelfReferentialGenericRecord<Boolean, Long> selfRef1 = new SelfReferentialGenericRecord<Boolean, Long>(true, 33L,
+                new SelfReferentialGenericRecord<Long, Boolean>(44L, false, null));
+        SelfReferentialGenericRecord<Boolean, Double> selfRef2 = new SelfReferentialGenericRecord<Boolean, Double>(true, 3.14,
+                new SelfReferentialGenericRecord<Double, Boolean>(3.42, true, null));
+        NestedSelfReferentialGenericRecord<Boolean, Long, Double> nested =
+                new NestedSelfReferentialGenericRecord<Boolean, Long, Double>(true, 42L, 44.0, selfRef1, selfRef2);
+        return new NestedSelfReferentialGenericHolderRecord(nested);
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        RecordCodecProvider automaticProvider = RecordCodecProvider.builder().automatic(true).build();
+        CodecRegistry automaticRegistry = getRegistryFromProvider(automaticProvider);
+
+        RecordCodecProvider packageProvider = RecordCodecProvider.builder().register("org.bson.codecs.pojo.entities.records").build();
+        CodecRegistry packageRegistry = getRegistryFromProvider(packageProvider);
+
+        List<Object[]> data = new ArrayList<Object[]>();
+
+        for (TestData testData : testCases()) {
+            data.add(new Object[]{format("%s", testData.getName()), testData.getRecord(), testData.getRegistry(), testData.getJson() });
+            data.add(new Object[]{format("%s [Auto]", testData.getName()), testData.getRecord(), automaticRegistry, testData.getJson() });
+            data.add(new Object[]{format("%s [Package]", testData.getName()), testData.getRecord(), packageRegistry, testData.getJson() });
+        }
+        return data;
+    }
+
+    private static class TestData {
+        private final String name;
+        private final Record record;
+        private final CodecRegistry registry;
+        private final String json;
+
+        TestData(final String name, final Record record, final CodecRegistry registry, final String json) {
+            this.name = name;
+            this.record = record;
+            this.registry = registry;
+            this.json = json;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Object getRecord() {
+            return record;
+        }
+
+        public CodecRegistry getRegistry() {
+            return registry;
+        }
+
+        public String getJson() {
+            return json;
+        }
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/AnnotationBsonPropertyIdRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/AnnotationBsonPropertyIdRecord.java
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+public record AnnotationBsonPropertyIdRecord(@BsonProperty("id") long id) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonCreatorRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonCreatorRecord.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.annotations.BsonCreator;
+
+public record BsonCreatorRecord(String stringField) {
+    @BsonCreator
+    public BsonCreatorRecord() {
+        this("");
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonIgnoreInvalidMapRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonIgnoreInvalidMapRecord.java
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.annotations.BsonIgnore;
+
+import java.util.Map;
+
+public record BsonIgnoreInvalidMapRecord(String stringField, @BsonIgnore Map<Integer, Integer> invalidMap) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonPropUnderscoreId.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonPropUnderscoreId.java
@@ -1,0 +1,6 @@
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+public record BsonPropUnderscoreId(@BsonProperty("_id") String id) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonPropUnderscoreIdNonIdName.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonPropUnderscoreIdNonIdName.java
@@ -1,0 +1,6 @@
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+public record BsonPropUnderscoreIdNonIdName(@BsonProperty("_id") String name) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonRepresentationRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonRepresentationRecord.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.BsonType;
+import org.bson.codecs.pojo.annotations.BsonRepresentation;
+
+public record BsonRepresentationRecord(@BsonRepresentation(BsonType.OBJECT_ID) String id, int age) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonRepresentationUnsupportedIntRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonRepresentationUnsupportedIntRecord.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.BsonType;
+import org.bson.codecs.pojo.annotations.BsonRepresentation;
+
+public record BsonRepresentationUnsupportedIntRecord(String id, @BsonRepresentation(BsonType.INT32) String s) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonRepresentationUnsupportedStringRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/BsonRepresentationUnsupportedStringRecord.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.BsonType;
+import org.bson.codecs.pojo.annotations.BsonRepresentation;
+
+public record BsonRepresentationUnsupportedStringRecord(String id, @BsonRepresentation(BsonType.INT32) String s) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/CollectionNestedRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/CollectionNestedRecord.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.records;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public record CollectionNestedRecord(List<SimpleRecord> listSimple, List<List<SimpleRecord>> listListSimple,
+                                     Set<SimpleRecord> setSimple, Set<Set<SimpleRecord>> setSetSimple, Map<String, SimpleRecord> mapSimple, Map<String,
+                                     Map<String, SimpleRecord>> mapMapSimple, Map<String, List<SimpleRecord>> mapListSimple, Map<String,
+                                     List<Map<String, SimpleRecord>>> mapListMapSimple, Map<String, Set<SimpleRecord>> mapSetSimple, List<Map<String,
+                                     SimpleRecord>> listMapSimple, List<Map<String, List<SimpleRecord>>> listMapListSimple, List<Map<String,
+                                     Set<SimpleRecord>>> listMapSetSimple) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ConcreteCollectionsRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ConcreteCollectionsRecord.java
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public record ConcreteCollectionsRecord(Collection<Integer> collection, List<Integer> list,
+                                        LinkedList<Integer> linked, Map<String, Double> map,
+                                        ConcurrentHashMap<String, Double> concurrent) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ConcreteInterfaceGenericRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ConcreteInterfaceGenericRecord.java
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record ConcreteInterfaceGenericRecord(String propertyA) implements InterfaceGenericRecord<String> {
+
+    @Override
+    public String getPropertyA() {
+        return propertyA;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ContainsAlternativeMapAndCollectionRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ContainsAlternativeMapAndCollectionRecord.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+
+public record ContainsAlternativeMapAndCollectionRecord(BsonArray customList, BsonDocument customMap) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ConventionRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ConventionRecord.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+@BsonDiscriminator(value = "AnnotatedConventionRecord", key = "_cls")
+public record ConventionRecord(@BsonId String customId, @BsonProperty(useDiscriminator = false) ConventionRecord child,
+                               @BsonProperty(value = "record", useDiscriminator = false) SimpleRecord simpleRecord) {
+    private static final int myStaticField = 10;
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ConverterRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ConverterRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record ConverterRecord(String id, String name) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/CustomPropertyCodecOptionalRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/CustomPropertyCodecOptionalRecord.java
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.entities.Optional;
+
+public record CustomPropertyCodecOptionalRecord(Optional<String> optionalField) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/GenericHolderRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/GenericHolderRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record GenericHolderRecord<P>(P myGenericField, Long myLongField) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/GenericTreeRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/GenericTreeRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record GenericTreeRecord<A, B>(A field1, B field2, GenericTreeRecord<A, B> left, GenericTreeRecord<A, B> right) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/InterfaceGenericRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/InterfaceGenericRecord.java
@@ -14,14 +14,8 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public interface InterfaceGenericRecord<T> {
+    T getPropertyA();
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/InterfaceImplA.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/InterfaceImplA.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+@BsonDiscriminator
+public record InterfaceImplA(boolean value, String name) implements InterfaceRecord {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/InterfaceRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/InterfaceRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public interface InterfaceRecord {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/InvalidCollectionRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/InvalidCollectionRecord.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.entities.InvalidCollection;
+
+import java.util.List;
+
+public record InvalidCollectionRecord(InvalidCollection collectionField) {
+    public InvalidCollectionRecord(final List<Integer> list) {
+        this(new InvalidCollection(list));
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/InvalidMapRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/InvalidMapRecord.java
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import java.util.Map;
+
+public record InvalidMapRecord(Map<Integer, Integer> invalidMap) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ListGenericExtendedRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ListGenericExtendedRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record ListGenericExtendedRecord() {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/MapStringObjectRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/MapStringObjectRecord.java
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import java.util.Map;
+
+public record MapStringObjectRecord(Map<String, Object> map) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/MultipleLevelGenericRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/MultipleLevelGenericRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record MultipleLevelGenericRecord<A>(A stringField, GenericTreeRecord<A, Integer> nested) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedFieldReusingClassTypeParameterRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedFieldReusingClassTypeParameterRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record NestedFieldReusingClassTypeParameterRecord(PropertyReusingClassTypeParameterRecord<String> nested) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedGenericHolderFieldWithMultipleTypeParamsRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedGenericHolderFieldWithMultipleTypeParamsRecord.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+public record NestedGenericHolderFieldWithMultipleTypeParamsRecord(@BsonProperty(useDiscriminator = false)
+                                                                   GenericHolderRecord<PropertyWithMultipleTypeParamsRecord<Integer, Long, String>> nested) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedGenericHolderMapRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedGenericHolderMapRecord.java
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import java.util.Map;
+
+public record NestedGenericHolderMapRecord(GenericHolderRecord<Map<String, SimpleRecord>> nested) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedGenericHolderRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedGenericHolderRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record NestedGenericHolderRecord(GenericHolderRecord<String> nested) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedGenericHolderSimpleGenericsRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedGenericHolderSimpleGenericsRecord.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import java.util.List;
+import java.util.Map;
+
+public record NestedGenericHolderSimpleGenericsRecord(GenericHolderRecord<SimpleGenericsRecord<Integer, List<SimpleRecord>, Map<String, SimpleRecord>>> nested) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedGenericTreeRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedGenericTreeRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record NestedGenericTreeRecord(Integer intField, GenericTreeRecord<String, Integer> nested) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedMultipleLevelGenericRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedMultipleLevelGenericRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record NestedMultipleLevelGenericRecord(Integer intField, MultipleLevelGenericRecord<String> nested) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedRecordsAndPojos.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedRecordsAndPojos.java
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.entities.SimpleModel;
+
+public record NestedRecordsAndPojos(String stringField, SimpleModel simpleModel, SimpleRecord simpleRecord, PojoContainsRecord pojoContainer, RecordContainsPojo recordContainer) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedReusedGenericsRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedReusedGenericsRecord.java
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import java.util.List;
+
+public record NestedReusedGenericsRecord(ReusedGenericsRecord<Long, List<SimpleRecord>, String> nested) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedSelfReferentialGenericHolderRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedSelfReferentialGenericHolderRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record NestedSelfReferentialGenericHolderRecord(NestedSelfReferentialGenericRecord<Boolean, Long, Double> nested) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedSelfReferentialGenericRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedSelfReferentialGenericRecord.java
@@ -14,14 +14,8 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record NestedSelfReferentialGenericRecord<T, V, Z>(T t, V v, Z z, SelfReferentialGenericRecord<T, V> selfRef1,
+                                                          SelfReferentialGenericRecord<T, Z> selfRef2) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedSimpleIdRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/NestedSimpleIdRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record NestedSimpleIdRecord(String id, SimpleIdRecord nestedSimpleIdRecord) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/PojoContainsGenericRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/PojoContainsGenericRecord.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.records;
+
+import java.util.Objects;
+
+public class PojoContainsGenericRecord {
+    private String stringField;
+    private GenericHolderRecord<String> genericRecord;
+
+    public PojoContainsGenericRecord() {
+    }
+
+    public PojoContainsGenericRecord(final String stringField, final GenericHolderRecord<String> genericRecord) {
+        this.stringField = stringField;
+        this.genericRecord = genericRecord;
+    }
+
+    public String getStringField() {
+        return stringField;
+    }
+
+    public void setStringField(final String stringField) {
+        this.stringField = stringField;
+    }
+
+    public GenericHolderRecord<String> getGenericRecord() {
+        return genericRecord;
+    }
+
+    public void setGenericRecord(final GenericHolderRecord<String> genericRecord) {
+        this.genericRecord = genericRecord;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PojoContainsGenericRecord that = (PojoContainsGenericRecord) o;
+        return Objects.equals(stringField, that.stringField) &&
+                Objects.equals(genericRecord, that.genericRecord);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stringField, genericRecord);
+    }
+
+    @Override
+    public String toString() {
+        return "PojoContainsGenericRecord{" +
+                "stringField='" + stringField + '\'' +
+                ", genericRecord=" + genericRecord +
+                '}';
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/PojoContainsRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/PojoContainsRecord.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities.records;
+
+import java.util.Objects;
+
+public class PojoContainsRecord {
+    private String stringField;
+    private SimpleRecord simpleRecord;
+
+    public PojoContainsRecord() {
+    }
+
+    public PojoContainsRecord(final String stringField, final SimpleRecord simpleRecord) {
+        this.stringField = stringField;
+        this.simpleRecord = simpleRecord;
+    }
+
+    public String getStringField() {
+        return stringField;
+    }
+
+    public void setStringField(final String stringField) {
+        this.stringField = stringField;
+    }
+
+    public Record getSimpleRecord() {
+        return simpleRecord;
+    }
+
+    public void setSimpleRecord(final SimpleRecord simpleRecord) {
+        this.simpleRecord = simpleRecord;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PojoContainsRecord that = (PojoContainsRecord) o;
+        return Objects.equals(stringField, that.stringField) &&
+                Objects.equals(simpleRecord, that.simpleRecord);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stringField, simpleRecord);
+    }
+
+    @Override
+    public String toString() {
+        return "PojoContainsRecord{" +
+                "name='" + stringField + '\'' +
+                ", SimpleRecord=" + simpleRecord +
+                '}';
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/PrimitivesRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/PrimitivesRecord.java
@@ -14,14 +14,8 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record PrimitivesRecord(boolean myBoolean, byte myByte, char myCharacter, double myDouble,
+                               float myFloat, int myInteger, long myLong, short myShort) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/PropertyReusingClassTypeParameterRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/PropertyReusingClassTypeParameterRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record PropertyReusingClassTypeParameterRecord<A>(GenericTreeRecord<A, A> tree) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/PropertySelectionRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/PropertySelectionRecord.java
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record PropertySelectionRecord(String stringField) {
+    private static final String staticFinalStringField = "staticFinalStringField";
+    private static String staticStringField = "staticStringField";
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/PropertyWithMultipleTypeParamsRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/PropertyWithMultipleTypeParamsRecord.java
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+@BsonDiscriminator("PropertyWithMultipleTypeParamsRecord")
+public record PropertyWithMultipleTypeParamsRecord<C, A, B>(@BsonProperty(useDiscriminator = true)
+                                                            SimpleGenericsRecord<A, B, C> simpleGenericsRecord) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/RecordContainsGenericPojo.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/RecordContainsGenericPojo.java
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.entities.GenericHolderModel;
+
+public record RecordContainsGenericPojo(String stringField, GenericHolderModel<String> genericField) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/RecordContainsPojo.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/RecordContainsPojo.java
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.entities.SimpleModel;
+
+public record RecordContainsPojo(String stringField, SimpleModel simpleModel) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ReusedGenericsRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/ReusedGenericsRecord.java
@@ -14,14 +14,8 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record ReusedGenericsRecord<A, B, C>(A field1, B field2, C field3, Integer field4, C field5, B field6,
+                                             A field7, String field8) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/SelfReferentialGenericRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/SelfReferentialGenericRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record SelfReferentialGenericRecord<T, V>(T t, V v, SelfReferentialGenericRecord<V, T> child) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/SimpleEnumRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/SimpleEnumRecord.java
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.codecs.pojo.entities.SimpleEnum;
+
+public record SimpleEnumRecord(SimpleEnum myEnum) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/SimpleGenericsRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/SimpleGenericsRecord.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import java.util.List;
+import java.util.Map;
+
+public record SimpleGenericsRecord<T, V, Z>(Integer myIntegerField, T myGenericField, List<V> myListField, Map<String, Z> myMapField) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/SimpleIdRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/SimpleIdRecord.java
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.types.ObjectId;
+
+public record SimpleIdRecord(ObjectId id, Integer integerField, String stringField) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/SimpleNestedRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/SimpleNestedRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record SimpleNestedRecord(SimpleRecord simple) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/SimpleRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/SimpleRecord.java
@@ -14,14 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+public record SimpleRecord(Integer integerField, String stringField) {
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/records/TreeWithIdRecord.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/records/TreeWithIdRecord.java
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include ':util'
-include 'record-support'
+package org.bson.codecs.pojo.entities.records;
+
+import org.bson.types.ObjectId;
+
+public record TreeWithIdRecord(ObjectId id, String level, TreeWithIdRecord left, TreeWithIdRecord right) {
+}

--- a/build.gradle
+++ b/build.gradle
@@ -79,8 +79,8 @@ configure(coreProjects) {
 configure(javaProjects) {
     apply plugin: 'java-library'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_15
+    targetCompatibility = JavaVersion.VERSION_15
 
     sourceSets {
         main {
@@ -101,8 +101,8 @@ configure(scalaProjects) {
 
     group = 'org.mongodb.scala'
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_15
+    targetCompatibility = JavaVersion.VERSION_15
 
     dependencies {
         compile ('org.scala-lang:scala-library:%scala-version%')
@@ -150,25 +150,28 @@ configure(scalaProjects) {
 configure(javaMainProjects) {
     apply plugin: 'nebula.optional-base'
     apply plugin: 'java-library'
-    
     dependencies {
         compileOnly 'com.google.code.findbugs:jsr305:1.3.9'
         api 'org.slf4j:slf4j-api:1.7.6', optional
         testImplementation 'com.google.code.findbugs:jsr305:1.3.9'
     }
-
     /* Compiling */
     tasks.withType(AbstractCompile) {
         options.encoding = 'ISO-8859-1'
         options.fork = true
         options.debug = true
-        options.compilerArgs = ['-Xlint:all']
+        options.compilerArgs = ['-Xlint:all', '--enable-preview']
+    }
+    test {
+        jvmArgs(['--enable-preview'])
     }
 }
 
 configure(javaAndScalaTestedProjects) {
     /* Testing */
     tasks.withType(Test) {
+        jvmArgs(['--enable-preview'])
+
         systemProperties(
                 'org.mongodb.test.uri': System.getProperty('org.mongodb.test.uri'),
                 'org.mongodb.test.transaction.uri': System.getProperty('org.mongodb.test.transaction.uri'),
@@ -250,6 +253,7 @@ configure(javaCodeCheckedProjects) {
     sourceSets {
         test {
             groovy.srcDirs = ['src/test/functional', 'src/test/unit']
+            java.srcDirs = ['src/test/functional', 'src/test/unit']
         }
     }
 

--- a/driver-core/src/main/com/mongodb/MongoClientSettings.java
+++ b/driver-core/src/main/com/mongodb/MongoClientSettings.java
@@ -38,6 +38,7 @@ import org.bson.codecs.MapCodecProvider;
 import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.jsr310.Jsr310CodecProvider;
+import org.bson.codecs.pojo.RecordCodecProvider;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -70,7 +71,8 @@ public final class MongoClientSettings {
                     new GridFSFileCodecProvider(),
                     new Jsr310CodecProvider(),
                     new JsonObjectCodecProvider(),
-                    new BsonCodecProvider()));
+                    new BsonCodecProvider(),
+                    RecordCodecProvider.builder().automatic(true).build()));
 
     private final ReadPreference readPreference;
     private final WriteConcern writeConcern;

--- a/driver-sync/src/test/functional/com/mongodb/client/MongoCollectionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/MongoCollectionTest.java
@@ -30,9 +30,11 @@ import org.bson.codecs.DocumentCodec;
 import org.bson.codecs.DocumentCodecProvider;
 import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
-import org.bson.json.JsonObject;
 import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bson.codecs.pojo.RecordCodecProvider;
 import org.bson.codecs.pojo.entities.conventions.BsonRepresentationModel;
+import org.bson.codecs.pojo.entities.records.SimpleRecord;
+import org.bson.json.JsonObject;
 import org.bson.types.ObjectId;
 import org.junit.Test;
 
@@ -46,9 +48,9 @@ import static java.util.Arrays.asList;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class MongoCollectionTest extends DatabaseTestCase {
@@ -244,5 +246,24 @@ public class MongoCollectionTest extends DatabaseTestCase {
 
         // then
         assertNotNull(test.find().first().getId());
+    }
+
+    @Test
+    public void testRecordSupport() {
+        //given
+        CodecRegistry recordCodecRegistry = fromRegistries(MongoClientSettings.getDefaultCodecRegistry(),
+                fromProviders(RecordCodecProvider.builder().automatic(true).build()));
+
+        MongoCollection<SimpleRecord> test =
+                database.getCollection("test", SimpleRecord.class)
+                        .withCodecRegistry(recordCodecRegistry);
+        test.drop();
+        SimpleRecord record = new SimpleRecord(42, "stringField");
+
+        // when
+        test.insertOne(record);
+
+        // then
+        assertEquals(record, test.find().first());
     }
 }


### PR DESCRIPTION
Leaving as a draft for the following reasons:
1. Testing is not finished. I was unable to get Junit running successfully in preview mode so I wrote my own little test runner. The tests I wrote make me confident that my implementation is correct, but we're going to want to add more coverage before merging this. All of the tests I have written so far are integration tests. I did not write a full suite of tests because I didn't want to waste time writing them in one format, when they'll just need to be converted to Junit tests before this gets merged anyway.
2. Annotations are not supported. I was having a problem getting the ElementType.RecordComponent to work because of preview mode. If we are able to use ElementType.RecordComponent it will be very easy to support annotations, but if this causes a Java 8 compatibility problem we'll have to think harder about how to do that.
3. There is a bunch of junk in this diff that I needed to do to get preview mode to work that needs to be deleted before it is merged.

I think it makes the most sense to hold off on fixing these problems until records are generally available instead of preview mode because it will save a lot of time and configuration headaches.