### PR TITLE
Improve assertion messages in unified test runner

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/unified/ContextElement.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/ContextElement.java
@@ -97,7 +97,7 @@ abstract class ContextElement {
         }
 
         public String toString() {
-            return "Started Operation Result Context: " + "\n"
+            return "Started Operation Context: " + "\n"
                     + "   Operation:\n"
                     + operation.toJson(JsonWriterSettings.builder().indent(true).build()) + "\n"
                     + "   Operation index: " + index + "\n";
@@ -116,7 +116,7 @@ abstract class ContextElement {
         }
 
         public String toString() {
-            return "Completed Operation Result Context: " + "\n"
+            return "Completed Operation Context: " + "\n"
                     + "   Operation:\n"
                     + operation.toJson(JsonWriterSettings.builder().indent(true).build()) + "\n"
                     + "   Actual result:\n"

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/ContextElement.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/ContextElement.java
@@ -35,8 +35,12 @@ abstract class ContextElement {
         return new TestContextContextElement(definition);
     }
 
-    static ContextElement ofOperation(final BsonDocument operation, final OperationResult result) {
-        return new OperationContextElement(operation, result);
+    static ContextElement ofStartedOperation(final BsonDocument operation, final int index) {
+        return new StartedOperationContextElement(operation, index);
+    }
+
+    static ContextElement ofCompletedOperation(final BsonDocument operation, final OperationResult result, final int index) {
+        return new CompletedOperationContextElement(operation, result, index);
     }
 
     static ContextElement ofValueMatcher(final BsonValue expected, final BsonValue actual, final String key, final int arrayPosition) {
@@ -83,21 +87,41 @@ abstract class ContextElement {
         }
     }
 
-    private static class OperationContextElement extends ContextElement {
+    private static class StartedOperationContextElement extends ContextElement {
         private final BsonDocument operation;
-        private final OperationResult result;
+        private final int index;
 
-        OperationContextElement(final BsonDocument operation, final OperationResult result) {
+        StartedOperationContextElement(final BsonDocument operation, final int index) {
             this.operation = operation;
-            this.result = result;
+            this.index = index;
         }
 
         public String toString() {
-            return "Operation Result Context: " + "\n"
+            return "Started Operation Result Context: " + "\n"
+                    + "   Operation:\n"
+                    + operation.toJson(JsonWriterSettings.builder().indent(true).build()) + "\n"
+                    + "   Operation index: " + index + "\n";
+        }
+    }
+
+    private static class CompletedOperationContextElement extends ContextElement {
+        private final BsonDocument operation;
+        private final OperationResult result;
+        private final int index;
+
+        CompletedOperationContextElement(final BsonDocument operation, final OperationResult result, final int index) {
+            this.operation = operation;
+            this.result = result;
+            this.index = index;
+        }
+
+        public String toString() {
+            return "Completed Operation Result Context: " + "\n"
                     + "   Operation:\n"
                     + operation.toJson(JsonWriterSettings.builder().indent(true).build()) + "\n"
                     + "   Actual result:\n"
-                    + result + "\n";
+                    + result + "\n"
+                    + "   Operation index: " + index + "\n";
         }
     }
 

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/OperationAsserter.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/OperationAsserter.java
@@ -19,5 +19,5 @@ package com.mongodb.client.unified;
 import org.bson.BsonDocument;
 
 interface OperationAsserter {
-    void assertOperation(BsonDocument operation);
+    void assertOperation(BsonDocument operation, int index);
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
@@ -702,8 +702,9 @@ final class UnifiedCrudHelper {
 
         return resultOf(() -> {
             session.withTransaction(() -> {
-                for (BsonValue cur : callback) {
-                    operationAsserter.assertOperation(cur.asDocument());
+                for (int i = 0; i < callback.size(); i++) {
+                    BsonValue cur = callback.get(i);
+                    operationAsserter.assertOperation(cur.asDocument(), i);
                 }
                 //noinspection ConstantConditions
                 return null;


### PR DESCRIPTION
* Add a context for operation execution.  This provides context when the
  operation itself asserts
* Include the index of the operation in the operations array.  This helps
  when there are multiple operations that are identical and you want to
  be able to determine which one failed

JAVA-4152