### PR TITLE
Remove most field name validation

### DIFF
--- a/bson/src/test/resources/bson/document.json
+++ b/bson/src/test/resources/bson/document.json
@@ -17,6 +17,26 @@
             "description": "Single-character key subdoc",
             "canonical_bson": "160000000378000E0000000261000200000062000000",
             "canonical_extjson": "{\"x\" : {\"a\" : \"b\"}}"
+        },
+        {
+            "description": "Dollar-prefixed key in sub-document",
+            "canonical_bson": "170000000378000F000000022461000200000062000000",
+            "canonical_extjson": "{\"x\" : {\"$a\" : \"b\"}}"
+        },
+        {
+            "description": "Dollar as key in sub-document",
+            "canonical_bson": "160000000378000E0000000224000200000061000000",
+            "canonical_extjson": "{\"x\" : {\"$\" : \"a\"}}"
+        },
+        {
+            "description": "Dotted key in sub-document",
+            "canonical_bson": "180000000378001000000002612E62000200000063000000",
+            "canonical_extjson": "{\"x\" : {\"a.b\" : \"c\"}}"
+        },
+        {
+            "description": "Dot as key in sub-document",
+            "canonical_bson": "160000000378000E000000022E000200000061000000",
+            "canonical_extjson": "{\"x\" : {\".\" : \"a\"}}"
         }
     ],
     "decodeErrors": [

--- a/bson/src/test/resources/bson/top.json
+++ b/bson/src/test/resources/bson/top.json
@@ -3,9 +3,24 @@
     "bson_type": "0x00",
     "valid": [
         {
-            "description": "Document with keys that start with $",
+            "description": "Dollar-prefixed key in top-level document",
             "canonical_bson": "0F00000010246B6579002A00000000",
             "canonical_extjson": "{\"$key\": {\"$numberInt\": \"42\"}}"
+        },
+        {
+            "description": "Dollar as key in top-level document",
+            "canonical_bson": "0E00000002240002000000610000",
+            "canonical_extjson": "{\"$\": \"a\"}"
+        },
+        {
+            "description": "Dotted key in top-level document",
+            "canonical_bson": "1000000002612E620002000000630000",
+            "canonical_extjson": "{\"a.b\": \"c\"}"
+        },
+        {
+            "description": "Dot as key in top-level document",
+            "canonical_bson": "0E000000022E0002000000610000",
+            "canonical_extjson": "{\".\": \"a\"}"
         }
     ],
     "decodeErrors": [
@@ -69,11 +84,11 @@
     "parseErrors": [
         {
             "description" : "Bad $regularExpression (extra field)",
-            "string" : "{\"a\" : \"$regularExpression\": {\"pattern\": \"abc\", \"options\": \"\", \"unrelated\": true}}}"
+            "string" : "{\"a\" : {\"$regularExpression\": {\"pattern\": \"abc\", \"options\": \"\", \"unrelated\": true}}}"
         },
         {
             "description" : "Bad $regularExpression (missing options field)",
-            "string" : "{\"a\" : \"$regularExpression\": {\"pattern\": \"abc\"}}}"
+            "string" : "{\"a\" : {\"$regularExpression\": {\"pattern\": \"abc\"}}}"
         },
         {
             "description": "Bad $regularExpression (pattern is number, not string)",
@@ -85,7 +100,7 @@
         },
         {
             "description" : "Bad $regularExpression (missing pattern field)",
-            "string" : "{\"a\" : \"$regularExpression\": {\"options\":\"ix\"}}}"
+            "string" : "{\"a\" : {\"$regularExpression\": {\"options\":\"ix\"}}}"
         },
         {
             "description": "Bad $oid (number, not string)",

--- a/docs/reference/content/whats-new.md
+++ b/docs/reference/content/whats-new.md
@@ -15,6 +15,15 @@ New features of the 4.3 Java driver release include:
 
 * Added support for the MongoDB Versioned API.  See the 
   [`ServerApi`]({{< apiref "mongodb-driver-core" "com/mongodb/ServerApi.html" >}}) API documentation for details.
+* Removed most restrictions on allowed characters in field names of documents being inserted or replaced.  This is a behavioral change 
+  for any application that is relying on client-side enforcement of these restrictions. In particular: 
+  * Restrictions on field names containing the "." character have been removed. This affects all insert and replace operations.
+  * Restrictions on field names starting with the "$" character have been removed for all insert operations.
+  * Restrictions in nested documents on field names starting with the "$" character have been removed for all replace operations.  
+  * Restrictions in the top-level document on field names starting with the "$" character remain for all replace operations. This is 
+    primarily to prevent accidental use of a replace operation when the intention was to use an update operation.
+  * Note that unacknowledged writes using dollar-prefixed or dotted keys may be silently rejected by pre-5.0 servers, where some 
+    restrictions on field names are still enforced in the server.
 
 # What's new in 4.2
 

--- a/driver-core/src/main/com/mongodb/internal/connection/InsertMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InsertMessage.java
@@ -17,7 +17,7 @@
 package com.mongodb.internal.connection;
 
 import com.mongodb.internal.bulk.InsertRequest;
-import com.mongodb.internal.validator.CollectibleDocumentFieldNameValidator;
+import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import org.bson.io.BsonOutput;
 
 /**
@@ -38,7 +38,7 @@ class InsertMessage extends LegacyMessage {
     protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput outputStream) {
         writeInsertPrologue(outputStream);
         int firstDocumentPosition = outputStream.getPosition();
-        addCollectibleDocument(insertRequest.getDocument(), outputStream, new CollectibleDocumentFieldNameValidator());
+        addCollectibleDocument(insertRequest.getDocument(), outputStream, new NoOpFieldNameValidator());
         return new EncodingMetadata(firstDocumentPosition);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/UpdateMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/UpdateMessage.java
@@ -17,7 +17,7 @@
 package com.mongodb.internal.connection;
 
 import com.mongodb.internal.bulk.UpdateRequest;
-import com.mongodb.internal.validator.CollectibleDocumentFieldNameValidator;
+import com.mongodb.internal.validator.ReplacingDocumentFieldNameValidator;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.internal.validator.UpdateFieldNameValidator;
 import org.bson.BsonValue;
@@ -56,7 +56,7 @@ class UpdateMessage extends LegacyMessage {
 
         addDocument(updateRequest.getFilter(), bsonOutput, new NoOpFieldNameValidator());
         if (updateRequest.getType() == REPLACE && updateRequest.getUpdateValue().isDocument()) {
-            addDocument(updateRequest.getUpdateValue().asDocument(), bsonOutput, new CollectibleDocumentFieldNameValidator());
+            addDocument(updateRequest.getUpdateValue().asDocument(), bsonOutput, new ReplacingDocumentFieldNameValidator());
         } else {
             int bufferPosition = bsonOutput.getPosition();
             BsonValue update = updateRequest.getUpdateValue();

--- a/driver-core/src/main/com/mongodb/internal/operation/BulkWriteBatch.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/BulkWriteBatch.java
@@ -36,9 +36,9 @@ import com.mongodb.internal.connection.BulkWriteBatchCombiner;
 import com.mongodb.internal.connection.IndexMap;
 import com.mongodb.internal.connection.SplittablePayload;
 import com.mongodb.internal.session.SessionContext;
-import com.mongodb.internal.validator.CollectibleDocumentFieldNameValidator;
 import com.mongodb.internal.validator.MappedFieldNameValidator;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
+import com.mongodb.internal.validator.ReplacingDocumentFieldNameValidator;
 import com.mongodb.internal.validator.UpdateFieldNameValidator;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
@@ -260,12 +260,10 @@ final class BulkWriteBatch {
     }
 
     public FieldNameValidator getFieldNameValidator() {
-        if (batchType == INSERT) {
-            return new CollectibleDocumentFieldNameValidator();
-        } else if (batchType == UPDATE || batchType == REPLACE) {
+        if (batchType == UPDATE || batchType == REPLACE) {
             Map<String, FieldNameValidator> rootMap = new HashMap<String, FieldNameValidator>();
             if (batchType == WriteRequest.Type.REPLACE) {
-                rootMap.put("u", new CollectibleDocumentFieldNameValidator());
+                rootMap.put("u", new ReplacingDocumentFieldNameValidator());
             } else {
                 rootMap.put("u", new UpdateFieldNameValidator());
             }

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
@@ -21,10 +21,10 @@ import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerDescription;
-import com.mongodb.internal.validator.CollectibleDocumentFieldNameValidator;
 import com.mongodb.internal.validator.MappedFieldNameValidator;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.internal.session.SessionContext;
+import com.mongodb.internal.validator.ReplacingDocumentFieldNameValidator;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -392,7 +392,7 @@ public class FindAndReplaceOperation<T> extends BaseFindAndModifyOperation<T> {
     @Override
     protected FieldNameValidator getFieldNameValidator() {
         Map<String, FieldNameValidator> map = new HashMap<String, FieldNameValidator>();
-        map.put("update", new CollectibleDocumentFieldNameValidator());
+        map.put("update", new ReplacingDocumentFieldNameValidator());
         return new MappedFieldNameValidator(new NoOpFieldNameValidator(), map);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidator.java
+++ b/driver-core/src/main/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidator.java
@@ -22,12 +22,13 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * A field name validator for document that are meant for storage in MongoDB collections.  It ensures that no fields contain a '.',
- * or start with '$' (with the exception of "$db", "$ref", and "$id", so that DBRefs are not rejected).
+ * A field name validator for document that are meant for storage in MongoDB collections via replace operations  It ensures that no
+ * top-level fields start with '$' (with the exception of "$db", "$ref", and "$id", so that DBRefs are not rejected).
  *
  * <p>This class should not be considered a part of the public API.</p>
  */
-public class CollectibleDocumentFieldNameValidator implements FieldNameValidator {
+public class ReplacingDocumentFieldNameValidator implements FieldNameValidator {
+    private static final NoOpFieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
     // Have to support DBRef fields
     private static final List<String> EXCEPTIONS = Arrays.asList("$db", "$ref", "$id");
 
@@ -37,18 +38,12 @@ public class CollectibleDocumentFieldNameValidator implements FieldNameValidator
             throw new IllegalArgumentException("Field name can not be null");
         }
 
-        if (fieldName.contains(".")) {
-            return false;
-        }
-
-        if (fieldName.startsWith("$") && !EXCEPTIONS.contains(fieldName)) {
-            return false;
-        }
-        return true;
+        return !fieldName.startsWith("$") || EXCEPTIONS.contains(fieldName);
     }
 
     @Override
     public FieldNameValidator getValidatorForField(final String fieldName) {
-        return this;
+        // Only top-level fields are validated
+        return NO_OP_FIELD_NAME_VALIDATOR;
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidator.java
+++ b/driver-core/src/main/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidator.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * A field name validator for document that are meant for storage in MongoDB collections via replace operations  It ensures that no
+ * A field name validator for documents that are meant for storage in MongoDB collections via replace operations. It ensures that no
  * top-level fields start with '$' (with the exception of "$db", "$ref", and "$id", so that DBRefs are not rejected).
  *
  * <p>This class should not be considered a part of the public API.</p>

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/WriteProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/WriteProtocolCommandEventSpecification.groovy
@@ -201,8 +201,8 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
 
     def 'should not deliver any events if encoding fails'() {
         given:
-        def insertRequest = new InsertRequest(new BsonDocument('$set', new BsonInt32(1)))
-        def protocol = new InsertProtocol(getNamespace(), true, insertRequest)
+        def updateRequest = new UpdateRequest(new BsonDocument(), new BsonDocument('$set', new BsonInt32(1)), REPLACE)
+        def protocol = new UpdateProtocol(getNamespace(), true, updateRequest)
         def commandListener = new TestCommandListener()
         protocol.commandListener = commandListener
 

--- a/driver-core/src/test/resources/transactions/errors-client.json
+++ b/driver-core/src/test/resources/transactions/errors-client.json
@@ -25,14 +25,15 @@
           "object": "session0"
         },
         {
-          "name": "insertOne",
+          "name": "updateOne",
           "object": "collection",
           "arguments": {
             "session": "session0",
-            "document": {
-              "_id": {
-                ".": "."
-              }
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 1
             }
           },
           "error": true
@@ -60,22 +61,23 @@
           "arguments": {
             "session": "session0",
             "document": {
-              "_id": 4
+              "_id": 1
             }
           },
           "result": {
-            "insertedId": 4
+            "insertedId": 1
           }
         },
         {
-          "name": "insertOne",
+          "name": "updateOne",
           "object": "collection",
           "arguments": {
             "session": "session0",
-            "document": {
-              "_id": {
-                ".": "."
-              }
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 1
             }
           },
           "error": true

--- a/driver-core/src/test/resources/unified-test-format/crud/aggregate-merge.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/aggregate-merge.json
@@ -1,6 +1,6 @@
 {
   "description": "aggregate-merge",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.1.11"

--- a/driver-core/src/test/resources/unified-test-format/crud/aggregate-out-readConcern.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/aggregate-out-readConcern.json
@@ -1,6 +1,6 @@
 {
   "description": "aggregate-out-readConcern",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.1.0",

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-arrayFilters-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-arrayFilters-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-arrayFilters-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.5.5"

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-arrayFilters.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-arrayFilters.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-arrayFilters",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.5.6"
@@ -90,7 +90,9 @@
           "expectResult": {
             "deletedCount": 0,
             "insertedCount": 0,
-            "insertedIds": {},
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
             "matchedCount": 1,
             "modifiedCount": 1,
             "upsertedCount": 0,
@@ -196,7 +198,9 @@
           "expectResult": {
             "deletedCount": 0,
             "insertedCount": 0,
-            "insertedIds": {},
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
             "matchedCount": 2,
             "modifiedCount": 2,
             "upsertedCount": 0,

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-delete-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-delete-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-delete-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.3.99"

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-delete-hint-serverError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-delete-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-delete-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4.0",

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-delete-hint.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-delete-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-delete-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.4"
@@ -87,7 +87,9 @@
           "expectResult": {
             "deletedCount": 2,
             "insertedCount": 0,
-            "insertedIds": {},
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
             "matchedCount": 0,
             "modifiedCount": 0,
             "upsertedCount": 0,
@@ -181,7 +183,9 @@
           "expectResult": {
             "deletedCount": 3,
             "insertedCount": 0,
-            "insertedIds": {},
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
             "matchedCount": 0,
             "modifiedCount": 0,
             "upsertedCount": 0,

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-insertOne-dots_and_dollars.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-insertOne-dots_and_dollars.json
@@ -1,0 +1,374 @@
+{
+  "description": "bulkWrite-insertOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "$a": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            },
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "$a": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dotted key",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "a.b": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            },
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a.b": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dollar-prefixed key in embedded doc",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            },
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "$b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in embedded doc",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            },
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "b.c": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-replaceOne-dots_and_dollars.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-replaceOne-dots_and_dollars.json
@@ -1,0 +1,532 @@
+{
+  "description": "bulkWrite-replaceOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Replacing document with top-level dotted key on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a.b": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a.b": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with top-level dotted key on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a.b": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a.b": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "b.c": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "b.c": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-update-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-update-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-update-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.3.99"

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-update-hint-serverError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-update-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-update-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4.0",

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-update-hint.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-update-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-update-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0"
@@ -97,7 +97,9 @@
           "expectResult": {
             "deletedCount": 0,
             "insertedCount": 0,
-            "insertedIds": {},
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
             "matchedCount": 2,
             "modifiedCount": 2,
             "upsertedCount": 0,
@@ -229,7 +231,9 @@
           "expectResult": {
             "deletedCount": 0,
             "insertedCount": 0,
-            "insertedIds": {},
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
             "matchedCount": 4,
             "modifiedCount": 4,
             "upsertedCount": 0,
@@ -353,7 +357,9 @@
           "expectResult": {
             "deletedCount": 0,
             "insertedCount": 0,
-            "insertedIds": {},
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
             "matchedCount": 2,
             "modifiedCount": 2,
             "upsertedCount": 0,

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-update-validation.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-update-validation.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-update-validation",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {
@@ -14,21 +14,21 @@
       "database": {
         "id": "database0",
         "client": "client0",
-        "databaseName": "crud-v2"
+        "databaseName": "crud-tests"
       }
     },
     {
       "collection": {
         "id": "collection0",
         "database": "database0",
-        "collectionName": "crud-v2"
+        "collectionName": "coll0"
       }
     }
   ],
   "initialData": [
     {
-      "collectionName": "crud-v2",
-      "databaseName": "crud-v2",
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
       "documents": [
         {
           "_id": 1,
@@ -50,8 +50,8 @@
       "description": "BulkWrite replaceOne prohibits atomic modifiers",
       "operations": [
         {
-          "object": "collection0",
           "name": "bulkWrite",
+          "object": "collection0",
           "arguments": {
             "requests": [
               {
@@ -69,7 +69,7 @@
             ]
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],
@@ -81,8 +81,8 @@
       ],
       "outcome": [
         {
-          "collectionName": "crud-v2",
-          "databaseName": "crud-v2",
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
           "documents": [
             {
               "_id": 1,
@@ -104,8 +104,8 @@
       "description": "BulkWrite updateOne requires atomic modifiers",
       "operations": [
         {
-          "object": "collection0",
           "name": "bulkWrite",
+          "object": "collection0",
           "arguments": {
             "requests": [
               {
@@ -121,7 +121,7 @@
             ]
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],
@@ -133,8 +133,8 @@
       ],
       "outcome": [
         {
-          "collectionName": "crud-v2",
-          "databaseName": "crud-v2",
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
           "documents": [
             {
               "_id": 1,
@@ -156,8 +156,8 @@
       "description": "BulkWrite updateMany requires atomic modifiers",
       "operations": [
         {
-          "object": "collection0",
           "name": "bulkWrite",
+          "object": "collection0",
           "arguments": {
             "requests": [
               {
@@ -175,7 +175,7 @@
             ]
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],
@@ -187,8 +187,8 @@
       ],
       "outcome": [
         {
-          "collectionName": "crud-v2",
-          "databaseName": "crud-v2",
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
           "documents": [
             {
               "_id": 1,

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-updateMany-dots_and_dollars.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-updateMany-dots_and_dollars.json
@@ -1,0 +1,452 @@
+{
+  "description": "bulkWrite-updateMany-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "$a"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "$a"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "a.b"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "a.b"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "$a"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "$a"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "a.b"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "a.b"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-updateOne-dots_and_dollars.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-updateOne-dots_and_dollars.json
@@ -1,0 +1,460 @@
+{
+  "description": "bulkWrite-updateOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "$a"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "$a"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "a.b"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "a.b"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "$a"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "$a"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "a.b"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "a.b"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/deleteMany-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/deleteMany-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "deleteMany-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.3.99"

--- a/driver-core/src/test/resources/unified-test-format/crud/deleteMany-hint-serverError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/deleteMany-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "deleteMany-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4.0",

--- a/driver-core/src/test/resources/unified-test-format/crud/deleteMany-hint.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/deleteMany-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "deleteMany-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.4"

--- a/driver-core/src/test/resources/unified-test-format/crud/deleteOne-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/deleteOne-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "deleteOne-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.3.99"

--- a/driver-core/src/test/resources/unified-test-format/crud/deleteOne-hint-serverError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/deleteOne-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "deleteOne-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4.0",

--- a/driver-core/src/test/resources/unified-test-format/crud/deleteOne-hint.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/deleteOne-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "deleteOne-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.4"

--- a/driver-core/src/test/resources/unified-test-format/crud/find-allowdiskuse-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/find-allowdiskuse-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "find-allowdiskuse-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.0.99"

--- a/driver-core/src/test/resources/unified-test-format/crud/find-allowdiskuse-serverError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/find-allowdiskuse-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "find-allowdiskuse-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.2",

--- a/driver-core/src/test/resources/unified-test-format/crud/find-allowdiskuse.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/find-allowdiskuse.json
@@ -1,6 +1,6 @@
 {
   "description": "find-allowdiskuse",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.1"

--- a/driver-core/src/test/resources/unified-test-format/crud/findOneAndDelete-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/findOneAndDelete-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndDelete-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "4.0.99"

--- a/driver-core/src/test/resources/unified-test-format/crud/findOneAndDelete-hint-serverError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/findOneAndDelete-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndDelete-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0",

--- a/driver-core/src/test/resources/unified-test-format/crud/findOneAndDelete-hint.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/findOneAndDelete-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndDelete-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.4"

--- a/driver-core/src/test/resources/unified-test-format/crud/findOneAndReplace-dots_and_dollars.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/findOneAndReplace-dots_and_dollars.json
@@ -1,0 +1,430 @@
+{
+  "description": "findOneAndReplace-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Replacing document with top-level dotted key on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a.b": 1
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with top-level dotted key on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a.b": 1
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/findOneAndReplace-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/findOneAndReplace-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndReplace-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "4.0.99"

--- a/driver-core/src/test/resources/unified-test-format/crud/findOneAndReplace-hint-serverError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/findOneAndReplace-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndReplace-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0",

--- a/driver-core/src/test/resources/unified-test-format/crud/findOneAndReplace-hint.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/findOneAndReplace-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndReplace-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.1"

--- a/driver-core/src/test/resources/unified-test-format/crud/findOneAndUpdate-dots_and_dollars.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/findOneAndUpdate-dots_and_dollars.json
@@ -1,0 +1,380 @@
+{
+  "description": "findOneAndUpdate-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "$a"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "_id": 1,
+            "foo": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "$a"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ],
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "a.b"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "_id": 1,
+            "foo": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "a.b"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ],
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "$a"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "_id": 1,
+            "foo": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "$a"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "a.b"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "_id": 1,
+            "foo": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "a.b"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/findOneAndUpdate-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/findOneAndUpdate-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndUpdate-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "4.0.99"

--- a/driver-core/src/test/resources/unified-test-format/crud/findOneAndUpdate-hint-serverError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/findOneAndUpdate-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndUpdate-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0",

--- a/driver-core/src/test/resources/unified-test-format/crud/findOneAndUpdate-hint.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/findOneAndUpdate-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndUpdate-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.1"

--- a/driver-core/src/test/resources/unified-test-format/crud/insertMany-dots_and_dollars.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/insertMany-dots_and_dollars.json
@@ -1,0 +1,334 @@
+{
+  "description": "insertMany-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "$a": 1
+              }
+            ]
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "$a": 1
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dotted key",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "a.b": 1
+              }
+            ]
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a.b": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dollar-prefixed key in embedded doc",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "a": {
+                  "$b": 1
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "$b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in embedded doc",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "a": {
+                  "b.c": 1
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "b.c": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/insertOne-dots_and_dollars.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/insertOne-dots_and_dollars.json
@@ -1,0 +1,606 @@
+{
+  "description": "insertOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1",
+        "collectionOptions": {
+          "writeConcern": {
+            "w": 0
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "$a": 1
+            }
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedId": {
+              "$$unsetOrMatches": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "$a": 1
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dotted key",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedId": {
+              "$$unsetOrMatches": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a.b": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dollar-prefixed key in embedded doc",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedId": {
+              "$$unsetOrMatches": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "$b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in embedded doc",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedId": {
+              "$$unsetOrMatches": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "b.c": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dollar-prefixed key in _id yields server-side error",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": {
+                "$a": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$a": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in _id on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": {
+                "a.b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedId": {
+              "$$unsetOrMatches": {
+                "a.b": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": {
+                        "a.b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in _id on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": {
+                "a.b": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": {
+                        "a.b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with DBRef-like keys",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "$db": "foo"
+              }
+            }
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedId": {
+              "$$unsetOrMatches": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "$db": "foo"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$db": "foo"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Unacknowledged write using dollar-prefixed or dotted keys may be silently rejected on pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "_id": {
+                "$a": 1
+              }
+            }
+          },
+          "expectResult": {
+            "acknowledged": {
+              "$$unsetOrMatches": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll1",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$a": 1
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": 0
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/replaceOne-dots_and_dollars.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/replaceOne-dots_and_dollars.json
@@ -1,0 +1,567 @@
+{
+  "description": "replaceOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1",
+        "collectionOptions": {
+          "writeConcern": {
+            "w": 0
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Replacing document with top-level dotted key on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a.b": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with top-level dotted key on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a.b": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "b.c": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "b.c": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Unacknowledged write using dollar-prefixed or dotted keys may be silently rejected on pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection1",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "acknowledged": {
+              "$$unsetOrMatches": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll1",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": 0
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/replaceOne-hint.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/replaceOne-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "replaceOne-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0"

--- a/driver-core/src/test/resources/unified-test-format/crud/replaceOne-validation.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/replaceOne-validation.json
@@ -1,6 +1,6 @@
 {
   "description": "replaceOne-validation",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {
@@ -14,21 +14,21 @@
       "database": {
         "id": "database0",
         "client": "client0",
-        "databaseName": "crud-v2"
+        "databaseName": "crud-tests"
       }
     },
     {
       "collection": {
         "id": "collection0",
         "database": "database0",
-        "collectionName": "crud-v2"
+        "collectionName": "coll0"
       }
     }
   ],
   "initialData": [
     {
-      "collectionName": "crud-v2",
-      "databaseName": "crud-v2",
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
       "documents": [
         {
           "_id": 1,
@@ -42,8 +42,8 @@
       "description": "ReplaceOne prohibits atomic modifiers",
       "operations": [
         {
-          "object": "collection0",
           "name": "replaceOne",
+          "object": "collection0",
           "arguments": {
             "filter": {
               "_id": 1
@@ -55,7 +55,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],
@@ -67,8 +67,8 @@
       ],
       "outcome": [
         {
-          "collectionName": "crud-v2",
-          "databaseName": "crud-v2",
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
           "documents": [
             {
               "_id": 1,

--- a/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-bulkWrite-delete-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-bulkWrite-delete-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-bulkWrite-delete-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-bulkWrite-update-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-bulkWrite-update-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-bulkWrite-update-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-deleteMany-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-deleteMany-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-deleteMany-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-deleteOne-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-deleteOne-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-deleteOne-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-findOneAndDelete-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-findOneAndDelete-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-findOneAndDelete-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-findOneAndReplace-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-findOneAndReplace-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-findOneAndReplace-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-findOneAndUpdate-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-findOneAndUpdate-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-findOneAndUpdate-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-replaceOne-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-replaceOne-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-replaceOne-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-updateMany-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-updateMany-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-updateMany-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-updateOne-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/unacknowledged-updateOne-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-updateOne-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/driver-core/src/test/resources/unified-test-format/crud/updateMany-dots_and_dollars.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateMany-dots_and_dollars.json
@@ -1,0 +1,404 @@
+{
+  "description": "updateMany-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "$a"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "$a"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "a.b"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "a.b"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "$a"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "$a"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "a.b"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "a.b"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/updateMany-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateMany-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "updateMany-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.3.99"

--- a/driver-core/src/test/resources/unified-test-format/crud/updateMany-hint-serverError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateMany-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "updateMany-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4.0",

--- a/driver-core/src/test/resources/unified-test-format/crud/updateMany-hint.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateMany-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "updateMany-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0"

--- a/driver-core/src/test/resources/unified-test-format/crud/updateMany-validation.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateMany-validation.json
@@ -1,6 +1,6 @@
 {
   "description": "updateMany-validation",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {
@@ -14,21 +14,21 @@
       "database": {
         "id": "database0",
         "client": "client0",
-        "databaseName": "crud-v2"
+        "databaseName": "crud-tests"
       }
     },
     {
       "collection": {
         "id": "collection0",
         "database": "database0",
-        "collectionName": "crud-v2"
+        "collectionName": "coll0"
       }
     }
   ],
   "initialData": [
     {
-      "collectionName": "crud-v2",
-      "databaseName": "crud-v2",
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
       "documents": [
         {
           "_id": 1,
@@ -47,11 +47,11 @@
   ],
   "tests": [
     {
-      "description": "UpdateOne requires atomic modifiers",
+      "description": "UpdateMany requires atomic modifiers",
       "operations": [
         {
-          "object": "collection0",
           "name": "updateMany",
+          "object": "collection0",
           "arguments": {
             "filter": {
               "_id": {
@@ -63,7 +63,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],
@@ -75,8 +75,8 @@
       ],
       "outcome": [
         {
-          "collectionName": "crud-v2",
-          "databaseName": "crud-v2",
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
           "documents": [
             {
               "_id": 1,

--- a/driver-core/src/test/resources/unified-test-format/crud/updateOne-dots_and_dollars.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateOne-dots_and_dollars.json
@@ -1,0 +1,412 @@
+{
+  "description": "updateOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "$a"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "$a"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "a.b"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "a.b"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "$a"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "$a"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "a.b"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "a.b"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/updateOne-hint-clientError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateOne-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "updateOne-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.3.99"

--- a/driver-core/src/test/resources/unified-test-format/crud/updateOne-hint-serverError.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateOne-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "updateOne-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4.0",

--- a/driver-core/src/test/resources/unified-test-format/crud/updateOne-hint.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateOne-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "updateOne-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0"

--- a/driver-core/src/test/resources/unified-test-format/crud/updateOne-validation.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateOne-validation.json
@@ -1,6 +1,6 @@
 {
   "description": "updateOne-validation",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {
@@ -14,21 +14,21 @@
       "database": {
         "id": "database0",
         "client": "client0",
-        "databaseName": "crud-v2"
+        "databaseName": "crud-tests"
       }
     },
     {
       "collection": {
         "id": "collection0",
         "database": "database0",
-        "collectionName": "crud-v2"
+        "collectionName": "coll0"
       }
     }
   ],
   "initialData": [
     {
-      "collectionName": "crud-v2",
-      "databaseName": "crud-v2",
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
       "documents": [
         {
           "_id": 1,
@@ -42,8 +42,8 @@
       "description": "UpdateOne requires atomic modifiers",
       "operations": [
         {
-          "object": "collection0",
           "name": "updateOne",
+          "object": "collection0",
           "arguments": {
             "filter": {
               "_id": 1
@@ -53,7 +53,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],
@@ -65,8 +65,8 @@
       ],
       "outcome": [
         {
-          "collectionName": "crud-v2",
-          "databaseName": "crud-v2",
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
           "documents": [
             {
               "_id": 1,

--- a/driver-core/src/test/resources/unified-test-format/crud/updateWithPipelines.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateWithPipelines.json
@@ -1,6 +1,6 @@
 {
   "description": "updateWithPipelines",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.1.11"

--- a/driver-core/src/test/resources/unified-test-format/valid-pass/poc-transactions.json
+++ b/driver-core/src/test/resources/unified-test-format/valid-pass/poc-transactions.json
@@ -61,14 +61,15 @@
           "object": "session0"
         },
         {
-          "name": "insertOne",
+          "name": "updateOne",
           "object": "collection0",
           "arguments": {
             "session": "session0",
-            "document": {
-              "_id": {
-                ".": "."
-              }
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 1
             }
           },
           "expectError": {

--- a/driver-core/src/test/unit/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidatorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidatorTest.java
@@ -18,11 +18,12 @@ package com.mongodb.internal.validator;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class CollectibleDocumentFieldNameValidatorTest {
-    private final CollectibleDocumentFieldNameValidator fieldNameValidator = new CollectibleDocumentFieldNameValidator();
+public class ReplacingDocumentFieldNameValidatorTest {
+    private final ReplacingDocumentFieldNameValidator fieldNameValidator = new ReplacingDocumentFieldNameValidator();
 
     @Test
     public void testFieldValidationSuccess() {
@@ -35,11 +36,6 @@ public class CollectibleDocumentFieldNameValidatorTest {
     }
 
     @Test
-    public void testFieldNameWithDotsValidation() {
-        assertFalse(fieldNameValidator.validate("1.2"));
-    }
-
-    @Test
     public void testFieldNameStartsWithDollarValidation() {
         assertFalse(fieldNameValidator.validate("$1"));
         assertTrue(fieldNameValidator.validate("$db"));
@@ -47,4 +43,8 @@ public class CollectibleDocumentFieldNameValidatorTest {
         assertTrue(fieldNameValidator.validate("$id"));
     }
 
+    @Test
+    public void testNestedDocumentsAreNotValidated() {
+        assertEquals(NoOpFieldNameValidator.class, fieldNameValidator.getValidatorForField("nested").getClass());
+    }
 }

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionOldTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionOldTest.java
@@ -308,12 +308,4 @@ public class DBCollectionOldTest extends DatabaseTestCase {
         }
         assertEquals(collection.count(), 2);
     }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testDotKeysFail() {
-        DBCollection c = collection;
-
-        DBObject obj = BasicDBObjectBuilder.start().add("x", 1).add("y", 2).add("foo.bar", "baz").get();
-        c.insert(obj);
-    }
 }

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionTest.java
@@ -186,38 +186,13 @@ public class DBCollectionTest extends DatabaseTestCase {
     }
 
     @Test
-    public void testDotInDBObject() {
-        try {
-            collection.save(new BasicDBObject("x.y", 1));
-            fail("Should throw exception");
-        } catch (IllegalArgumentException e) {
-            // all good
-        }
+    public void testDotInDBObjectSucceeds() {
+        collection.save(new BasicDBObject("x.y", 1));
+        collection.save(new BasicDBObject("x", new BasicDBObject("a.b", 1)));
 
-        try {
-            collection.save(new BasicDBObject("x", new BasicDBObject("a.b", 1)));
-            fail("Should throw exception");
-        } catch (IllegalArgumentException e) {
-            // all good
-        }
-
-        try {
-            Map<String, Integer> map = new HashMap<String, Integer>();
-            map.put("a.b", 1);
-            collection.save(new BasicDBObject("x", map));
-            fail("Should throw exception");
-        } catch (IllegalArgumentException e) {
-            // all good
-        }
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testJAVA794() {
-        Map<String, String> nested = new HashMap<String, String>();
-        nested.put("my.dot.field", "foo");
-        List<Map<String, String>> list = new ArrayList<Map<String, String>>();
-        list.add(nested);
-        collection.save(new BasicDBObject("_document_", new BasicDBObject("array", list)));
+        Map<String, Integer> map = new HashMap<String, Integer>();
+        map.put("a.b", 1);
+        collection.save(new BasicDBObject("x", map));
     }
 
     @Test
@@ -506,24 +481,22 @@ public class DBCollectionTest extends DatabaseTestCase {
         assertEquals(uuid, collection.findOne().get("uuid"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testDotKeysArrayFail() {
-        //JAVA-794
+    @Test
+    public void testDotKeysArraySucceeds() {
         DBObject obj = new BasicDBObject("x", 1).append("y", 2)
                                                 .append("array", new Object[]{new BasicDBObject("foo.bar", "baz")});
         collection.insert(obj);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testDotKeysListFail() {
-        //JAVA-794
+    @Test
+    public void testDotKeysListSucceeds() {
         DBObject obj = new BasicDBObject("x", 1).append("y", 2)
                                                 .append("array", asList(new BasicDBObject("foo.bar", "baz")));
         collection.insert(obj);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testDotKeysMapInArrayFail() {
+    @Test
+    public void testDotKeysMapInArraySucceeds() {
         final Map<String, Object> map = new HashMap<String, Object>(1);
         map.put("foo.bar", 2);
         DBObject obj = new BasicDBObject("x", 1).append("y", 2).append("array", new Object[]{map});

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
@@ -425,7 +425,11 @@ final class UnifiedCrudHelper {
     }
 
     private BsonDocument toExpected(final DeleteResult result) {
-        return new BsonDocument("deletedCount", new BsonInt32((int) result.getDeletedCount()));
+        if (result.wasAcknowledged()) {
+            return new BsonDocument("deletedCount", new BsonInt32((int) result.getDeletedCount()));
+        } else {
+            return new BsonDocument();
+        }
     }
 
     OperationResult executeUpdateOne(final BsonDocument operation) {
@@ -479,14 +483,18 @@ final class UnifiedCrudHelper {
     }
 
     private BsonDocument toExpected(final UpdateResult result) {
-        BsonDocument expectedDocument = new BsonDocument()
-                .append("matchedCount", new BsonInt32((int) result.getMatchedCount()))
-                .append("modifiedCount", new BsonInt32((int) result.getModifiedCount()))
-                .append("upsertedCount", new BsonInt32(result.getUpsertedId() == null ? 0 : 1));
-        if (result.getUpsertedId() != null) {
-            expectedDocument.append("upsertedId", result.getUpsertedId());
+        if (result.wasAcknowledged()) {
+            BsonDocument expectedDocument = new BsonDocument()
+                    .append("matchedCount", new BsonInt32((int) result.getMatchedCount()))
+                    .append("modifiedCount", new BsonInt32((int) result.getModifiedCount()))
+                    .append("upsertedCount", new BsonInt32(result.getUpsertedId() == null ? 0 : 1));
+            if (result.getUpsertedId() != null) {
+                expectedDocument.append("upsertedId", result.getUpsertedId());
+            }
+            return expectedDocument;
+        } else {
+            return new BsonDocument();
         }
-        return expectedDocument;
     }
 
 
@@ -514,7 +522,12 @@ final class UnifiedCrudHelper {
     }
 
     private BsonDocument toExpected(final InsertOneResult result) {
-        return new BsonDocument("insertedId", result.getInsertedId());
+        if (result.wasAcknowledged()) {
+            return new BsonDocument("insertedId", result.getInsertedId())
+                    .append("insertedCount", new BsonInt32(1));
+        } else {
+            return new BsonDocument();
+        }
     }
 
     OperationResult executeInsertMany(final BsonDocument operation) {
@@ -540,8 +553,13 @@ final class UnifiedCrudHelper {
     }
 
     private BsonDocument toExpected(final InsertManyResult result) {
-        return new BsonDocument("insertedIds", new BsonDocument(result.getInsertedIds().entrySet().stream()
-                .map(value -> new BsonElement(value.getKey().toString(), value.getValue())).collect(toList())));
+        if (result.wasAcknowledged()) {
+            return new BsonDocument("insertedIds", new BsonDocument(result.getInsertedIds().entrySet().stream()
+                    .map(value -> new BsonElement(value.getKey().toString(), value.getValue())).collect(toList())))
+                    .append("insertedCount", new BsonInt32(result.getInsertedIds().size()));
+        } else {
+            return new BsonDocument();
+        }
     }
 
     OperationResult executeBulkWrite(final BsonDocument operation) {
@@ -567,16 +585,20 @@ final class UnifiedCrudHelper {
     }
 
     private BsonDocument toExpected(final BulkWriteResult result) {
-        return new BsonDocument()
-                .append("deletedCount", new BsonInt32(result.getDeletedCount()))
-                .append("insertedCount", new BsonInt32(result.getInsertedCount()))
-                .append("matchedCount", new BsonInt32(result.getMatchedCount()))
-                .append("modifiedCount", new BsonInt32(result.getModifiedCount()))
-                .append("upsertedCount", new BsonInt32(result.getUpserts().size()))
-                .append("insertedIds", new BsonDocument(result.getInserts().stream()
-                        .map(value -> new BsonElement(Integer.toString(value.getIndex()), value.getId())).collect(toList())))
-                .append("upsertedIds", new BsonDocument(result.getUpserts().stream()
-                        .map(value -> new BsonElement(Integer.toString(value.getIndex()), value.getId())).collect(toList())));
+        if (result.wasAcknowledged()) {
+            return new BsonDocument()
+                    .append("deletedCount", new BsonInt32(result.getDeletedCount()))
+                    .append("insertedCount", new BsonInt32(result.getInsertedCount()))
+                    .append("matchedCount", new BsonInt32(result.getMatchedCount()))
+                    .append("modifiedCount", new BsonInt32(result.getModifiedCount()))
+                    .append("upsertedCount", new BsonInt32(result.getUpserts().size()))
+                    .append("insertedIds", new BsonDocument(result.getInserts().stream()
+                            .map(value -> new BsonElement(Integer.toString(value.getIndex()), value.getId())).collect(toList())))
+                    .append("upsertedIds", new BsonDocument(result.getUpserts().stream()
+                            .map(value -> new BsonElement(Integer.toString(value.getIndex()), value.getId())).collect(toList())));
+        } else {
+            return new BsonDocument();
+        }
     }
 
     private WriteModel<BsonDocument> toWriteModel(final BsonDocument document) {


### PR DESCRIPTION
* The driver no longer restricts field names containing ".".
* The driver no longer restricts field names starting with "$", except for
top-level fields in documents being saved via replaceOne, findOneAndReplace,
and ReplaceOneModel in bulkWrite.  This is to ensure that applications don't
accidentally use replace when they meant to use update.

JAVA-3996