### PR TITLE
Increase `waitQueueTimeoutMS` in some tests to reduce the probability of timing out accidentally

### DIFF
--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/wait-queue-timeout.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/wait-queue-timeout.json
@@ -4,7 +4,7 @@
   "description": "must aggressively timeout threads enqueued longer than waitQueueTimeoutMS",
   "poolOptions": {
     "maxPoolSize": 1,
-    "waitQueueTimeoutMS": 20
+    "waitQueueTimeoutMS": 50
   },
   "operations": [
     {

--- a/driver-core/src/test/resources/unified-test-format/load-balancers/wait-queue-timeouts.json
+++ b/driver-core/src/test/resources/unified-test-format/load-balancers/wait-queue-timeouts.json
@@ -15,7 +15,7 @@
         "useMultipleMongoses": true,
         "uriOptions": {
           "maxPoolSize": 1,
-          "waitQueueTimeoutMS": 5
+          "waitQueueTimeoutMS": 50
         },
         "observeEvents": [
           "connectionCheckedOutEvent",


### PR DESCRIPTION
JAVA-4194