### PR TITLE
Fix the read timeout implementation in NettyStream

### DIFF
--- a/driver-core/src/main/com/mongodb/annotations/ThreadSafe.java
+++ b/driver-core/src/main/com/mongodb/annotations/ThreadSafe.java
@@ -18,12 +18,12 @@ import java.lang.annotation.Target;
 
 
 /**
- * The class to which this annotation is applied is thread-safe.  This means that no sequences of accesses (reads and writes to public
- * fields, calls to public methods) may put the object into an invalid state, regardless of the interleaving of those actions by the
+ * The class or method to which this annotation is applied is thread-safe. This means that no sequences of accesses (reads and writes to
+ * public fields, calls to public methods) may put the object into an invalid state, regardless of the interleaving of those actions by the
  * runtime, and without requiring any additional synchronization or coordination on the part of the caller.
  */
 @Documented
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ThreadSafe {
 }

--- a/driver-core/src/main/com/mongodb/connection/netty/ReadTimeoutHandler.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/ReadTimeoutHandler.java
@@ -17,62 +17,180 @@
 
 package com.mongodb.connection.netty;
 
+import com.mongodb.annotations.NotThreadSafe;
+import com.mongodb.annotations.ThreadSafe;
+import com.mongodb.lang.Nullable;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.handler.timeout.ReadTimeoutException;
 
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.StampedLock;
 
-import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 
 /**
- * Passes a {@link ReadTimeoutException} if the time between a {@link #scheduleTimeout} and {@link #removeTimeout} is longer than the set
- * timeout.
+ * This {@link ChannelInboundHandler} allows {@linkplain #scheduleTimeout(int) scheduling} and {@linkplain #removeTimeout() removing}
+ * timeouts. A timeout is a delayed task that {@linkplain ChannelHandlerContext#fireExceptionCaught(Throwable) fires}
+ * {@link ReadTimeoutException#INSTANCE} and {@linkplain ChannelHandlerContext#close() closes} the channel;
+ * this can be prevented by removing the timeout.
+ * <p>
+ * This class guarantees that there are no concurrent timeouts scheduled for a channel.
+ * Note that despite instances of this class are not thread-safe
+ * (only {@linkplain io.netty.channel.ChannelHandler.Sharable sharable} handlers must be thread-safe),
+ * methods {@link #scheduleTimeout(int)} and {@link #removeTimeout()} are linearizable.
+ * <p>
+ * The Netty-related lifecycle management in this class is inspired by the {@link IdleStateHandler}.
+ * See the <a href="https://netty.io/wiki/new-and-noteworthy-in-4.0.html#simplified-channel-state-model">channel state model</a>
+ * for additional details.
  */
+@NotThreadSafe
 final class ReadTimeoutHandler extends ChannelInboundHandlerAdapter {
-    private final long readTimeout;
-    private volatile ScheduledFuture<?> timeout;
+    private final long readTimeoutMillis;
+    private final Lock nonreentrantLock;
+    @Nullable
+    private ChannelHandlerContext ctx;
+    @Nullable
+    private ScheduledFuture<?> timeout;
 
-    ReadTimeoutHandler(final long readTimeout) {
-        isTrueArgument("readTimeout must be greater than zero.", readTimeout > 0);
-        this.readTimeout = readTimeout;
+    ReadTimeoutHandler(final long readTimeoutMillis) {
+        isTrueArgument("readTimeoutMillis must be positive", readTimeoutMillis > 0);
+        this.readTimeoutMillis = readTimeoutMillis;
+        nonreentrantLock = new StampedLock().asWriteLock();
     }
 
-    void scheduleTimeout(final ChannelHandlerContext ctx, final int additionalTimeout) {
-        isTrue("Handler called from the eventLoop", ctx.channel().eventLoop().inEventLoop());
-        if (timeout == null) {
-            timeout = ctx.executor().schedule(new ReadTimeoutTask(ctx), readTimeout + additionalTimeout, TimeUnit.MILLISECONDS);
+    private void register(final ChannelHandlerContext context) {
+        nonreentrantLock.lock();
+        try {
+            final ChannelHandlerContext ctx = this.ctx;
+            if (ctx == context) {
+                return;
+            }
+            assert ctx == null : "Attempted to register a context before a previous one is deregistered";
+            this.ctx = context;
+        } finally {
+            nonreentrantLock.unlock();
         }
     }
 
-    void removeTimeout(final ChannelHandlerContext ctx) {
-        isTrue("Handler called from the eventLoop", ctx.channel().eventLoop().inEventLoop());
+    private void deregister() {
+        nonreentrantLock.lock();
+        try {
+            unsynchronizedCancel();
+            ctx = null;
+        } finally {
+            nonreentrantLock.unlock();
+        }
+    }
+
+    private void unsynchronizedCancel() {
+        final ScheduledFuture<?> timeout = this.timeout;
         if (timeout != null) {
             timeout.cancel(false);
-            timeout = null;
+            this.timeout = null;
         }
     }
 
-    private static final class ReadTimeoutTask implements Runnable {
+    @Override
+    public void channelActive(final ChannelHandlerContext ctx) throws Exception {
+        /* This method is invoked only if the handler is added to a channel pipeline before the channelActive event is fired.
+         * Because of this fact we also need to monitor the handlerAdded event.*/
+        register(ctx);
+        super.channelActive(ctx);
+    }
 
-        private final ChannelHandlerContext ctx;
-
-        ReadTimeoutTask(final ChannelHandlerContext ctx) {
-            this.ctx = ctx;
+    @Override
+    public void handlerAdded(final ChannelHandlerContext ctx) throws Exception {
+        final Channel channel = ctx.channel();
+        if (channel.isActive()//the channelActive event has already been fired and our channelActive method will not be called
+                /* Check that the channel is registered with an event loop.
+                 * If it is not the case, then our channelRegistered method calls the register method.*/
+                && channel.isRegistered()) {
+            register(ctx);
+        } else {
+            /* The channelActive event has not been fired. When it is fired, our channelActive method will be called
+             * and we will call the register method there.*/
         }
+        super.handlerAdded(ctx);
+    }
 
-        @Override
-        public void run() {
-            if (ctx.channel().isOpen()) {
+    @Override
+    public void channelRegistered(final ChannelHandlerContext ctx) throws Exception {
+        if (ctx.channel().isActive()) {//the channelActive event has already been fired and our channelActive method will not be called
+            register(ctx);
+        }
+        super.channelRegistered(ctx);
+    }
+
+    @Override
+    public void channelInactive(final ChannelHandlerContext ctx) throws Exception {
+        deregister();
+        super.channelInactive(ctx);
+    }
+
+    @Override
+    public void handlerRemoved(final ChannelHandlerContext ctx) throws Exception {
+        deregister();
+        super.handlerRemoved(ctx);
+    }
+
+    @Override
+    public void channelUnregistered(final ChannelHandlerContext ctx) throws Exception {
+        deregister();
+        super.channelUnregistered(ctx);
+    }
+
+    /**
+     * Schedules a new timeout.
+     * A timeout must be {@linkplain #removeTimeout() removed} before another one is allowed to be scheduled.
+     */
+    @ThreadSafe
+    void scheduleTimeout(final int additionalTimeoutMillis) {
+        isTrueArgument("additionalTimeoutMillis must not be negative", additionalTimeoutMillis >= 0);
+        nonreentrantLock.lock();
+        try {
+            final ChannelHandlerContext ctx = this.ctx;
+            if (ctx == null) {//no context is registered
+                return;
+            }
+            final ScheduledFuture<?> timeout = this.timeout;
+            assert timeout == null || timeout.isDone() : "Attempted to schedule a timeout before the previous one is removed or completed";
+            this.timeout = ctx.executor().schedule(() -> {
                 try {
-                    ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
-                    ctx.close();
-                } catch (Throwable t) {
+                    fireTimeoutException(ctx);
+                } catch (final Throwable t) {
                     ctx.fireExceptionCaught(t);
                 }
-            }
+            }, readTimeoutMillis + additionalTimeoutMillis, TimeUnit.MILLISECONDS);
+        } finally {
+            nonreentrantLock.unlock();
         }
+    }
+
+    /**
+     * Either removes the previously {@linkplain #scheduleTimeout(int) scheduled} timeout, or does nothing.
+     * After removing a timeout, another one may be scheduled.
+     */
+    @ThreadSafe
+    void removeTimeout() {
+        nonreentrantLock.lock();
+        try {
+            unsynchronizedCancel();
+        } finally {
+            nonreentrantLock.unlock();
+        }
+    }
+
+    private static void fireTimeoutException(final ChannelHandlerContext ctx) {
+        if (!ctx.channel().isOpen()) {
+            return;
+        }
+        ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
+        ctx.close();
     }
 }


### PR DESCRIPTION
Both the new approach and the original one achieve the guarantee that
there are no concurrent read timeouts scheduled for a channel.
This is an essential property needed for a timeout implementation,
let us call it "at-most-one".

The original approach of achieving the at-most-one property:
- Schedule timeouts only by an event loop thread.
- If another thread needs to schedule a timeout, it submits a new scheduleTimeout task
to the channel's event pool (asynchronous timeout scheduling).
This task schedules a new timeout if none is scheduled.

The original approach allowed executions in which a scheduleTimeout task runs after
completion of the read operation that submitted the task,
which resulted in unexpected timeout exceptions.

The new approach achieves the at-most-one property by using a lock.
As a result, timeouts can be scheduled by any thread and there is no
asynchronous timeout scheduling. This means we cannot miss removing a timeout
because it was submitted for scheduling, but has not been scheduled yet.

Other notable changes:
1) ReadTimeoutHandler is now actually implemented as a handler. It reacts to Netty events,
learns about the context and when to remove the timeout automatically
because the channel is closed, or because the channel is no longer registered with an event loop
(we do not use channels this way, but it is possible,
as described here
https://netty.io/wiki/new-and-noteworthy-in-4.0.html#deregistration-and-re-registration-of-a-channel-fromto-an-io-thread).
2) Netty channel handlers (all except for ReadTimeoutHandler) do not try to schedule timeouts anymore.
This was unnecessary even with the original approach.
3) Fields NettyStream.pendingReader, pendingException are always written/read
inside synchronized blocks that use the same NettyStream object,
so marking them volatile is unnecessary and potentially misleading.

JAVA-3920