### PR TITLE
Update error handling logic

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/ProtocolHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ProtocolHelper.java
@@ -53,6 +53,7 @@ import java.util.List;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.bson.codecs.BsonValueCodecProvider.getClassForBsonType;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 
@@ -62,6 +63,7 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 public final class ProtocolHelper {
     private static final Logger PROTOCOL_EVENT_LOGGER = Loggers.getLogger("protocol.event");
     private static final CodecRegistry REGISTRY = fromProviders(new BsonValueCodecProvider());
+    private static final int NO_ERROR_CODE = -1;
 
     private static WriteConcernResult createWriteResult(final BsonDocument result) {
         BsonBoolean updatedExisting = result.getBoolean("updatedExisting", BsonBoolean.FALSE);
@@ -226,8 +228,10 @@ public final class ProtocolHelper {
         }
     }
 
-    private static final List<Integer> NOT_MASTER_CODES = asList(10107, 13435);
+    private static final List<Integer> NOT_PRIMARY_CODES = asList(10107, 13435, 10058);
+    private static final List<String> NOT_PRIMARY_MESSAGES = singletonList("not master");
     private static final List<Integer> RECOVERING_CODES = asList(11600, 11602, 13436, 189, 91);
+    private static final List<String> RECOVERING_MESSAGES = asList("not master or secondary", "node is recovering");
     public static MongoException createSpecialException(final BsonDocument response, final ServerAddress serverAddress,
                                                         final String errorMessageFieldName) {
         if (response == null) {
@@ -237,10 +241,9 @@ public final class ProtocolHelper {
         String errorMessage = getErrorMessage(response, errorMessageFieldName);
         if (ErrorCategory.fromErrorCode(errorCode) == ErrorCategory.EXECUTION_TIMEOUT) {
             return new MongoExecutionTimeoutException(errorCode, errorMessage, response);
-        } else if (errorMessage.contains("not master or secondary") || errorMessage.contains("node is recovering")
-                || RECOVERING_CODES.contains(errorCode)) {
+        } else if (isNodeIsRecoveringError(errorCode, errorMessage)) {
             return new MongoNodeIsRecoveringException(response, serverAddress);
-        } else if (errorMessage.contains("not master") || NOT_MASTER_CODES.contains(errorCode)) {
+        } else if (isNotPrimaryError(errorCode, errorMessage)) {
             return new MongoNotPrimaryException(response, serverAddress);
         } else if (response.containsKey("writeConcernError")) {
             return createSpecialException(response.getDocument("writeConcernError"), serverAddress, "errmsg");
@@ -249,6 +252,15 @@ public final class ProtocolHelper {
         }
     }
 
+    private static boolean isNotPrimaryError(final int errorCode, final String errorMessage) {
+        return NOT_PRIMARY_CODES.contains(errorCode)
+                || (errorCode == NO_ERROR_CODE && NOT_PRIMARY_MESSAGES.stream().anyMatch(errorMessage::contains));
+    }
+
+    private static boolean isNodeIsRecoveringError(final int errorCode, final String errorMessage) {
+        return RECOVERING_CODES.contains(errorCode)
+                || (errorCode == NO_ERROR_CODE && (RECOVERING_MESSAGES.stream().anyMatch(errorMessage::contains)));
+    }
 
 
     private static boolean hasWriteError(final BsonDocument response) {

--- a/driver-core/src/test/resources/server-discovery-and-monitoring/errors/non-stale-topologyVersion-greater-LegacyNotPrimary.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/errors/non-stale-topologyVersion-greater-LegacyNotPrimary.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation timeout error beforeHandshakeCompletes",
+  "description": "Non-stale topologyVersion greater LegacyNotPrimary error",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -51,108 +51,46 @@
       }
     },
     {
-      "description": "Non-stale application network error",
+      "description": "Non-stale topologyVersion greater LegacyNotPrimary error marks server Unknown",
       "applicationErrors": [
         {
           "address": "a:27017",
           "when": "afterHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "network"
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "2"
+              }
+            }
+          }
         }
       ],
       "outcome": {
         "servers": {
           "a:27017": {
             "type": "Unknown",
-            "topologyVersion": null,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "2"
+              }
+            },
             "pool": {
-              "generation": 1
+              "generation": 0
             }
           }
         },
         "topologyType": "ReplicaSetNoPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
-      }
-    },
-    {
-      "description": "Primary A is rediscovered",
-      "responses": [
-        [
-          "a:27017",
-          {
-            "ok": 1,
-            "ismaster": true,
-            "hosts": [
-              "a:27017"
-            ],
-            "setName": "rs",
-            "minWireVersion": 0,
-            "maxWireVersion": 9,
-            "topologyVersion": {
-              "processId": {
-                "$oid": "000000000000000000000001"
-              },
-              "counter": {
-                "$numberLong": "1"
-              }
-            }
-          }
-        ]
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "topologyVersion": {
-              "processId": {
-                "$oid": "000000000000000000000001"
-              },
-              "counter": {
-                "$numberLong": "1"
-              }
-            },
-            "pool": {
-              "generation": 1
-            }
-          }
-        },
-        "topologyType": "ReplicaSetWithPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
-      }
-    },
-    {
-      "description": "Ignore stale timeout error (stale generation)",
-      "applicationErrors": [
-        {
-          "address": "a:27017",
-          "generation": 0,
-          "when": "beforeHandshakeCompletes",
-          "maxWireVersion": 9,
-          "type": "timeout"
-        }
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "RSPrimary",
-            "setName": "rs",
-            "topologyVersion": {
-              "processId": {
-                "$oid": "000000000000000000000001"
-              },
-              "counter": {
-                "$numberLong": "1"
-              }
-            },
-            "pool": {
-              "generation": 1
-            }
-          }
-        },
-        "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
         "setName": "rs"
       }

--- a/driver-core/src/test/resources/server-discovery-and-monitoring/errors/non-stale-topologyVersion-missing-LegacyNotPrimary.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/errors/non-stale-topologyVersion-missing-LegacyNotPrimary.json
@@ -1,0 +1,84 @@
+{
+  "description": "Non-stale topologyVersion missing LegacyNotPrimary error",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "description": "Primary A is discovered",
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            },
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "description": "Non-stale topologyVersion missing LegacyNotPrimary error marks server Unknown",
+      "applicationErrors": [
+        {
+          "address": "a:27017",
+          "when": "afterHandshakeCompletes",
+          "maxWireVersion": 9,
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058
+          }
+        }
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "topologyVersion": null,
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/server-discovery-and-monitoring/errors/non-stale-topologyVersion-proccessId-changed-LegacyNotPrimary.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/errors/non-stale-topologyVersion-proccessId-changed-LegacyNotPrimary.json
@@ -1,0 +1,99 @@
+{
+  "description": "Non-stale topologyVersion proccessId changed LegacyNotPrimary error",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "description": "Primary A is discovered",
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 9,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            },
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "description": "Non-stale topologyVersion proccessId changed LegacyNotPrimary error marks server Unknown",
+      "applicationErrors": [
+        {
+          "address": "a:27017",
+          "when": "afterHandshakeCompletes",
+          "maxWireVersion": 9,
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000002"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000002"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            },
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/server-discovery-and-monitoring/errors/post-42-LegacyNotPrimary.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/errors/post-42-LegacyNotPrimary.json
@@ -1,0 +1,69 @@
+{
+  "description": "Post-4.2 LegacyNotPrimary error",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "description": "Primary A is discovered",
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 8
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": null,
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "description": "Post-4.2 LegacyNotPrimary error marks server Unknown",
+      "applicationErrors": [
+        {
+          "address": "a:27017",
+          "when": "afterHandshakeCompletes",
+          "maxWireVersion": 8,
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058
+          }
+        }
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "topologyVersion": null,
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/server-discovery-and-monitoring/errors/pre-42-LegacyNotPrimary.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/errors/pre-42-LegacyNotPrimary.json
@@ -1,0 +1,69 @@
+{
+  "description": "Pre-4.2 LegacyNotPrimary error",
+  "uri": "mongodb://a/?replicaSet=rs",
+  "phases": [
+    {
+      "description": "Primary A is discovered",
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "hosts": [
+              "a:27017"
+            ],
+            "setName": "rs",
+            "minWireVersion": 0,
+            "maxWireVersion": 7
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs",
+            "topologyVersion": null,
+            "pool": {
+              "generation": 0
+            }
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "description": "Pre-4.2 LegacyNotPrimary error marks server Unknown and clears the pool",
+      "applicationErrors": [
+        {
+          "address": "a:27017",
+          "when": "afterHandshakeCompletes",
+          "maxWireVersion": 7,
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058
+          }
+        }
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "Unknown",
+            "topologyVersion": null,
+            "pool": {
+              "generation": 1
+            }
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/server-discovery-and-monitoring/errors/prefer-error-code.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/errors/prefer-error-code.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation timeout error beforeHandshakeCompletes",
+  "description": "Do not check errmsg when code exists",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -51,54 +51,19 @@
       }
     },
     {
-      "description": "Non-stale application network error",
+      "description": "errmsg \"not master\" gets ignored when error code exists",
       "applicationErrors": [
         {
           "address": "a:27017",
           "when": "afterHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "network"
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "not master",
+            "code": 1
+          }
         }
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "Unknown",
-            "topologyVersion": null,
-            "pool": {
-              "generation": 1
-            }
-          }
-        },
-        "topologyType": "ReplicaSetNoPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
-      }
-    },
-    {
-      "description": "Primary A is rediscovered",
-      "responses": [
-        [
-          "a:27017",
-          {
-            "ok": 1,
-            "ismaster": true,
-            "hosts": [
-              "a:27017"
-            ],
-            "setName": "rs",
-            "minWireVersion": 0,
-            "maxWireVersion": 9,
-            "topologyVersion": {
-              "processId": {
-                "$oid": "000000000000000000000001"
-              },
-              "counter": {
-                "$numberLong": "1"
-              }
-            }
-          }
-        ]
       ],
       "outcome": {
         "servers": {
@@ -114,7 +79,7 @@
               }
             },
             "pool": {
-              "generation": 1
+              "generation": 0
             }
           }
         },
@@ -124,14 +89,18 @@
       }
     },
     {
-      "description": "Ignore stale timeout error (stale generation)",
+      "description": "errmsg \"node is recovering\" gets ignored when error code exists",
       "applicationErrors": [
         {
           "address": "a:27017",
-          "generation": 0,
-          "when": "beforeHandshakeCompletes",
+          "when": "afterHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "timeout"
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "node is recovering",
+            "code": 1
+          }
         }
       ],
       "outcome": {
@@ -148,7 +117,7 @@
               }
             },
             "pool": {
-              "generation": 1
+              "generation": 0
             }
           }
         },

--- a/driver-core/src/test/resources/server-discovery-and-monitoring/errors/stale-generation-afterHandshakeCompletes-LegacyNotPrimary.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/errors/stale-generation-afterHandshakeCompletes-LegacyNotPrimary.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation timeout error beforeHandshakeCompletes",
+  "description": "Stale generation LegacyNotPrimary error afterHandshakeCompletes",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -124,14 +124,27 @@
       }
     },
     {
-      "description": "Ignore stale timeout error (stale generation)",
+      "description": "Ignore stale LegacyNotPrimary error (stale generation)",
       "applicationErrors": [
         {
           "address": "a:27017",
           "generation": 0,
-          "when": "beforeHandshakeCompletes",
+          "when": "afterHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "timeout"
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "2"
+              }
+            }
+          }
         }
       ],
       "outcome": {

--- a/driver-core/src/test/resources/server-discovery-and-monitoring/errors/stale-generation-afterHandshakeCompletes-network.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/errors/stale-generation-afterHandshakeCompletes-network.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation NotMasterNoSlaveOk error afterHandshakeCompletes",
+  "description": "Stale generation network error afterHandshakeCompletes",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -124,7 +124,7 @@
       }
     },
     {
-      "description": "Ignore stale NotMasterNoSlaveOk error (stale generation)",
+      "description": "Ignore stale network error (stale generation)",
       "applicationErrors": [
         {
           "address": "a:27017",

--- a/driver-core/src/test/resources/server-discovery-and-monitoring/errors/stale-generation-afterHandshakeCompletes-timeout.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/errors/stale-generation-afterHandshakeCompletes-timeout.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation NotMasterNoSlaveOk error afterHandshakeCompletes",
+  "description": "Stale generation timeout error afterHandshakeCompletes",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -124,7 +124,7 @@
       }
     },
     {
-      "description": "Ignore stale NotMasterNoSlaveOk error (stale generation)",
+      "description": "Ignore stale timeout error (stale generation)",
       "applicationErrors": [
         {
           "address": "a:27017",

--- a/driver-core/src/test/resources/server-discovery-and-monitoring/errors/stale-generation-beforeHandshakeCompletes-LegacyNotPrimary.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/errors/stale-generation-beforeHandshakeCompletes-LegacyNotPrimary.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation timeout error beforeHandshakeCompletes",
+  "description": "Stale generation LegacyNotPrimary error beforeHandshakeCompletes",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -124,14 +124,27 @@
       }
     },
     {
-      "description": "Ignore stale timeout error (stale generation)",
+      "description": "Ignore stale LegacyNotPrimary error (stale generation)",
       "applicationErrors": [
         {
           "address": "a:27017",
           "generation": 0,
           "when": "beforeHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "timeout"
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "2"
+              }
+            }
+          }
         }
       ],
       "outcome": {

--- a/driver-core/src/test/resources/server-discovery-and-monitoring/errors/stale-generation-beforeHandshakeCompletes-network.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/errors/stale-generation-beforeHandshakeCompletes-network.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation NotMasterNoSlaveOk error beforeHandshakeCompletes",
+  "description": "Stale generation network error beforeHandshakeCompletes",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -124,7 +124,7 @@
       }
     },
     {
-      "description": "Ignore stale NotMasterNoSlaveOk error (stale generation)",
+      "description": "Ignore stale network error (stale generation)",
       "applicationErrors": [
         {
           "address": "a:27017",

--- a/driver-core/src/test/resources/server-discovery-and-monitoring/errors/stale-topologyVersion-LegacyNotPrimary.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/errors/stale-topologyVersion-LegacyNotPrimary.json
@@ -1,5 +1,5 @@
 {
-  "description": "Stale generation timeout error beforeHandshakeCompletes",
+  "description": "Stale topologyVersion LegacyNotPrimary error",
   "uri": "mongodb://a/?replicaSet=rs",
   "phases": [
     {
@@ -51,54 +51,27 @@
       }
     },
     {
-      "description": "Non-stale application network error",
+      "description": "Ignore stale LegacyNotPrimary error (topologyVersion less)",
       "applicationErrors": [
         {
           "address": "a:27017",
           "when": "afterHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "network"
-        }
-      ],
-      "outcome": {
-        "servers": {
-          "a:27017": {
-            "type": "Unknown",
-            "topologyVersion": null,
-            "pool": {
-              "generation": 1
-            }
-          }
-        },
-        "topologyType": "ReplicaSetNoPrimary",
-        "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
-      }
-    },
-    {
-      "description": "Primary A is rediscovered",
-      "responses": [
-        [
-          "a:27017",
-          {
-            "ok": 1,
-            "ismaster": true,
-            "hosts": [
-              "a:27017"
-            ],
-            "setName": "rs",
-            "minWireVersion": 0,
-            "maxWireVersion": 9,
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058,
             "topologyVersion": {
               "processId": {
                 "$oid": "000000000000000000000001"
               },
               "counter": {
-                "$numberLong": "1"
+                "$numberLong": "0"
               }
             }
           }
-        ]
+        }
       ],
       "outcome": {
         "servers": {
@@ -114,7 +87,7 @@
               }
             },
             "pool": {
-              "generation": 1
+              "generation": 0
             }
           }
         },
@@ -124,14 +97,26 @@
       }
     },
     {
-      "description": "Ignore stale timeout error (stale generation)",
+      "description": "Ignore stale LegacyNotPrimary error (topologyVersion equal)",
       "applicationErrors": [
         {
           "address": "a:27017",
-          "generation": 0,
-          "when": "beforeHandshakeCompletes",
+          "when": "afterHandshakeCompletes",
           "maxWireVersion": 9,
-          "type": "timeout"
+          "type": "command",
+          "response": {
+            "ok": 0,
+            "errmsg": "LegacyNotPrimary",
+            "code": 10058,
+            "topologyVersion": {
+              "processId": {
+                "$oid": "000000000000000000000001"
+              },
+              "counter": {
+                "$numberLong": "1"
+              }
+            }
+          }
         }
       ],
       "outcome": {
@@ -148,7 +133,7 @@
               }
             },
             "pool": {
-              "generation": 1
+              "generation": 0
             }
           }
         },


### PR DESCRIPTION
Update logic for throwing MongoNotPrimaryException or MongoNodeIsRecoveringException:

* Add 10058 to the list of error codes that cause MongoNotPrimaryException
  to be thrown.
* Only examine error messages when no error code is included in the reply.

JAVA-3986