### PR TITLE
Fix and simplify server version checking for test runners

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -161,28 +161,12 @@ public final class ClusterFixture {
                 versionArray.get(2).asInt32().getValue()));
     }
 
-    public static boolean serverVersionAtLeast(final List<Integer> versionArray) {
-        return getServerVersion().compareTo(new ServerVersion(versionArray)) >= 0;
-    }
-
     public static boolean serverVersionAtLeast(final int majorVersion, final int minorVersion) {
-        return serverVersionAtLeast(asList(majorVersion, minorVersion, 0));
-    }
-
-    public static boolean serverVersionLessThan(final List<Integer> versionArray) {
-        return getServerVersion().compareTo(new ServerVersion(versionArray)) < 0;
+        return getServerVersion().compareTo(new ServerVersion(asList(majorVersion, minorVersion, 0))) >= 0;
     }
 
     public static boolean serverVersionLessThan(final int majorVersion, final int minorVersion) {
-        return serverVersionLessThan(asList(majorVersion, minorVersion, 0));
-    }
-
-    public static boolean serverVersionLessThan(final String versionString) {
-        return getServerVersion().compareTo(new ServerVersion(getVersionList(versionString).subList(0, 3))) < 0;
-    }
-
-    public static boolean serverVersionGreaterThan(final String versionString) {
-        return getServerVersion().compareTo(new ServerVersion(getVersionList(versionString).subList(0, 3))) > 0;
+        return getServerVersion().compareTo(new ServerVersion(asList(majorVersion, minorVersion, 0))) < 0;
     }
 
     public static List<Integer> getVersionList(final String versionString) {

--- a/driver-core/src/test/functional/com/mongodb/client/CommandMonitoringTestHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/CommandMonitoringTestHelper.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.client;
 
-import com.mongodb.ClusterFixture;
 import com.mongodb.event.CommandEvent;
 import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandStartedEvent;
@@ -44,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.CrudTestHelper.replaceTypeAssertionWithActual;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -90,7 +90,7 @@ public final class CommandMonitoringTestHelper {
                 }
 
                 // Not clear whether these global fields should be included, but also not clear how to efficiently exclude them
-                if (ClusterFixture.serverVersionAtLeast(3, 6)) {
+                if (serverVersionAtLeast(3, 6)) {
                     commandDocument.put("$db", new BsonString(actualDatabaseName));
                     if (operation != null && operation.containsKey("read_preference")) {
                         commandDocument.put("$readPreference", operation.getDocument("read_preference"));

--- a/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
@@ -30,7 +30,7 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.client.model.Accumulators.accumulator
 import static com.mongodb.client.model.Accumulators.addToSet
 import static com.mongodb.client.model.Accumulators.avg
@@ -123,7 +123,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
                                                                             new Document('_id', 3).append('x', 3).append('c', 'c')]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def '$project an exclusion'() {
         expect:
         aggregate([project(exclude('a', 'a1', 'z'))]) == [new Document('_id', 1).append('x', 1).append('y', 'a'),
@@ -157,7 +157,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
                                                                                   new Document('a', 6)]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def '$unwind with UnwindOptions'() {
         given:
         getCollectionHelper().drop()
@@ -216,7 +216,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         getCollectionHelper(new MongoNamespace(getDatabaseName(), outCollectionName)).find() == [a, b, c]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 3) })
+    @IgnoreIf({ serverVersionLessThan(4, 4) })
     def '$out to specified database'() {
         given:
         def outDatabaseName = getDatabaseName() + '_out'
@@ -230,7 +230,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         getCollectionHelper(new MongoNamespace(outDatabaseName, outCollectionName)).find() == [a, b, c]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 2) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def '$merge'() {
         given:
         def outCollectionName = getCollectionName() + '.out'
@@ -316,7 +316,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         getCollectionHelper(new MongoNamespace(getDatabaseName(), outCollectionName)).find() == [a, b, c]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def '$stdDev'() {
         when:
         def results = aggregate([group(null, stdDevPop('stdDevPop', '$x'), stdDevSamp('stdDevSamp', '$x'))]).first()
@@ -328,14 +328,14 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         results.get('stdDevSamp') == 1.0
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def '$sample'() {
         expect:
         containsAny([a, b, c], aggregate([sample(1)]).first())
     }
 
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def '$lookup'() {
         given:
         def fromCollectionName = 'lookupCollection'
@@ -363,7 +363,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         fromHelper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def '$lookup with pipeline'() {
         given:
         def fromCollectionName = 'warehouses'
@@ -408,7 +408,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         fromHelper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def '$lookup with pipeline without variables'() {
         given:
         def fromCollectionName = 'holidays'
@@ -463,7 +463,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         fromCollection?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def '$facet'() {
         given:
         def helper = getCollectionHelper()
@@ -520,7 +520,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         helper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def '$graphLookup'() {
         given:
         def fromCollectionName = 'contacts'
@@ -559,7 +559,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         fromHelper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def '$graphLookup with depth options'() {
         given:
         def fromCollectionName = 'contacts'
@@ -600,7 +600,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         fromHelper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def '$graphLookup with query filter option'() {
         given:
         def fromCollectionName = 'contacts'
@@ -651,7 +651,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         fromHelper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def '$bucket'() {
         given:
         def helper = getCollectionHelper()
@@ -685,7 +685,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         helper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def '$bucketAuto'() {
         given:
         def helper = getCollectionHelper()
@@ -719,7 +719,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         helper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def '$bucketAuto with options'() {
         given:
         def helper = getCollectionHelper()
@@ -745,7 +745,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         helper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def '$count'() {
         given:
         def helper = getCollectionHelper()
@@ -781,7 +781,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         helper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def '$sortByCount'() {
         given:
         def helper = getCollectionHelper()
@@ -816,7 +816,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         helper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 3) })
+    @IgnoreIf({ serverVersionLessThan(4, 4) })
     def '$accumulator'() {
         given:
         def helper = getCollectionHelper()
@@ -860,7 +860,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         helper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def '$addFields'() {
         given:
         def helper = getCollectionHelper()
@@ -934,7 +934,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         helper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 2) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def '$set'() {
         expect:
         aggregate([set(new Field('c', '$y'))]) == [new Document(a).append('c', 'a'),
@@ -942,7 +942,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
                                                    new Document(c).append('c', 'c')]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def '$replaceRoot'() {
         given:
         def helper = getCollectionHelper()
@@ -973,7 +973,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         results == [Document.parse('{b: 1, _id: 7}')]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 2) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def '$replaceWith'() {
         given:
         def helper = getCollectionHelper()
@@ -1004,7 +1004,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         results == [Document.parse('{b: 1, _id: 7}')]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 3) })
+    @IgnoreIf({ serverVersionLessThan(4, 4) })
     def '$unionWith'() {
         given:
         def coll1Helper = getCollectionHelper(new MongoNamespace(getDatabaseName(), 'coll1'))
@@ -1041,7 +1041,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         coll2Helper?.drop()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(5, 0) })
+    @IgnoreIf({ serverVersionLessThan(5, 0) })
     def '$setWindowFields'(Object partitionBy, Bson sortBy, WindowedComputation output, List<Object> expectedFieldValues) {
         given:
         ZoneId utc = ZoneId.of(ZoneOffset.UTC.getId())
@@ -1131,7 +1131,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
                 .denseRank('result') |[ 1, 1, 2 ]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(5, 0) })
+    @IgnoreIf({ serverVersionLessThan(5, 0) })
     def '$setWindowFields with multiple output'() {
         given:
         getCollectionHelper().drop()
@@ -1148,7 +1148,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         actual.get(0) == original[0].append('count', 1).append('max', 1)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(5, 0) })
+    @IgnoreIf({ serverVersionLessThan(5, 0) })
     def '$setWindowFields with empty output'() {
         given:
         getCollectionHelper().drop()

--- a/driver-core/src/test/functional/com/mongodb/client/model/FiltersFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/FiltersFunctionalSpecification.groovy
@@ -25,7 +25,7 @@ import spock.lang.IgnoreIf
 
 import java.util.regex.Pattern
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.client.model.Filters.all
 import static com.mongodb.client.model.Filters.and
 import static com.mongodb.client.model.Filters.bitsAllClear
@@ -33,6 +33,7 @@ import static com.mongodb.client.model.Filters.bitsAllSet
 import static com.mongodb.client.model.Filters.bitsAnyClear
 import static com.mongodb.client.model.Filters.bitsAnySet
 import static com.mongodb.client.model.Filters.elemMatch
+import static com.mongodb.client.model.Filters.empty
 import static com.mongodb.client.model.Filters.eq
 import static com.mongodb.client.model.Filters.exists
 import static com.mongodb.client.model.Filters.expr
@@ -41,7 +42,6 @@ import static com.mongodb.client.model.Filters.gte
 import static com.mongodb.client.model.Filters.jsonSchema
 import static com.mongodb.client.model.Filters.lt
 import static com.mongodb.client.model.Filters.lte
-import static com.mongodb.client.model.Filters.empty
 import static com.mongodb.client.model.Filters.mod
 import static com.mongodb.client.model.Filters.ne
 import static com.mongodb.client.model.Filters.nin
@@ -227,7 +227,7 @@ class FiltersFunctionalSpecification extends OperationFunctionalSpecification {
         find(size('a', 4)) == [b]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should render $bitsAllClear'() {
         when:
         def bitDoc = Document.parse('{_id: 1, bits: 20}')
@@ -238,7 +238,7 @@ class FiltersFunctionalSpecification extends OperationFunctionalSpecification {
         find(bitsAllClear('bits', 35)) == [bitDoc]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should render $bitsAllSet'() {
         when:
         def bitDoc = Document.parse('{_id: 1, bits: 54}')
@@ -249,7 +249,7 @@ class FiltersFunctionalSpecification extends OperationFunctionalSpecification {
         find(bitsAllSet('bits', 50)) == [bitDoc]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should render $bitsAnyClear'() {
         when:
         def bitDoc = Document.parse('{_id: 1, bits: 50}')
@@ -260,7 +260,7 @@ class FiltersFunctionalSpecification extends OperationFunctionalSpecification {
         find(bitsAnyClear('bits', 20)) == [bitDoc]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should render $bitsAnySet'() {
         when:
         def bitDoc = Document.parse('{_id: 1, bits: 20}')
@@ -277,7 +277,7 @@ class FiltersFunctionalSpecification extends OperationFunctionalSpecification {
         find(type('x', BsonType.ARRAY)) == []
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should render $type with a string type representation'() {
         expect:
         find(type('x', 'number')) == [a, b, c]
@@ -298,7 +298,7 @@ class FiltersFunctionalSpecification extends OperationFunctionalSpecification {
         find(text('GIANT', new TextSearchOptions().language('english'))) == [textDocument]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should render $text with 3.2 options'() {
         given:
         collectionHelper.drop()
@@ -330,14 +330,14 @@ class FiltersFunctionalSpecification extends OperationFunctionalSpecification {
         find(where('Array.isArray(this.a)')) == [a, b]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def '$expr'() {
         expect:
         find(expr(Document.parse('{ $eq: [ "$x" , 3 ] } '))) == [c]
     }
 
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def '$jsonSchema'() {
         expect:
         find(jsonSchema(Document.parse('{ bsonType : "object", properties: { x : {type : "number", minimum : 2} } } '))) == [b, c]

--- a/driver-core/src/test/functional/com/mongodb/client/model/IndexesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/IndexesFunctionalSpecification.groovy
@@ -19,7 +19,7 @@ package com.mongodb.client.model
 import com.mongodb.OperationFunctionalSpecification
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.serverVersionGreaterThan
+import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.client.model.Indexes.ascending
 import static com.mongodb.client.model.Indexes.compoundIndex
 import static com.mongodb.client.model.Indexes.descending
@@ -100,7 +100,7 @@ class IndexesFunctionalSpecification extends OperationFunctionalSpecification {
         getCollectionHelper().listIndexes()*.get('key').contains(parse('{x : "2d"}'))
     }
 
-    @IgnoreIf({ serverVersionGreaterThan('4.4') })
+    @IgnoreIf({ serverVersionAtLeast(5, 0) })
     def 'geoHaystack'() {
         when:
         getCollectionHelper().createIndex(geoHaystack('x', descending('b')), 2.0)

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/GetMoreProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/GetMoreProtocolCommandEventSpecification.groovy
@@ -40,11 +40,11 @@ import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getServerApi
 import static com.mongodb.ClusterFixture.getSslSettings
-import static com.mongodb.ClusterFixture.serverVersionGreaterThan
+import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.internal.connection.ProtocolTestHelper.execute
 
-@IgnoreIf({ serverVersionGreaterThan('5.0') })
+@IgnoreIf({ serverVersionAtLeast(5, 1) })
 class GetMoreProtocolCommandEventSpecification extends OperationFunctionalSpecification {
     @Shared
     InternalStreamConnection connection

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/KillCursorProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/KillCursorProtocolCommandEventSpecification.groovy
@@ -37,11 +37,11 @@ import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getServerApi
 import static com.mongodb.ClusterFixture.getSslSettings
-import static com.mongodb.ClusterFixture.serverVersionGreaterThan
+import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.internal.connection.ProtocolTestHelper.execute
 
-@IgnoreIf({ serverVersionGreaterThan('5.0') })
+@IgnoreIf({ serverVersionAtLeast(5, 1) })
 class KillCursorProtocolCommandEventSpecification extends OperationFunctionalSpecification {
     @Shared
     InternalStreamConnection connection;

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/QueryProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/QueryProtocolCommandEventSpecification.groovy
@@ -43,12 +43,12 @@ import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getServerApi
 import static com.mongodb.ClusterFixture.getSslSettings
-import static com.mongodb.ClusterFixture.serverVersionGreaterThan
+import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.internal.connection.ProtocolTestHelper.execute
 import static org.bson.BsonDocument.parse
 
-@IgnoreIf({ getSslSettings().isEnabled() || serverVersionGreaterThan('5.0') })
+@IgnoreIf({ getSslSettings().isEnabled() || serverVersionAtLeast(5, 1) })
 class QueryProtocolCommandEventSpecification extends OperationFunctionalSpecification {
     @Shared
     InternalStreamConnection nettyConnection

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/ScramSha256AuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/ScramSha256AuthenticationSpecification.groovy
@@ -16,7 +16,7 @@
 
 package com.mongodb.internal.connection
 
-import com.mongodb.ClusterFixture
+
 import com.mongodb.MongoCredential
 import com.mongodb.MongoSecurityException
 import com.mongodb.ReadConcern
@@ -39,11 +39,12 @@ import static com.mongodb.ClusterFixture.createCluster
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.getServerApi
 import static com.mongodb.ClusterFixture.isAuthenticated
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.MongoCredential.createCredential
 import static com.mongodb.MongoCredential.createScramSha1Credential
 import static com.mongodb.MongoCredential.createScramSha256Credential
 
-@IgnoreIf({ !ClusterFixture.serverVersionAtLeast(4, 0) || !isAuthenticated() })
+@IgnoreIf({ serverVersionLessThan(4, 0) || !isAuthenticated() })
 class ScramSha256AuthenticationSpecification extends Specification {
 
     static MongoCredential sha1Implicit = createCredential('sha1', 'admin', 'sha1'.toCharArray())

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/WriteProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/WriteProtocolCommandEventSpecification.groovy
@@ -40,13 +40,13 @@ import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getServerApi
 import static com.mongodb.ClusterFixture.getSslSettings
-import static com.mongodb.ClusterFixture.serverVersionGreaterThan
+import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.internal.bulk.WriteRequest.Type.REPLACE
 import static com.mongodb.internal.bulk.WriteRequest.Type.UPDATE
 import static com.mongodb.internal.connection.ProtocolTestHelper.execute
 
-@IgnoreIf({ serverVersionGreaterThan('5.0') })
+@IgnoreIf({ serverVersionAtLeast(5, 1) })
 class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecification {
     @Shared
     InternalStreamConnection connection

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/WriteProtocolSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/WriteProtocolSpecification.groovy
@@ -34,11 +34,11 @@ import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getServerApi
 import static com.mongodb.ClusterFixture.getSslSettings
-import static com.mongodb.ClusterFixture.serverVersionGreaterThan
+import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.internal.connection.ProtocolTestHelper.execute
 
-@IgnoreIf({ serverVersionGreaterThan('5.0') })
+@IgnoreIf({ serverVersionAtLeast(5, 1) })
 class WriteProtocolSpecification extends OperationFunctionalSpecification {
     @Shared
     InternalStreamConnection connection;

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateOperationSpecification.groovy
@@ -62,6 +62,7 @@ import static com.mongodb.ClusterFixture.getCluster
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.isStandalone
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.ExplainVerbosity.QUERY_PLANNER
 import static com.mongodb.connection.ServerType.STANDALONE
 import static com.mongodb.internal.connection.ServerHelper.waitForLastRelease
@@ -195,7 +196,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support collation'() {
         given:
         def document = BsonDocument.parse('{_id: 1, str: "foo"}')
@@ -257,7 +258,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should be able to aggregate on a view'() {
         given:
         def viewSuffix = '-view'
@@ -340,7 +341,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should be able to explain an empty pipeline'() {
         given:
         def operation = new AggregateOperation(getNamespace(), [], new BsonDocumentCodec())
@@ -357,7 +358,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should be able to aggregate with collation'() {
         when:
         AggregateOperation operation = new AggregateOperation<Document>(getNamespace(),
@@ -375,7 +376,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
     }
 
     // Explain output keeps changing so only testing this in the range where the assertion still works
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) || serverVersionAtLeast(4, 1) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) || serverVersionAtLeast(4, 2) })
     def 'should apply $hint'() {
         given:
         def index = new BsonDocument('a', new BsonInt32(1))
@@ -395,7 +396,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         [async, hint] << [[true, false], [BsonDocument.parse('{a: 1}'), new BsonString('a_1')]].combinations()
     }
 
-    @IgnoreIf({ isSharded() || !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ isSharded() || serverVersionLessThan(3, 6) })
     def 'should apply comment'() {
         given:
         def profileCollectionHelper = getCollectionHelper(new MongoNamespace(getDatabaseName(), 'system.profile'))
@@ -421,7 +422,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ isSharded() || !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ isSharded() || serverVersionLessThan(3, 2) })
     def 'should be able to respect maxTime with pipeline'() {
         given:
         enableMaxTimeFailPoint()

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateToCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateToCollectionOperationSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation
 
-
 import com.mongodb.MongoCommandException
 import com.mongodb.MongoExecutionTimeoutException
 import com.mongodb.MongoNamespace
@@ -47,7 +46,7 @@ import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.client.model.Filters.gte
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -145,7 +144,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 2) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def 'should be able to merge into a collection'() {
         when:
         AggregateToCollectionOperation operation =
@@ -199,7 +198,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error'() {
         given:
         AggregateToCollectionOperation operation =
@@ -219,7 +218,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should support bypassDocumentValidation'() {
         given:
         def collectionOutHelper = getCollectionHelper(new MongoNamespace(getDatabaseName(), 'collectionOut'))
@@ -311,7 +310,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [false, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support collation'() {
         given:
         getCollectionHelper().insertDocuments(BsonDocument.parse('{_id: 1, str: "foo"}'))
@@ -330,7 +329,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [true, false]
     }
 
-    @IgnoreIf({ isSharded() || !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ isSharded() || serverVersionLessThan(3, 6) })
     def 'should apply comment'() {
         given:
         def profileCollectionHelper = getCollectionHelper(new MongoNamespace(getDatabaseName(), 'system.profile'))

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationProseTestSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationProseTestSpecification.groovy
@@ -37,6 +37,7 @@ import static com.mongodb.ClusterFixture.getCluster
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isStandalone
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.internal.connection.ServerHelper.waitForLastRelease
 import static java.util.Arrays.asList
 
@@ -62,7 +63,7 @@ class ChangeStreamOperationProseTestSpecification extends OperationFunctionalSpe
         def exception = thrown(MongoException)
 
         then:
-        if (serverVersionAtLeast(4, 1)) {
+        if (serverVersionAtLeast(4, 2)) {
             exception instanceof MongoQueryException
         } else {
             exception instanceof MongoChangeStreamException
@@ -80,7 +81,7 @@ class ChangeStreamOperationProseTestSpecification extends OperationFunctionalSpe
     // Test that the ChangeStream will automatically resume one time on a resumable error (including not master)
     // with the initial pipeline and options, except for the addition/update of a resumeToken.
     //
-    @IgnoreIf({ !serverVersionAtLeast([4, 0, 0]) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(4, 0) || !isDiscoverableReplicaSet() })
     def 'should resume after single getMore Error'() {
         given:
         def helper = getHelper()

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
@@ -55,6 +55,7 @@ import static com.mongodb.ClusterFixture.getAsyncCluster
 import static com.mongodb.ClusterFixture.getCluster
 import static com.mongodb.ClusterFixture.isStandalone
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.internal.connection.ServerHelper.waitForLastRelease
 import static com.mongodb.internal.operation.OperationUnitSpecification.getMaxWireVersionForServerVersion
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -315,7 +316,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         waitForLastRelease(getCluster())
     }
 
-    @IgnoreIf({ !serverVersionAtLeast([4, 0, 1]) })
+    @IgnoreIf({ serverVersionLessThan(4, 0) })
     def 'should decode drop to ChangeStreamDocument '() {
         given:
         def helper = getHelper()
@@ -343,7 +344,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         waitForLastRelease(getCluster())
     }
 
-    @IgnoreIf({ !serverVersionAtLeast([4, 0, 1]) })
+    @IgnoreIf({ serverVersionLessThan(4, 0) })
     def 'should decode dropDatabase to ChangeStreamDocument '() {
         given:
         def helper = getHelper()
@@ -372,7 +373,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         waitForLastRelease(getCluster())
     }
 
-    @IgnoreIf({ !serverVersionAtLeast([4, 0, 1]) })
+    @IgnoreIf({ serverVersionLessThan(4, 0) })
     def 'should decode rename to ChangeStreamDocument '() {
         given:
         def helper = getHelper()
@@ -491,7 +492,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast([4, 0, 0]) })
+    @IgnoreIf({ serverVersionLessThan(4, 0) })
     def 'should work with a startAtOperationTime'() {
         given:
         def helper = getHelper()
@@ -562,7 +563,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast([4, 1, 0]) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def 'should work with a startAfter resumeToken'() {
         given:
         def helper = getHelper()

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CreateCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CreateCollectionOperationSpecification.groovy
@@ -32,6 +32,7 @@ import spock.lang.IgnoreIf
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 
 class CreateCollectionOperationSpecification extends OperationFunctionalSpecification {
 
@@ -52,7 +53,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         operation.getCollation() == null
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 0) })
+    @IgnoreIf({ serverVersionLessThan(3, 0) })
     def 'should set optional values correctly'(){
         given:
         def storageEngineOptions = BsonDocument.parse('{ wiredTiger : {}}')
@@ -100,11 +101,11 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 0) })
+    @IgnoreIf({ serverVersionLessThan(3, 0) })
     def 'should pass through storage engine options'() {
         given:
         def storageEngineOptions = new BsonDocument('wiredTiger', new BsonDocument('configString', new BsonString('block_compressor=zlib')))
-        if (!serverVersionAtLeast(4, 1)) {
+        if (serverVersionLessThan(4, 2)) {
             storageEngineOptions.append('mmapv1', new BsonDocument())
         }
         def operation = new CreateCollectionOperation(getDatabaseName(), getCollectionName())
@@ -122,11 +123,11 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 1) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def 'should pass through storage engine options- zstd compression'() {
         given:
         def storageEngineOptions = new BsonDocument('wiredTiger', new BsonDocument('configString', new BsonString('block_compressor=zstd')))
-        if (!serverVersionAtLeast(4, 1)) {
+        if (serverVersionLessThan(4, 2)) {
             storageEngineOptions.append('mmapv1', new BsonDocument())
         }
         def operation = new CreateCollectionOperation(getDatabaseName(), getCollectionName())
@@ -198,7 +199,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         false     | 0                       | false
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should allow indexOptionDefaults'() {
         given:
         assert !collectionNameExists(getCollectionName())
@@ -217,7 +218,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
     }
 
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should allow validator'() {
         given:
         assert !collectionNameExists(getCollectionName())
@@ -247,7 +248,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error'() {
         given:
         assert !collectionNameExists(getCollectionName())
@@ -280,7 +281,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         async << [false, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should be able to create a collection with a collation'() {
         given:
         def operation = new CreateCollectionOperation(getDatabaseName(), getCollectionName()).collation(defaultCollation)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CreateIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CreateIndexesOperationSpecification.groovy
@@ -41,7 +41,7 @@ import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
-import static com.mongodb.ClusterFixture.serverVersionGreaterThan
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static java.util.concurrent.TimeUnit.SECONDS
 
 class CreateIndexesOperationSpecification extends OperationFunctionalSpecification {
@@ -101,8 +101,8 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ serverVersionAtLeast(4, 3) })
-    def 'should throw exception if commit quorum is set where server < 4.3'() {
+    @IgnoreIf({ serverVersionAtLeast(4, 4) })
+    def 'should throw exception if commit quorum is set where server < 4.4'() {
         given:
         def keys = new BsonDocument('field', new BsonInt32(1))
         def operation = new CreateIndexesOperation(getNamespace(), [new IndexRequest(keys)])
@@ -118,7 +118,7 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !isDiscoverableReplicaSet() || !serverVersionAtLeast(4, 3) })
+    @IgnoreIf({ !isDiscoverableReplicaSet() || serverVersionLessThan(4, 4) })
     def 'should create index with commit quorum'() {
         given:
         def keys = new BsonDocument('field', new BsonInt32(1))
@@ -334,7 +334,7 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ serverVersionGreaterThan('4.4') })
+    @IgnoreIf({ serverVersionAtLeast(5, 0) })
     def 'should be able to create a geoHaystack indexes'() {
         given:
         def operation = new CreateIndexesOperation(getNamespace(),
@@ -434,7 +434,7 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 0) })
+    @IgnoreIf({ serverVersionLessThan(3, 0) })
     def 'should pass through storage engine options'() {
         given:
         def storageEngineOptions = new Document('wiredTiger', new Document('configString', 'block_compressor=zlib'))
@@ -452,7 +452,7 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should be able to create a partially filtered index'() {
         given:
         def partialFilterExpression = new Document('a', new Document('$gte', 10))
@@ -470,7 +470,7 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error'() {
         given:
         def keys = new BsonDocument('field', new BsonInt32(1))
@@ -508,7 +508,7 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         ].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should be able to create an index with collation'() {
         given:
         def operation = new CreateIndexesOperation(getNamespace(),
@@ -526,7 +526,7 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 1) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def 'should be able to create wildcard indexes'() {
         given:
         def operation = new CreateIndexesOperation(getNamespace(),
@@ -544,7 +544,7 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 1) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def 'should be able to create wildcard index with projection'() {
         given:
         def operation = new CreateIndexesOperation(getNamespace(),
@@ -562,7 +562,7 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 4) })
+    @IgnoreIf({ serverVersionLessThan(4, 4) })
     def 'should be able to set hidden index'() {
         given:
         def operation = new CreateIndexesOperation(getNamespace(), [new IndexRequest(new BsonDocument('field', new BsonInt32(1)))])

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CreateViewOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CreateViewOperationSpecification.groovy
@@ -32,10 +32,11 @@ import spock.lang.IgnoreIf
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 
 class CreateViewOperationSpecification extends OperationFunctionalSpecification {
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should create view'() {
         given:
         def viewOn = getCollectionName();
@@ -68,7 +69,7 @@ class CreateViewOperationSpecification extends OperationFunctionalSpecification 
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should create view with collation'() {
         given:
         def viewOn = getCollectionName();
@@ -112,7 +113,7 @@ class CreateViewOperationSpecification extends OperationFunctionalSpecification 
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error'() {
         given:
         def viewName = getCollectionName() + '-view'

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DeleteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DeleteOperationSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation
 
-import util.spock.annotations.Slow
 import com.mongodb.MongoClientException
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.WriteConcernResult
@@ -28,9 +27,11 @@ import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
+import util.spock.annotations.Slow
 
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.UNACKNOWLEDGED
 
@@ -102,7 +103,7 @@ class DeleteOperationSpecification extends OperationFunctionalSpecification {
         ].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support collation'() {
         given:
         getCollectionHelper().insertDocuments(Document.parse('{str: "foo"}'))
@@ -119,7 +120,7 @@ class DeleteOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should throw if collation is set and write is unacknowledged'() {
         given:
         def requests = [new DeleteRequest(BsonDocument.parse('{str: "FOO"}}')).collation(caseInsensitiveCollation)]
@@ -135,7 +136,7 @@ class DeleteOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 6) || !isDiscoverableReplicaSet() })
     def 'should support retryable writes'() {
         given:
         getCollectionHelper().insertDocuments(Document.parse('{str: "foo"}'))

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DistinctOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DistinctOperationSpecification.groovy
@@ -56,7 +56,7 @@ import spock.lang.IgnoreIf
 import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.executeAsync
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.connection.ServerType.STANDALONE
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand
 import static com.mongodb.internal.operation.ServerVersionHelper.MIN_WIRE_VERSION
@@ -266,7 +266,7 @@ class DistinctOperationSpecification extends OperationFunctionalSpecification {
         async << [false, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support collation'() {
         given:
         def document = Document.parse('{str: "foo"}')

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DropCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DropCollectionOperationSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation
 
-
 import com.mongodb.MongoNamespace
 import com.mongodb.MongoWriteConcernException
 import com.mongodb.OperationFunctionalSpecification
@@ -28,7 +27,7 @@ import spock.lang.IgnoreIf
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 
 class DropCollectionOperationSpecification extends OperationFunctionalSpecification {
 
@@ -80,7 +79,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
         !collectionNameExists('nonExistingCollection')
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentTo', 'createTheCollection'))

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DropDatabaseOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DropDatabaseOperationSpecification.groovy
@@ -31,6 +31,7 @@ import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 
 class DropDatabaseOperationSpecification extends OperationFunctionalSpecification {
 
@@ -84,7 +85,7 @@ class DropDatabaseOperationSpecification extends OperationFunctionalSpecificatio
         !databaseNameExists(dbName)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentTo', 'createTheCollection'))

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DropIndexOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DropIndexOperationSpecification.groovy
@@ -35,7 +35,7 @@ import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static java.util.concurrent.TimeUnit.SECONDS
 
 class DropIndexOperationSpecification extends OperationFunctionalSpecification {
@@ -161,7 +161,7 @@ class DropIndexOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error'() {
         given:
         collectionHelper.createIndex(new BsonDocument('theField', new BsonInt32(1)))

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndDeleteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndDeleteOperationSpecification.groovy
@@ -41,7 +41,7 @@ import static com.mongodb.ClusterFixture.disableFailPoint
 import static com.mongodb.ClusterFixture.disableOnPrimaryTransactionalWriteFailPoint
 import static com.mongodb.ClusterFixture.enableOnPrimaryTransactionalWriteFailPoint
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.UNACKNOWLEDGED
 import static com.mongodb.WriteConcern.W1
@@ -132,7 +132,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
     }
 
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 2) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error'() {
         given:
         CollectionHelper<Document> helper = new CollectionHelper<Document>(documentCodec, getNamespace())
@@ -156,7 +156,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 8) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 8) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error on multiple failpoint'() {
         given:
         CollectionHelper<Document> helper = new CollectionHelper<Document>(documentCodec, getNamespace())
@@ -249,7 +249,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         ].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 6) || !isDiscoverableReplicaSet() })
     def 'should support retryable writes'() {
         given:
         Document pete = new Document('name', 'Pete').append('job', 'handyman')
@@ -339,7 +339,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support collation'() {
         given:
         def document = Document.parse('{_id: 1, str: "foo"}')

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndReplaceOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndReplaceOperationSpecification.groovy
@@ -47,7 +47,7 @@ import static com.mongodb.ClusterFixture.disableFailPoint
 import static com.mongodb.ClusterFixture.disableOnPrimaryTransactionalWriteFailPoint
 import static com.mongodb.ClusterFixture.enableOnPrimaryTransactionalWriteFailPoint
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.UNACKNOWLEDGED
 import static com.mongodb.WriteConcern.W1
@@ -195,7 +195,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should support bypassDocumentValidation'() {
         given:
         def namespace = new MongoNamespace(getDatabaseName(), 'collectionOut')
@@ -234,7 +234,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 2) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error'() {
         given:
         CollectionHelper<Document> helper = new CollectionHelper<Document>(documentCodec, getNamespace())
@@ -275,7 +275,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
     }
 
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 8) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 8) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error on multiple failpoint'() {
         CollectionHelper<Document> helper = new CollectionHelper<Document>(documentCodec, getNamespace())
         Document pete = new Document('name', 'Pete').append('job', 'handyman')
@@ -375,7 +375,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         ].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 6) || !isDiscoverableReplicaSet() })
     def 'should support retryable writes'() {
         given:
         CollectionHelper<Document> helper = new CollectionHelper<Document>(documentCodec, getNamespace())
@@ -472,7 +472,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         async << [false, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support collation'() {
         given:
         def document = Document.parse('{_id: 1, str: "foo"}')

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndUpdateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndUpdateOperationSpecification.groovy
@@ -48,14 +48,13 @@ import static com.mongodb.ClusterFixture.disableFailPoint
 import static com.mongodb.ClusterFixture.disableOnPrimaryTransactionalWriteFailPoint
 import static com.mongodb.ClusterFixture.enableOnPrimaryTransactionalWriteFailPoint
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.UNACKNOWLEDGED
 import static com.mongodb.WriteConcern.W1
 import static com.mongodb.client.model.Filters.gte
 import static com.mongodb.connection.ServerType.REPLICA_SET_PRIMARY
 import static com.mongodb.connection.ServerType.STANDALONE
-import static java.util.Arrays.asList
 import static java.util.Collections.singletonList
 
 class FindAndUpdateOperationSpecification extends OperationFunctionalSpecification {
@@ -80,7 +79,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         operation.getCollation() == null
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(asList(4, 1, 11)) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def 'should have the correct defaults and passed values using update pipelines'() {
         when:
         def updatePipeline = new BsonArray(singletonList(new BsonDocument('update', new BsonInt32(1))))
@@ -123,7 +122,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         operation.getCollation() == defaultCollation
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(asList(4, 1, 11)) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def 'should set optional values correctly when using update pipelines'(){
         given:
         def filter = new BsonDocument('filter', new BsonInt32(1))
@@ -182,7 +181,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(asList(4, 1, 11)) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def 'should add field using update pipeline'() {
         given:
         CollectionHelper<Document> helper = new CollectionHelper<Document>(documentCodec, getNamespace())
@@ -247,7 +246,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(asList(4, 1, 11)) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def 'should update using pipeline when using custom codecs'() {
         given:
         CollectionHelper<Document> helper = new CollectionHelper<Document>(documentCodec, getNamespace())
@@ -300,7 +299,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(asList(4, 1, 11)) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def 'should throw an exception if update pipeline contains operations that are not supported'() {
         when:
         def update = new BsonArray(singletonList(new BsonDocument('$foo', new BsonDocument('x', new BsonInt32(1)))))
@@ -322,7 +321,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should support bypassDocumentValidation'() {
         given:
         def namespace = new MongoNamespace(getDatabaseName(), 'collectionOut')
@@ -361,7 +360,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 2) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('name', 'Pete'))
@@ -396,7 +395,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 8) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 8) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error on multiple failpoint'() {
         given:
         CollectionHelper<Document> helper = new CollectionHelper<Document>(documentCodec, getNamespace())
@@ -494,7 +493,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         ].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 6) || !isDiscoverableReplicaSet() })
     def 'should support retryable writes'() {
         given:
         CollectionHelper<Document> helper = new CollectionHelper<Document>(documentCodec, getNamespace())
@@ -592,7 +591,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         async << [false, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support collation'() {
         given:
         def document = Document.parse('{_id: 1, str: "foo"}')
@@ -612,7 +611,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should support array filters'() {
         given:
         def documentOne = Document.parse('{_id: 1, y: [ {b: 3}, {b: 1}]}')

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindOperationSpecification.groovy
@@ -62,6 +62,7 @@ import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.getCluster
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.CursorType.NonTailable
 import static com.mongodb.CursorType.Tailable
 import static com.mongodb.CursorType.TailableAwait
@@ -397,7 +398,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should apply $hint'() {
         given:
         def index = new BsonDocument('a', new BsonInt32(1))
@@ -486,7 +487,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 3) || ClusterFixture.isStandalone() })
+    @IgnoreIf({ serverVersionLessThan(4, 4) || ClusterFixture.isStandalone() })
     def 'should read from a secondary when hedge is specified'() {
         given:
         def documents = [new Document('_id', 3), new Document('_id', 1), new Document('_id', 2), new Document('_id', 5),
@@ -749,7 +750,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support collation'() {
         given:
         def document = BsonDocument.parse('{_id: 1, str: "foo"}')

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/InsertOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/InsertOperationSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation
 
-import util.spock.annotations.Slow
 import com.mongodb.DuplicateKeyException
 import com.mongodb.MongoClientException
 import com.mongodb.OperationFunctionalSpecification
@@ -27,11 +26,12 @@ import org.bson.BsonInt32
 import org.bson.BsonSerializationException
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.IgnoreIf
+import util.spock.annotations.Slow
 
 import static com.mongodb.ClusterFixture.getAsyncSingleConnectionBinding
 import static com.mongodb.ClusterFixture.getSingleConnectionBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.UNACKNOWLEDGED
 import static java.util.Arrays.asList
@@ -214,7 +214,7 @@ class InsertOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should throw if bypassDocumentValidation is set and write is unacknowledged'() {
         given:
         def operation = new InsertOperation(getNamespace(), true,  UNACKNOWLEDGED, false, [new InsertRequest(new BsonDocument())])
@@ -230,7 +230,7 @@ class InsertOperationSpecification extends OperationFunctionalSpecification {
         [async, bypassDocumentValidation] << [[true, false], [true, false]].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 6) || !isDiscoverableReplicaSet() })
     def 'should support retryable writes'() {
         given:
         def insert = new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ListCollectionsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ListCollectionsOperationSpecification.groovy
@@ -52,6 +52,7 @@ import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 class ListCollectionsOperationSpecification extends OperationFunctionalSpecification {
@@ -161,7 +162,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         !names.contains(collectionName)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || serverVersionAtLeast(4, 0) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || serverVersionAtLeast(4, 0) })
     def 'should get all fields when nameOnly is not requested'() {
         given:
         def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
@@ -175,7 +176,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         collection.size() > 2
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 0) })
+    @IgnoreIf({ serverVersionLessThan(4, 0) })
     def 'should only get collection names when nameOnly is requested'() {
         given:
         def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
@@ -190,7 +191,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         collection.size() == 2
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || serverVersionAtLeast(4, 0) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || serverVersionAtLeast(4, 0) })
     def 'should only get all field names when nameOnly is requested on server versions that do not support nameOnly'() {
         given:
         def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceToCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceToCollectionOperationSpecification.groovy
@@ -40,7 +40,6 @@ import spock.lang.IgnoreIf
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
-import static com.mongodb.ClusterFixture.serverVersionGreaterThan
 import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.client.model.Filters.gte
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -141,7 +140,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
         operation.getCollation() == defaultCollation
     }
 
-    @IgnoreIf({ serverVersionGreaterThan('4.2') })
+    @IgnoreIf({ serverVersionAtLeast(4, 4) })
     def 'should return the correct statistics and save the results'() {
         when:
         MapReduceStatistics results = execute(mapReduceOperation, async)
@@ -157,7 +156,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [true, false]
     }
 
-    @IgnoreIf({ serverVersionLessThan('4.3') })
+    @IgnoreIf({ serverVersionLessThan(4, 4) })
     def 'should return zero-valued statistics and save the results'() {
         when:
         MapReduceStatistics results = execute(mapReduceOperation, async)
@@ -174,7 +173,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
     }
 
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should support bypassDocumentValidation'() {
         given:
         def collectionOutHelper = getCollectionHelper(new MongoNamespace(getDatabaseName(), 'collectionOut'))
@@ -213,7 +212,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error'() {
         given:
         getCollectionHelper().insertDocuments(new BsonDocument())
@@ -321,7 +320,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [false, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support collation'() {
         given:
         def outCollectionHelper = getCollectionHelper(new MongoNamespace(mapReduceInputNamespace.getDatabaseName(), 'collectionOut'))

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceWithInlineResultsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceWithInlineResultsOperationSpecification.groovy
@@ -47,7 +47,7 @@ import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
 import static com.mongodb.ClusterFixture.executeAsync
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.connection.ServerType.STANDALONE
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand
 import static com.mongodb.internal.operation.ServerVersionHelper.MIN_WIRE_VERSION
@@ -231,7 +231,7 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
         async << [false, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support collation'() {
         given:
         def document = Document.parse('{_id: 1, str: "foo"}')

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
@@ -56,6 +56,7 @@ import static com.mongodb.ClusterFixture.getAsyncSingleConnectionBinding
 import static com.mongodb.ClusterFixture.getSingleConnectionBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.UNACKNOWLEDGED
 import static com.mongodb.client.model.Filters.eq
@@ -803,7 +804,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 8) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 8) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error on multiple failpoint'() {
         given:
         getCollectionHelper().insertDocuments(getTestInserts())
@@ -848,7 +849,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         ordered << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should throw if bypassDocumentValidation is set and writeConcern is UNACKNOWLEDGED'() {
         given:
         def operation = new MixedBulkWriteOperation(getNamespace(),
@@ -865,7 +866,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         [async, bypassDocumentValidation] << [[false, false], [true, false]].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should throw if collation is set and write is UNACKNOWLEDGED'() {
         given:
         def operation = new MixedBulkWriteOperation(getNamespace(),
@@ -881,7 +882,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         [async, bypassDocumentValidation] << [[true, false], [true, false]].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should honour the bypass validation flag for inserts'() {
         given:
         def namespace = new MongoNamespace(getDatabaseName(), 'collection')
@@ -915,7 +916,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         [async, ordered] << [[true, false], [true, false]].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should honour the bypass validation flag for updates'() {
         given:
         def namespace = new MongoNamespace(getDatabaseName(), 'collection')
@@ -976,7 +977,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         ].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support collation'() {
         given:
         getCollectionHelper().insertDocuments(Document.parse('{str: "foo"}'), Document.parse('{str: "bar"}'))
@@ -1039,7 +1040,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         ].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 6) || !isDiscoverableReplicaSet() })
     def 'should fail as expected with retryWrites and failPoints'() {
         given:
         def testWrites = getTestWrites()
@@ -1064,7 +1065,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         ].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 6) || !isDiscoverableReplicaSet() })
     def 'should not fail with unacknowledged writes, retryWrites and failPoints'() {
         given:
         def testWrites = getTestWrites()
@@ -1089,7 +1090,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         ].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should retry if the connection initially fails'() {
         when:
         def cannedResult = BsonDocument.parse('{ok: 1.0, n: 1}')
@@ -1140,7 +1141,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should not request retryable write for multi updates or deletes'() {
         given:
         def operation = new MixedBulkWriteOperation(getNamespace(), writes, true, ACKNOWLEDGED, true)
@@ -1178,7 +1179,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         ].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should support array filters'() {
         given:
         def documentOne = BsonDocument.parse('{_id: 1, y: [ {b: 3}, {b: 1}]}')
@@ -1225,7 +1226,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should throw if array filters is set and write concern is UNACKNOWLEDGED'() {
         given:
         def requests = [
@@ -1263,7 +1264,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || serverVersionAtLeast(4, 2) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || serverVersionAtLeast(4, 2) })
     def 'should throw if hint is set and write concern is UNACKNOWLEDGED'() {
         given:
         def requests = [

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/QueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/QueryBatchCursorFunctionalSpecification.groovy
@@ -48,7 +48,6 @@ import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.getServerApi
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.internal.operation.OperationHelper.cursorDocumentToQueryResult
 import static com.mongodb.internal.operation.QueryOperationHelper.makeAdditionalGetMoreCall
@@ -292,7 +291,7 @@ class QueryBatchCursorFunctionalSpecification extends OperationFunctionalSpecifi
         latch.await(5, TimeUnit.SECONDS)  // wait for cursor.close to complete
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 2) || isSharded() })
+    @IgnoreIf({ serverVersionLessThan(3, 2) || isSharded() })
     @Slow
     def 'test maxTimeMS'() {
         collectionHelper.create(collectionName, new CreateCollectionOptions().capped(true).sizeInBytes(1000))

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/RenameCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/RenameCollectionOperationSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation
 
-
 import com.mongodb.MongoNamespace
 import com.mongodb.MongoServerException
 import com.mongodb.MongoWriteConcernException
@@ -30,7 +29,7 @@ import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 
 @IgnoreIf( { isSharded() } )  // these tests don't reliably pass against mongos
 class RenameCollectionOperationSpecification extends OperationFunctionalSpecification {
@@ -93,7 +92,7 @@ class RenameCollectionOperationSpecification extends OperationFunctionalSpecific
         collectionNameExists(getCollectionName())
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentThat', 'forces creation of the Collection'))

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/UpdateOperationForReplacementSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/UpdateOperationForReplacementSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation
 
-import util.spock.annotations.Slow
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.internal.bulk.InsertRequest
 import com.mongodb.internal.bulk.UpdateRequest
@@ -26,9 +25,10 @@ import org.bson.BsonInt32
 import org.bson.BsonSerializationException
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.IgnoreIf
+import util.spock.annotations.Slow
 
 import static com.mongodb.ClusterFixture.getBinding
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.internal.bulk.WriteRequest.Type.REPLACE
 import static java.util.Arrays.asList
@@ -77,7 +77,7 @@ class UpdateOperationForReplacementSpecification extends OperationFunctionalSpec
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 2) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def 'should support hint'() {
         given:
         def insert = new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/UpdateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/UpdateOperationSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation
 
-import util.spock.annotations.Slow
 import com.mongodb.MongoClientException
 import com.mongodb.MongoException
 import com.mongodb.OperationFunctionalSpecification
@@ -30,9 +29,11 @@ import org.bson.Document
 import org.bson.codecs.DocumentCodec
 import org.bson.types.ObjectId
 import spock.lang.IgnoreIf
+import util.spock.annotations.Slow
 
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.UNACKNOWLEDGED
 import static com.mongodb.internal.bulk.WriteRequest.Type.UPDATE
@@ -245,7 +246,7 @@ class UpdateOperationSpecification extends OperationFunctionalSpecification {
         ].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support collation'() {
         given:
         getCollectionHelper().insertDocuments(Document.parse('{str: "foo"}'))
@@ -263,7 +264,7 @@ class UpdateOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should throw if collation is set and write is unacknowledged'() {
         given:
         def requests = [new UpdateRequest(BsonDocument.parse('{str: "FOO"}}'), BsonDocument.parse('{$set: {str: "bar"}}'), UPDATE)
@@ -280,7 +281,7 @@ class UpdateOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 6) || !isDiscoverableReplicaSet() })
     def 'should support retryable writes'() {
         given:
         def id = new ObjectId()
@@ -301,7 +302,7 @@ class UpdateOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 2) })
+    @IgnoreIf({ serverVersionLessThan(4, 2) })
     def 'should support hint'() {
         given:
         getCollectionHelper().insertDocuments(Document.parse('{str: "foo"}'))

--- a/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
@@ -25,7 +25,8 @@ import spock.lang.IgnoreIf
 import spock.lang.Specification
 
 import static BucketGranularity.R5
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static MongoTimeUnit.DAY
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.client.model.Accumulators.accumulator
 import static com.mongodb.client.model.Accumulators.addToSet
 import static com.mongodb.client.model.Accumulators.avg
@@ -68,7 +69,6 @@ import static com.mongodb.client.model.Projections.fields
 import static com.mongodb.client.model.Projections.include
 import static com.mongodb.client.model.Sorts.ascending
 import static com.mongodb.client.model.Sorts.descending
-import static MongoTimeUnit.DAY
 import static com.mongodb.client.model.Windows.Bound.CURRENT
 import static com.mongodb.client.model.Windows.Bound.UNBOUNDED
 import static com.mongodb.client.model.Windows.documents
@@ -77,7 +77,7 @@ import static org.bson.BsonDocument.parse
 
 class AggregatesSpecification extends Specification {
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 3) })
+    @IgnoreIf({ serverVersionLessThan(4, 4) })
     def 'should render $accumulator'() {
         given:
         def initFunction = 'function() { return { count : 0, sum : 0 } }';
@@ -870,7 +870,7 @@ class AggregatesSpecification extends Specification {
                 addFields(asList(new Field('b', 3), new Field('c', 5))).hashCode()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 3) })
+    @IgnoreIf({ serverVersionLessThan(4, 4) })
     def 'should test equals for accumulator operator'() {
         given:
         def initFunction = 'function() { return { count : 0, sum : 0 } }';
@@ -895,7 +895,7 @@ class AggregatesSpecification extends Specification {
                         finalizeFunction, 'js'))
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 3) })
+    @IgnoreIf({ serverVersionLessThan(4, 4) })
     def 'should test hashCode for accumulator operator'() {
         given:
         def initFunction = 'function() { return { count : 0, sum : 0 } }';

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionFunctionalSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionFunctionalSpecification.groovy
@@ -32,6 +32,7 @@ import spock.lang.Unroll
 
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static org.hamcrest.Matchers.contains
 import static org.hamcrest.Matchers.containsInAnyOrder
 import static spock.util.matcher.HamcrestSupport.that
@@ -417,7 +418,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         QueryBuilder.start('x').lessThan(2).get() | [y: -1] as BasicDBObject      | 5
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw WriteConcernException on write concern error for rename'() {
         given:
         assert database.getCollectionNames().contains(collectionName)
@@ -434,7 +435,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         collection.setWriteConcern(null)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw WriteConcernException on write concern error for drop'() {
         given:
         assert database.getCollectionNames().contains(collectionName)
@@ -451,7 +452,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         collection.setWriteConcern(null)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw WriteConcernException on write concern error for createIndex'() {
         given:
         assert database.getCollectionNames().contains(collectionName)
@@ -468,7 +469,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         collection.setWriteConcern(null)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw WriteConcernException on write concern error for dropIndex'() {
         given:
         assert database.getCollectionNames().contains(collectionName)
@@ -486,7 +487,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         collection.setWriteConcern(null)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support creating an index with collation options'() {
         given:
         def collation = Collation.builder()
@@ -520,7 +521,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         indexCollation == collation.asDocument()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should find with collation'() {
         given:
         def document = BasicDBObject.parse('{_id: 1, str: "foo"}')
@@ -540,7 +541,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         ++result == document
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should aggregate with collation'() {
         given:
         def document = BasicDBObject.parse('{_id: 1, str: "foo"}')
@@ -561,7 +562,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         ++result == document
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should count with collation'() {
         given:
         collection.insert(BasicDBObject.parse('{_id: 1, str: "foo"}'))
@@ -579,7 +580,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         result == 1L
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should update with collation'() {
         given:
         collection.insert(BasicDBObject.parse('{_id: 1, str: "foo"}'))
@@ -598,7 +599,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         result.getN() == 1
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should remove with collation'() {
         given:
         collection.insert(BasicDBObject.parse('{_id: 1, str: "foo"}'))
@@ -616,7 +617,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         result.getN() == 1
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should find and modify with collation'() {
         given:
         def document = BasicDBObject.parse('{_id: 1, str: "foo"}')

--- a/driver-legacy/src/test/functional/com/mongodb/DBCursorFunctionalSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCursorFunctionalSpecification.groovy
@@ -24,6 +24,7 @@ import spock.lang.IgnoreIf
 import spock.lang.Subject
 
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 
 class DBCursorFunctionalSpecification extends FunctionalSpecification {
 
@@ -51,7 +52,7 @@ class DBCursorFunctionalSpecification extends FunctionalSpecification {
         1 * decoder.decode(_ as byte[], collection)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 0) })
+    @IgnoreIf({ serverVersionLessThan(3, 0) })
     def 'should use provided hints for queries mongod > 3.0'() {
         given:
         collection.createIndex(new BasicDBObject('a', 1))
@@ -249,7 +250,7 @@ class DBCursorFunctionalSpecification extends FunctionalSpecification {
         exception.getMessage().startsWith('Collation not supported by wire version:')
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should support collation'() {
         when:
         def document = BasicDBObject.parse('{_id: 1, str: "foo"}')

--- a/driver-legacy/src/test/functional/com/mongodb/DBFunctionalSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBFunctionalSpecification.groovy
@@ -22,10 +22,11 @@ import spock.lang.IgnoreIf
 import static com.mongodb.ClusterFixture.configureFailPoint
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 
 class DBFunctionalSpecification extends FunctionalSpecification {
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw WriteConcernException on write concern error for drop'() {
         given:
         database.createCollection('ctest', new BasicDBObject())
@@ -51,7 +52,7 @@ class DBFunctionalSpecification extends FunctionalSpecification {
         database.setWriteConcern(null)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw WriteConcernException on write concern error for create collection'() {
         given:
         database.setWriteConcern(new WriteConcern(5))
@@ -67,7 +68,7 @@ class DBFunctionalSpecification extends FunctionalSpecification {
         database.setWriteConcern(null)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw WriteConcernException on write concern error for create view'() {
         given:
         database.setWriteConcern(new WriteConcern(5))

--- a/driver-legacy/src/test/functional/com/mongodb/MapReduceTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/MapReduceTest.java
@@ -40,11 +40,11 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
@@ -310,7 +310,7 @@ public class MapReduceTest extends DatabaseTestCase {
         MapReduceOutput output = collection.mapReduce(command);
 
         //then
-        if (serverVersionLessThan(4, 3)) {
+        if (serverVersionLessThan(4, 4)) {
             assertThat(output.getEmitCount(), is(6));
             assertThat(output.getInputCount(), is(3));
             assertThat(output.getOutputCount(), is(4));
@@ -334,7 +334,7 @@ public class MapReduceTest extends DatabaseTestCase {
         MapReduceOutput output = collection.mapReduce(command);
 
         //then
-        if (serverVersionLessThan(4, 3)) {
+        if (serverVersionLessThan(4, 4)) {
             assertThat(output.getDuration(), is(greaterThanOrEqualTo(0)));
             assertThat(output.getEmitCount(), is(6));
             assertThat(output.getInputCount(), is(3));

--- a/driver-legacy/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit
 import static Fixture.getDefaultDatabaseName
 import static Fixture.getMongoClientURI
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.Fixture.getMongoClient
 import static com.mongodb.Fixture.getOptions
 
@@ -46,7 +46,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         thrown(IllegalArgumentException)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should create session with correct defaults'() {
         given:
         def clientSession = getMongoClient().startSession()
@@ -69,7 +69,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6)  })
+    @IgnoreIf({ serverVersionLessThan(3, 6)  })
     def 'cluster time should advance'() {
         given:
         def firstOperationTime = new BsonTimestamp(42, 1)
@@ -113,7 +113,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6)  })
+    @IgnoreIf({ serverVersionLessThan(3, 6)  })
     def 'operation time should advance'() {
         given:
         def firstOperationTime = new BsonTimestamp(42, 1)
@@ -154,7 +154,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'methods that use the session should throw if the session is closed'() {
         given:
         def options = ClientSessionOptions.builder().build()
@@ -183,7 +183,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'informational methods should not throw if the session is closed'() {
         given:
         def options = ClientSessionOptions.builder().build()
@@ -203,7 +203,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should apply causally consistent session option to client session'() {
         when:
         def clientSession = getMongoClient().startSession(ClientSessionOptions.builder()
@@ -221,7 +221,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         causallyConsistent << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'client session should have server session with valid identifier'() {
         given:
         def clientSession = getMongoClient().startSession(ClientSessionOptions.builder().build())
@@ -240,7 +240,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should use a default session'() {
         given:
         def commandListener = new TestCommandListener()
@@ -267,7 +267,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
     // This test is inherently racy as it's possible that the server _does_ replicate fast enough and therefore the test passes anyway
     // even if causal consistency was not actually in effect.  For that reason the test iterates a number of times in order to increase
     // confidence that it's really causal consistency that is causing the test to succeed
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     @Slow
     def 'should find inserted document on a secondary when causal consistency is enabled'() {
         given:
@@ -300,7 +300,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
     }
 
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should not use an implicit session for an unacknowledged write'() {
         given:
         def commandListener = new TestCommandListener()
@@ -322,7 +322,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         client?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should throw exception if unacknowledged write used with explicit session'() {
         given:
         def session = getMongoClient().startSession()
@@ -339,7 +339,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         session?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 0) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(4, 0) || !isDiscoverableReplicaSet() })
     def 'should ignore unacknowledged write concern when in a transaction'() {
         given:
         def collection = getMongoClient().getDatabase(getDatabaseName()).getCollection(getCollectionName())

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientEncryptionCustomEndpointTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientEncryptionCustomEndpointTest.java
@@ -80,7 +80,7 @@ public class ClientEncryptionCustomEndpointTest {
 
     @Before
     public void setUp() {
-        assumeTrue(serverVersionAtLeast(4, 1));
+        assumeTrue(serverVersionAtLeast(4, 2));
         assumeTrue("Custom Endpoint tests disables", hasEncryptionTestsEnabled());
 
         Map<String, Map<String, Object>> kmsProviders = new HashMap<String, Map<String, Object>>() {{

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientEncryptionDataKeyAndDoubleEncryptionTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientEncryptionDataKeyAndDoubleEncryptionTest.java
@@ -69,7 +69,7 @@ public class ClientEncryptionDataKeyAndDoubleEncryptionTest {
 
     @Before
     public void setUp() {
-        assumeTrue(serverVersionAtLeast(4, 1));
+        assumeTrue(serverVersionAtLeast(4, 2));
         assumeTrue("Has encryption tests", hasEncryptionTestsEnabled());
 
         // Step 1: create unencrypted client

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionBypassAutoEncryptionTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionBypassAutoEncryptionTest.java
@@ -48,7 +48,7 @@ public class ClientSideEncryptionBypassAutoEncryptionTest {
 
     @Before
     public void setUp() throws Throwable {
-        assumeTrue(serverVersionAtLeast(4, 1));
+        assumeTrue(serverVersionAtLeast(4, 2));
 
         final byte[] localMasterKey = new byte[96];
         new SecureRandom().nextBytes(localMasterKey);

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionCorpusTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionCorpusTest.java
@@ -73,7 +73,7 @@ public class ClientSideEncryptionCorpusTest {
 
     @Before
     public void setUp() throws IOException, URISyntaxException {
-        assumeTrue(serverVersionAtLeast(4, 1));
+        assumeTrue(serverVersionAtLeast(4, 2));
         assumeTrue("Corpus tests disabled", hasEncryptionTestsEnabled());
 
         MongoClientSettings clientSettings = getMongoClientBuilderFromConnectionString()

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionExternalKeyVaultTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionExternalKeyVaultTest.java
@@ -65,7 +65,7 @@ public class ClientSideEncryptionExternalKeyVaultTest {
 
     @Before
     public void setUp() throws Throwable {
-        assumeTrue(serverVersionAtLeast(4, 1));
+        assumeTrue(serverVersionAtLeast(4, 2));
         assumeTrue("Encryption test with external keyVault is disabled",
                 System.getProperty("org.mongodb.test.awsAccessKeyId") != null
                         && !System.getProperty("org.mongodb.test.awsAccessKeyId").isEmpty());

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionViewAreProhibitedTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionViewAreProhibitedTest.java
@@ -44,7 +44,7 @@ public class ClientSideEncryptionViewAreProhibitedTest {
 
     @Before
     public void setUp() {
-        assumeTrue(serverVersionAtLeast(4, 1));
+        assumeTrue(serverVersionAtLeast(4, 2));
         assumeTrue("Encryption test with external keyVault is disabled",
                 System.getProperty("org.mongodb.test.awsAccessKeyId") != null
                         && !System.getProperty("org.mongodb.test.awsAccessKeyId").isEmpty());

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/MongoClientSessionSpecification.groovy
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/MongoClientSessionSpecification.groovy
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit
 import static Fixture.getMongoClient
 import static com.mongodb.ClusterFixture.TIMEOUT_DURATION
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.reactivestreams.client.Fixture.getDefaultDatabase
 import static com.mongodb.reactivestreams.client.Fixture.getMongoClientBuilderFromConnectionString
 
@@ -53,7 +53,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         thrown(IllegalArgumentException)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should create session with correct defaults'() {
         when:
         def options = ClientSessionOptions.builder().build()
@@ -78,7 +78,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'cluster time should advance'() {
         given:
         def firstOperationTime = new BsonTimestamp(42, 1)
@@ -122,7 +122,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'operation time should advance'() {
         given:
         def firstOperationTime = new BsonTimestamp(42, 1)
@@ -163,7 +163,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'methods that use the session should throw if the session is closed'() {
         given:
         def options = ClientSessionOptions.builder().build()
@@ -192,7 +192,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'informational methods should not throw if the session is closed'() {
         given:
         def options = ClientSessionOptions.builder().build()
@@ -209,7 +209,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         true
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should apply causally consistent session option to client session'() {
         when:
         def clientSession = startSession(ClientSessionOptions.builder().causallyConsistent(causallyConsistent).build())
@@ -225,7 +225,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         causallyConsistent << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'client session should have server session with valid identifier'() {
         given:
         def clientSession = startSession(ClientSessionOptions.builder().build())
@@ -244,7 +244,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should use a default session'() {
         given:
         def commandListener = new TestCommandListener()
@@ -263,7 +263,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         client?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should throw exception if unacknowledged write used with explicit session'() {
         given:
         def session = Mono.from(getMongoClient().startSession()).block(TIMEOUT_DURATION)
@@ -282,7 +282,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
     }
 
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 0) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(4, 0) || !isDiscoverableReplicaSet() })
     def 'should ignore unacknowledged write concern when in a transaction'() {
         given:
         def collection = getMongoClient().getDatabase(getDatabaseName()).getCollection(getCollectionName())
@@ -308,7 +308,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
     // This test is inherently racy as it's possible that the server _does_ replicate fast enough and therefore the test passes anyway
     // even if causal consistency was not actually in effect.  For that reason the test iterates a number of times in order to increase
     // confidence that it's really causal consistency that is causing the test to succeed
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     @Slow
     def 'should find inserted document on a secondary when causal consistency is enabled'() {
         given:

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/RetryableWritesProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/RetryableWritesProseTest.java
@@ -84,6 +84,6 @@ public class RetryableWritesProseTest extends DatabaseTestCase {
 
         return ((isSharded() || isDiscoverableReplicaSet())
                 && storageEngine != null && storageEngine.get("name").equals("mmapv1")
-                && serverVersionAtLeast(3, 6) && serverVersionLessThan(4, 1));
+                && serverVersionAtLeast(3, 6) && serverVersionLessThan(4, 2));
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/SmokeTestSpecification.groovy
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/SmokeTestSpecification.groovy
@@ -152,7 +152,7 @@ class SmokeTestSpecification extends FunctionalSpecification {
         !run('the collection name is no longer in the collectionNames list', database.&listCollectionNames).contains(collectionName)
     }
 
-    @IgnoreIf({ !(serverVersionAtLeast(3, 7) && isReplicaSet()) })
+    @IgnoreIf({ !(serverVersionAtLeast(4, 0) && isReplicaSet()) })
     def 'should commit a transaction'() {
         given:
         run('create collection', database.&createCollection, collection.namespace.collectionName)
@@ -170,7 +170,7 @@ class SmokeTestSpecification extends FunctionalSpecification {
         session?.close()
     }
 
-    @IgnoreIf({ !(serverVersionAtLeast(3, 7) && isReplicaSet()) })
+    @IgnoreIf({ !(serverVersionAtLeast(4, 0) && isReplicaSet()) })
     def 'should abort a transaction'() {
         given:
         run('create collection', database.&createCollection, collection.namespace.collectionName)

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/TransactionFailureTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/TransactionFailureTest.java
@@ -56,6 +56,6 @@ public class TransactionFailureTest extends DatabaseTestCase {
     }
 
     private boolean canRunTests() {
-        return serverVersionLessThan("4.0") || (serverVersionLessThan("4.1.0") && isSharded());
+        return serverVersionLessThan(4, 0) || (serverVersionLessThan(4, 2) && isSharded());
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/ConnectionsSurvivePrimaryStepDownProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/ConnectionsSurvivePrimaryStepDownProseTest.java
@@ -93,7 +93,7 @@ public class ConnectionsSurvivePrimaryStepDownProseTest {
 
     @Test
     public void testGetMoreIteration() {
-        assumeTrue(serverVersionAtLeast(asList(4, 1, 10)));
+        assumeTrue(serverVersionAtLeast(4, 2));
 
         List<Document> documents = asList(Document.parse("{_id: 1}"), Document.parse("{_id: 2}"), Document.parse("{_id: 3}"),
                                           Document.parse("{_id: 4}"), Document.parse("{_id: 5}"));
@@ -115,7 +115,7 @@ public class ConnectionsSurvivePrimaryStepDownProseTest {
 
     @Test
     public void testNotPrimaryKeepConnectionPool() {
-        assumeTrue(serverVersionAtLeast(asList(4, 1, 10)));
+        assumeTrue(serverVersionAtLeast(4, 2));
 
         collectionHelper.runAdminCommand("{configureFailPoint: 'failCommand',  mode: {times: 1}, "
                                                  + "data: {failCommands: ['insert'], errorCode: 10107}}");
@@ -134,7 +134,7 @@ public class ConnectionsSurvivePrimaryStepDownProseTest {
 
     @Test
     public void testNotPrimaryClearConnectionPool() {
-        assumeFalse(serverVersionAtLeast(asList(4, 1, 0)));
+        assumeFalse(serverVersionAtLeast(4, 2));
 
         collectionHelper.runAdminCommand("{configureFailPoint: 'failCommand',  mode: {times: 1}, "
                                                  + "data: {failCommands: ['insert'], errorCode: 10107}}");

--- a/driver-sync/src/examples/documentation/TransactionExample.java
+++ b/driver-sync/src/examples/documentation/TransactionExample.java
@@ -19,7 +19,6 @@ package documentation;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
-import com.mongodb.client.MongoClient;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
 import com.mongodb.ReadConcern;
@@ -27,6 +26,7 @@ import com.mongodb.ReadPreference;
 import com.mongodb.TransactionOptions;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
@@ -165,7 +165,7 @@ public class TransactionExample {
 
     private boolean canRunTest() {
         if (isSharded()) {
-            return serverVersionAtLeast(4, 1);
+            return serverVersionAtLeast(4, 2);
         } else if (isDiscoverableReplicaSet()) {
             return serverVersionAtLeast(4, 0);
         } else {

--- a/driver-sync/src/test/functional/com/mongodb/client/ChangeStreamProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ChangeStreamProseTest.java
@@ -132,7 +132,7 @@ public class ChangeStreamProseTest extends DatabaseTestCase {
         } catch (MongoChangeStreamException e) {
             exceptionFound = true;
         } catch (MongoQueryException e) {
-            if (serverVersionAtLeast(4, 1)) {
+            if (serverVersionAtLeast(4, 2)) {
                 exceptionFound = true;
             }
         } finally {
@@ -199,7 +199,7 @@ public class ChangeStreamProseTest extends DatabaseTestCase {
     //
     @Test
     public void testGetResumeTokenReturnsPostBatchResumeToken() throws NoSuchFieldException, IllegalAccessException {
-        assumeTrue(serverVersionAtLeast(asList(4, 0, 7)));
+        assumeTrue(serverVersionAtLeast(4, 0));
 
         MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor = collection.watch().cursor();
         assertNull(cursor.getResumeToken());
@@ -226,7 +226,7 @@ public class ChangeStreamProseTest extends DatabaseTestCase {
     //
     @Test
     public void testGetResumeTokenShouldWorkAsExpectedForEmptyAndIteratedBatch() {
-        assumeTrue(serverVersionLessThan(asList(4, 0, 7)));
+        assumeTrue(serverVersionLessThan(4, 0));
 
         BsonDocument resumeAfterToken;
         MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor = collection.watch().cursor();
@@ -287,7 +287,7 @@ public class ChangeStreamProseTest extends DatabaseTestCase {
     //
     @Test
     public void testGetResumeTokenReturnsStartAfter() {
-        assumeTrue(serverVersionAtLeast(asList(4, 1, 11)));
+        assumeTrue(serverVersionAtLeast(4, 2));
 
         BsonDocument resumeToken;
         MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor = collection.watch().cursor();
@@ -362,7 +362,7 @@ public class ChangeStreamProseTest extends DatabaseTestCase {
     @Test
     public void testGetResumeTokenReturnsPostBatchResumeTokenAfterGetMore()
             throws NoSuchFieldException, IllegalAccessException {
-        assumeTrue(serverVersionAtLeast(asList(4, 0, 7)));
+        assumeTrue(serverVersionAtLeast(4, 0));
 
         MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor = collection.watch().cursor();
         collection.insertOne(Document.parse("{ _id: 42, x: 1 }"));
@@ -395,7 +395,7 @@ public class ChangeStreamProseTest extends DatabaseTestCase {
     //
     @Test
     public void testGetResumeTokenReturnsIdOfPreviousDocument() {
-        assumeTrue(serverVersionLessThan(asList(4, 0, 7)));
+        assumeTrue(serverVersionLessThan(4, 0));
 
         BsonDocument resumeToken;
         MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor = collection.watch().cursor();

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientEncryptionCustomEndpointTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientEncryptionCustomEndpointTest.java
@@ -77,7 +77,7 @@ public class ClientEncryptionCustomEndpointTest {
 
     @Before
     public void setUp() {
-        assumeTrue(serverVersionAtLeast(4, 1));
+        assumeTrue(serverVersionAtLeast(4, 2));
         assumeTrue("Custom Endpoint tests disables", hasEncryptionTestsEnabled());
 
         Map<String, Map<String, Object>> kmsProviders = new HashMap<String, Map<String, Object>>() {{

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientEncryptionDataKeyAndDoubleEncryptionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientEncryptionDataKeyAndDoubleEncryptionTest.java
@@ -68,7 +68,7 @@ public class ClientEncryptionDataKeyAndDoubleEncryptionTest {
 
     @Before
     public void setUp() {
-        assumeTrue(serverVersionAtLeast(4, 1));
+        assumeTrue(serverVersionAtLeast(4, 2));
         assumeTrue("Has encryption tests", hasEncryptionTestsEnabled());
 
         // Step 1: create unencrypted client

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionBypassAutoEncryptionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionBypassAutoEncryptionTest.java
@@ -51,7 +51,7 @@ public class ClientSideEncryptionBypassAutoEncryptionTest {
 
     @Before
     public void setUp() {
-        assumeTrue(serverVersionAtLeast(4, 1));
+        assumeTrue(serverVersionAtLeast(4, 2));
 
         MongoClient mongoClient = getMongoClient();
 

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionCorpusTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionCorpusTest.java
@@ -71,7 +71,7 @@ public class ClientSideEncryptionCorpusTest {
 
     @Before
     public void setUp() throws IOException, URISyntaxException {
-        assumeTrue(serverVersionAtLeast(4, 1));
+        assumeTrue(serverVersionAtLeast(4, 2));
         assumeTrue("Corpus tests disabled", hasEncryptionTestsEnabled());
 
         MongoClientSettings clientSettings = getMongoClientSettingsBuilder()

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionExternalKeyVaultTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionExternalKeyVaultTest.java
@@ -63,7 +63,7 @@ public class ClientSideEncryptionExternalKeyVaultTest {
 
     @Before
     public void setUp() throws IOException, URISyntaxException {
-        assumeTrue(serverVersionAtLeast(4, 1));
+        assumeTrue(serverVersionAtLeast(4, 2));
         assumeTrue("Encryption test with external keyVault is disabled",
                 System.getProperty("org.mongodb.test.awsAccessKeyId") != null
                     && !System.getProperty("org.mongodb.test.awsAccessKeyId").isEmpty());

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionViewAreProhibitedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionViewAreProhibitedTest.java
@@ -42,7 +42,7 @@ public class ClientSideEncryptionViewAreProhibitedTest {
 
     @Before
     public void setUp() {
-        assumeTrue(serverVersionAtLeast(4, 1));
+        assumeTrue(serverVersionAtLeast(4, 2));
         assumeTrue("Encryption test with external keyVault is disabled",
                 System.getProperty("org.mongodb.test.awsAccessKeyId") != null
                         && !System.getProperty("org.mongodb.test.awsAccessKeyId").isEmpty());

--- a/driver-sync/src/test/functional/com/mongodb/client/ConnectionsSurvivePrimaryStepDownProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ConnectionsSurvivePrimaryStepDownProseTest.java
@@ -93,7 +93,7 @@ public class ConnectionsSurvivePrimaryStepDownProseTest {
 
     @Test
     public void testGetMoreIteration() {
-        assumeTrue(serverVersionAtLeast(asList(4, 1, 10)));
+        assumeTrue(serverVersionAtLeast(4, 2));
 
         List<Document> documents = asList(Document.parse("{_id: 1}"), Document.parse("{_id: 2}"), Document.parse("{_id: 3}"),
                 Document.parse("{_id: 4}"), Document.parse("{_id: 5}"));
@@ -111,7 +111,7 @@ public class ConnectionsSurvivePrimaryStepDownProseTest {
 
     @Test
     public void testNotPrimaryKeepConnectionPool() {
-        assumeTrue(serverVersionAtLeast(asList(4, 1, 10)));
+        assumeTrue(serverVersionAtLeast(4, 2));
 
         collectionHelper.runAdminCommand("{configureFailPoint: 'failCommand',  mode: {times: 1}, data: {failCommands: ['insert'], "
                 + "errorCode: 10107}}");
@@ -130,7 +130,7 @@ public class ConnectionsSurvivePrimaryStepDownProseTest {
 
     @Test
     public void testNotPrimaryClearConnectionPool() {
-        assumeFalse(serverVersionAtLeast(asList(4, 1, 0)));
+        assumeFalse(serverVersionAtLeast(4, 2));
 
         collectionHelper.runAdminCommand("{configureFailPoint: 'failCommand',  mode: {times: 1}, data: {failCommands: ['insert'], "
                 + "errorCode: 10107}}");

--- a/driver-sync/src/test/functional/com/mongodb/client/MongoClientSessionSpecification.groovy
+++ b/driver-sync/src/test/functional/com/mongodb/client/MongoClientSessionSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.client
 
-import util.spock.annotations.Slow
 import com.mongodb.ClientSessionOptions
 import com.mongodb.MongoClientException
 import com.mongodb.MongoClientSettings
@@ -33,11 +32,12 @@ import org.bson.BsonTimestamp
 import org.bson.Document
 import org.junit.Assert
 import spock.lang.IgnoreIf
+import util.spock.annotations.Slow
 
 import java.util.concurrent.TimeUnit
 
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.client.Fixture.getDefaultDatabaseName
 import static com.mongodb.client.Fixture.getMongoClient
 import static com.mongodb.client.Fixture.getMongoClientSettings
@@ -52,7 +52,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         thrown(IllegalArgumentException)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should create session with correct defaults'() {
         expect:
         clientSession.getOriginator() == getMongoClient()
@@ -76,7 +76,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
                           getMongoClient().startSession(ClientSessionOptions.builder().build())]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'cluster time should advance'() {
         given:
         def firstOperationTime = new BsonTimestamp(42, 1)
@@ -117,7 +117,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.getClusterTime() == secondClusterTime
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'operation time should advance'() {
         given:
         def firstOperationTime = new BsonTimestamp(42, 1)
@@ -155,7 +155,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.getOperationTime() == secondOperationTime
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'methods that use the session should throw if the session is closed'() {
         given:
         def options = ClientSessionOptions.builder().build()
@@ -181,7 +181,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         thrown(IllegalStateException)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'informational methods should not throw if the session is closed'() {
         given:
         def options = ClientSessionOptions.builder().build()
@@ -198,7 +198,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         noExceptionThrown()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should apply causally consistent session option to client session'() {
         when:
         def clientSession = getMongoClient().startSession(ClientSessionOptions.builder()
@@ -213,7 +213,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         causallyConsistent << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'client session should have server session with valid identifier'() {
         given:
         def clientSession = getMongoClient().startSession(ClientSessionOptions.builder().build())
@@ -229,7 +229,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         identifier.getBinary('id').data.length == 16
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should use a default session'() {
         given:
         def commandListener = new TestCommandListener()
@@ -255,7 +255,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
     // This test is inherently racy as it's possible that the server _does_ replicate fast enough and therefore the test passes anyway
     // even if causal consistency was not actually in effect.  For that reason the test iterates a number of times in order to increase
     // confidence that it's really causal consistency that is causing the test to succeed
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     @Slow
     def 'should find inserted document on a secondary when causal consistency is enabled'() {
         given:
@@ -287,7 +287,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         readConcern << [ReadConcern.DEFAULT, ReadConcern.LOCAL, ReadConcern.MAJORITY]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should not use an implicit session for an unacknowledged write'() {
         given:
         def commandListener = new TestCommandListener()
@@ -307,7 +307,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         client?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should throw exception if unacknowledged write used with explicit session'() {
         given:
         def session = getMongoClient().startSession()
@@ -325,7 +325,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
     }
 
 
-    @IgnoreIf({ !serverVersionAtLeast(4, 0) || !isDiscoverableReplicaSet() })
+    @IgnoreIf({ serverVersionLessThan(4, 0) || !isDiscoverableReplicaSet() })
     def 'should ignore unacknowledged write concern when in a transaction'() {
         given:
         def collection = getMongoClient().getDatabase(getDatabaseName()).getCollection(getCollectionName())

--- a/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
@@ -76,6 +76,6 @@ public class RetryableWritesProseTest extends DatabaseTestCase {
 
         return ((isSharded() || isDiscoverableReplicaSet())
                 && storageEngine != null && storageEngine.get("name").equals("mmapv1")
-                && serverVersionAtLeast(3, 6) && serverVersionLessThan(4, 1));
+                && serverVersionAtLeast(3, 6) && serverVersionLessThan(4, 2));
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/TransactionFailureTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/TransactionFailureTest.java
@@ -47,7 +47,7 @@ public class TransactionFailureTest extends DatabaseTestCase {
     }
 
     private boolean canRunTests() {
-        return serverVersionLessThan("4.0")
-                || (serverVersionLessThan("4.1.0") && isSharded());
+        return serverVersionLessThan(4, 0)
+                || (serverVersionLessThan(4, 2) && isSharded());
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/TransactionProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/TransactionProseTest.java
@@ -128,7 +128,7 @@ public class TransactionProseTest {
 
     private boolean canRunTests() {
         if (isSharded()) {
-            return serverVersionAtLeast(4, 1);
+            return serverVersionAtLeast(4, 2);
         } else {
             return false;
         }

--- a/driver-sync/src/test/functional/com/mongodb/client/WithTransactionProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/WithTransactionProseTest.java
@@ -17,7 +17,6 @@
 package com.mongodb.client;
 
 import com.mongodb.MongoException;
-
 import com.mongodb.client.internal.ClientSessionClock;
 import org.bson.Document;
 import org.junit.Before;
@@ -190,7 +189,7 @@ public class WithTransactionProseTest extends DatabaseTestCase {
 
     private boolean canRunTests() {
         if (isSharded()) {
-            return serverVersionAtLeast(4, 1);
+            return serverVersionAtLeast(4, 2);
         } else if (isDiscoverableReplicaSet()) {
             return serverVersionAtLeast(4, 0);
         } else {

--- a/driver-sync/src/test/functional/com/mongodb/client/gridfs/GridFSBucketSmokeTestSpecification.groovy
+++ b/driver-sync/src/test/functional/com/mongodb/client/gridfs/GridFSBucketSmokeTestSpecification.groovy
@@ -35,7 +35,7 @@ import org.bson.types.ObjectId
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.client.Fixture.getDefaultDatabase
 import static com.mongodb.client.Fixture.getDefaultDatabaseName
 import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder
@@ -460,7 +460,7 @@ class GridFSBucketSmokeTestSpecification extends FunctionalSpecification {
         direct << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 4) })
+    @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should not create if index is numerically the same'() {
         when:
         filesCollection.createIndex(new Document('filename', indexValue1).append('uploadDate', indexValue2))


### PR DESCRIPTION
* Standardized on two methods for checking server version and removed the others.
  The methods both take just major and minor version as their two arguments. The
  two remaining methods are serverVersionAtLeast and serverVersionLessThan.
* Simplified usage of these methods in tests.  Replaced double negatives by
  reversing the condition.
* Fixed a bug in the comparison logic which caused us to skip tests that shouldn't
  be fixed.
* Replaced references to development versions (e.g. 4.1) with supported versions

JAVA-4251