### PR TITLE
Unpin server from session on abort or first non-transactional operation 

### DIFF
--- a/driver-core/src/test/resources/unified-test-format/transactions/java-only-mongos-unpin.json
+++ b/driver-core/src/test/resources/unified-test-format/transactions/java-only-mongos-unpin.json
@@ -1,0 +1,96 @@
+{
+  "description": "java-only-mongos-unpin",
+  "schemaVersion": "1.1",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.2",
+      "topologies": [
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "mongos-unpin-db"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "mongos-unpin-db",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "unpin when a non-transaction read operation uses a session",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/transactions/mongos-unpin.json
+++ b/driver-core/src/test/resources/unified-test-format/transactions/mongos-unpin.json
@@ -1,0 +1,277 @@
+{
+  "description": "mongos-unpin",
+  "schemaVersion": "1.1",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.2",
+      "topologies": [
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "mongos-unpin-db"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "mongos-unpin-db",
+      "documents": []
+    }
+  ],
+  "_yamlAnchors": {
+    "anchors": 24
+  },
+  "tests": [
+    {
+      "description": "unpin after TransientTransctionError error on commit",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "commitTransaction"
+                ],
+                "errorCode": 24
+              }
+            }
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "expectError": {
+            "errorCode": 24,
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ],
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ]
+    },
+    {
+      "description": "unpin on successful abort",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ]
+    },
+    {
+      "description": "unpin after TransientTransctionError error on abort",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "targetedFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "abortTransaction"
+                ],
+                "errorCode": 24
+              }
+            }
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ]
+    },
+    {
+      "description": "unpin when a new transaction is started",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ]
+    },
+    {
+      "description": "unpin when a non-transaction operation uses a session",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertSessionPinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertSessionUnpinned",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ClientSession.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ClientSession.java
@@ -51,8 +51,9 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
      * <p>
      * For internal use only
      * </p>
+     * @param operation the operation
      */
-    void notifyNonCommitOperationInitiated();
+    void notifyOperationInitiated(Object operation);
 
     /**
      * Gets the transaction options.  Only call this method of the session has an active transaction

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ClientSession.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ClientSession.java
@@ -47,6 +47,14 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
     boolean notifyMessageSent();
 
     /**
+     * Notify the client session that command execution is being initiated. This should be called before server selection occurs.
+     * <p>
+     * For internal use only
+     * </p>
+     */
+    void notifyNonCommitOperationInitiated();
+
+    /**
      * Gets the transaction options.  Only call this method of the session has an active transaction
      *
      * @return the transaction options

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionPublisherImpl.java
@@ -29,8 +29,6 @@ import com.mongodb.internal.operation.AbortTransactionOperation;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.internal.operation.AsyncWriteOperation;
 import com.mongodb.internal.operation.CommitTransactionOperation;
-import com.mongodb.internal.operation.ReadOperation;
-import com.mongodb.internal.operation.WriteOperation;
 import com.mongodb.internal.session.BaseClientSessionImpl;
 import com.mongodb.internal.session.ServerSessionPool;
 import com.mongodb.reactivestreams.client.ClientSession;

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionPublisherImpl.java
@@ -26,6 +26,8 @@ import com.mongodb.WriteConcern;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.client.AsyncClientSession;
 import com.mongodb.internal.operation.AbortTransactionOperation;
+import com.mongodb.internal.operation.AsyncReadOperation;
+import com.mongodb.internal.operation.AsyncWriteOperation;
 import com.mongodb.internal.operation.CommitTransactionOperation;
 import com.mongodb.internal.operation.ReadOperation;
 import com.mongodb.internal.operation.WriteOperation;
@@ -79,7 +81,7 @@ final class ClientSessionPublisherImpl extends BaseClientSessionImpl implements 
 
     @Override
     public void notifyOperationInitiated(final Object operation) {
-        assertTrue(operation instanceof ReadOperation || operation instanceof WriteOperation);
+        assertTrue(operation instanceof AsyncReadOperation || operation instanceof AsyncWriteOperation);
         if (!(hasActiveTransaction() || operation instanceof CommitTransactionOperation)) {
             assertTrue(getPinnedServerAddress() == null
                     || (transactionState != TransactionState.ABORTED && transactionState != TransactionState.NONE));

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/OperationExecutorImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/OperationExecutorImpl.java
@@ -29,7 +29,6 @@ import com.mongodb.internal.binding.AsyncClusterBinding;
 import com.mongodb.internal.binding.AsyncReadWriteBinding;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.internal.operation.AsyncWriteOperation;
-import com.mongodb.internal.operation.CommitTransactionOperation;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ClientSession;
 import com.mongodb.reactivestreams.client.internal.crypt.Crypt;
@@ -60,7 +59,7 @@ public class OperationExecutorImpl implements OperationExecutor {
         notNull("readConcern", readConcern);
 
         if (session != null) {
-            session.notifyNonCommitOperationInitiated();
+            session.notifyOperationInitiated(operation);
         }
 
           return clientSessionHelper.withClientSession(session, this)
@@ -92,8 +91,8 @@ public class OperationExecutorImpl implements OperationExecutor {
         notNull("operation", operation);
         notNull("readConcern", readConcern);
 
-        if (session != null && !(operation instanceof CommitTransactionOperation)) {
-            session.notifyNonCommitOperationInitiated();
+        if (session != null) {
+            session.notifyOperationInitiated(operation);
         }
 
         return clientSessionHelper.withClientSession(session, this)

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncClientSession.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncClientSession.java
@@ -118,6 +118,11 @@ class SyncClientSession implements ClientSession {
     }
 
     @Override
+    public void notifyNonCommitOperationInitiated() {
+        wrapped.notifyNonCommitOperationInitiated();
+    }
+
+    @Override
     public TransactionOptions getTransactionOptions() {
         return wrapped.getTransactionOptions();
     }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncClientSession.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncClientSession.java
@@ -118,8 +118,8 @@ class SyncClientSession implements ClientSession {
     }
 
     @Override
-    public void notifyNonCommitOperationInitiated() {
-        wrapped.notifyNonCommitOperationInitiated();
+    public void notifyOperationInitiated(final Object operation) {
+        wrapped.notifyOperationInitiated(operation);
     }
 
     @Override

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedTransactionsTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedTransactionsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.unified;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.unified.UnifiedTest;
+import com.mongodb.reactivestreams.client.MongoClients;
+import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
+public class UnifiedTransactionsTest extends UnifiedTest {
+    public UnifiedTransactionsTest(@SuppressWarnings("unused") final String fileDescription,
+                                   @SuppressWarnings("unused") final String testDescription,
+                                   final String schemaVersion, final BsonArray runOnRequirements, final BsonArray entitiesArray,
+                                   final BsonArray initialData, final BsonDocument definition) {
+        super(schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
+    }
+
+    @Override
+    protected MongoClient createMongoClient(final MongoClientSettings settings) {
+        return new SyncMongoClient(MongoClients.create(settings));
+    }
+
+    @Parameterized.Parameters(name = "{0}: {1}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        return getTestData("unified-test-format/transactions");
+    }
+}

--- a/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncClientSession.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncClientSession.scala
@@ -54,7 +54,7 @@ case class SyncClientSession(wrapped: ClientSession, originator: Object) extends
 
   override def notifyMessageSent: Boolean = wrapped.notifyMessageSent
 
-  override def notifyNonCommitOperationInitiated(): Unit = wrapped.notifyNonCommitOperationInitiated()
+  override def notifyOperationInitiated(operation: Object): Unit = wrapped.notifyOperationInitiated(operation)
 
   override def getTransactionOptions: TransactionOptions = wrapped.getTransactionOptions
 

--- a/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncClientSession.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncClientSession.scala
@@ -54,6 +54,8 @@ case class SyncClientSession(wrapped: ClientSession, originator: Object) extends
 
   override def notifyMessageSent: Boolean = wrapped.notifyMessageSent
 
+  override def notifyNonCommitOperationInitiated(): Unit = wrapped.notifyNonCommitOperationInitiated()
+
   override def getTransactionOptions: TransactionOptions = wrapped.getTransactionOptions
 
   override def startTransaction(): Unit = wrapped.startTransaction()

--- a/driver-sync/src/main/com/mongodb/client/ClientSession.java
+++ b/driver-sync/src/main/com/mongodb/client/ClientSession.java
@@ -64,6 +64,15 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
     boolean notifyMessageSent();
 
     /**
+     *  Notify the client session that command execution is being initiated. This should be called before server selection occurs.
+     *  <p>
+     *      For internal use only
+     *  </p>
+     *
+     */
+    void notifyNonCommitOperationInitiated();
+
+    /**
      * Gets the transaction options.  Only call this method of the session has an active transaction
      *
      * @return the transaction options
@@ -123,5 +132,4 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
      * @mongodb.server.release 4.0
      * @since 3.11
      */
-    <T> T withTransaction(TransactionBody<T> transactionBody, TransactionOptions options);
-}
+    <T> T withTransaction(TransactionBody<T> transactionBody, TransactionOptions options);}

--- a/driver-sync/src/main/com/mongodb/client/ClientSession.java
+++ b/driver-sync/src/main/com/mongodb/client/ClientSession.java
@@ -69,8 +69,9 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
      *      For internal use only
      *  </p>
      *
+     * @param operation the operation
      */
-    void notifyNonCommitOperationInitiated();
+    void notifyOperationInitiated(Object operation);
 
     /**
      * Gets the transaction options.  Only call this method of the session has an active transaction

--- a/driver-sync/src/main/com/mongodb/client/ClientSession.java
+++ b/driver-sync/src/main/com/mongodb/client/ClientSession.java
@@ -132,4 +132,5 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
      * @mongodb.server.release 4.0
      * @since 3.11
      */
-    <T> T withTransaction(TransactionBody<T> transactionBody, TransactionOptions options);}
+    <T> T withTransaction(TransactionBody<T> transactionBody, TransactionOptions options);
+}

--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
@@ -33,6 +33,7 @@ import com.mongodb.internal.session.ServerSessionPool;
 
 import static com.mongodb.MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL;
 import static com.mongodb.MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL;
+import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -79,7 +80,9 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
 
     @Override
     public void notifyNonCommitOperationInitiated() {
-        if (transactionState == TransactionState.COMMITTED) {
+        if (transactionState != TransactionState.IN) {
+            assertTrue(getPinnedServerAddress() == null
+                    || (transactionState != TransactionState.ABORTED && transactionState != TransactionState.NONE));
             setPinnedServerAddress(null);
         }
     }

--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
@@ -28,6 +28,8 @@ import com.mongodb.client.ClientSession;
 import com.mongodb.client.TransactionBody;
 import com.mongodb.internal.operation.AbortTransactionOperation;
 import com.mongodb.internal.operation.CommitTransactionOperation;
+import com.mongodb.internal.operation.ReadOperation;
+import com.mongodb.internal.operation.WriteOperation;
 import com.mongodb.internal.session.BaseClientSessionImpl;
 import com.mongodb.internal.session.ServerSessionPool;
 
@@ -79,8 +81,9 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
 
 
     @Override
-    public void notifyNonCommitOperationInitiated() {
-        if (transactionState != TransactionState.IN) {
+    public void notifyOperationInitiated(final Object operation) {
+        assertTrue(operation instanceof ReadOperation || operation instanceof WriteOperation);
+        if (!(hasActiveTransaction() || operation instanceof CommitTransactionOperation)) {
             assertTrue(getPinnedServerAddress() == null
                     || (transactionState != TransactionState.ABORTED && transactionState != TransactionState.NONE));
             setPinnedServerAddress(null);

--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
@@ -76,6 +76,14 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
         }
     }
 
+
+    @Override
+    public void notifyNonCommitOperationInitiated() {
+        if (transactionState == TransactionState.COMMITTED) {
+            setPinnedServerAddress(null);
+        }
+    }
+
     @Override
     public TransactionOptions getTransactionOptions() {
         isTrue("in transaction", transactionState == TransactionState.IN || transactionState == TransactionState.COMMITTED);
@@ -163,10 +171,9 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
                         readConcern, this);
             }
         } catch (Exception e) {
-            if (e instanceof MongoException) {
-                unpinServerAddressOnError((MongoException) e);
-            }
+            // ignore exceptions from abort
         } finally {
+            setPinnedServerAddress(null);
             cleanupTransaction(TransactionState.ABORTED);
         }
     }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoClientDelegate.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoClientDelegate.java
@@ -38,7 +38,6 @@ import com.mongodb.internal.binding.ReadBinding;
 import com.mongodb.internal.binding.ReadWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.internal.connection.Cluster;
-import com.mongodb.internal.operation.CommitTransactionOperation;
 import com.mongodb.internal.operation.ReadOperation;
 import com.mongodb.internal.operation.WriteOperation;
 import com.mongodb.internal.session.ServerSessionPool;
@@ -165,7 +164,7 @@ final class MongoClientDelegate {
         public <T> T execute(final ReadOperation<T> operation, final ReadPreference readPreference, final ReadConcern readConcern,
                              @Nullable final ClientSession session) {
             if (session != null) {
-                session.notifyNonCommitOperationInitiated();
+                session.notifyOperationInitiated(operation);
             }
 
             ClientSession actualClientSession = getClientSession(session);
@@ -188,8 +187,8 @@ final class MongoClientDelegate {
 
         @Override
         public <T> T execute(final WriteOperation<T> operation, final ReadConcern readConcern, @Nullable final ClientSession session) {
-            if (session != null && !(operation instanceof CommitTransactionOperation)) {
-                session.notifyNonCommitOperationInitiated();
+            if (session != null) {
+                session.notifyOperationInitiated(operation);
             }
 
             ClientSession actualClientSession = getClientSession(session);

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
@@ -135,10 +135,14 @@ final class UnifiedCrudHelper {
         MongoCollection<BsonDocument> collection = entities.getCollection(operation.getString("object").getValue());
         BsonDocument arguments = operation.getDocument("arguments");
 
+        ClientSession session = getSession(arguments);
         BsonDocument filter = arguments.getDocument("filter");
-        FindIterable<BsonDocument> iterable = collection.find(filter);
+        FindIterable<BsonDocument> iterable = session == null
+                ? collection.find(filter)
+                : collection.find(session, filter);
         for (Map.Entry<String, BsonValue> cur : arguments.entrySet()) {
             switch (cur.getKey()) {
+                case "session":
                 case "filter":
                     break;
                 case "sort":

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -128,8 +128,6 @@ public abstract class UnifiedTest {
 
     @Before
     public void setUp() {
-//        assumeTrue(definition.getString("description").getValue().equals("unpin when a non-transaction operation uses a session"));
-        
         assertTrue(schemaVersion.startsWith("1.0") || schemaVersion.startsWith("1.1") || schemaVersion.startsWith("1.2"));
         if (runOnRequirements != null) {
             assumeTrue("Run-on requirements not met", runOnRequirementsMet(runOnRequirements, getServerVersion()));

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -128,6 +128,8 @@ public abstract class UnifiedTest {
 
     @Before
     public void setUp() {
+//        assumeTrue(definition.getString("description").getValue().equals("unpin when a non-transaction operation uses a session"));
+        
         assertTrue(schemaVersion.startsWith("1.0") || schemaVersion.startsWith("1.1") || schemaVersion.startsWith("1.2"));
         if (runOnRequirements != null) {
             assumeTrue("Run-on requirements not met", runOnRequirementsMet(runOnRequirements, getServerVersion()));

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTransactionsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTransactionsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.unified;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
+public class UnifiedTransactionsTest extends UnifiedTest {
+    public UnifiedTransactionsTest(@SuppressWarnings("unused") final String fileDescription,
+                                   @SuppressWarnings("unused") final String testDescription,
+                                   final String schemaVersion, final BsonArray runOnRequirements, final BsonArray entitiesArray,
+                                   final BsonArray initialData, final BsonDocument definition) {
+        super(schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
+    }
+
+    @Override
+    protected MongoClient createMongoClient(final MongoClientSettings settings) {
+        return MongoClients.create(settings);
+    }
+
+    @Parameterized.Parameters(name = "{0}: {1}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        return getTestData("unified-test-format/transactions");
+    }
+}


### PR DESCRIPTION
This change is a required precursor for load balancing support.  It fixes a couple of bugs in the pinning behavior of the driver for transactions that were uncovered by the new tests.

1. Server should be unpinned on successful abort of txn
2. Server should be unpinned on the first operation in a session after transaction has been committed 
 
JAVA-4096