### PR TITLE
Added MongoCrypt support for Azure and GCP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
     nettyVersion = '4.1.43.Final'
     snappyVersion = '1.1.4'
     zstdVersion = '1.3.8-3'
-    mongoCryptVersion = '1.0.1'
+    mongoCryptVersion = '1.1.0-SNAPSHOT'
     gitVersion = getGitVersion()
 }
 

--- a/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
+++ b/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
@@ -205,8 +205,7 @@ public final class AutoEncryptionSettings {
      * Gets the map of KMS provider properties.
      *
      * <p>
-     * Multiple KMS providers may be specified. Initially, two KMS providers are supported: "aws" and "local". The kmsProviders map
-     * values differ by provider:
+     * Multiple KMS providers may be specified. The kmsProviders map values differ by provider:
      * </p>
      * <p>
      * For "aws", the properties are:
@@ -214,6 +213,24 @@ public final class AutoEncryptionSettings {
      * <ul>
      *     <li>accessKeyId: a String containing the AWS access key identifier</li>
      *     <li>secretAccessKey: a String the AWS secret access key</li>
+     * </ul>
+     * <p>
+     * For "azure", the properties are:
+     * </p>
+     * <ul>
+     *     <li>tenantId: a String with the tenantId that identifies the organization for the account.</li>
+     *     <li>clientId: a String with the clientId to authenticate a registered application.</li>
+     *     <li>clientSecret: a String with the client secret to authenticate a registered application.</li>
+     *     <li>identityPlatformEndpoint: optional String with a host with optional port. e.g. "example.com" or "example.com:443".
+     *     Generally used for private Azure instances.</li>
+     * </ul>
+     * <p>
+     * For "gcp", the properties are:
+     * </p>
+     * <ul>
+     *     <li>email: a String with the service account email to authenticate.</li>
+     *     <li>privateKey: a String or byte[] with the encoded PKCS#8 encrypted key</li>
+     *     <li>endPoint: optional String with a host with optional port. e.g. "example.com" or "example.com:443".</li>
      * </ul>
      * <p>
      * For "local", the properties are:

--- a/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
@@ -16,9 +16,12 @@
 
 package com.mongodb.internal.capi;
 
+import com.mongodb.Block;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.connection.ClusterSettings;
+import com.mongodb.connection.SocketSettings;
 import com.mongodb.crypt.capi.MongoAwsKmsProviderOptions;
 import com.mongodb.crypt.capi.MongoCryptOptions;
 import com.mongodb.crypt.capi.MongoLocalKmsProviderOptions;
@@ -70,7 +73,7 @@ public final class MongoCryptHelper {
 
     @SuppressWarnings("unchecked")
     public static List<String> createMongocryptdSpawnArgs(final Map<String, Object> options) {
-        List<String> spawnArgs = new ArrayList<>();
+        List<String> spawnArgs = new ArrayList<String>();
 
         String path = options.containsKey("mongocryptdSpawnPath")
                 ? (String) options.get("mongocryptdSpawnPath")
@@ -91,10 +94,18 @@ public final class MongoCryptHelper {
     public static MongoClientSettings createMongocryptdClientSettings(final String connectionString) {
 
         return MongoClientSettings.builder()
-                .applyToClusterSettings(builder -> builder.serverSelectionTimeout(1, TimeUnit.SECONDS))
-                .applyToSocketSettings(builder -> {
-                    builder.readTimeout(1, TimeUnit.SECONDS);
-                    builder.connectTimeout(1, TimeUnit.SECONDS);
+                .applyToClusterSettings(new Block<ClusterSettings.Builder>() {
+                    @Override
+                    public void apply(final ClusterSettings.Builder builder) {
+                        builder.serverSelectionTimeout(1, TimeUnit.SECONDS);
+                    }
+                })
+                .applyToSocketSettings(new Block<SocketSettings.Builder>() {
+                    @Override
+                    public void apply(final SocketSettings.Builder builder) {
+                        builder.readTimeout(1, TimeUnit.SECONDS);
+                        builder.connectTimeout(1, TimeUnit.SECONDS);
+                    }
                 })
                 .applyConnectionString(new ConnectionString((connectionString != null)
                         ? connectionString : "mongodb://localhost:27020"))

--- a/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
@@ -273,7 +273,8 @@ class Crypt implements Closeable {
 
     private void fetchKeys(final MongoCryptContext keyBroker) {
         try {
-            for (BsonDocument bsonDocument : keyRetriever.find(keyBroker.getMongoOperation())) {
+            RawBsonDocument mongoOperation = keyBroker.getMongoOperation();
+            for (BsonDocument bsonDocument : keyRetriever.find(mongoOperation)) {
                 keyBroker.addMongoOperationResult(bsonDocument);
             }
             keyBroker.completeMongoOperation();

--- a/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
@@ -273,8 +273,7 @@ class Crypt implements Closeable {
 
     private void fetchKeys(final MongoCryptContext keyBroker) {
         try {
-            RawBsonDocument mongoOperation = keyBroker.getMongoOperation();
-            for (BsonDocument bsonDocument : keyRetriever.find(mongoOperation)) {
+            for (BsonDocument bsonDocument : keyRetriever.find(keyBroker.getMongoOperation())) {
                 keyBroker.addMongoOperationResult(bsonDocument);
             }
             keyBroker.completeMongoOperation();


### PR DESCRIPTION
Added calls to the new CAPI's:

  * mongocrypt_setopt_kms_providers - to support new KMS provider options.
  * mongocrypt_ctx_setopt_key_encryption_key - to support new data key options.
  * mongocrypt_setopt_crypto_hook_sign_rsaes_pkcs1_v1_5 - to support signature callback for GCP.

JAVA-3841