### PR TITLE
Add support for IAM role authentication to AWS Elastic Kubernetes Service (EKS)

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/aws/AwsCredentials.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/aws/AwsCredentials.java
@@ -1,0 +1,20 @@
+package com.mongodb.internal.connection.aws;
+
+public class AwsCredentials {
+
+    private final String accessKeyId;
+    private final String secretAccessKeyId;
+    private final String sessionToken;
+
+    public AwsCredentials(String accessKeyId, String secretAccessKeyId, String sessionToken) {
+        this.accessKeyId = accessKeyId;
+        this.secretAccessKeyId = secretAccessKeyId;
+        this.sessionToken = sessionToken;
+    }
+
+    public String getAccessKeyId() { return accessKeyId; }
+
+    public String getSecretAccessKeyId() { return secretAccessKeyId; }
+
+    public String getSessionToken() { return sessionToken; }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/aws/AwsCredentialsMiddleware.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/aws/AwsCredentialsMiddleware.java
@@ -1,0 +1,58 @@
+package com.mongodb.internal.connection.aws;
+
+import com.mongodb.MongoInternalException;
+import com.mongodb.lang.NonNull;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public abstract class AwsCredentialsMiddleware {
+
+    protected AwsCredentialsMiddleware next;
+
+    public AwsCredentialsMiddleware(AwsCredentialsMiddleware next) {
+        this.next = next;
+    }
+
+    public abstract AwsCredentials getCredentials();
+
+    @NonNull
+    protected static String getHttpContents(final String method, final String endpoint, final Map<String, String> headers) {
+        StringBuilder content = new StringBuilder();
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection) new URL(endpoint).openConnection();
+            conn.setRequestMethod(method);
+            conn.setReadTimeout(10000);
+            if (headers != null) {
+                for (Map.Entry<String, String> kvp : headers.entrySet()) {
+                    conn.setRequestProperty(kvp.getKey(), kvp.getValue());
+                }
+            }
+
+            int status = conn.getResponseCode();
+            if (status != HttpURLConnection.HTTP_OK) {
+                throw new IOException(String.format("%d %s", status, conn.getResponseMessage()));
+            }
+
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+                String inputLine;
+                while ((inputLine = in.readLine()) != null) {
+                    content.append(inputLine);
+                }
+            }
+        } catch (IOException e) {
+            throw new MongoInternalException("Unexpected IOException", e);
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+        return content.toString();
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/aws/Ec2CredentialsMiddleware.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/aws/Ec2CredentialsMiddleware.java
@@ -1,0 +1,37 @@
+package com.mongodb.internal.connection.aws;
+
+import org.bson.BsonDocument;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Ec2CredentialsMiddleware extends AwsCredentialsMiddleware {
+
+    private static String endpoint = "http://169.254.169.254";
+    private static String path = "/latest/meta-data/iam/security-credentials/";
+
+    public Ec2CredentialsMiddleware() {
+        super(null);
+    }
+
+    @Override
+    public AwsCredentials getCredentials() {
+
+        Map<String, String> header = new HashMap<>();
+        header.put("X-aws-ec2-metadata-token-ttl-seconds", "30");
+        String token = getHttpContents("PUT", endpoint + "/latest/api/token", header);
+
+        header.clear();
+        header.put("X-aws-ec2-metadata-token", token);
+        String role = getHttpContents("GET", endpoint + path, header);
+
+        String httpResponse = getHttpContents("GET", endpoint + path + role, header);
+
+        BsonDocument document = BsonDocument.parse(httpResponse);
+        String accessKeyId = document.getString("AccessKeyId").getValue();
+        String secretAccessKey = document.getString("SecretAccessKey").getValue();
+        String sessionToken = document.getString("Token").getValue();
+
+        return new AwsCredentials(accessKeyId, secretAccessKey, sessionToken);
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/aws/EcsCredentialsMiddleware.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/aws/EcsCredentialsMiddleware.java
@@ -1,0 +1,29 @@
+package com.mongodb.internal.connection.aws;
+
+import org.bson.BsonDocument;
+
+public class EcsCredentialsMiddleware extends AwsCredentialsMiddleware {
+
+    public EcsCredentialsMiddleware(final AwsCredentialsMiddleware next) {
+        super(next);
+    }
+
+    @Override
+    public AwsCredentials getCredentials() {
+
+        String path = System.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI");
+
+        if (path == null) {
+            return this.next.getCredentials();
+        }
+
+        String httpResponse = getHttpContents("GET", "http://169.254.170.2" + path, null);
+
+        BsonDocument document = BsonDocument.parse(httpResponse);
+        String accessKeyId = document.getString("AccessKeyId").getValue();
+        String secretAccessKey = document.getString("SecretAccessKey").getValue();
+        String token = document.getString("Token").getValue();
+
+        return new AwsCredentials(accessKeyId, secretAccessKey, token);
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/aws/EksCredentialsMiddleware.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/aws/EksCredentialsMiddleware.java
@@ -1,0 +1,70 @@
+package com.mongodb.internal.connection.aws;
+
+import com.mongodb.MongoClientException;
+import org.bson.BsonDocument;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+
+public class EksCredentialsMiddleware extends AwsCredentialsMiddleware{
+
+    public EksCredentialsMiddleware(final AwsCredentialsMiddleware next) {
+        super(next);
+    }
+
+    @Override
+    public AwsCredentials getCredentials() {
+
+        String identityTokenFilePath = System.getenv("AWS_WEB_IDENTITY_TOKEN_FILE");
+        String roleArn = System.getenv("AWS_ROLE_ARN");
+
+        if (identityTokenFilePath == null || roleArn == null) {
+            return this.next.getCredentials();
+        }
+
+        StringBuilder endpoint = new StringBuilder("https://sts.amazonaws.com/?Action=AssumeRoleWithWebIdentity");
+        endpoint.append("&DurationSeconds=").append(43200);
+        endpoint.append("&RoleSessionName=").append("app");
+        endpoint.append("&RoleArn=").append(roleArn);
+        endpoint.append("&WebIdentityToken=").append(getWebIdentityToken(identityTokenFilePath));
+        endpoint.append("&Version=2011-06-15");
+
+        Map<String, String> header = new HashMap<>();
+        header.put("Accept", "application/json");
+
+        String httpResponse = getHttpContents("POST", endpoint.toString(), header);
+        BsonDocument document = BsonDocument.parse(httpResponse);
+
+        BsonDocument credentials = document.getDocument("AssumeRoleWithWebIdentityResponse")
+                .getDocument("AssumeRoleWithWebIdentityResult")
+                .getDocument("Credentials");
+        String accessKeyId = credentials.getString("AccessKeyId").getValue();
+        String sessionToken = credentials.getString("SessionToken").getValue();
+        String secretAccessKeys = credentials.getString("SecretAccessKey").getValue();
+
+        return new AwsCredentials(accessKeyId, secretAccessKeys, sessionToken);
+    }
+
+    private String getWebIdentityToken(String identityTokenFilePath) {
+        BufferedReader br = null;
+        try {
+            br = new BufferedReader(new InputStreamReader(new FileInputStream(identityTokenFilePath), "UTF-8"));
+            return br.readLine();
+        } catch (FileNotFoundException e) {
+            throw new MongoClientException("Unable to locate AWS EKS specified web identity token file: " + identityTokenFilePath);
+        } catch (IOException e) {
+            throw new MongoClientException("Unable to read AWS EKS web identity token from file: " + identityTokenFilePath);
+        } finally {
+            try {
+                br.close();
+            } catch (Exception ignored) {
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
Mongodb driver supports authenticating with mongodb in AWS using IAM roles, currently it only supports retrieving the temporary credentials for the role in ECS and EC2. For those running on EKS (amazon managed kubernetes), you need to allow your pods to inherit the IAM role (and policies) of the node it is running on, which goes against the principle of least privilege. AWS recently released [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) which basically assigns an IAM role to the pod, allowing each deployed pod on a node to have its own IAM role, with this developers can explicitly prevent the pod from inheriting the nodes IAM role and instead use the IAM role assigned to it. This pull request adds support for using the IAM role on the pod to retrieve the temporary credentials used by the driver during authentication.

JAVA-4118