### PR TITLE
Add support for setting `io.netty.handler.ssl.SslContext`

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -333,7 +333,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          STREAM_TYPE=netty AUTH="${AUTH}" SSL="${SSL}" MONGODB_URI="${MONGODB_URI}" TOPOLOGY="${TOPOLOGY}" COMPRESSOR="${COMPRESSOR}" JDK="${JDK}" .evergreen/run-tests.sh
+          STREAM_TYPE="netty" AUTH="${AUTH}" SSL="${SSL}" NETTY_SSL_PROVIDER="${NETTY_SSL_PROVIDER}" MONGODB_URI="${MONGODB_URI}" TOPOLOGY="${TOPOLOGY}" COMPRESSOR="${COMPRESSOR}" JDK="${JDK}" .evergreen/run-tests.sh
 
   "run plain auth test":
     - command: shell.exec
@@ -1224,6 +1224,8 @@ tasks:
           name: "plain-auth-test"
         - variant: ".test-scala-variant"
           name: "scala-tests"
+        - variant: ".tests-netty-variant"
+          name: "netty-test"
       commands:
         - func: "publish snapshot"
 
@@ -1350,6 +1352,17 @@ axes:
         display_name: NoSSL
         variables:
            SSL: "nossl"
+  - id: netty-ssl-provider
+    display_name: Netty TLS/SSL protocol provider
+    values:
+      - id: "jdk"
+        display_name: JDK
+        variables:
+          NETTY_SSL_PROVIDER: "JDK"
+      - id: "openssl"
+        display_name: OpenSSL
+        variables:
+          NETTY_SSL_PROVIDER: "OPENSSL"
   - id: compressor
     display_name: Compressor
     values:
@@ -1489,10 +1502,17 @@ buildvariants:
 
 - matrix_name: "tests-netty"
   matrix_spec: { auth: "noauth", ssl: "*", jdk: "jdk8", version: ["4.2", "4.4"], topology: "replicaset", os: "linux" }
-  display_name: "Netty: ${version} ${topology} ${ssl} ${jdk} ${os} "
-  tags: ["tests-variant"]
+  display_name: "Netty: ${version} ${topology} ${ssl} ${auth} ${jdk} ${os} "
+  tags: ["tests-netty-variant"]
   tasks:
-    - name: "test"
+    - name: "netty-test"
+
+- matrix_name: "tests-netty-ssl-provider"
+  matrix_spec: { netty-ssl-provider: "*", auth: "auth", ssl: "ssl", jdk: "jdk8", version: ["5.0"], topology: "replicaset", os: "linux" }
+  display_name: "Netty SSL provider: ${version} ${topology} ${ssl} SslProvider.${netty-ssl-provider} ${auth} ${jdk} ${os} "
+  tags: ["tests-netty-variant"]
+  tasks:
+    - name: "netty-test"
 
 - matrix_name: "tests-socket-snappy-compression"
   matrix_spec: { compressor : "snappy", auth: "noauth", ssl: "nossl", jdk: "jdk8", version: ["4.2"], topology: "standalone", os: "linux" }

--- a/docs/reference/config.toml
+++ b/docs/reference/config.toml
@@ -8,6 +8,7 @@ disableKinds = ["section", "taxonomy", "taxonomyTerm", "404"]
 
 [params]
   javaSeDocsUri = "https://docs.oracle.com/javase/8/docs/"
+  nettyApiUri = "https://netty.io/4.1/api/"
 
 [blackfriday]
   plainIdAnchors = true

--- a/docs/reference/content/driver-reactive/tutorials/ssl.md
+++ b/docs/reference/content/driver-reactive/tutorials/ssl.md
@@ -79,21 +79,26 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoClient;
 import com.mongodb.connection.netty.NettyStreamFactoryFactory;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 ```
 
 To instruct the driver to use [`io.netty.handler.ssl.SslContext`]({{< nettyapiref "io/netty/handler/ssl/SslContext.html" >}}),
 use the method
-[`NettyStreamFactoryFactory.Builder.applyToNettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#applyToNettySslContext(java.util.function.Consumer)" >}}).
+[`NettyStreamFactoryFactory.Builder.nettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#nettySslContext(io.netty.handler.ssl.SslContext)" >}}).
 See the documentation of this method for details on which
 [`io.netty.handler.ssl.SslProvider`]({{< nettyapiref "io/netty/handler/ssl/SslProvider.html" >}})s are supported by the driver
 and implications of using them.
 
 ```java
+SslContext nettySslContext = SslContextBuilder.forClient()
+        .sslProvider(SslProvider.OPENSSL)
+        .build();
 MongoClientSettings settings = MongoClientSettings.builder()
         .applyToSslSettings(builder -> builder.enabled(true))
         .streamFactoryFactory(NettyStreamFactoryFactory.builder()
-                .applyToNettySslContext(builder -> builder.sslProvider(SslProvider.OPENSSL))
+                .nettySslContext(nettySslContext)
                 .build())
         .build();
 MongoClient client = MongoClients.create(settings);

--- a/docs/reference/content/driver-reactive/tutorials/ssl.md
+++ b/docs/reference/content/driver-reactive/tutorials/ssl.md
@@ -10,8 +10,9 @@ title = "TLS/SSL"
 
 ## TLS/SSL
 
-The Java driver supports TLS/SSL connections to MongoDB servers using
-the underlying support for TLS/SSL provided by the JDK. 
+By default the Java driver supports TLS/SSL connections to MongoDB servers using
+the underlying support for TLS/SSL provided by the JDK. This can be changed either by utilizing extensibility
+of the [Java SE API]({{< javaseref "api">}}), or via the [Netty API]({{< nettyapiref >}}).
 You can configure the driver to use TLS/SSL either with [`ConnectionString`]({{< apiref "mongodb-driver-core" "com/mongodb/ConnectionString" >}}) or with
 [`MongoClientSettings`]({{< apiref "mongodb-driver-core" "com/mongodb/MongoClientSettings" >}}).
 
@@ -49,25 +50,51 @@ MongoClientSettings settings = MongoClientSettings.builder()
 MongoClient client = MongoClients.create(settings);
 ```
 
-### Specify `SSLContext` via `MongoClientSettings`
+### Specify Java SE `SSLContext` via `MongoClientSettings`
 
 ```java
 import javax.net.ssl.SSLContext;
 import com.mongodb.MongoClientSettings;
-import com.mongodb.reactivestreams.client.MongoClients;
-import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.MongoClient;
 ```
 
-To specify the [`javax.net.ssl.SSLContext`]({{< javaseref "api/javax/net/ssl/SSLContext.html" >}}) with 
+To specify the [`javax.net.ssl.SSLContext`]({{< javaseref "api/javax/net/ssl/SSLContext.html" >}}) with
 [`MongoClientSettings`]({{< apiref "mongodb-driver-core" "com/mongodb/MongoClientSettings" >}}), set the `sslContext` property, as in:
 
 ```java
 SSLContext sslContext = ...
+        MongoClientSettings settings = MongoClientSettings.builder()
+        .applyToSslSettings(builder -> builder.enabled(true).context(sslContext))
+        .build();
+        MongoClient client = new MongoClient(settings);
+```
+
+### Specify Netty `SslContext` via `NettyStreamFactoryFactory`
+
+If you use the driver with [Netty](https://netty.io/) for network IO,
+you have an option to plug an alternative TLS/SSL protocol implementation provided by Netty.
+
+```java
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoClient;
+import com.mongodb.connection.netty.NettyStreamFactoryFactory;
+import io.netty.handler.ssl.SslProvider;
+```
+
+To instruct the driver to use [`io.netty.handler.ssl.SslContext`]({{< nettyapiref "io/netty/handler/ssl/SslContext.html" >}}),
+use the method
+[`NettyStreamFactoryFactory.Builder.applyToNettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#applyToNettySslContext(java.util.function.Consumer)" >}}).
+See the documentation of this method for details on which
+[`io.netty.handler.ssl.SslProvider`]({{< nettyapiref "io/netty/handler/ssl/SslProvider.html" >}})s are supported by the driver
+and implications of using them.
+
+```java
 MongoClientSettings settings = MongoClientSettings.builder()
-        .applyToSslSettings(builder -> {
-                    builder.enabled(true);
-                    builder.context(sslContext);
-                })
+        .applyToSslSettings(builder -> builder.enabled(true))
+        .streamFactoryFactory(NettyStreamFactoryFactory.builder()
+                .applyToNettySslContext(builder -> builder.sslProvider(SslProvider.OPENSSL))
+                .build())
         .build();
 MongoClient client = MongoClients.create(settings);
 ```
@@ -91,7 +118,10 @@ MongoClientSettings settings = MongoClientSettings.builder()
 ```
 
 ## Common TLS/SSL Configuration Tasks
-<p></p>
+
+This section is based on the documentation for [Oracle JDK](https://www.oracle.com/java/technologies/javase-downloads.html#JDK8),
+so some parts may be inapplicable to your JDK or to the custom TLS/SSL implementation you use.
+
 ### Configure Trust Store and Key Store
 One may either configure trust stores and key stores specific to the client via 
 [`javax.net.ssl.SSLContext.init(KeyManager[] km, TrustManager[] tm, SecureRandom random)`]

--- a/docs/reference/content/driver-reactive/tutorials/ssl.md
+++ b/docs/reference/content/driver-reactive/tutorials/ssl.md
@@ -86,19 +86,19 @@ import io.netty.handler.ssl.SslProvider;
 
 To instruct the driver to use [`io.netty.handler.ssl.SslContext`]({{< nettyapiref "io/netty/handler/ssl/SslContext.html" >}}),
 use the method
-[`NettyStreamFactoryFactory.Builder.nettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#nettySslContext(io.netty.handler.ssl.SslContext)" >}}).
+[`NettyStreamFactoryFactory.Builder.sslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#sslContext(io.netty.handler.ssl.SslContext)" >}}).
 See the documentation of this method for details on which
 [`io.netty.handler.ssl.SslProvider`]({{< nettyapiref "io/netty/handler/ssl/SslProvider.html" >}})s are supported by the driver
 and implications of using them.
 
 ```java
-SslContext nettySslContext = SslContextBuilder.forClient()
+SslContext sslContext = SslContextBuilder.forClient()
         .sslProvider(SslProvider.OPENSSL)
         .build();
 MongoClientSettings settings = MongoClientSettings.builder()
         .applyToSslSettings(builder -> builder.enabled(true))
         .streamFactoryFactory(NettyStreamFactoryFactory.builder()
-                .nettySslContext(nettySslContext)
+                .sslContext(sslContext)
                 .build())
         .build();
 MongoClient client = MongoClients.create(settings);

--- a/docs/reference/content/driver-scala/tutorials/ssl.md
+++ b/docs/reference/content/driver-scala/tutorials/ssl.md
@@ -10,8 +10,9 @@ title = "TLS/SSL"
 
 ## TLS/SSL
 
-The Java driver supports TLS/SSL connections to MongoDB servers using
-the underlying support for TLS/SSL provided by the JDK. 
+By default the Java driver supports TLS/SSL connections to MongoDB servers using
+the underlying support for TLS/SSL provided by the JDK. This can be changed either by utilizing extensibility
+of the [Java SE API]({{< javaseref "api">}}), or via the [Netty API]({{< nettyapiref >}}).
 You can configure the driver to use TLS/SSL either with [`ConnectionString`]({{< apiref "mongo-scala-driver" "org/mongodb/scala/package$$ConnectionString$.html" >}}) or with
 [`MongoClientSettings`]({{< apiref "mongo-scala-driver" "org/mongodb/scala/MongoClientSettings$.html" >}}).
 
@@ -42,7 +43,7 @@ val settings = MongoClientSettings.builder()
 val client = MongoClients.create(settings)
 ```
 
-### Specify `SSLContext` via `MongoClientSettings`
+### Specify Java SE `SSLContext` via `MongoClientSettings`
 
 ```scala
 import javax.net.ssl.SSLContext
@@ -58,6 +59,33 @@ val settings = MongoClientSettings.builder()
         builder.enabled(true)
         builder.context(sslContext)
     })
+    .build()
+val client = MongoClients.create(settings)
+```
+
+### Specify Netty `SslContext` via `NettyStreamFactoryFactory`
+
+If you use the driver with [Netty](https://netty.io/) for network IO,
+you have an option to plug an alternative TLS/SSL protocol implementation provided by Netty.
+
+```java
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+```
+
+To instruct the driver to use [`io.netty.handler.ssl.SslContext`]({{< nettyapiref "io/netty/handler/ssl/SslContext.html" >}}),
+use the method
+[`NettyStreamFactoryFactory.Builder.applyToNettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#applyToNettySslContext(java.util.function.Consumer)" >}}).
+See the documentation of this method for details on which
+[`io.netty.handler.ssl.SslProvider`]({{< nettyapiref "io/netty/handler/ssl/SslProvider.html" >}})s are supported by the driver
+and implications of using them.
+
+```scala
+val settings = MongoClientSettings.builder()
+    .applyToSslSettings((builder: SslSettings.Builder) => builder.enabled(true))
+    .streamFactoryFactory(NettyStreamFactoryFactory.builder()
+        .applyToNettySslContext((builder: SslContextBuilder) => builder.sslProvider(SslProvider.OPENSSL))
+        .build())
     .build()
 val client = MongoClients.create(settings)
 ```
@@ -81,7 +109,10 @@ val settings = MongoClientSettings.builder()
 ```
 
 ## Common TLS/SSL Configuration Tasks
-<p></p>
+
+This section is based on the documentation for [Oracle JDK](https://www.oracle.com/java/technologies/javase-downloads.html#JDK8),
+so some parts may be inapplicable to your JDK or to the custom TLS/SSL implementation you use.
+
 ### Configure Trust Store and Key Store
 One may either configure trust stores and key stores specific to the client via 
 [`javax.net.ssl.SSLContext.init(KeyManager[] km, TrustManager[] tm, SecureRandom random)`]

--- a/docs/reference/content/driver-scala/tutorials/ssl.md
+++ b/docs/reference/content/driver-scala/tutorials/ssl.md
@@ -75,19 +75,22 @@ import io.netty.handler.ssl.SslProvider;
 
 To instruct the driver to use [`io.netty.handler.ssl.SslContext`]({{< nettyapiref "io/netty/handler/ssl/SslContext.html" >}}),
 use the method
-[`NettyStreamFactoryFactory.Builder.applyToNettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#applyToNettySslContext(java.util.function.Consumer)" >}}).
+[`NettyStreamFactoryFactory.Builder.nettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#nettySslContext(io.netty.handler.ssl.SslContext)" >}}).
 See the documentation of this method for details on which
 [`io.netty.handler.ssl.SslProvider`]({{< nettyapiref "io/netty/handler/ssl/SslProvider.html" >}})s are supported by the driver
 and implications of using them.
 
 ```scala
+val nettySslContext = SslContextBuilder.forClient()
+    .sslProvider(SslProvider.OPENSSL)
+    .build();
 val settings = MongoClientSettings.builder()
     .applyToSslSettings((builder: SslSettings.Builder) => builder.enabled(true))
     .streamFactoryFactory(NettyStreamFactoryFactory.builder()
-        .applyToNettySslContext((builder: SslContextBuilder) => builder.sslProvider(SslProvider.OPENSSL))
+        .nettySslContext(nettySslContext)
         .build())
     .build()
-val client = MongoClients.create(settings)
+val client = MongoClient(settings)
 ```
 
 ## Disable Hostname Verification

--- a/docs/reference/content/driver-scala/tutorials/ssl.md
+++ b/docs/reference/content/driver-scala/tutorials/ssl.md
@@ -75,19 +75,19 @@ import io.netty.handler.ssl.SslProvider;
 
 To instruct the driver to use [`io.netty.handler.ssl.SslContext`]({{< nettyapiref "io/netty/handler/ssl/SslContext.html" >}}),
 use the method
-[`NettyStreamFactoryFactory.Builder.nettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#nettySslContext(io.netty.handler.ssl.SslContext)" >}}).
+[`NettyStreamFactoryFactory.Builder.sslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#sslContext(io.netty.handler.ssl.SslContext)" >}}).
 See the documentation of this method for details on which
 [`io.netty.handler.ssl.SslProvider`]({{< nettyapiref "io/netty/handler/ssl/SslProvider.html" >}})s are supported by the driver
 and implications of using them.
 
 ```scala
-val nettySslContext = SslContextBuilder.forClient()
+val sslContext = SslContextBuilder.forClient()
     .sslProvider(SslProvider.OPENSSL)
     .build();
 val settings = MongoClientSettings.builder()
     .applyToSslSettings((builder: SslSettings.Builder) => builder.enabled(true))
     .streamFactoryFactory(NettyStreamFactoryFactory.builder()
-        .nettySslContext(nettySslContext)
+        .sslContext(sslContext)
         .build())
     .build()
 val client = MongoClient(settings)

--- a/docs/reference/content/driver/tutorials/ssl.md
+++ b/docs/reference/content/driver/tutorials/ssl.md
@@ -80,21 +80,26 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoClient;
 import com.mongodb.connection.netty.NettyStreamFactoryFactory;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 ```
 
 To instruct the driver to use [`io.netty.handler.ssl.SslContext`]({{< nettyapiref "io/netty/handler/ssl/SslContext.html" >}}),
 use the method
-[`NettyStreamFactoryFactory.Builder.applyToNettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#applyToNettySslContext(java.util.function.Consumer)" >}}).
+[`NettyStreamFactoryFactory.Builder.nettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#nettySslContext(io.netty.handler.ssl.SslContext)" >}}).
 See the documentation of this method for details on which
 [`io.netty.handler.ssl.SslProvider`]({{< nettyapiref "io/netty/handler/ssl/SslProvider.html" >}})s are supported by the driver
 and implications of using them.
 
 ```java
+SslContext nettySslContext = SslContextBuilder.forClient()
+        .sslProvider(SslProvider.OPENSSL)
+        .build();
 MongoClientSettings settings = MongoClientSettings.builder()
         .applyToSslSettings(builder -> builder.enabled(true))
         .streamFactoryFactory(NettyStreamFactoryFactory.builder()
-                .applyToNettySslContext(builder -> builder.sslProvider(SslProvider.OPENSSL))
+                .nettySslContext(nettySslContext)
                 .build())
         .build();
 MongoClient client = MongoClients.create(settings);
@@ -160,21 +165,26 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoClient;
 import com.mongodb.connection.netty.NettyStreamFactoryFactory;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 ```
 
 To instruct the driver to use [`io.netty.handler.ssl.SslContext`]({{< nettyapiref "io/netty/handler/ssl/SslContext.html" >}}),
 use the method
-[`NettyStreamFactoryFactory.Builder.applyToNettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#applyToNettySslContext(java.util.function.Consumer)" >}}).
+[`NettyStreamFactoryFactory.Builder.nettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#nettySslContext(io.netty.handler.ssl.SslContext)" >}}).
 See the documentation of this method for details on which
 [`io.netty.handler.ssl.SslProvider`]({{< nettyapiref "io/netty/handler/ssl/SslProvider.html" >}})s are supported by the driver
 and implications of using them.
 
 ```java
+SslContext nettySslContext = SslContextBuilder.forClient()
+        .sslProvider(SslProvider.OPENSSL)
+        .build();
 MongoClientSettings settings = MongoClientSettings.builder()
         .applyToSslSettings(builder -> builder.enabled(true))
         .streamFactoryFactory(NettyStreamFactoryFactory.builder()
-                .applyToNettySslContext(builder -> builder.sslProvider(SslProvider.OPENSSL))
+                .nettySslContext(nettySslContext)
                 .build())
         .build();
 MongoClient client = MongoClients.create(settings);

--- a/docs/reference/content/driver/tutorials/ssl.md
+++ b/docs/reference/content/driver/tutorials/ssl.md
@@ -87,19 +87,19 @@ import io.netty.handler.ssl.SslProvider;
 
 To instruct the driver to use [`io.netty.handler.ssl.SslContext`]({{< nettyapiref "io/netty/handler/ssl/SslContext.html" >}}),
 use the method
-[`NettyStreamFactoryFactory.Builder.nettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#nettySslContext(io.netty.handler.ssl.SslContext)" >}}).
+[`NettyStreamFactoryFactory.Builder.sslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#sslContext(io.netty.handler.ssl.SslContext)" >}}).
 See the documentation of this method for details on which
 [`io.netty.handler.ssl.SslProvider`]({{< nettyapiref "io/netty/handler/ssl/SslProvider.html" >}})s are supported by the driver
 and implications of using them.
 
 ```java
-SslContext nettySslContext = SslContextBuilder.forClient()
+SslContext sslContext = SslContextBuilder.forClient()
         .sslProvider(SslProvider.OPENSSL)
         .build();
 MongoClientSettings settings = MongoClientSettings.builder()
         .applyToSslSettings(builder -> builder.enabled(true))
         .streamFactoryFactory(NettyStreamFactoryFactory.builder()
-                .nettySslContext(nettySslContext)
+                .sslContext(sslContext)
                 .build())
         .build();
 MongoClient client = MongoClients.create(settings);
@@ -172,19 +172,19 @@ import io.netty.handler.ssl.SslProvider;
 
 To instruct the driver to use [`io.netty.handler.ssl.SslContext`]({{< nettyapiref "io/netty/handler/ssl/SslContext.html" >}}),
 use the method
-[`NettyStreamFactoryFactory.Builder.nettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#nettySslContext(io.netty.handler.ssl.SslContext)" >}}).
+[`NettyStreamFactoryFactory.Builder.sslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#sslContext(io.netty.handler.ssl.SslContext)" >}}).
 See the documentation of this method for details on which
 [`io.netty.handler.ssl.SslProvider`]({{< nettyapiref "io/netty/handler/ssl/SslProvider.html" >}})s are supported by the driver
 and implications of using them.
 
 ```java
-SslContext nettySslContext = SslContextBuilder.forClient()
+SslContext sslContext = SslContextBuilder.forClient()
         .sslProvider(SslProvider.OPENSSL)
         .build();
 MongoClientSettings settings = MongoClientSettings.builder()
         .applyToSslSettings(builder -> builder.enabled(true))
         .streamFactoryFactory(NettyStreamFactoryFactory.builder()
-                .nettySslContext(nettySslContext)
+                .sslContext(sslContext)
                 .build())
         .build();
 MongoClient client = MongoClients.create(settings);

--- a/docs/reference/content/driver/tutorials/ssl.md
+++ b/docs/reference/content/driver/tutorials/ssl.md
@@ -10,8 +10,9 @@ title = "TLS/SSL"
 
 ## TLS/SSL
 
-The Java driver supports TLS/SSL connections to MongoDB servers using
-the underlying support for TLS/SSL provided by the JDK. 
+By default the Java driver supports TLS/SSL connections to MongoDB servers using
+the underlying support for TLS/SSL provided by the JDK. This can be changed either by utilizing extensibility
+of the [Java SE API]({{< javaseref "api">}}), or via the [Netty API]({{< nettyapiref >}}).
 You can configure the driver to use TLS/SSL either with [`ConnectionString`]({{< apiref "mongodb-driver-core" "com/mongodb/ConnectionString" >}}) or with
 [`MongoClientSettings`]({{< apiref "mongodb-driver-core" "com/mongodb/MongoClientSettings" >}}).
 
@@ -50,25 +51,51 @@ MongoClientSettings settings = MongoClientSettings.builder()
 MongoClient client = MongoClients.create(settings);
 ```
 
-### Specify `SSLContext` via `MongoClientSettings`
+### Specify Java SE `SSLContext` via `MongoClientSettings`
 
 ```java
 import javax.net.ssl.SSLContext;
 import com.mongodb.MongoClientSettings;
-import com.mongodb.client.MongoClients;
-import com.mongodb.client.MongoClient;
+import com.mongodb.MongoClient;
 ```
 
-To specify the [`javax.net.ssl.SSLContext`]({{< javaseref "api/javax/net/ssl/SSLContext.html" >}}) with 
+To specify the [`javax.net.ssl.SSLContext`]({{< javaseref "api/javax/net/ssl/SSLContext.html" >}}) with
 [`MongoClientSettings`]({{< apiref "mongodb-driver-core" "com/mongodb/MongoClientSettings" >}}), set the `sslContext` property, as in:
 
 ```java
 SSLContext sslContext = ...
 MongoClientSettings settings = MongoClientSettings.builder()
-        .applyToSslSettings(builder -> {
-                    builder.enabled(true);
-                    builder.context(sslContext);
-                })
+        .applyToSslSettings(builder -> builder.enabled(true).context(sslContext))
+        .build();
+MongoClient client = new MongoClient(settings);
+```
+
+### Specify Netty `SslContext` via `NettyStreamFactoryFactory`
+
+If you use the driver with [Netty](https://netty.io/) for network IO,
+you have an option to plug an alternative TLS/SSL protocol implementation provided by Netty.
+
+```java
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoClient;
+import com.mongodb.connection.netty.NettyStreamFactoryFactory;
+import io.netty.handler.ssl.SslProvider;
+```
+
+To instruct the driver to use [`io.netty.handler.ssl.SslContext`]({{< nettyapiref "io/netty/handler/ssl/SslContext.html" >}}),
+use the method
+[`NettyStreamFactoryFactory.Builder.applyToNettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#applyToNettySslContext(java.util.function.Consumer)" >}}).
+See the documentation of this method for details on which
+[`io.netty.handler.ssl.SslProvider`]({{< nettyapiref "io/netty/handler/ssl/SslProvider.html" >}})s are supported by the driver
+and implications of using them.
+
+```java
+MongoClientSettings settings = MongoClientSettings.builder()
+        .applyToSslSettings(builder -> builder.enabled(true))
+        .streamFactoryFactory(NettyStreamFactoryFactory.builder()
+                .applyToNettySslContext(builder -> builder.sslProvider(SslProvider.OPENSSL))
+                .build())
         .build();
 MongoClient client = MongoClients.create(settings);
 ```
@@ -104,7 +131,7 @@ To specify TLS/SSL with with [`MongoClientSettings`]({{< apiref "mongodb-driver-
  MongoClient client = new MongoClient(settings);
 ```
 
-### Specify `SSLContext` via `MongoClientSettings`
+### Specify Java SE `SSLContext` via `MongoClientSettings`
 
 ```java
 import javax.net.ssl.SSLContext;
@@ -112,7 +139,7 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoClient;
 ```
 
-To specify the [`javax.net.ssl.SSLContext`]({{< javaseref "api/javax/net/ssl/SSLContext.html" >}}) with 
+To specify the [`javax.net.ssl.SSLContext`]({{< javaseref "api/javax/net/ssl/SSLContext.html" >}}) with
 [`MongoClientSettings`]({{< apiref "mongodb-driver-core" "com/mongodb/MongoClientSettings" >}}), set the `sslContext` property, as in:
 
 ```java
@@ -121,6 +148,36 @@ MongoClientSettings settings = MongoClientSettings.builder()
         .applyToSslSettings(builder -> builder.enabled(true).context(sslContext))
         .build();
 MongoClient client = new MongoClient(settings);
+```
+
+### Specify Netty `SslContext` via `NettyStreamFactoryFactory`
+
+If you use the driver with [Netty](https://netty.io/) for network IO,
+you have an option to plug an alternative TLS/SSL protocol implementation provided by Netty.
+
+```java
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoClient;
+import com.mongodb.connection.netty.NettyStreamFactoryFactory;
+import io.netty.handler.ssl.SslProvider;
+```
+
+To instruct the driver to use [`io.netty.handler.ssl.SslContext`]({{< nettyapiref "io/netty/handler/ssl/SslContext.html" >}}),
+use the method
+[`NettyStreamFactoryFactory.Builder.applyToNettySslContext`]({{< apiref "mongodb-driver-core" "com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#applyToNettySslContext(java.util.function.Consumer)" >}}).
+See the documentation of this method for details on which
+[`io.netty.handler.ssl.SslProvider`]({{< nettyapiref "io/netty/handler/ssl/SslProvider.html" >}})s are supported by the driver
+and implications of using them.
+
+```java
+MongoClientSettings settings = MongoClientSettings.builder()
+        .applyToSslSettings(builder -> builder.enabled(true))
+        .streamFactoryFactory(NettyStreamFactoryFactory.builder()
+                .applyToNettySslContext(builder -> builder.sslProvider(SslProvider.OPENSSL))
+                .build())
+        .build();
+MongoClient client = MongoClients.create(settings);
 ```
 
 ## Disable Hostname Verification
@@ -142,7 +199,10 @@ MongoClientSettings settings = MongoClientSettings.builder()
 ```
 
 ## Common TLS/SSL Configuration Tasks
-<p></p>
+
+This section is based on the documentation for [Oracle JDK](https://www.oracle.com/java/technologies/javase-downloads.html#JDK8),
+so some parts may be inapplicable to your JDK or to the custom TLS/SSL implementation you use. 
+
 ### Configure Trust Store and Key Store
 One may either configure trust stores and key stores specific to the client via 
 [`javax.net.ssl.SSLContext.init(KeyManager[] km, TrustManager[] tm, SecureRandom random)`]

--- a/docs/reference/content/whats-new.md
+++ b/docs/reference/content/whats-new.md
@@ -24,6 +24,10 @@ New features of the 4.3 Java driver release include:
     primarily to prevent accidental use of a replace operation when the intention was to use an update operation.
   * Note that unacknowledged writes using dollar-prefixed or dotted keys may be silently rejected by pre-5.0 servers, where some 
     restrictions on field names are still enforced in the server.
+* Added support for setting
+  [Netty](https://netty.io/) [`io.netty.handler.ssl.SslContext`]({{< nettyapiref "io/netty/handler/ssl/SslContext.html" >}}),
+  which may be used as a convenient way to utilize [OpenSSL](https://www.openssl.org/) as an alternative
+  to the TLS/SSL protocol implementation in a JDK.
 
 # What's new in 4.2
 

--- a/docs/reference/layouts/shortcodes/nettyapiref.html
+++ b/docs/reference/layouts/shortcodes/nettyapiref.html
@@ -1,0 +1,1 @@
+{{ .Site.Params.nettyApiUri }}{{ .Get 0 }}

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -30,18 +30,26 @@ ext {
 // Add native-image.properties
 sourceSets.main.resources.srcDirs = ['src/resources']
 
+configurations {
+    consumableTestRuntimeOnly {
+        extendsFrom testRuntimeOnly
+        canBeConsumed = true
+    }
+}
+
 dependencies {
     api project(path: ':bson', configuration: 'default')
 
     implementation "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
     api "io.netty:netty-buffer:$nettyVersion", optional
     api "io.netty:netty-transport:$nettyVersion", optional
-    implementation "io.netty:netty-handler:$nettyVersion", optional
+    api "io.netty:netty-handler:$nettyVersion", optional
     implementation "org.xerial.snappy:snappy-java:$snappyVersion", optional
     implementation "com.github.luben:zstd-jni:$zstdVersion", optional
     implementation "org.mongodb:mongodb-crypt:$mongoCryptVersion", optional
 
     testImplementation project(':bson').sourceSets.test.output
+    testRuntimeOnly "io.netty:netty-tcnative-boringssl-static:2.0.39.Final"
 }
 
 buildConfig {

--- a/driver-core/src/main/com/mongodb/connection/SslSettings.java
+++ b/driver-core/src/main/com/mongodb/connection/SslSettings.java
@@ -110,7 +110,10 @@ public class SslSettings {
         /**
          * Sets the SSLContext for use when SSL is enabled.
          *
-         * @param context the SSLContext to use for connections.  Ignored if SSL is not enabled.
+         * @param context the SSLContext to use for connections. Ignored if TLS/SSL is not {@linkplain #enabled(boolean) enabled},
+         *                or if a {@link StreamFactory} {@linkplain StreamFactoryFactory#create(SocketSettings, SslSettings) created}
+         *                by the {@linkplain com.mongodb.MongoClientSettings.Builder#streamFactoryFactory(StreamFactoryFactory) specified}
+         *                {@link StreamFactoryFactory} does not use {@link SSLContext}.
          * @return this
          * @since 3.5
          */

--- a/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
@@ -111,7 +111,7 @@ final class NettyStream implements Stream {
     private final Class<? extends SocketChannel> socketChannelClass;
     private final ByteBufAllocator allocator;
     @Nullable
-    private final SslContext nettySslContext;
+    private final SslContext sslContext;
 
     private boolean isClosed;
     private volatile Channel channel;
@@ -133,14 +133,14 @@ final class NettyStream implements Stream {
 
     NettyStream(final ServerAddress address, final SocketSettings settings, final SslSettings sslSettings, final EventLoopGroup workerGroup,
                 final Class<? extends SocketChannel> socketChannelClass, final ByteBufAllocator allocator,
-                @Nullable final SslContext nettySslContext) {
+                @Nullable final SslContext sslContext) {
         this.address = address;
         this.settings = settings;
         this.sslSettings = sslSettings;
         this.workerGroup = workerGroup;
         this.socketChannelClass = socketChannelClass;
         this.allocator = allocator;
-        this.nettySslContext = nettySslContext;
+        this.sslContext = sslContext;
     }
 
     @Override
@@ -394,7 +394,7 @@ final class NettyStream implements Stream {
 
     private void addSslHandler(final SocketChannel channel) {
         SSLEngine engine;
-        if (nettySslContext == null) {
+        if (sslContext == null) {
             SSLContext sslContext;
             try {
                 sslContext = (sslSettings.getContext() == null) ? SSLContext.getDefault() : sslSettings.getContext();
@@ -403,7 +403,7 @@ final class NettyStream implements Stream {
             }
             engine = sslContext.createSSLEngine(address.getHost(), address.getPort());
         } else {
-            engine = nettySslContext.newEngine(channel.alloc(), address.getHost(), address.getPort());
+            engine = sslContext.newEngine(channel.alloc(), address.getHost(), address.getPort());
         }
         engine.setUseClientMode(true);
         SSLParameters sslParameters = engine.getSSLParameters();

--- a/driver-core/src/main/com/mongodb/connection/netty/NettyStreamFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyStreamFactory.java
@@ -44,7 +44,7 @@ public class NettyStreamFactory implements StreamFactory {
     private final Class<? extends SocketChannel> socketChannelClass;
     private final ByteBufAllocator allocator;
     @Nullable
-    private final SslContext nettySslContext;
+    private final SslContext sslContext;
 
     /**
      * Construct a new instance of the factory.
@@ -54,21 +54,21 @@ public class NettyStreamFactory implements StreamFactory {
      * @param eventLoopGroup the event loop group that all channels created by this factory will be a part of
      * @param socketChannelClass the socket channel class
      * @param allocator the allocator to use for ByteBuf instances
-     * @param nettySslContext the Netty {@link SslContext}
-     *                        as specified by {@link NettyStreamFactoryFactory.Builder#nettySslContext(SslContext)}.
+     * @param sslContext the Netty {@link SslContext}
+     *                   as specified by {@link NettyStreamFactoryFactory.Builder#sslContext(SslContext)}.
      *
      * @since 4.3
      */
     public NettyStreamFactory(final SocketSettings settings, final SslSettings sslSettings,
                               final EventLoopGroup eventLoopGroup, final Class<? extends SocketChannel> socketChannelClass,
                               final ByteBufAllocator allocator,
-                              @Nullable final SslContext nettySslContext) {
+                              @Nullable final SslContext sslContext) {
         this.settings = notNull("settings", settings);
         this.sslSettings = notNull("sslSettings", sslSettings);
         this.eventLoopGroup = notNull("eventLoopGroup", eventLoopGroup);
         this.socketChannelClass = notNull("socketChannelClass", socketChannelClass);
         this.allocator = notNull("allocator", allocator);
-        this.nettySslContext = nettySslContext;
+        this.sslContext = sslContext;
     }
 
     /**
@@ -126,7 +126,7 @@ public class NettyStreamFactory implements StreamFactory {
 
     @Override
     public Stream create(final ServerAddress serverAddress) {
-        return new NettyStream(serverAddress, settings, sslSettings, eventLoopGroup, socketChannelClass, allocator, nettySslContext);
+        return new NettyStream(serverAddress, settings, sslSettings, eventLoopGroup, socketChannelClass, allocator, sslContext);
     }
 
 }

--- a/driver-core/src/main/com/mongodb/connection/netty/NettyStreamFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyStreamFactory.java
@@ -29,9 +29,6 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-
-import java.util.function.Consumer;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -47,7 +44,7 @@ public class NettyStreamFactory implements StreamFactory {
     private final Class<? extends SocketChannel> socketChannelClass;
     private final ByteBufAllocator allocator;
     @Nullable
-    private final Consumer<? super SslContextBuilder> nettySslContextTuner;
+    private final SslContext nettySslContext;
 
     /**
      * Construct a new instance of the factory.
@@ -57,21 +54,21 @@ public class NettyStreamFactory implements StreamFactory {
      * @param eventLoopGroup the event loop group that all channels created by this factory will be a part of
      * @param socketChannelClass the socket channel class
      * @param allocator the allocator to use for ByteBuf instances
-     * @param nettySslContextTuner the tuner for a Netty {@link SslContext}
-     *                             as specified by {@link NettyStreamFactoryFactory.Builder#applyToNettySslContext(Consumer)}.
+     * @param nettySslContext the Netty {@link SslContext}
+     *                        as specified by {@link NettyStreamFactoryFactory.Builder#nettySslContext(SslContext)}.
      *
      * @since 4.3
      */
     public NettyStreamFactory(final SocketSettings settings, final SslSettings sslSettings,
                               final EventLoopGroup eventLoopGroup, final Class<? extends SocketChannel> socketChannelClass,
                               final ByteBufAllocator allocator,
-                              @Nullable final Consumer<? super SslContextBuilder> nettySslContextTuner) {
+                              @Nullable final SslContext nettySslContext) {
         this.settings = notNull("settings", settings);
         this.sslSettings = notNull("sslSettings", sslSettings);
         this.eventLoopGroup = notNull("eventLoopGroup", eventLoopGroup);
         this.socketChannelClass = notNull("socketChannelClass", socketChannelClass);
         this.allocator = notNull("allocator", allocator);
-        this.nettySslContextTuner = nettySslContextTuner;
+        this.nettySslContext = nettySslContext;
     }
 
     /**
@@ -129,7 +126,7 @@ public class NettyStreamFactory implements StreamFactory {
 
     @Override
     public Stream create(final ServerAddress serverAddress) {
-        return new NettyStream(serverAddress, settings, sslSettings, eventLoopGroup, socketChannelClass, allocator, nettySslContextTuner);
+        return new NettyStream(serverAddress, settings, sslSettings, eventLoopGroup, socketChannelClass, allocator, nettySslContext);
     }
 
 }

--- a/driver-core/src/main/com/mongodb/connection/netty/NettyStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyStreamFactoryFactory.java
@@ -47,7 +47,7 @@ public final class NettyStreamFactoryFactory implements StreamFactoryFactory {
     private final Class<? extends SocketChannel> socketChannelClass;
     private final ByteBufAllocator allocator;
     @Nullable
-    private final SslContext nettySslContext;
+    private final SslContext sslContext;
 
     /**
      * Gets a builder for an instance of {@code NettyStreamFactoryFactory}.
@@ -68,7 +68,7 @@ public final class NettyStreamFactoryFactory implements StreamFactoryFactory {
         private Class<? extends SocketChannel> socketChannelClass;
         private EventLoopGroup eventLoopGroup;
         @Nullable
-        private SslContext nettySslContext;
+        private SslContext sslContext;
 
         private Builder() {
             allocator(ByteBufAllocator.DEFAULT);
@@ -134,16 +134,16 @@ public final class NettyStreamFactoryFactory implements StreamFactoryFactory {
          *    </li>
          * </ul>
          *
-         * @param nettySslContext The Netty {@link SslContext}, which must be created via {@linkplain SslContextBuilder#forClient()}.
+         * @param sslContext The Netty {@link SslContext}, which must be created via {@linkplain SslContextBuilder#forClient()}.
          * @return {@code this}.
          *
          * @since 4.3
          */
-        public Builder nettySslContext(final SslContext nettySslContext) {
-            this.nettySslContext = notNull("nettySslContext", nettySslContext);
-            isTrueArgument("nettySslContext must be client-side", nettySslContext.isClient());
-            isTrueArgument("nettySslContext must not be reference counted",
-                    !(nettySslContext instanceof ReferenceCountedOpenSslClientContext));
+        public Builder sslContext(final SslContext sslContext) {
+            this.sslContext = notNull("sslContext", sslContext);
+            isTrueArgument("sslContext must be client-side", sslContext.isClient());
+            isTrueArgument("sslContext must use either SslProvider.JDK or SslProvider.OPENSSL TLS/SSL protocol provider",
+                    !(sslContext instanceof ReferenceCountedOpenSslClientContext));
 
             return this;
         }
@@ -159,7 +159,7 @@ public final class NettyStreamFactoryFactory implements StreamFactoryFactory {
 
     @Override
     public StreamFactory create(final SocketSettings socketSettings, final SslSettings sslSettings) {
-        return new NettyStreamFactory(socketSettings, sslSettings, eventLoopGroup, socketChannelClass, allocator, nettySslContext);
+        return new NettyStreamFactory(socketSettings, sslSettings, eventLoopGroup, socketChannelClass, allocator, sslContext);
     }
 
     @Override
@@ -168,7 +168,7 @@ public final class NettyStreamFactoryFactory implements StreamFactoryFactory {
                 + "eventLoopGroup=" + eventLoopGroup
                 + ", socketChannelClass=" + socketChannelClass
                 + ", allocator=" + allocator
-                + ", nettySslContext=" + nettySslContext
+                + ", sslContext=" + sslContext
                 + '}';
     }
 
@@ -180,6 +180,6 @@ public final class NettyStreamFactoryFactory implements StreamFactoryFactory {
         } else {
             eventLoopGroup = new NioEventLoopGroup();
         }
-        nettySslContext = builder.nettySslContext;
+        sslContext = builder.sslContext;
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -30,7 +30,6 @@ import com.mongodb.connection.SslSettings;
 import com.mongodb.connection.StreamFactory;
 import com.mongodb.connection.StreamFactoryFactory;
 import com.mongodb.connection.TlsChannelStreamFactoryFactory;
-import com.mongodb.connection.netty.NettyStreamFactory;
 import com.mongodb.connection.netty.NettyStreamFactoryFactory;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
@@ -58,6 +57,7 @@ import com.mongodb.internal.operation.DropDatabaseOperation;
 import com.mongodb.internal.operation.ReadOperation;
 import com.mongodb.internal.operation.WriteOperation;
 import com.mongodb.lang.Nullable;
+import io.netty.handler.ssl.SslProvider;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonString;
@@ -73,6 +73,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.connection.ClusterConnectionMode.LOAD_BALANCED;
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE;
 import static com.mongodb.connection.ClusterType.REPLICA_SET;
@@ -396,18 +397,15 @@ public final class ClusterFixture {
     }
 
     public static StreamFactory getAsyncStreamFactory() {
-        String streamType = System.getProperty("org.mongodb.test.async.type", "nio2");
-
-        if (streamType.equals("netty")) {
-            return new NettyStreamFactory(getSocketSettings(), getSslSettings());
-        } else if (streamType.equals("nio2")) {
+        StreamFactoryFactory overriddenStreamMetafactory = getOverriddenStreamFactoryFactory();
+        if (overriddenStreamMetafactory == null) { // use NIO2
             if (getSslSettings().isEnabled()) {
                 return new TlsChannelStreamFactoryFactory().create(getSocketSettings(), getSslSettings());
             } else {
                 return new AsynchronousSocketChannelStreamFactory(getSocketSettings(), getSslSettings());
             }
         } else {
-            throw new IllegalArgumentException("Unsupported stream type " + streamType);
+            return assertNotNull(overriddenStreamMetafactory).create(getSocketSettings(), getSslSettings());
         }
     }
 
@@ -415,13 +413,17 @@ public final class ClusterFixture {
     public static StreamFactoryFactory getOverriddenStreamFactoryFactory() {
         String streamType = System.getProperty("org.mongodb.test.async.type", "nio2");
 
-        if (streamType.equals("netty")) {
-            if (nettyStreamFactoryFactory == null) {
-                nettyStreamFactoryFactory = NettyStreamFactoryFactory.builder().build();
+        if (nettyStreamFactoryFactory == null) {
+            if (streamType.equals("netty")) {
+                NettyStreamFactoryFactory.Builder metafactoryBuilder = NettyStreamFactoryFactory.builder();
+                String nettySslProvider = System.getProperty("org.mongodb.test.netty.ssl.provider");
+                if (nettySslProvider != null) {
+                    metafactoryBuilder.applyToNettySslContext(builder -> builder.sslProvider(SslProvider.valueOf(nettySslProvider)));
+                }
+                nettyStreamFactoryFactory = metafactoryBuilder.build();
             }
-            return nettyStreamFactoryFactory;
         }
-        return null;
+        return nettyStreamFactoryFactory;
     }
 
     private static SocketSettings getSocketSettings() {

--- a/driver-reactive-streams/build.gradle
+++ b/driver-reactive-streams/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     testImplementation 'org.reactivestreams:reactive-streams-tck:1.0.2'
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.mockito:mockito-junit-jupiter:3.5.13'
+    testRuntimeOnly project(path: ':driver-core', configuration: 'consumableTestRuntimeOnly')
 }
 
 sourceSets {

--- a/driver-scala/build.gradle
+++ b/driver-scala/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testImplementation project(':driver-sync').sourceSets.test.output
     testImplementation project(':driver-core').sourceSets.test.output
     testImplementation project(':driver-reactive-streams').sourceSets.test.output
+    testRuntimeOnly project(path: ':driver-core', configuration: 'consumableTestRuntimeOnly')
 }
 
 

--- a/driver-sync/build.gradle
+++ b/driver-sync/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
     testImplementation project(':bson').sourceSets.test.output
     testImplementation project(':driver-core').sourceSets.test.output
+    testRuntimeOnly project(path: ':driver-core', configuration: 'consumableTestRuntimeOnly')
 }
 
 sourceSets {


### PR DESCRIPTION
This may be used as a convenient way to utilize OpenSSL as an alternative to the TLS/SSL protocol implementation in a JDK.

JAVA-4177