### PR TITLE
Flatmap observable fix

### DIFF
--- a/driver-scala/src/test/scala/org/mongodb/scala/internal/FlatMapObservableTest.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/internal/FlatMapObservableTest.scala
@@ -1,0 +1,42 @@
+package org.mongodb.scala.internal
+
+import org.mongodb.scala.{ BaseSpec, Observable, Observer }
+import org.scalatest.concurrent.{ Eventually, Futures }
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ Future, Promise }
+
+class FlatMapObservableTest extends BaseSpec with TableDrivenPropertyChecks with Futures with Eventually {
+  "FlatMapObservable" should "only complete once" in {
+    val p = Promise[Unit]()
+    val completedCounter = new AtomicInteger(0)
+    Observable(1 to 100)
+      .flatMap(
+        x =>
+          new Observable[Int] {
+            override def subscribe(observer: Observer[_ >: Int]): Unit = {
+              Future(()).onComplete(_ => {
+                observer.onNext(x)
+                observer.onComplete()
+              })
+
+            }
+          }
+      )
+      .subscribe(
+        _ => (),
+        p.failure,
+        () => {
+          completedCounter.incrementAndGet()
+          Thread.sleep(100)
+          p.success(())
+        }
+      )
+    eventually(assert(completedCounter.get() == 1, s"${completedCounter.get()}"))
+    Thread.sleep(200)
+    assert(completedCounter.get() == 1, s"${completedCounter.get()}")
+
+  }
+}


### PR DESCRIPTION
`volatile` doesn't protect agains cas-type operation here so let's use atomic boolean.
This would protect against repeated calls to parent's onComplete, which is currently breaking the spec.
I'm not sure this makes the implementation completely correct but I think this is a bit more safe.
I'm open to suggestions/alternatives so feel free to treat this PR as an issue-highlighter rather than a final fix.