### PR TITLE
DOCSP-16312: Link to new Java sync 4.3 docs site

### DIFF
--- a/docs/reference/themes/mongodb/layouts/partials/header.html
+++ b/docs/reference/themes/mongodb/layouts/partials/header.html
@@ -25,6 +25,6 @@
               <div class="documentwrapper">
                 <div class="bodywrapper">
                   <div class="body">
-                    {{ if ( findRE ".*mongo-java-driver\/4.3\/" .URL ) }}
+                    {{ if ( findRE ".*mongo-java-driver\/4.3\/(?!apidocs)" .URL ) }}
                       {{- partial "header/newSiteNotice.html" . -}}
                     {{ end }}

--- a/docs/reference/themes/mongodb/layouts/partials/header.html
+++ b/docs/reference/themes/mongodb/layouts/partials/header.html
@@ -25,3 +25,8 @@
               <div class="documentwrapper">
                 <div class="bodywrapper">
                   <div class="body">
+                    {{ if (and (hasPrefix .URL "/driver/") (eq .Site.Data.mongodb.currentVersion "4.3")) }}
+                      {{- partial "header/newSiteNotice.html" . -}}
+                    {{ end }}
+
+

--- a/docs/reference/themes/mongodb/layouts/partials/header.html
+++ b/docs/reference/themes/mongodb/layouts/partials/header.html
@@ -25,8 +25,6 @@
               <div class="documentwrapper">
                 <div class="bodywrapper">
                   <div class="body">
-                    {{ if (and (hasPrefix .URL "/driver/") (eq .Site.Data.mongodb.currentVersion "4.3")) }}
+                    {{ if ( findRE ".*mongo-java-driver\/4.3\/" .URL ) }}
                       {{- partial "header/newSiteNotice.html" . -}}
                     {{ end }}
-
-

--- a/docs/reference/themes/mongodb/layouts/partials/header/newSiteNotice.html
+++ b/docs/reference/themes/mongodb/layouts/partials/header/newSiteNotice.html
@@ -1,0 +1,6 @@
+<div style="padding: 15px; margin: 20px 0px; border-width: 1px 1px 1px 0px; border-style: solid; border-radius: 6px; font-size: 14px; line-height: 20px; color: rgb(17, 97, 73); border-color: rgb(195, 231, 202) rgb(195, 231, 202) rgb(195, 231, 202) rgb(19, 170, 82); background-color: rgb(228, 244, 228);">
+  This reference documentation site is for versions of the MongoDB Java synchronous driver up to 4.3-beta.
+  <br/>
+  See the <a style="font-weight: bold" href="https://docs.mongodb.com/drivers/java/sync">MongoDB Java Driver documentation site</a> for version 4.3 and later versions of the reference documentation.
+</div>
+

--- a/docs/reference/themes/mongodb/layouts/partials/header/newSiteNotice.html
+++ b/docs/reference/themes/mongodb/layouts/partials/header/newSiteNotice.html
@@ -1,6 +1,6 @@
 <div style="padding: 15px; margin: 20px 0px; border-width: 1px 1px 1px 0px; border-style: solid; border-radius: 6px; font-size: 14px; line-height: 20px; color: rgb(17, 97, 73); border-color: rgb(195, 231, 202) rgb(195, 231, 202) rgb(195, 231, 202) rgb(19, 170, 82); background-color: rgb(228, 244, 228);">
   This reference documentation site is for versions of the MongoDB Java synchronous driver up to 4.3-beta.
   <br/>
-  See the <a style="font-weight: bold" href="https://docs.mongodb.com/drivers/java/sync">MongoDB Java Driver documentation site</a> for version 4.3 and later versions of the reference documentation.
+  See the <a style="font-weight: bold" href="https://docs.mongodb.com/drivers/java/sync/current">MongoDB Java Driver documentation site</a> for version 4.3 and later versions of the reference documentation.
 </div>
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCSP-16312

These changes place a notice at the top of Java 4.3 reference documentation pages (not API documentation) that link to the new Java reference documentation site. Do not merge until the new documentation site is published.