### PR TITLE
POC for Atlas search builder API

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -551,6 +551,16 @@ functions:
           ${PREPARE_SHELL}
           JDK=${JDK} .evergreen/run-atlas-data-lake-test.sh
 
+  "run atlas search test":
+    - command: shell.exec
+      type: test
+      params:
+        silent: true
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          MONGODB_ATLAS_SEARCH_URI="${atlas_search_uri}" .evergreen/run-atlas-search-tests.sh
+
   "run-ocsp-test":
     - command: shell.exec
       type: test
@@ -1260,6 +1270,11 @@ tasks:
         - func: "bootstrap mongohoused"
         - func: "run atlas data lake test"
 
+    - name: "atlas-search-test"
+      commands:
+        - func: "bootstrap mongo-orchestration"
+        - func: "run atlas search test"
+
     - name: "gssapi-auth-test"
       commands:
         - func: "run gssapi auth test"
@@ -1731,3 +1746,9 @@ buildvariants:
   display_name: "CSFLE KMS TLS"
   tasks:
     - name: ".kms-tls"
+
+- matrix_name: "atlas-search-test"
+  matrix_spec: { os: "linux", version: [ "5.0" ], topology: ["standalone"] }
+  display_name: "Atlas Search Test"
+  tasks:
+    - name: "atlas-search-test"

--- a/.evergreen/run-atlas-search-tests.sh
+++ b/.evergreen/run-atlas-search-tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Don't trace since the URI contains a password that shouldn't show up in the logs
+set -o errexit  # Exit the script with error if any of the commands fail
+
+# Supported/used environment variables:
+#       MONGODB_ATLAS_SEARCH_URI                 Set the connection to an Atlas cluster
+
+############################################
+#            Main Program                  #
+############################################
+
+echo "Running Atlas search tests"
+
+export JAVA_HOME="/opt/java/jdk11"
+
+./gradlew -version
+
+./gradlew --stacktrace --info -Dorg.mongodb.test.search.uri=${MONGODB_ATLAS_SEARCH_URI} driver-core:test --tests SearchOperatorsIntegrationTest

--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -18,6 +18,7 @@ package com.mongodb.client.model;
 
 import com.mongodb.MongoNamespace;
 import com.mongodb.annotations.Beta;
+import com.mongodb.client.model.search.SearchOperator;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -648,6 +649,22 @@ public final class Aggregates {
                                                      final List<WindowedComputation> output) {
         notNull("output", output);
         return new SetWindowFieldsStage<>(partitionBy, sortBy, output);
+    }
+
+    /**
+     * Creates a {@code $search} pipeline stage, for use with Atlas search.
+     *
+     * <p>
+     * The $search stage performs a full-text search on the specified field or fields, which must be covered by an Atlas Search index.
+     * </p>
+     *
+     * @return The {@code $search} pipeline stage
+     * @since 4.4
+     * @mongodb.driver.manual.atlas reference/atlas-search/searching/
+     * @mongodb.driver.manual.atlas reference/atlas-search/query-syntax/
+     */
+    public static Bson search(SearchOperator searchOperator) {
+        return new SimplePipelineStage("$search", searchOperator);
     }
 
     static void writeBucketOutput(final CodecRegistry codecRegistry, final BsonDocumentWriter writer,

--- a/driver-core/src/main/com/mongodb/client/model/search/AutoCompleteSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/AutoCompleteSearchOperator.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import java.util.List;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+@Immutable
+public final class AutoCompleteSearchOperator extends SearchOperator {
+
+    public enum TokenOrder {
+        ANY("any"),
+
+        SEQUENTIAL("sequential");
+
+        private final String key;
+
+        TokenOrder(final String key) {
+            this.key = key;
+        }
+    }
+
+    private final List<String> query;
+    private final List<SearchPath> path;
+    private final TokenOrder tokenOrder;
+    private final Fuzzy fuzzy;
+    private final SearchScore score;
+
+    AutoCompleteSearchOperator(final List<String> query, final List<SearchPath> path, @Nullable final TokenOrder tokenOrder,
+            @Nullable final Fuzzy fuzzy, @Nullable final SearchScore score, @Nullable final String index) {
+        super(index);
+        this.query = notNull("query", query);
+        this.path = notNull("path", path);
+        this.tokenOrder = tokenOrder;
+        this.fuzzy = fuzzy;
+        this.score = score;
+    }
+
+    public List<String> getQuery() {
+        return query;
+    }
+
+    public List<SearchPath> getPath() {
+        return path;
+    }
+
+    @Nullable
+    public TokenOrder getTokenOrder() {
+        return tokenOrder;
+    }
+
+    @Nullable
+    public Fuzzy getFuzzy() {
+        return fuzzy;
+    }
+
+    @Nullable
+    public SearchScore getScore() {
+        return score;
+    }
+
+    public AutoCompleteSearchOperator tokenOrder(TokenOrder tokenOrder) {
+        return new AutoCompleteSearchOperator(query, path, tokenOrder, fuzzy, score, getIndex());
+    }
+
+    public AutoCompleteSearchOperator fuzzy(Fuzzy fuzzy) {
+        return new AutoCompleteSearchOperator(query, path, tokenOrder, fuzzy, score, getIndex());
+    }
+
+    public AutoCompleteSearchOperator score(SearchScore score) {
+        return new AutoCompleteSearchOperator(query, path, tokenOrder, fuzzy, score, getIndex());
+    }
+
+    @Override
+    public AutoCompleteSearchOperator index(final String index) {
+        return new AutoCompleteSearchOperator(query, path, tokenOrder, fuzzy, score, index);
+    }
+
+    @Override
+    public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+        BsonDocument searchStageDocument = new BsonDocument();
+        appendCommonFields(searchStageDocument);
+        BsonDocument autoCompleteOperatorDocument = new BsonDocument();
+        if (query.size() == 1) {
+            autoCompleteOperatorDocument.append("query", new BsonString(query.get(0)));
+        } else {
+            autoCompleteOperatorDocument.append("query", query.stream().map(BsonString::new).collect(BsonArray::new, BsonArray::add, BsonArray::addAll));
+        }
+
+        appendPath(autoCompleteOperatorDocument, path);
+
+        appendScore(autoCompleteOperatorDocument, score);
+
+        if (tokenOrder != null) {
+            autoCompleteOperatorDocument.append("tokenOrder", new BsonString(tokenOrder.key));
+        }
+
+        if (fuzzy != null) {
+            autoCompleteOperatorDocument.append("fuzzy", fuzzy.toBsonValue());
+        }
+
+        searchStageDocument.append("autocomplete", autoCompleteOperatorDocument);
+
+        return searchStageDocument;
+    }}

--- a/driver-core/src/main/com/mongodb/client/model/search/BoostSearchScore.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/BoostSearchScore.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonValue;
+
+@Immutable
+public final class BoostSearchScore extends SearchScore {
+    private final double value;
+
+    BoostSearchScore(final double value) {
+        this.value = value;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    @Override
+    public BsonValue toBsonValue() {
+        return new BsonDocument("boost", new BsonDocument("value", new BsonDouble(value)));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/CompoundSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/CompoundSearchOperator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static java.util.Collections.unmodifiableMap;
+
+@Immutable
+public final class CompoundSearchOperator extends SearchOperator {
+
+    private final Map<Clause, List<SearchOperator>> clauses;
+    @Nullable
+    private final Integer minimumShouldMatch;
+
+
+    public enum Clause {
+        MUST("must"),
+
+        MUST_NOT("mustNot"),
+
+        SHOULD("should"),
+
+        FILTER("filter");
+
+        private final String key;
+
+        Clause(final String key) {
+            this.key = key;
+        }
+    }
+
+    CompoundSearchOperator(Map<Clause, List<SearchOperator>> clauses, @Nullable Integer minimumShouldMatch, @Nullable final String index) {
+        super(index);
+        this.clauses = unmodifiableMap(notNull("clauses", clauses));
+        this.minimumShouldMatch = minimumShouldMatch;
+    }
+
+    @Override
+    public CompoundSearchOperator index(final String index) {
+        return new CompoundSearchOperator(clauses, minimumShouldMatch, index);
+    }
+
+    public CompoundSearchOperator minimumShouldMatch(final int value) {
+        return new CompoundSearchOperator(clauses, value, getIndex());
+    }
+
+    @Override
+    public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+        BsonDocument searchStageDocument = new BsonDocument();
+        appendCommonFields(searchStageDocument);
+        BsonDocument compoundOperatorDocument = new BsonDocument();
+
+        clauses.forEach((key, value) -> {
+            compoundOperatorDocument.append(key.key,
+                    value.stream().map((operator) -> operator.toBsonDocument(documentClass, codecRegistry))
+                            .collect(BsonArray::new, BsonArray::add, BsonArray::addAll));
+        });
+
+        if (minimumShouldMatch != null) {
+            compoundOperatorDocument.append("minimumShouldMatch", new BsonInt32(minimumShouldMatch));
+        }
+
+        searchStageDocument.append("compound", compoundOperatorDocument);
+
+        return searchStageDocument;
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/ConstantSearchScore.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/ConstantSearchScore.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonValue;
+
+@Immutable
+public final class ConstantSearchScore extends SearchScore {
+    private final double value;
+
+    ConstantSearchScore(final double value) {
+        this.value = value;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    @Override
+    public BsonValue toBsonValue() {
+        return new BsonDocument("constant", new BsonDocument("value", new BsonDouble(value)));
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ConstantSearchScore that = (ConstantSearchScore) o;
+
+        return Double.compare(that.value, value) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        long temp = Double.doubleToLongBits(value);
+        return (int) (temp ^ (temp >>> 32));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/EqualsSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/EqualsSearchOperator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonArray;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import java.util.List;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+@Immutable
+public final class EqualsSearchOperator extends SearchOperator {
+    private final BsonValue value;
+    private final List<SearchPath> path;
+
+    EqualsSearchOperator(final BsonValue value, final List<SearchPath> path, @Nullable final String index) {
+        super(index);
+        this.value = notNull("value", value);
+        this.path = notNull("path", path);
+    }
+
+    public BsonValue getValue() {
+        return value;
+    }
+
+    public List<SearchPath> getPath() {
+        return path;
+    }
+
+    @Override
+    public EqualsSearchOperator index(final String index) {
+        return new EqualsSearchOperator(value, path, index);
+    }
+
+    @Override
+    public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+        BsonDocument searchStageDocument = new BsonDocument();
+        appendCommonFields(searchStageDocument);
+        BsonDocument equalsOperatorDocument = new BsonDocument("value", value);
+
+        appendPath(equalsOperatorDocument, path);
+
+        searchStageDocument.append("equals", equalsOperatorDocument);
+
+        return searchStageDocument;
+    }
+
+    void appendPath(final BsonDocument searchOperatorDocument, final List<SearchPath> path) {
+        if (path.size() == 1) {
+            searchOperatorDocument.append("path", path.get(0).toBsonValue());
+        } else {
+            searchOperatorDocument.append("path", path.stream().map(SearchPath::toBsonValue).collect(BsonArray::new, BsonArray::add, BsonArray::addAll));
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/FieldSearchPath.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/FieldSearchPath.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.conversions.Bson;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+/**
+ * @since 4.4
+ */
+@Immutable
+public final class FieldSearchPath extends SearchPath {
+    private final String path;
+    @Nullable
+    private final String multi;
+
+    FieldSearchPath(final String path, @Nullable final String multi) {
+        this.path = notNull("path", path);
+        this.multi = multi;
+    }
+
+    FieldSearchPath multi(String multi) {
+        return new FieldSearchPath(path, multi);
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    @Nullable
+    public String getMulti() {
+        return multi;
+    }
+
+    @Override
+    public BsonValue toBsonValue() {
+        if (multi == null) {
+            return new BsonString(path);
+        } else {
+            return new BsonDocument("value", new BsonString(path)).append("multi", new BsonString(multi));
+        }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FieldSearchPath that = (FieldSearchPath) o;
+
+        return path.equals(that.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return path.hashCode();
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/Fuzzy.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/Fuzzy.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonValue;
+
+@Immutable
+public final class Fuzzy {
+    @Nullable private final Integer maxEdits;
+    @Nullable private final Integer prefixLength;
+    @Nullable private final Integer maxExpansions;
+
+    public static Fuzzy fuzzy() {
+        return new Fuzzy(null, null, null);
+    }
+
+    Fuzzy(@Nullable final Integer maxEdits, @Nullable final Integer prefixLength, @Nullable final Integer maxExpansions) {
+        this.maxEdits = maxEdits;
+        this.prefixLength = prefixLength;
+        this.maxExpansions = maxExpansions;
+    }
+
+    public Fuzzy maxEdits(int maxEdits) {
+        return new Fuzzy(maxEdits, prefixLength, maxExpansions);
+    }
+
+    public Fuzzy prefixLength(int prefixLength) {
+        return new Fuzzy(maxEdits, prefixLength, maxExpansions);
+    }
+
+    public Fuzzy maxExpansions(int maxExpansions) {
+        return new Fuzzy(maxEdits, prefixLength, maxExpansions);
+    }
+
+    @Nullable
+    public Integer getMaxEdits() {
+        return maxEdits;
+    }
+
+    @Nullable
+    public Integer getPrefixLength() {
+        return prefixLength;
+    }
+
+    @Nullable
+    public Integer getMaxExpansions() {
+        return maxExpansions;
+    }
+
+    BsonValue toBsonValue() {
+        BsonDocument document = new BsonDocument();
+
+        if (maxEdits != null) {
+             document.append("maxEdits", new BsonInt32(maxEdits));
+        }
+
+        if (prefixLength != null) {
+            document.append("prefixLength", new BsonInt32(prefixLength));
+        }
+
+        if (maxExpansions != null) {
+            document.append("maxExpansions", new BsonInt32(maxExpansions));
+        }
+
+        return document;
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/RangeSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/RangeSearchOperator.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonDecimal128;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonValue;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.types.Decimal128;
+
+import java.util.List;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+@Immutable
+public final class RangeSearchOperator extends SearchOperator {
+
+    private final List<SearchPath> path;
+    @Nullable private final BsonValue gt;
+    @Nullable private final BsonValue gte;
+    @Nullable private final BsonValue lt;
+    @Nullable private final BsonValue lte;
+
+    RangeSearchOperator(final List<SearchPath> path, @Nullable final String index,
+            @Nullable final BsonValue gt, @Nullable final BsonValue gte, @Nullable final BsonValue lt, @Nullable final BsonValue lte) {
+        super(index);
+        this.path = notNull("path", path);
+        this.gt = gt;
+        this.gte = gte;
+        this.lt = lt;
+        this.lte = lte;
+    }
+
+    public List<SearchPath> getPath() {
+        return path;
+    }
+
+    public RangeSearchOperator gt(Number value) {
+        return new RangeSearchOperator(path, getIndex(), numberToBsonValue(value), gte, lt, lte);
+    }
+
+    public RangeSearchOperator gte(Number value) {
+        return new RangeSearchOperator(path, getIndex(), gt, numberToBsonValue(value), lt, lte);
+    }
+
+    public RangeSearchOperator lt(Number value) {
+        return new RangeSearchOperator(path, getIndex(), gt, gte, numberToBsonValue(value), lte);
+    }
+
+    public RangeSearchOperator lte(Number value) {
+        return new RangeSearchOperator(path, getIndex(), gt, gte, lt, numberToBsonValue(value));
+    }
+
+    @Override
+    public RangeSearchOperator index(final String index) {
+        return new RangeSearchOperator(path, index, gt, gte, lt, lte);
+    }
+
+    @Override
+    public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+        BsonDocument searchStageDocument = new BsonDocument();
+        appendCommonFields(searchStageDocument);
+        BsonDocument rangeSearchOperator = new BsonDocument();
+
+        appendPath(rangeSearchOperator, path);
+
+        if (gt != null) {
+            rangeSearchOperator.append("gt", gt);
+        }
+
+        if (gte != null) {
+            rangeSearchOperator.append("gte", gte);
+        }
+
+        if (lt != null) {
+            rangeSearchOperator.append("lt", lt);
+        }
+
+        if (lte != null) {
+            rangeSearchOperator.append("lte", lte);
+        }
+
+        searchStageDocument.append("range", rangeSearchOperator);
+
+        return searchStageDocument;
+    }
+
+    private static BsonValue numberToBsonValue(final Number value) {
+        if (value instanceof Integer) {
+            return new BsonInt32((Integer) value);
+        } else if (value instanceof Long) {
+            return new BsonInt64((Long) value);
+        } else if (value instanceof Double) {
+            return new BsonDouble((Double) value);
+        } else if (value instanceof Decimal128) {
+            return new BsonDecimal128((Decimal128) value);
+        } else {
+            throw new IllegalArgumentException("Unsupported number subclass: " + value.getClass());
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.conversions.Bson;
+
+import java.util.List;
+
+/**
+ *
+ * @since 4.4
+ */
+@Immutable
+public abstract class SearchOperator implements Bson {
+    @Nullable
+    private final String index;
+
+    SearchOperator(@Nullable final String index) {
+        this.index = index;
+    }
+
+    @Nullable
+    public String getIndex() {
+        return index;
+    }
+
+    abstract public SearchOperator index(final String index);
+
+    void appendCommonFields(final BsonDocument searchStageDocument) {
+        if (index != null) {
+            searchStageDocument.append("index", new BsonString(index));
+        }
+    }
+
+    void appendPath(final BsonDocument searchOperatorDocument, final List<SearchPath> path) {
+        if (path.size() == 1) {
+            searchOperatorDocument.append("path", path.get(0).toBsonValue());
+        } else {
+            searchOperatorDocument.append("path",
+                    path.stream().map(SearchPath::toBsonValue).collect(BsonArray::new, BsonArray::add, BsonArray::addAll));
+        }
+    }
+
+    void appendScore(final BsonDocument searchOperatorDocument, @Nullable final SearchScore score) {
+        if (score != null) {
+            searchOperatorDocument.append("score", score.toBsonValue());
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperators.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperators.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import org.bson.BsonBoolean;
+import org.bson.BsonObjectId;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * Builder API for Atlas search.
+ *
+ * @since 4.4
+ * @mongodb.driver.manual.atlas/reference/atlas-search/query-syntax/
+ */
+public interface SearchOperators {
+
+    /**
+     * A builder for the {@code text} search operator.
+     *
+     * @param query the query 
+     * @param path the path
+     * @return an instance of {code TextSearchOperator} with the given query and path
+     * @mongodb.driver.manual.atlas reference/atlas-search/text/
+     */
+    static TextSearchOperator text(final String query, final SearchPath path) {
+        return new TextSearchOperator(singletonList(query), singletonList(path), null, null);
+    }
+
+    /**
+     * A builder for the {@code text} search operator.
+     *
+     * @param query the strings to search for. Atlas Search looks for a match for each term in the string separately.
+     * @param path the indexed fields to search in
+     * @return an instance of {code TextSearchOperator} with the given query and path
+     * @mongodb.driver.manual.atlas reference/atlas-search/text/
+     */
+    static TextSearchOperator text(final List<String> query, final List<SearchPath> path) {
+        return new TextSearchOperator(query, path, null, null);
+    }
+
+    static EqualsSearchOperator equal(final boolean value, final SearchPath path) {
+        return new EqualsSearchOperator(BsonBoolean.valueOf(value), singletonList(path), null);
+    }
+
+    static EqualsSearchOperator equal(final boolean value, final List<SearchPath> path) {
+        return new EqualsSearchOperator(BsonBoolean.valueOf(value), path, null);
+    }
+
+    static EqualsSearchOperator equal(final ObjectId value, final SearchPath path) {
+        return new EqualsSearchOperator(new BsonObjectId(value), singletonList(path), null);
+    }
+
+    static EqualsSearchOperator equal(final ObjectId value, final List<SearchPath> path) {
+        return new EqualsSearchOperator(new BsonObjectId(value), path, null);
+    }
+
+    static RangeSearchOperator range(final SearchPath path) {
+        return new RangeSearchOperator(singletonList(path), null, null, null, null, null);
+    }
+
+    static RangeSearchOperator range(final List<SearchPath> path) {
+        return new RangeSearchOperator(path, null, null, null, null, null);
+    }
+
+    static AutoCompleteSearchOperator autoComplete(final String query, final SearchPath path) {
+        return new AutoCompleteSearchOperator(singletonList(query), singletonList(path), null, null, null, null);
+
+    }
+
+    static AutoCompleteSearchOperator autoComplete(final List<String> query, final List<SearchPath> path) {
+        return new AutoCompleteSearchOperator(query, path, null, null, null, null);
+    }
+
+    static CompoundSearchOperator compound(final Map<CompoundSearchOperator.Clause, List<SearchOperator>> clauses) {
+         return new CompoundSearchOperator(clauses,null, null);
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperators.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperators.java
@@ -29,7 +29,7 @@ import static java.util.Collections.singletonList;
  * Builder API for Atlas search.
  *
  * @since 4.4
- * @mongodb.driver.manual.atlas/reference/atlas-search/query-syntax/
+ * @mongodb.driver.manual.atlas reference/atlas-search/query-syntax/
  */
 public interface SearchOperators {
 
@@ -90,7 +90,7 @@ public interface SearchOperators {
         return new AutoCompleteSearchOperator(query, path, null, null, null, null);
     }
 
-    static CompoundSearchOperator compound(final Map<CompoundSearchOperator.Clause, List<SearchOperator>> clauses) {
-         return new CompoundSearchOperator(clauses,null, null);
+    static CompoundSearchOperator compound() {
+        return new CompoundSearchOperator(null, null, null, null,null, null);
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchPath.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchPath.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import org.bson.BsonValue;
+
+/**
+ *
+ * @since 4.4
+ */
+@Immutable
+public abstract class SearchPath {
+
+    public static FieldSearchPath path(final String path) {
+        return new FieldSearchPath(path, null);
+    }
+
+    public static WildcardSearchPath wildcard(final String wildcard) {
+        return new WildcardSearchPath(wildcard);
+    }
+
+    public abstract BsonValue toBsonValue();
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchScore.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchScore.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import org.bson.BsonValue;
+
+@Immutable
+public abstract class SearchScore {
+    public static BoostSearchScore boost(final double value) {
+        return new BoostSearchScore(value);
+    }
+
+    public static ConstantSearchScore constant(final double value) {
+        return new ConstantSearchScore(value);
+    }
+
+    public abstract BsonValue toBsonValue();
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/TextSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/TextSearchOperator.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+/**
+ * Builder for the {@code text} operator for Atlas search.
+ *
+ * <p>
+ * The text operator performs a full-text search using the analyzer specified in the index configuration. If you do not specify an
+ * analyzer, the default standard analyzer is used.      
+ * </p>
+ *
+ * @see SearchOperators#text(String, SearchPath)
+ * @see SearchOperators#text(List, List)
+ * @mongodb.driver.manual.atlas reference/atlas-search/text/  
+ * @since 4.4
+ */
+@Immutable
+public final class TextSearchOperator extends SearchOperator {
+
+    private final List<String> query;
+    private final List<SearchPath> path;
+    @Nullable
+    private final SearchScore score;
+
+    TextSearchOperator(final List<String> query, final List<SearchPath> path, @Nullable SearchScore score, @Nullable final String index) {
+        super(index);
+        this.query = notNull("query", query);
+        this.path = notNull("path", path);
+        this.score = score;
+    }
+
+    /**
+     * The string or strings to search for. If there are multiple terms in a string, Atlas Search also looks for a match for each term in
+     * the string separately.
+     * 
+     * @return the query
+     */
+    public List<String> getQuery() {
+        return Collections.unmodifiableList(query);
+    }
+
+    /**
+     * The indexed field or fields to search.
+     *
+     * @return the path
+     */
+    public List<SearchPath> getPath() {
+        return Collections.unmodifiableList(path);
+    }
+
+    /**
+     * The score assigned to matching search term results.
+     *
+     * @return the score
+     */
+    @Nullable
+    public SearchScore getScore() {
+        return score;
+    }
+
+    /**
+     * Set the score assigned to matching search term results.
+     *
+     * @param score the score
+     * @return a new instance of {@code TextSearchOperator} which is a copy of {@code this}, but using the given score.
+     */
+    public TextSearchOperator score(final SearchScore score) {
+        return new TextSearchOperator(query, path, score, getIndex());
+    }
+
+    /**
+     * Set the index to use for the search.
+     *
+     * @param index the index
+     * @return a new instance of {@code TextSearchOperator} which is a copy of {@code this}, but using the given index.
+     */
+    @Override
+    public TextSearchOperator index(final String index) {
+        return new TextSearchOperator(query, path, score, index);
+    }
+
+    @Override
+    public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+        BsonDocument searchStageDocument = new BsonDocument();
+        appendCommonFields(searchStageDocument);
+        BsonDocument textOperatorDocument = new BsonDocument();
+        if (query.size() == 1) {
+            textOperatorDocument.append("query", new BsonString(query.get(0)));
+        } else {
+            textOperatorDocument.append("query", query.stream().map(BsonString::new).collect(BsonArray::new, BsonArray::add, BsonArray::addAll));
+        }
+
+        appendPath(textOperatorDocument, path);
+
+        appendScore(textOperatorDocument, score);
+
+        searchStageDocument.append("text", textOperatorDocument);
+
+        return searchStageDocument;
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/WildcardSearchPath.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/WildcardSearchPath.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+@Immutable
+public final class WildcardSearchPath extends SearchPath {
+    private final String wildcard;
+
+    WildcardSearchPath(final String wildcard) {
+        this.wildcard = notNull("wildcard", wildcard);
+    }
+
+    public String getWildcard() {
+        return wildcard;
+    }
+
+    @Override
+    public BsonValue toBsonValue() {
+        return new BsonDocument("wildcard", new BsonString(wildcard));
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        WildcardSearchPath that = (WildcardSearchPath) o;
+
+        return wildcard.equals(that.wildcard);
+    }
+
+    @Override
+    public int hashCode() {
+        return wildcard.hashCode();
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/package-info.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains models and options that help describe MongoCollection operations
+ */
+
+@NonNullApi
+package com.mongodb.client.model.search;
+
+import com.mongodb.lang.NonNullApi;

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -357,6 +357,9 @@ public final class ClusterFixture {
         return createCluster(getConnectionString(), streamFactory);
     }
 
+    public static Cluster createCluster(ConnectionString connectionString) {
+        return createCluster(connectionString, getStreamFactory(connectionString));
+    }
 
     public static Cluster createCluster(final MongoCredential credential) {
         return createCluster(credential, getStreamFactory());
@@ -383,6 +386,10 @@ public final class ClusterFixture {
                 connectionString.getCredential(),
                 null, null, null,
                 connectionString.getCompressorList(), getServerApi());
+    }
+
+    public static StreamFactory getStreamFactory(ConnectionString connectionString) {
+        return new SocketStreamFactory(SocketSettings.builder().build(), getSslSettings(connectionString));
     }
 
     public static StreamFactory getStreamFactory() {

--- a/driver-core/src/test/functional/com/mongodb/client/model/SearchOperatorsIntegrationTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/SearchOperatorsIntegrationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.model.search.SearchScore;
+import com.mongodb.client.test.CollectionHelper;
+import com.mongodb.internal.connection.Cluster;
+import org.bson.BsonDocument;
+import org.bson.codecs.BsonDocumentCodec;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.mongodb.ClusterFixture.createCluster;
+import static com.mongodb.client.model.Aggregates.project;
+import static com.mongodb.client.model.Aggregates.search;
+import static com.mongodb.client.model.Projections.excludeId;
+import static com.mongodb.client.model.Projections.fields;
+import static com.mongodb.client.model.Projections.include;
+import static com.mongodb.client.model.search.SearchOperators.text;
+import static com.mongodb.client.model.search.SearchPath.path;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class SearchOperatorsIntegrationTest {
+    private static Cluster cluster;
+    private static CollectionHelper<BsonDocument> collectionHelper;
+
+    @BeforeAll
+    public static void beforeAll() {
+        assumeTrue(System.getProperties().containsKey("org.mongodb.test.search.uri"));
+        cluster = createCluster(new ConnectionString(System.getProperty("org.mongodb.test.search.uri")));
+        collectionHelper = new CollectionHelper<>(new BsonDocumentCodec(), cluster,
+                new MongoNamespace("sample_mflix", "movies"));
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        if (cluster != null) {
+            cluster.close();
+        }
+    }
+
+    @Test
+    public void testTextOperator() {
+        List<Bson> pipeline = asList(
+                search(text("cowboy", path("title")).score(SearchScore.boost(1.5))),
+                project(fields(excludeId(), include("title"))));
+        List<BsonDocument> results = collectionHelper.aggregate(pipeline);
+
+        assertEquals(new HashSet<>(Arrays.asList("Cowboy del Amor", "Cowboy Bebop: The Movie", "Midnight Cowboy", "Cowboy",
+                        "Last Cowboy Standing", "The Cowboy and the Lady", "Urban Cowboy", "Drugstore Cowboy")),
+                results.stream().map((value) -> value.getString("title").getValue()).collect(Collectors.toSet()));
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.search;
+
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonString;
+import org.junit.jupiter.api.Test;
+
+import static com.mongodb.client.model.search.SearchPath.path;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SearchOperatorsTest {
+    @Test
+    public void testTextSearchOperator() {
+        TextSearchOperator operator = SearchOperators.text("query1", path("field1"));
+
+        assertEquals(new BsonDocument("text",
+                        new BsonDocument("query", new BsonString("query1"))
+                                .append("path", new BsonString("field1"))),
+                operator.toBsonDocument());
+
+        operator = operator.index("index1")
+                .score(SearchScore.boost(1.5));
+
+        assertEquals(new BsonDocument("index", new BsonString("index1"))
+                        .append("text", new BsonDocument("query", new BsonString("query1"))
+                                .append("path", new BsonString("field1"))
+                                .append("score", new BsonDocument("boost", new BsonDocument("value", new BsonDouble(1.5))))),
+                operator.toBsonDocument());
+    }
+
+    @Test
+    public void testEqualsSearchOperator() {
+        EqualsSearchOperator operator = SearchOperators.equal(true, path("field1"));
+
+        assertEquals(new BsonDocument("equals",
+                        new BsonDocument("value", BsonBoolean.TRUE).append("path", new BsonString("field1"))),
+                operator.toBsonDocument());
+
+        operator = operator.index("index1");
+
+        assertEquals(new BsonDocument("index", new BsonString("index1"))
+                        .append("equals", new BsonDocument("value", BsonBoolean.TRUE).append("path", new BsonString("field1"))),
+                operator.toBsonDocument());
+    }
+}


### PR DESCRIPTION
JAVA-4190

https://docs.atlas.mongodb.com/atlas-search/

This is a draft PR to gather feedback.  So as not to waste time, it only implements a small subset of a complete API that would cover all operators and options.  I think it's enough to get feedback on the following questions

1. Does this API substantially improve the development experience for users of Atlas search?
2. Are there improvements we can make on the proposed API?  For example, is immutability the right choice for the operators?


To give a flavor of what the API usage looks like with a realistic query, I translated an actual customer query from JSON to this API.  JSON looks like this:

```
{
    "$search": {
        "index": "shopUsed",
        "compound": {
            "filter": [
                {"text": {"query": "ACTIVE", "path": "status"}},
                {"equals": {"value": false, "path": "manuallySuppressed"}},
                {"equals": {"value": false,"path": "purchasePending"}},
                {
                    "range": {
                        "path": "ymmt.year",
                        "gte": 2012,
                        "lte": 2021
                    }
                },
            ],
            "must": [
                {
                    "compound": {
                        "should": [
                            {
                                "text": {
                                    "query": "Honda",
                                    "path": "ymmt.make"
                                }
                            },
                            {
                                "compound": {
                                    "should": [
                                        {
                                            "text": {
                                                "query": "Toyota",
                                                "path": "ymmt.make"
                                            }
                                        },
                                        {
                                            "text": {
                                                "query": "Camry",
                                                "path": "ymmt.model"
                                            }
                                        }
                                    ],
                                    "minimumShouldMatch": 2
                                }
                            },
                            {
                                "compound": {
                                    "should": [
                                        {
                                            "text": {
                                                "query": "Ford",
                                                "path": "ymmt.make"
                                            }
                                        },
                                        {
                                            "text": {
                                                "query": ["Focus", "Taurus", "F-150"],
                                                "path": "ymmt.model"
                                            }
                                        },
                                    ],
                                    "minimumShouldMatch": 2
                                }
                            }
                        ],
                        "minimumShouldMatch": 1,
                        "must": {"text": {
                            "query": "sedan",
                            "path": [
                                "bodyStyle"
                            ],
                            "fuzzy": {
                                "maxEdits": 1,
                                "maxExpansions": 100
                            }
                        }}
                    }
                }
            ]
        }
    }
}
```

Using this builder API (plus a lot of static imports), the same query looks like this:

```
                search(compound(
                        Map.of(FILTER, List.of(
                                        text("ACTIVE", path("status")),
                                        equal(false, path("manuallySuppressed")),
                                        equal(false, path("purchasePending")),
                                        range(path("ymmt.year")).gte(2012).lte(2021)),
                                MUST, List.of(
                                        compound(Map.of(
                                                SHOULD, List.of(
                                                        text("Honda", path("ymmt.make")),
                                                        compound(Map.of(SHOULD,
                                                                List.of(
                                                                        text("Toyota", path("ymmt.make")),
                                                                        text("Camry", path("ymmt.model"))
                                                                ))).minimumShouldMatch(2),
                                                        compound(Map.of(SHOULD,
                                                                List.of(
                                                                        text("Ford", path("ymmt.make")),
                                                                        text(asList("Focus", "Taurus", "F-150"), asList(path("ymmt.model")))
                                                                ))).minimumShouldMatch(2)),
                                                MUST, List.of(
                                                        text("sedan", path("bodyStyle"))
                                                ))).minimumShouldMatch(1))))
                        .index("shopUsed"))
```