### PR TITLE
Create internal MongoClient for auto-encryption

### DIFF
--- a/driver-core/src/main/com/mongodb/MongoClientSettings.java
+++ b/driver-core/src/main/com/mongodb/MongoClientSettings.java
@@ -477,12 +477,23 @@ public final class MongoClientSettings {
         /**
          * Sets the auto-encryption settings
          *
+         * A separate, internal {@code MongoClient} is created if any of the following are true:
+         *
+         * <ul>
+         *    <li>{@code AutoEncryptionSettings.keyVaultClient} is not passed</li>
+         *    <li>{@code AutoEncryptionSettings.bypassAutomaticEncryption} is {@code false}</li>
+         * </ul>
+         *
+         * If an internal {@code MongoClient} is created, it is configured with the same
+         * options as the parent {@code MongoClient} except {@code minPoolSize} is set to {@code 0}
+         * and {@code AutoEncryptionSettings} is omitted.
+         *
          * @param autoEncryptionSettings the auto-encryption settings
          * @return this
          * @since 3.11
          * @see #getAutoEncryptionSettings()
          */
-        public Builder autoEncryptionSettings(final AutoEncryptionSettings autoEncryptionSettings) {
+        public Builder autoEncryptionSettings(@Nullable final AutoEncryptionSettings autoEncryptionSettings) {
             this.autoEncryptionSettings = autoEncryptionSettings;
             return this;
         }

--- a/driver-core/src/test/resources/client-side-encryption/aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/aggregate.json
@@ -153,18 +153,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -271,18 +259,6 @@
               "cursor": {}
             },
             "command_name": "aggregate"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
           }
         },
         {

--- a/driver-core/src/test/resources/client-side-encryption/azureKMS.json
+++ b/driver-core/src/test/resources/client-side-encryption/azureKMS.json
@@ -142,18 +142,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/basic.json
+++ b/driver-core/src/test/resources/client-side-encryption/basic.json
@@ -147,18 +147,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -279,18 +267,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/driver-core/src/test/resources/client-side-encryption/bulk.json
+++ b/driver-core/src/test/resources/client-side-encryption/bulk.json
@@ -181,18 +181,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/count.json
+++ b/driver-core/src/test/resources/client-side-encryption/count.json
@@ -152,18 +152,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/countDocuments.json
+++ b/driver-core/src/test/resources/client-side-encryption/countDocuments.json
@@ -153,18 +153,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/delete.json
@@ -154,18 +154,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -272,18 +260,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/driver-core/src/test/resources/client-side-encryption/distinct.json
+++ b/driver-core/src/test/resources/client-side-encryption/distinct.json
@@ -164,18 +164,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/explain.json
+++ b/driver-core/src/test/resources/client-side-encryption/explain.json
@@ -158,18 +158,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/find.json
+++ b/driver-core/src/test/resources/client-side-encryption/find.json
@@ -163,18 +163,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -298,18 +286,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/driver-core/src/test/resources/client-side-encryption/findOneAndDelete.json
+++ b/driver-core/src/test/resources/client-side-encryption/findOneAndDelete.json
@@ -151,18 +151,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/findOneAndReplace.json
+++ b/driver-core/src/test/resources/client-side-encryption/findOneAndReplace.json
@@ -150,18 +150,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/findOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/findOneAndUpdate.json
@@ -152,18 +152,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/gcpKMS.json
+++ b/driver-core/src/test/resources/client-side-encryption/gcpKMS.json
@@ -144,18 +144,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/getMore.json
+++ b/driver-core/src/test/resources/client-side-encryption/getMore.json
@@ -182,18 +182,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/insert.json
+++ b/driver-core/src/test/resources/client-side-encryption/insert.json
@@ -134,18 +134,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -254,18 +242,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/driver-core/src/test/resources/client-side-encryption/keyAltName.json
+++ b/driver-core/src/test/resources/client-side-encryption/keyAltName.json
@@ -134,18 +134,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/localKMS.json
+++ b/driver-core/src/test/resources/client-side-encryption/localKMS.json
@@ -117,18 +117,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/localSchema.json
+++ b/driver-core/src/test/resources/client-side-encryption/localSchema.json
@@ -139,18 +139,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/missingKey.json
+++ b/driver-core/src/test/resources/client-side-encryption/missingKey.json
@@ -143,18 +143,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "different"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "different",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/replaceOne.json
+++ b/driver-core/src/test/resources/client-side-encryption/replaceOne.json
@@ -151,18 +151,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/types.json
+++ b/driver-core/src/test/resources/client-side-encryption/types.json
@@ -106,18 +106,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -257,18 +245,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -405,18 +381,6 @@
         }
       ],
       "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
         {
           "command_started_event": {
             "command": {
@@ -659,18 +623,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -807,18 +759,6 @@
         }
       ],
       "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
         {
           "command_started_event": {
             "command": {
@@ -1060,18 +1000,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -1217,18 +1145,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -1369,18 +1285,6 @@
         }
       ],
       "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
         {
           "command_started_event": {
             "command": {

--- a/driver-core/src/test/resources/client-side-encryption/updateMany.json
+++ b/driver-core/src/test/resources/client-side-encryption/updateMany.json
@@ -167,18 +167,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-core/src/test/resources/client-side-encryption/updateOne.json
+++ b/driver-core/src/test/resources/client-side-encryption/updateOne.json
@@ -153,18 +153,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoClientImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoClientImpl.java
@@ -115,7 +115,7 @@ public final class MongoClientImpl implements MongoClient {
         return crypt;
     }
 
-    MongoClientSettings getSettings() {
+    public MongoClientSettings getSettings() {
         return settings;
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypt.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypt.java
@@ -30,6 +30,7 @@ import com.mongodb.crypt.capi.MongoKeyDecryptor;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.lang.Nullable;
+import com.mongodb.reactivestreams.client.MongoClient;
 import org.bson.BsonBinary;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
@@ -52,6 +53,8 @@ public class Crypt implements Closeable {
     private final KeyRetriever keyRetriever;
     private final KeyManagementService keyManagementService;
     private final boolean bypassAutoEncryption;
+    @Nullable
+    private final MongoClient internalClient;
 
     /**
      * Create an instance to use for explicit encryption and decryption, and data key creation.
@@ -61,7 +64,7 @@ public class Crypt implements Closeable {
      * @param keyManagementService the key management service
      */
     Crypt(final MongoCrypt mongoCrypt, final KeyRetriever keyRetriever, final KeyManagementService keyManagementService) {
-        this(mongoCrypt, null, null, keyRetriever, keyManagementService, false);
+        this(mongoCrypt, null, null, keyRetriever, keyManagementService, false, null);
     }
 
     /**
@@ -78,13 +81,15 @@ public class Crypt implements Closeable {
           @Nullable final CommandMarker commandMarker,
           final KeyRetriever keyRetriever,
           final KeyManagementService keyManagementService,
-          final boolean bypassAutoEncryption) {
+          final boolean bypassAutoEncryption,
+          @Nullable final MongoClient internalClient) {
         this.mongoCrypt = mongoCrypt;
         this.collectionInfoRetriever = collectionInfoRetriever;
         this.commandMarker = commandMarker;
         this.keyRetriever = keyRetriever;
         this.keyManagementService = keyManagementService;
         this.bypassAutoEncryption = bypassAutoEncryption;
+        this.internalClient = internalClient;
     }
 
     /**
@@ -173,7 +178,9 @@ public class Crypt implements Closeable {
         if (commandMarker != null) {
             commandMarker.close();
         }
-        keyRetriever.close();
+        if (internalClient != null) {
+            internalClient.close();
+        }
         keyManagementService.close();
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypt.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypt.java
@@ -174,14 +174,14 @@ public class Crypt implements Closeable {
 
     @Override
     public void close() {
-        mongoCrypt.close();
-        if (commandMarker != null) {
-            commandMarker.close();
+        //noinspection EmptyTryBlock
+        try (MongoCrypt mongoCrypt = this.mongoCrypt;
+             CommandMarker commandMarker = this.commandMarker;
+             MongoClient internalClient = this.internalClient;
+             KeyManagementService keyManagementService = this.keyManagementService
+        ) {
+            // just using try-with-resources to ensure they all get closed, even in the case of exceptions
         }
-        if (internalClient != null) {
-            internalClient.close();
-        }
-        keyManagementService.close();
     }
 
     private Mono<RawBsonDocument> executeStateMachine(final Supplier<MongoCryptContext> cryptContextSupplier) {

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypts.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypts.java
@@ -22,9 +22,9 @@ import com.mongodb.MongoClientException;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoNamespace;
 import com.mongodb.crypt.capi.MongoCrypts;
-import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
+import com.mongodb.reactivestreams.client.internal.MongoClientImpl;
 
 import javax.net.ssl.SSLContext;
 import java.security.NoSuchAlgorithmException;
@@ -36,41 +36,34 @@ public final class Crypts {
     private Crypts() {
     }
 
-    public static Crypt createCrypt(final MongoClient client, final AutoEncryptionSettings options) {
-        return new Crypt(MongoCrypts.create(createMongoCryptOptions(options.getKmsProviders(), options.getSchemaMap())),
-                         new CollectionInfoRetriever(client),
-                         new CommandMarker(options.isBypassAutoEncryption(), options.getExtraOptions()),
-                         createKeyRetriever(client, options.getKeyVaultMongoClientSettings(), options.getKeyVaultNamespace()),
-                         createKeyManagementService(),
-                         options.isBypassAutoEncryption());
+    public static Crypt createCrypt(final MongoClientImpl client, final AutoEncryptionSettings options) {
+        MongoClient internalClient = null;
+        MongoClientSettings keyVaultMongoClientSettings = options.getKeyVaultMongoClientSettings();
+        if (keyVaultMongoClientSettings == null || !options.isBypassAutoEncryption()) {
+            MongoClientSettings settings = MongoClientSettings.builder(client.getSettings())
+                    .applyToConnectionPoolSettings(builder -> builder.minSize(0))
+                    .autoEncryptionSettings(null)
+                    .build();
+            internalClient = MongoClients.create(settings);
+        }
+        MongoClient collectionInfoRetrieverClient = internalClient;
+        MongoClient keyVaultClient = keyVaultMongoClientSettings == null
+                ? internalClient : MongoClients.create(keyVaultMongoClientSettings);
+        return new Crypt(MongoCrypts.create(createMongoCryptOptions(options.getKmsProviders(),
+                options.getSchemaMap())),
+                options.isBypassAutoEncryption() ? null : new CollectionInfoRetriever(collectionInfoRetrieverClient),
+                new CommandMarker(options.isBypassAutoEncryption(), options.getExtraOptions()),
+                new KeyRetriever(keyVaultClient, new MongoNamespace(options.getKeyVaultNamespace())),
+                createKeyManagementService(),
+                options.isBypassAutoEncryption(),
+                internalClient);
     }
 
     public static Crypt create(final MongoClient keyVaultClient, final ClientEncryptionSettings options) {
         return new Crypt(MongoCrypts.create(
                 createMongoCryptOptions(options.getKmsProviders(), null)),
-                         createKeyRetriever(keyVaultClient, false, options.getKeyVaultNamespace()),
+                         new KeyRetriever(keyVaultClient, new MongoNamespace(options.getKeyVaultNamespace())),
                          createKeyManagementService());
-    }
-
-    private static KeyRetriever createKeyRetriever(final MongoClient defaultKeyVaultClient,
-                                                   @Nullable final MongoClientSettings keyVaultMongoClientSettings,
-                                                   final String keyVaultNamespaceString) {
-        MongoClient keyVaultClient;
-        boolean keyRetrieverOwnsClient;
-        if (keyVaultMongoClientSettings != null) {
-            keyVaultClient = MongoClients.create(keyVaultMongoClientSettings);
-            keyRetrieverOwnsClient = true;
-        } else {
-            keyVaultClient = defaultKeyVaultClient;
-            keyRetrieverOwnsClient = false;
-        }
-
-        return createKeyRetriever(keyVaultClient, keyRetrieverOwnsClient, keyVaultNamespaceString);
-    }
-
-    private static KeyRetriever createKeyRetriever(final MongoClient keyVaultClient, final boolean keyRetrieverOwnsClient,
-                                                   final String keyVaultNamespaceString) {
-        return new KeyRetriever(keyVaultClient, keyRetrieverOwnsClient, new MongoNamespace(keyVaultNamespaceString));
     }
 
     private static KeyManagementService createKeyManagementService() {

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/KeyManagementService.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/KeyManagementService.java
@@ -32,6 +32,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
 
 import javax.net.ssl.SSLContext;
+import java.io.Closeable;
 import java.nio.channels.CompletionHandler;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -39,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-class KeyManagementService {
+class KeyManagementService implements Closeable {
     private final int defaultPort;
     private final TlsChannelStreamFactoryFactory tlsChannelStreamFactoryFactory;
     private final StreamFactory streamFactory;
@@ -53,7 +54,6 @@ class KeyManagementService {
                                                                            .build(),
                                                                    SslSettings.builder().enabled(true).context(sslContext).build());
     }
-
 
     public void close() {
         tlsChannelStreamFactoryFactory.close();

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/KeyRetriever.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/KeyRetriever.java
@@ -23,19 +23,16 @@ import org.bson.BsonDocument;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.io.Closeable;
 import java.util.List;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
-class KeyRetriever implements Closeable {
+class KeyRetriever {
     private final MongoClient client;
-    private final boolean ownsClient;
     private final MongoNamespace namespace;
 
-    KeyRetriever(final MongoClient client, final boolean ownsClient, final MongoNamespace namespace) {
+    KeyRetriever(final MongoClient client, final MongoNamespace namespace) {
         this.client = notNull("client", client);
-        this.ownsClient = ownsClient;
         this.namespace = notNull("namespace", namespace);
     }
 
@@ -45,12 +42,5 @@ class KeyRetriever implements Closeable {
                         .withReadConcern(ReadConcern.MAJORITY)
                         .find(keyFilter)
         ).collectList();
-    }
-
-    @Override
-    public void close() {
-        if (ownsClient) {
-            client.close();
-        }
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionDeadlockTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionDeadlockTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package com.mongodb.reactivestreams.client;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.AbstractClientSideEncryptionDeadlockTest;
+import com.mongodb.client.MongoClient;
+import com.mongodb.lang.NonNull;
+import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
+
+public class ClientSideEncryptionDeadlockTest extends AbstractClientSideEncryptionDeadlockTest {
+    @Override
+    @NonNull
+    protected MongoClient createMongoClient(@NonNull final MongoClientSettings settings) {
+        return new SyncMongoClient(MongoClients.create(settings));
+    }
+}

--- a/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
@@ -221,12 +221,12 @@ class Crypt implements Closeable {
 
     @Override
     public void close() {
-        mongoCrypt.close();
-        if (commandMarker != null) {
-            commandMarker.close();
-        }
-        if (internalClient != null) {
-            internalClient.close();
+        //noinspection EmptyTryBlock
+        try (MongoCrypt mongoCrypt = this.mongoCrypt;
+             CommandMarker commandMarker = this.commandMarker;
+             MongoClient internalClient = this.internalClient
+        ) {
+            // just using try-with-resources to ensure they all get closed, even in the case of exceptions
         }
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
@@ -19,6 +19,7 @@ package com.mongodb.client.internal;
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoInternalException;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.model.vault.DataKeyOptions;
 import com.mongodb.client.model.vault.EncryptOptions;
 import com.mongodb.crypt.capi.MongoCrypt;
@@ -49,6 +50,7 @@ class Crypt implements Closeable {
     private final KeyRetriever keyRetriever;
     private final KeyManagementService keyManagementService;
     private final boolean bypassAutoEncryption;
+    private final MongoClient internalClient;
 
     /**
      * Create an instance to use for explicit encryption and decryption, and data key creation.
@@ -58,7 +60,7 @@ class Crypt implements Closeable {
      * @param keyManagementService the key management service
      */
     Crypt(final MongoCrypt mongoCrypt, final KeyRetriever keyRetriever, final KeyManagementService keyManagementService) {
-        this(mongoCrypt, null, null, keyRetriever, keyManagementService, false);
+        this(mongoCrypt, null, null, keyRetriever, keyManagementService, false, null);
     }
 
     /**
@@ -71,14 +73,15 @@ class Crypt implements Closeable {
      * @param commandMarker the command marker
      */
     Crypt(final MongoCrypt mongoCrypt, @Nullable final CollectionInfoRetriever collectionInfoRetriever,
-          @Nullable final CommandMarker commandMarker, final KeyRetriever keyRetriever, final KeyManagementService keyManagementService,
-          final boolean bypassAutoEncryption) {
+          @Nullable final CommandMarker commandMarker, final KeyRetriever keyRetriever,
+          final KeyManagementService keyManagementService, final boolean bypassAutoEncryption, @Nullable final MongoClient internalClient) {
         this.mongoCrypt = mongoCrypt;
         this.collectionInfoRetriever = collectionInfoRetriever;
         this.commandMarker = commandMarker;
         this.keyRetriever = keyRetriever;
         this.keyManagementService = keyManagementService;
         this.bypassAutoEncryption = bypassAutoEncryption;
+        this.internalClient = internalClient;
     }
 
     /**
@@ -222,7 +225,9 @@ class Crypt implements Closeable {
         if (commandMarker != null) {
             commandMarker.close();
         }
-        keyRetriever.close();
+        if (internalClient != null) {
+            internalClient.close();
+        }
     }
 
     private RawBsonDocument executeStateMachine(final MongoCryptContext cryptContext, final String databaseName) {

--- a/driver-sync/src/main/com/mongodb/client/internal/Crypts.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypts.java
@@ -32,42 +32,39 @@ import static com.mongodb.internal.capi.MongoCryptHelper.createMongoCryptOptions
 
 public final class Crypts {
 
-    public static Crypt createCrypt(final MongoClient client, final AutoEncryptionSettings options) {
+    public static Crypt createCrypt(final MongoClientImpl client, final AutoEncryptionSettings options) {
+        MongoClient internalClient = null;
+        MongoClientSettings keyVaultMongoClientSettings = options.getKeyVaultMongoClientSettings();
+        if (keyVaultMongoClientSettings == null || !options.isBypassAutoEncryption()) {
+            MongoClientSettings settings = MongoClientSettings.builder(client.getSettings())
+                    .applyToConnectionPoolSettings(builder -> builder.minSize(0))
+                    .autoEncryptionSettings(null)
+                    .build();
+            internalClient = MongoClients.create(settings);
+        }
+        MongoClient collectionInfoRetrieverClient = internalClient;
+        MongoClient keyVaultClient = keyVaultMongoClientSettings == null
+                ? internalClient : MongoClients.create(keyVaultMongoClientSettings);
         return new Crypt(MongoCrypts.create(createMongoCryptOptions(options.getKmsProviders(),
                 options.getSchemaMap())),
-                new CollectionInfoRetriever(client),
+                options.isBypassAutoEncryption() ? null : new CollectionInfoRetriever(collectionInfoRetrieverClient),
                 new CommandMarker(options.isBypassAutoEncryption(), options.getExtraOptions()),
-                createKeyRetriever(client, options.getKeyVaultMongoClientSettings(), options.getKeyVaultNamespace()),
+                new KeyRetriever(keyVaultClient, new MongoNamespace(options.getKeyVaultNamespace())),
                 createKeyManagementService(),
-                options.isBypassAutoEncryption());
+                options.isBypassAutoEncryption(),
+                internalClient);
     }
 
     static Crypt create(final MongoClient keyVaultClient, final ClientEncryptionSettings options) {
         return new Crypt(MongoCrypts.create(
                 createMongoCryptOptions(options.getKmsProviders(), null)),
-                createKeyRetriever(keyVaultClient, false, options.getKeyVaultNamespace()),
+                createKeyRetriever(keyVaultClient, options.getKeyVaultNamespace()),
                 createKeyManagementService());
     }
 
-    private static KeyRetriever createKeyRetriever(final MongoClient defaultKeyVaultClient,
-                                                   final MongoClientSettings keyVaultMongoClientSettings,
+    private static KeyRetriever createKeyRetriever(final MongoClient keyVaultClient,
                                                    final String keyVaultNamespaceString) {
-        MongoClient keyVaultClient;
-        boolean keyRetrieverOwnsClient;
-        if (keyVaultMongoClientSettings != null) {
-            keyVaultClient = MongoClients.create(keyVaultMongoClientSettings);
-            keyRetrieverOwnsClient = true;
-        } else {
-            keyVaultClient = defaultKeyVaultClient;
-            keyRetrieverOwnsClient = false;
-        }
-
-        return createKeyRetriever(keyVaultClient, keyRetrieverOwnsClient, keyVaultNamespaceString);
-    }
-
-    private static KeyRetriever createKeyRetriever(final MongoClient keyVaultClient, final boolean keyRetrieverOwnsClient,
-                                                   final String keyVaultNamespaceString) {
-        return new KeyRetriever(keyVaultClient, keyRetrieverOwnsClient, new MongoNamespace(keyVaultNamespaceString));
+        return new KeyRetriever(keyVaultClient, new MongoNamespace(keyVaultNamespaceString));
     }
 
     private static KeyManagementService createKeyManagementService() {

--- a/driver-sync/src/main/com/mongodb/client/internal/KeyRetriever.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/KeyRetriever.java
@@ -21,20 +21,17 @@ import com.mongodb.ReadConcern;
 import com.mongodb.client.MongoClient;
 import org.bson.BsonDocument;
 
-import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
-class KeyRetriever implements Closeable {
+class KeyRetriever {
     private final MongoClient client;
-    private final boolean ownsClient;
     private final MongoNamespace namespace;
 
-    KeyRetriever(final MongoClient client, final boolean ownsClient, final MongoNamespace namespace) {
+    KeyRetriever(final MongoClient client, final MongoNamespace namespace) {
         this.client = notNull("client", client);
-        this.ownsClient = ownsClient;
         this.namespace = notNull("namespace", namespace);
     }
 
@@ -42,12 +39,5 @@ class KeyRetriever implements Closeable {
         return client.getDatabase(namespace.getDatabaseName()).getCollection(namespace.getCollectionName(), BsonDocument.class)
                 .withReadConcern(ReadConcern.MAJORITY)
                 .find(keyFilter).into(new ArrayList<BsonDocument>());
-    }
-
-    @Override
-    public void close() {
-        if (ownsClient) {
-            client.close();
-        }
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionDeadlockTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionDeadlockTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.AutoEncryptionSettings;
+import com.mongodb.ClientEncryptionSettings;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.ReadConcern;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.model.CreateCollectionOptions;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.ValidationOptions;
+import com.mongodb.client.model.vault.EncryptOptions;
+import com.mongodb.client.vault.ClientEncryption;
+import com.mongodb.client.vault.ClientEncryptions;
+import com.mongodb.event.CommandEvent;
+import com.mongodb.event.CommandListener;
+import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.internal.connection.TestCommandListener;
+import org.bson.BsonBinary;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.mongodb.client.Fixture.getMongoClient;
+import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static util.JsonPoweredTestHelper.getTestDocument;
+
+public abstract class AbstractClientSideEncryptionDeadlockTest {
+    private BsonBinary cipherText;
+    private MongoClient encryptingClient;
+    private Map<String, Map<String, Object>> kmsProviders;
+
+    protected abstract MongoClient createMongoClient(MongoClientSettings settings);
+
+    @BeforeEach
+    public void setUp() throws IOException, URISyntaxException {
+
+        MongoDatabase keyVaultDatabase = getMongoClient().getDatabase("keyvault");
+        MongoCollection<BsonDocument> dataKeysCollection = keyVaultDatabase.getCollection("datakeys", BsonDocument.class)
+                .withWriteConcern(WriteConcern.MAJORITY);
+        dataKeysCollection.drop();
+        dataKeysCollection.insertOne(bsonDocumentFromPath("external-key.json"));
+
+        MongoDatabase encryptedDatabase = getMongoClient().getDatabase("db");
+        MongoCollection<BsonDocument> encryptedCollection = encryptedDatabase.getCollection("coll", BsonDocument.class)
+                .withWriteConcern(WriteConcern.MAJORITY);
+        encryptedCollection.drop();
+        encryptedDatabase.createCollection("coll", new CreateCollectionOptions()
+                .validationOptions(new ValidationOptions()
+                        .validator(new BsonDocument("$jsonSchema", bsonDocumentFromPath("external-schema.json")))));
+
+        kmsProviders = new HashMap<>();
+        Map<String, Object> localProviderMap = new HashMap<>();
+        localProviderMap.put("key",
+                Base64.getDecoder().decode(
+                        "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZ"
+                                + "GJkTXVyZG9uSjFk"));
+        kmsProviders.put("local", localProviderMap);
+        ClientEncryption clientEncryption = ClientEncryptions.create(
+                ClientEncryptionSettings.builder()
+                        .keyVaultMongoClientSettings(getKeyVaultClientSettings(new TestCommandListener()))
+                        .keyVaultNamespace("keyvault.datakeys")
+                        .kmsProviders(kmsProviders)
+                        .build());
+        cipherText = clientEncryption.encrypt(new BsonString("string0"),
+                new EncryptOptions("AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic").keyAltName("local"));
+        clientEncryption.close();
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        if (encryptingClient != null) {
+            encryptingClient.close();
+        }
+    }
+
+    private static Stream<Arguments> testArgumentProvider() {
+        return Stream.of(
+                //
+                arguments(1, 2, false, false,
+                        asList(new ExpectedEvent("db", "listCollections"),
+                                new ExpectedEvent("keyvault", "find"),
+                                new ExpectedEvent("db", "insert"),
+                                new ExpectedEvent("db", "find")),
+                        emptyList()),
+                arguments(1, 2, false, true,
+                        asList(new ExpectedEvent("db", "listCollections"),
+                                new ExpectedEvent("db", "insert"),
+                                new ExpectedEvent("db", "find")),
+                        asList(new ExpectedEvent("keyvault", "find"))),
+                arguments(1, 2, true, false,
+                        asList(new ExpectedEvent("db", "find"),
+                                new ExpectedEvent("keyvault", "find")),
+                        emptyList()),
+
+                arguments(1, 1, true, true,
+                        asList(new ExpectedEvent("db", "find")),
+                        asList(new ExpectedEvent("keyvault", "find")))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testArgumentProvider")
+    public void shouldPassAllOutcomes(final int maxPoolSize,
+                                      final int expectedNumberOfClientsCreated,
+                                      final boolean bypassAutoEncryption,
+                                      final boolean externalKeyVaultClient,
+                                      final List<ExpectedEvent> expectedEncryptingClientEvents,
+                                      final List<ExpectedEvent> expectedExternalKeyVaultsClientEvents) {
+        AutoEncryptionSettings.Builder autoEncryptionSettingsBuilder = AutoEncryptionSettings.builder()
+                .keyVaultNamespace("keyvault.datakeys")
+                .kmsProviders(kmsProviders)
+                .bypassAutoEncryption(bypassAutoEncryption);
+        TestCommandListener externalKeyVaultClientCommandListener =
+                new TestCommandListener(singletonList("commandStartedEvent"), emptyList());
+        if (externalKeyVaultClient) {
+            autoEncryptionSettingsBuilder.keyVaultMongoClientSettings(getKeyVaultClientSettings(externalKeyVaultClientCommandListener));
+        }
+
+        TestCommandListener encryptingClientCommandListener = new TestCommandListener(singletonList("commandStartedEvent"), emptyList());
+        encryptingClient = createMongoClient(getClientSettings(maxPoolSize, encryptingClientCommandListener,
+                autoEncryptionSettingsBuilder.build()));
+
+        BsonDocument unencryptedDocument = new BsonDocument("_id", new BsonInt32(0)).append("encrypted", new BsonString("string0"));
+
+        if (bypassAutoEncryption) {
+            getMongoClient().getDatabase("db")
+                    .getCollection("coll", BsonDocument.class)
+                    .withWriteConcern(WriteConcern.MAJORITY)
+                    .insertOne(new BsonDocument("_id", new BsonInt32(0)).append("encrypted", cipherText));
+
+        } else {
+            encryptingClient.getDatabase("db")
+                    .getCollection("coll", BsonDocument.class)
+                    .withWriteConcern(WriteConcern.MAJORITY)
+                    .insertOne(unencryptedDocument);
+        }
+
+        BsonDocument result = encryptingClient.getDatabase("db")
+                .getCollection("coll", BsonDocument.class)
+                .find().filter(Filters.eq("_id", 0)).first();
+
+        assertEquals(unencryptedDocument, result);
+
+        assertEquals(expectedNumberOfClientsCreated, getNumUniqueClients(encryptingClientCommandListener), "Unique clients");
+
+        assertEventEquality(encryptingClientCommandListener, expectedEncryptingClientEvents);
+        assertEventEquality(externalKeyVaultClientCommandListener, expectedExternalKeyVaultsClientEvents);
+    }
+
+    private void assertEventEquality(final TestCommandListener commandListener, final List<ExpectedEvent> expectedStartEvents) {
+        List<CommandEvent> actualStartedEvents = commandListener.getCommandStartedEvents();
+        assertEquals(expectedStartEvents.size(), actualStartedEvents.size());
+        for (int i = 0; i < expectedStartEvents.size(); i++) {
+            ExpectedEvent expectedEvent = expectedStartEvents.get(i);
+            CommandStartedEvent actualEvent = (CommandStartedEvent) actualStartedEvents.get(i);
+            assertEquals(expectedEvent.getDatabase(), actualEvent.getDatabaseName(), "Database name");
+            assertEquals(expectedEvent.getCommandName(), actualEvent.getCommandName(), "Command name");
+        }
+    }
+
+    private int getNumUniqueClients(final TestCommandListener commandListener) {
+        Set<String> uniqueClients = new HashSet<>();
+        for (CommandEvent event : commandListener.getEvents()) {
+            uniqueClients.add(event.getConnectionDescription().getConnectionId().getServerId().getClusterId().getValue());
+        }
+        return uniqueClients.size();
+    }
+
+    @NotNull
+    private static MongoClientSettings getKeyVaultClientSettings(final CommandListener commandListener) {
+        return getClientSettings(1, commandListener, null);
+    }
+
+    @NotNull
+    private static MongoClientSettings getClientSettings(final int maxPoolSize,
+                                                         final CommandListener commandListener,
+                                                         final AutoEncryptionSettings autoEncryptionSettings) {
+        return getMongoClientSettingsBuilder()
+                .autoEncryptionSettings(autoEncryptionSettings)
+                .readConcern(ReadConcern.MAJORITY)
+                .writeConcern(WriteConcern.MAJORITY)
+                .addCommandListener(commandListener)
+                .applyToConnectionPoolSettings(builder -> builder.maxSize(maxPoolSize))
+                .build();
+    }
+
+    private static BsonDocument bsonDocumentFromPath(final String path) throws URISyntaxException, IOException {
+        return getTestDocument(new File(ClientSideEncryptionExternalKeyVaultTest.class
+                .getResource("/client-side-encryption-external/" + path).toURI()));
+    }
+
+    private static final class ExpectedEvent {
+        private final String database;
+        private final String commandName;
+
+        ExpectedEvent(final String database, final String commandName) {
+            this.database = database;
+            this.commandName = commandName;
+        }
+
+        String getDatabase() {
+            return database;
+        }
+
+        String getCommandName() {
+            return commandName;
+        }
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionDeadlockTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionDeadlockTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.MongoClientSettings;
+
+public class ClientSideEncryptionDeadlockTest extends AbstractClientSideEncryptionDeadlockTest {
+    @Override
+    protected MongoClient createMongoClient(final MongoClientSettings settings) {
+        return MongoClients.create(settings);
+    }
+}


### PR DESCRIPTION
JAVA-3932

During the testing of the reactive streams implementation, I discovered a bug in ListCollectionsOperation in which two connections were checked out concurrently (and only one used).  I've fixed that here as well.