### PR TITLE
Fail unified test if an operation throws an exception

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -158,6 +159,8 @@ public abstract class UnifiedTest {
         } else if (operation.containsKey("expectError")) {
             assertNotNull(context.getMessage("The operation expects an error but no exception was thrown"), result.getException());
             errorMatcher.assertErrorsMatch(operation.getDocument("expectError"), result.getException());
+        } else {
+            assertNull(context.getMessage("The operation expects no error but an exception occurred"), result.getException());
         }
         context.pop();
     }


### PR DESCRIPTION
A unified test should fail in the following circumstance:

* The operation specification defines neither expectResult nor expectError
* The operation throws an exception

JAVA-3960

A test for this is forthcoming in the spec test validator, but wanted to get the fix in now while it was fresh in my mind.