### PR TITLE
Deprecate mapReduce

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/MapReduceAction.java
+++ b/driver-core/src/main/com/mongodb/client/model/MapReduceAction.java
@@ -27,7 +27,9 @@ package com.mongodb.client.model;
  * @since 3.0
  * @mongodb.driver.manual reference/command/mapReduce/ mapReduce Command
  * @mongodb.driver.manual core/map-reduce/ mapReduce Overview
+ * @deprecated Superseded by aggregate
  */
+@Deprecated
 public enum MapReduceAction {
     /**
      * Replace the contents of the {@code collectionName} if the collection with the {@code collectionName} exists.

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -36,7 +36,6 @@ import com.mongodb.client.model.IndexModel;
 import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.InsertOneModel;
 import com.mongodb.client.model.InsertOneOptions;
-import com.mongodb.client.model.MapReduceAction;
 import com.mongodb.client.model.RenameCollectionOptions;
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.ReplaceOptions;
@@ -239,11 +238,13 @@ public final class Operations<TDocument> {
                 .let(toBsonDocument(variables));
     }
 
+    @SuppressWarnings("deprecation")
     public MapReduceToCollectionOperation mapReduceToCollection(final String databaseName, final String collectionName,
                                                                 final String mapFunction, final String reduceFunction,
                                                                 final String finalizeFunction, final Bson filter, final int limit,
                                                                 final long maxTimeMS, final boolean jsMode, final Bson scope,
-                                                                final Bson sort, final boolean verbose, final MapReduceAction action,
+                                                                final Bson sort, final boolean verbose,
+                                                                final com.mongodb.client.model.MapReduceAction action,
                                                                 final boolean nonAtomic, final boolean sharded,
                                                                 final Boolean bypassDocumentValidation, final Collation collation) {
         MapReduceToCollectionOperation operation = new MapReduceToCollectionOperation(namespace, new BsonJavaScript(mapFunction),

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -34,7 +34,6 @@ import com.mongodb.client.model.FindOneAndUpdateOptions;
 import com.mongodb.client.model.IndexModel;
 import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.InsertOneOptions;
-import com.mongodb.client.model.MapReduceAction;
 import com.mongodb.client.model.RenameCollectionOptions;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.UpdateOptions;
@@ -129,11 +128,13 @@ public final class SyncOperations<TDocument> {
                 variables, aggregationLevel);
     }
 
+    @SuppressWarnings("deprecation")
     public WriteOperation<MapReduceStatistics> mapReduceToCollection(final String databaseName, final String collectionName,
                                                                      final String mapFunction, final String reduceFunction,
                                                                      final String finalizeFunction, final Bson filter, final int limit,
                                                                      final long maxTimeMS, final boolean jsMode, final Bson scope,
-                                                                     final Bson sort, final boolean verbose, final MapReduceAction action,
+                                                                     final Bson sort, final boolean verbose,
+                                                                     final com.mongodb.client.model.MapReduceAction action,
                                                                      final boolean nonAtomic, final boolean sharded,
                                                                      final Boolean bypassDocumentValidation, final Collation collation) {
         return operations.mapReduceToCollection(databaseName, collectionName, mapFunction, reduceFunction, finalizeFunction, filter, limit,

--- a/driver-legacy/src/main/com/mongodb/MapReduceCommand.java
+++ b/driver-legacy/src/main/com/mongodb/MapReduceCommand.java
@@ -28,7 +28,9 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * This class groups the argument for a map/reduce operation and can build the underlying command object
  *
  * @mongodb.driver.manual applications/map-reduce Map-Reduce
+ * @deprecated Superseded by aggregate
  */
+@Deprecated
 public class MapReduceCommand {
 
     private final String mapReduce;

--- a/driver-legacy/src/main/com/mongodb/MapReduceOutput.java
+++ b/driver-legacy/src/main/com/mongodb/MapReduceOutput.java
@@ -28,7 +28,9 @@ import java.util.List;
  * by interacting directly with the collection the results were input into.
  *
  * @mongodb.driver.manual applications/map-reduce Map-Reduce
+ * @deprecated Superseded by aggregate
  */
+@Deprecated
 public class MapReduceOutput {
 
     private final DBCollection collection;

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionTest.java
@@ -1288,6 +1288,7 @@ public class DBCollectionTest extends DatabaseTestCase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testBypassDocumentValidationForNonInlineMapReduce() {
         //given

--- a/driver-legacy/src/test/functional/com/mongodb/MapReduceTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/MapReduceTest.java
@@ -50,6 +50,7 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
+@SuppressWarnings("deprecation")
 public class MapReduceTest extends DatabaseTestCase {
 
     private static final String MR_DATABASE = "output-" + System.nanoTime();

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MapReducePublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MapReducePublisher.java
@@ -18,7 +18,6 @@ package com.mongodb.reactivestreams.client;
 
 
 import com.mongodb.client.model.Collation;
-import com.mongodb.client.model.MapReduceAction;
 import com.mongodb.lang.Nullable;
 import org.bson.conversions.Bson;
 import org.reactivestreams.Publisher;
@@ -30,7 +29,9 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <TResult> The type of the result.
  * @since 1.0
+ * @deprecated Superseded by aggregate
  */
+@Deprecated
 public interface MapReducePublisher<TResult> extends Publisher<TResult> {
 
     /**
@@ -123,7 +124,7 @@ public interface MapReducePublisher<TResult> extends Publisher<TResult> {
      * @param action an {@link com.mongodb.client.model.MapReduceAction} to perform on the collection
      * @return this
      */
-    MapReducePublisher<TResult> action(MapReduceAction action);
+    MapReducePublisher<TResult> action(com.mongodb.client.model.MapReduceAction action);
 
     /**
      * Sets the name of the database to output into.

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoCollection.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoCollection.java
@@ -601,7 +601,9 @@ public interface MongoCollection<TDocument> {
      * @param reduceFunction A JavaScript function that "reduces" to a single object all the values associated with a particular key.
      * @return an publisher containing the result of the map-reduce operation
      * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
+     * @deprecated Superseded by aggregate
      */
+    @Deprecated
     MapReducePublisher<TDocument> mapReduce(String mapFunction, String reduceFunction);
 
     /**
@@ -613,7 +615,9 @@ public interface MongoCollection<TDocument> {
      * @param <TResult>      the target document type of the iterable.
      * @return a publisher containing the result of the map-reduce operation
      * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
+     * @deprecated Superseded by aggregate
      */
+    @Deprecated
     <TResult> MapReducePublisher<TResult> mapReduce(String mapFunction, String reduceFunction, Class<TResult> clazz);
 
     /**
@@ -626,7 +630,9 @@ public interface MongoCollection<TDocument> {
      * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated Superseded by aggregate
      */
+    @Deprecated
     MapReducePublisher<TDocument> mapReduce(ClientSession clientSession, String mapFunction, String reduceFunction);
 
     /**
@@ -641,7 +647,9 @@ public interface MongoCollection<TDocument> {
      * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated Superseded by aggregate
      */
+    @Deprecated
     <TResult> MapReducePublisher<TResult> mapReduce(ClientSession clientSession, String mapFunction, String reduceFunction,
                                                     Class<TResult> clazz);
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MapReducePublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MapReducePublisherImpl.java
@@ -19,7 +19,6 @@ package com.mongodb.reactivestreams.client.internal;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
 import com.mongodb.client.model.Collation;
-import com.mongodb.client.model.MapReduceAction;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
@@ -31,7 +30,6 @@ import com.mongodb.internal.operation.MapReduceAsyncBatchCursor;
 import com.mongodb.internal.operation.MapReduceStatistics;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ClientSession;
-import com.mongodb.reactivestreams.client.MapReducePublisher;
 import org.bson.BsonDocument;
 import org.bson.conversions.Bson;
 import org.reactivestreams.Publisher;
@@ -41,7 +39,8 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.notNull;
 
-final class MapReducePublisherImpl<T> extends BatchCursorPublisher<T> implements MapReducePublisher<T> {
+@SuppressWarnings("deprecation")
+final class MapReducePublisherImpl<T> extends BatchCursorPublisher<T> implements com.mongodb.reactivestreams.client.MapReducePublisher<T> {
 
     private final String mapFunction;
     private final String reduceFunction;
@@ -56,7 +55,7 @@ final class MapReducePublisherImpl<T> extends BatchCursorPublisher<T> implements
     private boolean jsMode;
     private boolean verbose = true;
     private long maxTimeMS;
-    private MapReduceAction action = MapReduceAction.REPLACE;
+    private com.mongodb.client.model.MapReduceAction action = com.mongodb.client.model.MapReduceAction.REPLACE;
     private String databaseName;
     private boolean sharded;
     private boolean nonAtomic;
@@ -74,95 +73,96 @@ final class MapReducePublisherImpl<T> extends BatchCursorPublisher<T> implements
     }
 
     @Override
-    public MapReducePublisher<T> collectionName(final String collectionName) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> collectionName(final String collectionName) {
         this.collectionName = notNull("collectionName", collectionName);
         this.inline = false;
         return this;
     }
 
     @Override
-    public MapReducePublisher<T> finalizeFunction(@Nullable final String finalizeFunction) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> finalizeFunction(@Nullable final String finalizeFunction) {
         this.finalizeFunction = finalizeFunction;
         return this;
     }
 
     @Override
-    public MapReducePublisher<T> scope(@Nullable final Bson scope) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> scope(@Nullable final Bson scope) {
         this.scope = scope;
         return this;
     }
 
     @Override
-    public MapReducePublisher<T> sort(@Nullable final Bson sort) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> sort(@Nullable final Bson sort) {
         this.sort = sort;
         return this;
     }
 
     @Override
-    public MapReducePublisher<T> filter(@Nullable final Bson filter) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> filter(@Nullable final Bson filter) {
         this.filter = filter;
         return this;
     }
 
     @Override
-    public MapReducePublisher<T> limit(final int limit) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> limit(final int limit) {
         this.limit = limit;
         return this;
     }
 
     @Override
-    public MapReducePublisher<T> jsMode(final boolean jsMode) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> jsMode(final boolean jsMode) {
         this.jsMode = jsMode;
         return this;
     }
 
     @Override
-    public MapReducePublisher<T> verbose(final boolean verbose) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> verbose(final boolean verbose) {
         this.verbose = verbose;
         return this;
     }
 
     @Override
-    public MapReducePublisher<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public MapReducePublisher<T> action(final MapReduceAction action) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> action(final com.mongodb.client.model.MapReduceAction action) {
         this.action = action;
         return this;
     }
 
     @Override
-    public MapReducePublisher<T> databaseName(@Nullable final String databaseName) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> databaseName(@Nullable final String databaseName) {
         this.databaseName = databaseName;
         return this;
     }
 
     @Deprecated
     @Override
-    public MapReducePublisher<T> sharded(final boolean sharded) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> sharded(final boolean sharded) {
         this.sharded = sharded;
         return this;
     }
 
     @Deprecated
     @Override
-    public MapReducePublisher<T> nonAtomic(final boolean nonAtomic) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> nonAtomic(final boolean nonAtomic) {
         this.nonAtomic = nonAtomic;
         return this;
     }
 
     @Override
-    public MapReducePublisher<T> batchSize(final int batchSize) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> batchSize(final int batchSize) {
         super.batchSize(batchSize);
         return this;
     }
 
     @Override
-    public MapReducePublisher<T> bypassDocumentValidation(@Nullable final Boolean bypassDocumentValidation) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> bypassDocumentValidation(
+            @Nullable final Boolean bypassDocumentValidation) {
         this.bypassDocumentValidation = bypassDocumentValidation;
         return this;
     }
@@ -176,7 +176,7 @@ final class MapReducePublisherImpl<T> extends BatchCursorPublisher<T> implements
     }
 
     @Override
-    public MapReducePublisher<T> collation(@Nullable final Collation collation) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> collation(@Nullable final Collation collation) {
         this.collation = collation;
         return this;
     }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoCollectionImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoCollectionImpl.java
@@ -50,7 +50,6 @@ import com.mongodb.reactivestreams.client.ClientSession;
 import com.mongodb.reactivestreams.client.DistinctPublisher;
 import com.mongodb.reactivestreams.client.FindPublisher;
 import com.mongodb.reactivestreams.client.ListIndexesPublisher;
-import com.mongodb.reactivestreams.client.MapReducePublisher;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import org.bson.BsonDocument;
 import org.bson.Document;
@@ -300,27 +299,31 @@ final class MongoCollectionImpl<T> implements MongoCollection<T> {
                                                pipeline, ChangeStreamLevel.COLLECTION);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
-    public MapReducePublisher<T> mapReduce(final String mapFunction, final String reduceFunction) {
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> mapReduce(final String mapFunction, final String reduceFunction) {
         return mapReduce(mapFunction, reduceFunction, getDocumentClass());
     }
 
+    @SuppressWarnings("deprecation")
     @Override
-    public <TResult> MapReducePublisher<TResult> mapReduce(final String mapFunction, final String reduceFunction,
-                                                           final Class<TResult> resultClass) {
+    public <TResult> com.mongodb.reactivestreams.client.MapReducePublisher<TResult> mapReduce(final String mapFunction,
+            final String reduceFunction, final Class<TResult> resultClass) {
         return new MapReducePublisherImpl<>(null, mongoOperationPublisher.withDocumentClass(resultClass), mapFunction,
                                             reduceFunction);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
-    public MapReducePublisher<T> mapReduce(final ClientSession clientSession, final String mapFunction,
+    public com.mongodb.reactivestreams.client.MapReducePublisher<T> mapReduce(final ClientSession clientSession, final String mapFunction,
                                            final String reduceFunction) {
         return mapReduce(clientSession, mapFunction, reduceFunction, getDocumentClass());
     }
 
+    @SuppressWarnings("deprecation")
     @Override
-    public <TResult> MapReducePublisher<TResult> mapReduce(final ClientSession clientSession, final String mapFunction,
-                                                           final String reduceFunction, final Class<TResult> resultClass) {
+    public <TResult> com.mongodb.reactivestreams.client.MapReducePublisher<TResult> mapReduce(final ClientSession clientSession,
+            final String mapFunction, final String reduceFunction, final Class<TResult> resultClass) {
         return new MapReducePublisherImpl<>(notNull("clientSession", clientSession),
                                             mongoOperationPublisher.withDocumentClass(resultClass), mapFunction, reduceFunction);
     }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/BatchCursorPublisherErrorTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/BatchCursorPublisherErrorTest.java
@@ -65,6 +65,7 @@ public class BatchCursorPublisherErrorTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @TestFactory
     @DisplayName("test batch cursors close the cursor if onNext throws an error")
     List<DynamicTest> testBatchCursorThrowsAnError() {

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMapReduceIterable.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMapReduceIterable.java
@@ -16,11 +16,8 @@
 
 package com.mongodb.reactivestreams.client.syncadapter;
 
-import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.model.Collation;
-import com.mongodb.client.model.MapReduceAction;
 import com.mongodb.lang.Nullable;
-import com.mongodb.reactivestreams.client.MapReducePublisher;
 import org.bson.conversions.Bson;
 import reactor.core.publisher.Mono;
 
@@ -29,10 +26,10 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
 
 @SuppressWarnings("deprecation")
-class SyncMapReduceIterable<T> extends SyncMongoIterable<T> implements MapReduceIterable<T> {
-    private final MapReducePublisher<T> wrapped;
+class SyncMapReduceIterable<T> extends SyncMongoIterable<T> implements com.mongodb.client.MapReduceIterable<T> {
+    private final com.mongodb.reactivestreams.client.MapReducePublisher<T> wrapped;
 
-    SyncMapReduceIterable(final MapReducePublisher<T> wrapped) {
+    SyncMapReduceIterable(final com.mongodb.reactivestreams.client.MapReducePublisher<T> wrapped) {
         super(wrapped);
         this.wrapped = wrapped;
     }
@@ -43,98 +40,98 @@ class SyncMapReduceIterable<T> extends SyncMongoIterable<T> implements MapReduce
     }
 
     @Override
-    public MapReduceIterable<T> collectionName(final String collectionName) {
+    public com.mongodb.client.MapReduceIterable<T> collectionName(final String collectionName) {
         wrapped.collectionName(collectionName);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> finalizeFunction(@Nullable final String finalizeFunction) {
+    public com.mongodb.client.MapReduceIterable<T> finalizeFunction(@Nullable final String finalizeFunction) {
         wrapped.finalizeFunction(finalizeFunction);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> scope(@Nullable final Bson scope) {
+    public com.mongodb.client.MapReduceIterable<T> scope(@Nullable final Bson scope) {
         wrapped.scope(scope);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> sort(@Nullable final Bson sort) {
+    public com.mongodb.client.MapReduceIterable<T> sort(@Nullable final Bson sort) {
         wrapped.sort(sort);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> filter(@Nullable final Bson filter) {
+    public com.mongodb.client.MapReduceIterable<T> filter(@Nullable final Bson filter) {
         wrapped.filter(filter);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> limit(final int limit) {
+    public com.mongodb.client.MapReduceIterable<T> limit(final int limit) {
         wrapped.limit(limit);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> jsMode(final boolean jsMode) {
+    public com.mongodb.client.MapReduceIterable<T> jsMode(final boolean jsMode) {
         wrapped.jsMode(jsMode);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> verbose(final boolean verbose) {
+    public com.mongodb.client.MapReduceIterable<T> verbose(final boolean verbose) {
         wrapped.verbose(verbose);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public com.mongodb.client.MapReduceIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
         wrapped.maxTime(maxTime, timeUnit);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> action(final MapReduceAction action) {
+    public com.mongodb.client.MapReduceIterable<T> action(final com.mongodb.client.model.MapReduceAction action) {
         wrapped.action(action);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> databaseName(@Nullable final String databaseName) {
+    public com.mongodb.client.MapReduceIterable<T> databaseName(@Nullable final String databaseName) {
         wrapped.databaseName(databaseName);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> sharded(final boolean sharded) {
+    public com.mongodb.client.MapReduceIterable<T> sharded(final boolean sharded) {
         wrapped.sharded(sharded);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> nonAtomic(final boolean nonAtomic) {
+    public com.mongodb.client.MapReduceIterable<T> nonAtomic(final boolean nonAtomic) {
         wrapped.nonAtomic(nonAtomic);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> batchSize(final int batchSize) {
+    public com.mongodb.client.MapReduceIterable<T> batchSize(final int batchSize) {
         wrapped.batchSize(batchSize);
         super.batchSize(batchSize);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> bypassDocumentValidation(@Nullable final Boolean bypassDocumentValidation) {
+    public com.mongodb.client.MapReduceIterable<T> bypassDocumentValidation(@Nullable final Boolean bypassDocumentValidation) {
         wrapped.bypassDocumentValidation(bypassDocumentValidation);
         return this;
     }
 
     @Override
-    public MapReduceIterable<T> collation(@Nullable final Collation collation) {
+    public com.mongodb.client.MapReduceIterable<T> collation(@Nullable final Collation collation) {
         wrapped.collation(collation);
         return this;
     }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCollection.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCollection.java
@@ -27,7 +27,6 @@ import com.mongodb.client.ClientSession;
 import com.mongodb.client.DistinctIterable;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.ListIndexesIterable;
-import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.CountOptions;
@@ -293,25 +292,30 @@ class SyncMongoCollection<T> implements MongoCollection<T> {
     }
 
     @Override
-    public MapReduceIterable<T> mapReduce(final String mapFunction, final String reduceFunction) {
+    @SuppressWarnings("deprecation")
+    public com.mongodb.client.MapReduceIterable<T> mapReduce(final String mapFunction, final String reduceFunction) {
         return new SyncMapReduceIterable<>(wrapped.mapReduce(mapFunction, reduceFunction, wrapped.getDocumentClass()));
     }
 
     @Override
-    public <TResult> MapReduceIterable<TResult> mapReduce(
+    @SuppressWarnings("deprecation")
+    public <TResult> com.mongodb.client.MapReduceIterable<TResult> mapReduce(
             final String mapFunction, final String reduceFunction,
             final Class<TResult> resultClass) {
         return new SyncMapReduceIterable<>(wrapped.mapReduce(mapFunction, reduceFunction, resultClass));
     }
 
     @Override
-    public MapReduceIterable<T> mapReduce(final ClientSession clientSession, final String mapFunction, final String reduceFunction) {
+    @SuppressWarnings("deprecation")
+    public com.mongodb.client.MapReduceIterable<T> mapReduce(final ClientSession clientSession, final String mapFunction,
+            final String reduceFunction) {
         return new SyncMapReduceIterable<>(wrapped.mapReduce(unwrap(clientSession), mapFunction, reduceFunction,
                                                              wrapped.getDocumentClass()));
     }
 
     @Override
-    public <TResult> MapReduceIterable<TResult> mapReduce(
+    @SuppressWarnings("deprecation")
+    public <TResult> com.mongodb.client.MapReduceIterable<TResult> mapReduce(
             final ClientSession clientSession, final String mapFunction,
             final String reduceFunction, final Class<TResult> resultClass) {
         return new SyncMapReduceIterable<>(wrapped.mapReduce(unwrap(clientSession), mapFunction, reduceFunction, resultClass));

--- a/driver-reactive-streams/src/test/tck/com/mongodb/reactivestreams/client/MapReducePublisherVerification.java
+++ b/driver-reactive-streams/src/test/tck/com/mongodb/reactivestreams/client/MapReducePublisherVerification.java
@@ -35,7 +35,7 @@ public class MapReducePublisherVerification extends PublisherVerification<Docume
         super(new TestEnvironment(DEFAULT_TIMEOUT_MILLIS), PUBLISHER_REFERENCE_CLEANUP_TIMEOUT_MILLIS);
     }
 
-
+    @SuppressWarnings("deprecation")
     @Override
     public Publisher<Document> createPublisher(final long elements) {
         assert (elements <= maxElementsFromPublisher());

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/PublisherApiTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/PublisherApiTest.java
@@ -25,7 +25,6 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.ListCollectionsIterable;
 import com.mongodb.client.ListDatabasesIterable;
 import com.mongodb.client.ListIndexesIterable;
-import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.gridfs.GridFSFindIterable;
 import com.mongodb.reactivestreams.client.gridfs.GridFSBuckets;
@@ -46,6 +45,7 @@ import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 public class PublisherApiTest {
 
+    @SuppressWarnings("deprecation")
     @TestFactory
     @DisplayName("test that publisher apis matches sync")
     List<DynamicTest> testPublisherApiMatchesSyncApi() {
@@ -61,7 +61,7 @@ public class PublisherApiTest {
                 dynamicTest("List Collections Api", () -> assertApis(ListCollectionsIterable.class, ListCollectionsPublisher.class)),
                 dynamicTest("List Databases Api", () -> assertApis(ListDatabasesIterable.class, ListDatabasesPublisher.class)),
                 dynamicTest("List Indexes Api", () -> assertApis(ListIndexesIterable.class, ListIndexesPublisher.class)),
-                dynamicTest("Map Reduce Api", () -> assertApis(MapReduceIterable.class, MapReducePublisher.class)),
+                dynamicTest("Map Reduce Api", () -> assertApis(com.mongodb.client.MapReduceIterable.class, MapReducePublisher.class)),
                 dynamicTest("GridFS Buckets Api", () -> assertApis(com.mongodb.client.gridfs.GridFSBuckets.class, GridFSBuckets.class)),
                 dynamicTest("GridFS Find Api", () -> assertApis(GridFSFindIterable.class, GridFSFindPublisher.class))
         );

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MapReducePublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MapReducePublisherImplTest.java
@@ -23,7 +23,6 @@ import com.mongodb.client.model.Sorts;
 import com.mongodb.internal.operation.MapReduceStatistics;
 import com.mongodb.internal.operation.MapReduceToCollectionOperation;
 import com.mongodb.internal.operation.MapReduceWithInlineResultsOperation;
-import com.mongodb.reactivestreams.client.MapReducePublisher;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonJavaScript;
@@ -42,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SuppressWarnings({"rawtypes"})
+@SuppressWarnings({"rawtypes", "deprecation"})
 public class MapReducePublisherImplTest extends TestHelper {
 
     private static final String MAP_FUNCTION = "mapFunction(){}";
@@ -55,7 +54,7 @@ public class MapReducePublisherImplTest extends TestHelper {
         configureBatchCursor();
 
         TestOperationExecutor executor = createOperationExecutor(asList(getBatchCursor(), getBatchCursor()));
-        MapReducePublisher<Document> publisher =
+        com.mongodb.reactivestreams.client.MapReducePublisher<Document> publisher =
                 new MapReducePublisherImpl<>(null, createMongoOperationPublisher(executor), MAP_FUNCTION, REDUCE_FUNCTION);
 
         MapReduceWithInlineResultsOperation<Document> expectedOperation =
@@ -110,7 +109,7 @@ public class MapReducePublisherImplTest extends TestHelper {
         MapReduceStatistics stats = Mockito.mock(MapReduceStatistics.class);
 
         TestOperationExecutor executor = createOperationExecutor(asList(stats, stats));
-        MapReducePublisher<Document> publisher =
+        com.mongodb.reactivestreams.client.MapReducePublisher<Document> publisher =
                 new MapReducePublisherImpl<>(null, createMongoOperationPublisher(executor), MAP_FUNCTION, REDUCE_FUNCTION)
                         .collectionName(NAMESPACE.getCollectionName());
 
@@ -159,7 +158,7 @@ public class MapReducePublisherImplTest extends TestHelper {
         TestOperationExecutor executor = createOperationExecutor(asList(new MongoException("Failure"), null, null));
 
         // Operation fails
-        MapReducePublisher<Document> publisher =
+        com.mongodb.reactivestreams.client.MapReducePublisher<Document> publisher =
                 new MapReducePublisherImpl<>(null, createMongoOperationPublisher(executor), MAP_FUNCTION, REDUCE_FUNCTION);
         assertThrows(MongoException.class, () -> Flux.from(publisher).blockFirst());
 

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoCollectionImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoCollectionImplTest.java
@@ -51,7 +51,6 @@ import com.mongodb.reactivestreams.client.ClientSession;
 import com.mongodb.reactivestreams.client.DistinctPublisher;
 import com.mongodb.reactivestreams.client.FindPublisher;
 import com.mongodb.reactivestreams.client.ListIndexesPublisher;
-import com.mongodb.reactivestreams.client.MapReducePublisher;
 import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.conversions.Bson;
@@ -807,6 +806,7 @@ public class MongoCollectionImplTest extends TestHelper {
         );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMapReduce() {
         String map = "map";
@@ -828,24 +828,24 @@ public class MongoCollectionImplTest extends TestHelper {
                                                      () -> collection.mapReduce(null, map, reduce, Document.class))
                   ),
                   () -> {
-                      MapReducePublisher<Document> expected =
+                      com.mongodb.reactivestreams.client.MapReducePublisher<Document> expected =
                               new MapReducePublisherImpl<>(null, mongoOperationPublisher, map, reduce);
                       assertPublisherIsTheSameAs(expected, collection.mapReduce(map, reduce), "Default");
                   },
                   () -> {
-                      MapReducePublisher<BsonDocument> expected =
+                      com.mongodb.reactivestreams.client.MapReducePublisher<BsonDocument> expected =
                               new MapReducePublisherImpl<>(null, mongoOperationPublisher.withDocumentClass(BsonDocument.class),
                                                            map, reduce);
                       assertPublisherIsTheSameAs(expected, collection.mapReduce(map, reduce, BsonDocument.class),
                                                  "With result class");
                   },
                   () -> {
-                      MapReducePublisher<Document> expected =
+                      com.mongodb.reactivestreams.client.MapReducePublisher<Document> expected =
                               new MapReducePublisherImpl<>(clientSession, mongoOperationPublisher, map, reduce);
                       assertPublisherIsTheSameAs(expected, collection.mapReduce(clientSession, map, reduce), "With client session");
                   },
                   () -> {
-                      MapReducePublisher<BsonDocument> expected =
+                      com.mongodb.reactivestreams.client.MapReducePublisher<BsonDocument> expected =
                               new MapReducePublisherImpl<>(clientSession, mongoOperationPublisher.withDocumentClass(BsonDocument.class),
                                                            map, reduce);
                       assertPublisherIsTheSameAs(expected, collection.mapReduce(clientSession, map, reduce, BsonDocument.class),

--- a/driver-scala/src/main/scala/org/mongodb/scala/MapReduceObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MapReduceObservable.scala
@@ -33,6 +33,7 @@ import scala.concurrent.duration.Duration
  * @tparam TResult The type of the result.
  * @since 1.0
  */
+@deprecated("Superseded by aggregate")
 case class MapReduceObservable[TResult](wrapped: MapReducePublisher[TResult]) extends Observable[TResult] {
 
   /**

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoCollection.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoCollection.scala
@@ -451,6 +451,7 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    * @return a Observable containing the result of the map-reduce operation
    *         [[http://docs.mongodb.org/manual/reference/command/mapReduce/ map-reduce]]
    */
+  @deprecated("Superseded by aggregate")
   def mapReduce[C](
       mapFunction: String,
       reduceFunction: String
@@ -469,6 +470,7 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    * @since 2.2
    * @note Requires MongoDB 3.6 or greater
    */
+  @deprecated("Superseded by aggregate")
   def mapReduce[C](clientSession: ClientSession, mapFunction: String, reduceFunction: String)(
       implicit
       e: C DefaultsTo TResult,

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/MapReduceAction.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/MapReduceAction.scala
@@ -26,6 +26,7 @@ import com.mongodb.client.model.{ MapReduceAction => JMapReduceAction }
  *
  * @since 1.0
  */
+@deprecated("Superseded by aggregate")
 object MapReduceAction {
 
   /**

--- a/driver-sync/src/main/com/mongodb/client/MapReduceIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/MapReduceIterable.java
@@ -17,7 +17,6 @@
 package com.mongodb.client;
 
 import com.mongodb.client.model.Collation;
-import com.mongodb.client.model.MapReduceAction;
 import com.mongodb.lang.Nullable;
 import org.bson.conversions.Bson;
 
@@ -31,7 +30,9 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <TResult> The type of the result.
  * @since 3.0
+ * @deprecated Superseded by aggregate
  */
+@Deprecated
 public interface MapReduceIterable<TResult> extends MongoIterable<TResult> {
 
     /**
@@ -131,10 +132,11 @@ public interface MapReduceIterable<TResult> extends MongoIterable<TResult> {
     /**
      * Specify the {@code MapReduceAction} to be used when writing to a collection.
      *
-     * @param action an {@link MapReduceAction} to perform on the collection
+     * @param action an {@link com.mongodb.client.model.MapReduceAction} to perform on the collection
      * @return this
      */
-    MapReduceIterable<TResult> action(MapReduceAction action);
+    @SuppressWarnings("deprecation")
+    MapReduceIterable<TResult> action(com.mongodb.client.model.MapReduceAction action);
 
     /**
      * Sets the name of the database to output into.

--- a/driver-sync/src/main/com/mongodb/client/MongoCollection.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoCollection.java
@@ -620,7 +620,9 @@ public interface MongoCollection<TDocument> {
      * @param reduceFunction A JavaScript function that "reduces" to a single object all the values associated with a particular key.
      * @return an iterable containing the result of the map-reduce operation
      * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
+     * @deprecated Superseded by aggregate
      */
+    @Deprecated
     MapReduceIterable<TDocument> mapReduce(String mapFunction, String reduceFunction);
 
     /**
@@ -632,7 +634,9 @@ public interface MongoCollection<TDocument> {
      * @param <TResult>      the target document type of the iterable.
      * @return an iterable containing the result of the map-reduce operation
      * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
+     * @deprecated Superseded by aggregate
      */
+    @Deprecated
     <TResult> MapReduceIterable<TResult> mapReduce(String mapFunction, String reduceFunction, Class<TResult> resultClass);
 
     /**
@@ -645,7 +649,9 @@ public interface MongoCollection<TDocument> {
      * @since 3.6
      * @mongodb.server.release 3.6
      * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
+     * @deprecated Superseded by aggregate
      */
+    @Deprecated
     MapReduceIterable<TDocument> mapReduce(ClientSession clientSession, String mapFunction, String reduceFunction);
 
     /**
@@ -660,7 +666,9 @@ public interface MongoCollection<TDocument> {
      * @since 3.6
      * @mongodb.server.release 3.6
      * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
+     * @deprecated Superseded by aggregate
      */
+    @Deprecated
     <TResult> MapReduceIterable<TResult> mapReduce(ClientSession clientSession, String mapFunction, String reduceFunction,
                                                    Class<TResult> resultClass);
 

--- a/driver-sync/src/main/com/mongodb/client/internal/MapReduceIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MapReduceIterableImpl.java
@@ -59,7 +59,6 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     private boolean jsMode;
     private boolean verbose = true;
     private long maxTimeMS;
-    @SuppressWarnings("deprecation")
     private com.mongodb.client.model.MapReduceAction action = com.mongodb.client.model.MapReduceAction.REPLACE;
     private String databaseName;
     private boolean sharded;
@@ -145,7 +144,6 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
         return this;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public com.mongodb.client.MapReduceIterable<TResult> action(final com.mongodb.client.model.MapReduceAction action) {
         this.action = action;

--- a/driver-sync/src/main/com/mongodb/client/internal/MapReduceIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MapReduceIterableImpl.java
@@ -21,9 +21,7 @@ import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.ClientSession;
-import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.model.Collation;
-import com.mongodb.client.model.MapReduceAction;
 import com.mongodb.internal.binding.ReadBinding;
 import com.mongodb.internal.client.model.FindOptions;
 import com.mongodb.internal.operation.BatchCursor;
@@ -43,7 +41,8 @@ import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.notNull;
 
 @SuppressWarnings("deprecation")
-class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> implements MapReduceIterable<TResult> {
+class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult>
+        implements com.mongodb.client.MapReduceIterable<TResult> {
     private final SyncOperations<TDocument> operations;
     private final MongoNamespace namespace;
     private final Class<TResult> resultClass;
@@ -60,7 +59,8 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     private boolean jsMode;
     private boolean verbose = true;
     private long maxTimeMS;
-    private MapReduceAction action = MapReduceAction.REPLACE;
+    @SuppressWarnings("deprecation")
+    private com.mongodb.client.model.MapReduceAction action = com.mongodb.client.model.MapReduceAction.REPLACE;
     private String databaseName;
     private boolean sharded;
     private boolean nonAtomic;
@@ -90,99 +90,100 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     }
 
     @Override
-    public MapReduceIterable<TResult> collectionName(final String collectionName) {
+    public com.mongodb.client.MapReduceIterable<TResult> collectionName(final String collectionName) {
         this.collectionName = notNull("collectionName", collectionName);
         this.inline = false;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> finalizeFunction(@Nullable final String finalizeFunction) {
+    public com.mongodb.client.MapReduceIterable<TResult> finalizeFunction(@Nullable final String finalizeFunction) {
         this.finalizeFunction = finalizeFunction;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> scope(@Nullable final Bson scope) {
+    public com.mongodb.client.MapReduceIterable<TResult> scope(@Nullable final Bson scope) {
         this.scope = scope;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> sort(@Nullable final Bson sort) {
+    public com.mongodb.client.MapReduceIterable<TResult> sort(@Nullable final Bson sort) {
         this.sort = sort;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> filter(@Nullable final Bson filter) {
+    public com.mongodb.client.MapReduceIterable<TResult> filter(@Nullable final Bson filter) {
         this.filter = filter;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> limit(final int limit) {
+    public com.mongodb.client.MapReduceIterable<TResult> limit(final int limit) {
         this.limit = limit;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> jsMode(final boolean jsMode) {
+    public com.mongodb.client.MapReduceIterable<TResult> jsMode(final boolean jsMode) {
         this.jsMode = jsMode;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> verbose(final boolean verbose) {
+    public com.mongodb.client.MapReduceIterable<TResult> verbose(final boolean verbose) {
         this.verbose = verbose;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
+    public com.mongodb.client.MapReduceIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
-    public MapReduceIterable<TResult> action(final MapReduceAction action) {
+    public com.mongodb.client.MapReduceIterable<TResult> action(final com.mongodb.client.model.MapReduceAction action) {
         this.action = action;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> databaseName(@Nullable final String databaseName) {
+    public com.mongodb.client.MapReduceIterable<TResult> databaseName(@Nullable final String databaseName) {
         this.databaseName = databaseName;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> sharded(final boolean sharded) {
+    public com.mongodb.client.MapReduceIterable<TResult> sharded(final boolean sharded) {
         this.sharded = sharded;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> nonAtomic(final boolean nonAtomic) {
+    public com.mongodb.client.MapReduceIterable<TResult> nonAtomic(final boolean nonAtomic) {
         this.nonAtomic = nonAtomic;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> batchSize(final int batchSize) {
+    public com.mongodb.client.MapReduceIterable<TResult> batchSize(final int batchSize) {
         super.batchSize(batchSize);
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> bypassDocumentValidation(@Nullable final Boolean bypassDocumentValidation) {
+    public com.mongodb.client.MapReduceIterable<TResult> bypassDocumentValidation(@Nullable final Boolean bypassDocumentValidation) {
         this.bypassDocumentValidation = bypassDocumentValidation;
         return this;
     }
 
     @Override
-    public MapReduceIterable<TResult> collation(@Nullable final Collation collation) {
+    public com.mongodb.client.MapReduceIterable<TResult> collation(@Nullable final Collation collation) {
         this.collation = collation;
         return this;
     }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
@@ -34,7 +34,6 @@ import com.mongodb.client.ClientSession;
 import com.mongodb.client.DistinctIterable;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.ListIndexesIterable;
-import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.result.InsertManyResult;
 import com.mongodb.client.result.InsertOneResult;
@@ -378,31 +377,36 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                 pipeline, resultClass, ChangeStreamLevel.COLLECTION, retryReads);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
-    public MapReduceIterable<TDocument> mapReduce(final String mapFunction, final String reduceFunction) {
+    public com.mongodb.client.MapReduceIterable<TDocument> mapReduce(final String mapFunction, final String reduceFunction) {
         return mapReduce(mapFunction, reduceFunction, documentClass);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
-    public <TResult> MapReduceIterable<TResult> mapReduce(final String mapFunction, final String reduceFunction,
+    public <TResult> com.mongodb.client.MapReduceIterable<TResult> mapReduce(final String mapFunction, final String reduceFunction,
                                                           final Class<TResult> resultClass) {
         return createMapReduceIterable(null, mapFunction, reduceFunction, resultClass);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
-    public MapReduceIterable<TDocument> mapReduce(final ClientSession clientSession, final String mapFunction,
+    public com.mongodb.client.MapReduceIterable<TDocument> mapReduce(final ClientSession clientSession, final String mapFunction,
                                                   final String reduceFunction) {
         return mapReduce(clientSession, mapFunction, reduceFunction, documentClass);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
-    public <TResult> MapReduceIterable<TResult> mapReduce(final ClientSession clientSession, final String mapFunction,
+    public <TResult> com.mongodb.client.MapReduceIterable<TResult> mapReduce(final ClientSession clientSession, final String mapFunction,
                                                           final String reduceFunction, final Class<TResult> resultClass) {
         notNull("clientSession", clientSession);
         return createMapReduceIterable(clientSession, mapFunction, reduceFunction, resultClass);
     }
 
-    private <TResult> MapReduceIterable<TResult> createMapReduceIterable(@Nullable final ClientSession clientSession,
+    @SuppressWarnings("deprecation")
+    private <TResult> com.mongodb.client.MapReduceIterable<TResult> createMapReduceIterable(@Nullable final ClientSession clientSession,
                                                                          final String mapFunction, final String reduceFunction,
                                                                          final Class<TResult> resultClass) {
         return new MapReduceIterableImpl<>(clientSession, namespace, documentClass, resultClass, codecRegistry,

--- a/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
@@ -552,6 +552,7 @@ public class JsonPoweredCrudTestHelper {
         return iterable;
     }
 
+    @SuppressWarnings("deprecation")
     BsonDocument getMapReduceResult(final BsonDocument collectionOptions, final BsonDocument arguments,
                                     @Nullable final ClientSession clientSession) {
         MapReduceIterable<BsonDocument> iterable;

--- a/driver-sync/src/test/functional/com/mongodb/client/MongoCollectionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/MongoCollectionTest.java
@@ -142,6 +142,7 @@ public class MongoCollectionTest extends DatabaseTestCase {
         assertThat(listOfObjectIds.get(0), is(firstItem.getId()));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMapReduceWithGenerics() {
         assumeFalse(isServerlessTest());


### PR DESCRIPTION
Deprecate all public API related to the mapReduce command, which has been
deprecated in MongoDB server as superseded by the aggregate command.

See https://docs.mongodb.com/manual/reference/command/mapReduce/ for more
information.

JAVA-4235