### PR TITLE
JAVA-3331.  InsertOneOptions and InsertManyOptions are final

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/InsertManyOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/InsertManyOptions.java
@@ -25,7 +25,7 @@ import com.mongodb.lang.Nullable;
  * @mongodb.driver.manual tutorial/insert-documents/ Insert Tutorial
  * @mongodb.driver.manual reference/command/insert/ Insert Command
  */
-public final class InsertManyOptions {
+public class InsertManyOptions {
     private boolean ordered = true;
     private Boolean bypassDocumentValidation;
 

--- a/driver-core/src/main/com/mongodb/client/model/InsertOneOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/InsertOneOptions.java
@@ -26,7 +26,7 @@ import com.mongodb.lang.Nullable;
  * @mongodb.driver.manual tutorial/insert-documents/ Insert Tutorial
  * @mongodb.driver.manual reference/command/insert/ Insert Command
  */
-public final class InsertOneOptions {
+public class InsertOneOptions {
     private Boolean bypassDocumentValidation;
 
     /**


### PR DESCRIPTION
this is my fix for the JIRA ticket for the issue [JAVA-3331](https://jira.mongodb.org/browse/JAVA-3331). 
it seems like a simple fix, and essential to  extend them and add things like WriteConcern and ReadPreference options .