### PR TITLE
Tighten up UUID parsing in JSON Reader

### DIFF
--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -1208,45 +1208,10 @@ public class JsonReader extends AbstractBsonReader {
         String uuidString = readStringFromExtendedJson();
         verifyToken(JsonTokenType.END_OBJECT);
         try {
-            validateHyphens(uuidString);
+            UuidStringValidator.validate(uuidString);
             return new BsonBinary(UUID.fromString(uuidString));
         } catch (IllegalArgumentException e) {
             throw new JsonParseException(e);
-        }
-    }
-
-    // UUID strings must be in the form 73ffd264-44b3-4c69-90e8-e7d1dfc035d4, but UUID.fromString fails to detect hyphens in the wrong
-    // positions.  For example, it will parse 73ff-d26444b-34c6-990e8e-7d1dfc035d4 (same as previous value but with hyphens in the wrong
-    // positions), but return a UUID that is not equal to the one it returns for the string with the hyphens in the correct positions.
-    // Given that, in order to comply with the Extended JSON specification, we add our own validation before calling UUID.fromString.
-    private void validateHyphens(final String uuidString) {
-        if (uuidString.length() != 36) {
-            throw new IllegalArgumentException(String.format("UUID string \"%s\" must be 36 characters", uuidString));
-        }
-
-        int dash1 = uuidString.indexOf('-', 0);
-        if (dash1 != 8) {
-            throw new IllegalArgumentException(String.format("First dash in UUID string \"%s\" must be at position 8", uuidString));
-        }
-
-        int dash2 = uuidString.indexOf('-', dash1 + 1);
-        if (dash2 != 13) {
-            throw new IllegalArgumentException(String.format("Second dash in UUID string \"%s\" must be at position 13", uuidString));
-        }
-
-        int dash3 = uuidString.indexOf('-', dash2 + 1);
-        if (dash3 != 18) {
-            throw new IllegalArgumentException(String.format("Third dash in UUID string \"%s\" must be at position 19", uuidString));
-        }
-
-        int dash4 = uuidString.indexOf('-', dash3 + 1);
-        if (dash4 != 23) {
-            throw new IllegalArgumentException(String.format("Fourth dash in UUID string \"%s\" must be at position 23", uuidString));
-        }
-
-        int dash5 = uuidString.indexOf('-', dash4 + 1);
-        if (dash5 != -1) {
-            throw new IllegalArgumentException(String.format("Too many dashes in UUID string \"%s\"", uuidString));
         }
     }
 

--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -1208,9 +1208,45 @@ public class JsonReader extends AbstractBsonReader {
         String uuidString = readStringFromExtendedJson();
         verifyToken(JsonTokenType.END_OBJECT);
         try {
+            validateHyphens(uuidString);
             return new BsonBinary(UUID.fromString(uuidString));
         } catch (IllegalArgumentException e) {
             throw new JsonParseException(e);
+        }
+    }
+
+    // UUID strings must be in the form 73ffd264-44b3-4c69-90e8-e7d1dfc035d4, but UUID.fromString fails to detect hyphens in the wrong
+    // positions.  For example, it will parse 73ff-d26444b-34c6-990e8e-7d1dfc035d4 (same as previous value but with hyphens in the wrong
+    // positions), but return a UUID that is not equal to the one it returns for the string with the hyphens in the correct positions.
+    // Given that, in order to comply with the Extended JSON specification, we add our own validation before calling UUID.fromString.
+    private void validateHyphens(final String uuidString) {
+        if (uuidString.length() != 36) {
+            throw new IllegalArgumentException(String.format("UUID string \"%s\" must be 36 characters", uuidString));
+        }
+
+        int dash1 = uuidString.indexOf('-', 0);
+        if (dash1 != 8) {
+            throw new IllegalArgumentException(String.format("First dash in UUID string \"%s\" must be at position 8", uuidString));
+        }
+
+        int dash2 = uuidString.indexOf('-', dash1 + 1);
+        if (dash2 != 13) {
+            throw new IllegalArgumentException(String.format("Second dash in UUID string \"%s\" must be at position 13", uuidString));
+        }
+
+        int dash3 = uuidString.indexOf('-', dash2 + 1);
+        if (dash3 != 18) {
+            throw new IllegalArgumentException(String.format("Third dash in UUID string \"%s\" must be at position 19", uuidString));
+        }
+
+        int dash4 = uuidString.indexOf('-', dash3 + 1);
+        if (dash4 != 23) {
+            throw new IllegalArgumentException(String.format("Fourth dash in UUID string \"%s\" must be at position 23", uuidString));
+        }
+
+        int dash5 = uuidString.indexOf('-', dash4 + 1);
+        if (dash5 != -1) {
+            throw new IllegalArgumentException(String.format("Too many dashes in UUID string \"%s\"", uuidString));
         }
     }
 

--- a/bson/src/main/org/bson/json/UuidStringValidator.java
+++ b/bson/src/main/org/bson/json/UuidStringValidator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.json;
+
+import java.util.BitSet;
+
+final class UuidStringValidator {
+    private static final BitSet HEX_CHARS;
+
+    static {
+        BitSet hexChars = new BitSet(256);
+
+        hexChars.set('0', '9' + 1);
+        hexChars.set('A', 'F' + 1);
+        hexChars.set('a', 'f' + 1);
+
+        HEX_CHARS = hexChars;
+    }
+
+    private static void validateFourHexChars(final String str, final int startPos) {
+        if (!(HEX_CHARS.get(str.charAt(startPos))
+                && HEX_CHARS.get(str.charAt(startPos + 1))
+                && HEX_CHARS.get(str.charAt(startPos + 2))
+                && HEX_CHARS.get(str.charAt(startPos + 3)))) {
+            throw new IllegalArgumentException(String.format("Expected four hexadecimal characters in UUID string \"%s\" starting at "
+                    + "position %d", str, startPos));
+        }
+    }
+
+    private static void validateDash(final String str, final int pos) {
+        if (str.charAt(pos) != '-') {
+            throw new IllegalArgumentException(String.format("Expected dash in UUID string \"%s\" at position %d", str, pos));
+        }
+    }
+
+    // UUID strings must be in the form 73ffd264-44b3-4c69-90e8-e7d1dfc035d4, but UUID.fromString fails to detect hyphens in the wrong
+    // positions.  For example, it will parse 73ff-d26444b-34c6-990e8e-7d1dfc035d4 (same as previous value but with hyphens in the wrong
+    // positions), but return a UUID that is not equal to the one it returns for the string with the hyphens in the correct positions.
+    // Given that, in order to comply with the Extended JSON specification, we add our own validation before calling UUID.fromString.
+    static void validate(final String uuidString) {
+        if (uuidString.length() != 36) {
+            throw new IllegalArgumentException(String.format("UUID string \"%s\" must be 36 characters", uuidString));
+        }
+
+        validateFourHexChars(uuidString, 0);
+        validateFourHexChars(uuidString, 4);
+        validateDash(uuidString, 8);
+        validateFourHexChars(uuidString, 9);
+        validateDash(uuidString, 13);
+        validateFourHexChars(uuidString, 14);
+        validateDash(uuidString, 18);
+        validateFourHexChars(uuidString, 19);
+        validateDash(uuidString, 23);
+        validateFourHexChars(uuidString, 24);
+        validateFourHexChars(uuidString, 28);
+        validateFourHexChars(uuidString, 32);
+    }
+
+    private UuidStringValidator() {
+    }
+}

--- a/bson/src/main/org/bson/json/UuidStringValidator.java
+++ b/bson/src/main/org/bson/json/UuidStringValidator.java
@@ -22,13 +22,10 @@ final class UuidStringValidator {
     private static final BitSet HEX_CHARS;
 
     static {
-        BitSet hexChars = new BitSet(256);
-
-        hexChars.set('0', '9' + 1);
-        hexChars.set('A', 'F' + 1);
-        hexChars.set('a', 'f' + 1);
-
-        HEX_CHARS = hexChars;
+        HEX_CHARS = new BitSet(256);
+        HEX_CHARS.set('0', '9' + 1);
+        HEX_CHARS.set('A', 'F' + 1);
+        HEX_CHARS.set('a', 'f' + 1);
     }
 
     private static void validateFourHexChars(final String str, final int startPos) {

--- a/bson/src/main/org/bson/json/UuidStringValidator.java
+++ b/bson/src/main/org/bson/json/UuidStringValidator.java
@@ -44,10 +44,11 @@ final class UuidStringValidator {
         }
     }
 
-    // UUID strings must be in the form 73ffd264-44b3-4c69-90e8-e7d1dfc035d4, but UUID.fromString fails to detect hyphens in the wrong
-    // positions.  For example, it will parse 73ff-d26444b-34c6-990e8e-7d1dfc035d4 (same as previous value but with hyphens in the wrong
-    // positions), but return a UUID that is not equal to the one it returns for the string with the hyphens in the correct positions.
-    // Given that, in order to comply with the Extended JSON specification, we add our own validation before calling UUID.fromString.
+    // UUID strings must be in the form 73ffd264-44b3-4c69-90e8-e7d1dfc035d4, but UUID.fromString fails to fully validate against that
+    // form, even though the Javadoc claims that it does  For example, it will parse 73ff-d26444b-34c6-990e8e-7d1dfc035d4 (same as previous
+    // value but with hyphens in the wrong positions), but return a UUID that is not equal to the one it returns for the string with the
+    // hyphens in the correct positions. Given that, in order to comply with the Extended JSON specification, we add our own validation
+    // before calling UUID.fromString.
     static void validate(final String uuidString) {
         if (uuidString.length() != 36) {
             throw new IllegalArgumentException(String.format("UUID string \"%s\" must be 36 characters", uuidString));

--- a/bson/src/main/org/bson/json/UuidStringValidator.java
+++ b/bson/src/main/org/bson/json/UuidStringValidator.java
@@ -22,7 +22,7 @@ final class UuidStringValidator {
     private static final BitSet HEX_CHARS;
 
     static {
-        HEX_CHARS = new BitSet(256);
+        HEX_CHARS = new BitSet('f' + 1);
         HEX_CHARS.set('0', '9' + 1);
         HEX_CHARS.set('A', 'F' + 1);
         HEX_CHARS.set('a', 'f' + 1);

--- a/bson/src/test/resources/bson/binary.json
+++ b/bson/src/test/resources/bson/binary.json
@@ -1,101 +1,113 @@
 {
-    "description": "Binary type",
-    "bson_type": "0x05",
-    "test_key": "x",
-    "valid": [
-        {
-            "description": "subtype 0x00 (Zero-length)",
-            "canonical_bson": "0D000000057800000000000000",
-            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"\", \"subType\" : \"00\"}}}"
-        },
-        {
-            "description": "subtype 0x00 (Zero-length, keys reversed)",
-            "canonical_bson": "0D000000057800000000000000",
-            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"\", \"subType\" : \"00\"}}}",
-            "degenerate_extjson": "{\"x\" : { \"$binary\" : {\"subType\" : \"00\", \"base64\" : \"\"}}}"
-        },
-        {
-            "description": "subtype 0x00",
-            "canonical_bson": "0F0000000578000200000000FFFF00",
-            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"00\"}}}"
-        },
-        {
-            "description": "subtype 0x01",
-            "canonical_bson": "0F0000000578000200000001FFFF00",
-            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"01\"}}}"
-        },
-        {
-            "description": "subtype 0x02",
-            "canonical_bson": "13000000057800060000000202000000FFFF00",
-            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"02\"}}}"
-        },
-        {
-            "description": "subtype 0x03",
-            "canonical_bson": "1D000000057800100000000373FFD26444B34C6990E8E7D1DFC035D400",
-            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"03\"}}}"
-        },
-        {
-            "description": "subtype 0x04",
-            "canonical_bson": "1D000000057800100000000473FFD26444B34C6990E8E7D1DFC035D400",
-            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}"
-        },
-        {
-            "description": "subtype 0x04 UUID",
-            "canonical_bson": "1D000000057800100000000473FFD26444B34C6990E8E7D1DFC035D400",
-            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}",
-            "degenerate_extjson": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}"
-        },
-        {
-            "description": "subtype 0x05",
-            "canonical_bson": "1D000000057800100000000573FFD26444B34C6990E8E7D1DFC035D400",
-            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"05\"}}}"
-        },
-        {
-            "description": "subtype 0x80",
-            "canonical_bson": "0F0000000578000200000080FFFF00",
-            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"80\"}}}"
-        },
-        {
-            "description": "$type query operator (conflicts with legacy $binary form with $type field)",
-            "canonical_bson": "1F000000037800170000000224747970650007000000737472696E67000000",
-            "canonical_extjson": "{\"x\" : { \"$type\" : \"string\"}}"
-        },
-        {
-            "description": "$type query operator (conflicts with legacy $binary form with $type field)",
-            "canonical_bson": "180000000378001000000010247479706500020000000000",
-            "canonical_extjson": "{\"x\" : { \"$type\" : {\"$numberInt\": \"2\"}}}"
-        }
-    ],
-    "decodeErrors": [
-        {
-            "description": "Length longer than document",
-            "bson": "1D000000057800FF0000000573FFD26444B34C6990E8E7D1DFC035D400"
-        },
-        {
-            "description": "Negative length",
-            "bson": "0D000000057800FFFFFFFF0000"
-        },
-        {
-            "description": "subtype 0x02 length too long ",
-            "bson": "13000000057800060000000203000000FFFF00"
-        },
-        {
-            "description": "subtype 0x02 length too short",
-            "bson": "13000000057800060000000201000000FFFF00"
-        },
-        {
-            "description": "subtype 0x02 length negative one",
-            "bson": "130000000578000600000002FFFFFFFFFFFF00"
-        }
-    ],
-    "parseErrors": [
-        {
-            "description": "$uuid wrong type",
-            "string": "{\"x\" : { \"$uuid\" : { \"data\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}}"
-        },
-        {
-            "description": "$uuid invalid value",
-            "string": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-90e8-e7d1dfc035d4\"}}"
-        }
-    ]
+  "description": "Binary type",
+  "bson_type": "0x05",
+  "test_key": "x",
+  "valid": [
+    {
+      "description": "subtype 0x00 (Zero-length)",
+      "canonical_bson": "0D000000057800000000000000",
+      "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"\", \"subType\" : \"00\"}}}"
+    },
+    {
+      "description": "subtype 0x00 (Zero-length, keys reversed)",
+      "canonical_bson": "0D000000057800000000000000",
+      "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"\", \"subType\" : \"00\"}}}",
+      "degenerate_extjson": "{\"x\" : { \"$binary\" : {\"subType\" : \"00\", \"base64\" : \"\"}}}"
+    },
+    {
+      "description": "subtype 0x00",
+      "canonical_bson": "0F0000000578000200000000FFFF00",
+      "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"00\"}}}"
+    },
+    {
+      "description": "subtype 0x01",
+      "canonical_bson": "0F0000000578000200000001FFFF00",
+      "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"01\"}}}"
+    },
+    {
+      "description": "subtype 0x02",
+      "canonical_bson": "13000000057800060000000202000000FFFF00",
+      "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"02\"}}}"
+    },
+    {
+      "description": "subtype 0x03",
+      "canonical_bson": "1D000000057800100000000373FFD26444B34C6990E8E7D1DFC035D400",
+      "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"03\"}}}"
+    },
+    {
+      "description": "subtype 0x04",
+      "canonical_bson": "1D000000057800100000000473FFD26444B34C6990E8E7D1DFC035D400",
+      "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}"
+    },
+    {
+      "description": "subtype 0x04 UUID",
+      "canonical_bson": "1D000000057800100000000473FFD26444B34C6990E8E7D1DFC035D400",
+      "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}",
+      "degenerate_extjson": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}"
+    },
+    {
+      "description": "subtype 0x05",
+      "canonical_bson": "1D000000057800100000000573FFD26444B34C6990E8E7D1DFC035D400",
+      "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"05\"}}}"
+    },
+    {
+      "description": "subtype 0x80",
+      "canonical_bson": "0F0000000578000200000080FFFF00",
+      "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"80\"}}}"
+    },
+    {
+      "description": "$type query operator (conflicts with legacy $binary form with $type field)",
+      "canonical_bson": "1F000000037800170000000224747970650007000000737472696E67000000",
+      "canonical_extjson": "{\"x\" : { \"$type\" : \"string\"}}"
+    },
+    {
+      "description": "$type query operator (conflicts with legacy $binary form with $type field)",
+      "canonical_bson": "180000000378001000000010247479706500020000000000",
+      "canonical_extjson": "{\"x\" : { \"$type\" : {\"$numberInt\": \"2\"}}}"
+    }
+  ],
+  "decodeErrors": [
+    {
+      "description": "Length longer than document",
+      "bson": "1D000000057800FF0000000573FFD26444B34C6990E8E7D1DFC035D400"
+    },
+    {
+      "description": "Negative length",
+      "bson": "0D000000057800FFFFFFFF0000"
+    },
+    {
+      "description": "subtype 0x02 length too long ",
+      "bson": "13000000057800060000000203000000FFFF00"
+    },
+    {
+      "description": "subtype 0x02 length too short",
+      "bson": "13000000057800060000000201000000FFFF00"
+    },
+    {
+      "description": "subtype 0x02 length negative one",
+      "bson": "130000000578000600000002FFFFFFFFFFFF00"
+    }
+  ],
+  "parseErrors": [
+    {
+      "description": "$uuid wrong type",
+      "string": "{\"x\" : { \"$uuid\" : { \"data\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}}"
+    },
+    {
+      "description": "$uuid invalid value--too short",
+      "string": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-90e8-e7d1dfc035d4\"}}"
+    },
+    {
+      "description": "$uuid invalid value--too long",
+      "string": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4-789e4\"}}"
+    },
+    {
+      "description": "$uuid invalid value--misplaced hyphens",
+      "string": "{\"x\" : { \"$uuid\" : \"73ff-d26444b-34c6-990e8e-7d1dfc035d4\"}}"
+    },
+    {
+      "description": "$uuid invalid value--too many hyphens",
+      "string": "{\"x\" : { \"$uuid\" : \"----d264-44b3-4--9-90e8-e7d1dfc0----\"}}"
+    }
+  ]
 }

--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -967,73 +967,17 @@ public class JsonReaderTest {
             assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
             return null;
         });
+    }
 
-        // wrong length
-        json = "{ \"$uuid\" : \"b5f21e0c2-a0d-42d6-ad03-d827008d8ab\"}}";
-        testStringAndStream(json, bsonReader -> {
-            try {
-                bsonReader.readBinaryData();
-                fail("Should fail to parse NumberDecimal constructor with a string");
-            } catch (JsonParseException e) {
-                // all good
-            }
-            return null;
-        });
-
+    // testing that JsonReader uses internal UuidStringValidator, as UUID.fromString accepts this UUID
+    @Test
+    public void testInvalidUuid() {
         // first hyphen out of place
-        json = "{ \"$uuid\" : \"b5f21e0c2-a0d-42d6-ad03-d827008d8ab6\"}}";
+        String json = "{ \"$uuid\" : \"73ff-d26444b-34c6-990e8e-7d1dfc035d4\"}}";
         testStringAndStream(json, bsonReader -> {
             try {
                 bsonReader.readBinaryData();
-                fail("Should fail to parse NumberDecimal constructor with a string");
-            } catch (JsonParseException e) {
-                // all good
-            }
-            return null;
-        });
-
-        // second hyphen out of place
-        json = "{ \"$uuid\" : \"b5f21e0c-2a0-d42d6-ad03-d827008d8ab6\"}}";
-        testStringAndStream(json, bsonReader -> {
-            try {
-                bsonReader.readBinaryData();
-                fail("Should fail to parse NumberDecimal constructor with a string");
-            } catch (JsonParseException e) {
-                // all good
-            }
-            return null;
-        });
-
-        // third hyphen out of place
-        json = "{ \"$uuid\" : \"b5f21e0c-2a0d-42d6ad-03-d827008d8ab6\"}}";
-        testStringAndStream(json, bsonReader -> {
-            try {
-                bsonReader.readBinaryData();
-                fail("Should fail to parse NumberDecimal constructor with a string");
-            } catch (JsonParseException e) {
-                // all good
-            }
-            return null;
-        });
-
-        // fourth hyphen out of place
-        json = "{ \"$uuid\" : \"b5f21e0c-2a0d-42d6-ad03d82700-8d8ab6\"}}";
-        testStringAndStream(json, bsonReader -> {
-            try {
-                bsonReader.readBinaryData();
-                fail("Should fail to parse NumberDecimal constructor with a string");
-            } catch (JsonParseException e) {
-                // all good
-            }
-            return null;
-        });
-
-        // too many hyphens
-        json = "{ \"$uuid\" : \"b5f21e0c-2a0d-42d6-ad03-d827008d8ab-\"}}";
-        testStringAndStream(json, bsonReader -> {
-            try {
-                bsonReader.readBinaryData();
-                fail("Should fail to parse NumberDecimal constructor with a string");
+                fail("Should fail to parse invalid UIUD");
             } catch (JsonParseException e) {
                 // all good
             }

--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -970,17 +970,12 @@ public class JsonReaderTest {
     }
 
     // testing that JsonReader uses internal UuidStringValidator, as UUID.fromString accepts this UUID
-    @Test
+    @Test(expected = JsonParseException.class)
     public void testInvalidUuid() {
         // first hyphen out of place
         String json = "{ \"$uuid\" : \"73ff-d26444b-34c6-990e8e-7d1dfc035d4\"}}";
         testStringAndStream(json, bsonReader -> {
-            try {
-                bsonReader.readBinaryData();
-                fail("Should fail to parse invalid UIUD");
-            } catch (JsonParseException e) {
-                // all good
-            }
+            bsonReader.readBinaryData();
             return null;
         });
     }

--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -967,7 +967,80 @@ public class JsonReaderTest {
             assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
             return null;
         });
+
+        // wrong length
+        json = "{ \"$uuid\" : \"b5f21e0c2-a0d-42d6-ad03-d827008d8ab\"}}";
+        testStringAndStream(json, bsonReader -> {
+            try {
+                bsonReader.readBinaryData();
+                fail("Should fail to parse NumberDecimal constructor with a string");
+            } catch (JsonParseException e) {
+                // all good
+            }
+            return null;
+        });
+
+        // first hyphen out of place
+        json = "{ \"$uuid\" : \"b5f21e0c2-a0d-42d6-ad03-d827008d8ab6\"}}";
+        testStringAndStream(json, bsonReader -> {
+            try {
+                bsonReader.readBinaryData();
+                fail("Should fail to parse NumberDecimal constructor with a string");
+            } catch (JsonParseException e) {
+                // all good
+            }
+            return null;
+        });
+
+        // second hyphen out of place
+        json = "{ \"$uuid\" : \"b5f21e0c-2a0-d42d6-ad03-d827008d8ab6\"}}";
+        testStringAndStream(json, bsonReader -> {
+            try {
+                bsonReader.readBinaryData();
+                fail("Should fail to parse NumberDecimal constructor with a string");
+            } catch (JsonParseException e) {
+                // all good
+            }
+            return null;
+        });
+
+        // third hyphen out of place
+        json = "{ \"$uuid\" : \"b5f21e0c-2a0d-42d6ad-03-d827008d8ab6\"}}";
+        testStringAndStream(json, bsonReader -> {
+            try {
+                bsonReader.readBinaryData();
+                fail("Should fail to parse NumberDecimal constructor with a string");
+            } catch (JsonParseException e) {
+                // all good
+            }
+            return null;
+        });
+
+        // fourth hyphen out of place
+        json = "{ \"$uuid\" : \"b5f21e0c-2a0d-42d6-ad03d82700-8d8ab6\"}}";
+        testStringAndStream(json, bsonReader -> {
+            try {
+                bsonReader.readBinaryData();
+                fail("Should fail to parse NumberDecimal constructor with a string");
+            } catch (JsonParseException e) {
+                // all good
+            }
+            return null;
+        });
+
+        // too many hyphens
+        json = "{ \"$uuid\" : \"b5f21e0c-2a0d-42d6-ad03-d827008d8ab-\"}}";
+        testStringAndStream(json, bsonReader -> {
+            try {
+                bsonReader.readBinaryData();
+                fail("Should fail to parse NumberDecimal constructor with a string");
+            } catch (JsonParseException e) {
+                // all good
+            }
+            return null;
+        });
     }
+
     @Test
     public void testUuidConstructor() {
         String json = "UUID(\"b5f21e0c-2a0d-42d6-ad03-d827008d8ab6\")";

--- a/bson/src/test/unit/org/bson/json/UuidStringValidatorTest.java
+++ b/bson/src/test/unit/org/bson/json/UuidStringValidatorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.json;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.bson.json.UuidStringValidator.validate;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class UuidStringValidatorTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            "dddddddd-dddd-dddd-dddd-dddddddddddd",
+            "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+            "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+            "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
+            "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC",
+            "DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD",
+            "EEEEEEEE-EEEE-EEEE-EEEE-EEEEEEEEEEEE",
+            "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF",
+            "00000000-0000-0000-0000-000000000000",
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+            "33333333-3333-3333-3333-333333333333",
+            "44444444-4444-4444-4444-444444444444",
+            "55555555-5555-5555-5555-555555555555",
+            "66666666-6666-6666-6666-666666666666",
+            "77777777-7777-7777-7777-777777777777",
+            "88888888-8888-8888-8888-888888888888",
+            "99999999-9999-9999-9999-999999999999"})
+    public void testValidUuidStrings(final String uuidString) {
+        validate(uuidString);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaaa",
+            "aaaaaaaa+aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa+aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa+aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa+aaaaaaaaaaaa",
+            "`aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "{aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "@aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "[aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "/aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            ":aaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "a:aaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "aa:aaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaa:aaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaa:aaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaaa:aa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaaaa:a-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-:aaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-a:aa-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aa:a-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaa:-aaaa-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-:aaa-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-a:aa-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aa:a-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaa:-aaaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-:aaa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-a:aa-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aa:a-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaa:-aaaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-:aaaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-a:aaaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aa:aaaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaa:aaaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaa:aaaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaa:aaaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaa:aaaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaa:aaaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaa:aaa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaa:aa",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa:a",
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa:"})
+    public void testInvalidUuidStrings(final String uuidString) {
+        try {
+            validate(uuidString);
+            fail("Should have failed to validate " + uuidString);
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+}

--- a/bson/src/test/unit/org/bson/json/UuidStringValidatorTest.java
+++ b/bson/src/test/unit/org/bson/json/UuidStringValidatorTest.java
@@ -20,7 +20,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.bson.json.UuidStringValidator.validate;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UuidStringValidatorTest {
 
@@ -49,7 +50,7 @@ public class UuidStringValidatorTest {
             "88888888-8888-8888-8888-888888888888",
             "99999999-9999-9999-9999-999999999999"})
     public void testValidUuidStrings(final String uuidString) {
-        validate(uuidString);
+        assertDoesNotThrow(() -> validate(uuidString));
     }
 
     @ParameterizedTest
@@ -97,11 +98,6 @@ public class UuidStringValidatorTest {
             "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa:a",
             "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa:"})
     public void testInvalidUuidStrings(final String uuidString) {
-        try {
-            validate(uuidString);
-            fail("Should have failed to validate " + uuidString);
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        assertThrows(IllegalArgumentException.class, () -> validate(uuidString));
     }
 }


### PR DESCRIPTION
The new spec test uncovered that UUID.fromString is more permissive in its parsing than is required by the test.  

So I added more restrictive parsing, but another option is to ignore the test.  The downside of the change I made is that it slows down the parsing code, but I doubt it will be detectable.

JAVA-3982
JAVA-3959