### PR TITLE
Potential fix for JAVA-3769

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/AutomaticPojoCodec.java
+++ b/bson/src/main/org/bson/codecs/pojo/AutomaticPojoCodec.java
@@ -66,4 +66,9 @@ final class AutomaticPojoCodec<T> extends PojoCodec<T> {
     ClassModel<T> getClassModel() {
         return pojoCodec.getClassModel();
     }
+
+    @Override
+    DiscriminatorLookup getDiscriminatorLookup() {
+        return pojoCodec.getDiscriminatorLookup();
+    }
 }

--- a/bson/src/main/org/bson/codecs/pojo/LazyPropertyModelCodec.java
+++ b/bson/src/main/org/bson/codecs/pojo/LazyPropertyModelCodec.java
@@ -67,7 +67,7 @@ class LazyPropertyModelCodec<T> implements Codec<T> {
             if (localCodec instanceof PojoCodec) {
                 PojoCodec<T> pojoCodec = (PojoCodec<T>) localCodec;
                 ClassModel<T> specialized = getSpecializedClassModel(pojoCodec.getClassModel(), propertyModel);
-                localCodec = new PojoCodecImpl<>(specialized, registry, propertyCodecRegistry, discriminatorLookup, true);
+                localCodec = new PojoCodecImpl<>(specialized, registry, propertyCodecRegistry, pojoCodec.getDiscriminatorLookup(), true);
             }
             codec = localCodec;
         }

--- a/bson/src/main/org/bson/codecs/pojo/PojoCodec.java
+++ b/bson/src/main/org/bson/codecs/pojo/PojoCodec.java
@@ -21,4 +21,6 @@ import org.bson.codecs.Codec;
 abstract class PojoCodec<T> implements Codec<T> {
 
     abstract ClassModel<T> getClassModel();
+
+    abstract DiscriminatorLookup getDiscriminatorLookup();
 }

--- a/bson/src/main/org/bson/codecs/pojo/PojoCodecImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/PojoCodecImpl.java
@@ -293,4 +293,9 @@ final class PojoCodecImpl<T> extends PojoCodec<T> {
         }
         return true;
     }
+
+    @Override
+    DiscriminatorLookup getDiscriminatorLookup() {
+        return discriminatorLookup;
+    }
 }

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -19,11 +19,13 @@ package org.bson.codecs.pojo;
 import org.bson.BsonReader;
 import org.bson.BsonWriter;
 import org.bson.Document;
+import org.bson.codecs.BsonValueCodecProvider;
 import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 import org.bson.codecs.LongCodec;
 import org.bson.codecs.MapCodec;
+import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.entities.AbstractInterfaceModel;
@@ -37,6 +39,7 @@ import org.bson.codecs.pojo.entities.ConstructorNotPublicModel;
 import org.bson.codecs.pojo.entities.ConventionModel;
 import org.bson.codecs.pojo.entities.ConverterModel;
 import org.bson.codecs.pojo.entities.CustomPropertyCodecOptionalModel;
+import org.bson.codecs.pojo.entities.GenericHolderModel;
 import org.bson.codecs.pojo.entities.GenericTreeModel;
 import org.bson.codecs.pojo.entities.InterfaceBasedModel;
 import org.bson.codecs.pojo.entities.InvalidCollectionModel;
@@ -45,13 +48,16 @@ import org.bson.codecs.pojo.entities.InvalidMapModel;
 import org.bson.codecs.pojo.entities.InvalidMapPropertyCodecProvider;
 import org.bson.codecs.pojo.entities.InvalidSetterArgsModel;
 import org.bson.codecs.pojo.entities.MapStringObjectModel;
+import org.bson.codecs.pojo.entities.NestedGenericHolderFieldWithMultipleTypeParamsModel;
 import org.bson.codecs.pojo.entities.NestedSimpleIdModel;
 import org.bson.codecs.pojo.entities.Optional;
 import org.bson.codecs.pojo.entities.OptionalPropertyCodecProvider;
 import org.bson.codecs.pojo.entities.PrimitivesModel;
 import org.bson.codecs.pojo.entities.PrivateSetterFieldModel;
+import org.bson.codecs.pojo.entities.PropertyWithMultipleTypeParamsModel;
 import org.bson.codecs.pojo.entities.SimpleEnum;
 import org.bson.codecs.pojo.entities.SimpleEnumModel;
+import org.bson.codecs.pojo.entities.SimpleGenericsModel;
 import org.bson.codecs.pojo.entities.SimpleIdImmutableModel;
 import org.bson.codecs.pojo.entities.SimpleIdModel;
 import org.bson.codecs.pojo.entities.SimpleModel;
@@ -625,6 +631,25 @@ public final class PojoCustomTest extends PojoTestCase {
     public void testRoundTripWithoutBsonAnnotation() {
         roundTrip(getPojoCodecProviderBuilder(BsonRepresentationModel.class).conventions(Arrays.asList(CLASS_AND_PROPERTY_CONVENTION)),
                 new BsonRepresentationModel("hello", 1), "{'_id': 'hello', 'age': 1}");
+    }
+
+    @Test
+    public void testMultiplePojoProviders() {
+        NestedGenericHolderFieldWithMultipleTypeParamsModel model = getNestedGenericHolderFieldWithMultipleTypeParamsModel();
+        PojoCodecProvider provider1 = PojoCodecProvider.builder().register(NestedGenericHolderFieldWithMultipleTypeParamsModel.class).build();
+        PojoCodecProvider provider2 = PojoCodecProvider.builder().register(PropertyWithMultipleTypeParamsModel.class).build();
+        PojoCodecProvider provider3 = PojoCodecProvider.builder().register(SimpleGenericsModel.class).build();
+        PojoCodecProvider provider4 = PojoCodecProvider.builder().register(GenericHolderModel.class).build();
+
+        CodecRegistry registry = fromProviders(provider1, provider2, provider3, provider4);
+        CodecRegistry actualRegistry = fromRegistries(fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider()), registry);
+
+        String json = "{'nested': {'myGenericField': {_t: 'PropertyWithMultipleTypeParamsModel', "
+                + "'simpleGenericsModel': {_t: 'org.bson.codecs.pojo.entities.SimpleGenericsModel', 'myIntegerField': 42, "
+                + "'myGenericField': {'$numberLong': '101'}, 'myListField': ['B', 'C'], 'myMapField': {'D': 2, 'E': 3, 'F': 4 }}},"
+                + "'myLongField': {'$numberLong': '42'}}}";
+
+        roundTrip(actualRegistry, model, json);
     }
 
     private List<Convention> getDefaultAndUseGettersConvention() {

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -636,7 +636,8 @@ public final class PojoCustomTest extends PojoTestCase {
     @Test
     public void testMultiplePojoProviders() {
         NestedGenericHolderFieldWithMultipleTypeParamsModel model = getNestedGenericHolderFieldWithMultipleTypeParamsModel();
-        PojoCodecProvider provider1 = PojoCodecProvider.builder().register(NestedGenericHolderFieldWithMultipleTypeParamsModel.class).build();
+        PojoCodecProvider provider1 = PojoCodecProvider.builder().register(NestedGenericHolderFieldWithMultipleTypeParamsModel.class)
+                .build();
         PojoCodecProvider provider2 = PojoCodecProvider.builder().register(PropertyWithMultipleTypeParamsModel.class).build();
         PojoCodecProvider provider3 = PojoCodecProvider.builder().register(SimpleGenericsModel.class).build();
         PojoCodecProvider provider4 = PojoCodecProvider.builder().register(GenericHolderModel.class).build();


### PR DESCRIPTION
I spent the day figuring out what was causing the failure, so I figured I might as well put a fix up for this in case that's the route we want to take. I don't believe, however, this should be fixed for the following reasons:
- By fixing we're basically endorsing using multiple PojoCodecProviders while that's not intended. 
- It adds some complexity (albeit not a lot) to the codebase for little reward

In my opinion there are three things we can do instead to make this better for users:
1. Add a line to our documentation saying that only one PojoCodecProvider can be used.

2. Add to the error message in DiscriminatorLookup::lookup to say something like: "Make sure only one PojoCodecProvider is in your registry." My only concern with this is it may confuse users who are getting that error for a different reason. Unfortunately it is not possible to detect when multiple PojoCodecProviders are the cause of the "class could not be found for the discriminator" error without some kind of global state because there is no way of knowing if the other providers have the discriminator that we can't find. Because of this, we cannot give a more specific error message.

3. Throw an exception in ProvidersCodecRegistry's constructor if multiple codecProviders are PojoCodecProviders. This allows us to throw a very descriptive error, but it's potentially a breaking change. This bug only causes failures when the Pojos are nested and separate providers are used (i.e. Person and Address have different providers and Person contains Address). If the providers are for two separate classes that do not contain each other, clients may be running code successfully using two PojoCodecProviders at once and we're breaking that now.

In my opinion the best thing to do is a combo of Option 1 and Option 2, but I wanted to lay out all the options and get some feedback. 