### PR TITLE
Fix regression in MongoWriteException error code

### DIFF
--- a/driver-core/src/main/com/mongodb/MongoWriteException.java
+++ b/driver-core/src/main/com/mongodb/MongoWriteException.java
@@ -33,7 +33,7 @@ public class MongoWriteException extends MongoServerException {
      * @param serverAddress the server address
      */
     public MongoWriteException(final WriteError error, final ServerAddress serverAddress) {
-        super("Write operation error on server " + serverAddress + ". Write error: " + error + ". ", serverAddress);
+        super(error.getCode(), "Write operation error on server " + serverAddress + ". Write error: " + error + ".", serverAddress);
         this.error = error;
     }
 

--- a/driver-core/src/test/unit/com/mongodb/MongoWriteExceptionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/MongoWriteExceptionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MongoWriteExceptionTest {
+
+    @Test
+    public void testExceptionProperties() {
+        WriteError writeError = new WriteError(11000, "Duplicate key", new BsonDocument("x", new BsonInt32(1)));
+        MongoWriteException e = new MongoWriteException(writeError, new ServerAddress("host1"));
+
+        assertEquals("Write operation error on server host1:27017. Write error: WriteError{code=11000, message='Duplicate key', "
+                + "details={\"x\": 1}}.",
+                e.getMessage());
+        assertEquals(writeError.getCode(), e.getCode());
+        assertEquals(writeError, e.getError());
+    }
+}


### PR DESCRIPTION
Ensure that the error code from the single WriteError is propagated to the
exception error code.

JAVA-4219