### PR TITLE
Add alternate constructor to Polygon and PolygonCoordinates

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/geojson/Polygon.java
+++ b/driver-core/src/main/com/mongodb/client/model/geojson/Polygon.java
@@ -45,6 +45,16 @@ public final class Polygon extends Geometry {
     /**
      * Construct an instance with the given coordinates.
      *
+     * @param exterior the exterior ring of the polygon
+     * @param holes    optional interior rings of the polygon
+     */
+    public Polygon(final List<Position> exterior, final List<List<Position>> holes) {
+        this(new PolygonCoordinates(exterior, holes));
+    }
+
+    /**
+     * Construct an instance with the given coordinates.
+     *
      * @param coordinates the coordinates
      */
     public Polygon(final PolygonCoordinates coordinates) {

--- a/driver-core/src/main/com/mongodb/client/model/geojson/Polygon.java
+++ b/driver-core/src/main/com/mongodb/client/model/geojson/Polygon.java
@@ -47,6 +47,7 @@ public final class Polygon extends Geometry {
      *
      * @param exterior the exterior ring of the polygon
      * @param holes    optional interior rings of the polygon
+     * @since 4.3
      */
     public Polygon(final List<Position> exterior, final List<List<Position>> holes) {
         this(new PolygonCoordinates(exterior, holes));

--- a/driver-core/src/main/com/mongodb/client/model/geojson/PolygonCoordinates.java
+++ b/driver-core/src/main/com/mongodb/client/model/geojson/PolygonCoordinates.java
@@ -41,6 +41,7 @@ public final class PolygonCoordinates {
      * @param holes    optional interior rings of the polygon
      */
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public PolygonCoordinates(final List<Position> exterior, final List<Position>... holes) {
         this(exterior, Arrays.asList(holes));
     }
@@ -50,6 +51,7 @@ public final class PolygonCoordinates {
      *
      * @param exterior the exterior ring of the polygon
      * @param holes    optional interior rings of the polygon
+     * @since 4.3
      */
     public PolygonCoordinates(final List<Position> exterior, final List<List<Position>> holes) {
         notNull("exteriorRing", exterior);

--- a/driver-core/src/main/com/mongodb/client/model/geojson/PolygonCoordinates.java
+++ b/driver-core/src/main/com/mongodb/client/model/geojson/PolygonCoordinates.java
@@ -17,6 +17,7 @@
 package com.mongodb.client.model.geojson;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -41,6 +42,16 @@ public final class PolygonCoordinates {
      */
     @SafeVarargs
     public PolygonCoordinates(final List<Position> exterior, final List<Position>... holes) {
+        this(exterior, Arrays.asList(holes));
+    }
+
+    /**
+     * Construct an instance.
+     *
+     * @param exterior the exterior ring of the polygon
+     * @param holes    optional interior rings of the polygon
+     */
+    public PolygonCoordinates(final List<Position> exterior, final List<List<Position>> holes) {
         notNull("exteriorRing", exterior);
         doesNotContainNull("exterior", exterior);
         isTrueArgument("ring must contain at least four positions", exterior.size() >= 4);
@@ -48,7 +59,7 @@ public final class PolygonCoordinates {
 
         this.exterior = Collections.unmodifiableList(exterior);
 
-        List<List<Position>> holesList = new ArrayList<List<Position>>(holes.length);
+        List<List<Position>> holesList = new ArrayList<List<Position>>(holes.size());
         for (List<Position> hole : holes) {
             notNull("interiorRing", hole);
             doesNotContainNull("hole", hole);

--- a/driver-core/src/test/unit/com/mongodb/client/model/geojson/PolygonSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/geojson/PolygonSpecification.groovy
@@ -70,6 +70,37 @@ class PolygonSpecification extends Specification {
 
         then:
         thrown(IllegalArgumentException)
+
+        when:
+        new Polygon(exterior,  [null])
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        new Polygon(exterior, [[new Position([40.0d, 18.0d]),
+                               new Position([40.0d, 19.0d]),
+                               null]])
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        new Polygon(exterior, [[new Position([40.0d, 18.0d]),
+                               new Position([40.0d, 19.0d]),
+                               new Position([41.0d, 19.0d])]])
+
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        new Polygon(exterior, [[new Position([40.0d, 18.0d]),
+                               new Position([40.0d, 19.0d]),
+                               new Position([41.0d, 19.0d]),
+                               new Position([1.0, 2.0])]])
+
+        then:
+        thrown(IllegalArgumentException)
     }
 
     def 'should get type'() {

--- a/driver-core/src/test/unit/com/mongodb/client/model/geojson/codecs/GeometryCodecSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/geojson/codecs/GeometryCodecSpecification.groovy
@@ -72,9 +72,9 @@ class GeometryCodecSpecification extends Specification {
                                   new PolygonCoordinates([new Position(100.0, 0.0), new Position(101.0, 0.0),
                                                           new Position(101.0, 1.0), new Position(100.0, 1.0),
                                                           new Position(100.0, 0.0)],
-                                          [new Position(100.2, 0.2), new Position(100.8, 0.2),
+                                          [[new Position(100.2, 0.2), new Position(100.8, 0.2),
                                            new Position(100.8, 0.8), new Position(100.2, 0.8),
-                                           new Position(100.2, 0.2)])]),
+                                           new Position(100.2, 0.2)]])]),
                 new GeometryCollection([new Point(new Position(100d, 0d)),
                                         new LineString([new Position(101d, 0d), new Position(102d, 1d)])])
         ]

--- a/driver-core/src/test/unit/com/mongodb/client/model/geojson/codecs/GeometryCollectionCodecSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/geojson/codecs/GeometryCollectionCodecSpecification.groovy
@@ -76,9 +76,9 @@ class GeometryCollectionCodecSpecification extends Specification {
                                   new PolygonCoordinates([new Position(100.0, 0.0), new Position(101.0, 0.0),
                                                           new Position(101.0, 1.0), new Position(100.0, 1.0),
                                                           new Position(100.0, 0.0)],
-                                          [new Position(100.2, 0.2), new Position(100.8, 0.2),
+                                          [[new Position(100.2, 0.2), new Position(100.8, 0.2),
                                            new Position(100.8, 0.8), new Position(100.2, 0.8),
-                                           new Position(100.2, 0.2)])]),
+                                           new Position(100.2, 0.2)]])]),
                 new GeometryCollection([new Point(new Position(100d, 0d)),
                                         new LineString([new Position(101d, 0d), new Position(102d, 1d)])])
         ])
@@ -124,9 +124,9 @@ class GeometryCollectionCodecSpecification extends Specification {
                                   new PolygonCoordinates([new Position(100.0, 0.0), new Position(101.0, 0.0),
                                                           new Position(101.0, 1.0), new Position(100.0, 1.0),
                                                           new Position(100.0, 0.0)],
-                                          [new Position(100.2, 0.2), new Position(100.8, 0.2),
+                                          [[new Position(100.2, 0.2), new Position(100.8, 0.2),
                                            new Position(100.8, 0.8), new Position(100.2, 0.8),
-                                           new Position(100.2, 0.2)])]),
+                                           new Position(100.2, 0.2)]])]),
                 new GeometryCollection([new Point(new Position(100d, 0d)),
                                         new LineString([new Position(101d, 0d), new Position(102d, 1d)])])
         ])

--- a/driver-core/src/test/unit/com/mongodb/client/model/geojson/codecs/MultiPolygonCodecSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/geojson/codecs/MultiPolygonCodecSpecification.groovy
@@ -45,9 +45,9 @@ class MultiPolygonCodecSpecification extends Specification {
                                                   new PolygonCoordinates([new Position(100.0, 0.0), new Position(101.0, 0.0),
                                                                           new Position(101.0, 1.0), new Position(100.0, 1.0),
                                                                           new Position(100.0, 0.0)],
-                                                                         [new Position(100.2, 0.2), new Position(100.8, 0.2),
+                                                                         [[new Position(100.2, 0.2), new Position(100.8, 0.2),
                                                                           new Position(100.8, 0.8), new Position(100.2, 0.8),
-                                                                          new Position(100.2, 0.2)])])
+                                                                          new Position(100.2, 0.2)]])])
 
         when:
         codec.encode(writer, multiMultiPolygon, context)
@@ -75,9 +75,9 @@ class MultiPolygonCodecSpecification extends Specification {
                                                   new PolygonCoordinates([new Position(100.0, 0.0), new Position(101.0, 0.0),
                                                                           new Position(101.0, 1.0), new Position(100.0, 1.0),
                                                                           new Position(100.0, 0.0)],
-                                                                         [new Position(100.2, 0.2), new Position(100.8, 0.2),
+                                                                         [[new Position(100.2, 0.2), new Position(100.8, 0.2),
                                                                           new Position(100.8, 0.8), new Position(100.2, 0.8),
-                                                                          new Position(100.2, 0.2)])])
+                                                                          new Position(100.2, 0.2)]])])
 
         when:
         codec.encode(writer, multiMultiPolygon, context)


### PR DESCRIPTION
Adds alternate constructors to Polygon and PolygonCoordinates that make it possible to construct a Mongo Polygon given a Polygon from some other library with a similar API.

Posting this PR to demonstrate what it would be nice to have, but this was a breaking change if consuming the driver using Groovy as can be seen in a few tests I changed. I would assume this exact solution won't work, so open to any ideas.

Basically just want to be able to convert a Polygon with this type of API to the Java Driver's Polygon:

```
class Coordinate {
    double[] getCoords();
}

class Polygon {
    List<Coordinate> getExterior();
    List<List<Coordinate>> getHoles();
}
```

which currently is not possible as converting the above Polygon holes to the Java Driver's would require instantiating and populating a `List<Position>[]`, which using conventional Java isn't allowed because of the compile error: "Cannot create a generic array of List<Position>". And I know using `newInstance()` I can make an array that will work, but just looking for some way to avoid using reflection if possible.

JAVA-4098