### PR TITLE
Fix manifest import-package imports

### DIFF
--- a/bson-scala/build.gradle
+++ b/bson-scala/build.gradle
@@ -48,4 +48,7 @@ test {
     maxParallelForks = 1
 }
 
-jar.manifest.attributes['Import-Package'] = 'org.bson.*'
+jar.manifest.attributes['Import-Package'] =  [
+        '!scala.*',
+        '*'
+].join(',')

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -64,20 +64,14 @@ afterEvaluate {
     jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.driver.core'
     jar.manifest.attributes['Bundle-SymbolicName'] = 'org.mongodb.driver-core'
     jar.manifest.attributes['Import-Package'] = [
-        'org.bson.*', // unfortunate that this is necessary, but if it's left out then it's not included
-        'javax.crypto.*',
-        'javax.management.*',
-        'javax.naming.*',
-        'javax.net.*',
-        'jdk.net.*',
-        'javax.security.sasl.*',
-        'javax.security.auth.callback.*',
-        'org.ietf.jgss.*',
-        'io.netty.*;resolution:=optional',
-        'org.xerial.snappy.*;resolution:=optional',
-        'com.github.luben.zstd.*;resolution:=optional',
-        'org.slf4j.*;resolution:=optional',
-        'jnr.unixsocket.*;resolution:=optional',
-        'com.mongodb.crypt.capi.*;resolution:=optional'
+            '!sun.misc.*',  // Used by DirectBufferDeallocator only for java 8
+            '!sun.nio.ch.*',  // Used by DirectBufferDeallocator only for java 8
+            'io.netty.*;resolution:=optional',
+            'org.xerial.snappy.*;resolution:=optional',
+            'com.github.luben.zstd.*;resolution:=optional',
+            'org.slf4j.*;resolution:=optional',
+            'jnr.unixsocket.*;resolution:=optional',
+            'com.mongodb.crypt.capi.*;resolution:=optional',
+            '*' // import all that is not excluded or modified before
     ].join(',')
 }

--- a/driver-reactive-streams/build.gradle
+++ b/driver-reactive-streams/build.gradle
@@ -69,9 +69,7 @@ afterEvaluate {
     jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.driver.reactivestreams'
     jar.manifest.attributes['Bundle-SymbolicName'] = 'org.mongodb.driver-reactivestreams'
     jar.manifest.attributes['Import-Package'] = [
-            'org.bson.*',
             'com.mongodb.crypt.capi.*;resolution:=optional',
-            'com.mongodb.*',
-            'reactor.core.*',
+            '*',
     ].join(',')
 }

--- a/driver-scala/build.gradle
+++ b/driver-scala/build.gradle
@@ -100,7 +100,7 @@ ext {
 afterEvaluate {
     jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.scala.mongo-scala-driver'
     jar.manifest.attributes['Import-Package'] = [
-            'org.bson.*',
-            'com.mongodb.*',
+            '!scala.*',
+            '*'
     ].join(',')
 }

--- a/driver-sync/build.gradle
+++ b/driver-sync/build.gradle
@@ -46,8 +46,7 @@ afterEvaluate {
     jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.driver.sync.client'
     jar.manifest.attributes['Bundle-SymbolicName'] = 'org.mongodb.driver-sync'
     jar.manifest.attributes['Import-Package'] = [
-            'org.bson.*',
             'com.mongodb.crypt.capi.*;resolution:=optional',
-            'com.mongodb.*',
+            '*',
     ].join(',')
 }


### PR DESCRIPTION
Refs: #771 Using the suggested method by @stbischof

Fixes imports in `mongo-scala-bson`, `mongodb-driver-sync`, `mongodb-driver-reactivestreams`, `mongodb-driver-core`.

JAVA-4274