### PR TITLE
[JAVA-3814] Supports BsonIgnore annotation for scala driver

### DIFF
--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/annotations/BsonIgnore.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/annotations/BsonIgnore.scala
@@ -1,0 +1,8 @@
+package org.mongodb.scala.bson.annotations
+
+import scala.annotation.StaticAnnotation
+
+/**
+ * Annotation to ignore a property.
+ */
+case class BsonIgnore() extends StaticAnnotation


### PR DESCRIPTION
Link to JIRA issue [here](https://jira.mongodb.org/browse/JAVA-3814?filter=-2)

Goal is to support `BsonIgnore` annotation for scala driver in order to ignore some fields during bson serialization which are not meant to be `Option`s

ie: 

```scala
case class Person(firstname: String, lastname: String, @BsonIgnore metadata: Seq[Metadata] = Vector())
```

Tests have been added to the `MacrosSpec`