### PR TITLE
Redaction improvements

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -90,6 +90,11 @@ public class InternalStreamConnection implements InternalConnection {
             "copydbsaslstart",
             "copydb"));
 
+    private static final Set<String> SECURITY_SENSITIVE_HELLO_COMMANDS = new HashSet<String>(asList(
+            "hello",
+            "ismaster",
+            "isMaster"));
+
     private static final Logger LOGGER = Loggers.getLogger("connection");
 
     private final ClusterConnectionMode clusterConnectionMode;
@@ -787,8 +792,8 @@ public class InternalStreamConnection implements InternalConnection {
 
     private CommandEventSender createCommandEventSender(final CommandMessage message, final ByteBufferBsonOutput bsonOutput) {
         if (opened() && (commandListener != null || COMMAND_PROTOCOL_LOGGER.isDebugEnabled())) {
-            return new LoggingCommandEventSender(SECURITY_SENSITIVE_COMMANDS, description, commandListener, message, bsonOutput,
-                    COMMAND_PROTOCOL_LOGGER);
+            return new LoggingCommandEventSender(SECURITY_SENSITIVE_COMMANDS, SECURITY_SENSITIVE_HELLO_COMMANDS, description,
+                    commandListener, message, bsonOutput, COMMAND_PROTOCOL_LOGGER);
         } else {
             return new NoOpCommandEventSender();
         }

--- a/driver-core/src/main/com/mongodb/internal/connection/LoggingCommandEventSender.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoggingCommandEventSender.java
@@ -66,9 +66,10 @@ class LoggingCommandEventSender implements CommandEventSender {
     @Override
     public void sendStartedEvent() {
         if (loggingRequired()) {
+            String commandString = redactionRequired ? String.format("{\"%s\": ...", commandName) : getTruncatedJsonCommand();
             logger.debug(
                     format("Sending command '%s' with request id %d to database %s on connection [%s] to server %s",
-                            getTruncatedJsonCommand(), message.getId(),
+                            commandString, message.getId(),
                             message.getNamespace().getDatabaseName(), description.getConnectionId(), description.getServerAddress()));
         }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
@@ -674,7 +674,10 @@ class InternalStreamConnectionSpecification extends Specification {
                 new BsonDocument('updateUser', new BsonInt32(1)),
                 new BsonDocument('copydbgetnonce', new BsonInt32(1)),
                 new BsonDocument('copydbsaslstart', new BsonInt32(1)),
-                new BsonDocument('copydb', new BsonInt32(1))
+                new BsonDocument('copydb', new BsonInt32(1)),
+                new BsonDocument('hello', new BsonInt32(1)).append('speculativeAuthenticate', new BsonDocument()),
+                new BsonDocument('ismaster', new BsonInt32(1)).append('speculativeAuthenticate', new BsonDocument()),
+                new BsonDocument('isMaster', new BsonInt32(1)).append('speculativeAuthenticate', new BsonDocument())
         ]
     }
 
@@ -707,7 +710,10 @@ class InternalStreamConnectionSpecification extends Specification {
                 new BsonDocument('updateUser', new BsonInt32(1)),
                 new BsonDocument('copydbgetnonce', new BsonInt32(1)),
                 new BsonDocument('copydbsaslstart', new BsonInt32(1)),
-                new BsonDocument('copydb', new BsonInt32(1))
+                new BsonDocument('copydb', new BsonInt32(1)),
+                new BsonDocument('hello', new BsonInt32(1)).append('speculativeAuthenticate', new BsonDocument()),
+                new BsonDocument('ismaster', new BsonInt32(1)).append('speculativeAuthenticate', new BsonDocument()),
+                new BsonDocument('isMaster', new BsonInt32(1)).append('speculativeAuthenticate', new BsonDocument())
         ]
     }
 
@@ -894,7 +900,10 @@ class InternalStreamConnectionSpecification extends Specification {
                 new BsonDocument('updateUser', new BsonInt32(1)),
                 new BsonDocument('copydbgetnonce', new BsonInt32(1)),
                 new BsonDocument('copydbsaslstart', new BsonInt32(1)),
-                new BsonDocument('copydb', new BsonInt32(1))
+                new BsonDocument('copydb', new BsonInt32(1)),
+                new BsonDocument('hello', new BsonInt32(1)).append('speculativeAuthenticate', new BsonDocument()),
+                new BsonDocument('ismaster', new BsonInt32(1)).append('speculativeAuthenticate', new BsonDocument()),
+                new BsonDocument('isMaster', new BsonInt32(1)).append('speculativeAuthenticate', new BsonDocument())
         ]
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
@@ -55,7 +55,8 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def logger = Stub(Logger) {
             isDebugEnabled() >> debugLoggingEnabled
         }
-        def sender = new LoggingCommandEventSender([] as Set, connectionDescription, commandListener, message, bsonOutput, logger)
+        def sender = new LoggingCommandEventSender([] as Set, [] as Set, connectionDescription, commandListener, message, bsonOutput,
+                logger)
 
         when:
         sender.sendStartedEvent()
@@ -94,7 +95,8 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def logger = Mock(Logger) {
             isDebugEnabled() >> true
         }
-        def sender = new LoggingCommandEventSender([] as Set, connectionDescription, commandListener, message, bsonOutput, logger)
+        def sender = new LoggingCommandEventSender([] as Set, [] as Set, connectionDescription, commandListener, message, bsonOutput,
+                logger)
         when:
         sender.sendStartedEvent()
         sender.sendSucceededEventForOneWayCommand()
@@ -140,7 +142,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def logger = Mock(Logger) {
             isDebugEnabled() >> true
         }
-        def sender = new LoggingCommandEventSender([] as Set, connectionDescription, null, message, bsonOutput, logger)
+        def sender = new LoggingCommandEventSender([] as Set, [] as Set, connectionDescription, null, message, bsonOutput, logger)
 
         when:
         sender.sendStartedEvent()

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/CommandMonitoringTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/CommandMonitoringTest.java
@@ -30,15 +30,12 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static org.junit.Assume.assumeFalse;
-
 public class CommandMonitoringTest extends UnifiedTest {
     public CommandMonitoringTest(@SuppressWarnings("unused") final String fileDescription,
                                  @SuppressWarnings("unused") final String testDescription,
                                  final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
                                  final BsonArray initialData, final BsonDocument definition) {
         super(schemaVersion, runOnRequirements, entities, initialData, definition);
-        assumeFalse(testDescription.equals("hello with speculative authenticate"));
     }
 
     @Override

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/CommandMonitoringTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/CommandMonitoringTest.java
@@ -28,8 +28,6 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static org.junit.Assume.assumeFalse;
-
 public class CommandMonitoringTest extends UnifiedTest {
 
 
@@ -39,7 +37,6 @@ public class CommandMonitoringTest extends UnifiedTest {
                                  @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
                                  final BsonDocument definition) {
         super(schemaVersion, runOnRequirements, entities, initialData, definition);
-        assumeFalse(testDescription.equals("hello with speculative authenticate"));
     }
 
     @Override


### PR DESCRIPTION
* Ensure command event for hello with speculativeAuthenticate is elided
* Ensure redacted commands are logged with elision (The fact that we don't currently elide redacted commands when logging is enabled is not currently a big problem, since we don't log commands executed during the handshake at all.  But there is a ticket which is going to change this behavior, and I'm concerned that once we start logging these commands we may forget to elide them.  So just taking care of it now.)

JAVA-4195