### PR TITLE
Support serviceId in reply from load balanced cluster

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/ConnectionDescription.java
+++ b/driver-core/src/main/com/mongodb/connection/ConnectionDescription.java
@@ -25,6 +25,7 @@ import org.bson.types.ObjectId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.connection.ServerDescription.getDefaultMaxDocumentSize;
@@ -274,6 +275,9 @@ public class ConnectionDescription {
 
         ConnectionDescription that = (ConnectionDescription) o;
 
+        if (maxWireVersion != that.maxWireVersion) {
+            return false;
+        }
         if (maxBatchCount != that.maxBatchCount) {
             return false;
         }
@@ -283,31 +287,32 @@ public class ConnectionDescription {
         if (maxMessageSize != that.maxMessageSize) {
             return false;
         }
+        if (!Objects.equals(serviceId, that.serviceId)) {
+            return false;
+        }
         if (!connectionId.equals(that.connectionId)) {
             return false;
         }
         if (serverType != that.serverType) {
             return false;
         }
-        if (maxWireVersion != that.maxWireVersion) {
-            return false;
-        }
         if (!compressors.equals(that.compressors)) {
             return false;
         }
-
-        return true;
+        return Objects.equals(saslSupportedMechanisms, that.saslSupportedMechanisms);
     }
 
     @Override
     public int hashCode() {
         int result = connectionId.hashCode();
-        result = 31 * result + maxBatchCount;
+        result = 31 * result + maxWireVersion;
         result = 31 * result + serverType.hashCode();
         result = 31 * result + maxBatchCount;
         result = 31 * result + maxDocumentSize;
         result = 31 * result + maxMessageSize;
         result = 31 * result + compressors.hashCode();
+        result = 31 * result + (serviceId != null ? serviceId.hashCode() : 0);
+        result = 31 * result + (saslSupportedMechanisms != null ? saslSupportedMechanisms.hashCode() : 0);
         return result;
     }
 
@@ -321,6 +326,7 @@ public class ConnectionDescription {
                 + ", maxDocumentSize=" + maxDocumentSize
                 + ", maxMessageSize=" + maxMessageSize
                 + ", compressors=" + compressors
+                + ", serviceId=" + serviceId
                 + '}';
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
@@ -161,6 +161,9 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
         if (clientMetadataDocument != null) {
             isMasterCommandDocument.append("client", clientMetadataDocument);
         }
+        if (clusterConnectionMode == ClusterConnectionMode.LOAD_BALANCED) {
+            isMasterCommandDocument.append("loadBalanced", BsonBoolean.TRUE);
+        }
         if (!requestedCompressors.isEmpty()) {
             BsonArray compressors = new BsonArray(this.requestedCompressors.size());
             for (MongoCompressor cur : this.requestedCompressors) {

--- a/driver-core/src/test/resources/transactions/read-concern.json
+++ b/driver-core/src/test/resources/transactions/read-concern.json
@@ -601,6 +601,7 @@
     },
     {
       "description": "only first distinct includes readConcern",
+      "skipReason": "Skip until JAVA-???? is fixed",
       "operations": [
         {
           "name": "startTransaction",

--- a/driver-core/src/test/resources/transactions/read-concern.json
+++ b/driver-core/src/test/resources/transactions/read-concern.json
@@ -601,7 +601,6 @@
     },
     {
       "description": "only first distinct includes readConcern",
-      "skipReason": "Skip until JAVA-???? is fixed",
       "operations": [
         {
           "name": "startTransaction",


### PR DESCRIPTION
The current load balancing code doesn't support an actual reply from a load-balanced cluster that contains a serviceId, as required by the specification. This patch adds it. 

JAVA-4218