### PR TITLE
Backport to 4.2.x JAVA-4044/PR#689 and the changes it depends on (JAVA-3938 & JAVA-3907 / PR#661)

### DIFF
--- a/driver-core/src/main/com/mongodb/assertions/Assertions.java
+++ b/driver-core/src/main/com/mongodb/assertions/Assertions.java
@@ -18,11 +18,18 @@
 package com.mongodb.assertions;
 
 import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.lang.Nullable;
 
 import java.util.Collection;
 
 /**
  * <p>Design by contract assertions.</p> <p>This class is not part of the public API and may be removed or changed at any time.</p>
+ * All {@code assert...} methods throw {@link AssertionError} and should be used to check conditions which may be violated if and only if
+ * the driver code is incorrect. The intended usage of this methods is the same as of the
+ * <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/language/assert.html">Java {@code assert} statement</a>. The reason
+ * for not using the {@code assert} statements is that they are not always enabled. We prefer having internal checks always done at the
+ * cost of our code doing a relatively small amount of additional work in production.
+ * The {@code assert...} methods return values to open possibilities of being used fluently.
  */
 public final class Assertions {
     /**
@@ -117,6 +124,57 @@ public final class Assertions {
                 throw new IllegalArgumentException(name + " can not contain a null value");
             }
         }
+    }
+
+    /**
+     * @param value A value to check.
+     * @param <T> The type of {@code value}.
+     * @return {@code null}.
+     * @throws AssertionError If {@code value} is not {@code null}.
+     */
+    @Nullable
+    public static <T> T assertNull(@Nullable final T value) throws AssertionError {
+        if (value != null) {
+            throw new AssertionError(value.toString());
+        }
+        return null;
+    }
+
+    /**
+     * @param value A value to check.
+     * @param <T> The type of {@code value}.
+     * @return {@code value}
+     * @throws AssertionError If {@code value} is {@code null}.
+     */
+    public static <T> T assertNotNull(@Nullable final T value) throws AssertionError {
+        if (value == null) {
+            throw new AssertionError();
+        }
+        return value;
+    }
+
+    /**
+     * @param value A value to check.
+     * @return {@code true}.
+     * @throws AssertionError If {@code value} is {@code false}.
+     */
+    public static boolean assertTrue(final boolean value) throws AssertionError {
+        if (!value) {
+            throw new AssertionError();
+        }
+        return true;
+    }
+
+    /**
+     * @param value A value to check.
+     * @return {@code false}.
+     * @throws AssertionError If {@code value} is {@code true}.
+     */
+    public static boolean assertFalse(final boolean value) throws AssertionError {
+        if (value) {
+            throw new AssertionError();
+        }
+        return false;
     }
 
     private Assertions() {

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncBatchCursor.java
@@ -65,12 +65,24 @@ public interface AsyncBatchCursor<T> extends Closeable {
     int getBatchSize();
 
     /**
-     * Return true if the AsyncBatchCursor has been closed
+     * Implementations of {@link AsyncBatchCursor} are allowed to close themselves, see {@link #close()} for more details.
      *
-     * @return true if the AsyncBatchCursor has been closed
+     * @return {@code true} if {@code this} has been closed or has closed itself.
      */
     boolean isClosed();
 
+    /**
+     * Implementations of {@link AsyncBatchCursor} are allowed to close themselves synchronously via methods
+     * {@link #next(SingleResultCallback)}/{@link #tryNext(SingleResultCallback)}.
+     * Self-closing behavior is discouraged because it introduces an additional burden on code that uses {@link AsyncBatchCursor}.
+     * To help making such code simpler, this method is required to be idempotent.
+     * <p>
+     * Another quirk is that this method is allowed to release resources "eventually",
+     * i.e., not before (in the happens before order) returning.
+     * Nevertheless, {@link #isClosed()} called after (in the happens-before order) {@link #close()} must return {@code true}.
+     *
+     * @see #close()
+     */
     @Override
     void close();
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ChangeStreamsCancellationTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ChangeStreamsCancellationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client;
+
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
+import static com.mongodb.reactivestreams.client.Fixture.drop;
+import static com.mongodb.reactivestreams.client.Fixture.getDefaultDatabase;
+import static com.mongodb.reactivestreams.client.Fixture.isReplicaSet;
+import static com.mongodb.reactivestreams.client.Fixture.serverVersionAtLeast;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class ChangeStreamsCancellationTest {
+
+    private MongoCollection<Document> collection;
+
+    @BeforeEach
+    public void setup() {
+        assumeTrue(isReplicaSet() && serverVersionAtLeast(3, 6));
+        collection = getDefaultDatabase().getCollection("changeStreamsCancellationTest");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (collection != null) {
+            drop(collection.getNamespace());
+        }
+    }
+
+    @Test
+    public void testCancelReleasesSessions() {
+        Mono.from(collection.insertOne(new Document())).block(TIMEOUT_DURATION);
+
+        TestSubscriber<ChangeStreamDocument<Document>> subscriber = new TestSubscriber<>();
+        subscriber.doOnSubscribe(sub -> {
+            sub.request(Integer.MAX_VALUE);
+            new Thread(() -> {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Sleep interrupted");
+                }
+                sub.cancel();
+            }).start();
+        });
+        collection.watch().subscribe(subscriber);
+
+        assertDoesNotThrow(Fixture::waitForLastServerSessionPoolRelease);
+    }
+
+}

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/TestSubscriber.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/TestSubscriber.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
@@ -33,6 +34,8 @@ public class TestSubscriber<T> implements Subscriber<T> {
     private final ArrayList<Throwable> onErrorEvents = new ArrayList<>();
     private final ArrayList<Void> onCompleteEvents = new ArrayList<>();
 
+    private Consumer<Subscription> doOnSubscribe = sub -> {};
+
     private Subscription subscription;
 
     public TestSubscriber() {
@@ -41,6 +44,11 @@ public class TestSubscriber<T> implements Subscriber<T> {
     @Override
     public void onSubscribe(final Subscription subscription) {
         this.subscription = subscription;
+        doOnSubscribe.accept(subscription);
+    }
+
+    public void doOnSubscribe(final Consumer<Subscription> doOnSubscribe) {
+        this.doOnSubscribe = doOnSubscribe;
     }
 
     /**

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorFluxTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorFluxTest.java
@@ -16,6 +16,8 @@
 package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.MongoClientSettings;
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import com.mongodb.client.result.InsertOneResult;
 import com.mongodb.event.CommandEvent;
 import com.mongodb.internal.connection.TestCommandListener;
 import com.mongodb.reactivestreams.client.FindPublisher;
@@ -23,12 +25,20 @@ import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import com.mongodb.reactivestreams.client.TestSubscriber;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.BsonTimestamp;
+import org.bson.BsonValue;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -39,12 +49,16 @@ import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
 import static com.mongodb.ClusterFixture.getDefaultDatabaseName;
 import static com.mongodb.reactivestreams.client.Fixture.drop;
 import static com.mongodb.reactivestreams.client.Fixture.getMongoClientBuilderFromConnectionString;
+import static com.mongodb.reactivestreams.client.Fixture.isReplicaSet;
+import static com.mongodb.reactivestreams.client.Fixture.serverVersionAtLeast;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
@@ -269,6 +283,21 @@ public class BatchCursorFluxTest {
 
     }
 
+    @Test
+    @DisplayName("ChangeStreamPublisher for a collection must complete after dropping the collection")
+    void changeStreamPublisherCompletesAfterDroppingCollection() {
+        assumeTrue(isReplicaSet() && serverVersionAtLeast(4, 0));
+        TestSubscriber<ChangeStreamDocument<Document>> subscriber = new TestSubscriber<>();
+        subscriber.doOnSubscribe(subscription -> {
+            subscription.request(Long.MAX_VALUE);
+        });
+        collection.watch()
+                .startAtOperationTime(ensureExists(client, collection))
+                .subscribe(subscriber);
+        Mono.from(collection.drop()).block(TIMEOUT_DURATION);
+        subscriber.assertTerminalEvent();
+        subscriber.assertNoErrors();
+    }
 
     private void assertCommandNames(final List<String> commandNames) {
         assertIterableEquals(commandNames,
@@ -282,4 +311,30 @@ public class BatchCursorFluxTest {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * This method ensures that the server considers the specified {@code collection} existing for the purposes of, e.g.,
+     * {@link MongoCollection#drop()}, instead of replying with
+     * {@code "errmsg": "ns not found", "code": 26, "codeName": "NamespaceNotFound"}.
+     *
+     * @return {@code operationTime} starting at which the {@code collection} is guaranteed to exist.
+     */
+    private static BsonTimestamp ensureExists(final MongoClient client, final MongoCollection<Document> collection) {
+        BsonValue insertedId = Mono.from(collection.insertOne(Document.parse("{}")))
+                .map(InsertOneResult::getInsertedId)
+                .block(TIMEOUT_DURATION);
+        BsonArray deleteStatements = new BsonArray();
+        deleteStatements.add(new BsonDocument()
+                .append("q", new BsonDocument()
+                        .append("_id", insertedId))
+                .append("limit", new BsonInt32(1)));
+        Publisher<Document> deletePublisher = client.getDatabase(collection.getNamespace().getDatabaseName())
+                .runCommand(new BsonDocument()
+                        .append("delete", new BsonString(collection.getNamespace().getCollectionName()))
+                        .append("deletes", deleteStatements));
+        BsonTimestamp operationTime = Mono.from(deletePublisher)
+                .map(doc -> doc.get("operationTime", BsonTimestamp.class))
+                .block(TIMEOUT_DURATION);
+        assertNotNull(operationTime);
+        return operationTime;
+    }
 }


### PR DESCRIPTION
JAVA-4044/https://github.com/mongodb/mongo-java-driver/pull/689, JAVA-3938 & JAVA-3907 / https://github.com/mongodb/mongo-java-driver/pull/661.

Both commits were cherry-picked without resolving conflicts manually.