### PR TITLE
Update serialization of ObjectId to a stable interchange format

### DIFF
--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -16,6 +16,8 @@
 
 package org.bson.types;
 
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
@@ -45,7 +47,8 @@ import static org.bson.assertions.Assertions.notNull;
  */
 public final class ObjectId implements Comparable<ObjectId>, Serializable {
 
-    private static final long serialVersionUID = 3670079982654483072L;
+    // unused, as this class uses a proxy for serialization
+    private static final long serialVersionUID = 1L;
 
     private static final int OBJECT_ID_LENGTH = 12;
     private static final int LOW_ORDER_THREE_BYTES = 0x00ffffff;
@@ -346,6 +349,30 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
     @Override
     public String toString() {
         return toHexString();
+    }
+
+    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
+    private Object writeReplace() {
+        return new SerializationProxy(this);
+    }
+
+    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
+    private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
+        throw new InvalidObjectException("Proxy required");
+    }
+
+    private static class SerializationProxy implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final byte[] bytes;
+
+        SerializationProxy(final ObjectId objectId) {
+            bytes = objectId.toByteArray();
+        }
+
+        private Object readResolve() {
+            return new ObjectId(bytes);
+        }
     }
 
     static {

--- a/bson/src/test/unit/org/bson/types/ObjectIdTest.java
+++ b/bson/src/test/unit/org/bson/types/ObjectIdTest.java
@@ -18,6 +18,11 @@ package org.bson.types;
 
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -182,5 +187,33 @@ public class ObjectIdTest {
     @Test
     public void testTimeMaxInt() throws ParseException {
         assertEquals(getDate("07-Feb-2106 06:28:15 -0000"), new ObjectId(0xFFFFFFFF, 0).getDate());
+    }
+
+    @Test
+    public void testObjectSerialization() throws IOException, ClassNotFoundException {
+        // given
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        ObjectId objectId = new ObjectId("5f8f4fcf27516f05e7eae5be");
+
+        // when
+        oos.writeObject(objectId);
+
+        // then
+        assertTrue(new String(baos.toByteArray()).contains("org.bson.types.ObjectId$SerializationProxy"));
+        assertArrayEquals(new byte[] {-84, -19, 0, 5, 115, 114, 0, 42, 111, 114, 103, 46, 98, 115, 111, 110, 46, 116, 121, 112, 101, 115,
+                        46, 79, 98, 106, 101, 99, 116, 73, 100, 36, 83, 101, 114, 105, 97, 108, 105, 122, 97, 116, 105, 111, 110, 80, 114,
+                        111, 120, 121, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 91, 0, 5, 98, 121, 116, 101, 115, 116, 0, 2, 91, 66, 120, 112, 117,
+                        114, 0, 2, 91, 66, -84, -13, 23, -8, 6, 8, 84, -32, 2, 0, 0, 120, 112, 0, 0, 0, 12, 95, -113, 79, -49, 39, 81, 111,
+                        5, -25, -22, -27, -66},
+                baos.toByteArray());
+
+        // when
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        ObjectId deserializedObjectId = (ObjectId) ois.readObject();
+
+        // then
+        assertEquals(objectId, deserializedObjectId);
     }
 }


### PR DESCRIPTION
The existing serialization format for ObjectId is the default format provided by the
ObjectOutputStream specification, which just serializes each field of the class.  But
in the 3.8.0 release we changed the fields, but neglected to even change the
serialVersionUID of the class, which makes any instances of ObjectId serialized prior
to 3.8.0 dangerously incompatible with subsequent driver releases.

This change updates the serialVersionUID for ObjectId, and also defines the serialized
form using a proxy via the writeReplace method.  This means that serialized instances
of ObjectId prior to this change will be incompatible, but at least an exception
will be thrown indicating the incompatibility. And now we have the freedom to change
the private representation of ObjectId without affecting serialization format in the
future.

JAVA-3854