### PR TITLE
Fixes SingleItemObservable to emit item only once

### DIFF
--- a/driver-scala/src/main/scala/org/mongodb/scala/internal/SingleItemObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/internal/SingleItemObservable.scala
@@ -25,15 +25,18 @@ private[scala] case class SingleItemObservable[A](item: A) extends SingleObserva
       new Subscription {
         @volatile
         private var subscribed: Boolean = true
+        @volatile
+        private var completed: Boolean = false
 
         override def isUnsubscribed: Boolean = !subscribed
 
         override def request(n: Long): Unit = {
           require(n > 0L, s"Number requested must be greater than zero: $n")
 
-          if (subscribed) {
+          if (subscribed && !completed) {
             observer.onNext(item)
             observer.onComplete()
+            completed = true
           }
         }
 


### PR DESCRIPTION
Hi MongoDB, @rozza,

I observed what seems to be a tiny bug.
It is about the `SingleItemObservable` class.
This class is called in `SingleObservable.scala` file

```scala
object SingleObservable {

  /**
   * Creates an SingleObservable from an item.
   *
   * Convenient for testing and or debugging.
   *
   * @param item the item to create an observable from
   * @tparam A the type of the SingleObservable
   * @return an Observable that emits the item
   */
  def apply[A](item: A): SingleObservable[A] = SingleItemObservable(item)
}
```

I figured it out when adding tests and mocking some DB calls, and returning `SingleObservable(aTestValue)`, I always got an exception :

```
java.lang.IllegalStateException: SingleObservable.onNext cannot be called with multiple results.
	at org.mongodb.scala.ObservableImplicits$ToSingleObservablePublisher$$anon$1.check(ObservableImplicits.scala:125)
	at org.mongodb.scala.ObservableImplicits$ToSingleObservablePublisher$$anon$1.onNext(ObservableImplicits.scala:114)
        ...
```

As a quick solution I have to use `Observable(aTestValue :: Nil).toSingle`, which is aware of wether it was already completed. This PR is meant to add this into the `SingleItemObservable` class.

I did not create a JIRA ticket for this, as it is a very tiny issue, but I can if necessary.

Thanks !