### PR TITLE
JAVA-4034 Refactor read/write retries to accommodate for both `PoolClearedError` and CSOT

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -119,7 +119,7 @@
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
         <module name="LineLength">
             <property name="max" value="140"/>
-            <property name="ignorePattern" value="^.*a\s*href\s*=.*$"/>
+            <property name="ignorePattern" value="^.*[(http://|https://)|{@see|{@link].*$"/>
         </module>
 
         <module name="MethodLength"/>

--- a/driver-core/src/main/com/mongodb/MongoClientException.java
+++ b/driver-core/src/main/com/mongodb/MongoClientException.java
@@ -16,6 +16,8 @@
 
 package com.mongodb;
 
+import com.mongodb.lang.Nullable;
+
 /**
  * A base class for exceptions indicating a failure condition with the MongoClient.
  *
@@ -40,7 +42,7 @@ public class MongoClientException extends MongoException {
      * @param message the message
      * @param cause the cause
      */
-    public MongoClientException(final String message, final Throwable cause) {
+    public MongoClientException(final String message, @Nullable final Throwable cause) {
         super(message, cause);
     }
 }

--- a/driver-core/src/main/com/mongodb/MongoConnectionPoolClearedException.java
+++ b/driver-core/src/main/com/mongodb/MongoConnectionPoolClearedException.java
@@ -23,13 +23,13 @@ import static com.mongodb.assertions.Assertions.assertNotNull;
 /* This exception is our way to deal with a race condition existing due to threads concurrently
  * checking out connections from ConnectionPool and invalidating it.*/
 /**
- * An exception that may happen usually as a result of another thread clearing a connection pool.
+ * An exception that may usually happen as a result of another thread clearing a connection pool.
  * Such clearing usually itself happens as a result of an exception,
  * in which case it may be specified via the {@link #getCause()} method.
  * <p>
  * It is always safe to retry an operation that failed with this exception.
  */
-public final class MongoConnectionPoolClearedException extends MongoException {
+public final class MongoConnectionPoolClearedException extends MongoClientException {
     private static final long serialVersionUID = 1;
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/async/SingleResultCallback.java
+++ b/driver-core/src/main/com/mongodb/internal/async/SingleResultCallback.java
@@ -16,17 +16,17 @@
 
 package com.mongodb.internal.async;
 
-import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+import com.mongodb.internal.async.function.AsyncCallbackFunction;
 
 /**
- * An interface to describe the completion of an asynchronous function, which may be represented as {@link AsyncCallbackSupplier}.
+ * An interface to describe the completion of an asynchronous function, which may be represented as {@link AsyncCallbackFunction}.
  *
  * @param <T> The type of a successful result. A failed result is of the {@link Throwable} type.
- * @see AsyncCallbackSupplier
+ * @see AsyncCallbackFunction
  */
 public interface SingleResultCallback<T> {
     /**
-     * Called when the function completes. This method must not complete abruptly, see {@link AsyncCallbackSupplier} for more details.
+     * Called when the function completes. This method must not complete abruptly, see {@link AsyncCallbackFunction} for more details.
      *
      * @param result the result, which may be null.  Always null if e is not null.
      * @param t      the throwable, or null if the operation completed normally

--- a/driver-core/src/main/com/mongodb/internal/async/SingleResultCallback.java
+++ b/driver-core/src/main/com/mongodb/internal/async/SingleResultCallback.java
@@ -16,16 +16,22 @@
 
 package com.mongodb.internal.async;
 
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+
 /**
- * An interface to describe the completion of an asynchronous operation.
+ * An interface to describe the completion of an asynchronous function, which may be represented as {@link AsyncCallbackSupplier}.
  *
- * @param <T> the result type
+ * @param <T> The type of a successful result. A failed result is of the {@link Throwable} type.
+ * @see AsyncCallbackSupplier
  */
 public interface SingleResultCallback<T> {
     /**
-     * Called when the operation completes.
+     * Called when the function completes. This method must not complete abruptly, see {@link AsyncCallbackSupplier} for more details.
+     *
      * @param result the result, which may be null.  Always null if e is not null.
      * @param t      the throwable, or null if the operation completed normally
+     * @throws RuntimeException Never.
+     * @throws Error Never, on the best effort basis.
      */
     void onResult(T result, Throwable t);
 }

--- a/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackBiFunction.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackBiFunction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.async.function;
+
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.lang.Nullable;
+
+import java.util.function.BiFunction;
+
+/**
+ * An {@linkplain AsyncCallbackFunction asynchronous callback-based function} of two parameters.
+ * This class is a callback-based counterpart of {@link BiFunction}.
+ *
+ * @param <P1> The type of the first parameter to the function.
+ * @param <P2> The type of the second parameter to the function.
+ * @param <R> See {@link AsyncCallbackFunction}
+ * @see AsyncCallbackFunction
+ */
+@FunctionalInterface
+public interface AsyncCallbackBiFunction<P1, P2, R> {
+    /**
+     * @param a The first {@code @}{@link Nullable} argument of the asynchronous function.
+     * @param b The second {@code @}{@link Nullable} argument of the asynchronous function.
+     * @see AsyncCallbackFunction#apply(Object, SingleResultCallback)
+     */
+    void apply(P1 a, P2 b, SingleResultCallback<R> callback);
+}

--- a/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackBiFunction.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackBiFunction.java
@@ -32,9 +32,9 @@ import java.util.function.BiFunction;
 @FunctionalInterface
 public interface AsyncCallbackBiFunction<P1, P2, R> {
     /**
-     * @param a The first {@code @}{@link Nullable} argument of the asynchronous function.
-     * @param b The second {@code @}{@link Nullable} argument of the asynchronous function.
+     * @param p1 The first {@code @}{@link Nullable} argument of the asynchronous function.
+     * @param p2 The second {@code @}{@link Nullable} argument of the asynchronous function.
      * @see AsyncCallbackFunction#apply(Object, SingleResultCallback)
      */
-    void apply(P1 a, P2 b, SingleResultCallback<R> callback);
+    void apply(P1 p1, P2 p2, SingleResultCallback<R> callback);
 }

--- a/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackFunction.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackFunction.java
@@ -18,31 +18,23 @@ package com.mongodb.internal.async.function;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.lang.Nullable;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Future;
 import java.util.function.Function;
 
 /**
- * An asynchronous callback-based function, i.e., a function that provides no guarantee that it completes before
+ * An asynchronous callback-based function, its synchronous counterpart is {@link Function}.
+ * <p>
+ * A asynchronous function provides no guarantee that it completes before
  * (in the happens-before order) the method {@link #apply(Object, SingleResultCallback)} completes,
- * and produces either a successful or failed result by passing it to a {@link SingleResultCallback} after
+ * and produces either a successful or a failed result by passing it to a {@link SingleResultCallback} after
  * (in the happens-before order) the function completes. That is, a callback is used to emulate both normal and abrupt completion of a
  * Java method, which is why the {@link #apply(Object, SingleResultCallback)} method is not allowed to complete abruptly.
  * If it completes abruptly, then the behavior is not defined, unless otherwise is explicitly specified, e.g., as in
- * {@link AsyncCallbackSupplier#andFinally(Runnable)}.
+ * {@link AsyncCallbackSupplier#whenComplete(Runnable)}.
  * <p>
  * When talking about an asynchronous function, the terms
  * <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.1">"normal" and "abrupt completion"</a>
  * are used as they defined by the Java Language Specification, while the terms "successful" and "failed completion" are used to refer to a
  * situation when the function produces either a successful or a failed result respectively.
- * <p>
- * This class is a callback-based counterpart of {@link Function}.
- * Apart from callback-based functions, other popular approaches to represent asynchronous computations are:
- * <ul>
- *     <li>functions that return {@link Future}/{@link CompletableFuture}/{@link CompletionStage};</li>
- *     <li>{@code java.util.concurrent.Flow}, a.k.a. <a href="https://www.reactive-streams.org/">reactive streams</a>.</li>
- * </ul>
  *
  * @param <P> The type of the first parameter to the function.
  * @param <R> The type of successful result. A failed result is of the {@link Throwable} type

--- a/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackFunction.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackFunction.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.async.function;
+
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.lang.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Future;
+import java.util.function.Function;
+
+/**
+ * An asynchronous callback-based function, i.e., a function that provides no guarantee that it completes before
+ * (in the happens-before order) the method {@link #apply(Object, SingleResultCallback)} completes,
+ * and produces either a successful or failed result by passing it to a {@link SingleResultCallback} after
+ * (in the happens-before order) the function completes. That is, a callback is used to emulate both normal and abrupt completion of a
+ * Java method, which is why the {@link #apply(Object, SingleResultCallback)} method is not allowed to complete abruptly.
+ * If it completes abruptly, then the behavior is not defined, unless otherwise is explicitly specified, e.g., as in
+ * {@link AsyncCallbackSupplier#andFinally(Runnable)}.
+ * <p>
+ * When talking about an asynchronous function, the terms
+ * <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.1">"normal" and "abrupt completion"</a>
+ * are used as they defined by the Java Language Specification, while the terms "successful" and "failed completion" are used to refer to a
+ * situation when the function produces either a successful or a failed result respectively.
+ * <p>
+ * This class is a callback-based counterpart of {@link Function}.
+ * Apart from callback-based functions, other popular approaches to represent asynchronous computations are:
+ * <ul>
+ *     <li>functions that return {@link Future}/{@link CompletableFuture}/{@link CompletionStage};</li>
+ *     <li>{@code java.util.concurrent.Flow}, a.k.a. <a href="https://www.reactive-streams.org/">reactive streams</a>.</li>
+ * </ul>
+ *
+ * @param <P> The type of the first parameter to the function.
+ * @param <R> The type of successful result. A failed result is of the {@link Throwable} type
+ * as defined by {@link SingleResultCallback#onResult(Object, Throwable)}.
+ */
+@FunctionalInterface
+public interface AsyncCallbackFunction<P, R> {
+    /**
+     * Initiates execution of the asynchronous function.
+     *
+     * @param a A {@code @}{@link Nullable} argument of the asynchronous function.
+     * @param callback A consumer of a result, {@link SingleResultCallback#onResult(Object, Throwable) completed} after
+     * (in the happens-before order) the asynchronous function completes.
+     * @throws RuntimeException Never. Exceptions must be relayed to the {@code callback}.
+     * @throws Error Never, on the best effort basis. Errors should be relayed to the {@code callback}.
+     */
+    void apply(P a, SingleResultCallback<R> callback);
+}

--- a/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackLoop.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackLoop.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.async.function;
+
+import com.mongodb.annotations.NotThreadSafe;
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.lang.Nullable;
+
+import java.util.function.Supplier;
+
+/**
+ * A decorator that implements automatic repeating of an {@link AsyncCallbackRunnable}.
+ * {@link AsyncCallbackLoop} may execute the original asynchronous function multiple times sequentially,
+ * while guaranteeing that the callback passed to {@link #run(SingleResultCallback)} is completed at most once.
+ * This class emulates the <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.12">{@code while(true)}</a>
+ * statement.
+ * <p>
+ * The original function may additionally observe or control looping via {@link LoopState}.
+ * Looping continues until either of the following happens:
+ * <ul>
+ *     <li>the original function fails as specified by {@link AsyncCallbackFunction};</li>
+ *     <li>the original function calls {@link LoopState#breakAndCompleteIf(Supplier, SingleResultCallback)}.</li>
+ * </ul>
+ *
+ */
+@NotThreadSafe
+public final class AsyncCallbackLoop implements AsyncCallbackRunnable {
+    private final LoopState state;
+    private final AsyncCallbackRunnable body;
+
+    public AsyncCallbackLoop(final LoopState state, final AsyncCallbackRunnable body) {
+        this.state = state;
+        this.body = body;
+    }
+
+    @Override
+    public void run(final SingleResultCallback<Void> callback) {
+        body.run(new LoopingCallback(callback));
+    }
+
+    /**
+     * This callback is allowed to be completed more than once.
+     */
+    @NotThreadSafe
+    private class LoopingCallback implements SingleResultCallback<Void> {
+        private final SingleResultCallback<Void> wrapped;
+
+        LoopingCallback(final SingleResultCallback<Void> callback) {
+            wrapped = callback;
+        }
+
+        @Override
+        public void onResult(@Nullable final Void result, @Nullable final Throwable t) {
+            if (t != null) {
+                wrapped.onResult(null, t);
+            } else {
+                boolean continueLooping;
+                try {
+                    continueLooping = state.advance();
+                } catch (Throwable e) {
+                    wrapped.onResult(null, e);
+                    return;
+                }
+                if (continueLooping) {
+                    body.run(this);
+                } else {
+                    wrapped.onResult(result, null);
+                }
+            }
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackLoop.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackLoop.java
@@ -41,6 +41,10 @@ public final class AsyncCallbackLoop implements AsyncCallbackRunnable {
     private final LoopState state;
     private final AsyncCallbackRunnable body;
 
+    /**
+     * @param state The {@link LoopState} to be deemed as initial for the purpose of the new {@link AsyncCallbackLoop}.
+     * @param body The body of the loop.
+     */
     public AsyncCallbackLoop(final LoopState state, final AsyncCallbackRunnable body) {
         this.state = state;
         this.body = body;

--- a/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackRunnable.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackRunnable.java
@@ -38,9 +38,9 @@ public interface AsyncCallbackRunnable {
     }
 
     /**
-     * @see AsyncCallbackSupplier#andFinally(Runnable)
+     * @see AsyncCallbackSupplier#whenComplete(Runnable)
      */
-    default AsyncCallbackRunnable andFinally(final Runnable after) {
-        return callback -> asSupplier().andFinally(after).get(callback);
+    default AsyncCallbackRunnable whenComplete(final Runnable after) {
+        return callback -> asSupplier().whenComplete(after).get(callback);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackRunnable.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackRunnable.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.async.function;
+
+import com.mongodb.internal.async.SingleResultCallback;
+
+/**
+ * An {@linkplain AsyncCallbackFunction asynchronous callback-based function} of no parameters and no successful result.
+ * This class is a callback-based counterpart of {@link Runnable}.
+ *
+ * @see AsyncCallbackFunction
+ */
+@FunctionalInterface
+public interface AsyncCallbackRunnable {
+    /**
+     * @see AsyncCallbackFunction#apply(Object, SingleResultCallback)
+     */
+    void run(SingleResultCallback<Void> callback);
+
+    /**
+     * Converts this {@link AsyncCallbackSupplier} to {@link AsyncCallbackSupplier}{@code <Void>}.
+     */
+    default AsyncCallbackSupplier<Void> asSupplier() {
+        return this::run;
+    }
+
+    /**
+     * @see AsyncCallbackSupplier#andFinally(Runnable)
+     */
+    default AsyncCallbackRunnable andFinally(final Runnable after) {
+        return callback -> asSupplier().andFinally(after).get(callback);
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackSupplier.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.async.function;
+
+import com.mongodb.annotations.NotThreadSafe;
+import com.mongodb.internal.async.SingleResultCallback;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+/**
+ * An {@linkplain AsyncCallbackFunction asynchronous callback-based function} of no parameters.
+ * This class is a callback-based counterpart of {@link Supplier}.
+ * Any asynchronous callback function with parameters may be represented this way by partially applying the function to its parameters
+ * until no parameters are left unapplied, and only a callback is left to be consumed.
+ * <p>
+ * This class provides some methods that facilitate composing functions, thus making it remotely similar to {@link CompletionStage}.
+ *
+ * @param <R> See {@link AsyncCallbackFunction}.
+ * @see AsyncCallbackFunction
+ */
+@FunctionalInterface
+public interface AsyncCallbackSupplier<R> {
+    /**
+     * @see AsyncCallbackFunction#apply(Object, SingleResultCallback)
+     */
+    void get(SingleResultCallback<R> callback);
+
+    /**
+     * Returns a composed asynchronous function that executes this {@link AsyncCallbackSupplier} always<sup>(1)</sup> followed
+     * (in the happens-before order) by the synchronous {@code after} action, which is then followed (in the happens-before order)
+     * by completing the callback of the composed asynchronous function.
+     *
+     * @param after The synchronous action to execute after this {@link AsyncCallbackSupplier}.
+     * If {@code after} completes abruptly, then its exception is used as the failed result of the composed asynchronous function,
+     * i.e., it is relayed to its callback. If this {@link AsyncCallbackSupplier} fails and {@code after}
+     * completes abruptly, then the {@code after} exception is {@linkplain Throwable#addSuppressed(Throwable) suppressed}
+     * by the failed result of this {@link AsyncCallbackSupplier}.
+     * <p>
+     * The {@code after} action is executed even if
+     * <ul>
+     *     <li>this {@link AsyncCallbackSupplier} fails;</li>
+     *     <li>the method {@link AsyncCallbackSupplier#get(SingleResultCallback)} of this {@link AsyncCallbackSupplier}
+     *     completes abruptly, thus violating its contract;</li>
+     * </ul>
+     * <sup>(1)</sup>but is not executed if
+     * <ul>
+     *     <li>the method {@link AsyncCallbackSupplier#get(SingleResultCallback)} of this {@link AsyncCallbackSupplier} neither completes
+     *     abruptly, nor completes its callback, i.e., violates its contract in the worst possible way.</li>
+     * </ul>
+     * In situations when {@code after} is executed despite
+     * {@link AsyncCallbackSupplier#get(SingleResultCallback)} violating its
+     * contract by completing abruptly, the {@code after} action is executed synchronously by the {@link #andFinally(Runnable)} method.
+     * This is a price we have to pay to provide a guarantee similar to that of the
+     * <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.20.2">{@code finally} block</a>.
+     */
+    default AsyncCallbackSupplier<R> andFinally(final Runnable after) {
+        @NotThreadSafe
+        final class MutableBoolean {
+            private boolean value;
+        }
+        MutableBoolean afterExecuted = new MutableBoolean();
+        Runnable trackableAfter = () -> {
+            try {
+                after.run();
+            } finally {
+                afterExecuted.value = true;
+            }
+        };
+        return callback -> {
+            SingleResultCallback<R> callbackThatCallsAfter = (result, t) -> {
+                Throwable primaryException = t;
+                try {
+                    trackableAfter.run();
+                } catch (Throwable afterException) {
+                    if (primaryException == null) {
+                        primaryException = afterException;
+                    } else {
+                        primaryException.addSuppressed(afterException);
+                    }
+                    callback.onResult(null, primaryException);
+                    return;
+                }
+                callback.onResult(result, primaryException);
+            };
+            Throwable primaryUnexpectedException = null;
+            try {
+                get(callbackThatCallsAfter);
+            } catch (Throwable unexpectedException){
+                primaryUnexpectedException = unexpectedException;
+                throw unexpectedException;
+            } finally {
+                if (primaryUnexpectedException != null && !afterExecuted.value) {
+                    try {
+                        trackableAfter.run();
+                    } catch (Throwable afterException) {
+                        primaryUnexpectedException.addSuppressed(afterException);
+                    }
+                }
+            }
+        };
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/AsyncCallbackSupplier.java
@@ -18,7 +18,6 @@ package com.mongodb.internal.async.function;
 import com.mongodb.annotations.NotThreadSafe;
 import com.mongodb.internal.async.SingleResultCallback;
 
-import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
 /**
@@ -26,8 +25,6 @@ import java.util.function.Supplier;
  * This class is a callback-based counterpart of {@link Supplier}.
  * Any asynchronous callback function with parameters may be represented this way by partially applying the function to its parameters
  * until no parameters are left unapplied, and only a callback is left to be consumed.
- * <p>
- * This class provides some methods that facilitate composing functions, thus making it remotely similar to {@link CompletionStage}.
  *
  * @param <R> See {@link AsyncCallbackFunction}.
  * @see AsyncCallbackFunction
@@ -40,7 +37,9 @@ public interface AsyncCallbackSupplier<R> {
     void get(SingleResultCallback<R> callback);
 
     /**
-     * Returns a composed asynchronous function that executes this {@link AsyncCallbackSupplier} always<sup>(1)</sup> followed
+     * Returns a composed asynchronous function that provides a guarantee of executing the {@code after} action similar to that of the
+     * <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.20.2">{@code finally} block</a>.
+     * The returned function that executes this {@link AsyncCallbackSupplier} always<sup>(1)</sup> followed
      * (in the happens-before order) by the synchronous {@code after} action, which is then followed (in the happens-before order)
      * by completing the callback of the composed asynchronous function.
      *
@@ -63,11 +62,10 @@ public interface AsyncCallbackSupplier<R> {
      * </ul>
      * In situations when {@code after} is executed despite
      * {@link AsyncCallbackSupplier#get(SingleResultCallback)} violating its
-     * contract by completing abruptly, the {@code after} action is executed synchronously by the {@link #andFinally(Runnable)} method.
-     * This is a price we have to pay to provide a guarantee similar to that of the
-     * <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.20.2">{@code finally} block</a>.
+     * contract by completing abruptly, the {@code after} action is executed synchronously by the {@link #whenComplete(Runnable)} method.
+     * This is a price we have to pay to provide a guarantee similar to that of the {@code finally} block.
      */
-    default AsyncCallbackSupplier<R> andFinally(final Runnable after) {
+    default AsyncCallbackSupplier<R> whenComplete(final Runnable after) {
         @NotThreadSafe
         final class MutableBoolean {
             private boolean value;

--- a/driver-core/src/main/com/mongodb/internal/async/function/LoopState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/LoopState.java
@@ -57,8 +57,8 @@ public final class LoopState {
         if (broken) {
             return false;
         } else {
-            removeAutoRemovableAttachments();
             iteration++;
+            removeAutoRemovableAttachments();
             return true;
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/async/function/LoopState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/LoopState.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.async.function;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.annotations.NotThreadSafe;
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.lang.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.mongodb.assertions.Assertions.assertFalse;
+import static com.mongodb.assertions.Assertions.assertNotNull;
+
+/**
+ * Represents both the state associated with a loop and a handle that can be used to affect looping, e.g.,
+ * to {@linkplain #breakAndCompleteIf(Supplier, SingleResultCallback) break} it.
+ * {@linkplain #attachment(AttachmentKey) Attachments} may be used by the associated loop
+ * to preserve a state between iterations.
+ *
+ * @see AsyncCallbackLoop
+ */
+@NotThreadSafe
+public final class LoopState {
+    private int iteration;
+    private boolean broken;
+    @Nullable
+    private Map<AttachmentKey<?>, AttachmentValueContainer> attachments;
+
+    public LoopState() {
+        iteration = 0;
+    }
+
+    /**
+     * Advances this {@link LoopState} such that it represents the state of a new iteration.
+     * Must not be called before the {@linkplain #firstIteration() first iteration}, must be called before each subsequent iteration.
+     *
+     * @return {@code true} if the next iteration must be executed; {@code false} iff the loop was {@link #lastIteration() broken}.
+     */
+    boolean advance() {
+        if (broken) {
+            return false;
+        } else {
+            removeAutoRemovableAttachments();
+            iteration++;
+            return true;
+        }
+    }
+
+    /**
+     * Returns {@code true} iff the current iteration is the first one.
+     *
+     * @see #iteration()
+     */
+    public boolean firstIteration() {
+        return iteration == 0;
+    }
+
+    /**
+     * Returns {@code true} iff {@link #breakAndCompleteIf(Supplier, SingleResultCallback)} / {@link #markAsLastIteration()} was called.
+     */
+    boolean lastIteration() {
+        return broken;
+    }
+
+    /**
+     * A 0-based iteration number.
+     */
+    public int iteration() {
+        return iteration;
+    }
+
+    /**
+     * This method emulates executing the <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.15">
+     * {@code break}</a> statement. Must not be called more than once per {@link LoopState}.
+     *
+     * @param predicate {@code true} iff the associated loop needs to be broken.
+     * @return {@code true} iff the {@code callback} was completed, which happens iff any of the following is true:
+     * <ul>
+     *     <li>the {@code predicate} completed abruptly, in which case the exception thrown is relayed to the {@code callback};</li>
+     *     <li>this method broke the associated loop.</li>
+     * </ul>
+     * If {@code true} is returned, the caller must complete the ongoing attempt.
+     * @see #lastIteration()
+     */
+    public boolean breakAndCompleteIf(final Supplier<Boolean> predicate, final SingleResultCallback<?> callback) {
+        assertFalse(broken);
+        try {
+            broken = predicate.get();
+        } catch (Throwable t) {
+            callback.onResult(null, t);
+            return true;
+        }
+        if (broken) {
+            callback.onResult(null, null);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * This method is similar to {@link #breakAndCompleteIf(Supplier, SingleResultCallback)}.
+     * The difference is that it allows the current iteration to continue, yet no more iterations will happen.
+     *
+     * @see #lastIteration()
+     */
+    void markAsLastIteration() {
+        assertFalse(broken);
+        broken = true;
+    }
+
+    /**
+     * @param autoRemove Specifies whether the attachment must be automatically removed before (in the happens-before order) the next
+     * {@linkplain #iteration() iteration} as if this removal were the very first action of the iteration.
+     * Note that this parameter cannot be used to guarantee that the attachment is removed once
+     * the loop with this {@link LoopState} is completed.
+     * @return {@code this}.
+     * @see #attachment(AttachmentKey)
+     */
+    public <V> LoopState attach(final AttachmentKey<V> key, final V value, final boolean autoRemove) {
+        attachments().put(assertNotNull(key), new AttachmentValueContainer(assertNotNull(value), autoRemove));
+        return this;
+    }
+
+    /**
+     * @see #attach(AttachmentKey, Object, boolean)
+     */
+    public <V> Optional<V> attachment(final LoopState.AttachmentKey<V> key) {
+        final AttachmentValueContainer valueContainer = attachments().get(assertNotNull(key));
+        @SuppressWarnings("unchecked")
+        final V value = valueContainer == null ? null : (V) valueContainer.value();
+        return Optional.ofNullable(value);
+    }
+
+    private Map<AttachmentKey<?>, AttachmentValueContainer> attachments() {
+        if (attachments == null) {
+            attachments = new HashMap<>();
+        }
+        return attachments;
+    }
+
+    private void removeAutoRemovableAttachments() {
+        if (attachments == null) {
+            return;
+        }
+        attachments.entrySet().removeIf(entry -> entry.getValue().autoRemove());
+    }
+
+    @Override
+    public String toString() {
+        return "LoopState{"
+                + "iteration=" + iteration
+                + ", attachments=" + attachments
+                + '}';
+    }
+
+    /**
+     * A <a href="https://docs.oracle.com/javase/8/docs/api/java/lang/doc-files/ValueBased.html">value-based</a>
+     * identifier of an attachment.
+     *
+     * @param <V> The type of the corresponding attachment value.
+     */
+    @Immutable
+    // the type parameter V is of the essence even though it is not used in the interface itself
+    @SuppressWarnings("unused")
+    public interface AttachmentKey<V> {
+    }
+
+    private static final class AttachmentValueContainer {
+        @Nullable
+        private final Object value;
+        private final boolean autoRemove;
+
+        AttachmentValueContainer(final Object value, final boolean autoRemove) {
+            this.value = value;
+            this.autoRemove = autoRemove;
+        }
+
+        @Nullable
+        Object value() {
+            return value;
+        }
+
+        boolean autoRemove() {
+            return autoRemove;
+        }
+
+        @Override
+        public String toString() {
+            return "AttachmentValueContainer{"
+                    + "value=" + value
+                    + ", autoRemove=" + autoRemove
+                    + '}';
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/async/function/LoopState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/LoopState.java
@@ -49,9 +49,9 @@ public final class LoopState {
 
     /**
      * Advances this {@link LoopState} such that it represents the state of a new iteration.
-     * Must not be called before the {@linkplain #firstIteration() first iteration}, must be called before each subsequent iteration.
+     * Must not be called before the {@linkplain #isFirstIteration() first iteration}, must be called before each subsequent iteration.
      *
-     * @return {@code true} if the next iteration must be executed; {@code false} iff the loop was {@link #lastIteration() broken}.
+     * @return {@code true} if the next iteration must be executed; {@code false} iff the loop was {@link #isLastIteration() broken}.
      */
     boolean advance() {
         if (lastIteration) {
@@ -68,14 +68,14 @@ public final class LoopState {
      *
      * @see #iteration()
      */
-    public boolean firstIteration() {
+    public boolean isFirstIteration() {
         return iteration == 0;
     }
 
     /**
      * Returns {@code true} iff {@link #breakAndCompleteIf(Supplier, SingleResultCallback)} / {@link #markAsLastIteration()} was called.
      */
-    boolean lastIteration() {
+    boolean isLastIteration() {
         return lastIteration;
     }
 
@@ -97,7 +97,7 @@ public final class LoopState {
      *     <li>this method broke the associated loop.</li>
      * </ul>
      * If {@code true} is returned, the caller must complete the ongoing attempt.
-     * @see #lastIteration()
+     * @see #isLastIteration()
      */
     public boolean breakAndCompleteIf(final Supplier<Boolean> predicate, final SingleResultCallback<?> callback) {
         assertFalse(lastIteration);
@@ -119,7 +119,7 @@ public final class LoopState {
      * This method is similar to {@link #breakAndCompleteIf(Supplier, SingleResultCallback)}.
      * The difference is that it allows the current iteration to continue, yet no more iterations will happen.
      *
-     * @see #lastIteration()
+     * @see #isLastIteration()
      */
     void markAsLastIteration() {
         assertFalse(lastIteration);
@@ -131,7 +131,7 @@ public final class LoopState {
      *
      * @param autoRemove Specifies whether the attachment must be automatically removed before (in the happens-before order) the next
      * {@linkplain #iteration() iteration} as if this removal were the very first action of the iteration.
-     * Note that there is no guarantee that the attachment is removed after the {@linkplain #lastIteration() last iteration}.
+     * Note that there is no guarantee that the attachment is removed after the {@linkplain #isLastIteration() last iteration}.
      * @return {@code this}.
      * @see #attachment(AttachmentKey)
      */

--- a/driver-core/src/main/com/mongodb/internal/async/function/LoopState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/LoopState.java
@@ -142,7 +142,7 @@ public final class LoopState {
     /**
      * @see #attach(AttachmentKey, Object, boolean)
      */
-    public <V> Optional<V> attachment(final LoopState.AttachmentKey<V> key) {
+    public <V> Optional<V> attachment(final AttachmentKey<V> key) {
         final AttachmentValueContainer valueContainer = attachments().get(assertNotNull(key));
         @SuppressWarnings("unchecked")
         final V value = valueContainer == null ? null : (V) valueContainer.value();

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
@@ -85,22 +85,20 @@ public final class RetryState {
      *     (the first argument of the {@code exceptionTransformer})</li>
      *     <li>and the exception from the most recent attempt (the second argument of the {@code exceptionTransformer}).</li>
      * </ul>
-     * The {@code exceptionTransformer} may either choose from its arguments, or return a different exception, but it must return
-     * a {@code @}{@link NonNull} value.
+     * The {@code exceptionTransformer} may either choose from its arguments, or return a different exception, a.k.a. transform,
+     * but it must return a {@code @}{@link NonNull} value.
      * The {@code exceptionTransformer} is called once before (in the happens-before order) the {@code retryPredicate},
      * regardless of whether the {@code retryPredicate} is called. The result of the {@code exceptionTransformer} does not affect
-     * the arguments passed to the {@code retryPredicate}, but they still may be mutated by the {@code exceptionTransformer}.
+     * what exception is passed to the {@code retryPredicate}.
      * @param retryPredicate {@code true} iff another attempt needs to be made. The {@code retryPredicate} is called not more than once
      * per attempt and only if all the following is true:
      * <ul>
      *     <li>{@code exceptionTransformer} completed normally;</li>
-     *     <li>retrying was not broken via
-     *     {@link #breakAndThrowIfRetryAnd(Supplier)} / {@link #breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)} /
-     *     {@link #markAsLastAttempt()};</li>
-     *     <li>there is at least one more {@linkplain #attempts() attempt} left.</li>
+     *     <li>the most recent attempt is not the {@linkplain #isLastAttempt() last} one.</li>
      * </ul>
-     * This {@linkplain RetryState} is updated after (in the happens-before order) testing the {@code retryPredicate},
-     * and only if the predicate completes normally.
+     * The {@code retryPredicate} accepts this {@link RetryState} and the exception from the most recent attempt,
+     * and may mutate the exception. The {@linkplain RetryState} advances to represent the state of a new attempt
+     * after (in the happens-before order) testing the {@code retryPredicate}, and only if the predicate completes normally.
      * @throws RuntimeException Iff any of the following is true:
      * <ul>
      *     <li>the {@code exceptionTransformer} completed abruptly;</li>
@@ -310,7 +308,7 @@ public final class RetryState {
      *
      * @see #attempts()
      */
-    boolean isLastAttempt() {
+    public boolean isLastAttempt() {
         return attempt() == attempts - 1 || loopState.isLastIteration();
     }
 

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
@@ -96,7 +96,7 @@ public final class RetryState {
      * per attempt and only if all the following is true:
      * <ul>
      *     <li>{@code exceptionTransformer} completed normally;</li>
-     *     <li>retrying was broken via
+     *     <li>retrying was not broken via
      *     {@link #breakAndThrowIfRetryAnd(Supplier)} / {@link #breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)} /
      *     {@link #markAsLastAttempt()};</li>
      *     <li>there is at least one more {@linkplain #attempts() attempt} left.</li>

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.async.function;
+
+import com.mongodb.annotations.NotThreadSafe;
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.async.function.LoopState.AttachmentKey;
+import com.mongodb.lang.NonNull;
+import com.mongodb.lang.Nullable;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Supplier;
+
+import static com.mongodb.assertions.Assertions.assertFalse;
+import static com.mongodb.assertions.Assertions.assertNotNull;
+import static com.mongodb.assertions.Assertions.assertTrue;
+
+/**
+ * Represents both the state associated with a retryable activity and a handle that can be used to affect retrying, e.g.,
+ * to {@linkplain #breakAndThrowIfRetryAnd(Supplier) break} it.
+ * {@linkplain #attachment(AttachmentKey) Attachments} may be used by the associated retryable activity either
+ * to preserve a state between attempts.
+ *
+ * @see RetryingSyncSupplier
+ * @see RetryingAsyncCallbackSupplier
+ */
+@NotThreadSafe
+public final class RetryState {
+    public static final int RETRIES = 1;
+    private static final int INFINITE_ATTEMPTS = Integer.MAX_VALUE;
+
+    private final LoopState loopState;
+    private final int attempts;
+    @Nullable
+    private Throwable exception;
+
+    /**
+     * @param retries A non-negative number of allowed retries.
+     * @see #attempts()
+     */
+    public RetryState(final int retries) {
+        assertTrue(retries >= 0);
+        assertTrue(retries < INFINITE_ATTEMPTS);
+        loopState = new LoopState();
+        attempts = retries + 1;
+    }
+
+    /**
+     * Creates a {@link RetryState} that does not limit the number of retries.
+     * @see #attempts()
+     */
+    public RetryState() {
+        loopState = new LoopState();
+        attempts = INFINITE_ATTEMPTS;
+    }
+
+    /**
+     * Advances this {@link RetryState} such that it represents the state of a new attempt.
+     * If there is at least one more {@linkplain #attempts() attempt} left, it is consumed by this method.
+     * Must not be called before the {@linkplain #firstAttempt() first attempt}, must be called before each subsequent attempt.
+     * <p>
+     * This method is intended to be used by code that generally does not handle {@link Error}s explicitly,
+     * which is usually synchronous code.
+     *
+     * @param attemptException The exception produced by the most recent attempt.
+     * It is passed to the {@code retryPredicate} and to the {@code exceptionTransformer}.
+     * @param exceptionTransformer A function that chooses which exception to preserve as a prospective failed result of the associated
+     * retryable activity and may also transform or mutate the exceptions.
+     * The choice is between
+     * <ul>
+     *     <li>the previously chosen exception or {@code null} if none has been chosen
+     *     (the first argument of the {@code exceptionTransformer})</li>
+     *     <li>and the exception from the most recent attempt (the second argument of the {@code exceptionTransformer}).</li>
+     * </ul>
+     * The {@code exceptionTransformer} may either choose from its arguments, or return a different exception, but it must return
+     * a {@code @}{@link NonNull} value.
+     * The {@code exceptionTransformer} is called once before (in the happens-before order) the {@code retryPredicate},
+     * regardless of whether the {@code retryPredicate} is called. The result of the {@code exceptionTransformer} does not affect
+     * the arguments passed to the {@code retryPredicate}, but they still may be mutated by the {@code exceptionTransformer}.
+     * @param retryPredicate {@code true} iff another attempt needs to be made. The {@code retryPredicate} is called not more than once
+     * per attempt and only if all the following is true:
+     * <ul>
+     *     <li>{@code exceptionTransformer} completed normally;</li>
+     *     <li>retrying was broken via
+     *     {@link #breakAndThrowIfRetryAnd(Supplier)} / {@link #breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)} /
+     *     {@link #markAsLastAttempt()};</li>
+     *     <li>there is at least one more {@linkplain #attempts() attempt} left.</li>
+     * </ul>
+     * This {@linkplain RetryState} is updated after (in the happens-before order) testing the {@code retryPredicate},
+     * and only if the predicate completes normally.
+     * @throws RuntimeException Iff any of the following is true:
+     * <ul>
+     *     <li>the {@code exceptionTransformer} completed abruptly;</li>
+     *     <li>the most recent attempt is the {@linkplain #lastAttempt() last} one;</li>
+     *     <li>retrying was broken via
+     *     {@link #breakAndThrowIfRetryAnd(Supplier)} / {@link #breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)} /
+     *     {@link #markAsLastAttempt()};</li>
+     *     <li>the {@code retryPredicate} completed abruptly;</li>
+     *     <li>the {@code retryPredicate} is {@code false}.</li>
+     * </ul>
+     * The exception thrown represents the failed result of the associated retryable activity,
+     * i.e., the caller must not do any more attempts.
+     * @see #advanceOrThrow(Throwable, BiFunction, BiPredicate)
+     */
+    void advanceOrThrow(final RuntimeException attemptException, final BiFunction<Throwable, Throwable, Throwable> exceptionTransformer,
+            final BiPredicate<RetryState, Throwable> retryPredicate) throws RuntimeException {
+        try {
+            doAdvanceOrThrow(attemptException, exceptionTransformer, retryPredicate, true);
+        } catch (RuntimeException | Error unchecked) {
+            throw unchecked;
+        } catch (Throwable checked) {
+            throw new AssertionError(checked);
+        }
+    }
+
+    /**
+     * This method is intended to be used by code that generally handles all {@link Throwable} types explicitly,
+     * which is usually asynchronous code.
+     *
+     * @see #advanceOrThrow(RuntimeException, BiFunction, BiPredicate)
+     */
+    void advanceOrThrow(final Throwable attemptException, final BiFunction<Throwable, Throwable, Throwable> exceptionChooser,
+            final BiPredicate<RetryState, Throwable> retryPredicate) throws Throwable {
+        doAdvanceOrThrow(attemptException, exceptionChooser, retryPredicate, false);
+    }
+
+    /**
+     * @param onlyRuntimeExceptions {@code true} iff the method must expect {@link #exception} and {@code attemptException} to be
+     * {@link RuntimeException}s and must not explicitly handle other {@link Throwable} types, of which only {@link Error} is possible
+     * as {@link RetryState} does not have any source of {@link Exception}s.
+     */
+    private void doAdvanceOrThrow(final Throwable attemptException,
+            final BiFunction<Throwable, Throwable, Throwable> exceptionTransformer,
+            final BiPredicate<RetryState, Throwable> retryPredicate,
+            final boolean onlyRuntimeExceptions) throws Throwable {
+        assertTrue(attempt() < attempts);
+        assertNotNull(attemptException);
+        if (onlyRuntimeExceptions) {
+            assertTrue(isRuntime(attemptException));
+        }
+        assertTrue(!firstAttempt() || exception == null);
+        Throwable newlyChosenException = transformException(exception, attemptException, onlyRuntimeExceptions, exceptionTransformer);
+        if (lastAttempt()) {
+            exception = newlyChosenException;
+            throw exception;
+        } else {
+            // note that we must not update the state, e.g, `exception`, `loopState`, before calling `retryPredicate`
+            boolean retry = decideRetry(this, attemptException, newlyChosenException, onlyRuntimeExceptions, retryPredicate);
+            exception = newlyChosenException;
+            if (retry) {
+                assertTrue(loopState.advance());
+            } else {
+                throw exception;
+            }
+        }
+    }
+
+    /**
+     * @param onlyRuntimeExceptions See {@link #doAdvanceOrThrow(Throwable, BiFunction, BiPredicate, boolean)}.
+     */
+    private static Throwable transformException(@Nullable final Throwable previouslyChosenException, final Throwable attemptException,
+            final boolean onlyRuntimeExceptions, final BiFunction<Throwable, Throwable, Throwable> exceptionTransformer) {
+        if (onlyRuntimeExceptions && previouslyChosenException != null) {
+            assertTrue(isRuntime(previouslyChosenException));
+        }
+        Throwable result;
+        try {
+            result = assertNotNull(exceptionTransformer.apply(previouslyChosenException, attemptException));
+            if (onlyRuntimeExceptions) {
+                assertTrue(isRuntime(result));
+            }
+        } catch (Throwable exceptionChooserException) {
+            if (onlyRuntimeExceptions && !isRuntime(exceptionChooserException)) {
+                throw exceptionChooserException;
+            }
+            if (previouslyChosenException != null) {
+                exceptionChooserException.addSuppressed(previouslyChosenException);
+            }
+            exceptionChooserException.addSuppressed(attemptException);
+            throw exceptionChooserException;
+        }
+        return result;
+    }
+
+    /**
+     * @param readOnlyRetryState Must not be mutated by this method.
+     * @param onlyRuntimeExceptions See {@link #doAdvanceOrThrow(Throwable, BiFunction, BiPredicate, boolean)}.
+     */
+    private boolean decideRetry(final RetryState readOnlyRetryState, final Throwable attemptException, final Throwable newlyChosenException,
+            final boolean onlyRuntimeExceptions, final BiPredicate<RetryState, Throwable> retryPredicate) {
+        try {
+            return retryPredicate.test(readOnlyRetryState, attemptException);
+        } catch (Throwable retryPredicateException) {
+            if (onlyRuntimeExceptions && !isRuntime(retryPredicateException)) {
+                throw retryPredicateException;
+            }
+            retryPredicateException.addSuppressed(newlyChosenException);
+            throw retryPredicateException;
+        }
+    }
+
+    private static boolean isRuntime(@Nullable final Throwable exception) {
+        return exception instanceof RuntimeException;
+    }
+
+    /**
+     * This method is similar to the semantics of the
+     * <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.15">{@code break} statement</a>, with the difference
+     * that breaking results in throwing an exception because the retry loop has more than one iteration iff the first iteration fails.
+     * Does nothing and completes normally if called during the {@linkplain #firstAttempt() first attempt}.
+     * This method is useful when the associated retryable activity detects that a retry attempt should not happen
+     * despite having been started. Must not be called more than once per {@link RetryState}.
+     * <p>
+     * If the {@code predicate} completes abruptly, this method also completes abruptly with the same exception but does not break retrying;
+     * if the {@code predicate} is {@code true}, then the method breaks retrying and completes abruptly by throwing the exception that is
+     * currently deemed to be a prospective failed result of the associated retryable activity. The thrown exception must also be used
+     * by the caller to complete the ongoing attempt.
+     * <p>
+     * If this method is called from
+     * {@linkplain RetryingSyncSupplier#RetryingSyncSupplier(RetryState, BiFunction, BiPredicate, Supplier)
+     * retry predicate / failed result chooser}, the behavior is unspecified.
+     *
+     * @param predicate {@code true} iff retrying needs to be broken.
+     * The {@code predicate} is not called during the {@linkplain #firstAttempt() first attempt}.
+     * @throws RuntimeException Iff any of the following is true:
+     * <ul>
+     *     <li>the {@code predicate} completed abruptly;</li>
+     *     <li>this method broke retrying.</li>
+     * </ul>
+     * The exception thrown represents the failed result of the associated retryable activity.
+     * @see #breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)
+     */
+    public void breakAndThrowIfRetryAnd(final Supplier<Boolean> predicate) throws RuntimeException {
+        assertFalse(loopState.lastIteration());
+        if (!firstAttempt()) {
+            assertNotNull(exception);
+            assertTrue(exception instanceof RuntimeException);
+            RuntimeException localException = (RuntimeException) exception;
+            try {
+                if (predicate.get()) {
+                    loopState.markAsLastIteration();
+                }
+            } catch (RuntimeException predicateException) {
+                predicateException.addSuppressed(localException);
+                throw predicateException;
+            }
+            if (loopState.lastIteration()) {
+                throw localException;
+            }
+        }
+    }
+
+    /**
+     * This method is intended to be used by callback-based code. It is similar to {@link #breakAndThrowIfRetryAnd(Supplier)},
+     * but instead of throwing an exception, it relays it to the {@code callback}.
+     * <p>
+     * If this method is called from
+     * {@linkplain RetryingAsyncCallbackSupplier#RetryingAsyncCallbackSupplier(RetryState, BiFunction, BiPredicate, com.mongodb.internal.async.function.AsyncCallbackSupplier)
+     * retry predicate / failed result chooser}, the behavior is unspecified.
+     *
+     * @return {@code true} iff the {@code callback} was completed, which happens in the same situations in which
+     * {@link #breakAndThrowIfRetryAnd(Supplier)} throws an exception. If {@code true} is returned, the caller must complete
+     * the ongoing attempt.
+     * @see #breakAndThrowIfRetryAnd(Supplier)
+     */
+    public boolean breakAndCompleteIfRetryAnd(final Supplier<Boolean> predicate, final SingleResultCallback<?> callback) {
+        try {
+            breakAndThrowIfRetryAnd(predicate);
+            return false;
+        } catch (Throwable t) {
+            callback.onResult(null, t);
+            return true;
+        }
+    }
+
+    /**
+     * This method is similar to
+     * {@link RetryState#breakAndThrowIfRetryAnd(Supplier)} / {@link RetryState#breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)}.
+     * The difference is that it allows the current attempt to continue, yet no more attempts will happen. Also, unlike the aforementioned
+     * methods, this method has effect even if called during the {@linkplain #firstAttempt() first attempt}.
+     */
+    public void markAsLastAttempt() {
+        loopState.markAsLastIteration();
+    }
+
+    /**
+     * Returns {@code true} iff the current attempt is the first one, i.e., no retries have been made.
+     *
+     * @see #attempts()
+     */
+    public boolean firstAttempt() {
+        return loopState.firstIteration();
+    }
+
+    /**
+     * Returns {@code true} iff the current attempt is known to be the last one, i.e., it is known that no more retries will be made.
+     * An attempt is known to be the last one either because the number of {@linkplain #attempts() attempts} is limited and the current
+     * attempt is the last one, or because {@link #breakAndThrowIfRetryAnd(Supplier)} /
+     * {@link #breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)} / {@link #markAsLastAttempt()} was called.
+     *
+     * @see #attempts()
+     */
+    public boolean lastAttempt() {
+        return attempt() == attempts - 1 || loopState.lastIteration();
+    }
+
+    /**
+     * A 0-based attempt number.
+     *
+     * @see #attempts()
+     */
+    public int attempt() {
+        return loopState.iteration();
+    }
+
+    /**
+     * Returns a positive maximum number of attempts:
+     * <ul>
+     *     <li>0 if the number of retries is {@linkplain #RetryState() unlimited};</li>
+     *     <li>1 if no retries are allowed;</li>
+     *     <li>{@link #RetryState(int) retries} + 1 otherwise.</li>
+     * </ul>
+     *
+     * @see #attempt()
+     * @see #firstAttempt()
+     * @see #lastAttempt()
+     */
+    public int attempts() {
+        return attempts == INFINITE_ATTEMPTS ? 0 : attempts;
+    }
+
+    /**
+     * Returns the exception that is currently deemed to be a prospective failed result of the associated retryable activity.
+     * Note that this exception is not necessary the one from the most recent failed attempt.
+     * Returns an {@linkplain Optional#isEmpty() empty} {@link Optional} iff called during the {@linkplain #firstAttempt() first attempt}.
+     * <p>
+     * In synchronous code the returned exception is of the type {@link RuntimeException}.
+     */
+    public Optional<Throwable> exception() {
+        assertTrue(exception == null || !firstAttempt());
+        return Optional.ofNullable(exception);
+    }
+
+    /**
+     * @see LoopState#attach(AttachmentKey, Object, boolean)
+     */
+    public <V> RetryState attach(final AttachmentKey<V> key, final V value, final boolean autoRemove) {
+        loopState.attach(key, value, autoRemove);
+        return this;
+    }
+
+    /**
+     * @see LoopState#attachment(AttachmentKey)
+     */
+    public <V> Optional<V> attachment(final AttachmentKey<V> key) {
+        return loopState.attachment(key);
+    }
+
+    @Override
+    public String toString() {
+        return "RetryState{"
+                + "loopState=" + loopState
+                + ", attempts=" + (attempts == INFINITE_ATTEMPTS ? "infinite" : attempts)
+                + ", exception=" + exception
+                + '}';
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
@@ -216,7 +216,7 @@ public final class RetryState {
     /**
      * This method is similar to the semantics of the
      * <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.15">{@code break} statement</a>, with the difference
-     * that breaking results in throwing an exception because the retry loop has more than one iteration iff the first iteration fails.
+     * that breaking results in throwing an exception because the retry loop has more than one iteration only if the first iteration fails.
      * Does nothing and completes normally if called during the {@linkplain #firstAttempt() first attempt}.
      * This method is useful when the associated retryable activity detects that a retry attempt should not happen
      * despite having been started. Must not be called more than once per {@link RetryState}.

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryingAsyncCallbackSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryingAsyncCallbackSupplier.java
@@ -52,26 +52,23 @@ public final class RetryingAsyncCallbackSupplier<R> implements AsyncCallbackSupp
      *     (the first argument of the {@code failedResultTransformer})</li>
      *     <li>and the failed result from the most recent attempt (the second argument of the {@code failedResultTransformer}).</li>
      * </ul>
-     * The {@code failedResultTransformer} may either choose from its arguments, or return a different exception, but it must return
-     * a {@code @}{@link NonNull} value.
+     * The {@code failedResultTransformer} may either choose from its arguments, or return a different exception, a.k.a. transform,
+     * but it must return a {@code @}{@link NonNull} value.
      * If it completes abruptly, then the {@code asyncFunction} cannot be retried and the exception thrown by
      * the {@code failedResultTransformer} is used as a failed result of this {@link RetryingAsyncCallbackSupplier}.
      * The {@code failedResultTransformer} is called before (in the happens-before order) the {@code retryPredicate}.
-     * The result of the {@code failedResultTransformer} does not affect the arguments passed to the {@code retryPredicate}.
+     * The result of the {@code failedResultTransformer} does not affect what exception is passed to the {@code retryPredicate}.
      * @param retryPredicate {@code true} iff another attempt needs to be made. If it completes abruptly,
      * then the {@code asyncFunction} cannot be retried and the exception thrown by the {@code retryPredicate}
      * is used as a failed result of this {@link RetryingAsyncCallbackSupplier}. The {@code retryPredicate} is called not more than once
      * per attempt and only if all the following is true:
      * <ul>
      *     <li>{@code failedResultTransformer} completed normally;</li>
-     *     <li>retrying was not broken via
-     *     {@link RetryState#breakAndThrowIfRetryAnd(Supplier)} /
-     *     {@link RetryState#breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)} /
-     *     {@link RetryState#markAsLastAttempt()};</li>
-     *     <li>there is at least one more {@linkplain RetryState#attempts() attempt} left.</li>
+     *     <li>the most recent attempt is not the {@linkplain RetryState#isLastAttempt() last} one.</li>
      * </ul>
-     * This {@linkplain RetryState} is updated after (in the happens-before order) testing the {@code retryPredicate},
-     * and only if the predicate completes normally.
+     * The {@code retryPredicate} accepts this {@link RetryState} and the exception from the most recent attempt,
+     * and may mutate the exception. The {@linkplain RetryState} advances to represent the state of a new attempt
+     * after (in the happens-before order) testing the {@code retryPredicate}, and only if the predicate completes normally.
      * @param asyncFunction The retryable {@link AsyncCallbackSupplier} to be decorated.
      */
     public RetryingAsyncCallbackSupplier(

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryingAsyncCallbackSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryingAsyncCallbackSupplier.java
@@ -39,7 +39,7 @@ import java.util.function.Supplier;
 public final class RetryingAsyncCallbackSupplier<R> implements AsyncCallbackSupplier<R> {
     private final RetryState retryState;
     private final BiPredicate<RetryState, Throwable> retryPredicate;
-    private final BiFunction<Throwable, Throwable, Throwable> failedResultChooser;
+    private final BiFunction<Throwable, Throwable, Throwable> failedResultTransformer;
     private final AsyncCallbackSupplier<R> asyncFunction;
 
     /**
@@ -63,7 +63,7 @@ public final class RetryingAsyncCallbackSupplier<R> implements AsyncCallbackSupp
      * is used as a failed result of this {@link RetryingAsyncCallbackSupplier}. The {@code retryPredicate} is called not more than once
      * per attempt and only if all the following is true:
      * <ul>
-     *     <li>{@code exceptionChooser} completed normally;</li>
+     *     <li>{@code failedResultTransformer} completed normally;</li>
      *     <li>retrying was broken via
      *     {@link RetryState#breakAndThrowIfRetryAnd(Supplier)} /
      *     {@link RetryState#breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)} /
@@ -81,7 +81,7 @@ public final class RetryingAsyncCallbackSupplier<R> implements AsyncCallbackSupp
             final AsyncCallbackSupplier<R> asyncFunction) {
         this.retryState = retryState;
         this.retryPredicate = retryPredicate;
-        this.failedResultChooser = failedResultTransformer;
+        this.failedResultTransformer = failedResultTransformer;
         this.asyncFunction = asyncFunction;
     }
 
@@ -107,7 +107,7 @@ public final class RetryingAsyncCallbackSupplier<R> implements AsyncCallbackSupp
         public void onResult(@Nullable final R result, @Nullable final Throwable t) {
             if (t != null) {
                 try {
-                    retryState.advanceOrThrow(t, failedResultChooser, retryPredicate);
+                    retryState.advanceOrThrow(t, failedResultTransformer, retryPredicate);
                 } catch (Throwable failedResult) {
                     wrapped.onResult(null, failedResult);
                     return;

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryingAsyncCallbackSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryingAsyncCallbackSupplier.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.async.function;
+
+import com.mongodb.annotations.NotThreadSafe;
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.lang.NonNull;
+import com.mongodb.lang.Nullable;
+
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Supplier;
+
+/**
+ * A decorator that implements automatic retrying of failed executions of an {@link AsyncCallbackSupplier}.
+ * {@link RetryingAsyncCallbackSupplier} may execute the original retryable asynchronous function multiple times sequentially,
+ * while guaranteeing that the callback passed to {@link #get(SingleResultCallback)} is completed at most once.
+ * <p>
+ * The original function may additionally observe or control retrying via {@link RetryState}.
+ * For example, the {@link RetryState#breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)} method may be used to
+ * break retrying if the original function decides so.
+ *
+ * @see RetryingSyncSupplier
+ */
+@NotThreadSafe
+public final class RetryingAsyncCallbackSupplier<R> implements AsyncCallbackSupplier<R> {
+    private final RetryState retryState;
+    private final BiPredicate<RetryState, Throwable> retryPredicate;
+    private final BiFunction<Throwable, Throwable, Throwable> failedResultChooser;
+    private final AsyncCallbackSupplier<R> asyncFunction;
+
+    /**
+     * @param retryState The {@link RetryState} to be deemed as initial for the purpose of the new {@link RetryingAsyncCallbackSupplier}.
+     * @param failedResultTransformer A function that chooses which failed result of the {@code asyncFunction} to preserve as a prospective
+     * failed result of this {@link RetryingAsyncCallbackSupplier} and may also transform or mutate the exceptions.
+     * The choice is between
+     * <ul>
+     *     <li>the previously chosen failed result or {@code null} if none has been chosen
+     *     (the first argument of the {@code failedResultTransformer})</li>
+     *     <li>and the failed result from the most recent attempt (the second argument of the {@code failedResultTransformer}).</li>
+     * </ul>
+     * The {@code failedResultTransformer} may either choose from its arguments, or return a different exception, but it must return
+     * a {@code @}{@link NonNull} value.
+     * If it completes abruptly, then the {@code asyncFunction} cannot be retried and the exception thrown by
+     * the {@code failedResultTransformer} is used as a failed result of this {@link RetryingAsyncCallbackSupplier}.
+     * The {@code failedResultTransformer} is called before (in the happens-before order) the {@code retryPredicate}.
+     * The result of the {@code failedResultTransformer} does not affect the arguments passed to the {@code retryPredicate}.
+     * @param retryPredicate {@code true} iff another attempt needs to be made. If it completes abruptly,
+     * then the {@code asyncFunction} cannot be retried and the exception thrown by the {@code retryPredicate}
+     * is used as a failed result of this {@link RetryingAsyncCallbackSupplier}. The {@code retryPredicate} is called not more than once
+     * per attempt and only if all the following is true:
+     * <ul>
+     *     <li>{@code exceptionChooser} completed normally;</li>
+     *     <li>retrying was broken via
+     *     {@link RetryState#breakAndThrowIfRetryAnd(Supplier)} /
+     *     {@link RetryState#breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)} /
+     *     {@link RetryState#markAsLastAttempt()};</li>
+     *     <li>there is at least one more {@linkplain RetryState#attempts() attempt} left.</li>
+     * </ul>
+     * This {@linkplain RetryState} is updated after (in the happens-before order) testing the {@code retryPredicate},
+     * and only if the predicate completes normally.
+     * @param asyncFunction The retryable {@link AsyncCallbackSupplier} to be decorated.
+     */
+    public RetryingAsyncCallbackSupplier(
+            final RetryState retryState,
+            final BiFunction<Throwable, Throwable, Throwable> failedResultTransformer,
+            final BiPredicate<RetryState, Throwable> retryPredicate,
+            final AsyncCallbackSupplier<R> asyncFunction) {
+        this.retryState = retryState;
+        this.retryPredicate = retryPredicate;
+        this.failedResultChooser = failedResultTransformer;
+        this.asyncFunction = asyncFunction;
+    }
+
+    @Override
+    public void get(final SingleResultCallback<R> callback) {
+        /* `asyncFunction` and `callback` are the only externally provided pieces of code for which we do not need to care about
+         * them throwing exceptions. If they do, that violates their contract and there is nothing we should do about it. */
+        asyncFunction.get(new RetryingCallback(callback));
+    }
+
+    /**
+     * This callback is allowed to be completed more than once.
+     */
+    @NotThreadSafe
+    private class RetryingCallback implements SingleResultCallback<R> {
+        private final SingleResultCallback<R> wrapped;
+
+        RetryingCallback(final SingleResultCallback<R> callback) {
+            wrapped = callback;
+        }
+
+        @Override
+        public void onResult(@Nullable final R result, @Nullable final Throwable t) {
+            if (t != null) {
+                try {
+                    retryState.advanceOrThrow(t, failedResultChooser, retryPredicate);
+                } catch (Throwable failedResult) {
+                    wrapped.onResult(null, failedResult);
+                    return;
+                }
+                asyncFunction.get(this);
+            } else {
+                wrapped.onResult(result, null);
+            }
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryingSyncSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryingSyncSupplier.java
@@ -35,7 +35,7 @@ import java.util.function.Supplier;
 public final class RetryingSyncSupplier<R> implements Supplier<R> {
     private final RetryState retryState;
     private final BiPredicate<RetryState, Throwable> retryPredicate;
-    private final BiFunction<Throwable, Throwable, Throwable> failedResultChooser;
+    private final BiFunction<Throwable, Throwable, Throwable> failedResultTransformer;
     private final Supplier<R> syncFunction;
 
     /**
@@ -54,7 +54,7 @@ public final class RetryingSyncSupplier<R> implements Supplier<R> {
             final Supplier<R> syncFunction) {
         this.retryState = retryState;
         this.retryPredicate = retryPredicate;
-        this.failedResultChooser = failedResultTransformer;
+        this.failedResultTransformer = failedResultTransformer;
         this.syncFunction = syncFunction;
     }
 
@@ -64,7 +64,7 @@ public final class RetryingSyncSupplier<R> implements Supplier<R> {
             try {
                 return syncFunction.get();
             } catch (RuntimeException attemptException) {
-                retryState.advanceOrThrow(attemptException, failedResultChooser, retryPredicate);
+                retryState.advanceOrThrow(attemptException, failedResultTransformer, retryPredicate);
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryingSyncSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryingSyncSupplier.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.async.function;
+
+import com.mongodb.annotations.NotThreadSafe;
+
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Supplier;
+
+/**
+ * A decorator that implements automatic retrying of failed executions of a {@link Supplier}.
+ * {@link RetryingSyncSupplier} may execute the original retryable function multiple times sequentially.
+ * <p>
+ * The original function may additionally observe or control retrying via {@link RetryState}.
+ * For example, the {@link RetryState#breakAndThrowIfRetryAnd(Supplier)} method may be used to
+ * break retrying if the original function decides so.
+ *
+ * @see RetryingAsyncCallbackSupplier
+ */
+@NotThreadSafe
+public final class RetryingSyncSupplier<R> implements Supplier<R> {
+    private final RetryState retryState;
+    private final BiPredicate<RetryState, Throwable> retryPredicate;
+    private final BiFunction<Throwable, Throwable, Throwable> failedResultChooser;
+    private final Supplier<R> syncFunction;
+
+    /**
+     * See {@link RetryingAsyncCallbackSupplier#RetryingAsyncCallbackSupplier(RetryState, BiFunction, BiPredicate, AsyncCallbackSupplier)}
+     * for the documentation of the parameters.
+     *
+     * @param failedResultTransformer Even though the {@code failedResultTransformer} accepts {@link Throwable},
+     * only {@link RuntimeException}s are passed to it.
+     * @param retryPredicate Even though the {@code retryPredicate} accepts {@link Throwable},
+     * only {@link RuntimeException}s are passed to it.
+     */
+    public RetryingSyncSupplier(
+            final RetryState retryState,
+            final BiFunction<Throwable, Throwable, Throwable> failedResultTransformer,
+            final BiPredicate<RetryState, Throwable> retryPredicate,
+            final Supplier<R> syncFunction) {
+        this.retryState = retryState;
+        this.retryPredicate = retryPredicate;
+        this.failedResultChooser = failedResultTransformer;
+        this.syncFunction = syncFunction;
+    }
+
+    @Override
+    public R get() {
+        while (true) {
+            try {
+                return syncFunction.get();
+            } catch (RuntimeException attemptException) {
+                retryState.advanceOrThrow(attemptException, failedResultChooser, retryPredicate);
+            }
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryingSyncSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryingSyncSupplier.java
@@ -33,7 +33,7 @@ import java.util.function.Supplier;
  */
 @NotThreadSafe
 public final class RetryingSyncSupplier<R> implements Supplier<R> {
-    private final RetryState retryState;
+    private final RetryState state;
     private final BiPredicate<RetryState, Throwable> retryPredicate;
     private final BiFunction<Throwable, Throwable, Throwable> failedResultTransformer;
     private final Supplier<R> syncFunction;
@@ -48,11 +48,11 @@ public final class RetryingSyncSupplier<R> implements Supplier<R> {
      * only {@link RuntimeException}s are passed to it.
      */
     public RetryingSyncSupplier(
-            final RetryState retryState,
+            final RetryState state,
             final BiFunction<Throwable, Throwable, Throwable> failedResultTransformer,
             final BiPredicate<RetryState, Throwable> retryPredicate,
             final Supplier<R> syncFunction) {
-        this.retryState = retryState;
+        this.state = state;
         this.retryPredicate = retryPredicate;
         this.failedResultTransformer = failedResultTransformer;
         this.syncFunction = syncFunction;
@@ -64,7 +64,7 @@ public final class RetryingSyncSupplier<R> implements Supplier<R> {
             try {
                 return syncFunction.get();
             } catch (RuntimeException attemptException) {
-                retryState.advanceOrThrow(attemptException, failedResultTransformer, retryPredicate);
+                state.advanceOrThrow(attemptException, failedResultTransformer, retryPredicate);
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/binding/SingleServerBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/SingleServerBinding.java
@@ -129,4 +129,3 @@ public class SingleServerBinding extends AbstractReferenceCounted implements Rea
         }
     }
 }
-

--- a/driver-core/src/main/com/mongodb/internal/operation/AbortTransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AbortTransactionOperation.java
@@ -22,8 +22,6 @@ import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerDescription;
 import org.bson.BsonDocument;
 
-import static com.mongodb.internal.operation.CommandOperationHelper.noOpRetryCommandModifier;
-
 /**
  * An operation that aborts a transaction.
  *
@@ -74,6 +72,6 @@ public class AbortTransactionOperation extends TransactionOperation {
 
     @Override
     protected Function<BsonDocument, BsonDocument> getRetryCommandModifier() {
-        return noOpRetryCommandModifier();
+        return cmd -> cmd;
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
@@ -50,8 +50,8 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommand;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableRead;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableReadAsync;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.OperationHelper.cursorDocumentToQueryResult;
 import static com.mongodb.internal.operation.OperationHelper.validateReadConcernAndCollation;
@@ -192,14 +192,14 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
 
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
-        return executeCommand(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
+        return executeRetryableRead(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
                 CommandResultDocumentCodec.create(decoder, FIELD_NAMES_WITH_RESULT), transformer(), retryReads);
     }
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
         SingleResultCallback<AsyncBatchCursor<T>> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-        executeCommandAsync(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
+        executeRetryableReadAsync(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
                 CommandResultDocumentCodec.create(decoder, FIELD_NAMES_WITH_RESULT), asyncTransformer(), retryReads, errHandlingCallback);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/BaseFindAndModifyOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/BaseFindAndModifyOperation.java
@@ -31,7 +31,8 @@ import org.bson.codecs.Decoder;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableCommand;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableWrite;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableWriteAsync;
 import static com.mongodb.internal.operation.OperationHelper.isRetryableWrite;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 
@@ -66,17 +67,18 @@ public abstract class BaseFindAndModifyOperation<T> implements AsyncWriteOperati
 
     @Override
     public T execute(final WriteBinding binding) {
-        return executeRetryableCommand(binding, getDatabaseName(), null, getFieldNameValidator(),
+        return executeRetryableWrite(binding, getDatabaseName(), null, getFieldNameValidator(),
                 CommandResultDocumentCodec.create(getDecoder(), "value"),
                 getCommandCreator(binding.getSessionContext()),
-                FindAndModifyHelper.<T>transformer());
+                FindAndModifyHelper.transformer(),
+                cmd -> cmd);
     }
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<T> callback) {
-        executeRetryableCommand(binding, getDatabaseName(), null, getFieldNameValidator(),
+        executeRetryableWriteAsync(binding, getDatabaseName(), null, getFieldNameValidator(),
                 CommandResultDocumentCodec.create(getDecoder(), "value"),
-                getCommandCreator(binding.getSessionContext()), FindAndModifyHelper.<T>asyncTransformer(), callback);
+                getCommandCreator(binding.getSessionContext()), FindAndModifyHelper.asyncTransformer(), cmd -> cmd, callback);
     }
 
     protected abstract String getDatabaseName();

--- a/driver-core/src/main/com/mongodb/internal/operation/BulkWriteBatch.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/BulkWriteBatch.java
@@ -70,7 +70,7 @@ import static com.mongodb.internal.operation.WriteConcernHelper.createWriteConce
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 
 
-final class BulkWriteBatch {
+public final class BulkWriteBatch {
     private static final CodecRegistry REGISTRY = fromProviders(new BsonValueCodecProvider());
     private static final Decoder<BsonDocument> DECODER = REGISTRY.get(BsonDocument.class);
     private static final FieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
@@ -89,7 +89,7 @@ final class BulkWriteBatch {
     private final List<WriteRequestWithIndex> unprocessed;
     private final SessionContext sessionContext;
 
-    public static BulkWriteBatch createBulkWriteBatch(final MongoNamespace namespace,
+    static BulkWriteBatch createBulkWriteBatch(final MongoNamespace namespace,
                                                       final ServerDescription serverDescription,
                                                       final ConnectionDescription connectionDescription,
                                                       final boolean ordered, final WriteConcern writeConcern,
@@ -194,7 +194,7 @@ final class BulkWriteBatch {
         this.command = command;
     }
 
-    public void addResult(final BsonDocument result) {
+    void addResult(final BsonDocument result) {
         if (writeConcern.isAcknowledged()) {
             if (hasError(result)) {
                 MongoBulkWriteException bulkWriteException = getBulkWriteException(result);
@@ -205,43 +205,43 @@ final class BulkWriteBatch {
         }
     }
 
-    public boolean getRetryWrites() {
+    boolean getRetryWrites() {
         return retryWrites;
     }
 
-    public BsonDocument getCommand() {
+    BsonDocument getCommand() {
         return command;
     }
 
-    public SplittablePayload getPayload() {
+    SplittablePayload getPayload() {
         return payload;
     }
 
-    public Decoder<BsonDocument> getDecoder() {
+    Decoder<BsonDocument> getDecoder() {
         return DECODER;
     }
 
-    public BulkWriteResult getResult() {
+    BulkWriteResult getResult() {
         return bulkWriteBatchCombiner.getResult();
     }
 
-    public boolean hasErrors() {
+    boolean hasErrors() {
         return bulkWriteBatchCombiner.hasErrors();
     }
 
-    public MongoBulkWriteException getError() {
+    MongoBulkWriteException getError() {
         return bulkWriteBatchCombiner.getError();
     }
 
-    public boolean shouldProcessBatch() {
+    boolean shouldProcessBatch() {
         return !bulkWriteBatchCombiner.shouldStopSendingMoreBatches() && !payload.isEmpty();
     }
 
-    public boolean hasAnotherBatch() {
+    boolean hasAnotherBatch() {
         return !unprocessed.isEmpty();
     }
 
-    public BulkWriteBatch getNextBatch() {
+    BulkWriteBatch getNextBatch() {
         if (payload.hasAnotherSplit()) {
             IndexMap nextIndexMap = IndexMap.create();
             int newIndex = 0;
@@ -259,7 +259,7 @@ final class BulkWriteBatch {
         }
     }
 
-    public FieldNameValidator getFieldNameValidator() {
+    FieldNameValidator getFieldNameValidator() {
         if (batchType == UPDATE || batchType == REPLACE) {
             Map<String, FieldNameValidator> rootMap = new HashMap<String, FieldNameValidator>();
             if (batchType == WriteRequest.Type.REPLACE) {

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -141,7 +141,7 @@ final class CommandOperationHelper {
         BsonDocument create(ServerDescription serverDescription, ConnectionDescription connectionDescription);
     }
 
-    private static Throwable chooseAndMutateRetryableReadException(
+    private static Throwable chooseRetryableReadException(
             @Nullable final Throwable previouslyChosenException, final Throwable mostRecentAttemptException) {
         if (previouslyChosenException == null
                 || mostRecentAttemptException instanceof MongoSocketException
@@ -152,7 +152,7 @@ final class CommandOperationHelper {
         }
     }
 
-    static Throwable chooseAndMutateRetryableWriteException(
+    static Throwable chooseRetryableWriteException(
             @Nullable final Throwable previouslyChosenException, final Throwable mostRecentAttemptException) {
         if (previouslyChosenException == null) {
             if (mostRecentAttemptException instanceof ResourceSupplierInternalException) {
@@ -173,13 +173,13 @@ final class CommandOperationHelper {
     }
 
     static <R> Supplier<R> decorateReadWithRetries(final RetryState retryState, final Supplier<R> readFunction) {
-        return new RetryingSyncSupplier<>(retryState, CommandOperationHelper::chooseAndMutateRetryableReadException,
+        return new RetryingSyncSupplier<>(retryState, CommandOperationHelper::chooseRetryableReadException,
                 CommandOperationHelper::shouldAttemptToRetryRead, readFunction);
     }
 
     static <R> AsyncCallbackSupplier<R> decorateReadWithRetries(final RetryState retryState,
             final AsyncCallbackSupplier<R> asyncReadFunction) {
-        return new RetryingAsyncCallbackSupplier<>(retryState, CommandOperationHelper::chooseAndMutateRetryableReadException,
+        return new RetryingAsyncCallbackSupplier<>(retryState, CommandOperationHelper::chooseRetryableReadException,
                 CommandOperationHelper::shouldAttemptToRetryRead, asyncReadFunction);
     }
 
@@ -342,13 +342,13 @@ final class CommandOperationHelper {
     }
 
     static <R> Supplier<R> decorateWriteWithRetries(final RetryState retryState, final Supplier<R> writeFunction) {
-        return new RetryingSyncSupplier<>(retryState, CommandOperationHelper::chooseAndMutateRetryableWriteException,
+        return new RetryingSyncSupplier<>(retryState, CommandOperationHelper::chooseRetryableWriteException,
                 CommandOperationHelper::shouldAttemptToRetryWrite, writeFunction);
     }
 
     static <R> AsyncCallbackSupplier<R> decorateWriteWithRetries(final RetryState retryState,
             final AsyncCallbackSupplier<R> asyncWriteFunction) {
-        return new RetryingAsyncCallbackSupplier<>(retryState, CommandOperationHelper::chooseAndMutateRetryableWriteException,
+        return new RetryingAsyncCallbackSupplier<>(retryState, CommandOperationHelper::chooseRetryableWriteException,
                 CommandOperationHelper::shouldAttemptToRetryWrite, asyncWriteFunction);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -364,7 +364,7 @@ final class CommandOperationHelper {
         RetryState retryState = initialRetryState(true);
         Supplier<R> retryingWrite = decorateWriteWithRetries(retryState, () -> {
             logRetryExecute(retryState);
-            boolean firstAttempt = retryState.firstAttempt();
+            boolean firstAttempt = retryState.isFirstAttempt();
             if (!firstAttempt && binding.getSessionContext().hasActiveTransaction()) {
                 binding.getSessionContext().clearTransactionContext();
             }
@@ -415,7 +415,7 @@ final class CommandOperationHelper {
         binding.retain();
         AsyncCallbackSupplier<R> asyncWrite = CommandOperationHelper.<R>decorateWriteWithRetries(retryState, funcCallback -> {
             logRetryExecute(retryState);
-            boolean firstAttempt = retryState.firstAttempt();
+            boolean firstAttempt = retryState.isFirstAttempt();
             if (!firstAttempt && binding.getSessionContext().hasActiveTransaction()) {
                 binding.getSessionContext().clearTransactionContext();
             }
@@ -562,7 +562,7 @@ final class CommandOperationHelper {
     }
 
     static void logRetryExecute(final RetryState retryState) {
-        if (LOGGER.isDebugEnabled() && !retryState.firstAttempt()) {
+        if (LOGGER.isDebugEnabled() && !retryState.isFirstAttempt()) {
             String commandDescription = retryState.attachment(AttachmentKeys.commandDescriptionSupplier()).map(Supplier::get).orElse(null);
             Throwable exception = retryState.exception().orElseThrow(Assertions::fail);
             int oneBasedAttempt = retryState.attempt() + 1;

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -41,7 +41,7 @@ import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.async.function.AsyncCallbackSupplier;
 import com.mongodb.internal.operation.MixedBulkWriteOperation.BulkWriteTracker;
 import com.mongodb.internal.async.function.RetryState;
-import com.mongodb.internal.operation.OperationHelper.SourceOrConnectionInternalException;
+import com.mongodb.internal.operation.OperationHelper.ResourceSupplierInternalException;
 import com.mongodb.internal.operation.retry.AttachmentKeys;
 import com.mongodb.internal.async.function.RetryingAsyncCallbackSupplier;
 import com.mongodb.internal.async.function.RetryingSyncSupplier;
@@ -157,11 +157,11 @@ final class CommandOperationHelper {
     static Throwable chooseAndMutateRetryableWriteException(
             @Nullable final Throwable previouslyChosenException, final Throwable mostRecentAttemptException) {
         if (previouslyChosenException == null) {
-            if (mostRecentAttemptException instanceof SourceOrConnectionInternalException) {
+            if (mostRecentAttemptException instanceof ResourceSupplierInternalException) {
                 return mostRecentAttemptException.getCause();
             }
             return mostRecentAttemptException;
-        } else if (mostRecentAttemptException instanceof SourceOrConnectionInternalException) {
+        } else if (mostRecentAttemptException instanceof ResourceSupplierInternalException) {
             return previouslyChosenException;
         } else {
             return mostRecentAttemptException;
@@ -502,7 +502,7 @@ final class CommandOperationHelper {
     }
 
     private static boolean shouldAttemptToRetryRead(final RetryState retryState, final Throwable attemptFailure) {
-        Throwable failure = attemptFailure instanceof SourceOrConnectionInternalException ? attemptFailure.getCause() : attemptFailure;
+        Throwable failure = attemptFailure instanceof ResourceSupplierInternalException ? attemptFailure.getCause() : attemptFailure;
         boolean decision = isRetryableException(failure);
         if (!decision) {
             logUnableToRetry(retryState.attachment(AttachmentKeys.operationName()).orElse(null), failure);
@@ -511,7 +511,7 @@ final class CommandOperationHelper {
     }
 
     static boolean shouldAttemptToRetryWrite(final RetryState retryState, final Throwable attemptFailure) {
-        Throwable failure = attemptFailure instanceof SourceOrConnectionInternalException ? attemptFailure.getCause() : attemptFailure;
+        Throwable failure = attemptFailure instanceof ResourceSupplierInternalException ? attemptFailure.getCause() : attemptFailure;
         boolean decision = false;
         MongoException exceptionRetryableRegardlessOfCommand = null;
         if (failure instanceof MongoConnectionPoolClearedException) {

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -19,12 +19,14 @@ package com.mongodb.internal.operation;
 import com.mongodb.Function;
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoCommandException;
+import com.mongodb.MongoConnectionPoolClearedException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoNodeIsRecoveringException;
 import com.mongodb.MongoNotPrimaryException;
+import com.mongodb.MongoServerException;
 import com.mongodb.MongoSocketException;
 import com.mongodb.ReadPreference;
-import com.mongodb.ServerApi;
+import com.mongodb.assertions.Assertions;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.internal.async.SingleResultCallback;
@@ -36,7 +38,12 @@ import com.mongodb.internal.binding.ReadBinding;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.internal.connection.AsyncConnection;
 import com.mongodb.internal.connection.Connection;
-import com.mongodb.internal.session.SessionContext;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+import com.mongodb.internal.operation.MixedBulkWriteOperation.BulkWriteTracker;
+import com.mongodb.internal.async.function.RetryState;
+import com.mongodb.internal.operation.retry.AttachmentKeys;
+import com.mongodb.internal.async.function.RetryingAsyncCallbackSupplier;
+import com.mongodb.internal.async.function.RetryingSyncSupplier;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
@@ -45,18 +52,18 @@ import org.bson.codecs.BsonDocumentCodec;
 import org.bson.codecs.Decoder;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import static com.mongodb.ReadPreference.primary;
+import static com.mongodb.assertions.Assertions.assertFalse;
+import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.OperationHelper.canRetryRead;
 import static com.mongodb.internal.operation.OperationHelper.canRetryWrite;
-import static com.mongodb.internal.operation.OperationHelper.releasingCallback;
-import static com.mongodb.internal.operation.OperationHelper.withAsyncConnection;
-import static com.mongodb.internal.operation.OperationHelper.withAsyncReadConnection;
-import static com.mongodb.internal.operation.OperationHelper.withReadConnectionSource;
-import static com.mongodb.internal.operation.OperationHelper.withReleasableConnection;
+import static com.mongodb.internal.operation.OperationHelper.withAsyncSourceAndConnection;
+import static com.mongodb.internal.operation.OperationHelper.withSourceAndConnection;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
@@ -107,34 +114,6 @@ final class CommandOperationHelper {
         R apply(T t, AsyncConnectionSource source, AsyncConnection connection);
     }
 
-    static class IdentityReadTransformer<T> implements CommandReadTransformer<T, T> {
-        @Override
-        public T apply(final T t, final ConnectionSource source, final Connection connection) {
-            return t;
-        }
-    }
-
-    static class IdentityWriteTransformer<T> implements CommandWriteTransformer<T, T> {
-        @Override
-        public T apply(final T t, final Connection connection) {
-            return t;
-        }
-    }
-
-    static class IdentityWriteTransformerAsync<T> implements CommandWriteTransformerAsync<T, T> {
-        @Override
-        public T apply(final T t, final AsyncConnection connection) {
-            return t;
-        }
-    }
-
-    static class IdentityTransformerAsync<T> implements CommandReadTransformerAsync<T, T> {
-        @Override
-        public T apply(final T t, final AsyncConnectionSource source, final AsyncConnection connection) {
-            return t;
-        }
-    }
-
     static CommandWriteTransformer<BsonDocument, Void> writeConcernErrorTransformer() {
         return (result, connection) -> {
             WriteConcernHelper.throwOnWriteConcernError(result, connection.getDescription().getServerAddress(),
@@ -159,384 +138,186 @@ final class CommandOperationHelper {
         };
     }
 
-    static Function<BsonDocument, BsonDocument> noOpRetryCommandModifier() {
-        return command -> command;
-    }
-
     interface CommandCreator {
         BsonDocument create(ServerDescription serverDescription, ConnectionDescription connectionDescription);
     }
 
+    private static Throwable chooseAndMutateRetryableReadException(
+            @Nullable final Throwable previouslyChosenException, final Throwable mostRecentAttemptException) {
+        if (previouslyChosenException == null
+                || mostRecentAttemptException instanceof MongoSocketException
+                || mostRecentAttemptException instanceof MongoServerException) {
+            return mostRecentAttemptException;
+        } else {
+            return previouslyChosenException;
+        }
+    }
+
+    static Throwable chooseAndMutateRetryableWriteException(
+            @Nullable final Throwable previouslyChosenException, final Throwable mostRecentAttemptException) {
+        return mostRecentAttemptException;
+    }
+
     /* Read Binding Helpers */
 
-    static BsonDocument executeCommand(final ReadBinding binding, final String database, final CommandCreator commandCreator,
-                                       final boolean retryReads) {
-        return executeCommand(binding, database, commandCreator, new BsonDocumentCodec(), retryReads);
+    static RetryState initialRetryState(final boolean retry) {
+        return new RetryState(retry ? RetryState.RETRIES : 0);
     }
 
-    static <T> T executeCommand(final ReadBinding binding, final String database, final CommandCreator commandCreator,
-                                final CommandReadTransformer<BsonDocument, T> transformer, final boolean retryReads) {
-        return executeCommand(binding, database, commandCreator, new BsonDocumentCodec(), transformer, retryReads);
+    static <R> Supplier<R> decorateReadWithRetries(final RetryState retryState, final Supplier<R> readFunction) {
+        return new RetryingSyncSupplier<>(retryState, CommandOperationHelper::chooseAndMutateRetryableReadException,
+                CommandOperationHelper::shouldAttemptToRetryRead, readFunction);
     }
 
-    static <T> T executeCommand(final ReadBinding binding, final String database, final CommandCreator commandCreator,
-                                final Decoder<T> decoder, final boolean retryReads) {
-        return executeCommand(binding, database, commandCreator, decoder, new IdentityReadTransformer<>(), retryReads);
+    static <R> AsyncCallbackSupplier<R> decorateReadWithRetries(final RetryState retryState,
+            final AsyncCallbackSupplier<R> asyncReadFunction) {
+        return new RetryingAsyncCallbackSupplier<>(retryState, CommandOperationHelper::chooseAndMutateRetryableReadException,
+                CommandOperationHelper::shouldAttemptToRetryRead, asyncReadFunction);
     }
 
-    static <D, T> T executeCommand(final ReadBinding binding, final String database, final CommandCreator commandCreator,
-                                   final Decoder<D> decoder, final CommandReadTransformer<D, T> transformer, final boolean retryReads) {
-        return withReadConnectionSource(binding, source -> executeCommandWithConnection(binding, source, database, commandCreator, decoder,
-                transformer, retryReads, source.getConnection()));
-    }
-
-    static <D, T> T executeCommandWithConnection(final ReadBinding binding, final ConnectionSource source, final String database,
-                                                 final CommandCreator commandCreator, final Decoder<D> decoder,
-                                                 final CommandReadTransformer<D, T> transformer, final boolean retryReads,
-                                                 final Connection connection) {
-        MongoException exception;
-        try {
-            BsonDocument command = commandCreator.create(source.getServerDescription(), connection.getDescription());
-            try {
-                return executeCommand(database, command, decoder, source, connection, binding.getReadPreference(), transformer,
-                        binding.getSessionContext(), binding.getServerApi());
-            } catch (MongoException e) {
-                exception = e;
-
-                if (!shouldAttemptToRetryRead(retryReads, e)) {
-                    if (retryReads) {
-                        logUnableToRetry(command.getFirstKey(), e);
-                    }
-                    throw exception;
-                }
-            }
-        }
-        finally {
-            connection.release();
-        }
-
-        return retryCommand(binding, database, commandCreator, decoder, transformer, exception);
-    }
-
-    private static <D, T> T retryCommand(final ReadBinding binding, final String database, final CommandCreator commandCreator,
-                                         final Decoder<D> decoder, final CommandReadTransformer<D, T> transformer,
-                                         final MongoException originalException) {
-        return withReleasableConnection(binding, originalException, (source, connection) -> {
-            try {
-                if (!canRetryRead(source.getServerDescription(), connection.getDescription(), binding.getSessionContext())) {
-                    throw originalException;
-                }
-                BsonDocument retryCommand = commandCreator.create(source.getServerDescription(), connection.getDescription());
-                logRetryExecute(retryCommand.getFirstKey(), originalException);
-                return executeCommand(database, retryCommand, decoder, source, connection, binding.getReadPreference(), transformer,
-                        binding.getSessionContext(), source.getServerApi());
-            } finally {
-                connection.release();
-            }
+    static <D, T> T executeRetryableRead(
+            final ReadBinding binding,
+            final String database,
+            final CommandCreator commandCreator,
+            final Decoder<D> decoder,
+            final CommandReadTransformer<D, T> transformer,
+            final boolean retryReads) {
+        RetryState retryState = initialRetryState(retryReads);
+        Supplier<T> read = decorateReadWithRetries(retryState, () -> {
+            logRetryExecute(retryState, () -> null);
+            return withSourceAndConnection(binding::getReadConnectionSource, null, (source, connection) -> {
+                retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
+                        binding.getSessionContext()));
+                return createReadCommandAndExecute(retryState, binding, source, database, commandCreator, decoder, transformer, connection);
+            });
         });
+        return read.get();
+    }
+
+    static <D, T> T createReadCommandAndExecute(
+            final RetryState retryState,
+            final ReadBinding binding,
+            final ConnectionSource source,
+            final String database,
+            final CommandCreator commandCreator,
+            final Decoder<D> decoder,
+            final CommandReadTransformer<D, T> transformer,
+            final Connection connection) {
+        BsonDocument command = commandCreator.create(source.getServerDescription(), connection.getDescription());
+        retryState.attach(AttachmentKeys.operationName(), command.getFirstKey(), false);
+        logRetryExecute(retryState, command::getFirstKey);
+        return transformer.apply(connection.command(database, command, new NoOpFieldNameValidator(), binding.getReadPreference(), decoder,
+                binding.getSessionContext(), binding.getServerApi()), source, connection);
     }
 
     /* Write Binding Helpers */
 
-    static BsonDocument executeCommand(final WriteBinding binding, final String database, final BsonDocument command) {
-        return executeCommand(binding, database, command, new IdentityWriteTransformer<>());
-    }
-
-    static <T> T executeCommand(final WriteBinding binding, final String database, final BsonDocument command,
-                                final Decoder<T> decoder) {
-        return executeCommand(binding, database, command, decoder, new IdentityWriteTransformer<>());
-    }
-
-    static <T> T executeCommand(final WriteBinding binding, final String database, final BsonDocument command,
-                                final CommandWriteTransformer<BsonDocument, T> transformer) {
-        return executeCommand(binding, database, command, new BsonDocumentCodec(), transformer);
-    }
-
+    /**
+     * Is package-access for the purpose of testing and must not be used for any other purpose outside of this class.
+     */
     static <D, T> T executeCommand(final WriteBinding binding, final String database, final BsonDocument command,
                                    final Decoder<D> decoder, final CommandWriteTransformer<D, T> transformer) {
-        return executeCommand(binding, database, command, new NoOpFieldNameValidator(), decoder, transformer);
+        return withSourceAndConnection(binding::getWriteConnectionSource, null, (source, connection) ->
+            transformer.apply(
+                    connection.command(database, command, new NoOpFieldNameValidator(), primary(), decoder, source.getSessionContext(),
+                            source.getServerApi()), connection));
     }
 
     static <T> T executeCommand(final WriteBinding binding, final String database, final BsonDocument command,
                                 final Connection connection, final CommandWriteTransformer<BsonDocument, T> transformer) {
-        return executeCommand(binding, database, command, new BsonDocumentCodec(), connection, transformer);
-    }
-
-    static <T> T executeCommand(final WriteBinding binding, final String database, final BsonDocument command,
-                                final Decoder<BsonDocument> decoder, final Connection connection,
-                                final CommandWriteTransformer<BsonDocument, T> transformer) {
         notNull("binding", binding);
-        return executeWriteCommand(database, command, decoder, connection, primary(), transformer, binding.getSessionContext(),
-                binding.getServerApi());
-    }
-
-    static <T> T executeCommand(final WriteBinding binding, final String database, final BsonDocument command,
-                                final FieldNameValidator fieldNameValidator, final Decoder<BsonDocument> decoder,
-                                final Connection connection, final CommandWriteTransformer<BsonDocument, T> transformer) {
-        notNull("binding", binding);
-        return executeWriteCommand(database, command, fieldNameValidator, decoder, connection, primary(), transformer,
-                binding.getSessionContext(), binding.getServerApi());
-    }
-
-    static <D, T> T executeCommand(final WriteBinding binding, final String database, final BsonDocument command,
-                                   final FieldNameValidator fieldNameValidator, final Decoder<D> decoder,
-                                   final CommandWriteTransformer<D, T> transformer) {
-        return withReleasableConnection(binding, (source, connection) -> {
-            try {
-                return transformer.apply(executeCommand(database, command, fieldNameValidator, decoder,
-                        source, connection, primary()), connection);
-            } finally {
-                connection.release();
-            }
-        });
-    }
-
-    static BsonDocument executeCommand(final WriteBinding binding, final String database, final BsonDocument command,
-                                       final Connection connection) {
-        notNull("binding", binding);
-        return executeWriteCommand(database, command, new BsonDocumentCodec(), connection, primary(),
-                binding.getSessionContext(), binding.getServerApi());
-    }
-
-    /* Private Read Connection Source Helpers */
-
-    private static <T> T executeCommand(final String database, final BsonDocument command,
-                                        final FieldNameValidator fieldNameValidator, final Decoder<T> decoder,
-                                        final ConnectionSource source, final Connection connection,
-                                        final ReadPreference readPreference) {
-        return executeCommand(database, command, fieldNameValidator, decoder, source, connection,
-                readPreference, new IdentityReadTransformer<>(), source.getSessionContext(), source.getServerApi());
-    }
-
-    /* Private Connection Helpers */
-
-    private static <D, T> T executeCommand(final String database, final BsonDocument command,
-                                           final Decoder<D> decoder, final ConnectionSource source, final Connection connection,
-                                           final ReadPreference readPreference,
-                                           final CommandReadTransformer<D, T> transformer, final SessionContext sessionContext,
-                                           final ServerApi serverApi) {
-        return executeCommand(database, command, new NoOpFieldNameValidator(), decoder, source, connection,
-                readPreference, transformer, sessionContext, serverApi);
-    }
-
-    private static <D, T> T executeCommand(final String database, final BsonDocument command,
-                                           final FieldNameValidator fieldNameValidator, final Decoder<D> decoder,
-                                           final ConnectionSource source, final Connection connection, final ReadPreference readPreference,
-                                           final CommandReadTransformer<D, T> transformer, final SessionContext sessionContext,
-                                           final ServerApi serverApi) {
-
-        return transformer.apply(connection.command(database, command, fieldNameValidator, readPreference, decoder, sessionContext,
-                serverApi), source, connection);
-    }
-
-    /* Private Connection Helpers */
-
-    private static <T> T executeWriteCommand(final String database, final BsonDocument command,
-                                             final Decoder<T> decoder, final Connection connection,
-                                             final ReadPreference readPreference, final SessionContext sessionContext,
-                                             final ServerApi serverApi) {
-        return executeWriteCommand(database, command, new NoOpFieldNameValidator(), decoder, connection,
-                readPreference, new IdentityWriteTransformer<>(), sessionContext, serverApi);
-    }
-
-    private static <D, T> T executeWriteCommand(final String database, final BsonDocument command,
-                                                final Decoder<D> decoder, final Connection connection,
-                                                final ReadPreference readPreference,
-                                                final CommandWriteTransformer<D, T> transformer, final SessionContext sessionContext,
-                                                final ServerApi serverApi) {
-        return executeWriteCommand(database, command, new NoOpFieldNameValidator(), decoder, connection,
-                readPreference, transformer, sessionContext, serverApi);
-    }
-
-    private static <D, T> T executeWriteCommand(final String database, final BsonDocument command,
-                                                final FieldNameValidator fieldNameValidator, final Decoder<D> decoder,
-                                                final Connection connection, final ReadPreference readPreference,
-                                                final CommandWriteTransformer<D, T> transformer, final SessionContext sessionContext,
-                                                final ServerApi serverApi) {
-
-        return transformer.apply(connection.command(database, command, fieldNameValidator, readPreference, decoder, sessionContext,
-                serverApi),
-                connection);
+        return transformer.apply(connection.command(database, command, new NoOpFieldNameValidator(), primary(), new BsonDocumentCodec(),
+                        binding.getSessionContext(), binding.getServerApi()), connection);
     }
 
     /* Async Read Binding Helpers */
 
-    static void executeCommandAsync(final AsyncReadBinding binding,
-                                    final String database,
-                                    final CommandCreator commandCreator,
-                                    final boolean retryReads,
-                                    final SingleResultCallback<BsonDocument> callback) {
-        executeCommandAsync(binding, database, commandCreator, new BsonDocumentCodec(), retryReads, callback);
-    }
-
-    static <T> void executeCommandAsync(final AsyncReadBinding binding,
-                                        final String database,
-                                        final CommandCreator commandCreator,
-                                        final Decoder<T> decoder,
-                                        final boolean retryReads,
-                                        final SingleResultCallback<T> callback) {
-        executeCommandAsync(binding, database, commandCreator, decoder, new IdentityTransformerAsync<>(), retryReads, callback);
-    }
-
-    static <T> void executeCommandAsync(final AsyncReadBinding binding,
-                                        final String database,
-                                        final CommandCreator commandCreator,
-                                        final CommandReadTransformerAsync<BsonDocument, T> transformer,
-                                        final boolean retryReads,
-                                        final SingleResultCallback<T> callback) {
-        executeCommandAsync(binding, database, commandCreator, new BsonDocumentCodec(), transformer, retryReads, callback);
-    }
-
-    static <D, T> void executeCommandAsync(final AsyncReadBinding binding,
-                                           final String database,
-                                           final CommandCreator commandCreator,
-                                           final Decoder<D> decoder,
-                                           final CommandReadTransformerAsync<D, T> transformer,
-                                           final boolean retryReads,
-                                           final SingleResultCallback<T> originalCallback) {
-        final SingleResultCallback<T> errorHandlingCallback = errorHandlingCallback(originalCallback, LOGGER);
-        withAsyncReadConnection(binding, (source, connection, t) -> {
-            if (t != null) {
-                releasingCallback(errorHandlingCallback, source, connection).onResult(null, t);
-            } else {
-                executeCommandAsyncWithConnection(binding, source, database, commandCreator, decoder, transformer,
-                        retryReads, connection, errorHandlingCallback);
-            }
-        });
-    }
-
-    static <D, T> void executeCommandAsync(final AsyncReadBinding binding,
-                                           final String database,
-                                           final CommandCreator commandCreator,
-                                           final Decoder<D> decoder,
-                                           final CommandReadTransformerAsync<D, T> transformer,
-                                           final boolean retryReads,
-                                           final AsyncConnection connection,
-                                           final SingleResultCallback<T> originalCallback) {
-        final SingleResultCallback<T> errorHandlingCallback = errorHandlingCallback(originalCallback, LOGGER);
-        binding.getReadConnectionSource((source, t) -> executeCommandAsyncWithConnection(binding, source, database,
-                commandCreator, decoder, transformer, retryReads, connection, errorHandlingCallback));
-    }
-
-    static <D, T> void executeCommandAsyncWithConnection(final AsyncReadBinding binding,
-                                                         final AsyncConnectionSource source,
-                                                         final String database,
-                                                         final CommandCreator commandCreator,
-                                                         final Decoder<D> decoder,
-                                                         final CommandReadTransformerAsync<D, T> transformer,
-                                                         final boolean retryReads,
-                                                         final AsyncConnection connection,
-                                                         final SingleResultCallback<T> callback) {
-        try {
-            BsonDocument command = commandCreator.create(source.getServerDescription(), connection.getDescription());
-            connection.commandAsync(database, command, new NoOpFieldNameValidator(), binding.getReadPreference(), decoder,
-                    binding.getSessionContext(), binding.getServerApi(),
-                    createCommandCallback(binding, source, connection, database, binding.getReadPreference(),
-                            command, commandCreator, new NoOpFieldNameValidator(), decoder, transformer, retryReads, callback));
-        } catch (IllegalArgumentException e) {
-            connection.release();
-            callback.onResult(null, e);
-        }
-    }
-
-    private static <T, R> SingleResultCallback<T> createCommandCallback(final AsyncReadBinding binding,
-                                                                        final AsyncConnectionSource oldSource,
-                                                                        final AsyncConnection oldConnection,
-                                                                        final String database,
-                                                                        final ReadPreference readPreference,
-                                                                        final BsonDocument originalCommand,
-                                                                        final CommandCreator commandCreator,
-                                                                        final FieldNameValidator fieldNameValidator,
-                                                                        final Decoder<T> commandResultDecoder,
-                                                                        final CommandReadTransformerAsync<T, R> transformer,
-                                                                        final boolean retryReads,
-                                                                        final SingleResultCallback<R> callback) {
-        return new SingleResultCallback<T>() {
-            @Override
-            public void onResult(final T result, final Throwable originalError) {
-                SingleResultCallback<R> releasingCallback = releasingCallback(callback, oldSource, oldConnection);
-                if (originalError != null) {
-                    checkRetryableException(originalError, releasingCallback);
-                } else {
-                    try {
-                        releasingCallback.onResult(transformer.apply(result, oldSource, oldConnection), null);
-                    } catch (Throwable transformError) {
-                        checkRetryableException(transformError, releasingCallback);
+    static <D, T> void executeRetryableReadAsync(
+            final AsyncReadBinding binding,
+            final String database,
+            final CommandCreator commandCreator,
+            final Decoder<D> decoder,
+            final CommandReadTransformerAsync<D, T> transformer,
+            final boolean retryReads,
+            final SingleResultCallback<T> callback) {
+        RetryState retryState = initialRetryState(retryReads);
+        binding.retain();
+        AsyncCallbackSupplier<T> asyncRead = CommandOperationHelper.<T>decorateReadWithRetries(retryState, funcCallback -> {
+            logRetryExecute(retryState, () -> null);
+            withAsyncSourceAndConnection(binding::getReadConnectionSource, null, funcCallback,
+                (source, connection, releasingCallback) -> {
+                    if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(),
+                            connection.getDescription(), binding.getSessionContext()), releasingCallback)) {
+                        return;
                     }
-                }
-            }
-
-            private void checkRetryableException(final Throwable originalError, final SingleResultCallback<R> callback) {
-                if (!shouldAttemptToRetryRead(retryReads, originalError)) {
-                    if (retryReads) {
-                        logUnableToRetry(originalCommand.getFirstKey(), originalError);
-                    }
-                    callback.onResult(null, originalError);
-                } else {
-                    oldSource.release();
-                    oldConnection.release();
-                    retryableCommand(originalError);
-                }
-            }
-
-            private void retryableCommand(final Throwable originalError) {
-                withAsyncReadConnection(binding, (source, connection, t) -> {
-                    if (t != null) {
-                        callback.onResult(null, originalError);
-                    } else if (!canRetryRead(source.getServerDescription(), connection.getDescription(),
-                            binding.getSessionContext())) {
-                        releasingCallback(callback, source, connection).onResult(null, originalError);
-                    } else {
-                        BsonDocument retryCommand = commandCreator.create(source.getServerDescription(), connection.getDescription());
-                        logRetryExecute(retryCommand.getFirstKey(), originalError);
-                        connection.commandAsync(database, retryCommand, fieldNameValidator, readPreference,
-                                commandResultDecoder, binding.getSessionContext(),
-                                binding.getServerApi(), new TransformingReadResultCallback<>(transformer, source, connection,
-                                        releasingCallback(callback, source, connection)));
-                    }
+                    createReadCommandAndExecuteAsync(retryState, binding, source, database, commandCreator, decoder, transformer,
+                            connection, releasingCallback);
                 });
+        }).andFinally(binding::release);
+        asyncRead.get(errorHandlingCallback(callback, LOGGER));
+    }
+
+    static <D, T> void createReadCommandAndExecuteAsync(
+            final RetryState retryState,
+            final AsyncReadBinding binding,
+            final AsyncConnectionSource source,
+            final String database,
+            final CommandCreator commandCreator,
+            final Decoder<D> decoder,
+            final CommandReadTransformerAsync<D, T> transformer,
+            final AsyncConnection connection,
+            final SingleResultCallback<T> callback) {
+        BsonDocument command;
+        try {
+            command = commandCreator.create(source.getServerDescription(), connection.getDescription());
+            retryState.attach(AttachmentKeys.operationName(), command.getFirstKey(), false);
+            logRetryExecute(retryState, command::getFirstKey);
+        } catch (IllegalArgumentException e) {
+            callback.onResult(null, e);
+            return;
+        }
+        connection.commandAsync(database, command, new NoOpFieldNameValidator(), binding.getReadPreference(), decoder,
+                binding.getSessionContext(), binding.getServerApi(),
+                transformingReadCallback(transformer, source, connection, callback));
+    }
+
+    private static <T, R> SingleResultCallback<T> transformingReadCallback(final CommandReadTransformerAsync<T, R> transformer,
+            final AsyncConnectionSource source, final AsyncConnection connection, final SingleResultCallback<R> callback) {
+        return (result, t) -> {
+            if (t != null) {
+                callback.onResult(null, t);
+            } else {
+                R transformedResult;
+                try {
+                    transformedResult = transformer.apply(result, source, connection);
+                } catch (Throwable e) {
+                    callback.onResult(null, e);
+                    return;
+                }
+                callback.onResult(transformedResult, null);
             }
         };
     }
 
-    static class TransformingReadResultCallback<T, R> implements SingleResultCallback<T> {
-        private final CommandReadTransformerAsync<T, R> transformer;
-        private final AsyncConnectionSource source;
-        private final AsyncConnection connection;
-        private final SingleResultCallback<R> callback;
-
-        TransformingReadResultCallback(final CommandReadTransformerAsync<T, R> transformer, final AsyncConnectionSource source,
-                                        final AsyncConnection connection, final SingleResultCallback<R> callback) {
-            this.transformer = transformer;
-            this.source = source;
-            this.connection = connection;
-            this.callback = callback;
-        }
-
-        @Override
-        public void onResult(final T result, final Throwable t) {
+    private static <T, R> SingleResultCallback<T> transformingWriteCallback(final CommandWriteTransformerAsync<T, R> transformer,
+            final AsyncConnection connection, final SingleResultCallback<R> callback) {
+        return (result, t) -> {
             if (t != null) {
                 callback.onResult(null, t);
             } else {
+                R transformedResult;
                 try {
-                    R transformedResult = transformer.apply(result, source, connection);
-                    callback.onResult(transformedResult, null);
-                } catch (Throwable transformError) {
-                    callback.onResult(null, transformError);
+                    transformedResult = transformer.apply(result, connection);
+                } catch (Throwable e) {
+                    callback.onResult(null, e);
+                    return;
                 }
+                callback.onResult(transformedResult, null);
             }
-        }
+        };
     }
 
     /* Async Write Binding Helpers */
-
-    static void executeCommandAsync(final AsyncWriteBinding binding,
-                                    final String database,
-                                    final BsonDocument command,
-                                    final AsyncConnection connection,
-                                    final SingleResultCallback<BsonDocument> callback) {
-        executeCommandAsync(binding, database, command, connection, new IdentityWriteTransformerAsync<>(), callback);
-    }
 
     static <T> void executeCommandAsync(final AsyncWriteBinding binding,
                                         final String database,
@@ -545,223 +326,136 @@ final class CommandOperationHelper {
                                         final CommandWriteTransformerAsync<BsonDocument, T> transformer,
                                         final SingleResultCallback<T> callback) {
         notNull("binding", binding);
-        executeCommandAsync(database, command, new BsonDocumentCodec(), connection, primary(), transformer,
-                binding.getSessionContext(), binding.getServerApi(), callback);
+        SingleResultCallback<T> addingRetryableLabelCallback = addingRetryableLabelCallback(callback,
+                connection.getDescription().getMaxWireVersion());
+        connection.commandAsync(database, command, new NoOpFieldNameValidator(), primary(), new BsonDocumentCodec(),
+                binding.getSessionContext(), binding.getServerApi(),
+                transformingWriteCallback(transformer, connection, addingRetryableLabelCallback));
     }
 
-    /* Async Connection Helpers */
-    private static <D, T> void executeCommandAsync(final String database, final BsonDocument command,
-                                                   final Decoder<D> decoder, final AsyncConnection connection,
-                                                   final ReadPreference readPreference,
-                                                   final CommandWriteTransformerAsync<D, T> transformer,
-                                                   final SessionContext sessionContext,
-                                                   final ServerApi serverApi, final SingleResultCallback<T> callback) {
-        connection.commandAsync(database, command, new NoOpFieldNameValidator(), readPreference, decoder, sessionContext,
-                serverApi, (result, t) -> {
-                    if (t != null) {
-                        callback.onResult(null, t);
-                    } else {
-                        try {
-                            T transformedResult = transformer.apply(result, connection);
-                            callback.onResult(transformedResult, null);
-                        } catch (Exception e) {
-                            callback.onResult(null, e);
-                        }
-                    }
-                });
-
+    static <R> Supplier<R> decorateWriteWithRetries(final RetryState retryState, final Supplier<R> writeFunction) {
+        return new RetryingSyncSupplier<>(retryState, CommandOperationHelper::chooseAndMutateRetryableWriteException,
+                CommandOperationHelper::shouldAttemptToRetryWrite, writeFunction);
     }
 
-    /* Retryable write helpers */
-    static <T, R> R executeRetryableCommand(final WriteBinding binding, final String database, final ReadPreference readPreference,
-                                            final FieldNameValidator fieldNameValidator, final Decoder<T> commandResultDecoder,
-                                            final CommandCreator commandCreator, final CommandWriteTransformer<T, R> transformer) {
-        return executeRetryableCommand(binding, database, readPreference, fieldNameValidator, commandResultDecoder, commandCreator,
-                transformer, noOpRetryCommandModifier());
+    static <R> AsyncCallbackSupplier<R> decorateWriteWithRetries(final RetryState retryState,
+            final AsyncCallbackSupplier<R> asyncWriteFunction) {
+        return new RetryingAsyncCallbackSupplier<>(retryState, CommandOperationHelper::chooseAndMutateRetryableWriteException,
+                CommandOperationHelper::shouldAttemptToRetryWrite, asyncWriteFunction);
     }
 
-    static <T, R> R executeRetryableCommand(final WriteBinding binding, final String database, final ReadPreference readPreference,
-                                            final FieldNameValidator fieldNameValidator, final Decoder<T> commandResultDecoder,
-                                            final CommandCreator commandCreator, final CommandWriteTransformer<T, R> transformer,
-                                            final Function<BsonDocument, BsonDocument> retryCommandModifier) {
-        return withReleasableConnection(binding, (source, connection) -> {
-            BsonDocument command = null;
-            MongoException exception;
-            try {
-                command = commandCreator.create(source.getServerDescription(), connection.getDescription());
-                return transformer.apply(connection.command(database, command, fieldNameValidator, readPreference,
-                        commandResultDecoder, binding.getSessionContext(), binding.getServerApi()), connection);
-            } catch (MongoException e) {
-                exception = e;
-                if (!shouldAttemptToRetryWrite(command, e, connection.getDescription().getMaxWireVersion())) {
-                    if (isRetryWritesEnabled(command)) {
-                        logUnableToRetry(command.getFirstKey(), e);
-                    }
-                    throw transformWriteException(exception);
-                }
-            } finally {
-                connection.release();
-            }
-
-            if (binding.getSessionContext().hasActiveTransaction()) {
+    static <T, R> R executeRetryableWrite(
+            final WriteBinding binding,
+            final String database,
+            final ReadPreference readPreference,
+            final FieldNameValidator fieldNameValidator,
+            final Decoder<T> commandResultDecoder,
+            final CommandCreator commandCreator,
+            final CommandWriteTransformer<T, R> transformer,
+            final Function<BsonDocument, BsonDocument> retryCommandModifier) {
+        RetryState retryState = initialRetryState(true);
+        Supplier<R> retryingWrite = decorateWriteWithRetries(retryState, () -> {
+            logRetryExecute(retryState, () -> null);
+            boolean firstAttempt = retryState.firstAttempt();
+            if (!firstAttempt && binding.getSessionContext().hasActiveTransaction()) {
                 binding.getSessionContext().clearTransactionContext();
             }
-            final BsonDocument originalCommand = command;
-            final MongoException originalException = exception;
-            return withReleasableConnection(binding, originalException, (source1, connection1) -> {
+            RuntimeException prospectiveFailedResult = (RuntimeException) retryState.exception().orElse(null);
+            return withSourceAndConnection(binding::getWriteConnectionSource, prospectiveFailedResult, (source, connection) -> {
+                int maxWireVersion = connection.getDescription().getMaxWireVersion();
                 try {
-                    if (!canRetryWrite(source1.getServerDescription(), connection1.getDescription(), binding.getSessionContext())) {
-                        throw originalException;
+                    retryState.breakAndThrowIfRetryAnd(() -> !canRetryWrite(source.getServerDescription(), connection.getDescription(),
+                            binding.getSessionContext()));
+                    BsonDocument command = retryState.attachment(AttachmentKeys.command())
+                            .map(previousAttemptCommand -> {
+                                assertFalse(firstAttempt);
+                                return retryCommandModifier.apply(previousAttemptCommand);
+                            }).orElseGet(() -> commandCreator.create(source.getServerDescription(), connection.getDescription()));
+                    // attach `command` and `maxWireVersion` ASAP because they are used to check whether we should retry
+                    retryState.attach(AttachmentKeys.maxWireVersion(), maxWireVersion, true)
+                            .attach(AttachmentKeys.command(), command, false);
+                    logRetryExecute(retryState, command::getFirstKey);
+                    return transformer.apply(connection.command(database, command, fieldNameValidator, readPreference,
+                            commandResultDecoder, binding.getSessionContext(), binding.getServerApi()), connection);
+                } catch (MongoException e) {
+                    if (!firstAttempt) {
+                        addRetryableWriteErrorLabel(e, maxWireVersion);
                     }
-                    BsonDocument retryCommand = retryCommandModifier.apply(originalCommand);
-                    logRetryExecute(retryCommand.getFirstKey(), originalException);
-                    try {
-                        return transformer.apply(connection1.command(database, retryCommand, fieldNameValidator,
-                                readPreference, commandResultDecoder, binding.getSessionContext(), binding.getServerApi()),
-                                connection1);
-                    } catch (MongoException e) {
-                        addRetryableWriteErrorLabel(e, connection1.getDescription().getMaxWireVersion());
-                        throw e;
-                    }
-                } finally {
-                    connection1.release();
+                    throw e;
                 }
             });
         });
-    }
-
-    static <T, R> void executeRetryableCommand(final AsyncWriteBinding binding, final String database, final ReadPreference readPreference,
-                                               final FieldNameValidator fieldNameValidator, final Decoder<T> commandResultDecoder,
-                                               final CommandCreator commandCreator,
-                                               final CommandWriteTransformerAsync<T, R> transformer,
-                                               final SingleResultCallback<R> originalCallback) {
-        executeRetryableCommand(binding, database, readPreference, fieldNameValidator, commandResultDecoder, commandCreator, transformer,
-                noOpRetryCommandModifier(), originalCallback);
-    }
-
-    static <T, R> void executeRetryableCommand(final AsyncWriteBinding binding, final String database, final ReadPreference readPreference,
-                                               final FieldNameValidator fieldNameValidator, final Decoder<T> commandResultDecoder,
-                                               final CommandCreator commandCreator,
-                                               final CommandWriteTransformerAsync<T, R> transformer,
-                                               final Function<BsonDocument, BsonDocument> retryCommandModifier,
-                                               final SingleResultCallback<R> originalCallback) {
-        final SingleResultCallback<R> errorHandlingCallback = errorHandlingCallback(originalCallback, LOGGER);
-        binding.getWriteConnectionSource((source, t) -> {
-            if (t != null) {
-                errorHandlingCallback.onResult(null, t);
-            } else {
-                source.getConnection((connection, t12) -> {
-                    if (t12 != null) {
-                        releasingCallback(errorHandlingCallback, source).onResult(null, t12);
-                    } else {
-                        try {
-                            BsonDocument command = commandCreator.create(source.getServerDescription(),
-                                    connection.getDescription());
-                            connection.commandAsync(database, command, fieldNameValidator, readPreference,
-                                    commandResultDecoder, binding.getSessionContext(),
-                                    binding.getServerApi(), createCommandCallback(binding, source, connection, database, readPreference,
-                                            command, fieldNameValidator, commandResultDecoder, transformer,
-                                            retryCommandModifier, errorHandlingCallback));
-                        } catch (Throwable t1) {
-                            releasingCallback(errorHandlingCallback, source, connection).onResult(null, t1);
-                        }
-                    }
-                });
-            }
-        });
-    }
-
-    private static <T, R> SingleResultCallback<T> createCommandCallback(final AsyncWriteBinding binding,
-                                                                        final AsyncConnectionSource oldSource,
-                                                                        final AsyncConnection oldConnection,
-                                                                        final String database,
-                                                                        final ReadPreference readPreference,
-                                                                        final BsonDocument command,
-                                                                        final FieldNameValidator fieldNameValidator,
-                                                                        final Decoder<T> commandResultDecoder,
-                                                                        final CommandWriteTransformerAsync<T, R> transformer,
-                                                                        final Function<BsonDocument, BsonDocument> retryCommandModifier,
-                                                                        final SingleResultCallback<R> callback) {
-        return new SingleResultCallback<T>() {
-            @Override
-            public void onResult(final T result, final Throwable originalError) {
-                SingleResultCallback<R> releasingCallback = releasingCallback(callback, oldSource, oldConnection);
-                if (originalError != null) {
-                    checkRetryableException(originalError, releasingCallback);
-                } else {
-                    try {
-                        releasingCallback.onResult(transformer.apply(result, oldConnection), null);
-                    } catch (Throwable transformError) {
-                        checkRetryableException(transformError, releasingCallback);
-                    }
-                }
-            }
-
-            private void checkRetryableException(final Throwable originalError, final SingleResultCallback<R> releasingCallback) {
-                if (!shouldAttemptToRetryWrite(command, originalError, oldConnection.getDescription().getMaxWireVersion())) {
-                    if (isRetryWritesEnabled(command)) {
-                        logUnableToRetry(command.getFirstKey(), originalError);
-                    }
-                    releasingCallback.onResult(null, originalError instanceof MongoException
-                            ? transformWriteException((MongoException) originalError) : originalError);
-                } else {
-                    oldConnection.release();
-                    oldSource.release();
-                    if (binding.getSessionContext().hasActiveTransaction()) {
-                        binding.getSessionContext().clearTransactionContext();
-                    }
-                    retryableCommand(originalError);
-                }
-            }
-
-            private void retryableCommand(final Throwable originalError) {
-                final BsonDocument retryCommand = retryCommandModifier.apply(command);
-                logRetryExecute(retryCommand.getFirstKey(), originalError);
-                withAsyncConnection(binding, (source, connection, t) -> {
-                    if (t != null) {
-                        callback.onResult(null, originalError);
-                    } else if (!canRetryWrite(source.getServerDescription(), connection.getDescription(),
-                            binding.getSessionContext())) {
-                        releasingCallback(callback, source, connection).onResult(null, originalError);
-                    } else {
-                        connection.commandAsync(database, retryCommand, fieldNameValidator, readPreference,
-                                commandResultDecoder, binding.getSessionContext(),
-                                binding.getServerApi(), new TransformingWriteResultCallback<>(transformer, connection,
-                                        releasingCallback(callback, source, connection)));
-                    }
-                });
-            }
-        };
-    }
-
-    static class TransformingWriteResultCallback<T, R> implements SingleResultCallback<T> {
-        private final CommandWriteTransformerAsync<T, R> transformer;
-        private final AsyncConnection connection;
-        private final SingleResultCallback<R> callback;
-
-        TransformingWriteResultCallback(final CommandWriteTransformerAsync<T, R> transformer,
-                                        final AsyncConnection connection, final SingleResultCallback<R> callback) {
-            this.transformer = transformer;
-            this.connection = connection;
-            this.callback = callback;
+        try {
+            return retryingWrite.get();
+        } catch (MongoException e) {
+            throw transformWriteException(e);
         }
+    }
 
-        @Override
-        public void onResult(final T result, final Throwable t) {
+    static <T, R> void executeRetryableWriteAsync(
+            final AsyncWriteBinding binding,
+            final String database,
+            final ReadPreference readPreference,
+            final FieldNameValidator fieldNameValidator,
+            final Decoder<T> commandResultDecoder,
+            final CommandCreator commandCreator,
+            final CommandWriteTransformerAsync<T, R> transformer,
+            final Function<BsonDocument, BsonDocument> retryCommandModifier,
+            final SingleResultCallback<R> callback) {
+        RetryState retryState = initialRetryState(true);
+        binding.retain();
+        AsyncCallbackSupplier<R> asyncWrite = CommandOperationHelper.<R>decorateWriteWithRetries(retryState, funcCallback -> {
+            logRetryExecute(retryState, () -> null);
+            boolean firstAttempt = retryState.firstAttempt();
+            if (!firstAttempt && binding.getSessionContext().hasActiveTransaction()) {
+                binding.getSessionContext().clearTransactionContext();
+            }
+            Throwable prospectiveFailedResult = retryState.exception().orElse(null);
+            withAsyncSourceAndConnection(binding::getWriteConnectionSource, prospectiveFailedResult, funcCallback,
+                    (source, connection, releasingCallback) -> {
+                int maxWireVersion = connection.getDescription().getMaxWireVersion();
+                SingleResultCallback<R> addingRetryableLabelCallback = firstAttempt
+                        ? releasingCallback
+                        : addingRetryableLabelCallback(releasingCallback, maxWireVersion);
+                if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryWrite(source.getServerDescription(), connection.getDescription(),
+                        binding.getSessionContext()), addingRetryableLabelCallback)) {
+                    return;
+                }
+                BsonDocument command;
+                try {
+                    command = retryState.attachment(AttachmentKeys.command())
+                            .map(previousAttemptCommand -> {
+                                assertFalse(firstAttempt);
+                                return retryCommandModifier.apply(previousAttemptCommand);
+                            }).orElseGet(() -> commandCreator.create(source.getServerDescription(), connection.getDescription()));
+                    // attach `command` and `maxWireVersion` ASAP because they are used to check whether we should retry
+                    retryState.attach(AttachmentKeys.maxWireVersion(), maxWireVersion, true)
+                            .attach(AttachmentKeys.command(), command, false);
+                    logRetryExecute(retryState, command::getFirstKey);
+                } catch (Throwable t) {
+                    addingRetryableLabelCallback.onResult(null, t);
+                    return;
+                }
+                connection.commandAsync(database, command, fieldNameValidator, readPreference,
+                        commandResultDecoder, binding.getSessionContext(),
+                        binding.getServerApi(), transformingWriteCallback(transformer, connection, addingRetryableLabelCallback));
+            });
+        }).andFinally(binding::release);
+        asyncWrite.get(exceptionTransformingCallback(errorHandlingCallback(callback, LOGGER)));
+    }
+
+    private static <R> SingleResultCallback<R> addingRetryableLabelCallback(final SingleResultCallback<R> callback,
+            final int maxWireVersion) {
+        return (result, t) -> {
             if (t != null) {
                 if (t instanceof MongoException) {
-                    addRetryableWriteErrorLabel((MongoException) t, connection.getDescription().getMaxWireVersion());
+                    addRetryableWriteErrorLabel((MongoException) t, maxWireVersion);
                 }
                 callback.onResult(null, t);
             } else {
-                try {
-                    R transformedResult = transformer.apply(result, connection);
-                    callback.onResult(transformedResult, null);
-                } catch (Throwable transformError) {
-                    callback.onResult(null, transformError);
-                }
+                callback.onResult(result, null);
             }
-        }
+        };
     }
 
     private static final List<Integer> RETRYABLE_ERROR_CODES = asList(6, 7, 89, 91, 189, 262, 9001, 13436, 13435, 11602, 11600, 10107);
@@ -770,7 +464,8 @@ final class CommandOperationHelper {
             return false;
         }
 
-        if (t instanceof MongoSocketException || t instanceof MongoNotPrimaryException || t instanceof MongoNodeIsRecoveringException) {
+        if (t instanceof MongoSocketException || t instanceof MongoNotPrimaryException || t instanceof MongoNodeIsRecoveringException
+                || t instanceof MongoConnectionPoolClearedException) {
             return true;
         }
         return RETRYABLE_ERROR_CODES.contains(((MongoException) t).getCode());
@@ -798,15 +493,53 @@ final class CommandOperationHelper {
         }
     }
 
-    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    private static boolean shouldAttemptToRetryRead(final boolean retryReadsEnabled, final Throwable t) {
-        return retryReadsEnabled && isRetryableException(t);
+    private static boolean shouldAttemptToRetryRead(final RetryState retryState, final Throwable attemptFailure) {
+        boolean decision = isRetryableException(attemptFailure);
+        if (!decision) {
+            logUnableToRetry(retryState.attachment(AttachmentKeys.operationName()).orElse(null), attemptFailure);
+        }
+        return decision;
     }
 
-    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    private static boolean shouldAttemptToRetryWrite(@Nullable final BsonDocument command, final Throwable t,
-                                                     final int maxWireVersion) {
-        return shouldAttemptToRetryWrite(isRetryWritesEnabled(command), t, maxWireVersion);
+    static boolean shouldAttemptToRetryWrite(final RetryState retryState, final Throwable attemptFailure) {
+        boolean decision = false;
+        MongoException exceptionRetryableRegardlessOfCommand = null;
+        if (attemptFailure instanceof MongoConnectionPoolClearedException) {
+            decision = true;
+            exceptionRetryableRegardlessOfCommand = (MongoException) attemptFailure;
+        }
+        BsonDocument writeCommand = retryState.attachment(AttachmentKeys.command()).orElse(null);
+        BulkWriteTracker bulkWriteTracker = retryState.attachment(AttachmentKeys.bulkWriteTracker()).orElse(null);
+        boolean attemptFailedBeforeCommandIsKnown = writeCommand == null && bulkWriteTracker == null;
+        assertTrue(attemptFailedBeforeCommandIsKnown || (writeCommand != null ^ bulkWriteTracker != null));
+        boolean retryableCommand;
+        if (writeCommand != null) {
+            retryableCommand = isRetryWritesEnabled(writeCommand);
+        } else if (bulkWriteTracker != null) {
+            retryableCommand = bulkWriteTracker.batch().map(BulkWriteBatch::getRetryWrites).orElse(false);
+        } else {
+            retryableCommand = false;
+        }
+        if (retryableCommand) {
+            if (exceptionRetryableRegardlessOfCommand != null) {
+                /* We are going to retry even if `retryableCommand` is false,
+                 * but we add the retryable label only if `retryableCommand` is true. */
+                exceptionRetryableRegardlessOfCommand.addLabel(RETRYABLE_WRITE_ERROR_LABEL);
+            } else if (decideRetryableAndAddRetryableWriteErrorLabel(attemptFailure, retryState.attachment(AttachmentKeys.maxWireVersion())
+                    .orElse(null))) {
+                decision = true;
+            } else {
+                String commandDescription;
+                if (writeCommand != null) {
+                    commandDescription = writeCommand.getFirstKey();
+                } else {
+                    commandDescription = bulkWriteTracker.batch().map(batch -> batch.getPayload().getPayloadType().toString())
+                            .orElseThrow(Assertions::fail);
+                }
+                logUnableToRetry(commandDescription, attemptFailure);
+            }
+        }
+        return decision;
     }
 
     private static boolean isRetryWritesEnabled(@Nullable final BsonDocument command) {
@@ -815,15 +548,15 @@ final class CommandOperationHelper {
     }
 
     static final String RETRYABLE_WRITE_ERROR_LABEL = "RetryableWriteError";
-    static boolean shouldAttemptToRetryWrite(final boolean retryWritesEnabled, final Throwable t, final int maxWireVersion) {
-        if (!retryWritesEnabled) {
-            return false;
-        } else if (!(t instanceof MongoException)) {
+
+    private static boolean decideRetryableAndAddRetryableWriteErrorLabel(final Throwable t, @Nullable final Integer maxWireVersion) {
+        if (!(t instanceof MongoException)) {
             return false;
         }
-
         MongoException exception = (MongoException) t;
-        addRetryableWriteErrorLabel(exception, maxWireVersion);
+        if (maxWireVersion != null) {
+            addRetryableWriteErrorLabel(exception, maxWireVersion);
+        }
         return exception.hasErrorLabel(RETRYABLE_WRITE_ERROR_LABEL);
     }
 
@@ -835,15 +568,23 @@ final class CommandOperationHelper {
         }
     }
 
-    static void logRetryExecute(final String operation, final Throwable originalError) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(format("Retrying operation %s due to an error \"%s\"", operation, originalError));
+    static void logRetryExecute(final RetryState retryState, final Supplier<String> commandDescriptionSupplier) {
+        if (LOGGER.isDebugEnabled() && !retryState.firstAttempt()) {
+            String commandDescription = commandDescriptionSupplier.get();
+            Throwable exception = retryState.exception().orElseThrow(Assertions::fail);
+            int oneBasedAttempt = retryState.attempt() + 1;
+            LOGGER.debug(commandDescription == null
+                    ? format("Retrying an operation due to the error \"%s\"; attempt #%d", exception, oneBasedAttempt)
+                    : format("Retrying the operation %s due to the error \"%s\"; attempt #%d",
+                            commandDescription, exception, oneBasedAttempt));
         }
     }
 
-    static void logUnableToRetry(final String operation, final Throwable originalError) {
+    static void logUnableToRetry(@Nullable final String operation, final Throwable originalError) {
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(format("Unable to retry operation %s due to error \"%s\"", operation, originalError));
+            LOGGER.debug(operation == null
+                    ? format("Unable to retry an operation due to the error \"%s\"", originalError)
+                    : format("Unable to retry the operation %s due to the error \"%s\"", operation, originalError));
         }
     }
 
@@ -857,6 +598,20 @@ final class CommandOperationHelper {
             return clientException;
         }
         return exception;
+    }
+
+    static <R> SingleResultCallback<R> exceptionTransformingCallback(final SingleResultCallback<R> callback) {
+        return (result, t) -> {
+            if (t != null) {
+                if (t instanceof MongoException) {
+                    callback.onResult(null, transformWriteException((MongoException) t));
+                } else {
+                    callback.onResult(null, t);
+                }
+            } else {
+                callback.onResult(result, null);
+            }
+        };
     }
 
     private CommandOperationHelper() {

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -263,7 +263,7 @@ final class CommandOperationHelper {
                     createReadCommandAndExecuteAsync(retryState, binding, source, database, commandCreator, decoder, transformer,
                             connection, releasingCallback);
                 });
-        }).andFinally(binding::release);
+        }).whenComplete(binding::release);
         asyncRead.get(errorHandlingCallback(callback, LOGGER));
     }
 
@@ -448,7 +448,7 @@ final class CommandOperationHelper {
                         commandResultDecoder, binding.getSessionContext(),
                         binding.getServerApi(), transformingWriteCallback(transformer, connection, addingRetryableLabelCallback));
             });
-        }).andFinally(binding::release);
+        }).whenComplete(binding::release);
         asyncWrite.get(exceptionTransformingCallback(errorHandlingCallback(callback, LOGGER)));
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
@@ -26,8 +26,8 @@ import org.bson.codecs.Decoder;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommand;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableRead;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableReadAsync;
 
 /**
  * An operation that executes an arbitrary command that reads from the server.
@@ -55,12 +55,13 @@ public class CommandReadOperation<T> implements AsyncReadOperation<T>, ReadOpera
 
     @Override
     public T execute(final ReadBinding binding) {
-        return executeCommand(binding, databaseName, getCommandCreator(), decoder, false);
+        return executeRetryableRead(binding, databaseName, getCommandCreator(), decoder, (result, source, connection) -> result, false);
     }
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<T> callback) {
-        executeCommandAsync(binding, databaseName, getCommandCreator(), decoder, false, callback);
+        executeRetryableReadAsync(binding, databaseName, getCommandCreator(), decoder, (result, source, connection) -> result,
+                false, callback);
     }
 
     private CommandCreator getCommandCreator() {

--- a/driver-core/src/main/com/mongodb/internal/operation/CountOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CountOperation.java
@@ -35,8 +35,8 @@ import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommand;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableRead;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableReadAsync;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.internal.operation.OperationHelper.validateReadConcernAndCollation;
@@ -124,13 +124,13 @@ public class CountOperation implements AsyncReadOperation<Long>, ReadOperation<L
 
     @Override
     public Long execute(final ReadBinding binding) {
-        return executeCommand(binding, namespace.getDatabaseName(),
+        return executeRetryableRead(binding, namespace.getDatabaseName(),
                 getCommandCreator(binding.getSessionContext()), DECODER, transformer(), retryReads);
     }
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<Long> callback) {
-        executeCommandAsync(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()), DECODER,
+        executeRetryableReadAsync(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()), DECODER,
                 asyncTransformer(), retryReads, callback);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
@@ -30,6 +30,7 @@ import com.mongodb.internal.operation.OperationHelper.CallableWithConnection;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
+import org.bson.codecs.BsonDocumentCodec;
 
 import java.util.List;
 
@@ -152,7 +153,8 @@ public class CreateViewOperation implements AsyncWriteOperation<Void>, WriteOper
                 if (!serverIsAtLeastVersionThreeDotFour(connection.getDescription())) {
                     throw createExceptionForIncompatibleServerVersion();
                 }
-                executeCommand(binding, databaseName, getCommand(connection.getDescription()), writeConcernErrorTransformer());
+                executeCommand(binding, databaseName, getCommand(connection.getDescription()), new BsonDocumentCodec(),
+                        writeConcernErrorTransformer());
                 return null;
             }
         });

--- a/driver-core/src/main/com/mongodb/internal/operation/DistinctOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DistinctOperation.java
@@ -42,8 +42,8 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommand;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableRead;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableReadAsync;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNullOrEmpty;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
@@ -179,14 +179,14 @@ public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor
 
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
-        return executeCommand(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()), createCommandDecoder(),
-                transformer(), retryReads);
+        return executeRetryableRead(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
+                createCommandDecoder(), transformer(), retryReads);
     }
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        executeCommandAsync(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()), createCommandDecoder(),
-                asyncTransformer(), retryReads, errorHandlingCallback(callback, LOGGER));
+        executeRetryableReadAsync(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
+                createCommandDecoder(), asyncTransformer(), retryReads, errorHandlingCallback(callback, LOGGER));
     }
 
     private Codec<BsonDocument> createCommandDecoder() {

--- a/driver-core/src/main/com/mongodb/internal/operation/EstimatedDocumentCountOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/EstimatedDocumentCountOperation.java
@@ -37,8 +37,8 @@ import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommand;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableRead;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableReadAsync;
 import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError;
 import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotZero;
@@ -73,7 +73,7 @@ public class EstimatedDocumentCountOperation implements AsyncReadOperation<Long>
     @Override
     public Long execute(final ReadBinding binding) {
         try {
-            return executeCommand(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
+            return executeRetryableRead(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
                     CommandResultDocumentCodec.create(DECODER, singletonList("firstBatch")), transformer(), retryReads);
         } catch (MongoCommandException e) {
             return rethrowIfNotNamespaceError(e, 0L);
@@ -82,7 +82,7 @@ public class EstimatedDocumentCountOperation implements AsyncReadOperation<Long>
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<Long> callback) {
-        executeCommandAsync(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
+        executeRetryableReadAsync(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
                 CommandResultDocumentCodec.create(DECODER, singletonList("firstBatch")), asyncTransformer(), retryReads,
                 (result, t) -> {
                     if (isNamespaceError(t)) {

--- a/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
@@ -657,7 +657,7 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
     public BatchCursor<T> execute(final ReadBinding binding) {
         RetryState retryState = initialRetryState(retryReads);
         Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () -> {
-            logRetryExecute(retryState, () -> null);
+            logRetryExecute(retryState);
             return withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
                         binding.getSessionContext()));
@@ -698,7 +698,7 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
         binding.retain();
         AsyncCallbackSupplier<AsyncBatchCursor<T>> asyncRead = CommandOperationHelper.<AsyncBatchCursor<T>>decorateReadWithRetries(
                 retryState, funcCallback -> {
-            logRetryExecute(retryState, () -> null);
+            logRetryExecute(retryState);
             withAsyncSourceAndConnection(binding::getReadConnectionSource, false, funcCallback,
                     (source, connection, releasingCallback) -> {
                 if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),

--- a/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
@@ -658,7 +658,7 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
         RetryState retryState = initialRetryState(retryReads);
         Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () -> {
             logRetryExecute(retryState, () -> null);
-            return withSourceAndConnection(binding::getReadConnectionSource, null, (source, connection) -> {
+            return withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
                         binding.getSessionContext()));
                 if (serverIsAtLeastVersionThreeDotTwo(connection.getDescription())) {
@@ -699,7 +699,7 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
         AsyncCallbackSupplier<AsyncBatchCursor<T>> asyncRead = CommandOperationHelper.<AsyncBatchCursor<T>>decorateReadWithRetries(
                 retryState, funcCallback -> {
             logRetryExecute(retryState, () -> null);
-            withAsyncSourceAndConnection(binding::getReadConnectionSource, null, funcCallback,
+            withAsyncSourceAndConnection(binding::getReadConnectionSource, false, funcCallback,
                     (source, connection, releasingCallback) -> {
                 if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
                         binding.getSessionContext()), releasingCallback)) {

--- a/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
@@ -741,7 +741,7 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
                     });
                 }
             });
-        }).andFinally(binding::release);
+        }).whenComplete(binding::release);
         asyncRead.get(errorHandlingCallback(callback, LOGGER));
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
@@ -35,7 +35,8 @@ import com.mongodb.internal.connection.AsyncConnection;
 import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.connection.NoOpSessionContext;
 import com.mongodb.internal.connection.QueryResult;
-import com.mongodb.internal.operation.OperationHelper.CallableWithSource;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+import com.mongodb.internal.async.function.RetryState;
 import com.mongodb.internal.session.SessionContext;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonBoolean;
@@ -47,6 +48,7 @@ import org.bson.BsonValue;
 import org.bson.codecs.Decoder;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.isTrueArgument;
@@ -56,18 +58,21 @@ import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandli
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandReadTransformer;
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandReadTransformerAsync;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsyncWithConnection;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandWithConnection;
+import static com.mongodb.internal.operation.CommandOperationHelper.createReadCommandAndExecute;
+import static com.mongodb.internal.operation.CommandOperationHelper.createReadCommandAndExecuteAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.decorateReadWithRetries;
+import static com.mongodb.internal.operation.CommandOperationHelper.initialRetryState;
+import static com.mongodb.internal.operation.CommandOperationHelper.logRetryExecute;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNullOrEmpty;
 import static com.mongodb.internal.operation.ExplainHelper.asExplainCommand;
 import static com.mongodb.internal.operation.OperationHelper.AsyncCallableWithConnectionAndSource;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
+import static com.mongodb.internal.operation.OperationHelper.canRetryRead;
 import static com.mongodb.internal.operation.OperationHelper.cursorDocumentToQueryResult;
-import static com.mongodb.internal.operation.OperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.OperationHelper.validateFindOptions;
-import static com.mongodb.internal.operation.OperationHelper.withAsyncReadConnection;
-import static com.mongodb.internal.operation.OperationHelper.withReadConnectionSource;
+import static com.mongodb.internal.operation.OperationHelper.withAsyncSourceAndConnection;
+import static com.mongodb.internal.operation.OperationHelper.withSourceAndConnection;
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand;
 import static com.mongodb.internal.operation.ServerVersionHelper.MIN_WIRE_VERSION;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
@@ -650,93 +655,94 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
 
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
-        return withReadConnectionSource(binding, new CallableWithSource<BatchCursor<T>>() {
-            @Override
-            public BatchCursor<T> call(final ConnectionSource source) {
-                Connection connection = source.getConnection();
+        RetryState retryState = initialRetryState(retryReads);
+        Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () -> {
+            logRetryExecute(retryState, () -> null);
+            return withSourceAndConnection(binding::getReadConnectionSource, null, (source, connection) -> {
+                retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
+                        binding.getSessionContext()));
                 if (serverIsAtLeastVersionThreeDotTwo(connection.getDescription())) {
                     try {
-                        return executeCommandWithConnection(binding, source, namespace.getDatabaseName(),
-                                getCommandCreator(binding.getSessionContext()),
-                                CommandResultDocumentCodec.create(decoder, FIRST_BATCH), transformer(), retryReads, connection);
+                        return createReadCommandAndExecute(retryState, binding, source, namespace.getDatabaseName(),
+                                getCommandCreator(binding.getSessionContext()), CommandResultDocumentCodec.create(decoder, FIRST_BATCH),
+                                transformer(), connection);
                     } catch (MongoCommandException e) {
                         throw new MongoQueryException(e);
                     }
                 } else {
-                    try {
-                        validateFindOptions(connection, binding.getSessionContext().getReadConcern(), collation, allowDiskUse);
-                        QueryResult<T> queryResult = connection.query(namespace,
-                                asDocument(connection.getDescription(), binding.getReadPreference()),
-                                projection,
-                                skip,
-                                limit,
-                                batchSize,
-                                isSecondaryOk() || binding.getReadPreference().isSecondaryOk(),
-                                isTailableCursor(),
-                                isAwaitData(),
-                                isNoCursorTimeout(),
-                                isPartial(),
-                                isOplogReplay(),
-                                decoder);
-                        return new QueryBatchCursor<T>(queryResult, limit, batchSize, getMaxTimeForCursor(), decoder, source, connection);
-                    } finally {
-                        connection.release();
-                    }
+                    retryState.markAsLastAttempt();
+                    validateFindOptions(connection, binding.getSessionContext().getReadConcern(), collation, allowDiskUse);
+                    QueryResult<T> queryResult = connection.query(namespace,
+                            asDocument(connection.getDescription(), binding.getReadPreference()),
+                            projection,
+                            skip,
+                            limit,
+                            batchSize,
+                            isSecondaryOk() || binding.getReadPreference().isSecondaryOk(),
+                            isTailableCursor(),
+                            isAwaitData(),
+                            isNoCursorTimeout(),
+                            isPartial(),
+                            isOplogReplay(),
+                            decoder);
+                    return new QueryBatchCursor<>(queryResult, limit, batchSize, getMaxTimeForCursor(), decoder, source, connection);
                 }
-            }
+            });
         });
+        return read.get();
     }
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        withAsyncReadConnection(binding, new AsyncCallableWithConnectionAndSource() {
-            @Override
-            public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
-                SingleResultCallback<AsyncBatchCursor<T>> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-                if (t != null) {
-                    errHandlingCallback.onResult(null, t);
-                } else {
-                    if (serverIsAtLeastVersionThreeDotTwo(connection.getDescription())) {
-                        final SingleResultCallback<AsyncBatchCursor<T>> wrappedCallback =
-                                exceptionTransformingCallback(errHandlingCallback);
-                        executeCommandAsyncWithConnection(binding, source, namespace.getDatabaseName(),
-                                getCommandCreator(binding.getSessionContext()), CommandResultDocumentCodec.create(decoder, FIRST_BATCH),
-                                asyncTransformer(), retryReads, connection, wrappedCallback);
-                    } else {
-                        final SingleResultCallback<AsyncBatchCursor<T>> wrappedCallback =
-                                releasingCallback(errHandlingCallback, source, connection);
-                        validateFindOptions(source, connection, binding.getSessionContext().getReadConcern(), collation,
-                                allowDiskUse,
-                                new AsyncCallableWithConnectionAndSource() {
-                                    @Override
-                                    public void call(final AsyncConnectionSource source, final AsyncConnection connection, final
-                                    Throwable t) {
-                                        if (t != null) {
-                                            wrappedCallback.onResult(null, t);
-                                        } else {
-                                            connection.queryAsync(namespace, asDocument(connection.getDescription(),
-                                                    binding.getReadPreference()), projection, skip, limit, batchSize,
-                                                    isSecondaryOk() || binding.getReadPreference().isSecondaryOk(),
-                                                    isTailableCursor(), isAwaitData(), isNoCursorTimeout(), isPartial(), isOplogReplay(),
-                                                    decoder, new SingleResultCallback<QueryResult<T>>() {
-                                                        @Override
-                                                        public void onResult(final QueryResult<T> result, final Throwable t) {
-                                                            if (t != null) {
-                                                                wrappedCallback.onResult(null, t);
-                                                            } else {
-                                                                wrappedCallback.onResult(new AsyncQueryBatchCursor<T>(result, limit,
-                                                                        batchSize, getMaxTimeForCursor(), decoder, source, connection),
-                                                                        null);
-                                                            }
-                                                        }
-                                                    });
-                                        }
-                                    }
-                        });
-                    }
+        RetryState retryState = initialRetryState(retryReads);
+        binding.retain();
+        AsyncCallbackSupplier<AsyncBatchCursor<T>> asyncRead = CommandOperationHelper.<AsyncBatchCursor<T>>decorateReadWithRetries(
+                retryState, funcCallback -> {
+            logRetryExecute(retryState, () -> null);
+            withAsyncSourceAndConnection(binding::getReadConnectionSource, null, funcCallback,
+                    (source, connection, releasingCallback) -> {
+                if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
+                        binding.getSessionContext()), releasingCallback)) {
+                    return;
                 }
-            }
-        });
+                if (serverIsAtLeastVersionThreeDotTwo(connection.getDescription())) {
+                    final SingleResultCallback<AsyncBatchCursor<T>> wrappedCallback = exceptionTransformingCallback(releasingCallback);
+                    createReadCommandAndExecuteAsync(retryState, binding, source, namespace.getDatabaseName(),
+                            getCommandCreator(binding.getSessionContext()), CommandResultDocumentCodec.create(decoder, FIRST_BATCH),
+                            asyncTransformer(), connection, wrappedCallback);
+                } else {
+                    retryState.markAsLastAttempt();
+                    validateFindOptions(source, connection, binding.getSessionContext().getReadConcern(), collation,
+                            allowDiskUse,
+                            new AsyncCallableWithConnectionAndSource() {
+                                @Override
+                                public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
+                                    if (t != null) {
+                                        releasingCallback.onResult(null, t);
+                                    } else {
+                                        connection.queryAsync(namespace, asDocument(connection.getDescription(),
+                                                binding.getReadPreference()), projection, skip, limit, batchSize,
+                                                isSecondaryOk() || binding.getReadPreference().isSecondaryOk(),
+                                                isTailableCursor(), isAwaitData(), isNoCursorTimeout(), isPartial(), isOplogReplay(),
+                                                decoder, new SingleResultCallback<QueryResult<T>>() {
+                                                    @Override
+                                                    public void onResult(final QueryResult<T> result, final Throwable t) {
+                                                        if (t != null) {
+                                                            releasingCallback.onResult(null, t);
+                                                        } else {
+                                                            releasingCallback.onResult(new AsyncQueryBatchCursor<T>(result, limit,
+                                                                    batchSize, getMaxTimeForCursor(), decoder, source, connection),
+                                                                    null);
+                                                        }
+                                                    }
+                                                });
+                                    }
+                                }
+                    });
+                }
+            });
+        }).andFinally(binding::release);
+        asyncRead.get(errorHandlingCallback(callback, LOGGER));
     }
 
     private static <T> SingleResultCallback<T> exceptionTransformingCallback(final SingleResultCallback<T> callback) {

--- a/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
@@ -233,7 +233,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
     public BatchCursor<T> execute(final ReadBinding binding) {
         RetryState retryState = initialRetryState(retryReads);
         Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () -> {
-            logRetryExecute(retryState, () -> null);
+            logRetryExecute(retryState);
             return withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
                         binding.getSessionContext()));
@@ -263,7 +263,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
         binding.retain();
         AsyncCallbackSupplier<AsyncBatchCursor<T>> asyncRead = CommandOperationHelper.<AsyncBatchCursor<T>>decorateReadWithRetries(
                 retryState, funcCallback -> {
-            logRetryExecute(retryState, () -> null);
+            logRetryExecute(retryState);
             withAsyncSourceAndConnection(binding::getReadConnectionSource, false, funcCallback,
                     (source, connection, releasingCallback) -> {
                 if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),

--- a/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
@@ -298,7 +298,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
                             });
                 }
             });
-        }).andFinally(binding::release);
+        }).whenComplete(binding::release);
         asyncRead.get(errorHandlingCallback(callback, LOGGER));
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
@@ -234,7 +234,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
         RetryState retryState = initialRetryState(retryReads);
         Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () -> {
             logRetryExecute(retryState, () -> null);
-            return withSourceAndConnection(binding::getReadConnectionSource, null, (source, connection) -> {
+            return withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
                         binding.getSessionContext()));
                 if (serverIsAtLeastVersionThreeDotZero(connection.getDescription())) {
@@ -264,7 +264,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
         AsyncCallbackSupplier<AsyncBatchCursor<T>> asyncRead = CommandOperationHelper.<AsyncBatchCursor<T>>decorateReadWithRetries(
                 retryState, funcCallback -> {
             logRetryExecute(retryState, () -> null);
-            withAsyncSourceAndConnection(binding::getReadConnectionSource, null, funcCallback,
+            withAsyncSourceAndConnection(binding::getReadConnectionSource, false, funcCallback,
                     (source, connection, releasingCallback) -> {
                 if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
                         binding.getSessionContext()), releasingCallback)) {

--- a/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
@@ -32,8 +32,10 @@ import com.mongodb.internal.binding.ReadBinding;
 import com.mongodb.internal.connection.AsyncConnection;
 import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.connection.QueryResult;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
 import com.mongodb.internal.operation.CommandOperationHelper.CommandReadTransformer;
 import com.mongodb.internal.operation.CommandOperationHelper.CommandReadTransformerAsync;
+import com.mongodb.internal.async.function.RetryState;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -50,27 +52,29 @@ import org.bson.codecs.DecoderContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.connection.ServerType.SHARD_ROUTER;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsyncWithConnection;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandWithConnection;
+import static com.mongodb.internal.operation.CommandOperationHelper.createReadCommandAndExecute;
+import static com.mongodb.internal.operation.CommandOperationHelper.createReadCommandAndExecuteAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.decorateReadWithRetries;
+import static com.mongodb.internal.operation.CommandOperationHelper.initialRetryState;
 import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError;
+import static com.mongodb.internal.operation.CommandOperationHelper.logRetryExecute;
 import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError;
 import static com.mongodb.internal.operation.CursorHelper.getCursorDocumentFromBatchSize;
-import static com.mongodb.internal.operation.OperationHelper.AsyncCallableWithConnectionAndSource;
-import static com.mongodb.internal.operation.OperationHelper.CallableWithSource;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
+import static com.mongodb.internal.operation.OperationHelper.canRetryRead;
 import static com.mongodb.internal.operation.OperationHelper.createEmptyAsyncBatchCursor;
 import static com.mongodb.internal.operation.OperationHelper.createEmptyBatchCursor;
 import static com.mongodb.internal.operation.OperationHelper.cursorDocumentToAsyncBatchCursor;
 import static com.mongodb.internal.operation.OperationHelper.cursorDocumentToBatchCursor;
-import static com.mongodb.internal.operation.OperationHelper.releasingCallback;
-import static com.mongodb.internal.operation.OperationHelper.withAsyncReadConnection;
-import static com.mongodb.internal.operation.OperationHelper.withReadConnectionSource;
+import static com.mongodb.internal.operation.OperationHelper.withAsyncSourceAndConnection;
+import static com.mongodb.internal.operation.OperationHelper.withSourceAndConnection;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotZero;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -227,76 +231,75 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
 
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
-        return withReadConnectionSource(binding, new CallableWithSource<BatchCursor<T>>() {
-            @Override
-            public BatchCursor<T> call(final ConnectionSource source) {
-                Connection connection = source.getConnection();
+        RetryState retryState = initialRetryState(retryReads);
+        Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () -> {
+            logRetryExecute(retryState, () -> null);
+            return withSourceAndConnection(binding::getReadConnectionSource, null, (source, connection) -> {
+                retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
+                        binding.getSessionContext()));
                 if (serverIsAtLeastVersionThreeDotZero(connection.getDescription())) {
                     try {
-                        return executeCommandWithConnection(binding, source, databaseName, getCommandCreator(), createCommandDecoder(),
-                                commandTransformer(), retryReads, connection);
+                        return createReadCommandAndExecute(retryState, binding, source, databaseName, getCommandCreator(),
+                                createCommandDecoder(), commandTransformer(), connection);
                     } catch (MongoCommandException e) {
                         return rethrowIfNotNamespaceError(e, createEmptyBatchCursor(createNamespace(), decoder,
                                 source.getServerDescription().getAddress(), batchSize));
                     }
                 } else {
-                    try {
-                        return new ProjectingBatchCursor(new QueryBatchCursor<BsonDocument>(connection.query(getNamespace(),
-                                asQueryDocument(connection.getDescription(), binding.getReadPreference()), null, 0, 0, batchSize,
-                                binding.getReadPreference().isSecondaryOk(), false, false, false, false, false,
-                                new BsonDocumentCodec()), 0, batchSize, new BsonDocumentCodec(), source));
-                    } finally {
-                        connection.release();
-                    }
+                    retryState.markAsLastAttempt();
+                    return new ProjectingBatchCursor(new QueryBatchCursor<>(connection.query(getNamespace(),
+                            asQueryDocument(connection.getDescription(), binding.getReadPreference()), null, 0, 0, batchSize,
+                            binding.getReadPreference().isSecondaryOk(), false, false, false, false, false,
+                            new BsonDocumentCodec()), 0, batchSize, new BsonDocumentCodec(), source));
                 }
-            }
+            });
         });
+        return read.get();
     }
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        withAsyncReadConnection(binding, new AsyncCallableWithConnectionAndSource() {
-            @Override
-            public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
-                SingleResultCallback<AsyncBatchCursor<T>> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-                if (t != null) {
-                    errHandlingCallback.onResult(null, t);
-                } else {
-                    if (serverIsAtLeastVersionThreeDotZero(connection.getDescription())) {
-                        executeCommandAsyncWithConnection(binding, source, databaseName, getCommandCreator(), createCommandDecoder(),
-                                asyncTransformer(), retryReads, connection,
-                                new SingleResultCallback<AsyncBatchCursor<T>>() {
-                                    @Override
-                                    public void onResult(final AsyncBatchCursor<T> result, final Throwable t) {
-                                        if (t != null && !isNamespaceError(t)) {
-                                            errHandlingCallback.onResult(null, t);
-                                        } else {
-                                            errHandlingCallback.onResult(result != null ? result : emptyAsyncCursor(source), null);
-                                        }
-                                    }
-                                });
-                    } else {
-                        final SingleResultCallback<AsyncBatchCursor<T>> wrappedCallback = releasingCallback(errHandlingCallback,
-                                source, connection);
-                        connection.queryAsync(getNamespace(), asQueryDocument(connection.getDescription(), binding.getReadPreference()),
-                                null, 0, 0, batchSize, binding.getReadPreference().isSecondaryOk(), false, false, false, false, false,
-                                new BsonDocumentCodec(), new SingleResultCallback<QueryResult<BsonDocument>>() {
-                                    @Override
-                                    public void onResult(final QueryResult<BsonDocument> result, final Throwable t) {
-                                        if (t != null) {
-                                            wrappedCallback.onResult(null, t);
-                                        } else {
-                                            wrappedCallback.onResult(new ProjectingAsyncBatchCursor(
-                                                    new AsyncQueryBatchCursor<BsonDocument>(result, 0,
-                                                            batchSize, 0, new BsonDocumentCodec(), source, connection)
-                                            ), null);
-                                        }
-                                    }
-                                });
-                    }
+        RetryState retryState = initialRetryState(retryReads);
+        binding.retain();
+        AsyncCallbackSupplier<AsyncBatchCursor<T>> asyncRead = CommandOperationHelper.<AsyncBatchCursor<T>>decorateReadWithRetries(
+                retryState, funcCallback -> {
+            logRetryExecute(retryState, () -> null);
+            withAsyncSourceAndConnection(binding::getReadConnectionSource, null, funcCallback,
+                    (source, connection, releasingCallback) -> {
+                if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
+                        binding.getSessionContext()), releasingCallback)) {
+                    return;
                 }
-            }
-        });
+                if (serverIsAtLeastVersionThreeDotZero(connection.getDescription())) {
+                    createReadCommandAndExecuteAsync(retryState, binding, source, databaseName, getCommandCreator(), createCommandDecoder(),
+                            asyncTransformer(), connection, (result, t) -> {
+                                if (t != null && !isNamespaceError(t)) {
+                                    releasingCallback.onResult(null, t);
+                                } else {
+                                    releasingCallback.onResult(result != null ? result : emptyAsyncCursor(source), null);
+                                }
+                    });
+                } else {
+                    retryState.markAsLastAttempt();
+                    connection.queryAsync(getNamespace(), asQueryDocument(connection.getDescription(), binding.getReadPreference()),
+                            null, 0, 0, batchSize, binding.getReadPreference().isSecondaryOk(), false, false, false, false, false,
+                            new BsonDocumentCodec(), new SingleResultCallback<QueryResult<BsonDocument>>() {
+                                @Override
+                                public void onResult(final QueryResult<BsonDocument> result, final Throwable t) {
+                                    if (t != null) {
+                                        releasingCallback.onResult(null, t);
+                                    } else {
+                                        releasingCallback.onResult(new ProjectingAsyncBatchCursor(
+                                                new AsyncQueryBatchCursor<BsonDocument>(result, 0,
+                                                        batchSize, 0, new BsonDocumentCodec(), source, connection)
+                                        ), null);
+                                    }
+                                }
+                            });
+                }
+            });
+        }).andFinally(binding::release);
+        asyncRead.get(errorHandlingCallback(callback, LOGGER));
     }
 
     private AsyncBatchCursor<T> emptyAsyncCursor(final AsyncConnectionSource source) {

--- a/driver-core/src/main/com/mongodb/internal/operation/ListDatabasesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListDatabasesOperation.java
@@ -40,8 +40,8 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommand;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableRead;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableReadAsync;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 
 
@@ -198,13 +198,13 @@ public class ListDatabasesOperation<T> implements AsyncReadOperation<AsyncBatchC
      */
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
-        return executeCommand(binding, "admin", getCommandCreator(),
+        return executeRetryableRead(binding, "admin", getCommandCreator(),
                 CommandResultDocumentCodec.create(decoder, "databases"), transformer(), retryReads);
     }
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        executeCommandAsync(binding, "admin", getCommandCreator(),
+        executeRetryableReadAsync(binding, "admin", getCommandCreator(),
                 CommandResultDocumentCodec.create(decoder, "databases"), asyncTransformer(),
                 retryReads, errorHandlingCallback(callback, LOGGER));
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
@@ -168,7 +168,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
     public BatchCursor<T> execute(final ReadBinding binding) {
         RetryState retryState = initialRetryState(retryReads);
         Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () -> {
-            logRetryExecute(retryState, () -> null);
+            logRetryExecute(retryState);
             return withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
                         binding.getSessionContext()));
@@ -198,7 +198,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
         binding.retain();
         AsyncCallbackSupplier<AsyncBatchCursor<T>> asyncRead = CommandOperationHelper.<AsyncBatchCursor<T>>decorateReadWithRetries(
                 retryState, funcCallback -> {
-            logRetryExecute(retryState, () -> null);
+            logRetryExecute(retryState);
             withAsyncSourceAndConnection(binding::getReadConnectionSource, false, funcCallback,
                     (source, connection, releasingCallback) -> {
                 if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),

--- a/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
@@ -169,7 +169,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
         RetryState retryState = initialRetryState(retryReads);
         Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () -> {
             logRetryExecute(retryState, () -> null);
-            return withSourceAndConnection(binding::getReadConnectionSource, null, (source, connection) -> {
+            return withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
                         binding.getSessionContext()));
                 if (serverIsAtLeastVersionThreeDotZero(connection.getDescription())) {
@@ -199,7 +199,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
         AsyncCallbackSupplier<AsyncBatchCursor<T>> asyncRead = CommandOperationHelper.<AsyncBatchCursor<T>>decorateReadWithRetries(
                 retryState, funcCallback -> {
             logRetryExecute(retryState, () -> null);
-            withAsyncSourceAndConnection(binding::getReadConnectionSource, null, funcCallback,
+            withAsyncSourceAndConnection(binding::getReadConnectionSource, false, funcCallback,
                     (source, connection, releasingCallback) -> {
                 if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
                         binding.getSessionContext()), releasingCallback)) {

--- a/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
@@ -232,7 +232,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
                             });
                 }
             });
-        }).andFinally(binding::release);
+        }).whenComplete(binding::release);
         asyncRead.get(errorHandlingCallback(callback, LOGGER));
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
@@ -30,9 +30,10 @@ import com.mongodb.internal.binding.ReadBinding;
 import com.mongodb.internal.connection.AsyncConnection;
 import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.connection.QueryResult;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
 import com.mongodb.internal.operation.CommandOperationHelper.CommandReadTransformer;
 import com.mongodb.internal.operation.CommandOperationHelper.CommandReadTransformerAsync;
-import com.mongodb.internal.operation.OperationHelper.CallableWithSource;
+import com.mongodb.internal.async.function.RetryState;
 import org.bson.BsonDocument;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
@@ -40,26 +41,29 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.Decoder;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.connection.ServerType.SHARD_ROUTER;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsyncWithConnection;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandWithConnection;
+import static com.mongodb.internal.operation.CommandOperationHelper.createReadCommandAndExecute;
+import static com.mongodb.internal.operation.CommandOperationHelper.createReadCommandAndExecuteAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.decorateReadWithRetries;
+import static com.mongodb.internal.operation.CommandOperationHelper.initialRetryState;
 import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError;
+import static com.mongodb.internal.operation.CommandOperationHelper.logRetryExecute;
 import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError;
 import static com.mongodb.internal.operation.CursorHelper.getCursorDocumentFromBatchSize;
-import static com.mongodb.internal.operation.OperationHelper.AsyncCallableWithConnectionAndSource;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
+import static com.mongodb.internal.operation.OperationHelper.canRetryRead;
 import static com.mongodb.internal.operation.OperationHelper.createEmptyAsyncBatchCursor;
 import static com.mongodb.internal.operation.OperationHelper.createEmptyBatchCursor;
 import static com.mongodb.internal.operation.OperationHelper.cursorDocumentToAsyncBatchCursor;
 import static com.mongodb.internal.operation.OperationHelper.cursorDocumentToBatchCursor;
-import static com.mongodb.internal.operation.OperationHelper.releasingCallback;
-import static com.mongodb.internal.operation.OperationHelper.withAsyncReadConnection;
-import static com.mongodb.internal.operation.OperationHelper.withReadConnectionSource;
+import static com.mongodb.internal.operation.OperationHelper.withAsyncSourceAndConnection;
+import static com.mongodb.internal.operation.OperationHelper.withSourceAndConnection;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotZero;
 
 /**
@@ -162,77 +166,74 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
 
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
-        return withReadConnectionSource(binding, new CallableWithSource<BatchCursor<T>>() {
-            @Override
-            public BatchCursor<T> call(final ConnectionSource source) {
-                Connection connection = source.getConnection();
+        RetryState retryState = initialRetryState(retryReads);
+        Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () -> {
+            logRetryExecute(retryState, () -> null);
+            return withSourceAndConnection(binding::getReadConnectionSource, null, (source, connection) -> {
+                retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
+                        binding.getSessionContext()));
                 if (serverIsAtLeastVersionThreeDotZero(connection.getDescription())) {
                     try {
-                        return executeCommandWithConnection(binding, source, namespace.getDatabaseName(), getCommandCreator(),
-                                createCommandDecoder(), transformer(), retryReads, connection);
+                        return createReadCommandAndExecute(retryState, binding, source, namespace.getDatabaseName(), getCommandCreator(),
+                                createCommandDecoder(), transformer(), connection);
                     } catch (MongoCommandException e) {
                         return rethrowIfNotNamespaceError(e, createEmptyBatchCursor(namespace, decoder,
-                                                                                    source.getServerDescription().getAddress(), batchSize));
+                                source.getServerDescription().getAddress(), batchSize));
                     }
                 } else {
-                    try {
-                        return new QueryBatchCursor<T>(connection.query(getIndexNamespace(),
-                                asQueryDocument(connection.getDescription(), binding.getReadPreference()), null, 0, 0, batchSize,
-                                binding.getReadPreference().isSecondaryOk(), false, false, false, false, false, decoder), 0, batchSize,
-                                decoder, source);
-                    } finally {
-                        connection.release();
-                    }
+                    retryState.markAsLastAttempt();
+                    return new QueryBatchCursor<>(connection.query(getIndexNamespace(),
+                            asQueryDocument(connection.getDescription(), binding.getReadPreference()), null, 0, 0, batchSize,
+                            binding.getReadPreference().isSecondaryOk(), false, false, false, false, false, decoder), 0, batchSize,
+                            decoder, source);
                 }
-            }
+            });
         });
+        return read.get();
     }
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        withAsyncReadConnection(binding, new AsyncCallableWithConnectionAndSource() {
-            @Override
-            public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
-                final SingleResultCallback<AsyncBatchCursor<T>> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-                if (t != null) {
-                    errHandlingCallback.onResult(null, t);
-                } else {
-                    if (serverIsAtLeastVersionThreeDotZero(connection.getDescription())) {
-                        executeCommandAsyncWithConnection(binding, source, namespace.getDatabaseName(), getCommandCreator(),
-                                createCommandDecoder(), asyncTransformer(), retryReads, connection,
-                                new SingleResultCallback<AsyncBatchCursor<T>>() {
-                                    @Override
-                                    public void onResult(final AsyncBatchCursor<T> result,
-                                                         final Throwable t) {
-                                        if (t != null && !isNamespaceError(t)) {
-                                            errHandlingCallback.onResult(null, t);
-                                        } else {
-                                            errHandlingCallback.onResult(result != null ? result : emptyAsyncCursor(source), null);
-                                        }
-                                    }
-                                });
-                    } else {
-                        final SingleResultCallback<AsyncBatchCursor<T>> wrappedCallback = releasingCallback(errHandlingCallback,
-                                source, connection);
-                        connection.queryAsync(getIndexNamespace(),
-                                asQueryDocument(connection.getDescription(), binding.getReadPreference()), null, 0, 0, batchSize,
-                                binding.getReadPreference().isSecondaryOk(), false, false, false, false, false, decoder,
-                                new SingleResultCallback<QueryResult<T>>() {
-                                    @Override
-                                    public void onResult(final QueryResult<T> result, final Throwable t) {
-                                        if (t != null) {
-                                            wrappedCallback.onResult(null, t);
-                                        } else {
-                                            wrappedCallback.onResult(new AsyncQueryBatchCursor<T>(result, 0, batchSize, 0, decoder, source,
-                                                                                                  connection),
-                                                    null);
-                                        }
-                                    }
-                                });
-                    }
+        RetryState retryState = initialRetryState(retryReads);
+        binding.retain();
+        AsyncCallbackSupplier<AsyncBatchCursor<T>> asyncRead = CommandOperationHelper.<AsyncBatchCursor<T>>decorateReadWithRetries(
+                retryState, funcCallback -> {
+            logRetryExecute(retryState, () -> null);
+            withAsyncSourceAndConnection(binding::getReadConnectionSource, null, funcCallback,
+                    (source, connection, releasingCallback) -> {
+                if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), connection.getDescription(),
+                        binding.getSessionContext()), releasingCallback)) {
+                    return;
                 }
-            }
-        });
+                if (serverIsAtLeastVersionThreeDotZero(connection.getDescription())) {
+                    createReadCommandAndExecuteAsync(retryState, binding, source, namespace.getDatabaseName(), getCommandCreator(),
+                            createCommandDecoder(), asyncTransformer(), connection, (result, t) -> {
+                                if (t != null && !isNamespaceError(t)) {
+                                    releasingCallback.onResult(null, t);
+                                } else {
+                                    releasingCallback.onResult(result != null ? result : emptyAsyncCursor(source), null);
+                                }
+                            });
+                } else {
+                    retryState.markAsLastAttempt();
+                    connection.queryAsync(getIndexNamespace(),
+                            asQueryDocument(connection.getDescription(), binding.getReadPreference()), null, 0, 0, batchSize,
+                            binding.getReadPreference().isSecondaryOk(), false, false, false, false, false, decoder,
+                            new SingleResultCallback<QueryResult<T>>() {
+                                @Override
+                                public void onResult(final QueryResult<T> result, final Throwable t) {
+                                    if (t != null) {
+                                        releasingCallback.onResult(null, t);
+                                    } else {
+                                        releasingCallback.onResult(new AsyncQueryBatchCursor<T>(result, 0, batchSize, 0, decoder,
+                                                        source, connection), null);
+                                    }
+                                }
+                            });
+                }
+            });
+        }).andFinally(binding::release);
+        asyncRead.get(errorHandlingCallback(callback, LOGGER));
     }
 
     private AsyncBatchCursor<T> emptyAsyncCursor(final AsyncConnectionSource source) {

--- a/driver-core/src/main/com/mongodb/internal/operation/MapReduceWithInlineResultsOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MapReduceWithInlineResultsOperation.java
@@ -45,8 +45,8 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommand;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableRead;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableReadAsync;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.internal.operation.DocumentHelper.putIfTrue;
@@ -355,14 +355,14 @@ public class MapReduceWithInlineResultsOperation<T> implements AsyncReadOperatio
     @Override
     @SuppressWarnings("unchecked")
     public MapReduceBatchCursor<T> execute(final ReadBinding binding) {
-        return executeCommand(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
+        return executeRetryableRead(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
                 CommandResultDocumentCodec.create(decoder, "results"), transformer(), false);
     }
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<MapReduceAsyncBatchCursor<T>> callback) {
         SingleResultCallback<MapReduceAsyncBatchCursor<T>> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-        executeCommandAsync(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
+        executeRetryableReadAsync(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
                 CommandResultDocumentCodec.create(decoder, "results"),
                 asyncTransformer(), false, errHandlingCallback);
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -238,7 +238,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
                         .orElseThrow(Assertions::fail);
                 SessionContext sessionContext = binding.getSessionContext();
                 WriteConcern writeConcern = getAppliedWriteConcern(sessionContext);
-                if (!retryState.firstAttempt() && !isRetryableWrite(retryWrites, writeConcern, source.getServerDescription(),
+                if (!retryState.isFirstAttempt() && !isRetryableWrite(retryWrites, writeConcern, source.getServerDescription(),
                         connectionDescription, sessionContext)) {
                     RuntimeException prospectiveFailedResult = (RuntimeException) retryState.exception().orElse(null);
                     retryState.breakAndThrowIfRetryAnd(() -> !(prospectiveFailedResult instanceof MongoWriteConcernWithResponseException));
@@ -289,7 +289,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
                         .orElseThrow(Assertions::fail);
                 SessionContext sessionContext = binding.getSessionContext();
                 WriteConcern writeConcern = getAppliedWriteConcern(sessionContext);
-                if (!retryState.firstAttempt() && !isRetryableWrite(retryWrites, writeConcern, source.getServerDescription(),
+                if (!retryState.isFirstAttempt() && !isRetryableWrite(retryWrites, writeConcern, source.getServerDescription(),
                         connectionDescription, sessionContext)) {
                     Throwable prospectiveFailedResult = retryState.exception().orElse(null);
                     if (retryState.breakAndCompleteIfRetryAnd(() ->
@@ -353,7 +353,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
                 currentBulkWriteTracker = BulkWriteTracker.attachNext(retryState, currentBatch);
                 currentBatch = currentBulkWriteTracker.batch().orElseThrow(Assertions::fail);
             } catch (MongoException exception) {
-                if (!(retryState.firstAttempt() || (exception instanceof MongoWriteConcernWithResponseException))) {
+                if (!(retryState.isFirstAttempt() || (exception instanceof MongoWriteConcernWithResponseException))) {
                     addRetryableWriteErrorLabel(exception, maxWireVersion);
                 }
                 throw exception;
@@ -401,7 +401,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
                 } else {
                     if (t instanceof MongoException) {
                         MongoException exception = (MongoException) t;
-                        if (!(retryState.firstAttempt() || (exception instanceof MongoWriteConcernWithResponseException))) {
+                        if (!(retryState.isFirstAttempt() || (exception instanceof MongoWriteConcernWithResponseException))) {
                             addRetryableWriteErrorLabel(exception, maxWireVersion);
                         }
                     }

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -182,13 +182,13 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
     }
 
     private <R> Supplier<R> decorateWriteWithRetries(final RetryState retryState, final Supplier<R> writeFunction) {
-        return new RetryingSyncSupplier<>(retryState, CommandOperationHelper::chooseAndMutateRetryableWriteException,
+        return new RetryingSyncSupplier<>(retryState, CommandOperationHelper::chooseRetryableWriteException,
                 this::shouldAttemptToRetryWrite, writeFunction);
     }
 
     private <R> AsyncCallbackSupplier<R> decorateWriteWithRetries(final RetryState retryState,
             final AsyncCallbackSupplier<R> writeFunction) {
-        return new RetryingAsyncCallbackSupplier<>(retryState, CommandOperationHelper::chooseAndMutateRetryableWriteException,
+        return new RetryingAsyncCallbackSupplier<>(retryState, CommandOperationHelper::chooseRetryableWriteException,
                 this::shouldAttemptToRetryWrite, writeFunction);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
@@ -17,7 +17,6 @@
 package com.mongodb.internal.operation;
 
 import com.mongodb.MongoClientException;
-import com.mongodb.MongoException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadConcern;
 import com.mongodb.ServerAddress;
@@ -30,6 +29,7 @@ import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.async.function.AsyncCallbackFunction;
 import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.binding.AsyncReadBinding;
 import com.mongodb.internal.binding.AsyncWriteBinding;
@@ -44,7 +44,10 @@ import com.mongodb.internal.bulk.WriteRequest;
 import com.mongodb.internal.connection.AsyncConnection;
 import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.connection.QueryResult;
+import com.mongodb.internal.async.function.AsyncCallbackBiFunction;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
 import com.mongodb.internal.session.SessionContext;
+import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonInt64;
 import org.bson.codecs.Decoder;
@@ -53,6 +56,9 @@ import org.bson.conversions.Bson;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
@@ -63,7 +69,6 @@ import static com.mongodb.internal.operation.ServerVersionHelper.serverIsLessTha
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsLessThanVersionThreeDotSix;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsLessThanVersionThreeDotTwo;
 import static java.lang.String.format;
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
 final class OperationHelper {
@@ -75,10 +80,6 @@ final class OperationHelper {
 
     interface CallableWithSource<T> {
         T call(ConnectionSource source);
-    }
-
-    interface CallableWithConnectionAndSource<T> {
-        T call(ConnectionSource source, Connection connection);
     }
 
     interface AsyncCallableWithConnection {
@@ -262,16 +263,18 @@ final class OperationHelper {
         validateWriteRequestHints(connectionDescription, requests, writeConcern);
     }
 
-    static void validateWriteRequests(final AsyncConnection connection, final Boolean bypassDocumentValidation,
-                                      final List<? extends WriteRequest> requests, final WriteConcern writeConcern,
-                                      final AsyncCallableWithConnection callable) {
+    static <R> boolean validateWriteRequestsAndCompleteIfInvalid(final ConnectionDescription connectionDescription,
+            final Boolean bypassDocumentValidation, final List<? extends WriteRequest> requests, final WriteConcern writeConcern,
+            final SingleResultCallback<R> callback) {
         try {
-            validateWriteRequests(connection.getDescription(), bypassDocumentValidation, requests, writeConcern);
-            callable.call(connection, null);
-        } catch (Throwable t) {
-            callable.call(connection, t);
+            validateWriteRequests(connectionDescription, bypassDocumentValidation, requests, writeConcern);
+            return false;
+        } catch (Throwable validationT) {
+            callback.onResult(null, validationT);
+            return true;
         }
     }
+
     static void validateIndexRequestCollations(final Connection connection, final List<IndexRequest> requests) {
         for (IndexRequest request : requests) {
             if (request.getCollation() != null) {
@@ -492,24 +495,8 @@ final class OperationHelper {
                 cursorId, serverAddress);
     }
 
-    static <T> SingleResultCallback<T> releasingCallback(final SingleResultCallback<T> wrapped, final AsyncConnectionSource source) {
-        return new ReferenceCountedReleasingWrappedCallback<T>(wrapped, singletonList(source));
-    }
-
     static <T> SingleResultCallback<T> releasingCallback(final SingleResultCallback<T> wrapped, final AsyncConnection connection) {
         return new ReferenceCountedReleasingWrappedCallback<T>(wrapped, singletonList(connection));
-    }
-
-    static <T> SingleResultCallback<T> releasingCallback(final SingleResultCallback<T> wrapped, final AsyncConnectionSource source,
-                                                         final AsyncConnection connection) {
-        return new ReferenceCountedReleasingWrappedCallback<T>(wrapped, asList(connection, source));
-    }
-
-    static <T> SingleResultCallback<T> releasingCallback(final SingleResultCallback<T> wrapped,
-                                                         final AsyncReadBinding readBinding,
-                                                         final AsyncConnectionSource source,
-                                                         final AsyncConnection connection) {
-        return new ReferenceCountedReleasingWrappedCallback<T>(wrapped, asList(readBinding, connection, source));
     }
 
     private static class ReferenceCountedReleasingWrappedCallback<T> implements SingleResultCallback<T> {
@@ -533,74 +520,10 @@ final class OperationHelper {
         }
     }
 
-    static class ConnectionReleasingWrappedCallback<T> implements SingleResultCallback<T> {
-        private final SingleResultCallback<T> wrapped;
-        private final AsyncConnectionSource source;
-        private final AsyncConnection connection;
-
-        ConnectionReleasingWrappedCallback(final SingleResultCallback<T> wrapped, final AsyncConnectionSource source,
-                                           final AsyncConnection connection) {
-            this.wrapped = wrapped;
-            this.source = notNull("source", source);
-            this.connection = notNull("connection", connection);
-        }
-
-        @Override
-        public void onResult(final T result, final Throwable t) {
-            connection.release();
-            source.release();
-            wrapped.onResult(result, t);
-        }
-
-        public SingleResultCallback<T> releaseConnectionAndGetWrapped() {
-            connection.release();
-            source.release();
-            return wrapped;
-        }
-    }
-
-    static <T> T withConnection(final ReadBinding binding, final CallableWithConnection<T> callable) {
-        ConnectionSource source = binding.getReadConnectionSource();
-        try {
-            return withConnectionSource(source, callable);
-        } finally {
-            source.release();
-        }
-    }
-
-    static <T> T withConnection(final ReadBinding binding, final CallableWithConnectionAndSource<T> callable) {
-        ConnectionSource source = binding.getReadConnectionSource();
-        try {
-            return withConnectionSource(source, callable);
-        } finally {
-            source.release();
-        }
-    }
-
     static <T> T withReadConnectionSource(final ReadBinding binding, final CallableWithSource<T> callable) {
         ConnectionSource source = binding.getReadConnectionSource();
         try {
             return callable.call(source);
-        } finally {
-            source.release();
-        }
-    }
-
-    static <T> T withReleasableConnection(final ReadBinding binding, final MongoException connectionException,
-                                          final CallableWithConnectionAndSource<T> callable) {
-        ConnectionSource source = null;
-        Connection connection;
-        try {
-            source = binding.getReadConnectionSource();
-            connection = source.getConnection();
-        } catch (Throwable t){
-            if (source != null) {
-                source.release();
-            }
-            throw connectionException;
-        }
-        try {
-            return callable.call(source, connection);
         } finally {
             source.release();
         }
@@ -615,35 +538,6 @@ final class OperationHelper {
         }
     }
 
-    static <T> T withReleasableConnection(final WriteBinding binding, final CallableWithConnectionAndSource<T> callable) {
-        ConnectionSource source = binding.getWriteConnectionSource();
-        try {
-            return callable.call(source, source.getConnection());
-        } finally {
-            source.release();
-        }
-    }
-
-    static <T> T withReleasableConnection(final WriteBinding binding, final MongoException connectionException,
-                                          final CallableWithConnectionAndSource<T> callable) {
-        ConnectionSource source = null;
-        Connection connection;
-        try {
-            source = binding.getWriteConnectionSource();
-            connection = source.getConnection();
-        } catch (Throwable t){
-            if (source != null) {
-                source.release();
-            }
-            throw connectionException;
-        }
-        try {
-            return callable.call(source, connection);
-        } finally {
-            source.release();
-        }
-    }
-
     static <T> T withConnectionSource(final ConnectionSource source, final CallableWithConnection<T> callable) {
         Connection connection = source.getConnection();
         try {
@@ -653,12 +547,51 @@ final class OperationHelper {
         }
     }
 
-    static <T> T withConnectionSource(final ConnectionSource source, final CallableWithConnectionAndSource<T> callable) {
-        Connection connection = source.getConnection();
+    /**
+     * Gets a {@link ConnectionSource} and a {@link Connection} from the {@code sourceSupplier} and executes the {@code function} with them.
+     * Guarantees to {@linkplain ReferenceCounted#release() release} the source and the connection after completion of the {@code function}.
+     *
+     * @param overrideSourceConnectionException An optional exception to use instead of an exception that may happen when trying to get
+     * either a {@link ConnectionSource} and a {@link Connection} before applying the {@code function}. This exception does not override
+     * an exception that the {@code function} may produce.
+     * @see #withAsyncSourceAndConnection(AsyncCallbackSupplier, Throwable, SingleResultCallback, AsyncCallbackBiFunction)
+     */
+    static <R> R withSourceAndConnection(final Supplier<ConnectionSource> sourceSupplier,
+            @Nullable final RuntimeException overrideSourceConnectionException,
+            final BiFunction<ConnectionSource, Connection, R> function) {
+        return withSuppliedResource(sourceSupplier, overrideSourceConnectionException, source ->
+                withSuppliedResource(source::getConnection, overrideSourceConnectionException, connection ->
+                        function.apply(source, connection)));
+    }
+
+    /**
+     * Gets a {@link ReferenceCounted} resource from the {@code resourceSupplier} and applies the {@code function} to it.
+     * Guarantees to {@linkplain ReferenceCounted#release() release} the resource after completion of the {@code function}.
+     *
+     * @param overrideSupplierException An optional exception to use instead of an exception that may happen when trying to get
+     * a resource before applying the {@code function}. This exception does not override an exception that the {@code function}
+     * may produce.
+     * @see #withAsyncSuppliedResource(AsyncCallbackSupplier, Throwable, SingleResultCallback, AsyncCallbackFunction)
+     */
+    static <R, T extends ReferenceCounted> R withSuppliedResource(final Supplier<T> resourceSupplier,
+            @Nullable final RuntimeException overrideSupplierException, final Function<T, R> function) {
+        T resource = null;
         try {
-            return callable.call(source, connection);
+            try {
+                resource = resourceSupplier.get();
+            } catch (RuntimeException supplierException) {
+                if (overrideSupplierException != null) {
+                    overrideSupplierException.addSuppressed(supplierException);
+                    throw overrideSupplierException;
+                } else {
+                    throw supplierException;
+                }
+            }
+            return function.apply(resource);
         } finally {
-            connection.release();
+            if (resource != null) {
+                resource.release();
+            }
         }
     }
 
@@ -674,8 +607,41 @@ final class OperationHelper {
         binding.getReadConnectionSource(errorHandlingCallback(new AsyncCallableWithSourceCallback(callable), LOGGER));
     }
 
-    static void withAsyncReadConnection(final AsyncReadBinding binding, final AsyncCallableWithConnectionAndSource callable) {
-        binding.getReadConnectionSource(errorHandlingCallback(new AsyncCallableWithConnectionAndSourceCallback(callable), LOGGER));
+    /**
+     * @see #withSourceAndConnection(Supplier, RuntimeException, BiFunction)
+     */
+    static <R> void withAsyncSourceAndConnection(final AsyncCallbackSupplier<AsyncConnectionSource> sourceAsyncSupplier,
+            @Nullable final Throwable overrideSourceConnectionException,
+            final SingleResultCallback<R> callback,
+            final AsyncCallbackBiFunction<AsyncConnectionSource, AsyncConnection, R> asyncFunction) {
+        SingleResultCallback<R> errorHandlingCallback = errorHandlingCallback(callback, LOGGER);
+        withAsyncSuppliedResource(sourceAsyncSupplier, overrideSourceConnectionException, errorHandlingCallback,
+                (source, sourceReleasingCallback) ->
+                        withAsyncSuppliedResource(source::getConnection, overrideSourceConnectionException, sourceReleasingCallback,
+                                (connection, connectionAndSourceReleasingCallback) ->
+                                        asyncFunction.apply(source, connection, connectionAndSourceReleasingCallback)));
+    }
+
+    /**
+     * @see #withSuppliedResource(Supplier, RuntimeException, Function)
+     */
+    static <R, T extends ReferenceCounted> void withAsyncSuppliedResource(final AsyncCallbackSupplier<T> resourceSupplier,
+            @Nullable final Throwable overrideSupplierException, final SingleResultCallback<R> callback,
+            final AsyncCallbackFunction<T, R> function) {
+        SingleResultCallback<R> errorHandlingCallback = errorHandlingCallback(callback, LOGGER);
+        resourceSupplier.get((resource, supplierException) -> {
+            if (supplierException != null) {
+                if (overrideSupplierException != null) {
+                    overrideSupplierException.addSuppressed(supplierException);
+                    supplierException = overrideSupplierException;
+                }
+                errorHandlingCallback.onResult(null, supplierException);
+            } else {
+                AsyncCallbackSupplier<R> curriedFunction = clbk -> function.apply(resource, clbk);
+                curriedFunction.andFinally(resource::release)
+                        .get(errorHandlingCallback);
+            }
+        });
     }
 
     private static class AsyncCallableWithConnectionCallback implements SingleResultCallback<AsyncConnectionSource> {

--- a/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
@@ -638,7 +638,7 @@ final class OperationHelper {
                 errorHandlingCallback.onResult(null, supplierException);
             } else {
                 AsyncCallbackSupplier<R> curriedFunction = clbk -> function.apply(resource, clbk);
-                curriedFunction.andFinally(resource::release)
+                curriedFunction.whenComplete(resource::release)
                         .get(errorHandlingCallback);
             }
         });

--- a/driver-core/src/main/com/mongodb/internal/operation/TransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/TransactionOperation.java
@@ -32,7 +32,8 @@ import org.bson.codecs.BsonDocumentCodec;
 import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableCommand;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableWrite;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableWriteAsync;
 import static com.mongodb.internal.operation.CommandOperationHelper.writeConcernErrorTransformer;
 import static com.mongodb.internal.operation.CommandOperationHelper.writeConcernErrorTransformerAsync;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
@@ -66,14 +67,14 @@ public abstract class TransactionOperation implements WriteOperation<Void>, Asyn
     @Override
     public Void execute(final WriteBinding binding) {
         isTrue("in transaction", binding.getSessionContext().hasActiveTransaction());
-        return executeRetryableCommand(binding, "admin", null, new NoOpFieldNameValidator(),
+        return executeRetryableWrite(binding, "admin", null, new NoOpFieldNameValidator(),
                 new BsonDocumentCodec(), getCommandCreator(), writeConcernErrorTransformer(), getRetryCommandModifier());
     }
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
         isTrue("in transaction", binding.getSessionContext().hasActiveTransaction());
-        executeRetryableCommand(binding, "admin", null, new NoOpFieldNameValidator(),
+        executeRetryableWriteAsync(binding, "admin", null, new NoOpFieldNameValidator(),
                 new BsonDocumentCodec(), getCommandCreator(), writeConcernErrorTransformerAsync(), getRetryCommandModifier(),
                 errorHandlingCallback(callback, LOGGER));
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/retry/AttachmentKeys.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/retry/AttachmentKeys.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.operation.retry;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.internal.async.function.LoopState.AttachmentKey;
+import com.mongodb.internal.operation.MixedBulkWriteOperation.BulkWriteTracker;
+import org.bson.BsonDocument;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.mongodb.assertions.Assertions.assertTrue;
+import static com.mongodb.assertions.Assertions.fail;
+
+/**
+ * @see AttachmentKey
+ */
+public final class AttachmentKeys {
+    private static final AttachmentKey<String> OPERATION_NAME = new DefaultAttachmentKey<>("operationName");
+    private static final AttachmentKey<Integer> MAX_WIRE_VERSION = new DefaultAttachmentKey<>("maxWireVersion");
+    private static final AttachmentKey<BsonDocument> COMMAND = new DefaultAttachmentKey<>("command");
+    private static final AttachmentKey<BulkWriteTracker> BULK_WRITE_TRACKER = new DefaultAttachmentKey<>("bulkWriteTracker");
+    private static final AttachmentKey<BulkWriteResult> BULK_WRITE_RESULT = new DefaultAttachmentKey<>("bulkWriteResult");
+
+    public static AttachmentKey<String> operationName() {
+        return OPERATION_NAME;
+    }
+
+    public static AttachmentKey<Integer> maxWireVersion() {
+        return MAX_WIRE_VERSION;
+    }
+
+    public static AttachmentKey<BsonDocument> command() {
+        return COMMAND;
+    }
+
+    public static AttachmentKey<BulkWriteTracker> bulkWriteTracker() {
+        return BULK_WRITE_TRACKER;
+    }
+
+    public static AttachmentKey<BulkWriteResult> bulkWriteResult() {
+        return BULK_WRITE_RESULT;
+    }
+
+    private AttachmentKeys() {
+        fail();
+    }
+
+    @Immutable
+    private static final class DefaultAttachmentKey<V> implements AttachmentKey<V> {
+        private static final Set<String> AVOID_KEY_DUPLICATION = new HashSet<>();
+
+        private final String key;
+
+        private DefaultAttachmentKey(final String key) {
+            assertTrue(AVOID_KEY_DUPLICATION.add(key));
+            this.key = key;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final DefaultAttachmentKey<?> that = (DefaultAttachmentKey<?>) o;
+            return key.equals(that.key);
+        }
+
+        @Override
+        public int hashCode() {
+            return key.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return key;
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/retry/AttachmentKeys.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/retry/AttachmentKeys.java
@@ -23,6 +23,7 @@ import org.bson.BsonDocument;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.assertions.Assertions.fail;
@@ -31,15 +32,13 @@ import static com.mongodb.assertions.Assertions.fail;
  * @see AttachmentKey
  */
 public final class AttachmentKeys {
-    private static final AttachmentKey<String> OPERATION_NAME = new DefaultAttachmentKey<>("operationName");
     private static final AttachmentKey<Integer> MAX_WIRE_VERSION = new DefaultAttachmentKey<>("maxWireVersion");
     private static final AttachmentKey<BsonDocument> COMMAND = new DefaultAttachmentKey<>("command");
+    private static final AttachmentKey<Boolean> RETRYABLE_COMMAND_FLAG = new DefaultAttachmentKey<>("retryableCommandFlag");
+    private static final AttachmentKey<Supplier<String>> COMMAND_DESCRIPTION_SUPPLIER = new DefaultAttachmentKey<>(
+            "commandDescriptionSupplier");
     private static final AttachmentKey<BulkWriteTracker> BULK_WRITE_TRACKER = new DefaultAttachmentKey<>("bulkWriteTracker");
     private static final AttachmentKey<BulkWriteResult> BULK_WRITE_RESULT = new DefaultAttachmentKey<>("bulkWriteResult");
-
-    public static AttachmentKey<String> operationName() {
-        return OPERATION_NAME;
-    }
 
     public static AttachmentKey<Integer> maxWireVersion() {
         return MAX_WIRE_VERSION;
@@ -47,6 +46,14 @@ public final class AttachmentKeys {
 
     public static AttachmentKey<BsonDocument> command() {
         return COMMAND;
+    }
+
+    public static AttachmentKey<Boolean> retryableCommandFlag() {
+        return RETRYABLE_COMMAND_FLAG;
+    }
+
+    public static AttachmentKey<Supplier<String>> commandDescriptionSupplier() {
+        return COMMAND_DESCRIPTION_SUPPLIER;
     }
 
     public static AttachmentKey<BulkWriteTracker> bulkWriteTracker() {

--- a/driver-core/src/main/com/mongodb/internal/operation/retry/AttachmentKeys.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/retry/AttachmentKeys.java
@@ -29,6 +29,8 @@ import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.assertions.Assertions.fail;
 
 /**
+ * A class with {@code static} methods providing access to {@link AttachmentKey}s relevant when implementing retryable operations.
+ *
  * @see AttachmentKey
  */
 public final class AttachmentKeys {

--- a/driver-core/src/test/functional/com/mongodb/client/syncadapter/SupplyingCallback.java
+++ b/driver-core/src/test/functional/com/mongodb/client/syncadapter/SupplyingCallback.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.syncadapter;
+
+import com.mongodb.annotations.ThreadSafe;
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.lang.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+@ThreadSafe
+public final class SupplyingCallback<R> implements SingleResultCallback<R>, Supplier<R> {
+    public static final long TIMEOUT_MINUTES = 1;
+
+    private final CompletableFuture<R> future;
+
+    public SupplyingCallback() {
+        future = new CompletableFuture<>();
+    }
+
+    @Override
+    public void onResult(@Nullable final R result, @Nullable final Throwable t) {
+        if (t != null) {
+            future.completeExceptionally(t);
+        } else {
+            future.complete(result);
+        }
+    }
+
+    @Override
+    public R get() {
+        try {
+            return future.get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (TimeoutException e) {
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause == null) {
+                throw new RuntimeException(e);
+            } else if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else if (cause instanceof Error) {
+                throw (Error) cause;
+            } else {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public boolean completed() {
+        return future.isDone();
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndDeleteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndDeleteOperationSpecification.groovy
@@ -297,7 +297,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 4, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 4, 0], [3, 4, 0]],
                 [REPLICA_SET_PRIMARY, REPLICA_SET_PRIMARY], originalException, async)
 
         then:
@@ -305,7 +305,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         commandException == originalException
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 6, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 6, 0], [3, 6, 0]],
                 [REPLICA_SET_PRIMARY, STANDALONE], originalException, async)
 
         then:
@@ -314,7 +314,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
-                [REPLICA_SET_PRIMARY], originalException, async)
+                [REPLICA_SET_PRIMARY], originalException, async, 1)
 
         then:
         commandException = thrown()

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndReplaceOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndReplaceOperationSpecification.groovy
@@ -428,7 +428,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 4, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 4, 0], [3, 4, 0]],
                 [REPLICA_SET_PRIMARY, REPLICA_SET_PRIMARY], originalException, async)
 
         then:
@@ -436,7 +436,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         commandException == originalException
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 6, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 6, 0], [3, 6, 0]],
                 [REPLICA_SET_PRIMARY, STANDALONE], originalException, async)
 
         then:
@@ -445,7 +445,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
 
         when:
         testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
-                [REPLICA_SET_PRIMARY], originalException, async)
+                [REPLICA_SET_PRIMARY], originalException, async, 1)
 
         then:
         commandException = thrown()

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndUpdateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndUpdateOperationSpecification.groovy
@@ -547,7 +547,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 4, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 4, 0], [3, 4, 0]],
                 [REPLICA_SET_PRIMARY, REPLICA_SET_PRIMARY], originalException, async)
 
         then:
@@ -555,7 +555,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         commandException == originalException
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 6, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 6, 0], [3, 6, 0]],
                 [REPLICA_SET_PRIMARY, STANDALONE], originalException, async)
 
         then:
@@ -564,7 +564,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
-                [REPLICA_SET_PRIMARY], originalException, async)
+                [REPLICA_SET_PRIMARY], originalException, async, 1)
 
         then:
         commandException = thrown()

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
@@ -1114,7 +1114,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 4, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 4, 0], [3, 4, 0]],
                 [REPLICA_SET_PRIMARY, REPLICA_SET_PRIMARY], originalException, async)
 
         then:
@@ -1122,7 +1122,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         commandException == originalException
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 6, 0]],
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 6, 0], [3, 6, 0]],
                 [REPLICA_SET_PRIMARY, STANDALONE], originalException, async)
 
         then:
@@ -1131,7 +1131,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
         when:
         testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
-                [REPLICA_SET_PRIMARY], originalException, async)
+                [REPLICA_SET_PRIMARY], originalException, async, 1)
 
         then:
         commandException = thrown()

--- a/driver-core/src/test/unit/com/mongodb/internal/async/function/LoopStateTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/function/LoopStateTest.java
@@ -31,19 +31,19 @@ final class LoopStateTest {
     void iterationsAndAdvance() {
         LoopState loopState = new LoopState();
         assertAll(
-                () -> assertTrue(loopState.firstIteration()),
+                () -> assertTrue(loopState.isFirstIteration()),
                 () -> assertEquals(0, loopState.iteration()),
-                () -> assertFalse(loopState.lastIteration()),
+                () -> assertFalse(loopState.isLastIteration()),
                 () -> assertTrue(loopState.advance()),
-                () -> assertFalse(loopState.firstIteration()),
+                () -> assertFalse(loopState.isFirstIteration()),
                 () -> assertEquals(1, loopState.iteration()),
-                () -> assertFalse(loopState.lastIteration())
+                () -> assertFalse(loopState.isLastIteration())
         );
         loopState.markAsLastIteration();
         assertAll(
-                () -> assertFalse(loopState.firstIteration()),
+                () -> assertFalse(loopState.isFirstIteration()),
                 () -> assertEquals(1, loopState.iteration()),
-                () -> assertTrue(loopState.lastIteration()),
+                () -> assertTrue(loopState.isLastIteration()),
                 () -> assertFalse(loopState.advance())
         );
     }
@@ -52,7 +52,7 @@ final class LoopStateTest {
     void maskAsLastIteration() {
         LoopState loopState = new LoopState();
         loopState.markAsLastIteration();
-        assertTrue(loopState.lastIteration());
+        assertTrue(loopState.isLastIteration());
         assertFalse(loopState.advance());
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/async/function/LoopStateTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/function/LoopStateTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.async.function;
+
+import com.mongodb.client.syncadapter.SupplyingCallback;
+import com.mongodb.internal.async.function.LoopState.AttachmentKey;
+import com.mongodb.internal.operation.retry.AttachmentKeys;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class LoopStateTest {
+    @Test
+    void iterationsAndAdvance() {
+        LoopState loopState = new LoopState();
+        assertAll(
+                () -> assertTrue(loopState.firstIteration()),
+                () -> assertEquals(0, loopState.iteration()),
+                () -> assertFalse(loopState.lastIteration()),
+                () -> assertTrue(loopState.advance()),
+                () -> assertFalse(loopState.firstIteration()),
+                () -> assertEquals(1, loopState.iteration()),
+                () -> assertFalse(loopState.lastIteration())
+        );
+        loopState.markAsLastIteration();
+        assertAll(
+                () -> assertFalse(loopState.firstIteration()),
+                () -> assertEquals(1, loopState.iteration()),
+                () -> assertTrue(loopState.lastIteration()),
+                () -> assertFalse(loopState.advance())
+        );
+    }
+
+    @Test
+    void maskAsLastIteration() {
+        LoopState loopState = new LoopState();
+        loopState.markAsLastIteration();
+        assertTrue(loopState.lastIteration());
+        assertFalse(loopState.advance());
+    }
+
+    @Test
+    void breakAndCompleteIfFalse() {
+        LoopState loopState = new LoopState();
+        SupplyingCallback<?> callback = new SupplyingCallback<>();
+        assertFalse(loopState.breakAndCompleteIf(() -> false, callback));
+        assertFalse(callback.completed());
+    }
+
+    @Test
+    void breakAndCompleteIfTrue() {
+        LoopState loopState = new LoopState();
+        SupplyingCallback<?> callback = new SupplyingCallback<>();
+        assertTrue(loopState.breakAndCompleteIf(() -> true, callback));
+        assertTrue(callback.completed());
+    }
+
+    @Test
+    void breakAndCompleteIfPredicateThrows() {
+        LoopState loopState = new LoopState();
+        SupplyingCallback<?> callback = new SupplyingCallback<>();
+        RuntimeException e = new RuntimeException() {
+        };
+        assertTrue(loopState.breakAndCompleteIf(() -> {
+            throw e;
+        }, callback));
+        assertThrows(e.getClass(), callback::get);
+    }
+
+    @Test
+    void attachAndAttachment() {
+        LoopState loopState = new LoopState();
+        AttachmentKey<String> attachmentKey = AttachmentKeys.operationName();
+        String attachmentValue = "attachmentValue";
+        assertFalse(loopState.attachment(attachmentKey).isPresent());
+        loopState.attach(attachmentKey, attachmentValue, false);
+        assertEquals(attachmentValue, loopState.attachment(attachmentKey).get());
+        loopState.advance();
+        assertEquals(attachmentValue, loopState.attachment(attachmentKey).get());
+        loopState.attach(attachmentKey, attachmentValue, true);
+        assertEquals(attachmentValue, loopState.attachment(attachmentKey).get());
+        loopState.advance();
+        assertFalse(loopState.attachment(attachmentKey).isPresent());
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/async/function/LoopStateTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/function/LoopStateTest.java
@@ -87,8 +87,8 @@ final class LoopStateTest {
     @Test
     void attachAndAttachment() {
         LoopState loopState = new LoopState();
-        AttachmentKey<String> attachmentKey = AttachmentKeys.operationName();
-        String attachmentValue = "attachmentValue";
+        AttachmentKey<Integer> attachmentKey = AttachmentKeys.maxWireVersion();
+        int attachmentValue = 1;
         assertFalse(loopState.attachment(attachmentKey).isPresent());
         loopState.attach(attachmentKey, attachmentValue, false);
         assertEquals(attachmentValue, loopState.attachment(attachmentKey).get());

--- a/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
@@ -34,23 +34,23 @@ final class RetryStateTest {
     void unlimitedAttemptsAndAdvance() {
         RetryState retryState = new RetryState();
         assertAll(
-                () -> assertTrue(retryState.firstAttempt()),
+                () -> assertTrue(retryState.isFirstAttempt()),
                 () -> assertEquals(0, retryState.attempt()),
-                () -> assertFalse(retryState.lastAttempt()),
+                () -> assertFalse(retryState.isLastAttempt()),
                 () -> assertEquals(0, retryState.attempts())
         );
         advance(retryState);
         assertAll(
-                () -> assertFalse(retryState.firstAttempt()),
+                () -> assertFalse(retryState.isFirstAttempt()),
                 () -> assertEquals(1, retryState.attempt()),
-                () -> assertFalse(retryState.lastAttempt()),
+                () -> assertFalse(retryState.isLastAttempt()),
                 () -> assertEquals(0, retryState.attempts())
         );
         retryState.markAsLastAttempt();
         assertAll(
-                () -> assertFalse(retryState.firstAttempt()),
+                () -> assertFalse(retryState.isFirstAttempt()),
                 () -> assertEquals(1, retryState.attempt()),
-                () -> assertTrue(retryState.lastAttempt()),
+                () -> assertTrue(retryState.isLastAttempt()),
                 () -> assertEquals(0, retryState.attempts())
         );
     }
@@ -61,16 +61,16 @@ final class RetryStateTest {
         RuntimeException attemptException = new RuntimeException() {
         };
         assertAll(
-                () -> assertTrue(retryState.firstAttempt()),
+                () -> assertTrue(retryState.isFirstAttempt()),
                 () -> assertEquals(0, retryState.attempt()),
-                () -> assertTrue(retryState.lastAttempt()),
+                () -> assertTrue(retryState.isLastAttempt()),
                 () -> assertEquals(1, retryState.attempts()),
                 () -> assertThrows(attemptException.getClass(), () ->
                         retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> true)),
                 // when there is only one attempt, it is both the first and the last one
-                () -> assertTrue(retryState.firstAttempt()),
+                () -> assertTrue(retryState.isFirstAttempt()),
                 () -> assertEquals(0, retryState.attempt()),
-                () -> assertTrue(retryState.lastAttempt()),
+                () -> assertTrue(retryState.isLastAttempt()),
                 () -> assertEquals(1, retryState.attempts())
         );
     }
@@ -79,7 +79,7 @@ final class RetryStateTest {
     void markAsLastAttemptAdvanceWithRuntimeException() {
         RetryState retryState = new RetryState();
         retryState.markAsLastAttempt();
-        assertTrue(retryState.lastAttempt());
+        assertTrue(retryState.isLastAttempt());
         RuntimeException attemptException = new RuntimeException() {
         };
         assertThrows(attemptException.getClass(),
@@ -90,7 +90,7 @@ final class RetryStateTest {
     void markAsLastAttemptAdvanceWithError() {
         RetryState retryState = new RetryState();
         retryState.markAsLastAttempt();
-        assertTrue(retryState.lastAttempt());
+        assertTrue(retryState.isLastAttempt());
         Error attemptException = new Error() {
         };
         assertThrows(attemptException.getClass(),
@@ -101,7 +101,7 @@ final class RetryStateTest {
     void breakAndThrowIfRetryAndFirstAttempt() {
         RetryState retryState = new RetryState();
         retryState.breakAndThrowIfRetryAnd(Assertions::fail);
-        assertFalse(retryState.lastAttempt());
+        assertFalse(retryState.isLastAttempt());
     }
 
     @Test
@@ -109,7 +109,7 @@ final class RetryStateTest {
         RetryState retryState = new RetryState();
         advance(retryState);
         retryState.breakAndThrowIfRetryAnd(() -> false);
-        assertFalse(retryState.lastAttempt());
+        assertFalse(retryState.isLastAttempt());
     }
 
     @Test
@@ -117,7 +117,7 @@ final class RetryStateTest {
         RetryState retryState = new RetryState();
         advance(retryState);
         assertThrows(RuntimeException.class, () -> retryState.breakAndThrowIfRetryAnd(() -> true));
-        assertTrue(retryState.lastAttempt());
+        assertTrue(retryState.isLastAttempt());
     }
 
     @Test
@@ -129,7 +129,7 @@ final class RetryStateTest {
         assertThrows(e.getClass(), () -> retryState.breakAndThrowIfRetryAnd(() -> {
             throw e;
         }));
-        assertFalse(retryState.lastAttempt());
+        assertFalse(retryState.isLastAttempt());
     }
 
     @Test
@@ -138,7 +138,7 @@ final class RetryStateTest {
         SupplyingCallback<?> callback = new SupplyingCallback<>();
         assertFalse(retryState.breakAndCompleteIfRetryAnd(Assertions::fail, callback));
         assertFalse(callback.completed());
-        assertFalse(retryState.lastAttempt());
+        assertFalse(retryState.isLastAttempt());
     }
 
     @Test
@@ -148,7 +148,7 @@ final class RetryStateTest {
         SupplyingCallback<?> callback = new SupplyingCallback<>();
         assertFalse(retryState.breakAndCompleteIfRetryAnd(() -> false, callback));
         assertFalse(callback.completed());
-        assertFalse(retryState.lastAttempt());
+        assertFalse(retryState.isLastAttempt());
     }
 
     @Test
@@ -158,7 +158,7 @@ final class RetryStateTest {
         SupplyingCallback<?> callback = new SupplyingCallback<>();
         assertTrue(retryState.breakAndCompleteIfRetryAnd(() -> true, callback));
         assertThrows(RuntimeException.class, callback::get);
-        assertTrue(retryState.lastAttempt());
+        assertTrue(retryState.isLastAttempt());
     }
 
     @Test
@@ -172,7 +172,7 @@ final class RetryStateTest {
             throw e;
         }, callback));
         assertThrows(e.getClass(), callback::get);
-        assertFalse(retryState.lastAttempt());
+        assertFalse(retryState.isLastAttempt());
     }
 
     @Test
@@ -199,7 +199,7 @@ final class RetryStateTest {
         RuntimeException attemptException = new RuntimeException() {
         };
         assertThrows(predicateException.getClass(), () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> {
-            assertTrue(rs.firstAttempt());
+            assertTrue(rs.isFirstAttempt());
             assertEquals(attemptException, e);
             throw predicateException;
         }));

--- a/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.async.function;
+
+import com.mongodb.client.syncadapter.SupplyingCallback;
+import com.mongodb.internal.async.function.LoopState.AttachmentKey;
+import com.mongodb.internal.operation.retry.AttachmentKeys;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+final class RetryStateTest {
+    @Test
+    void unlimitedAttemptsAndAdvance() {
+        RetryState retryState = new RetryState();
+        assertAll(
+                () -> assertTrue(retryState.firstAttempt()),
+                () -> assertEquals(0, retryState.attempt()),
+                () -> assertFalse(retryState.lastAttempt()),
+                () -> assertEquals(0, retryState.attempts())
+        );
+        advance(retryState);
+        assertAll(
+                () -> assertFalse(retryState.firstAttempt()),
+                () -> assertEquals(1, retryState.attempt()),
+                () -> assertFalse(retryState.lastAttempt()),
+                () -> assertEquals(0, retryState.attempts())
+        );
+        retryState.markAsLastAttempt();
+        assertAll(
+                () -> assertFalse(retryState.firstAttempt()),
+                () -> assertEquals(1, retryState.attempt()),
+                () -> assertTrue(retryState.lastAttempt()),
+                () -> assertEquals(0, retryState.attempts())
+        );
+    }
+
+    @Test
+    void limitedAttemptsAndAdvance() {
+        RetryState retryState = new RetryState(0);
+        RuntimeException attemptException = new RuntimeException() {
+        };
+        assertAll(
+                () -> assertTrue(retryState.firstAttempt()),
+                () -> assertEquals(0, retryState.attempt()),
+                () -> assertTrue(retryState.lastAttempt()),
+                () -> assertEquals(1, retryState.attempts()),
+                () -> assertThrows(attemptException.getClass(), () ->
+                        retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> true)),
+                // when there is only one attempt, it is both the first and the last one
+                () -> assertTrue(retryState.firstAttempt()),
+                () -> assertEquals(0, retryState.attempt()),
+                () -> assertTrue(retryState.lastAttempt()),
+                () -> assertEquals(1, retryState.attempts())
+        );
+    }
+
+    @Test
+    void markAsLastAttemptAdvanceWithRuntimeException() {
+        RetryState retryState = new RetryState();
+        retryState.markAsLastAttempt();
+        assertTrue(retryState.lastAttempt());
+        RuntimeException attemptException = new RuntimeException() {
+        };
+        assertThrows(attemptException.getClass(),
+                () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> fail()));
+    }
+
+    @Test
+    void markAsLastAttemptAdvanceWithError() {
+        RetryState retryState = new RetryState();
+        retryState.markAsLastAttempt();
+        assertTrue(retryState.lastAttempt());
+        Error attemptException = new Error() {
+        };
+        assertThrows(attemptException.getClass(),
+                () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> fail()));
+    }
+
+    @Test
+    void breakAndThrowIfRetryAndFirstAttempt() {
+        RetryState retryState = new RetryState();
+        retryState.breakAndThrowIfRetryAnd(Assertions::fail);
+        assertFalse(retryState.lastAttempt());
+    }
+
+    @Test
+    void breakAndThrowIfRetryAndFalse() {
+        RetryState retryState = new RetryState();
+        advance(retryState);
+        retryState.breakAndThrowIfRetryAnd(() -> false);
+        assertFalse(retryState.lastAttempt());
+    }
+
+    @Test
+    void breakAndThrowIfRetryAndTrue() {
+        RetryState retryState = new RetryState();
+        advance(retryState);
+        assertThrows(RuntimeException.class, () -> retryState.breakAndThrowIfRetryAnd(() -> true));
+        assertTrue(retryState.lastAttempt());
+    }
+
+    @Test
+    void breakAndThrowIfRetryIfPredicateThrows() {
+        RetryState retryState = new RetryState();
+        advance(retryState);
+        RuntimeException e = new RuntimeException() {
+        };
+        assertThrows(e.getClass(), () -> retryState.breakAndThrowIfRetryAnd(() -> {
+            throw e;
+        }));
+        assertFalse(retryState.lastAttempt());
+    }
+
+    @Test
+    void breakAndCompleteIfRetryAndFirstAttempt() {
+        RetryState retryState = new RetryState();
+        SupplyingCallback<?> callback = new SupplyingCallback<>();
+        assertFalse(retryState.breakAndCompleteIfRetryAnd(Assertions::fail, callback));
+        assertFalse(callback.completed());
+        assertFalse(retryState.lastAttempt());
+    }
+
+    @Test
+    void breakAndCompleteIfRetryAndFalse() {
+        RetryState retryState = new RetryState();
+        advance(retryState);
+        SupplyingCallback<?> callback = new SupplyingCallback<>();
+        assertFalse(retryState.breakAndCompleteIfRetryAnd(() -> false, callback));
+        assertFalse(callback.completed());
+        assertFalse(retryState.lastAttempt());
+    }
+
+    @Test
+    void breakAndCompleteIfRetryAndTrue() {
+        RetryState retryState = new RetryState();
+        advance(retryState);
+        SupplyingCallback<?> callback = new SupplyingCallback<>();
+        assertTrue(retryState.breakAndCompleteIfRetryAnd(() -> true, callback));
+        assertThrows(RuntimeException.class, callback::get);
+        assertTrue(retryState.lastAttempt());
+    }
+
+    @Test
+    void breakAndCompleteIfRetryAndPredicateThrows() {
+        RetryState retryState = new RetryState();
+        advance(retryState);
+        Error e = new Error() {
+        };
+        SupplyingCallback<?> callback = new SupplyingCallback<>();
+        assertTrue(retryState.breakAndCompleteIfRetryAnd(() -> {
+            throw e;
+        }, callback));
+        assertThrows(e.getClass(), callback::get);
+        assertFalse(retryState.lastAttempt());
+    }
+
+    @Test
+    void advanceOrThrowPredicateFalse() {
+        RetryState retryState = new RetryState();
+        RuntimeException attemptException = new RuntimeException() {
+        };
+        assertThrows(attemptException.getClass(), () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> false));
+    }
+
+    @Test
+    void advanceOrThrowPredicateTrueAndLastAttempt() {
+        RetryState retryState = new RetryState(0);
+        Error attemptException = new Error() {
+        };
+        assertThrows(attemptException.getClass(), () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> true));
+    }
+
+    @Test
+    void advanceOrThrowPredicateThrowsAfterFirstAttempt() {
+        RetryState retryState = new RetryState();
+        RuntimeException predicateException = new RuntimeException() {
+        };
+        RuntimeException attemptException = new RuntimeException() {
+        };
+        assertThrows(predicateException.getClass(), () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> {
+            assertTrue(rs.firstAttempt());
+            assertEquals(attemptException, e);
+            throw predicateException;
+        }));
+    }
+
+    @Test
+    void advanceOrThrowPredicateThrows() {
+        RetryState retryState = new RetryState();
+        RuntimeException firstAttemptException = new RuntimeException() {
+        };
+        retryState.advanceOrThrow(firstAttemptException, (e1, e2) -> e2, (rs, e) -> true);
+        RuntimeException secondAttemptException = new RuntimeException() {
+        };
+        RuntimeException predicateException = new RuntimeException() {
+        };
+        assertThrows(predicateException.getClass(), () -> retryState.advanceOrThrow(secondAttemptException, (e1, e2) -> e2, (rs, e) -> {
+            assertEquals(1, rs.attempt());
+            assertEquals(secondAttemptException, e);
+            throw predicateException;
+        }));
+    }
+
+    @Test
+    void advanceOrThrowTransformerThrowsAfterFirstAttempt() {
+        RetryState retryState = new RetryState();
+        RuntimeException transformerException = new RuntimeException() {
+        };
+        assertThrows(transformerException.getClass(), () -> retryState.advanceOrThrow(new AssertionError(),
+                (e1, e2) -> {
+                    throw transformerException;
+                },
+                (rs, e) -> fail()));
+    }
+
+    @Test
+    void advanceOrThrowTransformerThrows() throws Throwable {
+        RetryState retryState = new RetryState();
+        Error firstAttemptException = new Error() {
+        };
+        retryState.advanceOrThrow(firstAttemptException, (e1, e2) -> e2, (rs, e) -> true);
+        RuntimeException transformerException = new RuntimeException() {
+        };
+        assertThrows(transformerException.getClass(), () -> retryState.advanceOrThrow(new AssertionError(),
+                (e1, e2) -> {
+                    throw transformerException;
+                },
+                (rs, e) -> fail()));
+    }
+
+    @Test
+    void advanceOrThrowTransformAfterFirstAttempt() {
+        RetryState retryState = new RetryState();
+        RuntimeException attemptException = new RuntimeException() {
+        };
+        RuntimeException transformerResult = new RuntimeException() {
+        };
+        assertThrows(transformerResult.getClass(), () -> retryState.advanceOrThrow(attemptException,
+                (e1, e2) -> {
+                    assertNull(e1);
+                    assertEquals(attemptException, e2);
+                    return transformerResult;
+                },
+                (rs, e) -> {
+                    assertEquals(attemptException, e);
+                    return false;
+                }));
+    }
+
+    @Test
+    void advanceOrThrowTransform() {
+        RetryState retryState = new RetryState();
+        RuntimeException firstAttemptException = new RuntimeException() {
+        };
+        retryState.advanceOrThrow(firstAttemptException, (e1, e2) -> e2, (rs, e) -> true);
+        RuntimeException secondAttemptException = new RuntimeException() {
+        };
+        RuntimeException transformerResult = new RuntimeException() {
+        };
+        assertThrows(transformerResult.getClass(), () -> retryState.advanceOrThrow(secondAttemptException,
+                (e1, e2) -> {
+                    assertEquals(firstAttemptException, e1);
+                    assertEquals(secondAttemptException, e2);
+                    return transformerResult;
+                },
+                (rs, e) -> {
+                    assertEquals(secondAttemptException, e);
+                    return false;
+                }));
+    }
+
+    @Test
+    void attachAndAttachment() {
+        RetryState retryState = new RetryState();
+        AttachmentKey<String> attachmentKey = AttachmentKeys.operationName();
+        String attachmentValue = "attachmentValue";
+        assertFalse(retryState.attachment(attachmentKey).isPresent());
+        retryState.attach(attachmentKey, attachmentValue, false);
+        assertEquals(attachmentValue, retryState.attachment(attachmentKey).get());
+        advance(retryState);
+        assertEquals(attachmentValue, retryState.attachment(attachmentKey).get());
+        retryState.attach(attachmentKey, attachmentValue, true);
+        assertEquals(attachmentValue, retryState.attachment(attachmentKey).get());
+        advance(retryState);
+        assertFalse(retryState.attachment(attachmentKey).isPresent());
+    }
+
+    private static void advance(final RetryState retryState) {
+        retryState.advanceOrThrow(new RuntimeException(), (e1, e2) -> e2, (rs, e) -> true);
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
@@ -293,8 +293,8 @@ final class RetryStateTest {
     @Test
     void attachAndAttachment() {
         RetryState retryState = new RetryState();
-        AttachmentKey<String> attachmentKey = AttachmentKeys.operationName();
-        String attachmentValue = "attachmentValue";
+        AttachmentKey<Integer> attachmentKey = AttachmentKeys.maxWireVersion();
+        int attachmentValue = 1;
         assertFalse(retryState.attachment(attachmentKey).isPresent());
         retryState.attach(attachmentKey, attachmentValue, false);
         assertEquals(attachmentValue, retryState.attachment(attachmentKey).get());

--- a/driver-core/src/test/unit/com/mongodb/internal/function/AsyncCallbackSupplierTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/function/AsyncCallbackSupplierTest.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.function;
+
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
+import com.mongodb.lang.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+final class AsyncCallbackSupplierTest {
+    private static final Object RESULT = new Object();
+
+    private RuntimeException exception = new RuntimeException();
+    private Error exception2 = new Error();
+    @Nullable
+    private Thread getThread;
+    @Nullable
+    private Thread finallyThread;
+    private Callback callback;
+
+    @BeforeEach
+    void beforeEach() {
+        callback = new Callback();
+    }
+
+    @AfterEach
+    void afterEach() {
+        exception = new RuntimeException();
+        exception2 = new Error();
+        getThread = null;
+        finallyThread = null;
+        callback = new Callback();
+    }
+
+    @Test
+    void andFinally() {
+        try {
+            new PredefinedResultAsyncCallbackSupplier(RESULT)
+                    .andFinally(() -> {
+                        assertNull(finallyThread);
+                        finallyThread = Thread.currentThread();
+                    })
+                    .get(callback);
+        } finally {
+            callback.assertResult(RESULT);
+            assertNotNull(finallyThread);
+            assertNotSame(Thread.currentThread(), finallyThread);
+        }
+    }
+
+    @Test
+    void andFinally2() {
+        try {
+            new PredefinedResultAsyncCallbackSupplier(exception)
+                    .andFinally(() -> {
+                        assertNull(finallyThread);
+                        finallyThread = Thread.currentThread();
+                    })
+                    .get(callback);
+        } finally {
+            callback.assertResult(exception);
+            assertNotNull(finallyThread);
+            assertNotSame(Thread.currentThread(), finallyThread);
+        }
+    }
+
+    @Test
+    void andFinallyThrow() {
+        try {
+            new PredefinedResultAsyncCallbackSupplier(RESULT)
+                    .andFinally(() -> {
+                        assertNull(finallyThread);
+                        finallyThread = Thread.currentThread();
+                        throw exception;
+                    })
+                    .get(callback);
+        } finally {
+            callback.assertResult(exception);
+            assertNotNull(finallyThread);
+            assertNotSame(Thread.currentThread(), finallyThread);
+        }
+    }
+
+    @Test
+    void andFinallyThrow2() {
+        try {
+            new PredefinedResultAsyncCallbackSupplier(exception)
+                    .andFinally(() -> {
+                        assertNull(finallyThread);
+                        finallyThread = Thread.currentThread();
+                        throw exception2;
+                    })
+                    .get(callback);
+        } finally {
+            callback.assertResult(exception);
+            assertEquals(1, exception.getSuppressed().length);
+            assertSame(exception2, exception.getSuppressed()[0]);
+            assertNotNull(finallyThread);
+            assertNotSame(Thread.currentThread(), finallyThread);
+        }
+    }
+
+    @Test
+    void andFinallyCallbackThrows() {
+        PredefinedResultAsyncCallbackSupplier asyncSupplier = new PredefinedResultAsyncCallbackSupplier(RESULT);
+        try {
+            asyncSupplier
+                    .andFinally(() -> {
+                        assertNull(finallyThread);
+                        finallyThread = Thread.currentThread();
+                    })
+                    .get((result, t) -> {
+                        assertNull(getThread);
+                        getThread = Thread.currentThread();
+                        throw exception;
+                    });
+        } finally {
+            asyncSupplier.waitForCompletion();
+            assertNotNull(getThread);
+            assertNotSame(Thread.currentThread(), getThread);
+            assertNotNull(finallyThread);
+            assertNotSame(Thread.currentThread(), finallyThread);
+        }
+    }
+
+    @Test
+    void andFinallyCallbackThrowsSync() {
+        try {
+            assertThrows(exception.getClass(), () -> ((AsyncCallbackSupplier<Object>) callback ->
+                    callback.onResult(RESULT, null))
+                    .andFinally(() -> {
+                        assertNull(finallyThread);
+                        finallyThread = Thread.currentThread();
+                    })
+                    .get((result, t) -> {
+                        throw exception;
+                    }));
+        } finally {
+            assertSame(Thread.currentThread(), finallyThread);
+        }
+    }
+
+    @Test
+    void andFinallyThrowCallbackThrows() {
+        PredefinedResultAsyncCallbackSupplier asyncSupplier = new PredefinedResultAsyncCallbackSupplier(RESULT);
+        try {
+            asyncSupplier
+                    .andFinally(() -> {
+                        assertNull(finallyThread);
+                        finallyThread = Thread.currentThread();
+                        throw exception;
+                    })
+                    .get((result, t) -> {
+                        assertNull(getThread);
+                        getThread = Thread.currentThread();
+                        throw exception2;
+                    });
+        } finally {
+            asyncSupplier.waitForCompletion();
+            assertNotNull(getThread);
+            assertNotSame(Thread.currentThread(), getThread);
+            assertNotNull(finallyThread);
+            assertNotSame(Thread.currentThread(), finallyThread);
+        }
+    }
+
+    @Test
+    void andFinallyThrowCallbackThrowsSync() {
+        try {
+            assertThrows(exception2.getClass(), () -> ((AsyncCallbackSupplier<Object>) callback ->
+                    callback.onResult(RESULT, null))
+                    .andFinally(() -> {
+                        assertNull(finallyThread);
+                        finallyThread = Thread.currentThread();
+                        throw exception;
+                    })
+                    .get((result, t) -> {
+                        assertNull(getThread);
+                        getThread = Thread.currentThread();
+                        throw exception2;
+                    }));
+        } finally {
+            assertSame(Thread.currentThread(), finallyThread);
+            assertSame(Thread.currentThread(), getThread);
+        }
+    }
+
+    /**
+     * If {@link AsyncCallbackSupplier#get(SingleResultCallback)} does not throw an exception and also does not complete its
+     * callback, then it is impossible to execute the action supplied to {@link AsyncCallbackSupplier#andFinally(Runnable)}.
+     */
+    @Test
+    void andFinallyGetThrows() {
+        PredefinedResultAsyncCallbackSupplier asyncSupplier = new PredefinedResultAsyncCallbackSupplier(callback -> {
+            throw exception;
+        });
+        try {
+            asyncSupplier
+                    .andFinally(() -> {
+                        assertNull(finallyThread);
+                        finallyThread = Thread.currentThread();
+                    })
+                    .get((result, t) -> {
+                        assertNull(getThread);
+                        getThread = Thread.currentThread();
+                    });
+        } finally {
+            asyncSupplier.waitForCompletion();
+            assertNull(finallyThread);
+            assertNull(getThread);
+        }
+    }
+
+    @Test
+    void andFinallyGetThrowsSync() {
+        try {
+            assertThrows(exception.getClass(), () -> ((AsyncCallbackSupplier<Object>) callback -> {
+                        throw exception;
+                    })
+                    .andFinally(() -> {
+                        assertNull(finallyThread);
+                        finallyThread = Thread.currentThread();
+                    })
+                    .get((result, t) -> {
+                        assertNull(getThread);
+                        getThread = Thread.currentThread();
+                    }));
+        } finally {
+            assertSame(Thread.currentThread(), finallyThread);
+            assertNull(getThread);
+        }
+    }
+
+    @Test
+    void andFinallyThrowGetThrowsSync() {
+        try {
+            assertThrows(exception.getClass(), () -> ((AsyncCallbackSupplier<Object>) callback -> {
+                        throw exception;
+                    })
+                    .andFinally(() -> {
+                        assertNull(finallyThread);
+                        finallyThread = Thread.currentThread();
+                        throw exception2;
+                    })
+                    .get((result, t) -> {
+                        assertNull(getThread);
+                        getThread = Thread.currentThread();
+                    }));
+        } finally {
+            assertSame(Thread.currentThread(), finallyThread);
+            assertNull(getThread);
+            assertEquals(1, exception.getSuppressed().length);
+            assertSame(exception2, exception.getSuppressed()[0]);
+        }
+    }
+
+    private static final class Callback implements SingleResultCallback<Object> {
+        private final CompletableFuture<Object> result = new CompletableFuture<>();
+
+        @Override
+        public void onResult(@Nullable final Object result, @Nullable final Throwable t) {
+            if (t != null) {
+                this.result.completeExceptionally(t);
+            } else {
+                this.result.complete(result);
+            }
+        }
+
+        void assertResult(final Object expectedResult) {
+            try {
+                assertSame(expectedResult, result.get());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } catch (ExecutionException e) {
+                fail(e);
+            }
+        }
+
+        void assertResult(final Throwable expectedT) {
+            try {
+                result.get(3, TimeUnit.SECONDS);
+                fail();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } catch (ExecutionException e) {
+                assertSame(expectedT, e.getCause());
+            } catch (TimeoutException e) {
+                fail(e);
+            }
+        }
+    }
+
+    private static final class PredefinedResultAsyncCallbackSupplier implements AsyncCallbackSupplier<Object> {
+        @Nullable
+        private final Object result;
+        @Nullable
+        private final Throwable t;
+        @Nullable
+        private final Consumer<SingleResultCallback<Object>> get;
+        @Nullable
+        private Thread thread;
+
+        PredefinedResultAsyncCallbackSupplier(final Object result) {
+            this.result = result;
+            this.t = null;
+            get = null;
+        }
+
+        PredefinedResultAsyncCallbackSupplier(final Throwable t) {
+            this.result = null;
+            this.t = t;
+            get = null;
+        }
+
+        PredefinedResultAsyncCallbackSupplier(final Consumer<SingleResultCallback<Object>> asyncGet) {
+            this.result = null;
+            this.t = null;
+            this.get = asyncGet;
+        }
+
+        @Override
+        public void get(final SingleResultCallback<Object> callback) {
+            thread = new Thread(() -> {
+                if (get == null) {
+                    callback.onResult(result, t);
+                } else {
+                    get(callback);
+                }
+            });
+            thread.start();
+        }
+
+        void waitForCompletion() {
+            assertNotNull(thread);
+            try {
+                thread.join(TimeUnit.SECONDS.toMillis(3));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/function/AsyncCallbackSupplierTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/function/AsyncCallbackSupplierTest.java
@@ -62,10 +62,10 @@ final class AsyncCallbackSupplierTest {
     }
 
     @Test
-    void andFinally() {
+    void whenComplete() {
         try {
             new PredefinedResultAsyncCallbackSupplier(RESULT)
-                    .andFinally(() -> {
+                    .whenComplete(() -> {
                         assertNull(finallyThread);
                         finallyThread = Thread.currentThread();
                     })
@@ -78,10 +78,10 @@ final class AsyncCallbackSupplierTest {
     }
 
     @Test
-    void andFinally2() {
+    void whenComplete2() {
         try {
             new PredefinedResultAsyncCallbackSupplier(exception)
-                    .andFinally(() -> {
+                    .whenComplete(() -> {
                         assertNull(finallyThread);
                         finallyThread = Thread.currentThread();
                     })
@@ -94,10 +94,10 @@ final class AsyncCallbackSupplierTest {
     }
 
     @Test
-    void andFinallyThrow() {
+    void whenCompleteThrow() {
         try {
             new PredefinedResultAsyncCallbackSupplier(RESULT)
-                    .andFinally(() -> {
+                    .whenComplete(() -> {
                         assertNull(finallyThread);
                         finallyThread = Thread.currentThread();
                         throw exception;
@@ -111,10 +111,10 @@ final class AsyncCallbackSupplierTest {
     }
 
     @Test
-    void andFinallyThrow2() {
+    void whenCompleteThrow2() {
         try {
             new PredefinedResultAsyncCallbackSupplier(exception)
-                    .andFinally(() -> {
+                    .whenComplete(() -> {
                         assertNull(finallyThread);
                         finallyThread = Thread.currentThread();
                         throw exception2;
@@ -130,11 +130,11 @@ final class AsyncCallbackSupplierTest {
     }
 
     @Test
-    void andFinallyCallbackThrows() {
+    void whenCompleteCallbackThrows() {
         PredefinedResultAsyncCallbackSupplier asyncSupplier = new PredefinedResultAsyncCallbackSupplier(RESULT);
         try {
             asyncSupplier
-                    .andFinally(() -> {
+                    .whenComplete(() -> {
                         assertNull(finallyThread);
                         finallyThread = Thread.currentThread();
                     })
@@ -153,11 +153,11 @@ final class AsyncCallbackSupplierTest {
     }
 
     @Test
-    void andFinallyCallbackThrowsSync() {
+    void whenCompleteCallbackThrowsSync() {
         try {
             assertThrows(exception.getClass(), () -> ((AsyncCallbackSupplier<Object>) callback ->
                     callback.onResult(RESULT, null))
-                    .andFinally(() -> {
+                    .whenComplete(() -> {
                         assertNull(finallyThread);
                         finallyThread = Thread.currentThread();
                     })
@@ -170,11 +170,11 @@ final class AsyncCallbackSupplierTest {
     }
 
     @Test
-    void andFinallyThrowCallbackThrows() {
+    void whenCompleteThrowCallbackThrows() {
         PredefinedResultAsyncCallbackSupplier asyncSupplier = new PredefinedResultAsyncCallbackSupplier(RESULT);
         try {
             asyncSupplier
-                    .andFinally(() -> {
+                    .whenComplete(() -> {
                         assertNull(finallyThread);
                         finallyThread = Thread.currentThread();
                         throw exception;
@@ -194,11 +194,11 @@ final class AsyncCallbackSupplierTest {
     }
 
     @Test
-    void andFinallyThrowCallbackThrowsSync() {
+    void whenCompleteThrowCallbackThrowsSync() {
         try {
             assertThrows(exception2.getClass(), () -> ((AsyncCallbackSupplier<Object>) callback ->
                     callback.onResult(RESULT, null))
-                    .andFinally(() -> {
+                    .whenComplete(() -> {
                         assertNull(finallyThread);
                         finallyThread = Thread.currentThread();
                         throw exception;
@@ -216,16 +216,16 @@ final class AsyncCallbackSupplierTest {
 
     /**
      * If {@link AsyncCallbackSupplier#get(SingleResultCallback)} does not throw an exception and also does not complete its
-     * callback, then it is impossible to execute the action supplied to {@link AsyncCallbackSupplier#andFinally(Runnable)}.
+     * callback, then it is impossible to execute the action supplied to {@link AsyncCallbackSupplier#whenComplete(Runnable)}.
      */
     @Test
-    void andFinallyGetThrows() {
+    void whenCompleteGetThrows() {
         PredefinedResultAsyncCallbackSupplier asyncSupplier = new PredefinedResultAsyncCallbackSupplier(callback -> {
             throw exception;
         });
         try {
             asyncSupplier
-                    .andFinally(() -> {
+                    .whenComplete(() -> {
                         assertNull(finallyThread);
                         finallyThread = Thread.currentThread();
                     })
@@ -241,12 +241,12 @@ final class AsyncCallbackSupplierTest {
     }
 
     @Test
-    void andFinallyGetThrowsSync() {
+    void whenCompleteGetThrowsSync() {
         try {
             assertThrows(exception.getClass(), () -> ((AsyncCallbackSupplier<Object>) callback -> {
                         throw exception;
                     })
-                    .andFinally(() -> {
+                    .whenComplete(() -> {
                         assertNull(finallyThread);
                         finallyThread = Thread.currentThread();
                     })
@@ -261,12 +261,12 @@ final class AsyncCallbackSupplierTest {
     }
 
     @Test
-    void andFinallyThrowGetThrowsSync() {
+    void whenCompleteThrowGetThrowsSync() {
         try {
             assertThrows(exception.getClass(), () -> ((AsyncCallbackSupplier<Object>) callback -> {
                         throw exception;
                     })
-                    .andFinally(() -> {
+                    .whenComplete(() -> {
                         assertNull(finallyThread);
                         finallyThread = Thread.currentThread();
                         throw exception2;

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/CommandOperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/CommandOperationHelperSpecification.groovy
@@ -38,6 +38,7 @@ import com.mongodb.internal.session.SessionContext
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonInt32
+import org.bson.BsonNull
 import org.bson.BsonString
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.Decoder
@@ -45,8 +46,11 @@ import spock.lang.Specification
 
 import static com.mongodb.ReadPreference.primary
 import static com.mongodb.internal.operation.CommandOperationHelper.executeCommand
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableRead
 import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsync
-import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableCommand
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableReadAsync
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableWrite
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableWriteAsync
 import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError
 import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError
 import static com.mongodb.internal.operation.OperationUnitSpecification.getMaxWireVersionForServerVersion
@@ -173,8 +177,8 @@ class CommandOperationHelperSpecification extends Specification {
         }
 
         when:
-        executeRetryableCommand(writeBinding, dbName, primary(), new NoOpFieldNameValidator(), decoder, commandCreator,
-                FindAndModifyHelper.transformer())
+        executeRetryableWrite(writeBinding, dbName, primary(), new NoOpFieldNameValidator(), decoder, commandCreator,
+                FindAndModifyHelper.transformer()) { cmd -> cmd }
 
         then:
         2 * connection.command(dbName, command, _, primary(), decoder, _, null) >> { results.poll() }
@@ -228,8 +232,8 @@ class CommandOperationHelperSpecification extends Specification {
         }
 
         when:
-        executeRetryableCommand(asyncWriteBinding, dbName, primary(), new NoOpFieldNameValidator(), decoder,
-                commandCreator, FindAndModifyHelper.asyncTransformer(), callback)
+        executeRetryableWriteAsync(asyncWriteBinding, dbName, primary(), new NoOpFieldNameValidator(), decoder,
+                commandCreator, FindAndModifyHelper.asyncTransformer(), { cmd -> cmd }, callback)
 
         then:
         2 * connection.commandAsync(dbName, command, _, primary(), decoder, _, _, _) >> { it.last().onResult(results.poll(), null) }
@@ -242,7 +246,7 @@ class CommandOperationHelperSpecification extends Specification {
     def 'should use the ReadBindings readPreference'() {
         given:
         def dbName = 'db'
-        def command = new BsonDocument()
+        def command = new BsonDocument('fakeCommandName', BsonNull.VALUE)
         def commandCreator = { serverDescription, connectionDescription -> command }
         def decoder = Stub(Decoder)
         def function = Stub(CommandOperationHelper.CommandReadTransformer)
@@ -258,7 +262,7 @@ class CommandOperationHelperSpecification extends Specification {
         def connectionDescription = Stub(ConnectionDescription)
 
         when:
-        executeCommand(readBinding, dbName, commandCreator, decoder, function, false)
+        executeRetryableRead(readBinding, dbName, commandCreator, decoder, function, false)
 
         then:
         _ * connection.getDescription() >> connectionDescription
@@ -286,7 +290,7 @@ class CommandOperationHelperSpecification extends Specification {
         def connectionDescription = Stub(ConnectionDescription)
 
         when:
-        executeCommandAsync(asyncWriteBinding, dbName, command, connection, callback)
+        executeCommandAsync(asyncWriteBinding, dbName, command, connection, { t, conn -> t }, callback)
 
         then:
         _ * connection.getDescription() >> connectionDescription
@@ -297,7 +301,7 @@ class CommandOperationHelperSpecification extends Specification {
     def 'should use the AsyncReadBindings readPreference'() {
         given:
         def dbName = 'db'
-        def command = new BsonDocument()
+        def command = new BsonDocument('fakeCommandName', BsonNull.VALUE)
         def commandCreator = { serverDescription, connectionDescription -> command }
         def decoder = Stub(Decoder)
         def callback = Stub(SingleResultCallback)
@@ -315,7 +319,7 @@ class CommandOperationHelperSpecification extends Specification {
         def connectionDescription = Stub(ConnectionDescription)
 
         when:
-        executeCommandAsync(asyncReadBinding, dbName, commandCreator, decoder, function, false, callback)
+        executeRetryableReadAsync(asyncReadBinding, dbName, commandCreator, decoder, function, false, callback)
 
         then:
         _ * connection.getDescription() >> connectionDescription

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/OperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/OperationHelperSpecification.groovy
@@ -285,7 +285,7 @@ class OperationHelperSpecification extends Specification {
         def asyncConnection = Stub(AsyncConnection) {
             getDescription() >> connectionDescription
         }
-        validateWriteRequests(asyncConnection, bypassDocumentValidation, writeRequests, writeConcern, asyncCallableWithConnection)
+        validateWriteRequests(asyncConnection.getDescription(), bypassDocumentValidation, writeRequests, writeConcern)
 
         then:
         notThrown(IllegalArgumentException)
@@ -309,7 +309,7 @@ class OperationHelperSpecification extends Specification {
         def writeRequests = [new DeleteRequest(BsonDocument.parse('{a: "a"}}'))]
 
         when:
-        validateWriteRequests(asyncThreeTwoConnection, false, writeRequests, UNACKNOWLEDGED, asyncCallableWithConnection)
+        validateWriteRequests(asyncThreeTwoConnection.getDescription(), false, writeRequests, UNACKNOWLEDGED)
 
         then:
         thrown(MongoClientException)
@@ -317,7 +317,7 @@ class OperationHelperSpecification extends Specification {
         when:
         def writeRequestsWithCollation = [new DeleteRequest(BsonDocument.parse('{a: "a"}}'))
                                             .collation(enCollation)]
-        validateWriteRequests(asyncThreeTwoConnection, false, writeRequestsWithCollation, ACKNOWLEDGED, asyncCallableWithConnection)
+        validateWriteRequests(asyncThreeTwoConnection.getDescription(), false, writeRequestsWithCollation, ACKNOWLEDGED)
 
         then:
         thrown(IllegalArgumentException)
@@ -326,7 +326,7 @@ class OperationHelperSpecification extends Specification {
         def asyncThreeFourConnection = Stub(AsyncConnection) {
             getDescription() >> threeFourConnectionDescription
         }
-        validateWriteRequests(asyncThreeFourConnection, null, writeRequestsWithCollation, UNACKNOWLEDGED, asyncCallableWithConnection)
+        validateWriteRequests(asyncThreeFourConnection.getDescription(), null, writeRequestsWithCollation, UNACKNOWLEDGED)
 
         then:
         thrown(MongoClientException)

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/RetryableReadsProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/RetryableReadsProseTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client;
+
+import com.mongodb.client.RetryableWritesProseTest;
+import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static com.mongodb.client.model.Filters.eq;
+
+/**
+ * See
+ * <a href="https://github.com/mongodb/specifications/tree/master/source/retryable-reads/tests">Retryable Reads Tests</a>.
+ */
+public class RetryableReadsProseTest {
+    /**
+     * See
+     * <a href="https://github.com/mongodb/specifications/tree/master/source/retryable-reads/tests#poolclearederror-retryability-test">
+     * PoolClearedError Retryability Test</a>.
+     */
+    @Test
+    public void poolClearedExceptionMustBeRetryable() throws InterruptedException, ExecutionException, TimeoutException {
+        RetryableWritesProseTest.poolClearedExceptionMustBeRetryable(
+                mongoClientSettings -> new SyncMongoClient(MongoClients.create(mongoClientSettings)),
+                mongoCollection -> mongoCollection.find(eq(0)).iterator().hasNext(), "find", false);
+    }
+}

--- a/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
@@ -241,7 +241,8 @@ class ApiAliasAndCompanionSpec extends BaseSpec {
       "MongoObservable",
       "Name",
       "NameCodecProvider",
-      "TransactionBody"
+      "TransactionBody",
+      "FailPoint"
     )
 
     val wrapped = new Reflections(packageName, new SubTypesScanner(false))

--- a/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client;
+
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.conversions.Bson;
+
+public final class FailPoint implements AutoCloseable {
+    private final BsonDocument failPointDocument;
+    private final MongoClient client;
+
+    private FailPoint(final BsonDocument failPointDocument, final MongoClient client) {
+        this.failPointDocument = failPointDocument.toBsonDocument();
+        this.client = client;
+    }
+
+    /**
+     * @param configureFailPointDocument A document representing {@code configureFailPoint} command to be issued as is via
+     * {@link com.mongodb.client.MongoDatabase#runCommand(Bson)}.
+     */
+    public static FailPoint enable(final BsonDocument configureFailPointDocument, final MongoClient client) {
+        FailPoint result = new FailPoint(configureFailPointDocument, client);
+        client.getDatabase("admin").runCommand(configureFailPointDocument);
+        return result;
+    }
+
+    @Override
+    public void close() {
+        client.getDatabase("admin").runCommand(new BsonDocument()
+                .append("configureFailPoint", failPointDocument.getString("configureFailPoint"))
+                .append("mode", new BsonString("off")));
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/RetryableReadsProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/RetryableReadsProseTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static com.mongodb.client.model.Filters.eq;
+
+/**
+ * See
+ * <a href="https://github.com/mongodb/specifications/tree/master/source/retryable-reads/tests">Retryable Reads Tests</a>.
+ */
+public class RetryableReadsProseTest {
+    /**
+     * See
+     * <a href="https://github.com/mongodb/specifications/tree/master/source/retryable-reads/tests#poolclearederror-retryability-test">
+     * PoolClearedError Retryability Test</a>.
+     */
+    @Test
+    public void poolClearedExceptionMustBeRetryable() throws InterruptedException, ExecutionException, TimeoutException {
+        RetryableWritesProseTest.poolClearedExceptionMustBeRetryable(MongoClients::create,
+                mongoCollection -> mongoCollection.find(eq(0)).iterator().hasNext(), "find", false);
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
@@ -16,31 +16,61 @@
 
 package com.mongodb.client;
 
+import com.mongodb.Function;
 import com.mongodb.MongoClientException;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoException;
+import com.mongodb.event.ConnectionCheckOutFailedEvent;
+import com.mongodb.event.ConnectionCheckedOutEvent;
+import com.mongodb.event.ConnectionPoolClearedEvent;
+import com.mongodb.internal.connection.TestCommandListener;
+import com.mongodb.internal.connection.TestConnectionPoolListener;
+import org.bson.BsonArray;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
 import org.bson.Document;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import static com.mongodb.ClusterFixture.getServerStatus;
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isSharded;
+import static com.mongodb.ClusterFixture.isStandalone;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.ClusterFixture.serverVersionLessThan;
+import static com.mongodb.client.Fixture.getDefaultDatabaseName;
+import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+/**
+ * See
+ * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-writes/tests/README.rst#prose-tests">Retryable Write Prose Tests</a>.
+ */
 public class RetryableWritesProseTest extends DatabaseTestCase {
 
     @Before
     @Override
     public void setUp() {
-        assumeTrue(canRunTests());
         super.setUp();
     }
 
     @Test
     public void testRetryWritesWithInsertOneAgainstMMAPv1RaisesError() {
+        assumeTrue(canRunTests());
         boolean exceptionFound = false;
 
         try {
@@ -57,6 +87,7 @@ public class RetryableWritesProseTest extends DatabaseTestCase {
 
     @Test
     public void testRetryWritesWithFindOneAndDeleteAgainstMMAPv1RaisesError() {
+        assumeTrue(canRunTests());
         boolean exceptionFound = false;
 
         try {
@@ -69,6 +100,80 @@ public class RetryableWritesProseTest extends DatabaseTestCase {
             exceptionFound = true;
         }
         assertTrue(exceptionFound);
+    }
+
+    /**
+     * Prose test #2.
+     */
+    @Test
+    public void poolClearedExceptionMustBeRetryable() throws InterruptedException, ExecutionException, TimeoutException {
+        poolClearedExceptionMustBeRetryable(MongoClients::create,
+                mongoCollection -> mongoCollection.insertOne(new Document()), "insert", true);
+    }
+
+    @SuppressWarnings("try")
+    public static <R> void poolClearedExceptionMustBeRetryable(
+            final Function<MongoClientSettings, MongoClient> clientCreator,
+            final Function<MongoCollection<Document>, R> operation, final String operationName, final boolean write)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        assumeTrue(serverVersionAtLeast(4, 3) && !(write && isStandalone()));
+        TestConnectionPoolListener connectionPoolListener = new TestConnectionPoolListener(asList(
+                "connectionCheckedOutEvent",
+                "poolClearedEvent",
+                "connectionCheckOutFailedEvent"));
+        TestCommandListener commandListener = new TestCommandListener(
+                singletonList("commandStartedEvent"), asList("configureFailPoint", "drop"));
+        MongoClientSettings clientSettings = getMongoClientSettingsBuilder()
+                .applyToConnectionPoolSettings(builder -> builder
+                        .maxSize(1)
+                        .addConnectionPoolListener(connectionPoolListener))
+                .applyToServerSettings(builder -> builder
+                        /* We fake server's state by configuring a fail point. This breaks the mechanism of the
+                         * streaming server monitoring protocol
+                         * (https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-monitoring.rst#streaming-protocol)
+                         * that allows the server to determine whether or not it needs to send a new state to the client.
+                         * As a result, the client has to wait for at least its heartbeat delay until it hears back from a server
+                         * (while it waits for a response, calling `ServerMonitor.connect` has no effect).
+                         * Thus, we want to use small heartbeat delay to reduce delays in the test. */
+                        .minHeartbeatFrequency(50, TimeUnit.MILLISECONDS)
+                        .heartbeatFrequency(50, TimeUnit.MILLISECONDS))
+                .retryReads(true)
+                .retryWrites(true)
+                .addCommandListener(commandListener)
+                .build();
+        BsonDocument configureFailPoint = new BsonDocument()
+                .append("configureFailPoint", new BsonString("failCommand"))
+                .append("mode", new BsonDocument()
+                        .append("times", new BsonInt32(1)))
+                .append("data", new BsonDocument()
+                        .append("failCommands", new BsonArray(singletonList(new BsonString(operationName))))
+                        .append("errorCode", new BsonInt32(91))
+                        .append("errorLabels", write
+                                ? new BsonArray(singletonList(new BsonString("RetryableWriteError")))
+                                : new BsonArray())
+                        .append("blockConnection", BsonBoolean.valueOf(true))
+                        .append("blockTimeMS", new BsonInt32(1000)));
+        int timeoutSeconds = 5;
+        try (MongoClient client = clientCreator.apply(clientSettings);
+                FailPoint ignored = FailPoint.enable(configureFailPoint, client)) {
+            MongoCollection<Document> collection = client.getDatabase(getDefaultDatabaseName())
+                    .getCollection("poolClearedExceptionMustBeRetryable");
+            collection.drop();
+            ExecutorService ex = Executors.newFixedThreadPool(2);
+            try {
+                Future<R> result1 = ex.submit(() -> operation.apply(collection));
+                Future<R> result2 = ex.submit(() -> operation.apply(collection));
+                connectionPoolListener.waitForEvent(ConnectionCheckedOutEvent.class, 1, timeoutSeconds, SECONDS);
+                connectionPoolListener.waitForEvent(ConnectionPoolClearedEvent.class, 1, timeoutSeconds, SECONDS);
+                connectionPoolListener.waitForEvent(ConnectionCheckOutFailedEvent.class, 1, timeoutSeconds, SECONDS);
+                result1.get(timeoutSeconds, SECONDS);
+                result2.get(timeoutSeconds, SECONDS);
+            } finally {
+                ex.shutdownNow();
+            }
+            assertEquals(3, commandListener.getCommandStartedEvents().size());
+            commandListener.getCommandStartedEvents().forEach(event -> assertEquals(operationName, event.getCommandName()));
+        }
     }
 
     private boolean canRunTests() {

--- a/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
@@ -131,7 +131,7 @@ public class RetryableWritesProseTest extends DatabaseTestCase {
                         /* We fake server's state by configuring a fail point. This breaks the mechanism of the
                          * streaming server monitoring protocol
                          * (https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-monitoring.rst#streaming-protocol)
-                         * that allows the server to determine whether or not it needs to send a new state to the client.
+                         * that allows the server to determine whether it needs to send a new state to the client.
                          * As a result, the client has to wait for at least its heartbeat delay until it hears back from a server
                          * (while it waits for a response, calling `ServerMonitor.connect` has no effect).
                          * Thus, we want to use small heartbeat delay to reduce delays in the test. */


### PR DESCRIPTION
The baseline commit for this PR is the last commit in https://github.com/mongodb/mongo-java-driver/pull/701. As a consequence, I had to push the [`stIncMale:JAVA-3928`](https://github.com/stIncMale/mongo-java-driver/tree/JAVA-3928) branch to [mongodb/mongo-java-driver](https://github.com/mongodb/mongo-java-driver) to be able to create a PR with diffs relevant to JAVA-4034. Once this PR is reviewed and approved, I will:

- merge https://github.com/mongodb/mongo-java-driver/pull/701;
- change the target branch of this PR to `master`
- merge this PR
- delete [`mongodb:JAVA-3928`](https://github.com/mongodb/mongo-java-driver/tree/JAVA-3928).

Changes in this commit do the following two major things:

1. Selecting a server (`binding.get*ConnectionSource`)
and checking out a connection (`source.getConnection`) is now part of a retryable operation.
Such a change makes `MongoConnectionPoolClearedException`s part of the operation,
thus allowing us to retry the operation when the exception happens.

2. The retry limit (not more than two attempts) was hardcoded in the driver's code structure,
i.e., the code was written in such a way that it was describing the first attempt, then depending
on the outcome, the code for the second attempt was executed, with the code for the second attempt
mostly duplicating the code for the first attempt, but having different error handling. Such an approach
not only negatively affects the code readability, but also prevents changing the number of attempts,
let alone making decisions on whether to retry based not on an attempt limit.
The pseudocode in the specifications is also written this way, and at least some other drivers,
e.g., C#, Rust, took a similar approach to structure the code.

   Changes in this commit represent the outcome of refactoring the code related to the retry logic.
   In the new code the retry logic is decoupled from the logic of a retryable operation as much as possible.
   Since our operations are quite complex and may decide to break retrying in the middle of an attempt,
   e.g., because the server selected in the attempt does not support retries, the operation logic
   is still aware of the fact that it may be retried. However, it is important to understand that
   this awareness is a direct consequence of the business logic. It cannot be gotten rid of
   regardless of the approach taken to structure the code. Operations that have simpler business logic
   can be written in a retry-agnostic way without making changes to the retry framework
   that was added as part of this commit.

   With the changes in this commit, applying the client-side timeout (CSOT) to a retryable operation
   is as simple as replacing the hard retry limit condition with a condition that checks
   whether there is time left for attempting the operation again.

Here are also a few interesting stats:

- the line count in `CommandOperationHelper` changed from 865 to 620
- the line count in `OperationHelper` changed from 768 to 734
- the line count in `MixedBulkWriteOperation` stayed roughly the same (changed from 553 to 551, but a portion of it is comments, while previously it was all code)

Given that the business logic became more complicated due to the item #1 described above, I consider the above reduction in the amount of code expressing the business logic a very good thing, especially given that it is accompanied by the code (particularly callback-based) being made more linear and requiring almost no changes to support CSOT.

JAVA-4034