### PR TITLE
Make implementations of AsyncAggregateResponseBatchCursor more responsive to close signals

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
@@ -35,6 +35,7 @@ import com.mongodb.internal.connection.QueryResult
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonInt32
+import org.bson.BsonNull
 import org.bson.BsonString
 import org.bson.BsonTimestamp
 import org.bson.Document
@@ -301,6 +302,29 @@ class AsyncQueryBatchCursorFunctionalSpecification extends OperationFunctionalSp
         true      | 0
         true      | 100
         false     | 0
+    }
+
+    @Slow
+    def 'should unblock if closed while waiting for more data from tailable cursor'() {
+        given:
+        collectionHelper.create(collectionName, new CreateCollectionOptions().capped(true).sizeInBytes(1000))
+        collectionHelper.insertDocuments(new DocumentCodec(), Document.parse('{}'))
+        def firstBatch = executeQuery(new BsonDocument('_id', BsonNull.VALUE), 0, 1, true, true);
+
+        when:
+        cursor = new AsyncQueryBatchCursor<Document>(firstBatch, 0, 1, 500, new DocumentCodec(), connectionSource, connection)
+        Thread.start {
+            Thread.sleep(SECONDS.toMillis(2))
+            cursor.close()
+        }
+        def batch = nextBatch()
+
+        then:
+        cursor.isClosed()
+        batch == null
+        //both connection and connectionSource have reference count 1 when we pass them to the AsyncQueryBatchCursor constructor
+        connection.getCount() == 1
+        waitForRelease(connectionSource, 1)
     }
 
     def 'should respect limit'() {

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncQueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncQueryBatchCursorSpecification.groovy
@@ -474,7 +474,9 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         connectionA.getCount() == 0
-        connectionSource.getCount() == 0
+        if (response2 == null) { //otherwise connectionSource is released asynchronously, which is not easy to verify
+            connectionSource.getCount() == 0
+        }
         cursor.isClosed()
 
         where:
@@ -709,6 +711,9 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         int counter = 0
         def mock = Mock(AsyncConnectionSource)
         mock.getConnection(_) >> {
+            if (counter == 0) {
+                throw new IllegalStateException('Tried to use released AsyncConnectionSource')
+            }
             def (result, error) = connectionCallbackResults()
             it[0].onResult(result, error)
         }


### PR DESCRIPTION
This is a backport of a3ef19b171cdbfaa4677486fb43a2e8877d36d3a.

Evergreen patch: https://spruce.mongodb.com/version/601c2b582fbabe23aea4ed69.