### PR TITLE
docs: print using lambda in aggregation page

### DIFF
--- a/docs/reference/content/driver/tutorials/aggregation.md
+++ b/docs/reference/content/driver/tutorials/aggregation.md
@@ -28,19 +28,8 @@ The [aggregation pipeline]({{<docsref "core/aggregation-pipeline" >}}) is a fram
      import com.mongodb.client.model.Accumulators;
      import com.mongodb.client.model.Projections;
      import com.mongodb.client.model.Filters;
-     
+
      import org.bson.Document;
-     ```
-
-- Include the following code which the examples in the tutorials will use to print the results of the aggregation:
-
-     ```java
-     Block<Document> printBlock = new Block<Document>() {
-            @Override
-            public void apply(final Document document) {
-                System.out.println(document.toJson());
-            }
-        };
      ```
 
 ## Connect to a MongoDB Deployment
@@ -73,7 +62,7 @@ collection.aggregate(
               Aggregates.match(Filters.eq("categories", "Bakery")),
               Aggregates.group("$stars", Accumulators.sum("count", 1))
       )
-).forEach(printBlock);
+).forEach(doc -> System.out.println(doc.toJson()));
 ```
 
 ### Use Aggregation Expressions
@@ -98,7 +87,7 @@ collection.aggregate(
               )
           )
       )
-).forEach(printBlock);
+).forEach(doc -> System.out.println(doc.toJson()));
 ```
 
 ### Explain an Aggregation


### PR DESCRIPTION
From Slack:
> 
> Hey all, quick question. On the aggregation page it gives this helper to print out the contents
> ```
>         Block<Document> printBlock = new Block<Document>() {
>             @Override
>             public void apply(final Document document) {
>                 System.out.println(document.toJson());
>             }
>         };
> ```
> This doesn't seem to work. When I try to use it it I get the error
> ```
> intro.collection.aggregate(Arrays.asList(Aggregates.match(Filters.in("color", "red", "blue"))))
>     .forEach(printBlock)
>      ^^^^^^^
> The method forEach(Consumer<? super Document>) in the type Iterable<Document> is not applicable for the arguments (Block<Document>)
> ```
> 
> Since we're on Java 1.8 and above, can we use a lambda or is there a more preferable way?

This updates the example on the [aggregation](https://mongodb.github.io/mongo-java-driver/4.2/driver/tutorials/aggregation/) page. There are other uses of `printBlock` throughout the documentation that I can change as well, if requested.