### PR TITLE
Improve assertion error context in unified test runner

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/unified/EventMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/EventMatcher.java
@@ -37,7 +37,7 @@ final class EventMatcher {
     }
 
     public void assertEventsEquality(final String client, final BsonArray expectedEventDocuments, final List<CommandEvent> events) {
-        context.push(ContextElement.ofEvents(client));
+        context.push(ContextElement.ofEvents(client, expectedEventDocuments, events));
         assertEquals(context.getMessage("Number of events must be the same"), expectedEventDocuments.size(), events.size());
 
         for (int i = 0; i < events.size(); i++) {

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/OperationResult.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/OperationResult.java
@@ -55,4 +55,15 @@ final class OperationResult {
     public Exception getException() {
         return exception;
     }
+
+    @Override
+    public String toString() {
+        if (result != null) {
+            return result.toString();
+        } else if (exception != null) {
+            return exception.toString();
+        } else {
+            return "<No Result>";
+        }
+    }
 }


### PR DESCRIPTION
Sorry for the noise on this.  But I found a number of places where the assertion context was insufficient to debug test failures in the versioned API and thought it best to fix it in a small, separate PR.

JAVA-3495