### PR TITLE
Replace SimpleDateFormat with DateDateFormatter for ISODate string parsing

### DIFF
--- a/bson/src/main/org/bson/json/DateTimeFormatter.java
+++ b/bson/src/main/org/bson/json/DateTimeFormatter.java
@@ -17,25 +17,30 @@
 package org.bson.json;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQuery;
 
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
 final class DateTimeFormatter {
+    private static final int DATE_STRING_LENGTH = "1970-01-01".length();
+
     static long parse(final String dateTimeString) {
-        try {
+        // ISO_OFFSET_DATE_TIME will not parse date strings consisting of just year-month-day, so use ISO_LOCAL_DATE for those
+        if (dateTimeString.length() == DATE_STRING_LENGTH) {
+            return LocalDate.parse(dateTimeString, ISO_LOCAL_DATE).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
+        } else {
             return ISO_OFFSET_DATE_TIME.parse(dateTimeString, new TemporalQuery<Instant>() {
                 @Override
                 public Instant queryFrom(final TemporalAccessor temporal) {
                     return Instant.from(temporal);
                 }
             }).toEpochMilli();
-        } catch (DateTimeParseException e) {
-            throw new IllegalArgumentException(e.getMessage());
         }
     }
 
@@ -45,4 +50,5 @@ final class DateTimeFormatter {
 
     private DateTimeFormatter() {
     }
+
 }

--- a/bson/src/main/org/bson/json/JsonParseException.java
+++ b/bson/src/main/org/bson/json/JsonParseException.java
@@ -45,6 +45,7 @@ public class JsonParseException extends RuntimeException {
         super(s);
     }
 
+
     /**
      * Constructs a new runtime exception with string formatted using specified pattern and arguments.
      *
@@ -56,9 +57,20 @@ public class JsonParseException extends RuntimeException {
     }
 
     /**
+     * Constructs a new runtime exception with the specified detail message and root cause.
+     *
+     * @param s The detail message
+     * @param t the throwable root cause
+     * @since 4.2
+     */
+    public JsonParseException(final String s, final Throwable t) {
+        super(s, t);
+    }
+
+    /**
      * Create a JSONParseException with the given {@link Throwable} cause.
      *
-     * @param t the throwable root case
+     * @param t the throwable root cause
      */
     public JsonParseException(final Throwable t) {
         super(t);

--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -141,6 +141,17 @@ public class JsonReaderTest {
     }
 
     @Test
+    public void testDateTimeShellDateOnly() {
+        String json = "ISODate(\"1970-01-01\")";
+        testStringAndStream(json, bsonReader -> {
+            assertEquals(BsonType.DATE_TIME, bsonReader.readBsonType());
+            assertEquals(0, bsonReader.readDateTime());
+            assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+            return null;
+        });
+    }
+
+    @Test
     public void testDateTimeShell() {
         String json = "ISODate(\"1970-01-01T00:00:00Z\")";
         testStringAndStream(json, bsonReader -> {


### PR DESCRIPTION
The JsonReader class already uses java.time.format.DateTimeFormatter for parsing
date strings from relaxed extended JSON. But for historical reasons it still
used the older java.text.SimpleDateFormat for parsing ISODate strings from shell
mode JSON.

This patch replaces the SimpleDateFormat usage with DateTimeFormatter, which will
preserve the existing behavior, but also remove a dependency on Locale.ENGLISH
time zones, which has caused problems for some users of GraalVM (which in some
configurations does not include any of the resources associated with Locale.ENGLISH.

Note that SimpleDateFormat is still used when parsing date strings for the shell-mode
Date constructor, but that is less commonly used and in addition the current shell
support is not localizable and is tied to English-language usage.

JAVA-3851