### PR TITLE
Handle 0 maxSize in `DefaultConnectionPool` and allow passing 0 to `MongoClientOptions.Builder.maxSize`

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/ConnectionPoolSettings.java
+++ b/driver-core/src/main/com/mongodb/connection/ConnectionPoolSettings.java
@@ -112,7 +112,7 @@ public class ConnectionPoolSettings {
          *
          * <p>Default is 100.</p>
          *
-         * @param maxSize the maximum number of connections in the pool.
+         * @param maxSize the maximum number of connections in the pool; if 0, then there is no limit.
          * @return this
          */
         public Builder maxSize(final int maxSize) {
@@ -261,7 +261,7 @@ public class ConnectionPoolSettings {
      *
      * <p>Default is 100.</p>
      *
-     * @return the maximum number of connections in the pool.
+     * @return the maximum number of connections in the pool; if 0, then there is no limit.
      */
     public int getMaxSize() {
         return maxSize;
@@ -410,7 +410,7 @@ public class ConnectionPoolSettings {
     }
 
     ConnectionPoolSettings(final Builder builder) {
-        isTrue("maxSize > 0", builder.maxSize > 0);
+        isTrue("maxSize >= 0", builder.maxSize >= 0);
         isTrue("minSize >= 0", builder.minSize >= 0);
         isTrue("maintenanceInitialDelayMS >= 0", builder.maintenanceInitialDelayMS >= 0);
         isTrue("maxConnectionLifeTime >= 0", builder.maxConnectionLifeTimeMS >= 0);

--- a/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static com.mongodb.assertions.Assertions.assertFalse;
+import static com.mongodb.assertions.Assertions.assertTrue;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
@@ -36,6 +37,10 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  * <p>This class should not be considered a part of the public API.</p>
  */
 public class ConcurrentPool<T> implements Pool<T> {
+    /**
+     * {@link Integer#MAX_VALUE}.
+     */
+    public static final int INFINITE_SIZE = Integer.MAX_VALUE;
 
     private final int maxSize;
     private final ItemFactory<T> itemFactory;
@@ -74,10 +79,11 @@ public class ConcurrentPool<T> implements Pool<T> {
     /**
      * Initializes a new pool of objects.
      *
-     * @param maxSize     max to hold to at any given time. if < 0 then no limit
+     * @param maxSize     max to hold to at any given time, must be positive.
      * @param itemFactory factory used to create and close items in the pool
      */
     public ConcurrentPool(final int maxSize, final ItemFactory<T> itemFactory) {
+        assertTrue(maxSize > 0);
         this.maxSize = maxSize;
         this.itemFactory = itemFactory;
         permits = new Semaphore(maxSize, true);
@@ -259,7 +265,7 @@ public class ConcurrentPool<T> implements Pool<T> {
         }
     }
 
-    public int getMaxSize() {
+    int getMaxSize() {
         return maxSize;
     }
 
@@ -278,7 +284,7 @@ public class ConcurrentPool<T> implements Pool<T> {
     public String toString() {
         StringBuilder buf = new StringBuilder();
         buf.append("pool: ")
-           .append(" maxSize: ").append(maxSize)
+           .append(" maxSize: ").append(sizeToString(maxSize))
            .append(" availableCount ").append(getAvailableCount())
            .append(" inUseCount ").append(getInUseCount());
         return buf.toString();
@@ -297,5 +303,12 @@ public class ConcurrentPool<T> implements Pool<T> {
 
     static IllegalStateException poolClosedException() {
         return new IllegalStateException("The pool is closed");
+    }
+
+    /**
+     * @return {@link Integer#toString()} if {@code size} is not {@link #INFINITE_SIZE}, otherwise returns {@code "infinite"}.
+     */
+    static String sizeToString(final int size) {
+        return size == INFINITE_SIZE ? "infinite" : Integer.toString(size);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/PowerOfTwoBufferPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/PowerOfTwoBufferPool.java
@@ -27,6 +27,8 @@ import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.mongodb.internal.connection.ConcurrentPool.INFINITE_SIZE;
+
 /**
  * Power-of-two buffer pool implementation.
  *
@@ -52,7 +54,7 @@ public class PowerOfTwoBufferPool implements BufferProvider {
         int powerOfTwo = 1;
         for (int i = 0; i <= highestPowerOfTwo; i++) {
             final int size = powerOfTwo;
-            powerOfTwoToPoolMap.put(i, new ConcurrentPool<ByteBuffer>(Integer.MAX_VALUE,
+            powerOfTwoToPoolMap.put(i, new ConcurrentPool<>(INFINITE_SIZE,
                                                                          new ConcurrentPool.ItemFactory<ByteBuffer>() {
                                                                              @Override
                                                                              public ByteBuffer create() {

--- a/driver-core/src/main/com/mongodb/internal/session/ServerSessionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/session/ServerSessionPool.java
@@ -46,13 +46,14 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.mongodb.assertions.Assertions.isTrue;
+import static com.mongodb.internal.connection.ConcurrentPool.INFINITE_SIZE;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class ServerSessionPool {
     private static final int END_SESSIONS_BATCH_SIZE = 10000;
 
     private final ConcurrentPool<ServerSessionImpl> serverSessionPool =
-            new ConcurrentPool<ServerSessionImpl>(Integer.MAX_VALUE, new ServerSessionItemFactory());
+            new ConcurrentPool<>(INFINITE_SIZE, new ServerSessionItemFactory());
     private final Cluster cluster;
     private final ServerSessionPool.Clock clock;
     private volatile boolean closing;

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
@@ -244,6 +244,27 @@ public class DefaultConnectionPoolTest {
         assertTrue(connectionFactory.getCreatedConnections().get(0).isClosed());
     }
 
+    @Test
+    void infiniteMaxSize() {
+        int defaultMaxSize = ConnectionPoolSettings.builder().build().getMaxSize();
+        provider = new DefaultConnectionPool(SERVER_ID, connectionFactory,
+                ConnectionPoolSettings.builder().maxSize(0).build());
+        List<InternalConnection> connections = new ArrayList<>();
+        try {
+            for (int i = 0; i < 2 * defaultMaxSize; i++) {
+                connections.add(provider.get());
+            }
+        } finally {
+            connections.forEach(connection -> {
+                try {
+                    connection.close();
+                } catch (RuntimeException e) {
+                    // ignore
+                }
+            });
+        }
+    }
+
     @ParameterizedTest
     @MethodSource("concurrentUsageArguments")
     public void concurrentUsage(final int minSize, final int maxSize, final int concurrentUsersCount,

--- a/driver-core/src/test/unit/com/mongodb/connection/ConnectionPoolSettingsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ConnectionPoolSettingsSpecification.groovy
@@ -100,6 +100,12 @@ class ConnectionPoolSettingsSpecification extends Specification {
         thrown(IllegalStateException)
 
         when:
+        ConnectionPoolSettings.builder().maxSize(-1).build()
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
         ConnectionPoolSettings.builder().maintenanceInitialDelay(-1, MILLISECONDS).build()
 
         then:
@@ -204,5 +210,10 @@ class ConnectionPoolSettingsSpecification extends Specification {
         expect:
         ConnectionPoolSettings.builder().maxWaitTime(5, SECONDS).build().hashCode() !=
         ConnectionPoolSettings.builder().maxWaitTime(3, SECONDS).build().hashCode()
+    }
+
+    def 'should allow 0 (infinite) maxSize'() {
+        expect:
+        ConnectionPoolSettings.builder().maxSize(0).build().getMaxSize() == 0
     }
 }

--- a/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
@@ -1164,13 +1164,13 @@ public class MongoClientOptions {
         /**
          * Sets the maximum number of connections per host.
          *
-         * @param connectionsPerHost maximum number of connections
+         * @param connectionsPerHost the maximum size of the connection pool per host; if 0, then there is no limit.
          * @return {@code this}
-         * @throws IllegalArgumentException if {@code connectionsPerHost < 1}
+         * @throws IllegalArgumentException if {@code connectionsPerHost < 0}
          * @see MongoClientOptions#getConnectionsPerHost()
          */
         public Builder connectionsPerHost(final int connectionsPerHost) {
-            isTrueArgument("connectionPerHost must be > 0", connectionsPerHost > 0);
+            isTrueArgument("connectionPerHost must be >= 0", connectionsPerHost >= 0);
             this.maxConnectionsPerHost = connectionsPerHost;
             return this;
         }

--- a/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
@@ -303,7 +303,7 @@ public class MongoClientOptions {
      *
      * <p>Default is 100.</p>
      *
-     * @return the maximum size of the connection pool per host
+     * @return the maximum size of the connection pool per host; if 0, then there is no limit.
      */
     public int getConnectionsPerHost() {
         return maxConnectionsPerHost;

--- a/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
@@ -118,7 +118,7 @@ class MongoClientOptionsSpecification extends Specification {
         thrown(IllegalArgumentException)
 
         when:
-        builder.connectionsPerHost(0)
+        builder.connectionsPerHost(-1)
         then:
         thrown(IllegalArgumentException)
 
@@ -742,6 +742,11 @@ class MongoClientOptionsSpecification extends Specification {
 
         then:
         actual == expected
+    }
+
+    def 'should allow 0 (infinite) connectionsPerHost'() {
+        expect:
+        MongoClientOptions.builder().connectionsPerHost(0).build().getConnectionsPerHost() == 0
     }
 
     private static class MyDBEncoderFactory implements DBEncoderFactory {


### PR DESCRIPTION
See also JAVA-4160 and [CMAP Connection Pool Options]( https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-options-1).

JAVA-4216