### PR TITLE
Sync retryable write tests to add error label

### DIFF
--- a/driver-core/src/test/resources/retryable-writes/insertOne-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/insertOne-serverErrors.json
@@ -966,7 +966,10 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down"
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
           }
         }
       },


### PR DESCRIPTION
Couple of questions...
1. To sync the tests we just copy the files over from the spec repo right? There's no fancy command or git setup?
2. I didn't see us using any yaml files for the tests, so I'm assuming I only have to copy over the json ones? Drivers get to pick which ones they want to use?
3. I understand why this didn't cause any failures (it's just adding an error label that we need to have at the end), but I'm confused how we were passing it initially. I set breakpoints everywhere I thought we could add a RetryableWriteError and couldn't find where it actually happened. CommandOperationHelper::addRetryableErrorLabel wasn't doing it because the maxWireVersion = 9 and it wasn't a socket exception.

Evergreen patch: https://spruce.mongodb.com/version/5f6e2ad5d1fe07104a068d9a/tasks