### PR TITLE
JAVA-3684: deprecate geohaystack

### DIFF
--- a/docs/reference/content/builders/indexes.md
+++ b/docs/reference/content/builders/indexes.md
@@ -123,19 +123,3 @@ This example specifies a 2d index on the `points` field:
 geo2d("points")
 ```
 
-
-#### geoHaystack
-
-To specify a [geoHaystack]({{< docsref "core/geohaystack/" >}}) index key, use the `geoHaystack` method.
-
-{{% note class="important"%}}
-For queries that use spherical geometry, a 2dsphere index is a better option than a haystack index. 2dsphere indexes allow field reordering;
-geoHaystack indexes require the first field to be the location field. Also, geoHaystack indexes are only usable via commands and so always
-return all results at once.
-{{% /note %}}
-
-This example specifies a geoHaystack index on the `position` field and an ascending index on the `type` field:
-
-```java
-geoHaystack("position", ascending("type"))
-```

--- a/docs/reference/content/driver-reactive/tutorials/indexes.md
+++ b/docs/reference/content/driver-reactive/tutorials/indexes.md
@@ -163,23 +163,6 @@ collection.createIndex(Indexes.geo2dsphere("contact.location"))
           .subscribe(new PrintToStringSubscriber<String>());
 ```
 
-### geoHaystack
-
-To create a specification for a [`geoHaystack` index]({{<docsref "core/geohaystack/" >}}), use the [`Indexes.geoHaystack`]({{< apiref "mongodb-driver-core" "com/mongodb/client/model/Indexes.html#geoHaystack(java.lang.String,org.bson.conversions.Bson)" >}}) method. `geoHaystack` indexes can improve performance on queries that use flat geometries.
-
-The following example creates a `geoHaystack` index on the `contact.location` field and an ascending index on the `stars` field:
-
-```java
-IndexOptions haystackOption = new IndexOptions().bucketSize(1.0);
-collection.createIndex(
-            Indexes.geoHaystack("contact.location", Indexes.ascending("stars")),
-            haystackOption)
-        .subscribe(new PrintToStringSubscriber<String>());
-```
-
-
-To query a haystack index, use the [`geoSearch`]({{<docsref "reference/command/geoSearch" >}}) command.
-
 ## IndexOptions
 
 ```java

--- a/docs/reference/content/driver-scala/builders/indexes.md
+++ b/docs/reference/content/driver-scala/builders/indexes.md
@@ -117,20 +117,3 @@ This example specifies a 2d index on the `points` field:
 ```scala
 geo2d("points")
 ```
-
-
-#### geoHaystack
-
-To specify a [geoHaystack]({{< docsref "core/geohaystack/" >}}) index key, use the `geoHaystack` method.
-
-{{% note class="important"%}}
-For queries that use spherical geometry, a 2dsphere index is a better option than a haystack index. 2dsphere indexes allow field reordering; 
-geoHaystack indexes require the first field to be the location field. Also, geoHaystack indexes are only usable via commands and so always 
-return all results at once.
-{{% /note %}}
-
-This example specifies a geoHaystack index on the `position` field and an ascending index on the `type` field:
-
-```scala
-geoHaystack("position", ascending("type"))
-```

--- a/docs/reference/content/driver-scala/tutorials/indexes.md
+++ b/docs/reference/content/driver-scala/tutorials/indexes.md
@@ -156,23 +156,6 @@ collection.createIndex(Indexes.geo2dsphere("contact.location"))
           .printResults()
 ```
 
-### geoHaystack
-
-To create a specification for a [`geoHaystack` index]({{<docsref "core/geohaystack/" >}}), use the [`Indexes.geoHaystack`]({{< apiref "mongo-scala-driver" "org/mongodb/scala/model/Indexes$.html#geoHaystack(fieldName:String,additional:org.mongodb.scala.bson.conversions.Bson):org.mongodb.scala.bson.conversions.Bson" >}}) method. `geoHaystack` indexes can improve performance on queries that use flat geometries.
-
-The following example creates a `geoHaystack` index on the `contact.location` field and an ascending index on the `stars` field:
-
-```scala
-val haystackOption = IndexOptions().bucketSize(1.0)
-collection.createIndex(
-            Indexes.geoHaystack("contact.location", Indexes.ascending("stars")),
-            haystackOption)
-        .printResults()
-```
-
-
-To query a haystack index, use the [`geoSearch`]({{<docsref "reference/command/geoSearch" >}}) command.
-
 ## IndexOptions
 
 ```scala

--- a/docs/reference/content/driver/tutorials/indexes.md
+++ b/docs/reference/content/driver/tutorials/indexes.md
@@ -147,22 +147,6 @@ The following example creates a `2dsphere` index on the `"contact.location"` fie
 collection.createIndex(Indexes.geo2dsphere("contact.location"));
 ```
 
-### geoHaystack
-
-To create a specification for a [`geoHaystack` index]({{<docsref "core/geohaystack/" >}}), use the [`Indexes.geoHaystack`]({{< apiref "mongodb-driver-core" "com/mongodb/client/model/Indexes.html#geoHaystack(java.lang.String,org.bson.conversions.Bson)" >}}) method. `geoHaystack` indexes can improve performance on queries that use flat geometries.
-
-The following example creates a `geoHaystack` index on the `contact.location` field and an ascending index on the `stars` field:
-
-```java
-IndexOptions haystackOption = new IndexOptions().bucketSize(1.0);
-collection.createIndex(
-         Indexes.geoHaystack("contact.location", Indexes.ascending("stars")),
-         haystackOption);
-```
-
-
-To query a haystack index, use the [`geoSearch`]({{<docsref "reference/command/geoSearch" >}}) command.
-
 ## IndexOptions
 
 ```java

--- a/driver-core/src/main/com/mongodb/client/model/IndexOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/IndexOptions.java
@@ -376,6 +376,7 @@ public class IndexOptions {
      *
      * @return the specified the number of units within which to group the location values for geoHaystack Indexes
      * @mongodb.driver.manual core/geohaystack/ geoHaystack Indexes
+     * @deprecated geoHaystack is deprecated in MongoDB 4.4
      */
     @Nullable
     @Deprecated
@@ -389,6 +390,7 @@ public class IndexOptions {
      * @param bucketSize the specified the number of units within which to group the location values for geoHaystack Indexes
      * @return this
      * @mongodb.driver.manual core/geohaystack/ geoHaystack Indexes
+     * @deprecated geoHaystack is deprecated in MongoDB 4.4
      */
     @Deprecated
     public IndexOptions bucketSize(@Nullable final Double bucketSize) {

--- a/driver-core/src/main/com/mongodb/client/model/IndexOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/IndexOptions.java
@@ -378,6 +378,7 @@ public class IndexOptions {
      * @mongodb.driver.manual core/geohaystack/ geoHaystack Indexes
      */
     @Nullable
+    @Deprecated
     public Double getBucketSize() {
         return bucketSize;
     }
@@ -389,6 +390,7 @@ public class IndexOptions {
      * @return this
      * @mongodb.driver.manual core/geohaystack/ geoHaystack Indexes
      */
+    @Deprecated
     public IndexOptions bucketSize(@Nullable final Double bucketSize) {
         this.bucketSize = bucketSize;
         return this;

--- a/driver-core/src/main/com/mongodb/client/model/Indexes.java
+++ b/driver-core/src/main/com/mongodb/client/model/Indexes.java
@@ -128,6 +128,8 @@ public final class Indexes {
     }
 
     /**
+     * @deprecated Prefer {@link Indexes#geo2dsphere(String...)}
+     *
      * Create an index key for a geohaystack index on the given field.
      *
      * <p>

--- a/driver-core/src/main/com/mongodb/client/model/Indexes.java
+++ b/driver-core/src/main/com/mongodb/client/model/Indexes.java
@@ -141,6 +141,7 @@ public final class Indexes {
      * @return the index specification
      * @mongodb.driver.manual core/geohaystack geoHaystack index
      */
+    @Deprecated
     public static Bson geoHaystack(final String fieldName, final Bson additional) {
         notNull("fieldName", fieldName);
         return compoundIndex(new BsonDocument(fieldName, new BsonString("geoHaystack")), additional);

--- a/driver-core/src/main/com/mongodb/client/model/Indexes.java
+++ b/driver-core/src/main/com/mongodb/client/model/Indexes.java
@@ -128,8 +128,6 @@ public final class Indexes {
     }
 
     /**
-     * @deprecated Prefer {@link Indexes#geo2dsphere(String...)}
-     *
      * Create an index key for a geohaystack index on the given field.
      *
      * <p>
@@ -142,6 +140,7 @@ public final class Indexes {
      * @param additional the additional field that forms the geoHaystack index key
      * @return the index specification
      * @mongodb.driver.manual core/geohaystack geoHaystack index
+     * @deprecated geoHaystack is deprecated in MongoDB 4.4, prefer {@link Indexes#geo2dsphere(String...)}
      */
     @Deprecated
     public static Bson geoHaystack(final String fieldName, final Bson additional) {

--- a/driver-core/src/main/com/mongodb/internal/bulk/IndexRequest.java
+++ b/driver-core/src/main/com/mongodb/internal/bulk/IndexRequest.java
@@ -397,6 +397,7 @@ public class IndexRequest {
      * @return the specified the number of units within which to group the location values for geoHaystack Indexes
      * @mongodb.driver.manual core/geohaystack/ geoHaystack Indexes
      */
+    @Deprecated
     public Double getBucketSize() {
         return bucketSize;
     }
@@ -408,6 +409,7 @@ public class IndexRequest {
      * @return this
      * @mongodb.driver.manual core/geohaystack/ geoHaystack Indexes
      */
+    @Deprecated
     public IndexRequest bucketSize(final Double bucketSize) {
         this.bucketSize = bucketSize;
         return this;

--- a/driver-core/src/main/com/mongodb/internal/bulk/IndexRequest.java
+++ b/driver-core/src/main/com/mongodb/internal/bulk/IndexRequest.java
@@ -396,6 +396,7 @@ public class IndexRequest {
      *
      * @return the specified the number of units within which to group the location values for geoHaystack Indexes
      * @mongodb.driver.manual core/geohaystack/ geoHaystack Indexes
+     * @deprecated geoHaystack is deprecated in MongoDB 4.4
      */
     @Deprecated
     public Double getBucketSize() {
@@ -408,6 +409,7 @@ public class IndexRequest {
      * @param bucketSize the specified the number of units within which to group the location values for geoHaystack Indexes
      * @return this
      * @mongodb.driver.manual core/geohaystack/ geoHaystack Indexes
+     * @deprecated geoHaystack is deprecated in MongoDB 4.4
      */
     @Deprecated
     public IndexRequest bucketSize(final Double bucketSize) {

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Indexes.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Indexes.scala
@@ -75,8 +75,6 @@ object Indexes {
   def geo2d(fieldName: String): Bson = JIndexes.geo2d(fieldName)
 
   /**
-   * @deprecated Prefer [[geo2dsphere]]
-   *
    * Create an index key for a geohaystack index on the given field.
    *
    * <p>

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Indexes.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Indexes.scala
@@ -75,6 +75,8 @@ object Indexes {
   def geo2d(fieldName: String): Bson = JIndexes.geo2d(fieldName)
 
   /**
+   * @deprecated Prefer [[geo2dsphere]]
+   *
    * Create an index key for a geohaystack index on the given field.
    *
    * <p>

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Indexes.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Indexes.scala
@@ -88,6 +88,7 @@ object Indexes {
    * @return the index specification
    * @see [[http://docs.mongodb.org/manual/core/geohaystack geoHaystack index]]
    */
+  @deprecated("geoHaystack is deprecated in MongoDB 4.4", "4.2.1")
   def geoHaystack(fieldName: String, additional: Bson): Bson = JIndexes.geoHaystack(fieldName, additional)
 
   /**


### PR DESCRIPTION
This removes mention of geoHaystack from the docs and marks methods as deprecated.