### PR TITLE
Scala: Ensure implicit conversion keeps type fidelity

### DIFF
--- a/driver-scala/src/main/scala/org/mongodb/scala/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/package.scala
@@ -16,17 +16,13 @@
 
 package org.mongodb
 
-import org.bson.codecs.{ BsonDocumentCodec, DecoderContext, DocumentCodec, EncoderContext }
-import org.bson.{ BsonBinaryReader, BsonBinaryWriter, ByteBufNIO }
-import org.bson.io.{ BasicOutputBuffer, ByteBufferBsonInput }
-import org.bson.json.{ JsonMode, JsonWriterSettings }
-
-import _root_.scala.language.implicitConversions
-import _root_.scala.reflect.ClassTag
+import org.bson.BsonDocumentReader
+import org.bson.codecs.{ DecoderContext, DocumentCodec }
 import org.mongodb.scala.bson.BsonDocument
 import org.mongodb.scala.internal.WriteConcernImplicits
 
-import java.nio.ByteBuffer
+import _root_.scala.language.implicitConversions
+import _root_.scala.reflect.ClassTag
 
 /**
  * The MongoDB Scala Driver package
@@ -402,15 +398,9 @@ package object scala extends ClientSessionImplicits with ObservableImplicits wit
   implicit def documentToUntypedDocument(doc: Document): org.bson.Document =
     bsonDocumentToUntypedDocument(doc.underlying)
 
+  private lazy val DOCUMENT_CODEC = new DocumentCodec()
   implicit def bsonDocumentToUntypedDocument(doc: BsonDocument): org.bson.Document = {
-    val writer: BsonBinaryWriter = new BsonBinaryWriter(new BasicOutputBuffer())
-    new BsonDocumentCodec().encode(writer, doc, EncoderContext.builder().build())
-
-    val buffer: BasicOutputBuffer = writer.getBsonOutput.asInstanceOf[BasicOutputBuffer];
-    val reader: BsonBinaryReader =
-      new BsonBinaryReader(new ByteBufferBsonInput(new ByteBufNIO(ByteBuffer.wrap(buffer.toByteArray))))
-
-    new DocumentCodec().decode(reader, DecoderContext.builder().build())
+    DOCUMENT_CODEC.decode(new BsonDocumentReader(doc), DecoderContext.builder().build())
   }
 
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/ScalaPackageSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ScalaPackageSpec.scala
@@ -141,7 +141,7 @@ class ScalaPackageSpec extends BaseSpec {
     scalaCredential5 should equal(javaCredential5)
   }
 
-  it should "implicitly convert to org.Bson.document with type fidelity" in {
+  it should "implicitly convert to org.bson.document with type fidelity" in {
 
     val bsonDocument = Document(
       "null" -> BsonNull(),

--- a/driver-scala/src/test/scala/org/mongodb/scala/ScalaPackageSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ScalaPackageSpec.scala
@@ -17,15 +17,14 @@
 package org.mongodb.scala
 
 import java.util.concurrent.TimeUnit
-
 import _root_.scala.concurrent.duration.Duration
-
 import com.mongodb.{ MongoCredential => JMongoCredential }
-
+import org.bson.BsonDocumentWrapper
+import org.bson.codecs.DocumentCodec
 import org.mongodb.scala
-import org.mongodb.scala.bson.BsonString
+import org.mongodb.scala.MongoClient.DEFAULT_CODEC_REGISTRY
+import org.mongodb.scala.bson._
 import org.mongodb.scala.model._
-import org.scalatest.{ FlatSpec, Matchers }
 
 class ScalaPackageSpec extends BaseSpec {
 
@@ -66,9 +65,9 @@ class ScalaPackageSpec extends BaseSpec {
 
   it should "be able to create Documents" in {
     val doc = Document("a" -> BsonString("1"))
-    val doc2 = org.mongodb.scala.bson.collection.Document("a" -> BsonString("1"))
+    val doc2 = collection.Document("a" -> BsonString("1"))
 
-    doc shouldBe a[org.mongodb.scala.bson.collection.immutable.Document]
+    doc shouldBe a[collection.immutable.Document]
     doc should equal(doc2)
   }
 
@@ -140,5 +139,34 @@ class ScalaPackageSpec extends BaseSpec {
     val scalaCredential5 = MongoCredential.createGSSAPICredential("userName")
     val javaCredential5 = JMongoCredential.createGSSAPICredential("userName")
     scalaCredential5 should equal(javaCredential5)
+  }
+
+  it should "implicitly convert to org.Bson.document with type fidelity" in {
+
+    val bsonDocument = Document(
+      "null" -> BsonNull(),
+      "int32" -> BsonInt32(32),
+      "int64" -> BsonInt64(64L),
+      "decimal128" -> BsonDecimal128(128),
+      "boolean" -> BsonBoolean(true),
+      "date" -> BsonDateTime(123456789),
+      "double" -> BsonDouble(1.1),
+      "string" -> BsonString("String"),
+      "minKey" -> BsonMinKey(),
+      "maxKey" -> BsonMaxKey(),
+      "javaScript" -> BsonJavaScript("function () {}"),
+      "objectId" -> BsonObjectId(),
+      "codeWithScope" -> BsonJavaScriptWithScope("function () {}", Document()),
+      "regex" -> BsonRegularExpression("/(.*)/"),
+      "symbol" -> BsonSymbol(Symbol("sym")),
+      "timestamp" -> BsonTimestamp(),
+      "undefined" -> BsonUndefined(),
+      "binary" -> BsonBinary(Array[Byte](128.toByte)),
+      "array" -> BsonArray(List("a", "b", "c")),
+      "document" -> Document("a" -> 1, "b" -> List(1, 2, 3))
+    )
+
+    val document: org.bson.Document = bsonDocument
+    BsonDocumentWrapper.asBsonDocument(document, DEFAULT_CODEC_REGISTRY) should equal(bsonDocument.underlying)
   }
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/ScalaPackageSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ScalaPackageSpec.scala
@@ -147,7 +147,7 @@ class ScalaPackageSpec extends BaseSpec {
       "null" -> BsonNull(),
       "int32" -> BsonInt32(32),
       "int64" -> BsonInt64(Long.MaxValue),
-      "decimal128" -> BsonDecimal128(128),
+      "decimal128" -> BsonDecimal128(128.1),
       "boolean" -> BsonBoolean(true),
       "date" -> BsonDateTime(123456789),
       "double" -> BsonDouble(1.1),

--- a/driver-scala/src/test/scala/org/mongodb/scala/ScalaPackageSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ScalaPackageSpec.scala
@@ -146,7 +146,7 @@ class ScalaPackageSpec extends BaseSpec {
     val bsonDocument = Document(
       "null" -> BsonNull(),
       "int32" -> BsonInt32(32),
-      "int64" -> BsonInt64(64L),
+      "int64" -> BsonInt64(Long.MaxValue),
       "decimal128" -> BsonDecimal128(128),
       "boolean" -> BsonBoolean(true),
       "date" -> BsonDateTime(123456789),


### PR DESCRIPTION
When converting from a BsonDocument to org.bson.Document
the scala driver previously used json. The implementation
should not rely on the json output format, but rather use
the Codecs to do the conversion.

JAVA-3916