### PR TITLE
Include versioned API options in all commands

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
@@ -284,14 +284,14 @@ public final class CommandMessage extends RequestMessage {
             if (firstMessageInTransaction) {
                 extraElements.add(new BsonElement("startTransaction", BsonBoolean.TRUE));
                 addReadConcernDocument(extraElements, sessionContext);
-                if (serverApi != null) {
-                    addServerApiElements(extraElements);
-                }
             }
             extraElements.add(new BsonElement("autocommit", BsonBoolean.FALSE));
-        } else if (serverApi != null) {
+        }
+
+        if (serverApi != null) {
             addServerApiElements(extraElements);
         }
+
         if (readPreference != null) {
             if (!readPreference.equals(primary())) {
                 extraElements.add(new BsonElement("$readPreference", readPreference.toDocument()));
@@ -333,7 +333,7 @@ public final class CommandMessage extends RequestMessage {
     }
 
     private static boolean isServerVersionAtLeastThreeDotSix(final MessageSettings settings) {
-          return settings.getMaxWireVersion() >= THREE_DOT_SIX_WIRE_VERSION;
+        return settings.getMaxWireVersion() >= THREE_DOT_SIX_WIRE_VERSION;
     }
 
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncQueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncQueryBatchCursor.java
@@ -247,7 +247,7 @@ class AsyncQueryBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
         if (serverIsAtLeastVersionThreeDotTwo(connection.getDescription())) {
             connection.commandAsync(namespace.getDatabaseName(), asGetMoreCommandDocument(cursor.getId()), NO_OP_FIELD_NAME_VALIDATOR,
                     ReadPreference.primary(), CommandResultDocumentCodec.create(decoder, "nextBatch"),
-                    connectionSource.getSessionContext(), null /* spec requires no server api for getMore */,
+                    connectionSource.getSessionContext(), connectionSource.getServerApi(),
                     new CommandResultSingleResultCallback(connection, cursor, callback, tryNext));
 
         } else {

--- a/driver-core/src/main/com/mongodb/internal/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/QueryBatchCursor.java
@@ -273,7 +273,7 @@ class QueryBatchCursor<T> implements AggregateResponseBatchCursor<T> {
                             ReadPreference.primary(),
                             CommandResultDocumentCodec.create(decoder, "nextBatch"),
                             connectionSource.getSessionContext(),
-                            null /* As per spec, ServerApi elements are not included in getMore commands */));
+                            connectionSource.getServerApi()));
                 } catch (MongoCommandException e) {
                     throw translateCommandException(e, serverCursor);
                 }

--- a/driver-core/src/test/resources/versioned-api/crud-api-version-1-strict.json
+++ b/driver-core/src/test/resources/versioned-api/crud-api-version-1-strict.json
@@ -651,7 +651,7 @@
       ]
     },
     {
-      "description": "find command with declared API version appends to the command, but getMore does not",
+      "description": "find and getMore append API version",
       "operations": [
         {
           "name": "find",
@@ -712,14 +712,10 @@
                       "long"
                     ]
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
+                  "apiStrict": true,
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }

--- a/driver-core/src/test/resources/versioned-api/crud-api-version-1.json
+++ b/driver-core/src/test/resources/versioned-api/crud-api-version-1.json
@@ -643,7 +643,7 @@
       ]
     },
     {
-      "description": "find command with declared API version appends to the command, but getMore does not",
+      "description": "find and getMore append API version",
       "operations": [
         {
           "name": "find",
@@ -704,15 +704,11 @@
                       "long"
                     ]
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
+                  "apiDeprecationErrors": true
                 }
               }
             }

--- a/driver-core/src/test/resources/versioned-api/transaction-handling.json
+++ b/driver-core/src/test/resources/versioned-api/transaction-handling.json
@@ -53,17 +53,6 @@
         "apiDeprecationErrors": {
           "$$unsetOrMatches": false
         }
-      },
-      {
-        "apiVersion": {
-          "$$exists": false
-        },
-        "apiStrict": {
-          "$$exists": false
-        },
-        "apiDeprecationErrors": {
-          "$$exists": false
-        }
       }
     ]
   },
@@ -97,7 +86,7 @@
   ],
   "tests": [
     {
-      "description": "Only the first command in a transaction declares an API version",
+      "description": "All commands in a transaction declare an API version",
       "runOnRequirements": [
         {
           "topologies": [
@@ -193,119 +182,6 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "commitTransaction": 1,
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "Committing a transaction twice does not append server API options",
-      "runOnRequirements": [
-        {
-          "topologies": [
-            "replicaset",
-            "sharded-replicaset"
-          ]
-        }
-      ],
-      "operations": [
-        {
-          "name": "startTransaction",
-          "object": "session"
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session",
-            "document": {
-              "_id": 6,
-              "x": 66
-            }
-          },
-          "expectResult": {
-            "$$unsetOrMatches": {
-              "insertedId": {
-                "$$unsetOrMatches": 6
-              }
-            }
-          }
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session",
-            "document": {
-              "_id": 7,
-              "x": 77
-            }
-          },
-          "expectResult": {
-            "$$unsetOrMatches": {
-              "insertedId": {
-                "$$unsetOrMatches": 7
-              }
-            }
-          }
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session"
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session"
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "insert": "test",
-                  "documents": [
-                    {
-                      "_id": 6,
-                      "x": 66
-                    }
-                  ],
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "startTransaction": true,
                   "apiVersion": "1",
                   "apiStrict": {
                     "$$unsetOrMatches": false
@@ -319,62 +195,16 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "insert": "test",
-                  "documents": [
-                    {
-                      "_id": 7,
-                      "x": 77
-                    }
-                  ],
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
                   "commitTransaction": 1,
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "commitTransaction": 1,
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }
@@ -384,7 +214,7 @@
       ]
     },
     {
-      "description": "abortTransaction does not include an API version",
+      "description": "abortTransaction includes an API version",
       "runOnRequirements": [
         {
           "topologies": [
@@ -480,14 +310,12 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }
@@ -499,14 +327,12 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }


### PR DESCRIPTION
Previously they were excluded from getMore and transaction-continuing
commands. Now they are included.

JAVA-4128