### PR TITLE
Support calling `QueryBatchCursor.close` concurrently with other `QueryBatchCursor` methods

### DIFF
--- a/.evergreen/run-load-balancer-tests.sh
+++ b/.evergreen/run-load-balancer-tests.sh
@@ -74,11 +74,22 @@ echo $first
   --tests UnifiedTransactionsTest \
   --tests InitialDnsSeedlistDiscoveryTest
 second=$?
+echo $second
+
+./gradlew -PjdkHome=/opt/java/${JDK} \
+  -Dorg.mongodb.test.uri=${SINGLE_MONGOS_LB_URI} \
+  -Dorg.mongodb.test.transaction.uri=${MULTI_MONGOS_LB_URI} \
+  ${GRADLE_EXTRA_VARS} --stacktrace --info --continue driver-core:test \
+  --tests QueryBatchCursorFunctionalSpecification
+third=$?
+echo $third
 
 if [ $first -ne 0 ]; then
    exit $first
 elif [ $second -ne 0 ]; then
    exit $second
+elif [ $third -ne 0 ]; then
+   exit $third
 else
    exit 0
 fi

--- a/driver-core/src/main/com/mongodb/assertions/Assertions.java
+++ b/driver-core/src/main/com/mongodb/assertions/Assertions.java
@@ -179,7 +179,7 @@ public final class Assertions {
 
     /**
      * @throws AssertionError Always
-     * @return Never completes normally. The return type is {@link AssertionError} to allow writing {@code throws fail()}.
+     * @return Never completes normally. The return type is {@link AssertionError} to allow writing {@code throw fail()}.
      * This may be helpful in non-{@code void} methods.
      */
     public static AssertionError fail() throws AssertionError {
@@ -189,7 +189,7 @@ public final class Assertions {
     /**
      * @param msg The failure message.
      * @throws AssertionError Always
-     * @return Never completes normally. The return type is {@link AssertionError} to allow writing {@code throws fail("failure message")}.
+     * @return Never completes normally. The return type is {@link AssertionError} to allow writing {@code throw fail("failure message")}.
      * This may be helpful in non-{@code void} methods.
      */
     public static AssertionError fail(final String msg) throws AssertionError {

--- a/driver-core/src/main/com/mongodb/assertions/Assertions.java
+++ b/driver-core/src/main/com/mongodb/assertions/Assertions.java
@@ -179,9 +179,21 @@ public final class Assertions {
 
     /**
      * @throws AssertionError Always
+     * @return Never completes normally. The return type is {@link AssertionError} to allow writing {@code throws fail()}.
+     * This may be helpful in non-{@code void} methods.
      */
-    public static void fail() throws AssertionError {
+    public static AssertionError fail() throws AssertionError {
         throw new AssertionError();
+    }
+
+    /**
+     * @param msg The failure message.
+     * @throws AssertionError Always
+     * @return Never completes normally. The return type is {@link AssertionError} to allow writing {@code throws fail("failure message")}.
+     * This may be helpful in non-{@code void} methods.
+     */
+    public static AssertionError fail(final String msg) throws AssertionError {
+        throw new AssertionError(assertNotNull(msg));
     }
 
     private Assertions() {

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncBatchCursor.java
@@ -66,10 +66,8 @@ public interface AsyncBatchCursor<T> extends Closeable {
      * To help making such code simpler, this method is required to be idempotent.
      * <p>
      * Another quirk is that this method is allowed to release resources "eventually",
-     * i.e., not before (in the happens before order) returning.
+     * i.e., not before (in the happens-before order) returning.
      * Nevertheless, {@link #isClosed()} called after (in the happens-before order) {@link #close()} must return {@code true}.
-     *
-     * @see #close()
      */
     @Override
     void close();

--- a/driver-core/src/main/com/mongodb/internal/binding/ConnectionSource.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/ConnectionSource.java
@@ -20,6 +20,7 @@ import com.mongodb.ServerApi;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.session.SessionContext;
+import com.mongodb.lang.Nullable;
 
 /**
  * A source of connections to a single MongoDB server.
@@ -42,8 +43,10 @@ public interface ConnectionSource extends ReferenceCounted {
      *
      * @since 3.6
      */
+    @Nullable
     SessionContext getSessionContext();
 
+    @Nullable
     ServerApi getServerApi();
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -333,7 +333,9 @@ class DefaultConnectionPool implements ConnectionPool {
         }
     }
 
-
+    /**
+     * Is package-access for the purpose of testing and must not be used for any other purpose outside of this class.
+     */
     ConcurrentPool<UsageTrackingInternalConnection> getPool() {
         return pool;
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServer.java
@@ -209,6 +209,9 @@ class DefaultServer implements ClusterableServer {
         serverMonitor.connect();
     }
 
+    /**
+     * Is package-access for the purpose of testing and must not be used for any other purpose outside of this class.
+     */
     ConnectionPool getConnectionPool() {
         return connectionPool;
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedServer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedServer.java
@@ -144,6 +144,13 @@ public class LoadBalancedServer implements ClusterableServer {
         });
     }
 
+    /**
+     * Is package-access for the purpose of testing and must not be used for any other purpose outside of this class.
+     */
+    ConnectionPool getConnectionPool() {
+        return connectionPool;
+    }
+
     private class LoadBalancedServerProtocolExecutor implements ProtocolExecutor {
         @SuppressWarnings("unchecked")
         @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/BatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/BatchCursor.java
@@ -19,6 +19,7 @@ package com.mongodb.internal.operation;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerCursor;
 import com.mongodb.annotations.NotThreadSafe;
+import com.mongodb.lang.Nullable;
 
 import java.io.Closeable;
 import java.util.Iterator;
@@ -37,6 +38,15 @@ import java.util.List;
  */
 @NotThreadSafe
 public interface BatchCursor<T> extends Iterator<List<T>>, Closeable {
+    /**
+     * Despite this interface being {@linkplain NotThreadSafe non-thread-safe},
+     * {@link #close()} is allowed to be called concurrently with any method of the cursor, including itself.
+     * This is useful to cancel blocked {@link #hasNext()}, {@link #next()}.
+     * This method is idempotent.
+     * <p>
+     * Another quirk is that this method is allowed to release resources "eventually",
+     * i.e., not before (in the happens-before order) returning.
+     */
     @Override
     void close();
 
@@ -85,6 +95,7 @@ public interface BatchCursor<T> extends Iterator<List<T>>, Closeable {
      *
      * @return ServerCursor
      */
+    @Nullable
     ServerCursor getServerCursor();
 
     /**

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateOperationSpecification.groovy
@@ -452,6 +452,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         binding.sessionContext >> sessionContext
         source.connection >> connection
         source.retain() >> source
+        source.getServerApi() >> null
         def commandDocument = new BsonDocument('aggregate', new BsonString(getCollectionName()))
                 .append('pipeline', new BsonArray())
                 .append('cursor', new BsonDocument())

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CountDocumentsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CountDocumentsOperationSpecification.groovy
@@ -324,6 +324,7 @@ class CountDocumentsOperationSpecification extends OperationFunctionalSpecificat
         binding.sessionContext >> sessionContext
         source.connection >> connection
         source.retain() >> source
+        source.getServerApi() >> null
         def pipeline = new BsonArray([BsonDocument.parse('{ $match: {}}'), BsonDocument.parse('{$group: {_id: 1, n: {$sum: 1}}}')])
         def commandDocument = new BsonDocument('aggregate', new BsonString(getCollectionName()))
                 .append('pipeline', pipeline)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DistinctOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DistinctOperationSpecification.groovy
@@ -295,6 +295,7 @@ class DistinctOperationSpecification extends OperationFunctionalSpecification {
         binding.sessionContext >> sessionContext
         source.connection >> connection
         source.retain() >> source
+        source.getServerApi() >> null
         def commandDocument = new BsonDocument('distinct', new BsonString(getCollectionName()))
                 .append('key', new BsonString('str'))
         appendReadConcernToCommand(sessionContext, MIN_WIRE_VERSION, commandDocument)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindOperationSpecification.groovy
@@ -529,6 +529,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         binding.sessionContext >> sessionContext
         source.connection >> connection
         source.retain() >> source
+        source.getServerApi() >> null
         def commandDocument = new BsonDocument('find', new BsonString(getCollectionName()))
         appendReadConcernToCommand(sessionContext, MIN_WIRE_VERSION, commandDocument)
 
@@ -609,6 +610,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         binding.sessionContext >> sessionContext
         source.connection >> connection
         source.retain() >> source
+        source.getServerApi() >> null
         def commandDocument = new BsonDocument('find', new BsonString(getCollectionName())).append('allowDiskUse', BsonBoolean.TRUE)
         appendReadConcernToCommand(sessionContext, MIN_WIRE_VERSION, commandDocument)
 
@@ -694,6 +696,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         binding.readConnectionSource >> source
         source.connection >> connection
         source.retain() >> source
+        source.getServerApi() >> null
 
         when:
         operation.execute(binding)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceWithInlineResultsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceWithInlineResultsOperationSpecification.groovy
@@ -265,6 +265,7 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
         binding.sessionContext >> sessionContext
         source.connection >> connection
         source.retain() >> source
+        source.getServerApi() >> null
         def commandDocument = BsonDocument.parse('''
             { "mapreduce" : "coll",
               "map" : { "$code" : "function(){ }" },

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/QueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/QueryBatchCursorFunctionalSpecification.groovy
@@ -24,6 +24,7 @@ import com.mongodb.ServerCursor
 import com.mongodb.WriteConcern
 import com.mongodb.client.model.CreateCollectionOptions
 import com.mongodb.internal.binding.ConnectionSource
+import com.mongodb.internal.connection.Connection
 import com.mongodb.internal.connection.NoOpSessionContext
 import com.mongodb.internal.connection.QueryResult
 import com.mongodb.internal.validator.NoOpFieldNameValidator
@@ -268,18 +269,19 @@ class QueryBatchCursorFunctionalSpecification extends OperationFunctionalSpecifi
 
     @Slow
     def 'hasNext should throw when cursor is closed in another thread'() {
+        Connection conn = connectionSource.getConnection()
         collectionHelper.create(collectionName, new CreateCollectionOptions().capped(true).sizeInBytes(1000))
         collectionHelper.insertDocuments(new DocumentCodec(), new Document('_id', 1).append('ts', new BsonTimestamp(5, 0)))
         def firstBatch = executeQuery(new BsonDocument('ts', new BsonDocument('$gte', new BsonTimestamp(5, 0))), 0, 2, true, true);
-        cursor = new QueryBatchCursor<Document>(firstBatch, 0, 2, new DocumentCodec(), connectionSource)
+        cursor = new QueryBatchCursor<Document>(firstBatch, 0, 2, 0, new DocumentCodec(), connectionSource, conn)
         cursor.next()
-        def latch = new CountDownLatch(1)
+        def closeCompleted = new CountDownLatch(1)
 
         // wait a second then close the cursor
         new Thread({
             sleep(1000)
             cursor.close()
-            latch.countDown()
+            closeCompleted.countDown()
         } as Runnable).start()
 
         when:
@@ -287,9 +289,11 @@ class QueryBatchCursorFunctionalSpecification extends OperationFunctionalSpecifi
 
         then:
         thrown(Exception)
+        closeCompleted.await(5, TimeUnit.SECONDS)
+        conn.getCount() == 1
 
         cleanup:
-        latch.await(5, TimeUnit.SECONDS)  // wait for cursor.close to complete
+        conn.release()
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 2) || isSharded() })

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncQueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncQueryBatchCursorSpecification.groovy
@@ -27,6 +27,7 @@ import com.mongodb.connection.ServerConnectionState
 import com.mongodb.connection.ServerDescription
 import com.mongodb.connection.ServerType
 import com.mongodb.connection.ServerVersion
+import com.mongodb.internal.async.SingleResultCallback
 import com.mongodb.internal.binding.AsyncConnectionSource
 import com.mongodb.internal.connection.AsyncConnection
 import com.mongodb.internal.connection.QueryResult
@@ -365,8 +366,11 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         given:
         def connectionA = referenceCountedAsyncConnection(serverVersion)
         def connectionB = referenceCountedAsyncConnection(serverVersion)
-        def connectionSource = getAsyncConnectionSource(connectionA, connectionB)
+        def connectionSource = getAsyncConnectionSource(serverType, connectionA, connectionB)
         def initialResult = queryResult()
+        Object getMoreResponse = useCommand
+                ? documentResponse([], getMoreResponseHasCursor ? 42 : 0)
+                : queryResult([], getMoreResponseHasCursor ? 42 : 0)
 
         when:
         def cursor = new AsyncQueryBatchCursor<Document>(initialResult, 0, 0, 0, CODEC, connectionSource, connectionA)
@@ -379,21 +383,24 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         nextBatch(cursor)
 
         then:
-        if (commandAsync) {
-            _ * connectionA.commandAsync(_, _, _, _, _, _, _, _) >> {
-                // Simulate the user calling close while the getMore is in flight
+        // simulate the user calling `close` while `getMore` is in flight
+        if (useCommand) {
+            // in LB mode the same connection is used to execute both `getMore` and `killCursors`
+            int numberOfInvocations = serverType == ServerType.LOAD_BALANCER
+                    ? getMoreResponseHasCursor ? 2 : 1
+                    : 1
+            numberOfInvocations * connectionA.commandAsync(_, _, _, _, _, _, _, _) >> {
+                // `getMore` command
                 cursor.close()
-                it[7].onResult(response, null)
+                ((SingleResultCallback<?>) it[7]).onResult(getMoreResponse, null)
             } >> {
-                it[7].onResult(response2, null)
+                // `killCursors` command
+                ((SingleResultCallback<?>) it[7]).onResult(null, null)
             }
         } else {
-            _ * connectionA.getMoreAsync(_, _, _, _, _) >> {
-                // Simulate the user calling close while the getMore is in flight
+            1 * connectionA.getMoreAsync(_, _, _, _, _) >> {
                 cursor.close()
-                it[4].onResult(response, null)
-            } >> {
-                it[4].onResult(response2, null)
+                ((SingleResultCallback<?>) it[4]).onResult(getMoreResponse, null)
             }
         }
 
@@ -402,25 +409,23 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         connectionA.getCount() == 0
-        if (response2 == null) { //otherwise connectionSource is released asynchronously, which is not easy to verify
-            connectionSource.getCount() == 0
-        }
         cursor.isClosed()
 
         where:
-        serverVersion                | commandAsync  | response                | response2
-        new ServerVersion([3, 2, 0]) | true          | documentResponse([])    | documentResponse([], 0)
-        new ServerVersion([3, 2, 0]) | true          | documentResponse([], 0) | null
-        new ServerVersion([3, 0, 0]) | false         | new QueryResult(NAMESPACE, [], 42, SERVER_ADDRESS) |
-                new QueryResult(NAMESPACE, [], 0, SERVER_ADDRESS)
-        new ServerVersion([3, 0, 0]) | false         | new QueryResult(NAMESPACE, [], 0, SERVER_ADDRESS) | null
+        serverVersion                | useCommand  | getMoreResponseHasCursor | serverType
+        new ServerVersion([5, 0, 0]) | true          | true                     | ServerType.LOAD_BALANCER
+        new ServerVersion([5, 0, 0]) | true          | false                    | ServerType.LOAD_BALANCER
+        new ServerVersion([3, 2, 0]) | true          | true                     | ServerType.STANDALONE
+        new ServerVersion([3, 2, 0]) | true          | false                    | ServerType.STANDALONE
+        new ServerVersion([3, 0, 0]) | false         | true                     | ServerType.STANDALONE
+        new ServerVersion([3, 0, 0]) | false         | false                    | ServerType.STANDALONE
     }
 
     def 'should close cursor after getMore finishes if cursor was closed while getMore was in progress and getMore throws exception'() {
         given:
         def connectionA = referenceCountedAsyncConnection(serverVersion)
         def connectionB = referenceCountedAsyncConnection(serverVersion)
-        def connectionSource = getAsyncConnectionSource(connectionA, connectionB)
+        def connectionSource = getAsyncConnectionSource(serverType, connectionA, connectionB)
         def initialResult = queryResult()
 
         when:
@@ -434,17 +439,22 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         nextBatch(cursor)
 
         then:
+        // simulate the user calling `close` while `getMore` is throwing a `MongoException`
         if (commandAsync) {
-            1 * connectionA.commandAsync(_, _, _, _, _, _, _, _) >> {
-                // Simulate the user calling close while the getMore is throwing a MongoException
+            // in LB mode the same connection is used to execute both `getMore` and `killCursors`
+            int numberOfInvocations = serverType == ServerType.LOAD_BALANCER ? 2 : 1
+            numberOfInvocations * connectionA.commandAsync(_, _, _, _, _, _, _, _) >> {
+                // `getMore` command
                 cursor.close()
-                it[7].onResult(null, MONGO_EXCEPTION)
+                ((SingleResultCallback<?>) it[7]).onResult(null, MONGO_EXCEPTION)
+            } >> {
+                // `killCursors` command
+                ((SingleResultCallback<?>) it[7]).onResult(null, null)
             }
         } else {
             1 * connectionA.getMoreAsync(_, _, _, _, _) >> {
-                // Simulate the user calling close while the getMore is throwing a MongoException
                 cursor.close()
-                it[4].onResult(null, MONGO_EXCEPTION)
+                ((SingleResultCallback<?>) it[4]).onResult(null, MONGO_EXCEPTION)
             }
         }
 
@@ -456,15 +466,16 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         cursor.isClosed()
 
         where:
-        serverVersion                | commandAsync
-        new ServerVersion([3, 2, 0]) | true
-        new ServerVersion([3, 0, 0]) | false
+        serverVersion                | commandAsync | serverType
+        new ServerVersion([5, 0, 0]) | true         | ServerType.LOAD_BALANCER
+        new ServerVersion([3, 2, 0]) | true         | ServerType.STANDALONE
+        new ServerVersion([3, 0, 0]) | false        | ServerType.STANDALONE
     }
 
     def 'should handle errors when calling close'() {
         given:
         def connection = referenceCountedAsyncConnection()
-        def connectionSource = getAsyncConnectionSourceWithResult { [null, MONGO_EXCEPTION] }
+        def connectionSource = getAsyncConnectionSourceWithResult(ServerType.STANDALONE) { [null, MONGO_EXCEPTION] }
         def cursor = new AsyncQueryBatchCursor<Document>(queryResult(), 0, 0, 0, CODEC, connectionSource, connection)
 
         when:
@@ -484,7 +495,7 @@ class AsyncQueryBatchCursorSpecification extends Specification {
     def 'should handle errors when getting a connection for getMore'() {
         given:
         def connection = referenceCountedAsyncConnection()
-        def connectionSource = getAsyncConnectionSourceWithResult { [null, MONGO_EXCEPTION] }
+        def connectionSource = getAsyncConnectionSourceWithResult(ServerType.STANDALONE) { [null, MONGO_EXCEPTION] }
 
         when:
         def cursor = new AsyncQueryBatchCursor<Document>(queryResult(), 0, 0, 0, CODEC, connectionSource, connection)
@@ -576,14 +587,14 @@ class AsyncQueryBatchCursorSpecification extends Specification {
     private static final COMMAND_EXCEPTION = new MongoCommandException(BsonDocument.parse('{"ok": false, "errmsg": "error"}'),
             SERVER_ADDRESS)
 
-    def documentResponse(results, cursorId = 42) {
+    private static BsonDocument documentResponse(results, cursorId = 42) {
         new BsonDocument('ok', new BsonInt32(1)).append('cursor',
                 new BsonDocument('id', new BsonInt64(cursorId)).append('ns',
                         new BsonString(NAMESPACE.getFullName()))
                         .append('nextBatch', new BsonArrayWrapper(results)))
     }
 
-    def queryResult(results = FIRST_BATCH, cursorId = 42) {
+    private static QueryResult<?> queryResult(results = FIRST_BATCH, cursorId = 42) {
         new QueryResult(NAMESPACE, results, cursorId, SERVER_ADDRESS)
     }
 
@@ -619,19 +630,23 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         mock
     }
 
-    def getAsyncConnectionSource(AsyncConnection... connections) {
-        def index = -1
-        getAsyncConnectionSourceWithResult { index += 1; [connections.toList().get(index).retain(), null] }
+    AsyncConnectionSource getAsyncConnectionSource(AsyncConnection... connections) {
+        getAsyncConnectionSource(ServerType.STANDALONE, connections)
     }
 
-    def getAsyncConnectionSourceWithResult(connectionCallbackResults) {
+    AsyncConnectionSource getAsyncConnectionSource(ServerType serverType, AsyncConnection... connections) {
+        def index = -1
+        getAsyncConnectionSourceWithResult(serverType) { index += 1; [connections.toList().get(index).retain(), null] }
+    }
+
+    def getAsyncConnectionSourceWithResult(ServerType serverType, Closure<?> connectionCallbackResults) {
         def released = false
         int counter = 0
         def mock = Mock(AsyncConnectionSource)
         mock.getServerDescription() >> {
             ServerDescription.builder()
                     .address(new ServerAddress())
-                    .type(ServerType.STANDALONE)
+                    .type(serverType)
                     .state(ServerConnectionState.CONNECTED)
                     .build()
         }

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/FindOperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/FindOperationUnitSpecification.groovy
@@ -58,6 +58,7 @@ class FindOperationUnitSpecification extends OperationUnitSpecification {
         }
         def connectionSource = Stub(ConnectionSource) {
             getConnection() >> connection
+            getServerApi() >> null
         }
         def readBinding = Stub(ReadBinding) {
             getReadPreference() >> readPreference
@@ -204,6 +205,7 @@ class FindOperationUnitSpecification extends OperationUnitSpecification {
         def readBinding = Stub(ReadBinding) {
             getReadConnectionSource() >> Stub(ConnectionSource) {
                 getConnection() >> connection
+                getServerApi() >> null
             }
             getReadPreference() >> Stub(ReadPreference) {
                 isSecondaryOk() >> secondaryOk

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/QueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/QueryBatchCursorSpecification.groovy
@@ -133,6 +133,7 @@ class QueryBatchCursorSpecification extends Specification {
         }
         def connectionSource = Stub(ConnectionSource) {
             getConnection() >> { throw new MongoSocketOpenException("can't open socket", SERVER_ADDRESS, new IOException()) }
+            getServerApi() >> null
         }
         connectionSource.retain() >> connectionSource
 

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/QueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/QueryBatchCursorSpecification.groovy
@@ -16,11 +16,16 @@
 
 package com.mongodb.internal.operation
 
+import com.mongodb.MongoException
 import com.mongodb.MongoNamespace
 import com.mongodb.MongoSocketException
 import com.mongodb.MongoSocketOpenException
 import com.mongodb.ServerAddress
 import com.mongodb.connection.ConnectionDescription
+import com.mongodb.connection.ServerConnectionState
+import com.mongodb.connection.ServerDescription
+import com.mongodb.connection.ServerType
+import com.mongodb.connection.ServerVersion
 import com.mongodb.internal.binding.ConnectionSource
 import com.mongodb.internal.connection.Connection
 import com.mongodb.internal.connection.QueryResult
@@ -30,9 +35,15 @@ import org.bson.BsonInt64
 import org.bson.BsonString
 import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
+import org.bson.codecs.DocumentCodec
 import spock.lang.Specification
 
+import static com.mongodb.internal.operation.OperationUnitSpecification.getMaxWireVersionForServerVersion
+
 class QueryBatchCursorSpecification extends Specification {
+    private static final MongoNamespace NAMESPACE = new MongoNamespace('db', 'coll')
+    private static final ServerAddress SERVER_ADDRESS = new ServerAddress()
+
     def 'should generate expected command with batchSize and maxTimeMS'() {
         given:
         def connection = Mock(Connection) {
@@ -46,16 +57,13 @@ class QueryBatchCursorSpecification extends Specification {
         }
         connectionSource.retain() >> connectionSource
 
-        def database = 'test'
-        def collection = 'QueryBatchCursorSpecification'
         def cursorId = 42
 
-        def namespace = new MongoNamespace(database, collection)
-        def firstBatch = new QueryResult(namespace, [], cursorId, new ServerAddress())
+        def firstBatch = new QueryResult(NAMESPACE, [], cursorId, SERVER_ADDRESS)
         def cursor = new QueryBatchCursor<Document>(firstBatch, 0, batchSize, maxTimeMS, new BsonDocumentCodec(), connectionSource,
                                                     connection)
         def expectedCommand = new BsonDocument('getMore': new BsonInt64(cursorId))
-                .append('collection', new BsonString(collection))
+                .append('collection', new BsonString(NAMESPACE.getCollectionName()))
         if (batchSize != 0) {
             expectedCommand.append('batchSize', new BsonInt32(batchSize))
         }
@@ -66,14 +74,14 @@ class QueryBatchCursorSpecification extends Specification {
         def reply = new BsonDocument('ok', new BsonInt32(1))
                 .append('cursor',
                         new BsonDocument('id', new BsonInt64(0))
-                                .append('ns', new BsonString(namespace.getFullName()))
+                                .append('ns', new BsonString(NAMESPACE.getFullName()))
                                 .append('nextBatch', new BsonArrayWrapper([])))
 
         when:
         cursor.hasNext()
 
         then:
-        1 * connection.command(database, expectedCommand, _, _, _, _, null) >> {
+        1 * connection.command(NAMESPACE.getDatabaseName(), expectedCommand, _, _, _, _, null) >> {
             reply
         }
         1 * connection.release()
@@ -87,13 +95,12 @@ class QueryBatchCursorSpecification extends Specification {
 
     def 'should handle exceptions when closing'() {
         given:
-        def serverAddress = new ServerAddress()
         def connection = Mock(Connection) {
             _ * getDescription() >> Stub(ConnectionDescription) {
                 getMaxWireVersion() >> 4
             }
-            _ * killCursor(_, _) >> { throw new MongoSocketException('No MongoD', serverAddress) }
-            _ * command(_, _, _, _, _) >> { throw new MongoSocketException('No MongoD', serverAddress) }
+            _ * killCursor(_, _) >> { throw new MongoSocketException('No MongoD', SERVER_ADDRESS) }
+            _ * command(_, _, _, _, _) >> { throw new MongoSocketException('No MongoD', SERVER_ADDRESS) }
         }
         def connectionSource = Stub(ConnectionSource) {
             getServerApi() >> null
@@ -101,8 +108,7 @@ class QueryBatchCursorSpecification extends Specification {
         }
         connectionSource.retain() >> connectionSource
 
-        def namespace = new MongoNamespace('test', 'QueryBatchCursorSpecification')
-        def firstBatch = new QueryResult(namespace, [], 42, serverAddress)
+        def firstBatch = new QueryResult(NAMESPACE, [], 42, SERVER_ADDRESS)
         def cursor = new QueryBatchCursor<Document>(firstBatch, 0, 2, 100, new BsonDocumentCodec(), connectionSource, connection)
 
         when:
@@ -120,19 +126,17 @@ class QueryBatchCursorSpecification extends Specification {
 
     def 'should handle exceptions when killing cursor and a connection can not be obtained'() {
         given:
-        def serverAddress = new ServerAddress()
         def connection = Mock(Connection) {
             _ * getDescription() >> Stub(ConnectionDescription) {
                 getMaxWireVersion() >> 4
             }
         }
         def connectionSource = Stub(ConnectionSource) {
-            getConnection() >> { throw new MongoSocketOpenException("can't open socket", serverAddress, new IOException()) }
+            getConnection() >> { throw new MongoSocketOpenException("can't open socket", SERVER_ADDRESS, new IOException()) }
         }
         connectionSource.retain() >> connectionSource
 
-        def namespace = new MongoNamespace('test', 'QueryBatchCursorSpecification')
-        def firstBatch = new QueryResult(namespace, [], 42, serverAddress)
+        def firstBatch = new QueryResult(NAMESPACE, [], 42, SERVER_ADDRESS)
         def cursor = new QueryBatchCursor<Document>(firstBatch, 0, 2, 100, new BsonDocumentCodec(), connectionSource, connection)
 
         when:
@@ -146,5 +150,209 @@ class QueryBatchCursorSpecification extends Specification {
 
         then:
         notThrown(Exception)
+    }
+
+    def 'should close cursor after getMore finishes if cursor was closed while getMore was in progress and getMore returns a response'() {
+        given:
+        Connection conn = mockConnection(serverVersion)
+        ConnectionSource connSource
+        if (serverType == ServerType.LOAD_BALANCER) {
+            connSource = mockConnectionSource(SERVER_ADDRESS, serverType)
+        } else {
+            connSource = mockConnectionSource(SERVER_ADDRESS, serverType, conn, mockConnection(serverVersion))
+        }
+        List<Document> firstBatch = [new Document()]
+        QueryResult<Document> initialResult = new QueryResult<>(NAMESPACE, firstBatch, 1, SERVER_ADDRESS)
+        Object getMoreResponse = useCommand
+                ? emptyGetMoreCommandResponse(NAMESPACE, getMoreResponseHasCursor ? 42 : 0)
+                : emptyGetMoreQueryResponse(NAMESPACE, SERVER_ADDRESS, getMoreResponseHasCursor ? 42 : 0)
+
+        when:
+        QueryBatchCursor<Document> cursor = new QueryBatchCursor<>(initialResult, 0, 0, 0, new DocumentCodec(), connSource, conn)
+        List<Document> batch = cursor.next()
+
+        then:
+        batch == firstBatch
+
+        when:
+        cursor.next()
+
+        then:
+        // simulate the user calling `close` while `getMore` is in flight
+        if (useCommand) {
+            // in LB mode the same connection is used to execute both `getMore` and `killCursors`
+            int numberOfInvocations = serverType == ServerType.LOAD_BALANCER
+                    ? getMoreResponseHasCursor ? 2 : 1
+                    : 1
+            numberOfInvocations * conn.command(*_) >> {
+                // `getMore` command
+                cursor.close()
+                getMoreResponse
+            } >> {
+                // `killCursors` command
+                null
+            }
+        } else {
+            1 * conn.getMore(*_) >> {
+                cursor.close()
+                getMoreResponse
+            }
+        }
+
+        then:
+        IllegalStateException e = thrown()
+        e.getMessage() == 'Cursor has been closed'
+
+        then:
+        conn.getCount() == 1
+        connSource.getCount() == 1
+
+        where:
+        serverVersion                | useCommand | getMoreResponseHasCursor | serverType
+        new ServerVersion([5, 0, 0]) | true       | true                     | ServerType.LOAD_BALANCER
+        new ServerVersion([5, 0, 0]) | true       | false                    | ServerType.LOAD_BALANCER
+        new ServerVersion([3, 2, 0]) | true       | true                     | ServerType.STANDALONE
+        new ServerVersion([3, 2, 0]) | true       | false                    | ServerType.STANDALONE
+        new ServerVersion([3, 0, 0]) | false      | true                     | ServerType.STANDALONE
+        new ServerVersion([3, 0, 0]) | false      | false                    | ServerType.STANDALONE
+    }
+
+    def 'should close cursor after getMore finishes if cursor was closed while getMore was in progress and getMore throws exception'() {
+        given:
+        Connection conn = mockConnection(serverVersion)
+        ConnectionSource connSource
+        if (serverType == ServerType.LOAD_BALANCER) {
+            connSource = mockConnectionSource(SERVER_ADDRESS, serverType)
+        } else {
+            connSource = mockConnectionSource(SERVER_ADDRESS, serverType, conn, mockConnection(serverVersion))
+        }
+        List<Document> firstBatch = [new Document()]
+        QueryResult<Document> initialResult = new QueryResult<>(NAMESPACE, firstBatch, 1, SERVER_ADDRESS)
+        String exceptionMessage = 'test'
+
+        when:
+        QueryBatchCursor<Document> cursor = new QueryBatchCursor<>(initialResult, 0, 0, 0, new DocumentCodec(), connSource, conn)
+        List<Document> batch = cursor.next()
+
+        then:
+        batch == firstBatch
+
+        when:
+        cursor.next()
+
+        then:
+        // simulate the user calling `close` while `getMore` is in flight
+        if (useCommand) {
+            // in LB mode the same connection is used to execute both `getMore` and `killCursors`
+            int numberOfInvocations = serverType == ServerType.LOAD_BALANCER ? 2 : 1
+            numberOfInvocations * conn.command(*_) >> {
+                // `getMore` command
+                cursor.close()
+                throw new MongoException(exceptionMessage)
+            } >> {
+                // `killCursors` command
+                null
+            }
+        } else {
+            1 * conn.getMore(*_) >> {
+                cursor.close()
+                throw new MongoException(exceptionMessage)
+            }
+        }
+
+        then:
+        MongoException e = thrown()
+        e.getMessage() == exceptionMessage
+
+        then:
+        conn.getCount() == 1
+        connSource.getCount() == 1
+
+        where:
+        serverVersion                | useCommand | serverType
+        new ServerVersion([5, 0, 0]) | true       | ServerType.LOAD_BALANCER
+        new ServerVersion([3, 2, 0]) | true       | ServerType.STANDALONE
+        new ServerVersion([3, 0, 0]) | false      | ServerType.STANDALONE
+    }
+
+    /**
+     * Creates a {@link Connection} with {@link Connection#getCount()} returning 1.
+     */
+    private Connection mockConnection(ServerVersion serverVersion) {
+        int refCounter = 1
+        Connection mockConn = Mock(Connection) {
+            getDescription() >> Stub(ConnectionDescription) {
+                getMaxWireVersion() >> getMaxWireVersionForServerVersion(serverVersion.getVersionList())
+            }
+        }
+        mockConn.retain() >> {
+            if (refCounter == 0) {
+                throw new IllegalStateException('Tried to retain Connection when already released')
+            } else {
+                refCounter += 1
+            }
+            mockConn
+        }
+        mockConn.release() >> {
+            refCounter -= 1
+            if (refCounter < 0) {
+                throw new IllegalStateException('Tried to release Connection below 0')
+            }
+        }
+        mockConn.getCount() >> { refCounter }
+        mockConn
+    }
+
+    private ConnectionSource mockConnectionSource(ServerAddress serverAddress, ServerType serverType, Connection... connections) {
+        int connIdx = 0
+        int refCounter = 1
+        ConnectionSource mockConnectionSource = Mock(ConnectionSource)
+        mockConnectionSource.getServerDescription() >> {
+            ServerDescription.builder()
+                    .address(serverAddress)
+                    .type(serverType)
+                    .state(ServerConnectionState.CONNECTED)
+                    .build()
+        }
+        mockConnectionSource.retain() >> {
+            if (refCounter == 0) {
+                throw new IllegalStateException('Tried to retain ConnectionSource when already released')
+            } else {
+                refCounter += 1
+            }
+            mockConnectionSource
+        }
+        mockConnectionSource.release() >> {
+            refCounter -= 1
+            if (refCounter < 0) {
+                throw new IllegalStateException('Tried to release ConnectionSource below 0')
+            }
+        }
+        mockConnectionSource.getCount() >> { refCounter }
+        mockConnectionSource.getConnection() >> {
+            if (refCounter == 0) {
+                throw new IllegalStateException('Tried to use released ConnectionSource')
+            }
+            Connection conn
+            if (connIdx < connections.length) {
+                conn = connections[connIdx]
+            } else {
+                throw new IllegalStateException('Requested more than maxConnections=' + maxConnections)
+            }
+            connIdx++
+            conn.retain()
+        }
+        mockConnectionSource
+    }
+
+    private static BsonDocument emptyGetMoreCommandResponse(MongoNamespace namespace, long cursorId) {
+        new BsonDocument('ok', new BsonInt32(1))
+                .append('cursor', new BsonDocument('id', new BsonInt64(cursorId))
+                        .append('ns', new BsonString(namespace.getFullName()))
+                        .append('nextBatch', new BsonArrayWrapper([])))
+    }
+
+    private static <T> QueryResult<T> emptyGetMoreQueryResponse(MongoNamespace namespace, ServerAddress serverAddress, long cursorId) {
+        new QueryResult(namespace, [], cursorId, serverAddress)
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/MongoChangeStreamCursor.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoChangeStreamCursor.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.client;
 
+import com.mongodb.annotations.NotThreadSafe;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 
@@ -24,17 +25,18 @@ import org.bson.BsonDocument;
  * <p>
  * An application should ensure that a cursor is closed in all circumstances, e.g. using a try-with-resources statement:
  * </p>
- * <blockquote><pre>
- * try (MongoChangeStreamCursor&lt;Document&gt; cursor = collection.find().cursor()) {
+ * <pre>{@code
+ * try (MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor = collection.watch().cursor()) {
  *     while (cursor.hasNext()) {
  *         System.out.println(cursor.next());
  *     }
  * }
- * </pre></blockquote>
+ * }</pre>
  *
  * @since 3.11
  * @param <TResult> The type of documents the cursor contains
  */
+@NotThreadSafe
 public interface MongoChangeStreamCursor<TResult> extends MongoCursor<TResult> {
     /**
      * Returns the resume token. If a batch has been iterated to the last change stream document in the batch

--- a/driver-sync/src/main/com/mongodb/client/MongoCursor.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoCursor.java
@@ -29,20 +29,25 @@ import java.util.Iterator;
  * <p>
  * An application should ensure that a cursor is closed in all circumstances, e.g. using a try-with-resources statement:
  *
- * <blockquote><pre>
- * try (MongoCursor&lt;Document&gt; cursor = collection.find().iterator()) {
+ * <pre>{@code
+ * try (MongoCursor<Document> cursor = collection.find().cursor()) {
  *     while (cursor.hasNext()) {
  *         System.out.println(cursor.next());
  *     }
  * }
- * </pre></blockquote>
+ * }</pre>
  *
  * @since 3.0
  * @param <TResult> The type of documents the cursor contains
  */
 @NotThreadSafe
 public interface MongoCursor<TResult> extends Iterator<TResult>, Closeable {
-
+    /**
+     * Despite this interface being {@linkplain NotThreadSafe non-thread-safe},
+     * {@link #close()} is allowed to be called concurrently with any method of the cursor, including itself.
+     * This is useful to cancel blocked {@link #hasNext()}, {@link #next()}.
+     * This method is idempotent.
+     */
     @Override
     void close();
 


### PR DESCRIPTION
Run `QueryBatchCursor` integration tests (`QueryBatchCursorFunctionalSpecification`) with load balancer.

The high-level implementation idea is described in the documentation of the class `QueryBatchCursor.ResourceManager`. Only `QueryBatchCursor` required a change as per this [analysis](https://jira.mongodb.org/browse/JAVA-4183?focusedCommentId=3950629&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-3950629).

JAVA-4183