### PR TITLE
Add assertion context to the unified test runner

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/unified/AssertionContext.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/AssertionContext.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.unified;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+final class AssertionContext {
+
+    private final Deque<ContextElement> contextStack = new ArrayDeque<>();
+
+    public void push(final ContextElement contextElement) {
+        contextStack.push(contextElement);
+    }
+
+    public void pop() {
+        contextStack.pop();
+    }
+
+    public String getMessage(final String rootMessage) {
+        StringBuilder builder = new StringBuilder();
+
+        builder.append(rootMessage).append("\n\n");
+        builder.append("Assertion Context:\n\n");
+
+        for (ContextElement contextElement : contextStack) {
+            builder.append(contextElement.toString()).append('\n');
+        }
+
+        return builder.toString();
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/ContextElement.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/ContextElement.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.unified;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.event.CommandEvent;
+import com.mongodb.event.CommandFailedEvent;
+import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.event.CommandSucceededEvent;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.json.JsonWriterSettings;
+
+import java.util.List;
+
+abstract class ContextElement {
+    static ContextElement ofOperation(final BsonDocument operation) {
+        return new OperationContextElement(operation);
+    }
+
+    static ContextElement ofValueMatcher(final BsonValue expected, final BsonValue actual, final String key, final int arrayPosition) {
+        return new ValueMatchingContextElement(expected, actual, key, arrayPosition);
+    }
+
+    static ContextElement ofError(final BsonDocument expectedError, final Exception e) {
+        return new ErrorMatchingContextElement(expectedError, e);
+    }
+
+    static ContextElement ofOutcome(final MongoNamespace namespace, final List<BsonDocument> expectedOutcome,
+                                           final List<BsonDocument> actualOutcome) {
+        return new OutcomeMatchingContextElement(namespace, expectedOutcome, actualOutcome);
+    }
+
+    static ContextElement ofEvents(final String client) {
+        return new EventsMatchingContextElement(client);
+    }
+
+    static ContextElement ofEvent(final BsonDocument expected, final CommandEvent actual, final int eventPosition) {
+        return new EventMatchingContextElement(expected, actual, eventPosition);
+    }
+
+    private static class OperationContextElement extends ContextElement {
+        private final BsonDocument operation;
+
+        OperationContextElement(final BsonDocument operation) {
+            this.operation = operation;
+        }
+
+        public String toString() {
+            return "Operation Context: " + "\n"
+                    + operation.toJson(JsonWriterSettings.builder().indent(true).build());
+        }
+    }
+
+    private static class ValueMatchingContextElement extends ContextElement {
+        private final BsonValue expected;
+        private final BsonValue actual;
+        private final String key;
+        private final int arrayPosition;
+
+        ValueMatchingContextElement(final BsonValue expected, final BsonValue actual, final String key, final int arrayPosition) {
+            this.expected = expected;
+            this.actual = actual;
+            this.key = key;
+            this.arrayPosition = arrayPosition;
+        }
+
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("Value Matching Context:\n");
+            if (key != null) {
+                builder.append("   Key: ").append(key).append("\n");
+            }
+            if (arrayPosition != -1) {
+                builder.append("   Array position: ").append(arrayPosition).append("\n");
+            }
+            builder.append("   Expected value:\n      ");
+            builder.append(expected.toString()).append("\n");
+            builder.append("   Actual value:\n      ");
+            builder.append(actual.toString()).append("\n");
+            return builder.toString();
+        }
+    }
+
+    private static class ErrorMatchingContextElement extends ContextElement {
+        private final BsonDocument expectedError;
+        private final Exception actalError;
+
+        ErrorMatchingContextElement(final BsonDocument expectedError, final Exception actualError) {
+            this.expectedError = expectedError;
+            this.actalError = actualError;
+        }
+
+        public String toString() {
+            return "Error Matching Context:\n"
+                    + "   Expected error:\n"
+                    + expectedError.toJson(JsonWriterSettings.builder().indent(true).build()) + "\n"
+                    + "   Actual error:\n"
+                    + actalError.toString() + "\n";
+        }
+    }
+
+    private static class OutcomeMatchingContextElement extends ContextElement {
+        private final MongoNamespace namespace;
+        private final List<BsonDocument> expectedOutcome;
+        private final List<BsonDocument> actualOutcome;
+
+        OutcomeMatchingContextElement(final MongoNamespace namespace, final List<BsonDocument> expectedOutcome,
+                                             final List<BsonDocument> actualOutcome) {
+            this.namespace = namespace;
+            this.expectedOutcome = expectedOutcome;
+            this.actualOutcome = actualOutcome;
+        }
+
+        public String toString() {
+            return "Outcome Matching Context:\n"
+                    + "   Namespace: " + namespace + "\n"
+                    + "   Expected outcome:\n      "
+                    + expectedOutcome + "\n"
+                    + "   Actual outcome:\n      "
+                    + actualOutcome + "\n";
+        }
+    }
+
+    private static class EventsMatchingContextElement extends ContextElement {
+        private final String client;
+
+        EventsMatchingContextElement(final String client) {
+            this.client = client;
+        }
+
+        @Override
+        public String toString() {
+            return "Events MatchingContext: \n"
+                    + "   client: '" + client + "\n";
+        }
+    }
+
+    private static class EventMatchingContextElement extends ContextElement {
+        private final BsonDocument expectedEvent;
+        private final CommandEvent actualEvent;
+        private final int eventPosition;
+
+        EventMatchingContextElement(final BsonDocument expectedEvent, final CommandEvent actualEvent, final int eventPosition) {
+            this.expectedEvent = expectedEvent;
+            this.actualEvent = actualEvent;
+            this.eventPosition = eventPosition;
+        }
+
+        @Override
+        public String toString() {
+            return "Event Matching Context\n"
+                    + "   event position: " + eventPosition + "\n"
+                    + "   expected event: " + expectedEvent + "\n"
+                    + "   actual event:   " + eventToDocument(actualEvent) + "\n";
+        }
+
+        BsonDocument eventToDocument(final CommandEvent event) {
+            if (event instanceof CommandStartedEvent) {
+                CommandStartedEvent commandStartedEvent = (CommandStartedEvent) event;
+                return new BsonDocument("commandStartedEvent",
+                        new BsonDocument("command", commandStartedEvent.getCommand())
+                                .append("databaseName", new BsonString(commandStartedEvent.getDatabaseName())));
+            }
+            if (event instanceof CommandSucceededEvent) {
+                CommandSucceededEvent commandSucceededEvent = (CommandSucceededEvent) event;
+                return new BsonDocument("commandSucceededEvent",
+                        new BsonDocument("reply", commandSucceededEvent.getResponse())
+                                .append("commandName", new BsonString(commandSucceededEvent.getCommandName())));
+            } else if (event instanceof CommandFailedEvent) {
+                CommandFailedEvent commandFailedEvent = (CommandFailedEvent) event;
+                return new BsonDocument("commandFailedEvent",
+                        new BsonDocument("commandName", new BsonString(commandFailedEvent.getCommandName())));
+            } else {
+                throw new UnsupportedOperationException("Unsupported command event: " + event.getClass().getName());
+            }
+        }
+    }
+}


### PR DESCRIPTION
It's too hard to debug failing unified tests.  The assertions don't provide enough context to see what the failure is, so the only way to figure it out is to look at the JSON test to see what it looks like and then set breakpoints to get some context on the assertion failure.

This patch adds context to the messages that are printed by Junit whenever an assertion fails.  Here's an example:

```
Expected BSON numbers to be equal

Assertion Context:

Value Matching Context:
   Key: $gt
   Expected value:
      BsonInt32{value=2}
   Actual value:
      BsonInt32{value=1}

Value Matching Context:
   Key: _id
   Expected value:
      {"$gt": 2}
   Actual value:
      {"$gt": 1}

Value Matching Context:
   Key: $match
   Expected value:
      {"_id": {"$gt": 2}}
   Actual value:
      {"_id": {"$gt": 1}}

Value Matching Context:
   Key: pipeline
   Array position: 0
   Expected value:
      {"$match": {"_id": {"$gt": 2}}}
   Actual value:
      {"$match": {"_id": {"$gt": 1}}}

Value Matching Context:
   Key: pipeline
   Expected value:
      BsonArray{values=[{"$match": {"_id": {"$gt": 2}}}, {"$sort": {"x": 1}}]}
   Actual value:
      BsonArray{values=[{"$match": {"_id": {"$gt": 1}}}, {"$sort": {"x": 1}}]}

Value Matching Context:
   Expected value:
      {"aggregate": "coll", "pipeline": [{"$match": {"_id": {"$gt": 2}}}, {"$sort": {"x": 1}}]}
   Actual value:
      {"aggregate": "coll", "pipeline": [{"$match": {"_id": {"$gt": 1}}}, {"$sort": {"x": 1}}], "cursor": {}, "$db": "retryable-reads-tests", "lsid": {"id": {"$binary": {"base64": "rt9V9BLoRvOrEuR+O5pwoA==", "subType": "04"}}}}

Event Matching Context
   event position: 0
   expected event: {"commandStartedEvent": {"command": {"aggregate": "coll", "pipeline": [{"$match": {"_id": {"$gt": 2}}}, {"$sort": {"x": 1}}]}, "databaseName": "retryable-reads-tests"}}
   actual event:   {"commandStartedEvent": {"command": {"aggregate": "coll", "pipeline": [{"$match": {"_id": {"$gt": 1}}}, {"$sort": {"x": 1}}], "cursor": {}, "$db": "retryable-reads-tests", "lsid": {"id": {"$binary": {"base64": "rt9V9BLoRvOrEuR+O5pwoA==", "subType": "04"}}}}, "databaseName": "retryable-reads-tests"}}

Events MatchingContext: 
   client: 'client0

Operation Context: 
{
  "description": "Aggregate succeeds after InterruptedAtShutdown",
  "operations": [
    {
      "name": "failPoint",
      "object": "testRunner",
      "arguments": {
        "client": "client0",
        "failPoint": {
          "configureFailPoint": "failCommand",
          "mode": {
            "times": 1
          },
          "data": {
            "failCommands": [
              "aggregate"
            ],
            "errorCode": 11600
          }
        }
      }
    },
    {
      "name": "aggregate",
      "object": "collection0",
      "arguments": {
        "pipeline": [
          {
            "$match": {
              "_id": {
                "$gt": 1
              }
            }
          },
          {
            "$sort": {
              "x": 1
            }
          }
        ]
      },
      "expectResult": [
        {
          "_id": 2,
          "x": 22
        },
        {
          "_id": 3,
          "x": 33
        }
      ]
    }
  ],
  "expectEvents": [
    {
      "client": "client0",
      "events": [
        {
          "commandStartedEvent": {
            "command": {
              "aggregate": "coll",
              "pipeline": [
                {
                  "$match": {
                    "_id": {
                      "$gt": 2
                    }
                  }
                },
                {
                  "$sort": {
                    "x": 1
                  }
                }
              ]
            },
            "databaseName": "retryable-reads-tests"
          }
        },
        {
          "commandStartedEvent": {
            "command": {
              "aggregate": "coll",
              "pipeline": [
                {
                  "$match": {
                    "_id": {
                      "$gt": 1
                    }
                  }
                },
                {
                  "$sort": {
                    "x": 1
                  }
                }
              ]
            },
            "databaseName": "retryable-reads-tests"
          }
        }
      ]
    }
  ]
}
 expected:<2.0> but was:<1.0>
Expected :2.0
Actual   :1.0
```

See https://spruce.mongodb.com/task/mongo_java_driver_tests_jdk_secure__version~latest_os~linux_topology~standalone_auth~auth_ssl~ssl_jdk~jdk11_test_patch_53e04dc193f793c7f58a7515ee7140e31f8af7b6_5fa952af3627e011bd2b6102_20_11_09_14_31_53/tests?execution=1&statuses=fail for some (artificially) failed tests.

JAVA-3495