### PR TITLE
Make impls of AsyncAggregateResponseBatchCursor more responsive to close signals and improve/fix releasing of resources

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/ResourcePreservingCallback.java
+++ b/driver-core/src/main/com/mongodb/internal/async/ResourcePreservingCallback.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.async;
+
+import com.mongodb.internal.binding.ReferenceCounted;
+import com.mongodb.lang.Nullable;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+/**
+ * A decorator that {@linkplain ReferenceCounted#retain() retains} the supplied resource in the constructor
+ * and idempotently {@linkplain ReferenceCounted#release() releases} it in {@link #onResult(Object, Throwable)}.
+ * <p>
+ * This class is not part of the public API and may be removed or changed at any time.
+ *
+ * @param <T> the result type
+ */
+public final class ResourcePreservingCallback<T> implements SingleResultCallback<T> {
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<ResourcePreservingCallback, ReferenceCounted> RESOURCE =
+            AtomicReferenceFieldUpdater.newUpdater(ResourcePreservingCallback.class, ReferenceCounted.class, "resource");
+
+    @Nullable
+    private volatile ReferenceCounted resource;
+    @Nullable
+    private final SingleResultCallback<? super T> wrapped;
+
+    private ResourcePreservingCallback(final ReferenceCounted resource, @Nullable final SingleResultCallback<? super T> wrapped) {
+        this.resource = notNull("resource must not be null", resource);
+        resource.retain();
+        this.wrapped = wrapped;
+    }
+
+    public static <T> SingleResultCallback<T> resourcePreservingCallback(
+            final ReferenceCounted resource, @Nullable final SingleResultCallback<T> wrapped) {
+        notNull("resource must not be null", resource);
+        return new ResourcePreservingCallback<>(resource, wrapped);
+    }
+
+    @Override
+    public void onResult(final T result, final Throwable t) {
+        try {
+            releaseResourceIdempotently();
+        } finally {
+            if (wrapped != null) {
+                wrapped.onResult(result, t);
+            }
+        }
+    }
+
+    private void releaseResourceIdempotently() {
+        ReferenceCounted localResource = RESOURCE.getAndSet(this, null);
+        if (localResource != null) {
+            localResource.release();
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/binding/AsyncConnectionSource.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/AsyncConnectionSource.java
@@ -51,6 +51,11 @@ public interface AsyncConnectionSource extends ReferenceCounted {
 
     /**
      * Gets a connection from this source.
+     * <p>
+     * Implementations must {@link #retain()} {@code this} {@link AsyncConnectionSource} so that it does not
+     * accidentally become unreferenced concurrently with still being accessed for the purpose of the method;
+     * implementations must {@link #release()} {@code this} {@link AsyncConnectionSource}
+     * once it is no longer needed for the purpose of the method.
      *
      * @param callback the to be passed the connection
      */

--- a/driver-core/src/main/com/mongodb/internal/connection/AsyncConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsyncConnection.java
@@ -40,6 +40,12 @@ import java.util.List;
  * <p> Implementations of this class are thread safe.  </p>
  *
  * <p> This interface is not stable. While methods will not be removed, new ones may be added. </p>
+ * <p>
+ * <b>{@code *Async} methods</b><br>
+ * Implementations of any {@code *Async} method must {@link #retain()} {@code this} {@link AsyncConnection} so that it does not
+ * accidentally become unreferenced concurrently with still being accessed for the purpose of the method;
+ * implementations must {@link #release()} {@code this} {@link AsyncConnection}
+ * once it is no longer needed for the purpose of the method.
  *
  * @since 3.0
  */

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncQueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncQueryBatchCursor.java
@@ -69,9 +69,9 @@ class AsyncQueryBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
     private volatile int batchSize;
     private final AtomicInteger count = new AtomicInteger();
     private volatile BsonDocument postBatchResumeToken;
-    private volatile BsonTimestamp operationTime;
-    private volatile boolean firstBatchEmpty;
-    private volatile int maxWireVersion = 0;
+    private final BsonTimestamp operationTime;
+    private final boolean firstBatchEmpty;
+    private final int maxWireVersion;
 
     /* protected by `this` */
     private boolean isOperationInProgress = false;
@@ -100,6 +100,8 @@ class AsyncQueryBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
         if (result != null) {
             this.operationTime = result.getTimestamp(OPERATION_TIME, null);
             this.postBatchResumeToken = getPostBatchResumeTokenFromResponse(result);
+        } else {
+            this.operationTime = null;
         }
 
         firstBatchEmpty = firstBatch.getResults().isEmpty();
@@ -109,9 +111,7 @@ class AsyncQueryBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
                 killCursor(connection);
             }
         }
-        if (connection != null) {
-            this.maxWireVersion = connection.getDescription().getMaxWireVersion();
-        }
+        this.maxWireVersion = connection == null ? 0 : connection.getDescription().getMaxWireVersion();
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncQueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncQueryBatchCursor.java
@@ -70,6 +70,9 @@ class AsyncQueryBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
     private final AtomicInteger count = new AtomicInteger();
     private volatile BsonDocument postBatchResumeToken;
     private final BsonTimestamp operationTime;
+    /**
+     * May be true for a tailable cursor.
+     */
     private final boolean firstBatchEmpty;
     private final int maxWireVersion;
 
@@ -190,12 +193,10 @@ class AsyncQueryBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
         if (isClosed()) {
             callback.onResult(null, new MongoException(format("%s called after the cursor was closed.",
                     tryNext ? "tryNext()" : "next()")));
-        } else if (firstBatch != null && (tryNext || !firstBatch.getResults().isEmpty())) {
-            // May be empty for a tailable cursor
-            List<T> results = firstBatch.getResults();
-            if (tryNext && results.isEmpty()) {
-                results = null;
-            }
+        } else if (firstBatch != null && (tryNext || !firstBatchEmpty)) {
+            List<T> results = tryNext && firstBatchEmpty
+                    ? null
+                    : firstBatch.getResults();
             firstBatch = null;
             ServerCursor localCursor = getServerCursor();
             if (localCursor == null) {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerConnectionSpecification.groovy
@@ -212,8 +212,8 @@ class DefaultServerConnectionSpecification extends Specification {
         connection.insertAsync(namespace, true, insertRequest, callback)
 
         then:
-        1 * executor.executeAsync({ compare(new InsertProtocol(namespace, true, insertRequest), it) }, internalConnection,
-                {expect callback, isTheSameAs(it.wrapped)})
+        1 * executor.executeAsync({ compare(new InsertProtocol(namespace, true, insertRequest), it) }, internalConnection) {
+            expect callback, isTheSameAs(it.wrapped) }
     }
 
     def 'should execute update protocol asynchronously'() {
@@ -226,8 +226,8 @@ class DefaultServerConnectionSpecification extends Specification {
         connection.updateAsync(namespace, true, updateRequest, callback)
 
         then:
-        1 * executor.executeAsync({ compare(new UpdateProtocol(namespace, true, updateRequest), it) },
-                                  internalConnection, {expect callback, isTheSameAs(it.wrapped)})
+        1 * executor.executeAsync({ compare(new UpdateProtocol(namespace, true, updateRequest), it) }, internalConnection) {
+            expect callback, isTheSameAs(it.wrapped) }
     }
 
     def 'should execute delete protocol asynchronously'() {
@@ -240,8 +240,8 @@ class DefaultServerConnectionSpecification extends Specification {
         connection.deleteAsync(namespace, true, deleteRequest, callback)
 
         then:
-        1 * executor.executeAsync({ compare(new DeleteProtocol(namespace, true, deleteRequest), it) }, internalConnection,
-                {expect callback, isTheSameAs(it.wrapped)})
+        1 * executor.executeAsync({ compare(new DeleteProtocol(namespace, true, deleteRequest), it) }, internalConnection) {
+            expect callback, isTheSameAs(it.wrapped) }
     }
 
     def 'should execute command protocol asynchronously'() {
@@ -259,7 +259,7 @@ class DefaultServerConnectionSpecification extends Specification {
         then:
         1 * executor.executeAsync({
             compare(new CommandProtocolImpl('test', command, validator, ReadPreference.primary(), codec, getServerApi()), it)
-        }, internalConnection, NoOpSessionContext.INSTANCE, {expect callback, isTheSameAs(it.wrapped)})
+        }, internalConnection, NoOpSessionContext.INSTANCE) { expect callback, isTheSameAs(it.wrapped) }
     }
 
     def 'should execute query protocol asynchronously'() {
@@ -283,7 +283,7 @@ class DefaultServerConnectionSpecification extends Specification {
                                                .partial(true)
                                                .oplogReplay(false)
                                        , it)
-                             }, internalConnection, {expect callback, isTheSameAs(it.wrapped)})
+                             }, internalConnection) { expect callback, isTheSameAs(it.wrapped) }
 
         where:
         slaveOk << [true, false]
@@ -311,7 +311,7 @@ class DefaultServerConnectionSpecification extends Specification {
                                                .partial(true)
                                                .oplogReplay(false)
                                        , it)
-                             }, internalConnection, {expect callback, isTheSameAs(it.wrapped)})
+                             }, internalConnection) { expect callback, isTheSameAs(it.wrapped) }
 
         where:
         connectionDescription           | expectedSlaveOk
@@ -329,8 +329,8 @@ class DefaultServerConnectionSpecification extends Specification {
         connection.getMoreAsync(namespace, 1000L, 1, codec, callback)
 
         then:
-        1 * executor.executeAsync({ compare(new GetMoreProtocol(namespace, 1000L, 1, codec), it) }, internalConnection,
-                {expect callback, isTheSameAs(it.wrapped)})
+        1 * executor.executeAsync({ compare(new GetMoreProtocol(namespace, 1000L, 1, codec), it) }, internalConnection) {
+            expect callback, isTheSameAs(it.wrapped) }
     }
 
     def 'should execute kill cursor protocol asynchronously'() {
@@ -342,7 +342,7 @@ class DefaultServerConnectionSpecification extends Specification {
         connection.killCursorAsync(namespace, [5], callback)
 
         then:
-        1 * executor.executeAsync({ compare(new KillCursorProtocol(namespace, [5]), it) }, internalConnection,
-                {expect callback, isTheSameAs(it.wrapped)})
+        1 * executor.executeAsync({ compare(new KillCursorProtocol(namespace, [5]), it) }, internalConnection) {
+            expect callback, isTheSameAs(it.wrapped) }
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerConnectionSpecification.groovy
@@ -41,9 +41,11 @@ import spock.lang.Specification
 
 import static com.mongodb.ClusterFixture.getServerApi
 import static com.mongodb.CustomMatchers.compare
+import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.connection.ServerType.SHARD_ROUTER
 import static com.mongodb.connection.ServerType.STANDALONE
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback
+import static spock.util.matcher.HamcrestSupport.expect
 
 class DefaultServerConnectionSpecification extends Specification {
     def namespace = new MongoNamespace('test', 'test')
@@ -211,7 +213,7 @@ class DefaultServerConnectionSpecification extends Specification {
 
         then:
         1 * executor.executeAsync({ compare(new InsertProtocol(namespace, true, insertRequest), it) }, internalConnection,
-                callback)
+                {expect callback, isTheSameAs(it.wrapped)})
     }
 
     def 'should execute update protocol asynchronously'() {
@@ -225,7 +227,7 @@ class DefaultServerConnectionSpecification extends Specification {
 
         then:
         1 * executor.executeAsync({ compare(new UpdateProtocol(namespace, true, updateRequest), it) },
-                                  internalConnection, callback)
+                                  internalConnection, {expect callback, isTheSameAs(it.wrapped)})
     }
 
     def 'should execute delete protocol asynchronously'() {
@@ -239,7 +241,7 @@ class DefaultServerConnectionSpecification extends Specification {
 
         then:
         1 * executor.executeAsync({ compare(new DeleteProtocol(namespace, true, deleteRequest), it) }, internalConnection,
-                callback)
+                {expect callback, isTheSameAs(it.wrapped)})
     }
 
     def 'should execute command protocol asynchronously'() {
@@ -257,7 +259,7 @@ class DefaultServerConnectionSpecification extends Specification {
         then:
         1 * executor.executeAsync({
             compare(new CommandProtocolImpl('test', command, validator, ReadPreference.primary(), codec, getServerApi()), it)
-        }, internalConnection, NoOpSessionContext.INSTANCE, callback)
+        }, internalConnection, NoOpSessionContext.INSTANCE, {expect callback, isTheSameAs(it.wrapped)})
     }
 
     def 'should execute query protocol asynchronously'() {
@@ -281,7 +283,7 @@ class DefaultServerConnectionSpecification extends Specification {
                                                .partial(true)
                                                .oplogReplay(false)
                                        , it)
-                             }, internalConnection, callback)
+                             }, internalConnection, {expect callback, isTheSameAs(it.wrapped)})
 
         where:
         slaveOk << [true, false]
@@ -309,7 +311,7 @@ class DefaultServerConnectionSpecification extends Specification {
                                                .partial(true)
                                                .oplogReplay(false)
                                        , it)
-                             }, internalConnection, callback)
+                             }, internalConnection, {expect callback, isTheSameAs(it.wrapped)})
 
         where:
         connectionDescription           | expectedSlaveOk
@@ -327,7 +329,8 @@ class DefaultServerConnectionSpecification extends Specification {
         connection.getMoreAsync(namespace, 1000L, 1, codec, callback)
 
         then:
-        1 * executor.executeAsync({ compare(new GetMoreProtocol(namespace, 1000L, 1, codec), it) }, internalConnection, callback)
+        1 * executor.executeAsync({ compare(new GetMoreProtocol(namespace, 1000L, 1, codec), it) }, internalConnection,
+                {expect callback, isTheSameAs(it.wrapped)})
     }
 
     def 'should execute kill cursor protocol asynchronously'() {
@@ -339,6 +342,7 @@ class DefaultServerConnectionSpecification extends Specification {
         connection.killCursorAsync(namespace, [5], callback)
 
         then:
-        1 * executor.executeAsync({ compare(new KillCursorProtocol(namespace, [5]), it) }, internalConnection, callback)
+        1 * executor.executeAsync({ compare(new KillCursorProtocol(namespace, [5]), it) }, internalConnection,
+                {expect callback, isTheSameAs(it.wrapped)})
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncQueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncQueryBatchCursorSpecification.groovy
@@ -626,7 +626,7 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         cursor.close()
 
         then:
-        connectionSource.getCount() == 1
+        connectionSource.getCount() == 0
 
         where:
         serverVersion                | commandAsync | exception


### PR DESCRIPTION
It is recommended to review the PR commit by commit for the commits described below: each commit serves its own purpose, reviewing them one by one should simplify the process. We may also have a meeting for a code walkthrough.

Short explanations (what I recall) for the most important commits (see commit messages for more info):
1. [Change implementations of AsyncAggregateResponseBatchCursor to make them more responsive to close signals (4110f51)](https://github.com/mongodb/mongo-java-driver/pull/651/commits/4110f51857f760419953a1b340aed4232eca3f96) - Implements the fix expressed in [JAVA-3907 scenario 2)](https://jira.mongodb.org/browse/JAVA-3907?focusedCommentId=3577246&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-3577246). However, as a result of this change (which does not create new references to reference counted objects), the method `killCursorOnClose` stopped working because of inability to borrow a connection when running the [`Hang`](https://jira.mongodb.org/browse/JAVA-3907?focusedCommentId=3577246&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-3577246) litmus code (this definitely caused many other tests to hang). Additionally, `AsyncQueryBatchCursorSpecification.'should close cursor after getMore finishes if cursor was closed while getMore was in progress and getMore returns a response'` also started failing.
2. [Fix connection reference counting in AsyncQueryBatchCursor (f692551)](https://github.com/mongodb/mongo-java-driver/pull/651/commits/f692551d2b5eb4f7ced5dcaf003897a055c24046) - Fixes reference counting for connections. `AsyncQueryBatchCursorSpecification.'should close cursor after getMore finishes if cursor was closed while getMore was in progress and getMore returns a response'` still fails.
3. [Start releasing connectionSource in AsyncQueryBatchCursor.close (3262a2c)](https://github.com/mongodb/mongo-java-driver/pull/651/commits/3262a2c9c7df7bcdff80ace86c422469dafcc546) - Fixes `AsyncQueryBatchCursorSpecification.'should close cursor after getMore finishes if cursor was closed while getMore was in progress and getMore returns a response'` and changes `close` so that it releases `connectionSurce` synchronously.