### PR TITLE
Add specialized unified test runner for valid-fail tests

### DIFF
--- a/driver-core/src/test/resources/unified-test-format/valid-fail/entity-bucket-database-undefined.json
+++ b/driver-core/src/test/resources/unified-test-format/valid-fail/entity-bucket-database-undefined.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-bucket-database-undefined",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/valid-fail/entity-client-apiVersion-unsupported.json
+++ b/driver-core/src/test/resources/unified-test-format/valid-fail/entity-client-apiVersion-unsupported.json
@@ -1,0 +1,20 @@
+{
+  "description": "entity-client-apiVersion-unsupported",
+  "schemaVersion": "1.1",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "serverApi": {
+          "version": "server_will_never_support_this_api_version"
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/valid-fail/entity-collection-database-undefined.json
+++ b/driver-core/src/test/resources/unified-test-format/valid-fail/entity-collection-database-undefined.json
@@ -1,0 +1,19 @@
+{
+  "description": "entity-collection-database-undefined",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "foo",
+        "collectionName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/valid-fail/entity-database-client-undefined.json
+++ b/driver-core/src/test/resources/unified-test-format/valid-fail/entity-database-client-undefined.json
@@ -1,0 +1,19 @@
+{
+  "description": "entity-database-client-undefined",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "database": {
+        "id": "database0",
+        "client": "foo",
+        "databaseName": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/valid-fail/entity-session-client-undefined.json
+++ b/driver-core/src/test/resources/unified-test-format/valid-fail/entity-session-client-undefined.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-session-client-undefined",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "session": {
+        "id": "session0",
+        "client": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/valid-fail/operation-failure.json
+++ b/driver-core/src/test/resources/unified-test-format/valid-fail/operation-failure.json
@@ -1,0 +1,56 @@
+{
+  "description": "operation-failure",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "operation-failure"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Unsupported command",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "unsupportedCommand",
+            "command": {
+              "unsupportedCommand": 1
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Unsupported query operator",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "$unsupportedQueryOperator": 1
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/valid-fail/returnDocument-enum-invalid.json
+++ b/driver-core/src/test/resources/unified-test-format/valid-fail/returnDocument-enum-invalid.json
@@ -1,0 +1,66 @@
+{
+  "description": "returnDocument-enum-invalid",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "FindOneAndReplace returnDocument invalid enum value",
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "x": 111
+            },
+            "returnDocument": "invalid"
+          }
+        }
+      ]
+    },
+    {
+      "description": "FindOneAndUpdate returnDocument invalid enum value",
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "invalid"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/valid-fail/schemaVersion-unsupported.json
+++ b/driver-core/src/test/resources/unified-test-format/valid-fail/schemaVersion-unsupported.json
@@ -1,0 +1,10 @@
+{
+  "description": "schemaVersion-unsupported",
+  "schemaVersion": "0.1",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestFailureValidator.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestFailureValidator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.unified;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
+public class UnifiedTestFailureValidator extends UnifiedTest {
+    private final String fileDescription;
+    private final String testDescription;
+    private Throwable setupException;
+
+    public UnifiedTestFailureValidator(final String fileDescription, final String testDescription, final String schemaVersion,
+                                       @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
+                                       final BsonDocument definition) {
+        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+        this.fileDescription = fileDescription;
+        this.testDescription = testDescription;
+    }
+
+    @Before
+    public void setUp() {
+        try {
+            super.setUp();
+        } catch (Throwable e) {
+            setupException = e;
+        }
+    }
+
+    @Test(expected = Throwable.class)
+    public void shouldPassAllOutcomes() {
+        if (setupException != null) {
+            throw new AssertionError("Setup failed (expected)", setupException);
+        } else {
+            super.shouldPassAllOutcomes();
+        }
+    }
+
+    @Override
+    protected MongoClient createMongoClient(final MongoClientSettings settings) {
+        return MongoClients.create(settings);
+    }
+
+    @Parameterized.Parameters(name = "{0}: {1}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        return getTestData("unified-test-format/valid-fail");
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestFailureValidator.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestFailureValidator.java
@@ -30,35 +30,37 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class UnifiedTestFailureValidator extends UnifiedTest {
-    private final String fileDescription;
-    private final String testDescription;
-    private Throwable setupException;
+import static org.junit.Assert.assertNotNull;
 
-    public UnifiedTestFailureValidator(final String fileDescription, final String testDescription, final String schemaVersion,
-                                       @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
-                                       final BsonDocument definition) {
+public class UnifiedTestFailureValidator extends UnifiedTest {
+    private Throwable exception;
+
+    public UnifiedTestFailureValidator(@SuppressWarnings("unused") final String fileDescription,
+                                       @SuppressWarnings("unused") final String testDescription,
+                                       final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
+                                       final BsonArray initialData, final BsonDocument definition) {
         super(schemaVersion, runOnRequirements, entities, initialData, definition);
-        this.fileDescription = fileDescription;
-        this.testDescription = testDescription;
     }
 
     @Before
     public void setUp() {
         try {
             super.setUp();
-        } catch (Throwable e) {
-            setupException = e;
+        } catch (AssertionError | RuntimeException e) {
+            exception = e;
         }
     }
 
-    @Test(expected = Throwable.class)
+    @Test
     public void shouldPassAllOutcomes() {
-        if (setupException != null) {
-            throw new AssertionError("Setup failed (expected)", setupException);
-        } else {
-            super.shouldPassAllOutcomes();
+        if (exception == null) {
+            try {
+                super.shouldPassAllOutcomes();
+            } catch (AssertionError | RuntimeException e) {
+                exception = e;
+            }
         }
+        assertNotNull("Excepted exception but not was thrown", exception);
     }
 
     @Override

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestFailureValidator.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestFailureValidator.java
@@ -60,7 +60,7 @@ public class UnifiedTestFailureValidator extends UnifiedTest {
                 exception = e;
             }
         }
-        assertNotNull("Excepted exception but not was thrown", exception);
+        assertNotNull("Expected exception but not was thrown", exception);
     }
 
     @Override


### PR DESCRIPTION
This runner is strange because we actually want the test to pass only if the
actual unified test runner fails.  Due to the nature of the tests the failure
can happen either in the setup method or in the actual test, so we have to
handle both cases.

JAVA-4003

I hadn't done this with the original batch of valid-fail tests, but with JAVA-4003 being a test for something the Java driver got wrong in the original implementation, I decided to find a way to run all of the valid-fail tests, which are included in this patch as well as the one specific to JAVA-4003.

This seems like a pretty hacky way to run these tests, so please let me know if you have any other ideas.