### PR TITLE
Only sleep when necessary in SyncMongoCursor construction or close

### DIFF
--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoClient.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoClient.java
@@ -35,24 +35,44 @@ import static java.util.Objects.requireNonNull;
 
 public class SyncMongoClient implements MongoClient {
 
-    // Unfortunately this is the only way to wait for a query to be initiated, since Reactive Streams is asynchronous
-    // and we have no way of knowing. Tests which require cursor initiation to complete before execution of the next operation
-    // can set this to a positive value.  A value of 256 ms has been shown to work well.
-    // Defaults to 0
     private static long sleepAfterCursorOpenMS;
 
-    // Unfortunately this is the only way to wait for close to complete, since it's asynchronous.
-    // This is inherently racy but there are not any other good options. Tests which require cursor cancellation to complete before
-    // execution of the next operation can set this to a positive value.  A value of 256 ms has been shown to work well.
-    // Defaults to 0
     private static long sleepAfterCursorCloseMS;
 
-    public static void setSleepAfterCursorOpen(final long sleepMS) {
+    /**
+     * Unfortunately this is the only way to wait for a query to be initiated, since Reactive Streams is asynchronous
+     * and we have no way of knowing. Tests which require cursor initiation to complete before execution of the next operation
+     * can set this to a positive value.  A value of 256 ms has been shown to work well. The default value is 0.
+     */
+    public static void enableSleepAfterCursorOpen(final long sleepMS) {
+        if (sleepAfterCursorOpenMS != 0) {
+            throw new IllegalStateException("Already enabled");
+        }
+        if (sleepMS <= 0) {
+            throw new IllegalArgumentException("sleepMS must be a postive value");
+        }
         sleepAfterCursorOpenMS = sleepMS;
     }
 
-    public static void setSleepAfterCursorClose(final long sleepMS) {
+    /**
+     * Unfortunately this is the only way to wait for close to complete, since it's asynchronous.
+     * This is inherently racy but there are not any other good options. Tests which require cursor cancellation to complete before
+     * execution of the next operation can set this to a positive value.  A value of 256 ms has been shown to work well. The default
+     * value is 0.
+     */
+    public static void enableSleepAfterCursorClose(final long sleepMS) {
+        if (sleepAfterCursorCloseMS != 0) {
+            throw new IllegalStateException("Already enabled");
+        }
+        if (sleepMS <= 0) {
+            throw new IllegalArgumentException("sleepMS must be a postive value");
+        }
         sleepAfterCursorCloseMS = sleepMS;
+    }
+
+    public static void disableCursorSleep() {
+        sleepAfterCursorOpenMS = 0;
+        sleepAfterCursorCloseMS = 0;
     }
 
     public static long getSleepAfterCursorOpen() {

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoClient.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoClient.java
@@ -34,6 +34,35 @@ import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
 import static java.util.Objects.requireNonNull;
 
 public class SyncMongoClient implements MongoClient {
+
+    // Unfortunately this is the only way to wait for a query to be initiated, since Reactive Streams is asynchronous
+    // and we have no way of knowing. Tests which require cursor initiation to complete before execution of the next operation
+    // can set this to a positive value.  A value of 256 ms has been shown to work well.
+    // Defaults to 0
+    private static long sleepAfterCursorOpenMS;
+
+    // Unfortunately this is the only way to wait for close to complete, since it's asynchronous.
+    // This is inherently racy but there are not any other good options. Tests which require cursor cancellation to complete before
+    // execution of the next operation can set this to a positive value.  A value of 256 ms has been shown to work well.
+    // Defaults to 0
+    private static long sleepAfterCursorCloseMS;
+
+    public static void setSleepAfterCursorOpen(final long sleepMS) {
+        sleepAfterCursorOpenMS = sleepMS;
+    }
+
+    public static void setSleepAfterCursorClose(final long sleepMS) {
+        sleepAfterCursorCloseMS = sleepMS;
+    }
+
+    public static long getSleepAfterCursorOpen() {
+        return sleepAfterCursorOpenMS;
+    }
+
+    public static long getSleepAfterCursorClose() {
+        return sleepAfterCursorCloseMS;
+    }
+
     private final com.mongodb.reactivestreams.client.MongoClient wrapped;
 
     public SyncMongoClient(final com.mongodb.reactivestreams.client.MongoClient wrapped) {

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCursor.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCursor.java
@@ -81,9 +81,7 @@ class SyncMongoCursor<T> implements MongoCursor<T> {
             if (!latch.await(TIMEOUT, TimeUnit.SECONDS)) {
                 throw new MongoTimeoutException("Timeout waiting for subscription");
             }
-            if (getSleepAfterCursorOpen() > 0) {
-                Thread.sleep(getSleepAfterCursorOpen());
-            }
+            sleep(getSleepAfterCursorOpen());
         } catch (InterruptedException e) {
             throw new MongoInterruptedException("Interrupted waiting for asynchronous cursor establishment", e);
         }
@@ -92,14 +90,17 @@ class SyncMongoCursor<T> implements MongoCursor<T> {
     @Override
     public void close() {
         subscription.cancel();
-        if (getSleepAfterCursorClose() > 0) {
-            try {
-                Thread.sleep(getSleepAfterCursorClose());
-            } catch (InterruptedException e) {
-                throw new MongoInterruptedException("Interrupted from nap", e);
-            }
+        sleep(getSleepAfterCursorClose());
+    }
+
+    private static void sleep(final long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            throw new MongoInterruptedException("Interrupted from nap", e);
         }
     }
+
     @Override
     @SuppressWarnings("unchecked")
     public boolean hasNext() {

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/LoadBalancerTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/LoadBalancerTest.java
@@ -51,7 +51,8 @@ public class LoadBalancerTest extends UnifiedTest {
             Arrays.asList(
                     "pinned connections are returned to the pool when the cursor is closed",
                     "only connections for a specific serviceId are closed when pools are cleared",
-                    "pinned connections are returned after a network error during a killCursors request");
+                    "pinned connections are returned after a network error during a killCursors request",
+                    "a connection can be shared by a transaction and a cursor");
 
     public LoadBalancerTest(@SuppressWarnings("unused") final String fileDescription,
                             final String testDescription,

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/LoadBalancerTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/LoadBalancerTest.java
@@ -33,6 +33,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.disableCursorSleep;
+import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.enableSleepAfterCursorClose;
+import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.enableSleepAfterCursorOpen;
 import static org.junit.Assume.assumeFalse;
 
 public class LoadBalancerTest extends UnifiedTest {
@@ -68,19 +71,18 @@ public class LoadBalancerTest extends UnifiedTest {
         assumeFalse(testDescription.equals("change streams pin to a connection"));
 
         if (CURSOR_OPEN_TIMING_SENSITIVE_TESTS.contains(testDescription)) {
-            SyncMongoClient.setSleepAfterCursorOpen(256);
+            enableSleepAfterCursorOpen(256);
         }
 
         if (CURSOR_CLOSE_TIMING_SENSITIVE_TESTS.contains(testDescription)) {
-            SyncMongoClient.setSleepAfterCursorClose(256);
+            enableSleepAfterCursorClose(256);
         }
     }
 
     @After
     public void cleanUp() {
         super.cleanUp();
-        SyncMongoClient.setSleepAfterCursorOpen(0);
-        SyncMongoClient.setSleepAfterCursorClose(0);
+        disableCursorSleep();
     }
 
     @Override

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/LoadBalancerTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/LoadBalancerTest.java
@@ -24,15 +24,34 @@ import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.junit.After;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import static org.junit.Assume.assumeFalse;
 
 public class LoadBalancerTest extends UnifiedTest {
+
+    private static final List<String> CURSOR_OPEN_TIMING_SENSITIVE_TESTS =
+            Arrays.asList(
+                    "pinned connections are returned when the cursor is drained",
+                    "only connections for a specific serviceId are closed when pools are cleared",
+                    "pinned connections are returned to the pool when the cursor is closed",
+                    "no connection is pinned if all documents are returned in the initial batch",
+                    "stale errors are ignored",
+                    "a connection can be shared by a transaction and a cursor",
+                    "wait queue timeout errors include cursor statistics");
+
+    private static final List<String> CURSOR_CLOSE_TIMING_SENSITIVE_TESTS =
+            Arrays.asList(
+                    "pinned connections are returned to the pool when the cursor is closed",
+                    "only connections for a specific serviceId are closed when pools are cleared",
+                    "pinned connections are returned after a network error during a killCursors request");
 
     public LoadBalancerTest(@SuppressWarnings("unused") final String fileDescription,
                             final String testDescription,
@@ -46,6 +65,21 @@ public class LoadBalancerTest extends UnifiedTest {
         // Reactive streams driver can't implement this test because there is no way to tell that a change stream cursor
         // that has not yet received any results has even initiated the change stream
         assumeFalse(testDescription.equals("change streams pin to a connection"));
+
+        if (CURSOR_OPEN_TIMING_SENSITIVE_TESTS.contains(testDescription)) {
+            SyncMongoClient.setSleepAfterCursorOpen(256);
+        }
+
+        if (CURSOR_CLOSE_TIMING_SENSITIVE_TESTS.contains(testDescription)) {
+            SyncMongoClient.setSleepAfterCursorClose(256);
+        }
+    }
+
+    @After
+    public void cleanUp() {
+        super.cleanUp();
+        SyncMongoClient.setSleepAfterCursorOpen(0);
+        SyncMongoClient.setSleepAfterCursorClose(0);
     }
 
     @Override


### PR DESCRIPTION
Turns out sleeping too much can cause problems...

The reason some transaction tests were failing is because, on Evergreen, we set `transactionLifetimeLimitSeconds` server parameter to something like 2 seconds.  And some of the transaction tests in pin-mongos.json open like 7 cursors in a single transaction.  Since we sleep for half a second per cursor, the transactions were timing out.

The solution, suggested by Valentin, is to only do the sleeps where necessary, for specific Load Balancer tests that require them.

JAVA-4176