### PR TITLE
3.8.x continuous matrix testing

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -194,7 +194,7 @@ functions:
   "upload test results":
     - command: attach.xunit_results
       params:
-        file: ./src/*/build/test-results/TEST-*.xml
+        file: ./src/*/build/test-results/test/TEST-*.xml
 
   "bootstrap mongo-orchestration":
     - command: shell.exec

--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -316,15 +316,6 @@ functions:
           ${PREPARE_SHELL}
           echo '{"results": [{ "status": "FAIL", "test_file": "Build", "log_raw": "No test-results.json found was created"  } ]}' > ${PROJECT_DIRECTORY}/test-results.json
 
-  "install dependencies":
-    type: test
-    params:
-      working_dir: "src"
-      script: |
-        ${PREPARE_SHELL}
-        file="${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
-        [ -f ${file} ] && sh ${file} || echo "${file} not available, skipping"
-
 # Anchors
 
 hosts: &hosts
@@ -337,7 +328,6 @@ pre:
   - func: "fix absolute paths"
   - func: "init test-results"
   - func: "make files executable"
-  - func: "install dependencies"
 
 post:
   # Removed, causing timeouts
@@ -357,9 +347,6 @@ tasks:
         - func: "upload build"
 
     - name: "test"
-      depends_on:
-        - variant: "static-checks"
-          name: "static-analysis"
       commands:
         - func: "bootstrap mongo-orchestration"
         - func: "run tests"
@@ -408,6 +395,10 @@ axes:
   - id: version
     display_name: MongoDB Version
     values:
+      - id: "4.2"
+        display_name: "4.2"
+        variables:
+          VERSION: "4.2"
       - id: "4.0"
         display_name: "4.0"
         variables:
@@ -539,14 +530,14 @@ buildvariants:
 
 - matrix_name: "tests-jdk6-secure"
   matrix_spec:  { auth: "auth", ssl: "ssl", jdk: "jdk6", version: "*", topology: "*", os: "*" }
-  exclude_spec: { auth: "auth", ssl: "ssl", jdk: "jdk6", version: ["4.0"], topology: "*", os: "*" }
+  exclude_spec: { auth: "auth", ssl: "ssl", jdk: "jdk6", version: ["4.0", "4.2"], topology: "*", os: "*" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
   tags: ["tests-variant"]
   tasks:
      - name: "test"
 
 - matrix_name: "tests-jdk8-secure"
-  matrix_spec: { auth: "auth", ssl: "ssl", jdk: "jdk8", version: ["4.0"], topology: "*", os: "*" }
+  matrix_spec: { auth: "auth", ssl: "ssl", jdk: "jdk8", version: ["4.0", "4.2"], topology: "*", os: "*" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
   tags: ["tests-variant"]
   tasks:

--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -395,6 +395,10 @@ axes:
   - id: version
     display_name: MongoDB Version
     values:
+      - id: "4.4"
+        display_name: "4.4"
+        variables:
+          VERSION: "4.4"
       - id: "4.2"
         display_name: "4.2"
         variables:
@@ -530,14 +534,14 @@ buildvariants:
 
 - matrix_name: "tests-jdk6-secure"
   matrix_spec:  { auth: "auth", ssl: "ssl", jdk: "jdk6", version: "*", topology: "*", os: "*" }
-  exclude_spec: { auth: "auth", ssl: "ssl", jdk: "jdk6", version: ["4.0", "4.2"], topology: "*", os: "*" }
+  exclude_spec: { auth: "auth", ssl: "ssl", jdk: "jdk6", version: ["4.0", "4.2", "4.4"], topology: "*", os: "*" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
   tags: ["tests-variant"]
   tasks:
      - name: "test"
 
 - matrix_name: "tests-jdk8-secure"
-  matrix_spec: { auth: "auth", ssl: "ssl", jdk: "jdk8", version: ["4.0", "4.2"], topology: "*", os: "*" }
+  matrix_spec: { auth: "auth", ssl: "ssl", jdk: "jdk8", version: ["4.0", "4.2", "4.4"], topology: "*", os: "*" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
   tags: ["tests-variant"]
   tasks:

--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -395,6 +395,10 @@ axes:
   - id: version
     display_name: MongoDB Version
     values:
+      - id: "latest"
+        display_name: "latest"
+        variables:
+          VERSION: "latest"
       - id: "4.4"
         display_name: "4.4"
         variables:
@@ -534,14 +538,14 @@ buildvariants:
 
 - matrix_name: "tests-jdk6-secure"
   matrix_spec:  { auth: "auth", ssl: "ssl", jdk: "jdk6", version: "*", topology: "*", os: "*" }
-  exclude_spec: { auth: "auth", ssl: "ssl", jdk: "jdk6", version: ["4.0", "4.2", "4.4"], topology: "*", os: "*" }
+  exclude_spec: { auth: "auth", ssl: "ssl", jdk: "jdk6", version: ["4.0", "4.2", "4.4", "latest"], topology: "*", os: "*" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
   tags: ["tests-variant"]
   tasks:
      - name: "test"
 
 - matrix_name: "tests-jdk8-secure"
-  matrix_spec: { auth: "auth", ssl: "ssl", jdk: "jdk8", version: ["4.0", "4.2", "4.4"], topology: "*", os: "*" }
+  matrix_spec: { auth: "auth", ssl: "ssl", jdk: "jdk8", version: ["4.0", "4.2", "4.4", "latest"], topology: "*", os: "*" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
   tags: ["tests-variant"]
   tasks:

--- a/COMPATIBILITY.MD
+++ b/COMPATIBILITY.MD
@@ -1,0 +1,19 @@
+### Incompatibilities with MongoDB 4.2
+
+MongoDB 4.2 introduced the "NonResumableChangeStreamError" error label, which is not recognized
+by the 4.0-era Java driver.  This may cause the 4.0-era driver to resume a change stream in cases
+where the server has indicated that it should not. This may cause iteration of a change stream to 
+loop infinitely instead of reporting an error to the application
+                                              
+### Incompatibilities with MongoDB 4.4
+
+MongoDB 4.4 introduced the "ResumableChangeStreamError" error label, which is not recognized
+by the 4.0-era Java driver. This may cause the 4.0-era driver to not resume a change stream in cases
+where the server has indicated that it should.  
+
+MongoDB 4.4 removed support for mapReduce statistics.  The 4.0-era driver assumes statistics are always
+included in the reply, so any use of mapReduce with the 4.0-era driver will fail.  MongoDB 4.4 also 
+removed support for the default values of sharded and nonAtomic fields for mapReduce to a collection.
+The 4.0-era driver always includes the default values of these fields (even if unset by the application), 
+so this will cause any mapReduce with $out to fail as well.
+

--- a/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
@@ -45,6 +45,10 @@ public final class ServerVersionHelper {
         return serverIsAtLeastVersion(description, new ServerVersion(4, 0));
     }
 
+    public static boolean serverIsAtLeastVersionFourDotFour(final ConnectionDescription description) {
+        return serverIsAtLeastVersion(description, new ServerVersion(4, 4));
+    }
+
     private static boolean serverIsAtLeastVersion(final ConnectionDescription description, final ServerVersion serverVersion) {
         return description.getServerVersion().compareTo(serverVersion) >= 0;
     }

--- a/driver-core/src/main/com/mongodb/operation/MapReduceHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/MapReduceHelper.java
@@ -17,6 +17,7 @@
 package com.mongodb.operation;
 
 import org.bson.BsonDocument;
+import org.bson.BsonInt32;
 
 final class MapReduceHelper {
 
@@ -26,19 +27,19 @@ final class MapReduceHelper {
     }
 
     private static int getInputCount(final BsonDocument result) {
-        return result.getDocument("counts").getNumber("input").intValue();
+        return result.getDocument("counts", new BsonDocument()).getNumber("input", new BsonInt32(0)).intValue();
     }
 
     private static int getOutputCount(final BsonDocument result) {
-        return result.getDocument("counts").getNumber("output").intValue();
+        return result.getDocument("counts", new BsonDocument()).getNumber("output", new BsonInt32(0)).intValue();
     }
 
     private static int getEmitCount(final BsonDocument result) {
-        return result.getDocument("counts").getNumber("emit").intValue();
+        return result.getDocument("counts", new BsonDocument()).getNumber("emit", new BsonInt32(0)).intValue();
     }
 
     private static int getDuration(final BsonDocument result) {
-        return result.getNumber("timeMillis").intValue();
+        return result.getNumber("timeMillis", new BsonInt32(0)).intValue();
     }
 
     private MapReduceHelper() {

--- a/driver-core/src/test/functional/com/mongodb/client/CommandMonitoringTestHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/CommandMonitoringTestHelper.java
@@ -193,9 +193,12 @@ public final class CommandMonitoringTestHelper {
             if (response.containsKey("writeErrors")) {
                 for (BsonValue bsonValue : response.getArray("writeErrors")) {
                     BsonDocument cur = bsonValue.asDocument();
-                    cur.put("code", new BsonInt32(42));
-                    cur.put("errmsg", new BsonString(""));
-                    cur.remove("codeName");
+                    BsonDocument newWriteErrorDocument =
+                            new BsonDocument().append("index", cur.get("index"))
+                                    .append("code", new BsonInt32(42))
+                                    .append("errmsg", new BsonString(""));
+                    cur.clear();
+                    cur.putAll(newWriteErrorDocument);
                 }
             }
             if (actual.getCommandName().equals("update")) {

--- a/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
@@ -674,7 +674,6 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         helper.drop()
 
         helper.insertDocuments(Document.parse('{_id: 0, x: 1}'))
-        helper.insertDocuments(Document.parse('{_id: 1, x: 2}'))
         helper.insertDocuments(Document.parse('{_id: 2, x: 1}'))
         helper.insertDocuments(Document.parse('{_id: 3, x: 0}'))
 
@@ -682,14 +681,12 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
 
         then:
         results == [Document.parse('{_id: 1, count: 2}'),
-                    Document.parse('{_id: 0, count: 1}'),
-                    Document.parse('{_id: 2, count: 1}')]
+                    Document.parse('{_id: 0, count: 1}')]
 
         when:
         helper.drop()
 
         helper.insertDocuments(Document.parse('{_id: 0, x: 1.4}'))
-        helper.insertDocuments(Document.parse('{_id: 1, x: 2.3}'))
         helper.insertDocuments(Document.parse('{_id: 2, x: 1.1}'))
         helper.insertDocuments(Document.parse('{_id: 3, x: 0.5}'))
 
@@ -697,8 +694,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
 
         then:
         results == [Document.parse('{_id: 1, count: 2}'),
-                    Document.parse('{_id: 0, count: 1}'),
-                    Document.parse('{_id: 2, count: 1}')]
+                    Document.parse('{_id: 0, count: 1}')]
 
         cleanup:
         helper?.drop()

--- a/driver-core/src/test/functional/com/mongodb/client/model/IndexesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/IndexesFunctionalSpecification.groovy
@@ -17,7 +17,9 @@
 package com.mongodb.client.model
 
 import com.mongodb.OperationFunctionalSpecification
+import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.serverVersionGreaterThan
 import static com.mongodb.client.model.Indexes.ascending
 import static com.mongodb.client.model.Indexes.compoundIndex
 import static com.mongodb.client.model.Indexes.descending
@@ -98,6 +100,7 @@ class IndexesFunctionalSpecification extends OperationFunctionalSpecification {
         getCollectionHelper().listIndexes()*.get('key').contains(parse('{x : "2d"}'))
     }
 
+    @IgnoreIf({ serverVersionGreaterThan('4.4') })
     def 'geoHaystack'() {
         when:
         getCollectionHelper().createIndex(geoHaystack('x', descending('b')), 2.0)

--- a/driver-core/src/test/functional/com/mongodb/client/model/ProjectionFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/ProjectionFunctionalSpecification.groovy
@@ -23,6 +23,7 @@ import org.bson.conversions.Bson
 
 import static com.mongodb.client.model.Filters.and
 import static com.mongodb.client.model.Filters.eq
+import static com.mongodb.client.model.Filters.text
 import static com.mongodb.client.model.Projections.elemMatch
 import static com.mongodb.client.model.Projections.exclude
 import static com.mongodb.client.model.Projections.excludeId
@@ -32,21 +33,21 @@ import static com.mongodb.client.model.Projections.metaTextScore
 import static com.mongodb.client.model.Projections.slice
 
 class ProjectionFunctionalSpecification extends OperationFunctionalSpecification {
-    def a = new Document('_id', 1).append('x', 1).append('y', [new Document('a', 1).append('b', 2),
-                                                               new Document('a', 2).append('b', 3),
-                                                               new Document('a', 3).append('b', 4)])
-    def aYSlice1 = new Document('_id', 1).append('x', 1).append('y', [new Document('a', 1).append('b', 2)])
-    def aYSlice12 = new Document('_id', 1).append('x', 1).append('y', [new Document('a', 2).append('b', 3),
-                                                                       new Document('a', 3).append('b', 4)])
-    def aNoY = new Document('_id', 1).append('x', 1)
+    def a = new Document('_id', 1).append('x', 'coffee').append('y', [new Document('a', 1).append('b', 2),
+                                                                      new Document('a', 2).append('b', 3),
+                                                                      new Document('a', 3).append('b', 4)])
+    def aYSlice1 = new Document('_id', 1).append('x', 'coffee').append('y', [new Document('a', 1).append('b', 2)])
+    def aYSlice12 = new Document('_id', 1).append('x', 'coffee').append('y', [new Document('a', 2).append('b', 3),
+                                                                              new Document('a', 3).append('b', 4)])
+    def aNoY = new Document('_id', 1).append('x', 'coffee')
     def aId = new Document('_id', 1)
-    def aNoId = new Document().append('x', 1).append('y', [new Document('a', 1).append('b', 2),
-                                                           new Document('a', 2).append('b', 3),
-                                                           new Document('a', 3).append('b', 4)])
-    def aWithScore = new Document('_id', 1).append('x', 1).append('y', [new Document('a', 1).append('b', 2),
-                                                                        new Document('a', 2).append('b', 3),
-                                                                        new Document('a', 3).append('b', 4)])
-                                           .append('score', 0.0)
+    def aNoId = new Document().append('x', 'coffee').append('y', [new Document('a', 1).append('b', 2),
+                                                                  new Document('a', 2).append('b', 3),
+                                                                  new Document('a', 3).append('b', 4)])
+    def aWithScore = new Document('_id', 1).append('x', 'coffee').append('y', [new Document('a', 1).append('b', 2),
+                                                                               new Document('a', 2).append('b', 3),
+                                                                               new Document('a', 3).append('b', 4)])
+            .append('score', 1.0)
 
     def setup() {
         getCollectionHelper().insertDocuments(a)
@@ -74,7 +75,7 @@ class ProjectionFunctionalSpecification extends OperationFunctionalSpecification
         find(exclude(['x', 'y', 'x'])) == [aId]
     }
 
-    def 'excludeId'() {
+    def 'excludeId helper'() {
         expect:
         find(excludeId()) == [aNoId]
     }
@@ -98,10 +99,10 @@ class ProjectionFunctionalSpecification extends OperationFunctionalSpecification
 
     def 'metaTextScore'() {
         given:
-        getCollectionHelper().createIndex(new Document('y', 'text'))
+        getCollectionHelper().createIndex(new Document('x', 'text'))
 
         expect:
-        find(metaTextScore('score')) == [aWithScore]
+        find(text('coffee'), metaTextScore('score')) == [aWithScore]
     }
 
     def 'combine fields'() {

--- a/driver-core/src/test/functional/com/mongodb/client/model/SortsFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/SortsFunctionalSpecification.groovy
@@ -27,13 +27,13 @@ import static com.mongodb.client.model.Sorts.orderBy
 
 class SortsFunctionalSpecification extends OperationFunctionalSpecification {
     def a = new Document('_id', 1).append('x', 1)
-                                  .append('y', 'b')
+                                  .append('y', 'bear')
 
     def b = new Document('_id', 2).append('x', 1)
-                                  .append('y', 'a')
+                                  .append('y', 'albatross')
 
     def c = new Document('_id', 3).append('x', 2)
-                                  .append('y', 'c')
+                                  .append('y', 'cat')
 
     def setup() {
         getCollectionHelper().insertDocuments(a, b, c)
@@ -44,7 +44,11 @@ class SortsFunctionalSpecification extends OperationFunctionalSpecification {
     }
 
     def 'find'(Bson sort, Bson projection) {
-        getCollectionHelper().find(new Document(), sort, projection)
+        find(new Document(), sort, projection)
+    }
+
+    def 'find'(Bson filter, Bson sort, Bson projection) {
+        getCollectionHelper().find(filter, sort, projection)
     }
 
     def 'ascending'() {
@@ -66,7 +70,8 @@ class SortsFunctionalSpecification extends OperationFunctionalSpecification {
         getCollectionHelper().createIndex(new Document('y', 'text'))
 
         expect:
-        find(metaTextScore('score'), new Document('score', new Document('$meta', 'textScore')))*.containsKey('score')
+        find(new Document('$text', new Document('$search', 'bear')), metaTextScore('score'),
+                new Document('score', new Document('$meta', 'textScore')))*.containsKey('score')
     }
 
     def 'orderBy'() {

--- a/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
@@ -354,7 +354,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         def result = execute(operation, async)
 
         then:
-        result.containsKey('stages')
+        result.containsKey('stages') || result.containsKey('queryPlanner')
 
         where:
         async << [true, false]
@@ -377,7 +377,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         [async, options] << [[true, false], [defaultCollation, null, Collation.builder().build()]].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || serverVersionAtLeast(4, 2) })
     def 'should apply $hint'() {
         given:
         def index = new BsonDocument('a', new BsonInt32(1))

--- a/driver-core/src/test/functional/com/mongodb/operation/AggregateToCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AggregateToCollectionOperationSpecification.groovy
@@ -291,7 +291,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || (serverVersionAtLeast(4, 2) && isSharded()) })
     def 'should apply $hint'() {
         given:
         def hint = new BsonDocument('a', new BsonInt32(1))

--- a/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
@@ -390,6 +390,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         waitForLastRelease(getCluster())
     }
 
+    @IgnoreIf({ serverVersionAtLeast([4, 2, 0]) })
     def 'should throw if the _id field is projected out'() {
         given:
         def helper = getHelper()

--- a/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
@@ -466,9 +466,13 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         when:
         helper.killCursor(helper.getNamespace(), cursor.getWrapped().getServerCursor())
         expected = insertDocuments(helper, [3, 4])
+        def results = nextAndClean(cursor, async)
+        if (results.size() < expected.size()) {
+            results.addAll(nextAndClean(cursor, async))
+        }
 
         then:
-        nextAndClean(cursor, async) == expected
+        results == expected
 
         then:
         tryNextAndClean(cursor, async) == null
@@ -476,9 +480,13 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         when:
         expected = insertDocuments(helper, [5, 6])
         helper.killCursor(helper.getNamespace(), cursor.getWrapped().getServerCursor())
-
+        results = nextAndClean(cursor, async)
+        if (results.size() < expected.size()) {
+            results.addAll(nextAndClean(cursor, async))
+        }
+        
         then:
-        nextAndClean(cursor, async) == expected
+        results == expected
 
         cleanup:
         cursor?.close()

--- a/driver-core/src/test/functional/com/mongodb/operation/CreateCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/CreateCollectionOperationSpecification.groovy
@@ -108,8 +108,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         given:
         def operation = new CreateCollectionOperation(getDatabaseName(), getCollectionName())
                 .storageEngineOptions(new BsonDocument('wiredTiger',
-                                                       new BsonDocument('configString', new BsonString('block_compressor=zlib')))
-                                              .append('mmapv1', new BsonDocument()))
+                                                       new BsonDocument('configString', new BsonString('block_compressor=zlib'))))
 
         when:
         execute(operation, async)
@@ -123,6 +122,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         async << [true, false]
     }
 
+    @IgnoreIf( {serverVersionAtLeast(4, 2) })
     def 'should set flags for use power of two sizes'() {
         given:
         assert !collectionNameExists(getCollectionName())
@@ -195,7 +195,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         false     | 0                       | false
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 2) || serverVersionAtLeast(4, 2)})
     def 'should allow indexOptionDefaults'() {
         given:
         assert !collectionNameExists(getCollectionName())

--- a/driver-core/src/test/functional/com/mongodb/operation/CreateIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/CreateIndexesOperationSpecification.groovy
@@ -389,7 +389,7 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 0) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 0) || serverVersionAtLeast(4, 2)})
     def 'should pass through storage engine options'() {
         given:
         def storageEngineOptions = new Document('wiredTiger', new Document('configString', 'block_compressor=zlib'))

--- a/driver-core/src/test/functional/com/mongodb/operation/CreateIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/CreateIndexesOperationSpecification.groovy
@@ -38,6 +38,7 @@ import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionGreaterThan
 import static java.util.concurrent.TimeUnit.SECONDS
 
 class CreateIndexesOperationSpecification extends OperationFunctionalSpecification {
@@ -290,6 +291,7 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
+    @IgnoreIf({ serverVersionGreaterThan('4.4') })
     def 'should be able to create a geoHaystack indexes'() {
         given:
         def operation = new CreateIndexesOperation(getNamespace(),

--- a/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
@@ -351,6 +351,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         ].combinations()
     }
 
+    @IgnoreIf( {serverVersionAtLeast(4, 2) })
     def '$max should limit items returned'() {
         given:
         (1..100).each {
@@ -370,6 +371,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
+    @IgnoreIf( {serverVersionAtLeast(4, 2) })
     def '$min should limit items returned'() {
         given:
         (1..100).each {

--- a/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
@@ -61,6 +61,7 @@ import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.getCluster
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionGreaterThan
 import static com.mongodb.CursorType.NonTailable
 import static com.mongodb.CursorType.Tailable
 import static com.mongodb.CursorType.TailableAwait
@@ -682,7 +683,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         ].combinations()
     }
 
-
+    @IgnoreIf({ serverVersionGreaterThan("4.4") })
     def 'should explain with $explain modifier'() {
         given:
         def operation = new FindOperation<BsonDocument>(getNamespace(), new BsonDocumentCodec())

--- a/driver-core/src/test/functional/com/mongodb/operation/MapReduceToCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/MapReduceToCollectionOperationSpecification.groovy
@@ -26,18 +26,22 @@ import com.mongodb.client.model.ValidationOptions
 import com.mongodb.client.test.CollectionHelper
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
+import org.bson.BsonDouble
 import org.bson.BsonInt32
 import org.bson.BsonInt64
 import org.bson.BsonJavaScript
 import org.bson.BsonNull
 import org.bson.BsonString
 import org.bson.Document
+import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionGreaterThan
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.client.model.Filters.gte
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
@@ -48,10 +52,10 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
                                                                 new BsonJavaScript('function(){ emit( this.name , 1 ); }'),
                                                                 new BsonJavaScript('function(key, values){ return values.length; }'),
                                                                 mapReduceOutputNamespace.getCollectionName())
-    def expectedResults = [['_id': 'Pete', 'value': 2.0] as Document,
-                           ['_id': 'Sam', 'value': 1.0] as Document]
-    def helper = new CollectionHelper<Document>(new DocumentCodec(), mapReduceOutputNamespace)
-
+    def expectedResults = [new BsonDocument('_id', new BsonString('Pete')).append('value', new BsonDouble(2.0)),
+                           new BsonDocument('_id', new BsonString('Sam')).append('value', new BsonDouble(1.0))] as Set
+    def helper = new CollectionHelper<BsonDocument>(new BsonDocumentCodec(), mapReduceOutputNamespace)
+    
     def setup() {
         CollectionHelper<Document> helper = new CollectionHelper<Document>(new DocumentCodec(), mapReduceInputNamespace)
         Document pete = new Document('name', 'Pete').append('job', 'handyman')
@@ -137,6 +141,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
         operation.getCollation() == defaultCollation
     }
 
+    @IgnoreIf({ serverVersionGreaterThan('4.2') })
     def 'should return the correct statistics and save the results'() {
         when:
         MapReduceStatistics results = execute(mapReduceOperation, async)
@@ -152,6 +157,21 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [true, false]
     }
 
+    @IgnoreIf({ serverVersionLessThan('4.4') })
+    def 'should return zero-valued statistics and save the results'() {
+        when:
+        MapReduceStatistics results = execute(mapReduceOperation, async)
+
+        then:
+        results.emitCount == 0
+        results.inputCount == 0
+        results.outputCount == 0
+        helper.count() == 2
+        helper.find() as Set == expectedResults
+
+        where:
+        async << [true, false]
+    }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 2) })
     def 'should support bypassDocumentValidation'() {
@@ -232,12 +252,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
         def expectedCommand = new BsonDocument('mapreduce', new BsonString(getCollectionName()))
                 .append('map', mapF)
                 .append('reduce', reduceF)
-                .append('out', BsonDocument.parse('{replace: "outCollection", sharded: false, nonAtomic: false}'))
-                .append('query', BsonNull.VALUE)
-                .append('sort', BsonNull.VALUE)
-                .append('finalize', BsonNull.VALUE)
-                .append('scope', BsonNull.VALUE)
-                .append('verbose', BsonBoolean.FALSE)
+                .append('out', BsonDocument.parse('{replace: "outCollection"}'))
 
         if (includeWriteConcern) {
             expectedCommand.append('writeConcern', WriteConcern.MAJORITY.asDocument())
@@ -258,7 +273,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
                 .bypassDocumentValidation(true)
                 .verbose(true)
 
-        expectedCommand.append('out', BsonDocument.parse('{merge: "outCollection", sharded: false, nonAtomic: false, db: "dbName"}'))
+        expectedCommand.append('out', BsonDocument.parse('{merge: "outCollection", db: "dbName"}'))
                 .append('query', filter)
                 .append('sort', sort)
                 .append('finalize', finalizeF)

--- a/driver-core/src/test/functional/com/mongodb/operation/ParallelCollectionScanOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ParallelCollectionScanOperationSpecification.groovy
@@ -49,9 +49,10 @@ import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.loopCursor
+import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static org.junit.Assert.assertTrue
 
-@IgnoreIf({ isSharded() })
+@IgnoreIf({ isSharded() || serverVersionAtLeast(4, 2) } )
 @Category(Slow)
 class ParallelCollectionScanOperationSpecification extends OperationFunctionalSpecification {
     Map<Integer, Boolean> ids = [] as ConcurrentHashMap

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionTest.java
@@ -52,6 +52,7 @@ import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isSharded;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.ClusterFixture.serverVersionLessThan;
 import static com.mongodb.DBObjectMatchers.hasSubdocument;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -969,6 +970,7 @@ public class DBCollectionTest extends DatabaseTestCase {
     @Category(Slow.class)
     public void testParallelScan() throws UnknownHostException {
         assumeThat(isSharded(), is(false));
+        assumeThat(serverVersionLessThan("4.2"), is(true));
 
         Set<Integer> ids = new HashSet<Integer>();
         List<BasicDBObject> documents = new ArrayList<BasicDBObject>(2000);

--- a/driver-legacy/src/test/functional/com/mongodb/DBCursorTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCursorTest.java
@@ -320,6 +320,7 @@ public class DBCursorTest extends DatabaseTestCase {
 
     @Test
     public void testMax() {
+        assumeFalse(serverVersionAtLeast(4, 2));
         countResults(new DBCursor(collection, new BasicDBObject(), new BasicDBObject(), ReadPreference.primary())
                      .addSpecial("$max", new BasicDBObject("x", 4)), 4);
         countResults(new DBCursor(collection, new BasicDBObject(), new BasicDBObject(), ReadPreference.primary())
@@ -328,6 +329,7 @@ public class DBCursorTest extends DatabaseTestCase {
 
     @Test
     public void testMin() {
+        assumeFalse(serverVersionAtLeast(4, 2));
         countResults(new DBCursor(collection, new BasicDBObject(), new BasicDBObject(), ReadPreference.primary())
                      .addSpecial("$min", new BasicDBObject("x", 4)), 6);
         countResults(new DBCursor(collection, new BasicDBObject(), new BasicDBObject(), ReadPreference.primary())

--- a/driver-legacy/src/test/functional/com/mongodb/DBTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBTest.java
@@ -38,6 +38,7 @@ import static com.mongodb.ClusterFixture.isAuthenticated;
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isSharded;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.ClusterFixture.serverVersionLessThan;
 import static com.mongodb.DBObjectMatchers.hasFields;
 import static com.mongodb.DBObjectMatchers.hasSubdocument;
 import static com.mongodb.Fixture.getDefaultDatabaseName;
@@ -218,6 +219,7 @@ public class DBTest extends DatabaseTestCase {
     @Test
     public void shouldDoEval() {
         assumeThat(isAuthenticated(), is(false));
+        assumeThat(serverVersionLessThan("4.2"), is(true));
         String code = "function(name, incAmount) {\n"
                       + "var doc = db.myCollection.findOne( { name : name } );\n"
                       + "doc = doc || { name : name , num : 0 , total : 0 , avg : 0 , _id: 1 };\n"
@@ -237,6 +239,7 @@ public class DBTest extends DatabaseTestCase {
 
     @Test(expected = MongoException.class)
     public void shouldThrowErrorwhileDoingEval() {
+        assumeThat(serverVersionLessThan("4.2"), is(true));
         String code = "function(a, b) {\n"
                       + "var doc = db.myCollection.findOne( { name : b } );\n"
                       + "}";
@@ -246,6 +249,7 @@ public class DBTest extends DatabaseTestCase {
     @Test
     public void shouldInsertDocumentsUsingEval() {
         assumeThat(isAuthenticated(), is(false));
+        assumeThat(serverVersionLessThan("4.2"), is(true));
         // when
         database.eval("db." + collectionName + ".insert({name: 'Bob'})");
 
@@ -286,7 +290,7 @@ public class DBTest extends DatabaseTestCase {
 
     @Test
     public void shouldNotThrowAnExceptionOnCommandFailure() {
-        CommandResult commandResult = database.command(new BasicDBObject("collStats", "a" + System.currentTimeMillis()));
+        CommandResult commandResult = database.command(new BasicDBObject("nonExistentCommand", 1));
         assertThat(commandResult, hasFields(new String[]{"ok", "errmsg"}));
     }
 

--- a/driver-legacy/src/test/functional/com/mongodb/MapReduceTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/MapReduceTest.java
@@ -30,6 +30,7 @@ import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isSharded;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.ClusterFixture.serverVersionLessThan;
 import static com.mongodb.DBObjectMatchers.hasFields;
 import static com.mongodb.DBObjectMatchers.hasSubdocument;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -150,6 +151,7 @@ public class MapReduceTest extends DatabaseTestCase {
                                                         MapReduceCommand.OutputType.REPLACE,
                                                         new BasicDBObject());
         command.setOutputDB(MR_DATABASE);
+        getClient().getDatabase(MR_DATABASE).createCollection(DEFAULT_COLLECTION);
         MapReduceOutput output = collection.mapReduce(command);
 
 
@@ -311,9 +313,15 @@ public class MapReduceTest extends DatabaseTestCase {
         //then
         //duration is not working on the unstable server version
         //        assertThat(output.getDuration(), is(greaterThan(0)));
-        assertThat(output.getEmitCount(), is(6));
-        assertThat(output.getInputCount(), is(3));
-        assertThat(output.getOutputCount(), is(4));
+        if (serverVersionLessThan("4.4")) {
+            assertThat(output.getEmitCount(), is(6));
+            assertThat(output.getInputCount(), is(3));
+            assertThat(output.getOutputCount(), is(4));
+        } else {
+            assertThat(output.getEmitCount(), is(0));
+            assertThat(output.getInputCount(), is(0));
+            assertThat(output.getOutputCount(), is(0));
+        }
     }
 
     @Test
@@ -329,10 +337,17 @@ public class MapReduceTest extends DatabaseTestCase {
         MapReduceOutput output = collection.mapReduce(command);
 
         //then
-        assertThat(output.getDuration(), is(greaterThanOrEqualTo(0)));
-        assertThat(output.getEmitCount(), is(6));
-        assertThat(output.getInputCount(), is(3));
-        assertThat(output.getOutputCount(), is(4));
+        if (serverVersionLessThan("4.4")) {
+            assertThat(output.getDuration(), is(greaterThanOrEqualTo(0)));
+            assertThat(output.getEmitCount(), is(6));
+            assertThat(output.getInputCount(), is(3));
+            assertThat(output.getOutputCount(), is(4));
+        } else {
+            assertThat(output.getDuration(), is(0));
+            assertThat(output.getEmitCount(), is(0));
+            assertThat(output.getInputCount(), is(0));
+            assertThat(output.getOutputCount(), is(0));
+        }
     }
 
 

--- a/driver-sync/src/test/functional/com/mongodb/client/MongoCollectionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/MongoCollectionTest.java
@@ -39,6 +39,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class MongoCollectionTest extends DatabaseTestCase {
 
@@ -135,8 +136,8 @@ public class MongoCollectionTest extends DatabaseTestCase {
         List<Name> result = collection.mapReduce(mapFunction, reduceFunction, Name.class).into(new ArrayList<Name>());
 
         // then
-        assertEquals(new Name("Pete", 2), result.get(0));
-        assertEquals(new Name("Sam", 1), result.get(1));
+        assertTrue(result.contains(new Name("Pete", 2)));
+        assertTrue(result.contains(new Name("Sam", 1)));
     }
 
     @Test


### PR DESCRIPTION
This is a patch to the 3.8.x branch to fulfill the goals for continuous matrix testing for the 4.0-era driver, which was 3.8.0.  Similar PRs will be done for the 4.2 and 4.4 era release branches.   What I've done here is two things:

1. Modify or skip tests that will not pass against later server versions.  Mostly because the features under test have been removed
2. In cases where the server made breaking changes to commands that prevents the driver code from working, I changed the driver code to make it work with the later server versions.  This seemed easier than disabling all the tests of that feature, though that is another option we could consider.  Look at the changes to MapReduceToCollectionOperation for an example of this. 

There's nothing really new here.  All these changes have been applied already in one form or another to the master branch of the driver.  It was just a matter of finding them and copying them to this branch.

JAVA-3942

Full patch build: https://spruce.mongodb.com/version/60133b4d9ccd4e019373ad0d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC