### PR TITLE
Code improvements split from JAVA-3907

### DIFF
--- a/driver-core/src/main/com/mongodb/ServerCursor.java
+++ b/driver-core/src/main/com/mongodb/ServerCursor.java
@@ -16,6 +16,8 @@
 
 package com.mongodb;
 
+import com.mongodb.annotations.Immutable;
+
 import java.io.Serializable;
 
 /**
@@ -24,6 +26,7 @@ import java.io.Serializable;
  *
  * @since 3.0
  */
+@Immutable
 public final class ServerCursor implements Serializable {
 
     private static final long serialVersionUID = -7013636754565190109L;

--- a/driver-core/src/main/com/mongodb/internal/binding/ReferenceCounted.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/ReferenceCounted.java
@@ -23,7 +23,7 @@ package com.mongodb.internal.binding;
  */
 public interface ReferenceCounted {
     /**
-     * Gets the current reference count, which starts at 0.
+     * Gets the current reference count, which starts at 1.
      *
      * @return the current count, which must be greater than or equal to 0
      */

--- a/driver-core/src/main/com/mongodb/internal/connection/QueryResult.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/QueryResult.java
@@ -35,7 +35,7 @@ public class QueryResult<T> {
     private final long cursorId;
     private final ServerAddress serverAddress;
     @Nullable
-    private ServerCursor serverCursor;//intentionally plain, we depend on ServerCursor being immutable
+    private ServerCursor serverCursor; //intentionally plain, we depend on ServerCursor being immutable
 
     /**
      * Construct an instance.
@@ -75,13 +75,13 @@ public class QueryResult<T> {
         } else {
             /* Actions r and w cause executions to have data race, which is benign because ServerCursor is immutable.
              * See https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.5.1
-             * and https://shipilev.net/blog/2016/close-encounters-of-jmm-kind/#wishful-benign-is-resilient */
-            ServerCursor localServerCursor = serverCursor;//r
+             * and https://shipilev.net/blog/2016/close-encounters-of-jmm-kind/#wishful-benign-is-resilient. */
+            ServerCursor localServerCursor = serverCursor; //r
             if (localServerCursor == null) {
                 localServerCursor = new ServerCursor(cursorId, serverAddress);
-                serverCursor = localServerCursor;//w
+                serverCursor = localServerCursor; //w
             }
-            return localServerCursor;//must read from the local variable for correctness
+            return localServerCursor; //must read from the local variable for correctness
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncQueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncQueryBatchCursor.java
@@ -69,9 +69,9 @@ class AsyncQueryBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
     private volatile int batchSize;
     private final AtomicInteger count = new AtomicInteger();
     private volatile BsonDocument postBatchResumeToken;
-    private volatile BsonTimestamp operationTime;
-    private volatile boolean firstBatchEmpty;
-    private volatile int maxWireVersion = 0;
+    private final BsonTimestamp operationTime;
+    private final boolean firstBatchEmpty;
+    private final int maxWireVersion;
 
     /* protected by `this` */
     private boolean isOperationInProgress = false;
@@ -100,6 +100,8 @@ class AsyncQueryBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
         if (result != null) {
             this.operationTime = result.getTimestamp(OPERATION_TIME, null);
             this.postBatchResumeToken = getPostBatchResumeTokenFromResponse(result);
+        } else {
+            this.operationTime = null;
         }
 
         firstBatchEmpty = firstBatch.getResults().isEmpty();
@@ -109,9 +111,7 @@ class AsyncQueryBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
                 killCursor(connection);
             }
         }
-        if (connection != null) {
-            this.maxWireVersion = connection.getDescription().getMaxWireVersion();
-        }
+        this.maxWireVersion = connection == null ? 0 : connection.getDescription().getMaxWireVersion();
     }
 
     @Override

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/package-info.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/package-info.java
@@ -15,6 +15,16 @@
  */
 
 /**
- * This packages contains classes for the reactive stream client implementation
+ * This packages contains classes for the reactive stream client implementation.
+ * <p>
+ * All {@link org.reactivestreams.Publisher}s are <a href="https://projectreactor.io/docs/core/release/reference/#reactor.hotCold">cold</a>,
+ * meaning that nothing happens until they are subscribed to.
+ * So just creating a {@link org.reactivestreams.Publisher} won’t cause any network IO.
+ * It’s not until {@link org.reactivestreams.Publisher#subscribe(org.reactivestreams.Subscriber)} is called that the driver executes the
+ * operation.
+ * <p>
+ * All {@link org.reactivestreams.Publisher}s are unicast.
+ * Each {@link org.reactivestreams.Subscription} to a {@link org.reactivestreams.Publisher} relates to a single MongoDB operation and its
+ * {@link org.reactivestreams.Subscriber} will receive its own specific set of results.
  */
 package com.mongodb.reactivestreams.client;


### PR DESCRIPTION
* ReferenceCounted.getCount documentation was changed.
It is documented to start at 1, which is with accordance to
what the current driver code expects. The common usage pattern is as follows:
ReferenceCounted resource = new ...;
//note that resource.retain() is not called because we expect the resource is created with counter 1
try {
  //use resource witho;
} finally {
  resource.release();
}
Changing implementations of ReferenceCounted.getCount to start with 0 would result in
resource.release() throwing IllegalStateException("Attempted to decrement the reference count below 0").
As long as the method ReferenceCounted.getCount is exposed, its behavior
is a part of the ReferenceCounted contract.

* Some fields in AsyncQueryBatchCursor were made final.

* Reduced the amount of garbage produced by QueryResult.getCursor.

* Documented Publisher properties in com.mongodb.reactivestreams.client.