### PR TITLE
Change connection-closed log message to debug

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -735,8 +735,8 @@ class DefaultConnectionPool implements ConnectionPool {
                 }
             } else {
                 connectionClosed(connectionPoolListener, getId(connection), getReasonForClosing(connection));
-                if (LOGGER.isInfoEnabled()) {
-                    LOGGER.info(format("Closed connection [%s] to %s because %s.", getId(connection), serverId.getAddress(),
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(format("Closed connection [%s] to %s because %s.", getId(connection), serverId.getAddress(),
                             getReasonStringForClosing(connection)));
                 }
             }


### PR DESCRIPTION
Previously it was info, and it's the only connection pool-related
log message at that high a level.

JAVA-4189