### PR TITLE
Add Bson#toBsonDocument() overload with a default implementation

### DIFF
--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/ImmutableDocumentCodec.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/ImmutableDocumentCodec.scala
@@ -43,7 +43,7 @@ case class ImmutableDocumentCodec(registry: Option[CodecRegistry]) extends Colle
 
   override def generateIdIfAbsentFromDocument(document: Document): Document = {
     if (!underlying.documentHasId(document.underlying)) {
-      Document(underlying.generateIdIfAbsentFromDocument(document.toBsonDocument))
+      Document(underlying.generateIdIfAbsentFromDocument(document.toBsonDocument.clone))
     } else {
       document
     }

--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/collection/BaseDocument.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/collection/BaseDocument.scala
@@ -242,7 +242,7 @@ private[bson] trait BaseDocument[T] extends Traversable[(String, BsonValue)] wit
   /**
    * Returns a copy of the underlying BsonDocument
    */
-  def toBsonDocument: BsonDocument = copyBsonDocument()
+  override def toBsonDocument: BsonDocument = copyBsonDocument()
 
   override def toBsonDocument[TDocument](documentClass: Class[TDocument], codecRegistry: CodecRegistry): BsonDocument =
     underlying

--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/collection/BaseDocument.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/collection/BaseDocument.scala
@@ -239,10 +239,7 @@ private[bson] trait BaseDocument[T] extends Traversable[(String, BsonValue)] wit
    */
   def toJson(settings: JsonWriterSettings): String = underlying.toJson(settings)
 
-  /**
-   * Returns a copy of the underlying BsonDocument
-   */
-  override def toBsonDocument: BsonDocument = copyBsonDocument()
+  override def toBsonDocument: BsonDocument = underlying
 
   override def toBsonDocument[TDocument](documentClass: Class[TDocument], codecRegistry: CodecRegistry): BsonDocument =
     underlying

--- a/bson/src/main/org/bson/RawBsonDocument.java
+++ b/bson/src/main/org/bson/RawBsonDocument.java
@@ -226,17 +226,17 @@ public final class RawBsonDocument extends BsonDocument {
 
     @Override
     public Set<Entry<String, BsonValue>> entrySet() {
-        return toBsonDocument().entrySet();
+        return toBaseBsonDocument().entrySet();
     }
 
     @Override
     public Collection<BsonValue> values() {
-        return toBsonDocument().values();
+        return toBaseBsonDocument().values();
     }
 
     @Override
     public Set<String> keySet() {
-        return toBsonDocument().keySet();
+        return toBaseBsonDocument().keySet();
     }
 
     @Override
@@ -332,12 +332,12 @@ public final class RawBsonDocument extends BsonDocument {
 
     @Override
     public boolean equals(final Object o) {
-        return toBsonDocument().equals(o);
+        return toBaseBsonDocument().equals(o);
     }
 
     @Override
     public int hashCode() {
-        return toBsonDocument().hashCode();
+        return toBaseBsonDocument().hashCode();
     }
 
     @Override
@@ -349,7 +349,8 @@ public final class RawBsonDocument extends BsonDocument {
         return new BsonBinaryReader(new ByteBufferBsonInput(getByteBuffer()));
     }
 
-    private BsonDocument toBsonDocument() {
+    // Transform to an org.bson.BsonDocument instance
+    private BsonDocument toBaseBsonDocument() {
         BsonBinaryReader bsonReader = createReader();
         try {
             return new BsonDocumentCodec().decode(bsonReader, DecoderContext.builder().build());

--- a/bson/src/main/org/bson/conversions/Bson.java
+++ b/bson/src/main/org/bson/conversions/Bson.java
@@ -17,7 +17,18 @@
 package org.bson.conversions;
 
 import org.bson.BsonDocument;
+import org.bson.codecs.BsonCodecProvider;
+import org.bson.codecs.BsonValueCodecProvider;
+import org.bson.codecs.DocumentCodecProvider;
+import org.bson.codecs.IterableCodecProvider;
+import org.bson.codecs.JsonObjectCodecProvider;
+import org.bson.codecs.MapCodecProvider;
+import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.jsr310.Jsr310CodecProvider;
+
+import static java.util.Arrays.asList;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 
 /**
  * An interface for types that are able to render themselves into a {@code BsonDocument}.
@@ -26,7 +37,36 @@ import org.bson.codecs.configuration.CodecRegistry;
  */
 public interface Bson {
     /**
-     * Render the filter into a BsonDocument.
+     * This registry includes the following providers:
+     * <ul>
+     *     <li>{@link ValueCodecProvider}</li>
+     *     <li>{@link BsonValueCodecProvider}</li>
+     *     <li>{@link DocumentCodecProvider}</li>
+     *     <li>{@link IterableCodecProvider}</li>
+     *     <li>{@link MapCodecProvider}</li>
+     *     <li>{@link Jsr310CodecProvider}</li>
+     *     <li>{@link JsonObjectCodecProvider}</li>
+     *     <li>{@link BsonCodecProvider}</li>
+     * </ul>
+     * <p>
+     * Additional providers may be added in a future release.
+     * </p>
+     *
+     * @since 4.2
+     */
+    CodecRegistry DEFAULT_CODEC_REGISTRY =
+            fromProviders(asList(
+                    new ValueCodecProvider(),
+                    new BsonValueCodecProvider(),
+                    new DocumentCodecProvider(),
+                    new IterableCodecProvider(),
+                    new MapCodecProvider(),
+                    new Jsr310CodecProvider(),
+                    new JsonObjectCodecProvider(),
+                    new BsonCodecProvider()));
+
+    /**
+     * Render into a BsonDocument.
      *
      * @param documentClass the document class in scope for the collection.  This parameter may be ignored, but it may be used to alter
      *                      the structure of the returned {@code BsonDocument} based on some knowledge of the document class.
@@ -36,4 +76,18 @@ public interface Bson {
      * @return the BsonDocument
      */
     <TDocument> BsonDocument toBsonDocument(Class<TDocument> documentClass, CodecRegistry codecRegistry);
+
+    /**
+     * Render into a BsonDocument using a document class and codec registry appropriate for the implementation.
+     * <p>
+     * The default implementation of this method calls {@link #toBsonDocument(Class, CodecRegistry)} with the
+     * {@link BsonDocument} class as the first argument and {@link #DEFAULT_CODEC_REGISTRY} as the second argument.
+     * </p>
+     *
+     * @return the BsonDocument
+     * @since 4.2
+     */
+    default BsonDocument toBsonDocument() {
+        return toBsonDocument(BsonDocument.class, DEFAULT_CODEC_REGISTRY);
+    }
 }

--- a/bson/src/test/unit/org/bson/DocumentTest.java
+++ b/bson/src/test/unit/org/bson/DocumentTest.java
@@ -26,6 +26,7 @@ import org.bson.codecs.EncoderContext;
 import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 import org.bson.json.JsonReader;
 import org.junit.Test;
 
@@ -129,6 +130,18 @@ public class DocumentTest {
         }
 
         assertEquals("{\"database\": {\"name\": \"MongoDB\"}}", customDocument.toJson(customDocumentCodec));
+    }
+
+    @Test
+    public void toBsonDocumentShouldCreateBsonDocument() {
+        BsonDocument expected = new BsonDocument()
+                .append("a", new BsonInt32(1))
+                .append("b", new BsonInt32(2))
+                .append("c", new BsonDocument("x", BsonBoolean.TRUE))
+                .append("d", new BsonArray(asList(new BsonDocument("y", BsonBoolean.FALSE), new BsonInt32(1))));
+
+        assertEquals(expected, document.toBsonDocument(BsonDocument.class, Bson.DEFAULT_CODEC_REGISTRY));
+        assertEquals(expected, document.toBsonDocument());
     }
 
     public class Name {

--- a/driver-core/src/main/com/mongodb/internal/connection/AbstractByteBufBsonDocument.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AbstractByteBufBsonDocument.java
@@ -97,17 +97,17 @@ abstract class AbstractByteBufBsonDocument extends BsonDocument {
 
     @Override
     public Set<Entry<String, BsonValue>> entrySet() {
-        return toBsonDocument().entrySet();
+        return toBaseBsonDocument().entrySet();
     }
 
     @Override
     public Collection<BsonValue> values() {
-        return toBsonDocument().values();
+        return toBaseBsonDocument().values();
     }
 
     @Override
     public Set<String> keySet() {
-        return toBsonDocument().keySet();
+        return toBaseBsonDocument().keySet();
     }
 
     @Override
@@ -205,19 +205,19 @@ abstract class AbstractByteBufBsonDocument extends BsonDocument {
 
     //AbstractBsonReader getBsonReader();
 
-    abstract BsonDocument toBsonDocument();
+    abstract BsonDocument toBaseBsonDocument();
 
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
         }
-        return toBsonDocument().equals(o);
+        return toBaseBsonDocument().equals(o);
     }
 
     @Override
     public int hashCode() {
-        return toBsonDocument().hashCode();
+        return toBaseBsonDocument().hashCode();
     }
 
     private BsonValue deserializeBsonValue(final BsonReader bsonReader) {
@@ -226,7 +226,7 @@ abstract class AbstractByteBufBsonDocument extends BsonDocument {
 
     // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
     Object writeReplace() {
-        return toBsonDocument();
+        return toBaseBsonDocument();
     }
 
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/ByteBufBsonDocument.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ByteBufBsonDocument.java
@@ -151,7 +151,7 @@ class ByteBufBsonDocument extends AbstractByteBufBsonDocument {
         return byteBuf.getInt(byteBuf.position());
     }
 
-    BsonDocument toBsonDocument() {
+    BsonDocument toBaseBsonDocument() {
         ByteBuf duplicateByteBuf = byteBuf.duplicate();
         BsonBinaryReader bsonReader = new BsonBinaryReader(new ByteBufferBsonInput(duplicateByteBuf));
         try {

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
@@ -110,7 +110,7 @@ public final class CommandMessage extends RequestMessage {
         BsonDocument commandBsonDocument;
 
         if (useOpMsg() && containsPayload()) {
-            commandBsonDocument = byteBufBsonDocument.toBsonDocument();
+            commandBsonDocument = byteBufBsonDocument.toBaseBsonDocument();
 
             int payloadStartPosition = getEncodingMetadata().getFirstDocumentPosition()
                     + byteBufBsonDocument.getSizeInBytes()


### PR DESCRIPTION
The default implementation simply calls Bson#toBsonDocument(Class<T>, CodecRegistry)

JAVA-3885