### PR TITLE
[JAVA-4311] Change ToSingleObservableVoid -> ToSingleObservableUnit so that operations returning Publisher[Void] can be composed using monadic operations

### DIFF
--- a/driver-scala/src/it/scala/org/mongodb/scala/documentation/DocumentationTransactionsExampleSpec.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/documentation/DocumentationTransactionsExampleSpec.scala
@@ -74,7 +74,7 @@ class DocumentationTransactionsExampleSpec extends RequiresMongoDBISpec {
     })
   }
 
-  def commitAndRetry(observable: SingleObservable[Void]): SingleObservable[Void] = {
+  def commitAndRetry(observable: SingleObservable[Unit]): SingleObservable[Unit] = {
     observable.recoverWith({
       case e: MongoException if e.hasErrorLabel(MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL) => {
         println("UnknownTransactionCommitResult, retrying commit operation ...")
@@ -87,7 +87,7 @@ class DocumentationTransactionsExampleSpec extends RequiresMongoDBISpec {
     })
   }
 
-  def runTransactionAndRetry(observable: SingleObservable[Void]): SingleObservable[Void] = {
+  def runTransactionAndRetry(observable: SingleObservable[Unit]): SingleObservable[Unit] = {
     observable.recoverWith({
       case e: MongoException if e.hasErrorLabel(MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL) => {
         println("TransientTransactionError, aborting transaction and retrying ...")
@@ -96,14 +96,14 @@ class DocumentationTransactionsExampleSpec extends RequiresMongoDBISpec {
     })
   }
 
-  def updateEmployeeInfoWithRetry(client: MongoClient): SingleObservable[Void] = {
+  def updateEmployeeInfoWithRetry(client: MongoClient): SingleObservable[Unit] = {
 
     val database = client.getDatabase("hr")
     val updateEmployeeInfoObservable: SingleObservable[ClientSession] =
       updateEmployeeInfo(database, client.startSession())
-    val commitTransactionObservable: SingleObservable[Void] =
+    val commitTransactionObservable: SingleObservable[Unit] =
       updateEmployeeInfoObservable.flatMap(clientSession => clientSession.commitTransaction())
-    val commitAndRetryObservable: SingleObservable[Void] = commitAndRetry(commitTransactionObservable)
+    val commitAndRetryObservable: SingleObservable[Unit] = commitAndRetry(commitTransactionObservable)
 
     runTransactionAndRetry(commitAndRetryObservable)
   }

--- a/driver-scala/src/main/scala/org/mongodb/scala/ObservableImplicits.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/ObservableImplicits.scala
@@ -153,21 +153,9 @@ trait ObservableImplicits {
     override def subscribe(observer: Observer[_ >: GridFSFile]): Unit = publisher.toSingle().subscribe(observer)
   }
 
-  implicit class ToSingleObservableVoid(pub: => Publisher[Void]) extends SingleObservable[Void] {
+  implicit class ToSingleObservableUnit(pub: => Publisher[Void]) extends SingleObservable[Unit] {
     val publisher = pub
-    override def subscribe(observer: Observer[_ >: Void]): Unit =
-      publisher
-        .toSingle()
-        .subscribe(new Observer[Void] {
-
-          override def onSubscribe(subscription: Subscription): Unit = observer.onSubscribe(subscription)
-
-          override def onNext(result: Void): Unit = {}
-
-          override def onError(e: Throwable): Unit = observer.onError(e)
-
-          override def onComplete(): Unit = observer.onComplete()
-        })
+    override def subscribe(observer: Observer[_ >: Unit]): Unit = SingleItemObservable(()).subscribe(observer)
   }
 
   implicit class ObservableFuture[T](obs: => Observable[T]) {

--- a/driver-scala/src/test/scala/org/mongodb/scala/ObservableImplicitsSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ObservableImplicitsSpec.scala
@@ -1,0 +1,21 @@
+package org.mongodb.scala
+
+import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+
+class ObservableImplicitsSpec extends BaseSpec with MockFactory with ScalaFutures {
+
+  "ToSingleObservableVoid" should "subscribe to an Observable[Unit], rather than Observable[Void], so that it is composable using monad operations" in {
+    case class CustomVoidMongoResult(namespace: MongoNamespace, additionalMetadata: Map[String, String])
+    val expected = CustomVoidMongoResult(MongoNamespace("database", "collection"), Map.empty)
+    val voidObservable = SingleObservable.apply[Void](null).publisher
+    val stringObservable = voidObservable
+    // show that you can map, filter, etc. over an Observable that's implicitly converted from Publisher[Void]
+      .map(_ => expected)
+      .filter(_ => true)
+    val actual = stringObservable.head().futureValue
+
+    assert(actual === expected)
+  }
+
+}


### PR DESCRIPTION
[JAVA-4311](https://jira.mongodb.org/browse/JAVA-4311)