### PR TITLE
Use standard UUID representation for JSON generation

### DIFF
--- a/bson/src/main/org/bson/Document.java
+++ b/bson/src/main/org/bson/Document.java
@@ -16,13 +16,18 @@
 
 package org.bson;
 
+import org.bson.codecs.BsonValueCodecProvider;
+import org.bson.codecs.Codec;
 import org.bson.codecs.Decoder;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.DocumentCodec;
+import org.bson.codecs.DocumentCodecProvider;
 import org.bson.codecs.Encoder;
 import org.bson.codecs.EncoderContext;
+import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
+import org.bson.internal.CodecRegistryHelper;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonReader;
 import org.bson.json.JsonWriter;
@@ -40,8 +45,10 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static org.bson.assertions.Assertions.isTrue;
 import static org.bson.assertions.Assertions.notNull;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 
 /**
  * A representation of a document as a {@code Map}.  All iterators will traverse the elements in insertion order, as with {@code
@@ -51,6 +58,12 @@ import static org.bson.assertions.Assertions.notNull;
  * @since 3.0.0
  */
 public class Document implements Map<String, Object>, Serializable, Bson {
+    private static final Codec<Document> DEFAULT_CODEC =
+            CodecRegistryHelper.createRegistry(
+                    fromProviders(asList(new ValueCodecProvider(), new BsonValueCodecProvider(), new DocumentCodecProvider())),
+                    UuidRepresentation.STANDARD)
+                    .get(Document.class);
+
     private static final long serialVersionUID = 6297731997167536582L;
 
     private final LinkedHashMap<String, Object> documentAsMap;
@@ -92,7 +105,7 @@ public class Document implements Map<String, Object>, Serializable, Bson {
      * @mongodb.driver.manual reference/mongodb-extended-json/ MongoDB Extended JSON
      */
     public static Document parse(final String json) {
-        return parse(json, new DocumentCodec());
+        return parse(json, DEFAULT_CODEC);
     }
 
     /**
@@ -410,7 +423,7 @@ public class Document implements Map<String, Object>, Serializable, Bson {
      * @throws org.bson.codecs.configuration.CodecConfigurationException if the document contains types not in the default registry
      */
     public String toJson(final JsonWriterSettings writerSettings) {
-        return toJson(writerSettings, new DocumentCodec());
+        return toJson(writerSettings, DEFAULT_CODEC);
     }
 
     /**

--- a/bson/src/test/unit/org/bson/DocumentTest.java
+++ b/bson/src/test/unit/org/bson/DocumentTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static java.util.Arrays.asList;
 import static org.bson.codecs.configuration.CodecRegistries.fromCodecs;
@@ -142,6 +143,15 @@ public class DocumentTest {
 
         assertEquals(expected, document.toBsonDocument(BsonDocument.class, Bson.DEFAULT_CODEC_REGISTRY));
         assertEquals(expected, document.toBsonDocument());
+    }
+
+    @Test
+    public void toJsonShouldRenderUuidAsStandard() {
+        UUID uuid = UUID.randomUUID();
+        Document doc = new Document("_id", uuid);
+
+        String json = doc.toJson();
+        assertEquals(new BsonDocument("_id", new BsonBinary(uuid)), BsonDocument.parse(json));
     }
 
     public class Name {

--- a/driver-core/src/test/unit/com/mongodb/BasicDBObjectTest.java
+++ b/driver-core/src/test/unit/com/mongodb/BasicDBObjectTest.java
@@ -18,6 +18,8 @@ package com.mongodb;
 
 import org.bson.BSONObject;
 import org.bson.BasicBSONObject;
+import org.bson.BsonBinary;
+import org.bson.BsonDocument;
 import org.bson.codecs.Codec;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
@@ -34,9 +36,9 @@ import java.util.UUID;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
@@ -76,6 +78,24 @@ public class BasicDBObjectTest {
         assertEquals("{\"int\": 1, \"string\": \"abc\", \"_id\": ObjectId(\"000000000000000000000000\"), "
                 + "\"dbRef\": {\"$ref\": \"collection\", \"$id\": ObjectId(\"01234567890123456789abcd\"), \"$db\": \"db\"}}",
                 document.toJson(JsonWriterSettings.builder().outputMode(JsonMode.SHELL).build(), DECODER));
+    }
+
+    @Test
+    public void toJsonShouldRenderUuidAsStandard() {
+        UUID uuid = UUID.randomUUID();
+        BasicDBObject doc = new BasicDBObject("_id", uuid);
+
+        String json = doc.toJson();
+        assertEquals(new BsonDocument("_id", new BsonBinary(uuid)), BsonDocument.parse(json));
+    }
+
+    @Test
+    public void toStringShouldRenderUuidAsStandard() {
+        UUID uuid = UUID.randomUUID();
+        BasicDBObject doc = new BasicDBObject("_id", uuid);
+
+        String json = doc.toString();
+        assertEquals(new BsonDocument("_id", new BsonBinary(uuid)), BsonDocument.parse(json));
     }
 
     @Test


### PR DESCRIPTION
Change the behavior of the following methods:

* Document.toJson
* BasicDBObject.toJson
* BasicDBObject.toString

to use standard UUID representation when generating JSON.  Prior to this change,
an exception would be thrown when the document contains a UUID value.

JAVA-4140