### PR TITLE
Fix reactive streams batch cursor regression.

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/client/model/FindOptions.java
+++ b/driver-core/src/main/com/mongodb/internal/client/model/FindOptions.java
@@ -60,6 +60,7 @@ public final class FindOptions {
     public FindOptions() {
     }
 
+    //CHECKSTYLE:OFF
     FindOptions(
             final int batchSize, final int limit, final Bson projection, final long maxTimeMS, final long maxAwaitTimeMS, final int skip,
             final Bson sort, final CursorType cursorType, final boolean noCursorTimeout, final boolean oplogReplay, final boolean partial,
@@ -86,6 +87,7 @@ public final class FindOptions {
         this.showRecordId = showRecordId;
         this.allowDiskUse = allowDiskUse;
     }
+    //CHECKSTYLE:ON
 
     public FindOptions withBatchSize(final int batchSize) {
         return new FindOptions(batchSize, limit, projection, maxTimeMS, maxAwaitTimeMS, skip, sort, cursorType, noCursorTimeout,

--- a/driver-core/src/main/com/mongodb/internal/client/model/FindOptions.java
+++ b/driver-core/src/main/com/mongodb/internal/client/model/FindOptions.java
@@ -60,6 +60,38 @@ public final class FindOptions {
     public FindOptions() {
     }
 
+    FindOptions(
+            final int batchSize, final int limit, final Bson projection, final long maxTimeMS, final long maxAwaitTimeMS, final int skip,
+            final Bson sort, final CursorType cursorType, final boolean noCursorTimeout, final boolean oplogReplay, final boolean partial,
+            final Collation collation, final String comment, final Bson hint, final String hintString, final Bson max, final Bson min,
+            final boolean returnKey, final boolean showRecordId, final Boolean allowDiskUse) {
+        this.batchSize = batchSize;
+        this.limit = limit;
+        this.projection = projection;
+        this.maxTimeMS = maxTimeMS;
+        this.maxAwaitTimeMS = maxAwaitTimeMS;
+        this.skip = skip;
+        this.sort = sort;
+        this.cursorType = cursorType;
+        this.noCursorTimeout = noCursorTimeout;
+        this.oplogReplay = oplogReplay;
+        this.partial = partial;
+        this.collation = collation;
+        this.comment = comment;
+        this.hint = hint;
+        this.hintString = hintString;
+        this.max = max;
+        this.min = min;
+        this.returnKey = returnKey;
+        this.showRecordId = showRecordId;
+        this.allowDiskUse = allowDiskUse;
+    }
+
+    public FindOptions withBatchSize(final int batchSize) {
+        return new FindOptions(batchSize, limit, projection, maxTimeMS, maxAwaitTimeMS, skip, sort, cursorType, noCursorTimeout,
+                oplogReplay, partial, collation, comment, hint, hintString, max, min, returnKey, showRecordId, allowDiskUse);
+    }
+
     /**
      * Gets the limit to apply.  The default is null.
      *

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
@@ -77,8 +77,11 @@ class BatchCursorFlux<T> implements Publisher<T> {
                 Mono.from(batchCursor.next())
                         .doOnCancel(this::closeCursor)
                         .doOnError((e) -> {
-                            closeCursor();
-                            sink.error(e);
+                            try {
+                                closeCursor();
+                            } finally {
+                                sink.error(e);
+                            }
                         })
                         .doOnSuccess(results -> {
                             if (results != null) {

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
@@ -48,7 +48,13 @@ class BatchCursorFlux<T> implements Publisher<T> {
                         batchCursorPublisher.batchCursor(batchSize).subscribe(bc -> {
                             batchCursor = bc;
                             inProgress.set(false);
-                            recurseCursor();
+
+                            // Handle any cancelled subscriptions that happen during the time it takes to get the batchCursor
+                            if (sink.isCancelled()) {
+                                closeCursor();
+                            } else {
+                                recurseCursor();
+                            }
                         }, sink::error);
                     } else {
                         inProgress.set(false);
@@ -97,8 +103,6 @@ class BatchCursorFlux<T> implements Publisher<T> {
                         })
                         .subscribe();
                 }
-        } else if (sink.isCancelled()) {
-            closeCursor();
         }
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
@@ -30,7 +30,7 @@ class BatchCursorFlux<T> implements Publisher<T> {
     private final BatchCursorPublisher<T> batchCursorPublisher;
     private final AtomicBoolean inProgress = new AtomicBoolean(false);
     private final AtomicLong demandDelta = new AtomicLong(0);
-    private BatchCursor<T> batchCursor;
+    private volatile BatchCursor<T> batchCursor;
     private FluxSink<T> sink;
 
     BatchCursorFlux(final BatchCursorPublisher<T> batchCursorPublisher) {

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
@@ -68,7 +68,7 @@ class BatchCursorFlux<T> implements Publisher<T> {
         }
     }
 
-    void recurseCursor(){
+    private void recurseCursor(){
         if (!sink.isCancelled() && sink.requestedFromDownstream() > 0 && inProgress.compareAndSet(false, true)) {
             if (batchCursor.isClosed()) {
                 sink.complete();

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
@@ -94,6 +94,8 @@ class BatchCursorFlux<T> implements Publisher<T> {
                         })
                         .subscribe();
                 }
+        } else if (sink.isCancelled()) {
+            closeCursor();
         }
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.internal;
+
+import com.mongodb.lang.Nullable;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+class BatchCursorFlux<T> implements Publisher<T> {
+
+    private final BatchCursorPublisher<T> batchCursorPublisher;
+    private final Integer originalBatchSize;
+    private final Runnable resetBatchSize;
+    private final AtomicBoolean inProgress = new AtomicBoolean(false);
+    private final AtomicLong demandDelta = new AtomicLong(0);
+    private BatchCursor<T> batchCursor;
+    private FluxSink<T> sink;
+
+    BatchCursorFlux(final BatchCursorPublisher<T> batchCursorPublisher,
+                    @Nullable final Integer originalBatchSize,
+                    final Runnable resetBatchSize) {
+        this.batchCursorPublisher = batchCursorPublisher;
+        this.originalBatchSize = originalBatchSize;
+        this.resetBatchSize = resetBatchSize;
+    }
+
+    @Override
+    public void subscribe(final Subscriber<? super T> subscriber) {
+        Flux.<T>create(sink -> {
+            this.sink = sink;
+            sink.onRequest(l -> {
+                if (demandDelta.addAndGet(l) > 0 && inProgress.compareAndSet(false, true)) {
+                    if (batchCursor == null) {
+                        batchCursorPublisher.batchSize(calculateBatchSize());
+                        batchCursorPublisher.batchCursor().subscribe(bc -> {
+                            batchCursor = bc;
+                            inProgress.set(false);
+                            recurseCursor();
+                        }, sink::error);
+                        resetBatchSize.run();
+                    } else {
+                        inProgress.set(false);
+                        recurseCursor();
+                    }
+                }
+            });
+            sink.onCancel(this::closeCursor);
+            sink.onDispose(this::closeCursor);
+        }, FluxSink.OverflowStrategy.BUFFER)
+        .subscribe(subscriber);
+    }
+
+    void closeCursor() {
+        if (batchCursor != null && !batchCursor.isClosed()) {
+            batchCursor.close();
+        }
+    }
+
+    void recurseCursor(){
+        if (!sink.isCancelled() && sink.requestedFromDownstream() > 0 && inProgress.compareAndSet(false, true)) {
+            if (batchCursor.isClosed()) {
+                sink.complete();
+            } else {
+                batchCursor.setBatchSize(calculateBatchSize());
+                Mono.from(batchCursor.next())
+                        .doOnCancel(this::closeCursor)
+                        .doOnError((e) -> {
+                            closeCursor();
+                            sink.error(e);
+                        })
+                        .doOnSuccess(results -> {
+                            if (results != null) {
+                                results.forEach(sink::next);
+                                demandDelta.addAndGet(-results.size());
+                            }
+                            if (batchCursor.isClosed()) {
+                                sink.complete();
+                            } else {
+                                inProgress.set(false);
+                                recurseCursor();
+                            }
+                        })
+                        .subscribe();
+                }
+        }
+    }
+
+
+    int calculateBatchSize() {
+        if (originalBatchSize != null) {
+            return originalBatchSize;
+        } else if (sink.requestedFromDownstream() > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return Math.max(2, (int) sink.requestedFromDownstream());
+    }
+
+}

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorPublisher.java
@@ -42,10 +42,10 @@ abstract class BatchCursorPublisher<T> implements Publisher<T> {
         this.mongoOperationPublisher = notNull("mongoOperationPublisher", mongoOperationPublisher);
     }
 
-    abstract AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation();
+    abstract AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(int initialBatchSize);
 
     AsyncReadOperation<AsyncBatchCursor<T>> asAsyncFirstReadOperation() {
-        return asAsyncReadOperation();
+        return asAsyncReadOperation(1);
     }
 
     @Nullable
@@ -112,12 +112,11 @@ abstract class BatchCursorPublisher<T> implements Publisher<T> {
 
     @Override
     public void subscribe(final Subscriber<? super T> subscriber) {
-        Integer originalBatchSize = getBatchSize();
-        new BatchCursorFlux<>(this, originalBatchSize, () -> batchSize = originalBatchSize).subscribe(subscriber);
+        new BatchCursorFlux<>(this).subscribe(subscriber);
     }
 
-    public Mono<BatchCursor<T>> batchCursor() {
-        return batchCursor(this::asAsyncReadOperation);
+    public Mono<BatchCursor<T>> batchCursor(final int initialBatchSize) {
+        return batchCursor(() -> asAsyncReadOperation(initialBatchSize));
     }
 
     Mono<BatchCursor<T>> batchCursor(final Supplier<AsyncReadOperation<AsyncBatchCursor<T>>> supplier) {

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImpl.java
@@ -114,8 +114,8 @@ final class ChangeStreamPublisherImpl<T> extends BatchCursorPublisher<ChangeStre
     public <TDocument> Publisher<TDocument> withDocumentClass(final Class<TDocument> clazz) {
         return new BatchCursorPublisher<TDocument>(getClientSession(), getMongoOperationPublisher().withDocumentClass(clazz)) {
             @Override
-            AsyncReadOperation<AsyncBatchCursor<TDocument>> asAsyncReadOperation() {
-                return createChangeStreamOperation(getMongoOperationPublisher().getCodecRegistry().get(clazz));
+            AsyncReadOperation<AsyncBatchCursor<TDocument>> asAsyncReadOperation(final int initialBatchSize) {
+                return createChangeStreamOperation(getMongoOperationPublisher().getCodecRegistry().get(clazz), initialBatchSize);
             }
         };
     }
@@ -133,14 +133,14 @@ final class ChangeStreamPublisherImpl<T> extends BatchCursorPublisher<ChangeStre
     }
 
     @Override
-    AsyncReadOperation<AsyncBatchCursor<ChangeStreamDocument<T>>> asAsyncReadOperation() {
-        return createChangeStreamOperation(codec);
+    AsyncReadOperation<AsyncBatchCursor<ChangeStreamDocument<T>>> asAsyncReadOperation(final int initialBatchSize) {
+        return createChangeStreamOperation(codec, initialBatchSize);
     }
 
-    private <S> AsyncReadOperation<AsyncBatchCursor<S>> createChangeStreamOperation(final Codec<S> codec) {
+    private <S> AsyncReadOperation<AsyncBatchCursor<S>> createChangeStreamOperation(final Codec<S> codec, final int initialBatchSize) {
         return new ChangeStreamOperation<>(getNamespace(), fullDocument,
                                            createBsonDocumentList(pipeline), codec, changeStreamLevel)
-                .batchSize(getBatchSize())
+                .batchSize(initialBatchSize)
                 .collation(collation)
                 .maxAwaitTime(maxAwaitTimeMS, MILLISECONDS)
                 .resumeAfter(resumeToken)

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/DistinctPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/DistinctPublisherImpl.java
@@ -70,7 +70,8 @@ final class DistinctPublisherImpl<T> extends BatchCursorPublisher<T> implements 
     }
 
     @Override
-    AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation() {
+    AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
+        // initialBatchSize is ignored for distinct operations.
         return getOperations().distinct(fieldName, filter, getDocumentClass(), maxTimeMS, collation);
     }
 }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/FindPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/FindPublisherImpl.java
@@ -207,9 +207,7 @@ final class FindPublisherImpl<T> extends BatchCursorPublisher<T> implements Find
 
     @Override
     AsyncExplainableReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
-        int originalBatchSize = findOptions.getBatchSize();
-        FindOperation<T> operation = getOperations().find(filter, getDocumentClass(), findOptions.batchSize(initialBatchSize));
-        findOptions.batchSize(originalBatchSize);
+        FindOperation<T> operation = getOperations().find(filter, getDocumentClass(), findOptions.withBatchSize(initialBatchSize));
         return operation;
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/FindPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/FindPublisherImpl.java
@@ -23,6 +23,7 @@ import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.client.model.FindOptions;
 import com.mongodb.internal.operation.AsyncExplainableReadOperation;
 import com.mongodb.internal.operation.AsyncReadOperation;
+import com.mongodb.internal.operation.FindOperation;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ClientSession;
 import com.mongodb.reactivestreams.client.FindPublisher;
@@ -199,14 +200,17 @@ final class FindPublisherImpl<T> extends BatchCursorPublisher<T> implements Find
     private <E> Publisher<E> publishExplain(final Class<E> explainResultClass, @Nullable final ExplainVerbosity verbosity) {
         notNull("explainDocumentClass", explainResultClass);
         return getMongoOperationPublisher().createReadOperationMono(() ->
-                        asAsyncReadOperation().asAsyncExplainableOperation(verbosity,
+                        asAsyncReadOperation(0).asAsyncExplainableOperation(verbosity,
                                 getCodecRegistry().get(explainResultClass)),
                 getClientSession());
     }
 
     @Override
-    AsyncExplainableReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation() {
-        return getOperations().find(filter, getDocumentClass(), findOptions);
+    AsyncExplainableReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
+        int originalBatchSize = findOptions.getBatchSize();
+        FindOperation<T> operation = getOperations().find(filter, getDocumentClass(), findOptions.batchSize(initialBatchSize));
+        findOptions.batchSize(originalBatchSize);
+        return operation;
     }
 
     @Override

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImpl.java
@@ -59,8 +59,8 @@ final class ListCollectionsPublisherImpl<T> extends BatchCursorPublisher<T> impl
         return this;
     }
 
-    AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation() {
+    AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
         return getOperations().listCollections(getNamespace().getDatabaseName(), getDocumentClass(), filter, collectionNamesOnly,
-                                               getBatchSize(), maxTimeMS);
+                initialBatchSize, maxTimeMS);
     }
 }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListDatabasesPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListDatabasesPublisherImpl.java
@@ -67,7 +67,8 @@ final class ListDatabasesPublisherImpl<T> extends BatchCursorPublisher<T> implem
         return this;
     }
 
-    AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation() {
+    AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
+// initialBatchSize is ignored for distinct operations.
         return getOperations().listDatabases(getDocumentClass(), filter, nameOnly, maxTimeMS, authorizedDatabasesOnly);
     }
 }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListIndexesPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListIndexesPublisherImpl.java
@@ -48,7 +48,7 @@ final class ListIndexesPublisherImpl<T> extends BatchCursorPublisher<T> implemen
         return this;
     }
 
-    AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation() {
-        return getOperations().listIndexes(getDocumentClass(), getBatchSize(), maxTimeMS);
+    AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
+        return getOperations().listIndexes(getDocumentClass(), initialBatchSize, maxTimeMS);
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/TestSubscriber.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/TestSubscriber.java
@@ -29,47 +29,20 @@ import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
 
 public class TestSubscriber<T> implements Subscriber<T> {
 
-    private final Subscriber<T> delegate;
+    private static final int DEFAULT_MAX_RETRIES = 10;
     private final CountDownLatch latch = new CountDownLatch(1);
-    private final ArrayList<T> onNextEvents = new ArrayList<T>();
-    private final ArrayList<Throwable> onErrorEvents = new ArrayList<Throwable>();
-    private final ArrayList<Void> onCompleteEvents = new ArrayList<Void>();
+    private final ArrayList<T> onNextEvents = new ArrayList<>();
+    private final ArrayList<Throwable> onErrorEvents = new ArrayList<>();
+    private final ArrayList<Void> onCompleteEvents = new ArrayList<>();
 
     private Subscription subscription;
 
-    public TestSubscriber(final Subscriber<T> delegate) {
-        this.delegate = delegate;
-    }
-
     public TestSubscriber() {
-        this(new Subscriber<T>() {
-
-            @Override
-            public void onSubscribe(final Subscription subscription) {
-                // do nothing
-            }
-
-            @Override
-            public void onNext(final T result) {
-                // do nothing
-            }
-
-            @Override
-            public void onComplete() {
-                // do nothing
-            }
-
-            @Override
-            public void onError(final Throwable e) {
-                // do nothing
-            }
-        });
     }
 
     @Override
     public void onSubscribe(final Subscription subscription) {
         this.subscription = subscription;
-        delegate.onSubscribe(subscription);
     }
 
     /**
@@ -86,7 +59,6 @@ public class TestSubscriber<T> implements Subscriber<T> {
     @Override
     public void onNext(final T result) {
         onNextEvents.add(result);
-        delegate.onNext(result);
     }
 
     /**
@@ -102,7 +74,6 @@ public class TestSubscriber<T> implements Subscriber<T> {
     public void onError(final Throwable e) {
         try {
             onErrorEvents.add(e);
-            delegate.onError(e);
         } finally {
             latch.countDown();
         }
@@ -118,7 +89,6 @@ public class TestSubscriber<T> implements Subscriber<T> {
     public void onComplete() {
         try {
             onCompleteEvents.add(null);
-            delegate.onComplete();
         } finally {
             latch.countDown();
         }
@@ -154,22 +124,13 @@ public class TestSubscriber<T> implements Subscriber<T> {
     }
 
     /**
-     * Returns the subscription to the this {@link Subscriber}.
-     *
-     * @return the subscription or null if not subscribed to
-     */
-    public Subscription getSubscription() {
-        return subscription;
-    }
-
-    /**
      * Assert that a particular sequence of items was received by this {@link Subscriber} in order.
      *
      * @param items the sequence of items expected to have been observed
      * @throws AssertionError if the sequence of items observed does not exactly match {@code items}
      */
     public void assertReceivedOnNext(final List<T> items) {
-        if (!tryMultipleTimes(10, () -> getOnNextEvents().size() == items.size())) {
+        if (!retry(() -> getOnNextEvents().size() == items.size())) {
             throw new AssertionError("Number of items does not match. Provided: " + items.size() + "  Actual: " + getOnNextEvents().size());
         }
 
@@ -188,29 +149,12 @@ public class TestSubscriber<T> implements Subscriber<T> {
         }
     }
 
-    private boolean tryMultipleTimes(final int noTimes, final Supplier<Boolean> test) {
-        int counter = noTimes;
-        while (counter > 0) {
-            if (test.get()) {
-                return true;
-            }
-            counter--;
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-                return false;
-            }
-        }
-        return false;
-    }
-
     /**
      * Assert that a single terminal event occurred, either {@link #onComplete} or {@link #onError}.
      *
      * @throws AssertionError if not exactly one terminal event notification was received
      */
     public void assertTerminalEvent() {
-
         try {
             //noinspection ResultOfMethodCallIgnored
             latch.await(TIMEOUT_DURATION.toMillis(), TimeUnit.MILLISECONDS);
@@ -253,20 +197,26 @@ public class TestSubscriber<T> implements Subscriber<T> {
      */
     public void assertNoErrors() {
         if (onErrorEvents.size() > 0) {
-            // can't use AssertionError because (message, cause) doesn't exist until Java 7
-            throw new RuntimeException("Unexpected onError events: " + getOnErrorEvents().size(), getOnErrorEvents().get(0));
+            throw new AssertionError("Unexpected onError events: " + getOnErrorEvents().size(), getOnErrorEvents().get(0));
         }
+    }
+    private boolean retry(final Supplier<Boolean> check) {
+        int retry = 0;
+        long totalSleepTimeMS = 0;
+        while (totalSleepTimeMS < TIMEOUT_DURATION.toMillis()) {
+            retry++;
+            if (check.get()) {
+                return true;
+            }
+            long sleepTimeMS = 100 + (100 * (long) Math.pow(retry, 2));
+            totalSleepTimeMS += sleepTimeMS;
+            try {
+                Thread.sleep(sleepTimeMS);
+            } catch (InterruptedException e) {
+                return false;
+            }
+        }
+        return false;
     }
 
-    /**
-     * Assert that this {@link Subscriber} has received an {@code onError} notification.
-     *
-     * @throws AssertionError if this {@link Subscriber} did not received an {@link #onError} notifications
-     */
-    public void assertErrored() {
-        if (onErrorEvents.size() == 0) {
-            // can't use AssertionError because (message, cause) doesn't exist until Java 7
-            throw new RuntimeException("No onError events");
-        }
-    }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorFluxTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorFluxTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.reactivestreams.client.internal;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.event.CommandEvent;
+import com.mongodb.internal.connection.TestCommandListener;
+import com.mongodb.reactivestreams.client.FindPublisher;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.TestSubscriber;
+import org.bson.Document;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
+import static com.mongodb.ClusterFixture.getDefaultDatabaseName;
+import static com.mongodb.reactivestreams.client.Fixture.drop;
+import static com.mongodb.reactivestreams.client.Fixture.getMongoClientBuilderFromConnectionString;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertArrayEquals;
+
+public class BatchCursorFluxTest {
+
+    private MongoClient client;
+    private TestCommandListener commandListener;
+    private MongoCollection<Document> collection;
+
+    @Before
+    public void setUp() {
+        commandListener = new TestCommandListener(singletonList("commandStartedEvent"), singletonList("insert"));
+        MongoClientSettings mongoClientSettings = getMongoClientBuilderFromConnectionString().addCommandListener(commandListener).build();
+        client = MongoClients.create(mongoClientSettings);
+        collection = client.getDatabase(getDefaultDatabaseName()).getCollection(getClass().getName());
+        drop(collection.getNamespace());
+    }
+
+    @After
+    public void tearDown() {
+        if (collection != null) {
+            drop(collection.getNamespace());
+        }
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @Test
+    public void testBatchCursorRespectsTheSetBatchSize() {
+        List<Document> docs = createDocs(20);
+        Mono.from(collection.insertMany(docs)).block(TIMEOUT_DURATION);
+
+        TestSubscriber<Document> subscriber = new TestSubscriber<>();
+        collection.find().batchSize(5).subscribe(subscriber);
+        assertCommandNames(emptyList());
+
+        subscriber.requestMore(5);
+        subscriber.assertReceivedOnNext(docs.subList(0, 5));
+        assertCommandNames(singletonList("find"));
+
+        subscriber.requestMore(5);
+        subscriber.assertReceivedOnNext(docs.subList(0, 10));
+        assertCommandNames(asList("find", "getMore"));
+
+        subscriber.requestMore(10);
+        subscriber.assertReceivedOnNext(docs);
+        subscriber.assertNoTerminalEvent();
+        assertCommandNames(asList("find", "getMore", "getMore", "getMore"));
+
+        subscriber.requestMore(1);
+        subscriber.assertNoErrors();
+        subscriber.assertTerminalEvent();
+        assertCommandNames(asList("find", "getMore", "getMore", "getMore", "getMore"));
+    }
+
+    @Test
+    public void testBatchCursorSupportsBatchSizeZero() {
+        List<Document> docs = createDocs(200);
+        Mono.from(collection.insertMany(docs)).block(TIMEOUT_DURATION);
+
+        TestSubscriber<Document> subscriber = new TestSubscriber<>();
+        collection.find().batchSize(0).subscribe(subscriber);
+        assertCommandNames(emptyList());
+
+        subscriber.requestMore(100);
+        subscriber.assertReceivedOnNext(docs.subList(0, 100));
+        assertCommandNames(singletonList("find"));
+
+        subscriber.requestMore(101);
+        subscriber.assertNoErrors();
+        subscriber.assertTerminalEvent();
+        assertCommandNames(asList("find", "getMore"));
+    }
+
+    @Test
+    public void testBatchCursorConsumesBatchesThenGetMores() {
+        List<Document> docs = createDocs(99);
+        Mono.from(collection.insertMany(docs)).block(TIMEOUT_DURATION);
+
+        TestSubscriber<Document> subscriber = new TestSubscriber<>();
+        collection.find().batchSize(50).subscribe(subscriber);
+        assertCommandNames(emptyList());
+
+        subscriber.requestMore(25);
+        subscriber.assertReceivedOnNext(docs.subList(0, 25));
+        assertCommandNames(singletonList("find"));
+
+        subscriber.requestMore(25);
+        subscriber.assertReceivedOnNext(docs.subList(0, 50));
+        assertCommandNames(singletonList("find"));
+
+        subscriber.requestMore(25);
+        subscriber.assertReceivedOnNext(docs.subList(0, 75));
+        subscriber.assertNoTerminalEvent();
+        assertCommandNames(asList("find", "getMore"));
+
+        subscriber.requestMore(25);
+        subscriber.assertNoErrors();
+        subscriber.assertTerminalEvent();
+        assertCommandNames(asList("find", "getMore"));
+    }
+
+    @Test
+    public void testBatchCursorDynamicBatchSize() {
+        List<Document> docs = createDocs(200);
+        Mono.from(collection.insertMany(docs)).block(TIMEOUT_DURATION);
+
+        TestSubscriber<Document> subscriber = new TestSubscriber<>();
+        FindPublisher<Document> findPublisher = collection.find();
+        findPublisher.subscribe(subscriber);
+        assertCommandNames(emptyList());
+
+        subscriber.requestMore(20);
+        subscriber.assertReceivedOnNext(docs.subList(0, 20));
+        assertCommandNames(singletonList("find"));
+
+        subscriber.requestMore(150);
+        subscriber.assertReceivedOnNext(docs.subList(0, 170));
+        assertCommandNames(asList("find", "getMore"));
+
+        subscriber.requestMore(40);
+        subscriber.assertNoErrors();
+        subscriber.assertReceivedOnNext(docs);
+        subscriber.assertTerminalEvent();
+        assertCommandNames(asList("find", "getMore", "getMore"));
+    }
+
+    @Test
+    public void testBatchCursorCompletesAsExpectedWithLimit() {
+        List<Document> docs = createDocs(100);
+        Mono.from(collection.insertMany(docs)).block(TIMEOUT_DURATION);
+
+        TestSubscriber<Document> subscriber = new TestSubscriber<>();
+        FindPublisher<Document> findPublisher = collection.find().limit(100);
+        findPublisher.subscribe(subscriber);
+        assertCommandNames(emptyList());
+
+        subscriber.requestMore(100);
+        subscriber.assertReceivedOnNext(docs);
+        subscriber.assertNoErrors();
+        subscriber.assertTerminalEvent();
+        assertCommandNames(singletonList("find"));
+    }
+
+    @Test
+    public void testBatchCursorDynamicBatchSizeOnReuse() {
+        List<Document> docs = createDocs(200);
+        Mono.from(collection.insertMany(docs)).block(TIMEOUT_DURATION);
+
+        TestSubscriber<Document> subscriber = new TestSubscriber<>();
+        FindPublisher<Document> findPublisher = collection.find();
+        findPublisher.subscribe(subscriber);
+        assertCommandNames(emptyList());
+
+        subscriber.requestMore(100);
+        subscriber.assertReceivedOnNext(docs.subList(0, 100));
+        assertCommandNames(singletonList("find"));
+
+        subscriber.requestMore(200);
+        subscriber.assertNoErrors();
+        subscriber.assertReceivedOnNext(docs);
+        subscriber.assertTerminalEvent();
+        assertCommandNames(asList("find", "getMore"));
+
+        commandListener.reset();
+        subscriber = new TestSubscriber<>();
+        findPublisher.subscribe(subscriber);
+        assertCommandNames(emptyList());
+
+        subscriber.requestMore(Long.MAX_VALUE);
+        subscriber.assertNoErrors();
+        subscriber.assertReceivedOnNext(docs);
+        assertCommandNames(singletonList("find"));
+        subscriber.assertTerminalEvent();
+    }
+
+    private void assertCommandNames(final List<String> commandNames) {
+        assertArrayEquals(commandNames.toArray(),
+                commandListener.getCommandStartedEvents().stream().map(CommandEvent::getCommandName).toArray());
+    }
+
+    private List<Document> createDocs(final int amount) {
+        return IntStream.rangeClosed(1, amount)
+                .boxed()
+                .map(i -> new Document("_id", i))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorFluxTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorFluxTest.java
@@ -45,6 +45,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 
@@ -233,8 +234,7 @@ public class BatchCursorFluxTest {
 
     @Test
     public void testCalculateDemand() {
-        BatchCursorFlux<Document> batchCursorFlux = new BatchCursorFlux<>(batchCursorPublisher, 10, () -> {
-        });
+        BatchCursorFlux<Document> batchCursorFlux = new BatchCursorFlux<>(batchCursorPublisher);
 
         assertAll("Calculating demand",
                 () -> assertEquals(0, batchCursorFlux.calculateDemand(0)),
@@ -249,23 +249,24 @@ public class BatchCursorFluxTest {
 
     @Test
     public void testCalculateBatchSize() {
-        BatchCursorFlux<Document> batchCursorFluxWithBatchSize = new BatchCursorFlux<>(batchCursorPublisher, 10, () -> {
-        });
-        BatchCursorFlux<Document> batchCursorFluxNoSetBatchSize = new BatchCursorFlux<>(batchCursorPublisher, null, () -> {
-        });
+        BatchCursorFlux<Document> batchCursorFlux = new BatchCursorFlux<>(batchCursorPublisher);
 
-        assertAll("Calculating batch size with set batch size",
-                () -> assertEquals(10, batchCursorFluxWithBatchSize.calculateBatchSize(100)),
-                () -> assertEquals(10, batchCursorFluxWithBatchSize.calculateBatchSize(Long.MAX_VALUE)),
-                () -> assertEquals(10, batchCursorFluxWithBatchSize.calculateBatchSize(1))
-        );
-
+        when(batchCursorPublisher.getBatchSize()).thenReturn(null);
         assertAll("Calculating batch size with dynamic batch size",
-                () -> assertEquals(2, batchCursorFluxNoSetBatchSize.calculateBatchSize(1)),
-                () -> assertEquals(1000, batchCursorFluxNoSetBatchSize.calculateBatchSize(1000)),
-                () -> assertEquals(Integer.MAX_VALUE, batchCursorFluxNoSetBatchSize.calculateBatchSize(Integer.MAX_VALUE)),
-                () -> assertEquals(Integer.MAX_VALUE, batchCursorFluxNoSetBatchSize.calculateBatchSize(Long.MAX_VALUE))
+                () -> assertEquals(2, batchCursorFlux.calculateBatchSize(1)),
+                () -> assertEquals(1000, batchCursorFlux.calculateBatchSize(1000)),
+                () -> assertEquals(Integer.MAX_VALUE, batchCursorFlux.calculateBatchSize(Integer.MAX_VALUE)),
+                () -> assertEquals(Integer.MAX_VALUE, batchCursorFlux.calculateBatchSize(Long.MAX_VALUE))
         );
+
+
+        when(batchCursorPublisher.getBatchSize()).thenReturn(10);
+        assertAll("Calculating batch size with set batch size",
+                () -> assertEquals(10, batchCursorFlux.calculateBatchSize(100)),
+                () -> assertEquals(10, batchCursorFlux.calculateBatchSize(Long.MAX_VALUE)),
+                () -> assertEquals(10, batchCursorFlux.calculateBatchSize(1))
+        );
+
     }
 
 

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorFluxTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorFluxTest.java
@@ -50,7 +50,7 @@ public class BatchCursorFluxTest {
 
     @Before
     public void setUp() {
-        commandListener = new TestCommandListener(singletonList("commandStartedEvent"), singletonList("insert"));
+        commandListener = new TestCommandListener(singletonList("commandStartedEvent"), asList("insert", "killCursors"));
         MongoClientSettings mongoClientSettings = getMongoClientBuilderFromConnectionString().addCommandListener(commandListener).build();
         client = MongoClients.create(mongoClientSettings);
         collection = client.getDatabase(getDefaultDatabaseName()).getCollection(getClass().getName());

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorPublisherTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorPublisherTest.java
@@ -166,7 +166,7 @@ public class BatchCursorPublisherTest {
         BatchCursorPublisher<Document> publisher = new BatchCursorPublisher<Document>(
                 null, OPERATION_PUBLISHER) {
             @Override
-            AsyncReadOperation<AsyncBatchCursor<Document>> asAsyncReadOperation() {
+            AsyncReadOperation<AsyncBatchCursor<Document>> asAsyncReadOperation(final int initialBatchSize) {
                 return readOperation;
             }
         };

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/ConnectionsSurvivePrimaryStepDownProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/ConnectionsSurvivePrimaryStepDownProseTest.java
@@ -101,7 +101,7 @@ public class ConnectionsSurvivePrimaryStepDownProseTest {
 
         int connectionCount = connectionPoolListener.countEvents(com.mongodb.event.ConnectionAddedEvent.class);
 
-        BatchCursor<Document> cursor = ((FindPublisherImpl<Document>) collection.find().batchSize(2)).batchCursor()
+        BatchCursor<Document> cursor = ((FindPublisherImpl<Document>) collection.find().batchSize(2)).batchCursor(2)
                 .block(TIMEOUT_DURATION);
         assertNotNull(cursor);
         assertEquals(asList(documents.get(0), documents.get(1)), Mono.from(cursor.next()).block(TIMEOUT_DURATION));

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/AggregatePublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/AggregatePublisherImplTest.java
@@ -58,6 +58,7 @@ public class AggregatePublisherImplTest extends TestHelper {
 
         AggregateOperation<Document> expectedOperation = new AggregateOperation<>(NAMESPACE, pipeline,
                                                                                   getDefaultCodecRegistry().get(Document.class))
+                .batchSize(Integer.MAX_VALUE)
                 .retryReads(true);
 
         // default input should be as expected

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImplTest.java
@@ -94,6 +94,7 @@ public class ChangeStreamPublisherImplTest extends TestHelper {
 
         ChangeStreamOperation<BsonDocument> expectedOperation =
                 new ChangeStreamOperation<>(NAMESPACE, FullDocument.DEFAULT, pipeline, getDefaultCodecRegistry().get(BsonDocument.class))
+                        .batchSize(Integer.MAX_VALUE)
                         .retryReads(true);
 
         // default input should be as expected

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImplTest.java
@@ -55,6 +55,7 @@ public class ChangeStreamPublisherImplTest extends TestHelper {
 
         ChangeStreamOperation<ChangeStreamDocument<Document>> expectedOperation =
                 new ChangeStreamOperation<>(NAMESPACE, FullDocument.DEFAULT, pipeline, codec)
+                        .batchSize(Integer.MAX_VALUE)
                         .retryReads(true);
 
         // default input should be as expected

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/FindPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/FindPublisherImplTest.java
@@ -52,6 +52,7 @@ public class FindPublisherImplTest extends TestHelper {
         FindPublisher<Document> publisher = new FindPublisherImpl<>(null, createMongoOperationPublisher(executor), new Document());
 
         FindOperation<Document> expectedOperation = new FindOperation<>(NAMESPACE, getDefaultCodecRegistry().get(Document.class))
+                .batchSize(Integer.MAX_VALUE)
                 .retryReads(true)
                 .filter(new BsonDocument());
 

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImplTest.java
@@ -44,6 +44,7 @@ public class ListCollectionsPublisherImplTest extends TestHelper {
 
         ListCollectionsOperation<String> expectedOperation = new ListCollectionsOperation<>(DATABASE_NAME,
                                                                                             getDefaultCodecRegistry().get(String.class))
+                .batchSize(Integer.MAX_VALUE)
                 .nameOnly(true).retryReads(true);
 
         // default input should be as expected

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListIndexesPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListIndexesPublisherImplTest.java
@@ -44,6 +44,7 @@ public class ListIndexesPublisherImplTest extends TestHelper {
 
         ListIndexesOperation<Document> expectedOperation =
                 new ListIndexesOperation<>(NAMESPACE, getDefaultCodecRegistry().get(Document.class))
+                        .batchSize(Integer.MAX_VALUE)
                         .retryReads(true);
 
         // default input should be as expected


### PR DESCRIPTION
The BatchCursorPublisher now waits for demand to be signalled before
creating the cursor.

The batch cursor publisher also internally respects the batch size.
Its either the configured batch size if set or the amount requested.

JAVA-3973