### PR TITLE
Ensure DNS errors bubble up as errors in reactive streams

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -164,39 +164,38 @@ public class InternalStreamConnection implements InternalConnection {
         isTrue("Open already called", stream == null, callback);
         try {
             stream = streamFactory.create(serverId.getAddress());
+            stream.openAsync(new AsyncCompletionHandler<Void>() {
+                @Override
+                public void completed(final Void aVoid) {
+                    connectionInitializer.initializeAsync(InternalStreamConnection.this,
+                            new SingleResultCallback<InternalConnectionInitializationDescription>() {
+                                @Override
+                                public void onResult(final InternalConnectionInitializationDescription result, final Throwable t) {
+                                    if (t != null) {
+                                        close();
+                                        callback.onResult(null, t);
+                                    } else {
+                                        description = result.getConnectionDescription();
+                                        initialServerDescription = result.getServerDescription();
+                                        opened.set(true);
+                                        sendCompressor = findSendCompressor(description);
+                                        if (LOGGER.isInfoEnabled()) {
+                                            LOGGER.info(format("Opened connection [%s] to %s", getId(), serverId.getAddress()));
+                                        }
+                                        callback.onResult(null, null);
+                                    }
+                                }
+                            });
+                }
+
+                @Override
+                public void failed(final Throwable t) {
+                    callback.onResult(null, t);
+                }
+            });
         } catch (Throwable t) {
             callback.onResult(null, t);
-            return;
         }
-        stream.openAsync(new AsyncCompletionHandler<Void>() {
-            @Override
-            public void completed(final Void aVoid) {
-                connectionInitializer.initializeAsync(InternalStreamConnection.this,
-                        new SingleResultCallback<InternalConnectionInitializationDescription>() {
-                    @Override
-                    public void onResult(final InternalConnectionInitializationDescription result, final Throwable t) {
-                        if (t != null) {
-                            close();
-                            callback.onResult(null, t);
-                        } else {
-                            description = result.getConnectionDescription();
-                            initialServerDescription = result.getServerDescription();
-                            opened.set(true);
-                            sendCompressor = findSendCompressor(description);
-                            if (LOGGER.isInfoEnabled()) {
-                                LOGGER.info(format("Opened connection [%s] to %s", getId(), serverId.getAddress()));
-                            }
-                            callback.onResult(null, null);
-                        }
-                    }
-                });
-            }
-
-            @Override
-            public void failed(final Throwable t) {
-                callback.onResult(null, t);
-            }
-        });
     }
 
     private Map<Byte, Compressor> createCompressorMap(final List<MongoCompressor> compressorList) {


### PR DESCRIPTION
Currently DNS lookups happen synchronously in the reactive streams
driver.  This isn't good, but with this change at least DNS errors
will be properly reported.

JAVA-3852