### PR TITLE
Use $collStats for estimatedDocumentCount on 5.0+ servers

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/CountDocumentsOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CountDocumentsOperation.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.model.Collation;
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.binding.AsyncReadBinding;
+import com.mongodb.internal.binding.ReadBinding;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonValue;
+import org.bson.codecs.BsonDocumentCodec;
+import org.bson.codecs.Decoder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+public class CountDocumentsOperation implements AsyncReadOperation<Long>, ReadOperation<Long> {
+    private static final Decoder<BsonDocument> DECODER = new BsonDocumentCodec();
+    private final MongoNamespace namespace;
+    private boolean retryReads;
+    private BsonDocument filter;
+    private BsonValue hint;
+    private long skip;
+    private long limit;
+    private long maxTimeMS;
+    private Collation collation;
+
+    public CountDocumentsOperation(final MongoNamespace namespace) {
+        this.namespace = notNull("namespace", namespace);
+    }
+
+    public BsonDocument getFilter() {
+        return filter;
+    }
+
+    public CountDocumentsOperation filter(final BsonDocument filter) {
+        this.filter = filter;
+        return this;
+    }
+
+    public CountDocumentsOperation retryReads(final boolean retryReads) {
+        this.retryReads = retryReads;
+        return this;
+    }
+
+    public boolean getRetryReads() {
+        return retryReads;
+    }
+
+    public BsonValue getHint() {
+        return hint;
+    }
+
+    public CountDocumentsOperation hint(final BsonValue hint) {
+        this.hint = hint;
+        return this;
+    }
+
+    public long getLimit() {
+        return limit;
+    }
+
+    public CountDocumentsOperation limit(final long limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    public long getSkip() {
+        return skip;
+    }
+
+    public CountDocumentsOperation skip(final long skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public long getMaxTime(final TimeUnit timeUnit) {
+        notNull("timeUnit", timeUnit);
+        return timeUnit.convert(maxTimeMS, TimeUnit.MILLISECONDS);
+    }
+
+    public CountDocumentsOperation maxTime(final long maxTime, final TimeUnit timeUnit) {
+        notNull("timeUnit", timeUnit);
+        this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
+        return this;
+    }
+
+    public Collation getCollation() {
+        return collation;
+    }
+
+    public CountDocumentsOperation collation(final Collation collation) {
+        this.collation = collation;
+        return this;
+    }
+
+    @Override
+    public Long execute(final ReadBinding binding) {
+        BatchCursor<BsonDocument> cursor = getAggregateOperation().execute(binding);
+        return cursor.hasNext() ? getCountFromAggregateResults(cursor.next()) : 0;
+    }
+
+    @Override
+    public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<Long> callback) {
+        getAggregateOperation().executeAsync(binding, (result, t) -> {
+            if (t != null) {
+                callback.onResult(null, t);
+            } else {
+                result.next((result1, t1) -> {
+                    if (t1 != null) {
+                        callback.onResult(null, t1);
+                    } else {
+                        callback.onResult(getCountFromAggregateResults(result1), null);
+                    }
+                });
+            }
+        });
+    }
+
+    private AggregateOperation<BsonDocument> getAggregateOperation() {
+        return new AggregateOperation<BsonDocument>(namespace, getPipeline(), DECODER)
+                .retryReads(retryReads)
+                .collation(collation)
+                .hint(hint)
+                .maxTime(maxTimeMS, TimeUnit.MILLISECONDS);
+    }
+
+    private List<BsonDocument> getPipeline() {
+        ArrayList<BsonDocument> pipeline = new ArrayList<BsonDocument>();
+        pipeline.add(new BsonDocument("$match", filter != null ? filter : new BsonDocument()));
+        if (skip > 0) {
+            pipeline.add(new BsonDocument("$skip", new BsonInt64(skip)));
+        }
+        if (limit > 0) {
+            pipeline.add(new BsonDocument("$limit", new BsonInt64(limit)));
+        }
+        pipeline.add(new BsonDocument("$group", new BsonDocument("_id", new BsonInt32(1))
+                .append("n", new BsonDocument("$sum", new BsonInt32(1)))));
+        return pipeline;
+    }
+
+    private Long getCountFromAggregateResults(final List<BsonDocument> results) {
+        if (results == null || results.isEmpty()) {
+            return 0L;
+        } else {
+            return results.get(0).getNumber("n").longValue();
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -28,6 +28,7 @@ import com.mongodb.client.model.DeleteManyModel;
 import com.mongodb.client.model.DeleteOneModel;
 import com.mongodb.client.model.DeleteOptions;
 import com.mongodb.client.model.DropIndexOptions;
+import com.mongodb.client.model.EstimatedDocumentCountOptions;
 import com.mongodb.client.model.FindOneAndDeleteOptions;
 import com.mongodb.client.model.FindOneAndReplaceOptions;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
@@ -50,7 +51,6 @@ import com.mongodb.internal.bulk.InsertRequest;
 import com.mongodb.internal.bulk.UpdateRequest;
 import com.mongodb.internal.bulk.WriteRequest;
 import com.mongodb.internal.client.model.AggregationLevel;
-import com.mongodb.internal.client.model.CountStrategy;
 import com.mongodb.internal.client.model.FindOptions;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
@@ -127,8 +127,8 @@ public final class Operations<TDocument> {
         return retryReads;
     }
 
-    public CountOperation count(final Bson filter, final CountOptions options, final CountStrategy countStrategy) {
-        CountOperation operation = new CountOperation(namespace, countStrategy)
+    public CountDocumentsOperation countDocuments(final Bson filter, final CountOptions options) {
+        CountDocumentsOperation operation = new CountDocumentsOperation(namespace)
                 .retryReads(retryReads)
                 .filter(toBsonDocument(filter))
                 .skip(options.getSkip())
@@ -141,6 +141,12 @@ public final class Operations<TDocument> {
             operation.hint(new BsonString(options.getHintString()));
         }
         return operation;
+    }
+
+    public EstimatedDocumentCountOperation estimatedDocumentCount(final EstimatedDocumentCountOptions options) {
+        return new EstimatedDocumentCountOperation(namespace)
+                .retryReads(retryReads)
+                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS);
     }
 
     public <TResult> FindOperation<TResult> findFirst(final Bson filter, final Class<TResult> resultClass,

--- a/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
@@ -31,6 +31,7 @@ public final class ServerVersionHelper {
     public static final int FOUR_DOT_ZERO_WIRE_VERSION = 7;
     public static final int FOUR_DOT_TWO_WIRE_VERSION = 8;
     public static final int FOUR_DOT_FOUR_WIRE_VERSION = 9;
+    public static final int FIVE_DOT_ZERO_WIRE_VERSION = 12;
 
     public static boolean serverIsAtLeastVersionThreeDotZero(final ConnectionDescription description) {
         return description.getMaxWireVersion() >= THREE_DOT_ZERO_WIRE_VERSION;
@@ -58,6 +59,10 @@ public final class ServerVersionHelper {
 
     public static boolean serverIsAtLeastVersionFourDotFour(final ConnectionDescription description) {
         return description.getMaxWireVersion() >= FOUR_DOT_FOUR_WIRE_VERSION;
+    }
+
+    public static boolean serverIsAtLeastVersionFiveDotZero(final ConnectionDescription description) {
+        return description.getMaxWireVersion() >= FIVE_DOT_ZERO_WIRE_VERSION;
     }
 
     public static boolean serverIsLessThanVersionThreeDotZero(final ConnectionDescription description) {

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -27,6 +27,7 @@ import com.mongodb.client.model.CountOptions;
 import com.mongodb.client.model.CreateIndexOptions;
 import com.mongodb.client.model.DeleteOptions;
 import com.mongodb.client.model.DropIndexOptions;
+import com.mongodb.client.model.EstimatedDocumentCountOptions;
 import com.mongodb.client.model.FindOneAndDeleteOptions;
 import com.mongodb.client.model.FindOneAndReplaceOptions;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
@@ -39,7 +40,6 @@ import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.internal.client.model.AggregationLevel;
-import com.mongodb.internal.client.model.CountStrategy;
 import com.mongodb.internal.client.model.FindOptions;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
@@ -79,8 +79,12 @@ public final class SyncOperations<TDocument> {
                 retryWrites, retryReads);
     }
 
-    public ReadOperation<Long> count(final Bson filter, final CountOptions options, final CountStrategy countStrategy) {
-        return operations.count(filter, options, countStrategy);
+    public ReadOperation<Long> countDocuments(final Bson filter, final CountOptions options) {
+        return operations.countDocuments(filter, options);
+    }
+
+    public ReadOperation<Long> estimatedDocumentCount(final EstimatedDocumentCountOptions options) {
+        return operations.estimatedDocumentCount(options);
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> findFirst(final Bson filter, final Class<TResult> resultClass,

--- a/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
@@ -35,7 +35,7 @@ import com.mongodb.internal.bulk.WriteRequest;
 import com.mongodb.internal.operation.AggregateOperation;
 import com.mongodb.internal.operation.BatchCursor;
 import com.mongodb.internal.operation.CommandReadOperation;
-import com.mongodb.internal.operation.CountOperation;
+import com.mongodb.internal.operation.CountDocumentsOperation;
 import com.mongodb.internal.operation.CreateCollectionOperation;
 import com.mongodb.internal.operation.CreateIndexesOperation;
 import com.mongodb.internal.operation.DropCollectionOperation;
@@ -336,15 +336,15 @@ public final class CollectionHelper<T> {
     }
 
     public long count(final ReadBinding binding) {
-        return new CountOperation(namespace).execute(binding);
+        return new CountDocumentsOperation(namespace).execute(binding);
     }
 
     public long count(final AsyncReadWriteBinding binding) throws Throwable {
-        return executeAsync(new CountOperation(namespace), binding);
+        return executeAsync(new CountDocumentsOperation(namespace), binding);
     }
 
     public long count(final Bson filter) {
-        return new CountOperation(namespace).filter(toBsonDocument(filter)).execute(getBinding());
+        return new CountDocumentsOperation(namespace).filter(toBsonDocument(filter)).execute(getBinding());
     }
 
     public BsonDocument wrap(final Document document) {

--- a/driver-core/src/test/resources/retryable-reads/estimatedDocumentCount-4.9.json
+++ b/driver-core/src/test/resources/retryable-reads/estimatedDocumentCount-4.9.json
@@ -1,0 +1,246 @@
+{
+    "runOn": [
+        {
+            "minServerVersion": "4.9.0"
+        }
+    ],
+    "database_name": "retryable-reads-tests",
+    "collection_name": "coll",
+    "data": [
+        {
+            "_id": 1,
+            "x": 11
+        },
+        {
+            "_id": 2,
+            "x": 22
+        }
+    ],
+    "tests": [
+        {
+            "description": "EstimatedDocumentCount succeeds on first attempt",
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds on second attempt",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "closeConnection": true
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount fails on first attempt",
+            "clientOptions": {
+                "retryReads": false
+            },
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "closeConnection": true
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "error": true
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount fails on second attempt",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 2
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "closeConnection": true
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "error": true
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/driver-core/src/test/resources/retryable-reads/estimatedDocumentCount-pre4.9.json
+++ b/driver-core/src/test/resources/retryable-reads/estimatedDocumentCount-pre4.9.json
@@ -2,6 +2,7 @@
   "runOn": [
     {
       "minServerVersion": "4.0",
+      "maxServerVersion": "4.8.99",
       "topology": [
         "single",
         "replicaset"
@@ -9,6 +10,7 @@
     },
     {
       "minServerVersion": "4.1.7",
+      "maxServerVersion": "4.8.99",
       "topology": [
         "sharded"
       ]

--- a/driver-core/src/test/resources/retryable-reads/estimatedDocumentCount-serverErrors-4.9.json
+++ b/driver-core/src/test/resources/retryable-reads/estimatedDocumentCount-serverErrors-4.9.json
@@ -1,0 +1,911 @@
+{
+    "runOn": [
+        {
+            "minServerVersion": "4.9.0"
+        }
+    ],
+    "database_name": "retryable-reads-tests",
+    "collection_name": "coll",
+    "data": [
+        {
+            "_id": 1,
+            "x": 11
+        },
+        {
+            "_id": 2,
+            "x": 22
+        }
+    ],
+    "tests": [
+        {
+            "description": "EstimatedDocumentCount succeeds after InterruptedAtShutdown",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 11600
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after InterruptedDueToReplStateChange",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 11602
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after NotMaster",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 10107
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after NotMasterNoSlaveOk",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 13435
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after NotMasterOrSecondary",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 13436
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after PrimarySteppedDown",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 189
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after ShutdownInProgress",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 91
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after HostNotFound",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 7
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after HostUnreachable",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 6
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after NetworkTimeout",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 89
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount succeeds after SocketException",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 9001
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "result": 2
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount fails after two NotMaster errors",
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 2
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 10107
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "error": true
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        },
+        {
+            "description": "EstimatedDocumentCount fails after NotMaster when retryReads is false",
+            "clientOptions": {
+                "retryReads": false
+            },
+            "failPoint": {
+                "configureFailPoint": "failCommand",
+                "mode": {
+                    "times": 1
+                },
+                "data": {
+                    "failCommands": [
+                        "aggregate"
+                    ],
+                    "errorCode": 10107
+                }
+            },
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection",
+                    "error": true
+                }
+            ],
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "aggregate": "coll",
+                            "pipeline": [
+                                {
+                                    "$collStats": {
+                                        "count": {}
+                                    }
+                                },
+                                {
+                                    "$group": {
+                                        "_id": 1,
+                                        "n": {
+                                            "$sum": "$count"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "database_name": "retryable-reads-tests"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/driver-core/src/test/resources/retryable-reads/estimatedDocumentCount-serverErrors-pre4.9.json
+++ b/driver-core/src/test/resources/retryable-reads/estimatedDocumentCount-serverErrors-pre4.9.json
@@ -2,6 +2,7 @@
   "runOn": [
     {
       "minServerVersion": "4.0",
+      "maxServerVersion": "4.8.99",
       "topology": [
         "single",
         "replicaset"
@@ -9,6 +10,7 @@
     },
     {
       "minServerVersion": "4.1.7",
+      "maxServerVersion": "4.8.99",
       "topology": [
         "sharded"
       ]

--- a/driver-core/src/test/resources/unified-test-format/crud/estimatedDocumentCount.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/estimatedDocumentCount.json
@@ -1,0 +1,562 @@
+{
+    "description": "estimatedDocumentCount",
+    "schemaVersion": "1.0",
+    "createEntities": [
+        {
+            "client": {
+                "id": "client0",
+                "observeEvents": [
+                    "commandStartedEvent"
+                ],
+                "uriOptions": {
+                    "retryReads": false
+                },
+              "useMultipleMongoses": false
+            }
+        },
+        {
+            "database": {
+                "id": "database0",
+                "client": "client0",
+                "databaseName": "edc-tests"
+            }
+        },
+        {
+            "collection": {
+                "id": "collection0",
+                "database": "database0",
+                "collectionName": "coll0"
+            }
+        },
+        {
+            "collection": {
+                "id": "collection1",
+                "database": "database0",
+                "collectionName": "coll1"
+            }
+        }
+    ],
+    "initialData": [
+        {
+            "collectionName": "coll0",
+            "databaseName": "edc-tests",
+            "documents": [
+                {
+                    "_id": 1,
+                    "x": 11
+                },
+                {
+                    "_id": 2,
+                    "x": 22
+                },
+                {
+                    "_id": 3,
+                    "x": 33
+                }
+            ]
+        }
+    ],
+    "tests": [
+        {
+            "description": "estimatedDocumentCount uses $collStats on 4.9.0 or greater",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.9.0"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "expectResult": 3
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "aggregate": "coll0",
+                                    "pipeline": [
+                                        {
+                                            "$collStats": {
+                                                "count": {}
+                                            }
+                                        },
+                                        {
+                                            "$group": {
+                                                "_id": 1,
+                                                "n": {
+                                                    "$sum": "$count"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "commandName": "aggregate",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount with maxTimeMS on 4.9.0 or greater",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.9.0"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "arguments": {
+                        "maxTimeMS": 6000
+                    },
+                    "expectResult": 3
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "aggregate": "coll0",
+                                    "pipeline": [
+                                        {
+                                            "$collStats": {
+                                                "count": {}
+                                            }
+                                        },
+                                        {
+                                            "$group": {
+                                                "_id": 1,
+                                                "n": {
+                                                    "$sum": "$count"
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "maxTimeMS": 6000
+                                },
+                                "commandName": "aggregate",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount on non-existent collection on 4.9.0 or greater",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.9.0"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection1",
+                    "expectResult": 0
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "aggregate": "coll1",
+                                    "pipeline": [
+                                        {
+                                            "$collStats": {
+                                                "count": {}
+                                            }
+                                        },
+                                        {
+                                            "$group": {
+                                                "_id": 1,
+                                                "n": {
+                                                    "$sum": "$count"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "commandName": "aggregate",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount errors correctly on 4.9.0 or greater--command error",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.9.0"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "failPoint",
+                    "object": "testRunner",
+                    "arguments": {
+                        "client": "client0",
+                        "failPoint": {
+                            "configureFailPoint": "failCommand",
+                            "mode": {
+                                "times": 1
+                            },
+                            "data": {
+                                "failCommands": [
+                                    "aggregate"
+                                ],
+                                "errorCode": 8
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "expectError": {
+                        "errorCode": 8
+                    }
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "aggregate": "coll0",
+                                    "pipeline": [
+                                        {
+                                            "$collStats": {
+                                                "count": {}
+                                            }
+                                        },
+                                        {
+                                            "$group": {
+                                                "_id": 1,
+                                                "n": {
+                                                    "$sum": "$count"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "commandName": "aggregate",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount errors correctly on 4.9.0 or greater--socket error",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.9.0"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "failPoint",
+                    "object": "testRunner",
+                    "arguments": {
+                        "client": "client0",
+                        "failPoint": {
+                            "configureFailPoint": "failCommand",
+                            "mode": {
+                                "times": 1
+                            },
+                            "data": {
+                                "failCommands": [
+                                    "aggregate"
+                                ],
+                                "closeConnection": true
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "expectError": {
+                        "isError": true
+                    }
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "aggregate": "coll0",
+                                    "pipeline": [
+                                        {
+                                            "$collStats": {
+                                                "count": {}
+                                            }
+                                        },
+                                        {
+                                            "$group": {
+                                                "_id": 1,
+                                                "n": {
+                                                    "$sum": "$count"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "commandName": "aggregate",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount uses count on less than 4.9.0",
+            "runOnRequirements": [
+                {
+                    "maxServerVersion": "4.8.99"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "expectResult": 3
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "count": "coll0"
+                                },
+                                "commandName": "count",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount with maxTimeMS on less than 4.9.0",
+            "runOnRequirements": [
+                {
+                    "maxServerVersion": "4.8.99"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "arguments": {
+                        "maxTimeMS": 6000
+                    },
+                    "expectResult": 3
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "count": "coll0",
+                                    "maxTimeMS": 6000
+                                },
+                                "commandName": "count",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount on non-existent collection on less than 4.9.0",
+            "runOnRequirements": [
+                {
+                    "maxServerVersion": "4.8.99"
+                }
+            ],
+            "operations": [
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection1",
+                    "expectResult": 0
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "count": "coll1"
+                                },
+                                "commandName": "count",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount errors correctly on less than 4.9.0--command error",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.0.0",
+                    "maxServerVersion": "4.8.99",
+                    "topologies": [
+                        "single",
+                        "replicaset"
+                    ]
+                },
+                {
+                    "minServerVersion": "4.2.0",
+                    "maxServerVersion": "4.8.99",
+                    "topologies": [
+                        "sharded"
+                    ]
+                }
+            ],
+            "operations": [
+                {
+                    "name": "failPoint",
+                    "object": "testRunner",
+                    "arguments": {
+                        "client": "client0",
+                        "failPoint": {
+                            "configureFailPoint": "failCommand",
+                            "mode": {
+                                "times": 1
+                            },
+                            "data": {
+                                "failCommands": [
+                                    "count"
+                                ],
+                                "errorCode": 8
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "expectError": {
+                        "errorCode": 8
+                    }
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "count": "coll0"
+                                },
+                                "commandName": "count",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "estimatedDocumentCount errors correctly on less than 4.9.0--socket error",
+            "runOnRequirements": [
+                {
+                    "minServerVersion": "4.0.0",
+                    "maxServerVersion": "4.8.99",
+                    "topologies": [
+                        "single",
+                        "replicaset"
+                    ]
+                },
+                {
+                    "minServerVersion": "4.2.0",
+                    "maxServerVersion": "4.8.99",
+                    "topologies": [
+                        "sharded"
+                    ]
+                }
+            ],
+            "operations": [
+                {
+                    "name": "failPoint",
+                    "object": "testRunner",
+                    "arguments": {
+                        "client": "client0",
+                        "failPoint": {
+                            "configureFailPoint": "failCommand",
+                            "mode": {
+                                "times": 1
+                            },
+                            "data": {
+                                "failCommands": [
+                                    "count"
+                                ],
+                                "closeConnection": true
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "estimatedDocumentCount",
+                    "object": "collection0",
+                    "expectError": {
+                        "isError": true
+                    }
+                }
+            ],
+            "expectEvents": [
+                {
+                    "client": "client0",
+                    "events": [
+                        {
+                            "commandStartedEvent": {
+                                "command": {
+                                    "count": "coll0"
+                                },
+                                "commandName": "count",
+                                "databaseName": "edc-tests"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/driver-core/src/test/resources/versioned-api/crud-api-version-1.json
+++ b/driver-core/src/test/resources/versioned-api/crud-api-version-1.json
@@ -587,7 +587,12 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount appends declared API version",
+      "description": "estimatedDocumentCount appends declared API version on less than 4.9.0",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.8.99"
+        }
+      ],
       "operations": [
         {
           "name": "estimatedDocumentCount",
@@ -603,6 +608,55 @@
               "commandStartedEvent": {
                 "command": {
                   "count": "test",
+                  "apiVersion": "1",
+                  "apiStrict": {
+                    "$$unsetOrMatches": false
+                  },
+                  "apiDeprecationErrors": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "estimatedDocumentCount appends declared API version on 4.9.0 or greater",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "arguments": {}
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$collStats": {
+                        "count": {}
+                      }
+                    },
+                    {
+                      "$group": {
+                        "_id": 1,
+                        "n": {
+                          "$sum": "$count"
+                        }
+                      }
+                    }
+                  ],
                   "apiVersion": "1",
                   "apiStrict": {
                     "$$unsetOrMatches": false

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
@@ -55,7 +55,6 @@ import com.mongodb.client.result.InsertOneResult;
 import com.mongodb.client.result.UpdateResult;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.bulk.WriteRequest;
-import com.mongodb.internal.client.model.CountStrategy;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.internal.operation.AsyncWriteOperation;
 import com.mongodb.internal.operation.CommandReadOperation;
@@ -82,7 +81,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.internal.client.model.CountOptionsHelper.fromEstimatedDocumentCountOptions;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.bson.internal.CodecRegistryHelper.createRegistry;
@@ -279,14 +277,12 @@ public final class MongoOperationPublisher<T> {
 
 
     Publisher<Long> estimatedDocumentCount(final EstimatedDocumentCountOptions options) {
-        return createReadOperationMono(() -> operations.count(new BsonDocument(),
-                                                              fromEstimatedDocumentCountOptions(notNull("options", options)),
-                                                              CountStrategy.COMMAND), null);
+        return createReadOperationMono(() -> operations.estimatedDocumentCount(notNull("options", options)), null);
     }
 
     Publisher<Long> countDocuments(@Nullable final ClientSession clientSession, final Bson filter, final CountOptions options) {
-        return createReadOperationMono(() -> operations.count(notNull("filter", filter), notNull("options", options),
-                                                              CountStrategy.AGGREGATE), clientSession);
+        return createReadOperationMono(() -> operations.countDocuments(notNull("filter", filter), notNull("options", options)
+        ), clientSession);
     }
 
     Publisher<BulkWriteResult> bulkWrite(

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ReadConcernTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ReadConcernTest.java
@@ -62,18 +62,16 @@ public class ReadConcernTest {
 
         Mono.from(mongoClient.getDatabase(getDefaultDatabaseName()).getCollection("test")
                 .withReadConcern(ReadConcern.LOCAL)
-                .estimatedDocumentCount())
+                .find())
                 .block(TIMEOUT_DURATION);
 
         List<CommandEvent> events = commandListener.getCommandStartedEvents();
 
-        BsonDocument commandDocument = new BsonDocument("count", new BsonString("test"))
+        BsonDocument commandDocument = new BsonDocument("find", new BsonString("test"))
                 .append("readConcern", ReadConcern.LOCAL.asDocument())
-                .append("query", new BsonDocument());
-        if (serverVersionAtLeast(3, 6)) {
-            commandDocument.put("$db", new BsonString(getDefaultDatabaseName()));
-        }
-        assertEventsEquality(singletonList(new CommandStartedEvent(1, null, getDefaultDatabaseName(), "count", commandDocument)), events);
+                .append("filter", new BsonDocument());
+
+        assertEventsEquality(singletonList(new CommandStartedEvent(1, null, getDefaultDatabaseName(), "find", commandDocument)), events);
     }
 
     private boolean canRunTests() {

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedCrudTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedCrudTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.unified;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.unified.UnifiedTest;
+import com.mongodb.lang.Nullable;
+import com.mongodb.reactivestreams.client.MongoClients;
+import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
+public class UnifiedCrudTest extends UnifiedTest {
+    @SuppressWarnings("FieldCanBeLocal")
+    private final String fileDescription;
+    @SuppressWarnings("FieldCanBeLocal")
+    private final String testDescription;
+
+    public UnifiedCrudTest(final String fileDescription, final String testDescription, final String schemaVersion,
+                            @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
+                            final BsonDocument definition) {
+        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+        this.fileDescription = fileDescription;
+        this.testDescription = testDescription;
+    }
+
+    @Override
+    protected MongoClient createMongoClient(final MongoClientSettings settings) {
+        return new SyncMongoClient(MongoClients.create(settings));
+    }
+
+    @Parameterized.Parameters(name = "{0}: {1}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        return getTestData("unified-test-format/crud");
+    }
+}

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
@@ -59,7 +59,6 @@ import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 import com.mongodb.internal.bulk.WriteRequest;
-import com.mongodb.internal.client.model.CountStrategy;
 import com.mongodb.internal.client.model.changestream.ChangeStreamLevel;
 import com.mongodb.internal.operation.IndexHelper;
 import com.mongodb.internal.operation.RenameCollectionOperation;
@@ -82,7 +81,6 @@ import static com.mongodb.internal.bulk.WriteRequest.Type.DELETE;
 import static com.mongodb.internal.bulk.WriteRequest.Type.INSERT;
 import static com.mongodb.internal.bulk.WriteRequest.Type.REPLACE;
 import static com.mongodb.internal.bulk.WriteRequest.Type.UPDATE;
-import static com.mongodb.internal.client.model.CountOptionsHelper.fromEstimatedDocumentCountOptions;
 import static java.util.Collections.singletonList;
 import static org.bson.internal.CodecRegistryHelper.createRegistry;
 
@@ -189,7 +187,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public long countDocuments(final Bson filter, final CountOptions options) {
-        return executeCount(null, filter, options, CountStrategy.AGGREGATE);
+        return executeCount(null, filter, options);
     }
 
     @Override
@@ -205,7 +203,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     @Override
     public long countDocuments(final ClientSession clientSession, final Bson filter, final CountOptions options) {
         notNull("clientSession", clientSession);
-        return executeCount(clientSession, filter, options, CountStrategy.AGGREGATE);
+        return executeCount(clientSession, filter, options);
     }
 
     @Override
@@ -215,12 +213,11 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public long estimatedDocumentCount(final EstimatedDocumentCountOptions options) {
-        return executeCount(null, new BsonDocument(), fromEstimatedDocumentCountOptions(options), CountStrategy.COMMAND);
+        return executor.execute(operations.estimatedDocumentCount(options), readPreference, readConcern, null);
     }
 
-    private long executeCount(@Nullable final ClientSession clientSession, final Bson filter, final CountOptions options,
-                              final CountStrategy countStrategy) {
-        return executor.execute(operations.count(filter, options, countStrategy), readPreference, readConcern, clientSession);
+    private long executeCount(@Nullable final ClientSession clientSession, final Bson filter, final CountOptions options) {
+        return executor.execute(operations.countDocuments(filter, options), readPreference, readConcern, clientSession);
     }
 
     @Override

--- a/driver-sync/src/test/functional/com/mongodb/client/ReadConcernTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ReadConcernTest.java
@@ -28,6 +28,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -68,18 +69,16 @@ public class ReadConcernTest {
     @Test
     public void shouldIncludeReadConcernInCommand() {
         mongoClient.getDatabase(getDefaultDatabaseName()).getCollection("test")
-                .withReadConcern(ReadConcern.LOCAL).estimatedDocumentCount();
+                .withReadConcern(ReadConcern.LOCAL).find().into(new ArrayList<>());
 
         List<CommandEvent> events = commandListener.getCommandStartedEvents();
 
-        BsonDocument commandDocument = new BsonDocument("count", new BsonString("test"))
+        BsonDocument commandDocument = new BsonDocument("find", new BsonString("test"))
                 .append("readConcern", ReadConcern.LOCAL.asDocument())
-                .append("query", new BsonDocument());
-        if (serverVersionAtLeast(3, 6)) {
-            commandDocument.put("$db", new BsonString(getDefaultDatabaseName()));
-        }
+                .append("filter", new BsonDocument());
+
         assertEventsEquality(Arrays.<CommandEvent>asList(new CommandStartedEvent(1, null, getDefaultDatabaseName(),
-                        "count", commandDocument)), events);
+                        "find", commandDocument)), events);
     }
 
     private boolean canRunTests() {

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/ErrorMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/ErrorMatcher.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 final class ErrorMatcher {
     private static final Set<String> EXPECTED_ERROR_FIELDS = new HashSet<>(
-            asList("isError", "expectError", "isClientError", "errorCodeName", "errorContains",
+            asList("isError", "expectError", "isClientError", "errorCode", "errorCodeName", "errorContains",
                     "isClientError", "errorLabelsOmit", "errorLabelsContain", "expectResult"));
 
     private final AssertionContext context;
@@ -63,6 +63,13 @@ final class ErrorMatcher {
             String errorContains = expectedError.getString("errorContains").getValue();
             assertTrue(context.getMessage("Error message does not contain expected string: " + errorContains),
                     mongoCommandException.getErrorMessage().contains(errorContains));
+        }
+        if (expectedError.containsKey("errorCode")) {
+            assertTrue(context.getMessage("Exception must be of type MongoCommandException when checking for error codes"),
+                    e instanceof MongoCommandException);
+            MongoCommandException mongoCommandException = (MongoCommandException) e;
+            assertEquals(context.getMessage("Error codes must match"), expectedError.getNumber("errorCode").intValue(),
+                    mongoCommandException.getErrorCode());
         }
         if (expectedError.containsKey("errorCodeName")) {
             assertTrue(context.getMessage("Exception must be of type MongoCommandException when checking for error codes"),

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.unified;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
+public class UnifiedCrudTest extends UnifiedTest {
+
+    @SuppressWarnings("FieldCanBeLocal")
+    private final String fileDescription;
+    @SuppressWarnings("FieldCanBeLocal")
+    private final String testDescription;
+
+    public UnifiedCrudTest(final String fileDescription, final String testDescription, final String schemaVersion,
+                            @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
+                            final BsonDocument definition) {
+        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+        this.fileDescription = fileDescription;
+        this.testDescription = testDescription;
+    }
+
+    @Override
+    protected MongoClient createMongoClient(final MongoClientSettings settings) {
+        return MongoClients.create(settings);
+    }
+
+    @Parameterized.Parameters(name = "{0}: {1}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        return getTestData("unified-test-format/crud");
+    }}


### PR DESCRIPTION
There are three commits, which I'll summarize here:

1. Refactor CountOperation into three operations: CountOperation was already complex in that it was supporting three different use cases.  One for estimatedDocumentCount, one for countDocuments, and one for the legacy DBCollection.count.  Trying to add the $collStats support into this class was going to make it even messier, as now there would be two different aggregation pipelines.  It was just too much, so I split it out, which allowed me to get rid of all the conditional logic.  
2. Add support for errorCode to unified test runner.  This was just a small missing piece that was needed by the new tests
3. The last commit is the functional change required by the spec, plus all the new tests.

JAVA-3989