### PR TITLE
Remove documentation of legacy slaveok URI parameter

### DIFF
--- a/driver-legacy/src/main/com/mongodb/MongoClientURI.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientURI.java
@@ -146,8 +146,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * <p>Read preference configuration:</p>
  * <ul>
- * <li>{@code slaveOk=true|false}: Whether a driver connected to a replica set will send reads to slaves/secondaries.</li>
- * <li>{@code readPreference=enum}: The read preference for this connection.  If set, it overrides any slaveOk value.
+ * <li>{@code readPreference=enum}: The read preference for this connection.
  * <ul>
  * <li>Enumerated values:
  * <ul>


### PR DESCRIPTION
This query parameter has been deprecated for many years and
superseded by the readPreference query parameter.  Removing
the Javadoc for the parameter, with support to be removed in
the next major release

JAVA-4144