### PR TITLE
Fix deadlock and couple more problems in `DefaultConnectionPool`

### DIFF
--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -190,10 +190,10 @@
         <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE"/>
     </Match>
 
-    <!-- The return value of Condition.awaitNanos is ignored on purpose for infinite timeouts. -->
+    <!-- The method is a wrapper for `Condition.await`, naturally it does not call it in a loop. -->
     <Match>
         <Class name="com.mongodb.internal.connection.DefaultConnectionPool$OpenConcurrencyLimiter"/>
         <Method name="awaitNanos"/>
-        <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
+        <Bug pattern="WA_AWAIT_NOT_IN_LOOP"/>
     </Match>
 </FindBugsFilter>

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -733,10 +733,10 @@ class DefaultConnectionPool implements ConnectionPool {
          * one becomes available while waiting for a permit.
          * The first phase has one of the following outcomes:
          * <ol>
-         *     <li>A {@link MongoTimeoutException} or a different {@link Exception} is thrown.</li>
+         *     <li>A {@link MongoTimeoutException} or a different {@link Exception} is thrown,
+         *     and the specified {@code connection} is {@linkplain PooledConnection#closeSilently() silently closed}.</li>
          *     <li>An opened connection different from the specified one is returned,
-         *     and the specified {@code connection} is {@linkplain PooledConnection#closeSilently() silently closed}.
-         *     </li>
+         *     and the specified {@code connection} is {@linkplain PooledConnection#closeSilently() silently closed}.</li>
          *     <li>A permit is acquired, {@link #connectionCreated(ConnectionPoolListener, ConnectionId)} is reported
          *     and an attempt to open the specified {@code connection} is made. This is the second phase in which
          *     the {@code connection} is {@linkplain PooledConnection#open() opened synchronously}.


### PR DESCRIPTION
I discovered 3 problems in `DefaultConnectionPool` and `ConcurrentPool` introduced by me in https://github.com/mongodb/mongo-java-driver/pull/685.

1. [deadlock] See this [commit message](https://github.com/mongodb/mongo-java-driver/pull/699/commits/9e7348281b27be21288783330e6d0e9cdeac9e7d) for the details.
2. [not expecting an exception where it may happen] Removing from `OpenConcurrencyLimiter.desiredConnectionSlots` despite not putting anything there previously. See this [commit message](https://github.com/mongodb/mongo-java-driver/pull/699/commits/9e7348281b27be21288783330e6d0e9cdeac9e7d) for the details.
3. [double release on exception] The method `ConcurrentPool.ensureMinSize` explicitly requires a caller to release resources if `initialize` throws an exception, but then releases the permit for `newItem` itself, which leads to double release. This was by far the hardest problem to investigate and find the cause. See this [commit message](https://github.com/mongodb/mongo-java-driver/pull/699/commits/5ec1763d8e403b96db8d0fd3b3bf2206b6bb87d7) for more details.

Commits in this PR can be reviewed one by one.

JAVA-3927