### PR TITLE
docs: Fix builder links

### DIFF
--- a/docs/reference/content/builders/index.md
+++ b/docs/reference/content/builders/index.md
@@ -11,10 +11,10 @@ title = "Builders"
 
 The driver provides several classes that make it easier to use the CRUD API.
 
-- [Filters]({{< relref "filters.md" >}}): Documentation of the driver's support for building query filters
-- [Projections]({{< relref "projections.md" >}}): Documentation of the driver's support for building projections
-- [Sorts]({{< relref "sorts.md" >}}): Documentation of the driver's support for building sort criteria
-- [Aggregation]({{< relref "aggregation.md" >}}): Documentation of the driver's support for building aggregation pipelines
-- [Updates]({{< relref "updates.md" >}}): Documentation of the driver's support for building updates
-- [Indexes]({{< relref "indexes.md" >}}): Documentation of the driver's support for creating index keys
+- [Filters]({{< relref "builders/filters.md" >}}): Documentation of the driver's support for building query filters
+- [Projections]({{< relref "builders/projections.md" >}}): Documentation of the driver's support for building projections
+- [Sorts]({{< relref "builders/sorts.md" >}}): Documentation of the driver's support for building sort criteria
+- [Aggregation]({{< relref "builders/aggregation.md" >}}): Documentation of the driver's support for building aggregation pipelines
+- [Updates]({{< relref "builders/updates.md" >}}): Documentation of the driver's support for building updates
+- [Indexes]({{< relref "builders/indexes.md" >}}): Documentation of the driver's support for creating index keys
 

--- a/docs/reference/content/driver-reactive/tutorials/aggregation.md
+++ b/docs/reference/content/driver-reactive/tutorials/aggregation.md
@@ -97,8 +97,7 @@ collection.aggregate(
 ### Explain an Aggregation
 
 To [explain]({{< docsref "reference/command/explain/" >}}) an aggregation pipeline, call the
-[`AggregatePublisher.explain()`]({{< apiref "mongodb-driver-reactivestreams" "com/mongodb/reactivestreams/client/AggregatePublisher.html#explain()" 
-> >}}) 
+[`AggregatePublisher.explain()`]({{< apiref "mongodb-driver-reactivestreams" "com/mongodb/reactivestreams/client/AggregatePublisher.html#explain()" >}})
 method:
 
 ```java


### PR DESCRIPTION
Updates the links on the builder's index page to link to the correct pages. They [currently link](https://mongodb.github.io/mongo-java-driver/4.2/builders/) to the scala builders.