### PR TITLE
 Refactor `DefaultConnectionPool` to use single worker thread when checking out asynchronously

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
@@ -141,7 +141,7 @@ public class ConcurrentPool<T> implements Pool<T> {
     @Override
     public T get(final long timeout, final TimeUnit timeUnit) {
         if (closed) {
-            throw new IllegalStateException("The pool is closed");
+            throw poolClosedException();
         }
 
         if (!acquirePermit(timeout, timeUnit)) {
@@ -293,5 +293,9 @@ public class ConcurrentPool<T> implements Pool<T> {
         } catch (RuntimeException e) {
             // ItemFactory.close() really should not throw
         }
+    }
+
+    static IllegalStateException poolClosedException() {
+        return new IllegalStateException("The pool is closed");
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -53,10 +53,12 @@ import org.bson.types.ObjectId;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -65,7 +67,8 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.locks.StampedLock;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.assertFalse;
 import static com.mongodb.assertions.Assertions.assertNotNull;
@@ -91,7 +94,7 @@ class DefaultConnectionPool implements ConnectionPool {
     private final ConnectionPoolSettings settings;
     private final AtomicInteger generation = new AtomicInteger(0);
     private final ScheduledExecutorService sizeMaintenanceTimer;
-    private final Workers workers;
+    private final AsyncWorkManager asyncWorkManager;
     private final Runnable maintenanceTask;
     private final ConnectionPoolListener connectionPoolListener;
     private final ServerId serverId;
@@ -113,7 +116,7 @@ class DefaultConnectionPool implements ConnectionPool {
         sizeMaintenanceTimer = createMaintenanceTimer();
         connectionPoolCreated(connectionPoolListener, serverId, settings);
         openConcurrencyLimiter = new OpenConcurrencyLimiter(MAX_CONNECTING);
-        workers = new Workers();
+        asyncWorkManager = new AsyncWorkManager();
         connectionGenerationSupplier = new ConnectionGenerationSupplier() {
             @Override
             public int getGeneration() {
@@ -172,25 +175,10 @@ class DefaultConnectionPool implements ConnectionPool {
                 errHandlingCallback.onResult(null, checkOutFailed(failure));
             }
         };
-        PooledConnection immediateConnection = null;
-
-        try {
-            immediateConnection = getPooledConnection(Timeout.immediate());
-        } catch (MongoTimeoutException e) {
-            // fall through
-        } catch (RuntimeException e) {
-            eventSendingCallback.onResult(null, e);
-            return;
-        }
-
-        if (immediateConnection != null) {
-            openAsync(immediateConnection, timeout, eventSendingCallback);
-        } else {
-            workers.getter().execute(() -> {
-                if (timeout.expired()) {
-                    eventSendingCallback.onResult(null, createTimeoutException(timeout));
-                    return;
-                }
+        asyncWorkManager.enqueue(new Task(timeout, t -> {
+            if (t != null) {
+                eventSendingCallback.onResult(null, t);
+            } else {
                 PooledConnection connection;
                 try {
                     connection = getPooledConnection(timeout);
@@ -198,9 +186,21 @@ class DefaultConnectionPool implements ConnectionPool {
                     eventSendingCallback.onResult(null, e);
                     return;
                 }
-                openAsync(connection, timeout, eventSendingCallback);
-            });
-        }
+                if (connection.opened()) {
+                    if (LOGGER.isTraceEnabled()) {
+                        LOGGER.trace(format("Pooled connection %s to server %s is already open",
+                                getId(connection), serverId));
+                    }
+                    eventSendingCallback.onResult(connection, null);
+                } else {
+                    if (LOGGER.isTraceEnabled()) {
+                        LOGGER.trace(format("Pooled connection %s to server %s is not yet open",
+                                getId(connection), serverId));
+                    }
+                    openConcurrencyLimiter.openAsyncOrGetAvailable(connection, timeout, eventSendingCallback);
+                }
+            }
+        }));
     }
 
     /**
@@ -221,23 +221,6 @@ class DefaultConnectionPool implements ConnectionPool {
             connectionPoolListener.connectionCheckOutFailed(new ConnectionCheckOutFailedEvent(serverId, Reason.UNKNOWN));
         }
         return result;
-    }
-
-    private void openAsync(final PooledConnection pooledConnection, final Timeout timeout,
-                           final SingleResultCallback<InternalConnection> callback) {
-        if (pooledConnection.opened()) {
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace(format("Pooled connection %s to server %s is already open",
-                        getId(pooledConnection), serverId));
-            }
-            callback.onResult(pooledConnection, null);
-        } else {
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace(format("Pooled connection %s to server %s is not yet open",
-                        getId(pooledConnection), serverId));
-            }
-            workers.opener().execute(() -> openConcurrencyLimiter.openAsyncOrGetAvailable(pooledConnection, timeout, callback));
-        }
     }
 
     @Override
@@ -264,7 +247,7 @@ class DefaultConnectionPool implements ConnectionPool {
             if (sizeMaintenanceTimer != null) {
                 sizeMaintenanceTimer.shutdownNow();
             }
-            workers.close();
+            asyncWorkManager.close();
             closed = true;
             connectionPoolListener.connectionPoolClosed(new ConnectionPoolClosedEvent(serverId));
         }
@@ -1170,55 +1153,174 @@ class DefaultConnectionPool implements ConnectionPool {
         }
     }
 
+    /**
+     * This class maintains threads needed to perform {@link #getAsync(SingleResultCallback)}.
+     */
     @ThreadSafe
-    private static class Workers implements AutoCloseable {
-        private volatile ExecutorService getter;
-        private volatile ExecutorService opener;
+    private static class AsyncWorkManager implements AutoCloseable {
+        private volatile State state;
+        private volatile BlockingQueue<Task> tasks;
         private final Lock lock;
+        private final Condition closedOrTaskAddedCondition;
+        @Nullable
+        private ExecutorService worker;
 
-        Workers() {
-            lock = new StampedLock().asWriteLock();
+        AsyncWorkManager() {
+            state = State.NEW;
+            tasks = new LinkedBlockingQueue<>();
+            lock = new ReentrantLock();
+            closedOrTaskAddedCondition = lock.newCondition();
         }
 
-        Executor getter() {
-            if (getter == null) {
-                lock.lock();
-                try {
-                    if (getter == null) {
-                        getter = Executors.newSingleThreadExecutor(new DaemonThreadFactory("AsyncGetter"));
-                    }
-                } finally {
-                    lock.unlock();
-                }
-            }
-            return getter;
-        }
-
-        Executor opener() {
-            if (opener == null) {
-                lock.lock();
-                try {
-                    if (opener == null) {
-                        opener = Executors.newSingleThreadExecutor(new DaemonThreadFactory("AsyncOpener"));
-                    }
-                } finally {
-                    lock.unlock();
-                }
-            }
-            return opener;
-        }
-
-        @Override
-        public void close() {
+        void enqueue(final Task task) {
+            lock.lock();
             try {
-                if (getter != null) {
-                    getter.shutdownNow();
+                if (initUnlessClosed()) {
+                    tasks.add(task);
+                    closedOrTaskAddedCondition.signalAll();
+                    return;
                 }
             } finally {
-                if (opener != null) {
-                    opener.shutdownNow();
-                }
+                lock.unlock();
             }
+            task.failAsClosed();
+        }
+
+        /**
+         * @return {@code false} iff the {@link #state} is {@link State#CLOSED}.
+         */
+        private boolean initUnlessClosed() {
+            boolean result = true;
+            if (state == State.NEW) {
+                worker = Executors.newSingleThreadExecutor(new DaemonThreadFactory("AsyncGetter"));
+                assertNotNull(worker).submit(() -> runAndLogUncaught(this::workerRun));
+                state = State.INITIALIZED;
+            } else if (state == State.CLOSED) {
+                result = false;
+            }
+            return result;
+        }
+
+        /**
+         * {@linkplain Thread#interrupt() Interrupts} all workers and causes queued tasks to
+         * {@linkplain Task#failAsClosed() fail} asynchronously.
+         */
+        @Override
+        @SuppressWarnings("try")
+        public void close() {
+            lock.lock();
+            try {
+                if (state != State.CLOSED) {
+                    try (UncheckedAutoCloseable ignored = UncheckedAutoCloseable.create(worker)) {
+                        state = State.CLOSED;
+                        closedOrTaskAddedCondition.signalAll();
+                    } // at this point we interrupt `worker`s thread
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private void workerRun() {
+            try {
+                while (state != State.CLOSED) {
+                    try {
+                        Task task = tasks.take();
+                        if (task.timeout().expired()) {
+                            task.failAsTimedOut();
+                        } else {
+                            task.execute();
+                        }
+                    } catch (RuntimeException e) {
+                        LOGGER.error(null, e);
+                    }
+                }
+            } catch (InterruptedException closed) {
+                // fail the rest of the tasks and stop
+            }
+            failAllTasksAfterClosing();
+        }
+
+        private void failAllTasksAfterClosing() {
+            Queue<Task> localGets;
+            lock.lock();
+            try {
+                assertTrue(state == State.CLOSED);
+                // at this point it is guaranteed that no thread enqueues a task
+                localGets = tasks;
+                if (!tasks.isEmpty()) {
+                    tasks = new LinkedBlockingQueue<>();
+                }
+            } finally {
+                lock.unlock();
+            }
+            localGets.forEach(Task::failAsClosed);
+            localGets.clear();
+        }
+
+        private void runAndLogUncaught(final Runnable runnable) {
+            try {
+                runnable.run();
+            } catch (Throwable t) {
+                LOGGER.error("The pool is not going to work correctly from now on. You may want to recreate the MongoClient", t);
+                throw t;
+            }
+        }
+
+        private enum State {
+            NEW,
+            INITIALIZED,
+            CLOSED
+        }
+
+        private interface UncheckedAutoCloseable extends AutoCloseable {
+            @Override
+            void close();
+
+            static UncheckedAutoCloseable create(@Nullable final ExecutorService ex) {
+                return () -> {
+                    if (ex != null) {
+                        ex.shutdownNow();
+                    }
+                };
+            }
+        }
+    }
+
+    /**
+     * An action that is allowed to be completed (failed or executed) at most once, and a timeout associated with it.
+     */
+    @NotThreadSafe
+    final class Task {
+        private final Timeout timeout;
+        private final Consumer<RuntimeException> action;
+        private boolean completed;
+
+        Task(final Timeout timeout, final Consumer<RuntimeException> action) {
+            this.timeout = timeout;
+            this.action = action;
+        }
+
+        void execute() {
+            doComplete(() -> null);
+        }
+
+        void failAsClosed() {
+            doComplete(ConcurrentPool::poolClosedException);
+        }
+
+        void failAsTimedOut() {
+            doComplete(() -> createTimeoutException(timeout));
+        }
+
+        private void doComplete(final Supplier<RuntimeException> failureSupplier) {
+            assertFalse(completed);
+            completed = true;
+            action.accept(failureSupplier.get());
+        }
+
+        Timeout timeout() {
+            return timeout;
         }
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestInternalConnectionFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestInternalConnectionFactory.java
@@ -26,16 +26,16 @@ import com.mongodb.internal.session.SessionContext;
 import org.bson.ByteBuf;
 import org.bson.codecs.Decoder;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.mongodb.connection.ServerDescription.getDefaultMaxDocumentSize;
 
 class TestInternalConnectionFactory implements InternalConnectionFactory {
     private final AtomicInteger incrementingId = new AtomicInteger();
-    private final List<TestInternalConnection> createdConnections = new ArrayList<TestInternalConnection>();
+    private final List<TestInternalConnection> createdConnections = new CopyOnWriteArrayList<>();
 
     @Override
     public InternalConnection create(final ServerId serverId, final ConnectionGenerationSupplier connectionGenerationSupplier) {
@@ -55,8 +55,8 @@ class TestInternalConnectionFactory implements InternalConnectionFactory {
     class TestInternalConnection implements InternalConnection {
         private final ConnectionId connectionId;
         private final int generation;
-        private boolean closed;
-        private boolean opened;
+        private volatile boolean closed;
+        private volatile boolean opened;
 
         TestInternalConnection(final ServerId serverId, final int generation) {
             this.connectionId = new ConnectionId(serverId, incrementingId.incrementAndGet(), null);

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/MainTransactionsTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/MainTransactionsTest.java
@@ -32,7 +32,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class MainTransactionsTest extends AbstractMainTransactionsTest {
-    private static final Set<String> SESSION_CLOSE_TIMING_SENSITIVE_TESTS = new HashSet<>(Collections.singletonList(
+    public static final Set<String> SESSION_CLOSE_TIMING_SENSITIVE_TESTS = new HashSet<>(Collections.singletonList(
             "implicit abort"));
 
     public MainTransactionsTest(final String filename, final String description, final String databaseName, final String collectionName,

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/MainTransactionsTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/MainTransactionsTest.java
@@ -24,8 +24,17 @@ import com.mongodb.connection.StreamFactoryFactory;
 import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 public class MainTransactionsTest extends AbstractMainTransactionsTest {
+    private static final Set<String> SESSION_CLOSE_TIMING_SENSITIVE_TESTS = new HashSet<>(Collections.singletonList(
+            "implicit abort"));
+
     public MainTransactionsTest(final String filename, final String description, final String databaseName, final String collectionName,
                                 final BsonArray data, final BsonDocument definition, final boolean skipTest) {
         super(filename, description, databaseName, collectionName, data, definition, skipTest);
@@ -39,5 +48,17 @@ public class MainTransactionsTest extends AbstractMainTransactionsTest {
     @Override
     protected StreamFactoryFactory getStreamFactoryFactory() {
         return ClusterFixture.getOverriddenStreamFactoryFactory();
+    }
+
+    @Before
+    public void before() {
+        if (SESSION_CLOSE_TIMING_SENSITIVE_TESTS.contains(getDescription())) {
+            SyncMongoClient.enableSleepAfterSessionClose(256);
+        }
+    }
+
+    @After
+    public void after() {
+        SyncMongoClient.disableSleep();
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncClientSession.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncClientSession.java
@@ -17,6 +17,7 @@
 package com.mongodb.reactivestreams.client.syncadapter;
 
 import com.mongodb.ClientSessionOptions;
+import com.mongodb.MongoInterruptedException;
 import com.mongodb.ServerAddress;
 import com.mongodb.TransactionOptions;
 import com.mongodb.client.ClientSession;
@@ -27,6 +28,7 @@ import org.bson.BsonTimestamp;
 import reactor.core.publisher.Mono;
 
 import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
+import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.getSleepAfterSessionClose;
 
 class SyncClientSession implements ClientSession {
     private final com.mongodb.reactivestreams.client.ClientSession wrapped;
@@ -114,6 +116,7 @@ class SyncClientSession implements ClientSession {
     @Override
     public void close() {
         wrapped.close();
+        sleep(getSleepAfterSessionClose());
     }
 
     @Override
@@ -164,5 +167,13 @@ class SyncClientSession implements ClientSession {
     @Override
     public <T> T withTransaction(final TransactionBody<T> transactionBody, final TransactionOptions options) {
         throw new UnsupportedOperationException();
+    }
+
+    private static void sleep(final long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            throw new MongoInterruptedException(null, e);
+        }
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/LoadBalancerTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/LoadBalancerTest.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.disableCursorSleep;
+import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.disableSleep;
 import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.enableSleepAfterCursorClose;
 import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.enableSleepAfterCursorOpen;
 import static org.junit.Assume.assumeFalse;
@@ -82,7 +82,7 @@ public class LoadBalancerTest extends UnifiedTest {
     @After
     public void cleanUp() {
         super.cleanUp();
-        disableCursorSleep();
+        disableSleep();
     }
 
     @Override

--- a/driver-scala/build.gradle
+++ b/driver-scala/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     testImplementation project(':bson').sourceSets.test.output
     testImplementation project(':driver-sync').sourceSets.test.output
     testImplementation project(':driver-core').sourceSets.test.output
+    testImplementation project(':driver-reactive-streams').sourceSets.test.output
 }
 
 

--- a/driver-scala/src/it/scala/org/mongodb/scala/MainTransactionsTest.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/MainTransactionsTest.scala
@@ -20,6 +20,8 @@ import com.mongodb.client.AbstractMainTransactionsTest
 import org.bson.{ BsonArray, BsonDocument }
 import org.junit.{ After, Before }
 import org.mongodb.scala.syncadapter.SyncMongoClient
+import com.mongodb.reactivestreams.client.MainTransactionsTest.SESSION_CLOSE_TIMING_SENSITIVE_TESTS
+import com.mongodb.reactivestreams.client.syncadapter.{ SyncMongoClient => JSyncMongoClient }
 
 class MainTransactionsTest(
     val filename: String,
@@ -42,12 +44,9 @@ class MainTransactionsTest(
     SyncMongoClient(MongoClient(settings))
 
   @Before def before(): Unit = {
-    if (com.mongodb.reactivestreams.client.MainTransactionsTest.SESSION_CLOSE_TIMING_SENSITIVE_TESTS
-          .contains(getDescription))
-      com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.enableSleepAfterSessionClose(256)
+    if (SESSION_CLOSE_TIMING_SENSITIVE_TESTS.contains(getDescription))
+      JSyncMongoClient.enableSleepAfterSessionClose(256)
   }
 
-  @After def after(): Unit = {
-    com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.disableSleep()
-  }
+  @After def after(): Unit = JSyncMongoClient.disableSleep()
 }

--- a/driver-scala/src/it/scala/org/mongodb/scala/MainTransactionsTest.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/MainTransactionsTest.scala
@@ -18,6 +18,7 @@ package org.mongodb.scala
 
 import com.mongodb.client.AbstractMainTransactionsTest
 import org.bson.{ BsonArray, BsonDocument }
+import org.junit.{ After, Before }
 import org.mongodb.scala.syncadapter.SyncMongoClient
 
 class MainTransactionsTest(
@@ -39,4 +40,14 @@ class MainTransactionsTest(
     ) {
   override protected def createMongoClient(settings: com.mongodb.MongoClientSettings) =
     SyncMongoClient(MongoClient(settings))
+
+  @Before def before(): Unit = {
+    if (com.mongodb.reactivestreams.client.MainTransactionsTest.SESSION_CLOSE_TIMING_SENSITIVE_TESTS
+          .contains(getDescription))
+      com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.enableSleepAfterSessionClose(256)
+  }
+
+  @After def after(): Unit = {
+    com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.disableSleep()
+  }
 }

--- a/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncClientSession.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncClientSession.scala
@@ -21,6 +21,7 @@ import com.mongodb.client.{ TransactionBody, ClientSession => JClientSession }
 import com.mongodb.session.ServerSession
 import org.bson.{ BsonDocument, BsonTimestamp }
 import org.mongodb.scala._
+import com.mongodb.reactivestreams.client.syncadapter.{ SyncMongoClient => JSyncMongoClient }
 
 case class SyncClientSession(wrapped: ClientSession, originator: Object) extends JClientSession {
 
@@ -48,7 +49,7 @@ case class SyncClientSession(wrapped: ClientSession, originator: Object) extends
 
   override def close(): Unit = {
     wrapped.close()
-    sleep(com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.getSleepAfterSessionClose)
+    sleep(JSyncMongoClient.getSleepAfterSessionClose)
   }
 
   override def hasActiveTransaction: Boolean = wrapped.hasActiveTransaction

--- a/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
@@ -65,7 +65,18 @@ class ApiAliasAndCompanionSpec extends BaseSpec {
       "SingleResultCallback",
       "SubjectProvider",
       "TransactionExample",
-      "UnixServerAddress"
+      "UnixServerAddress",
+      "SubscriberHelpers",
+      "PublisherHelpers",
+      "TargetDocument",
+      "UpdatePrimer",
+      "InsertPrimer",
+      "IndexesPrimer",
+      "QueryPrimer",
+      "DocumentationSamples",
+      "AggregatePrimer",
+      "RemovePrimer",
+      "SyncMongoClient"
     )
     val scalaExclusions = Set(
       "BuildInfo",

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractUnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractUnifiedTest.java
@@ -137,6 +137,10 @@ public abstract class AbstractUnifiedTest {
         return null;
     }
 
+    protected final String getDescription() {
+        return description;
+    }
+
     @Before
     public void setUp() {
         assumeFalse(skipTest);


### PR DESCRIPTION
This PR is a successor of https://github.com/mongodb/mongo-java-driver/pull/719, and uses a different, much more resource-effective approach: we are back to using a single worker for async check outs, which, given that all check out operations currently have the same timeout, puts us back to a situation when async timeouts are handled correctly. Please see the commit messages for more details.

With CSOT different check out operations will have different timeouts, and we will have to change the `DefaultConnectionPool` code to handle timeouts correctly. However, that's a task for future. We can either do the same thing I did in https://github.com/mongodb/mongo-java-driver/pull/719, or we can mix the logic handling timeouts into existing blocking calls done by the (now single) async worker thread. Because of the changes done in the current PR (removal of the `getAsync` optimization that allowed the method to sometimes be executed synchronously), putting the timeout handling logic in the same async worker thread now does not seem to be a practically impossible task (I'd like to thank @BorisDog for useful conversations we had around this topic) because now it does not break fairness guarantees.

JAVA-4146