### PR TITLE
Support TLS in AbstractConnectionPoolTest and its subclasses

### DIFF
--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
@@ -150,7 +150,7 @@ public abstract class AbstractConnectionPoolTest {
                                 MongoDriverInformation.builder().build(),
                                 Collections.emptyList(),
                                 new TestCommandListener(),
-                                null),
+                                ClusterFixture.getServerApi()),
                         settings));
                 setFailPoint();
                 break;

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
@@ -144,7 +144,7 @@ public abstract class AbstractConnectionPoolTest {
                 ServerId serverId = new ServerId(new ClusterId(), ClusterFixture.getPrimary());
                 pool = new ConnectionIdAdjustingConnectionPool(new DefaultConnectionPool(serverId,
                         new InternalStreamConnectionFactory(
-                                createStreamFactory(SocketSettings.builder().build(), SslSettings.builder().enabled(false).build()),
+                                createStreamFactory(SocketSettings.builder().build(), ClusterFixture.getSslSettings()),
                                 ClusterFixture.getCredentialWithCache(),
                                 fileName + ": " + description,
                                 MongoDriverInformation.builder().build(),

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ConnectionPoolAsyncTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ConnectionPoolAsyncTest.java
@@ -21,6 +21,9 @@ import com.mongodb.connection.AsynchronousSocketChannelStreamFactory;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.SslSettings;
 import com.mongodb.connection.StreamFactory;
+import com.mongodb.connection.TlsChannelStreamFactoryFactory;
+import com.mongodb.diagnostics.logging.Logger;
+import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.internal.async.SingleResultCallback;
 import org.bson.BsonDocument;
 import org.junit.runner.RunWith;
@@ -34,6 +37,7 @@ import java.util.concurrent.Callable;
 @SuppressWarnings("deprecation")
 @RunWith(Parameterized.class)
 public class ConnectionPoolAsyncTest extends AbstractConnectionPoolTest {
+    private static final Logger LOGGER = Loggers.getLogger(ConnectionPoolAsyncTest.class.getSimpleName());
 
     public ConnectionPoolAsyncTest(final String fileName, final String description, final BsonDocument definition, final boolean skipTest) {
         super(fileName, description, definition, skipTest);
@@ -64,6 +68,7 @@ public class ConnectionPoolAsyncTest extends AbstractConnectionPoolTest {
                         callback.get();
                         return null;
                     } catch (Exception e) {
+                        LOGGER.error("", e);
                         return e;
                     }
                 }
@@ -88,6 +93,11 @@ public class ConnectionPoolAsyncTest extends AbstractConnectionPoolTest {
 
     @Override
     protected StreamFactory createStreamFactory(final SocketSettings socketSettings, final SslSettings sslSettings) {
-        return new AsynchronousSocketChannelStreamFactory(socketSettings, sslSettings);
+        if (sslSettings.isEnabled()) {
+            return new TlsChannelStreamFactoryFactory().create(socketSettings, sslSettings);
+        } else {
+            return new AsynchronousSocketChannelStreamFactory(socketSettings, sslSettings);
+        }
+
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ConnectionPoolTest.java
@@ -20,6 +20,8 @@ import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.SocketStreamFactory;
 import com.mongodb.connection.SslSettings;
 import com.mongodb.connection.StreamFactory;
+import com.mongodb.diagnostics.logging.Logger;
+import com.mongodb.diagnostics.logging.Loggers;
 import org.bson.BsonDocument;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -32,6 +34,7 @@ import java.util.concurrent.Callable;
 @SuppressWarnings("deprecation")
 @RunWith(Parameterized.class)
 public class ConnectionPoolTest extends AbstractConnectionPoolTest {
+    private static final Logger LOGGER = Loggers.getLogger(ConnectionPoolTest.class.getSimpleName());
 
     public ConnectionPoolTest(final String fileName, final String description, final BsonDocument definition, final boolean skipTest) {
         super(fileName, description, definition, skipTest);
@@ -51,6 +54,7 @@ public class ConnectionPoolTest extends AbstractConnectionPoolTest {
                         }
                         return null;
                     } catch (Exception e) {
+                        LOGGER.error("", e);
                         return e;
                     }
                 }


### PR DESCRIPTION
Also log exceptions that happen while tests run

JAVA-4104