### PR TITLE
Execute aggregate with $out/$merge on secondaries

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionBinding.java
@@ -125,6 +125,12 @@ public class ClientSessionBinding implements AsyncReadWriteBinding {
     }
 
     @Override
+    public void getReadConnectionSource(final int minWireVersion, final ReadPreference fallbackReadPreference,
+            final SingleResultCallback<AsyncConnectionSource> callback) {
+        wrapped.getReadConnectionSource(minWireVersion, fallbackReadPreference, callback);
+    }
+
+    @Override
     public void release() {
         wrapped.release();
         closeSessionIfCountIsZero();
@@ -167,6 +173,11 @@ public class ClientSessionBinding implements AsyncReadWriteBinding {
         @Override
         public RequestContext getRequestContext() {
             return wrapped.getRequestContext();
+        }
+
+        @Override
+        public ReadPreference getReadPreference() {
+            return wrapped.getReadPreference();
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/internal/binding/AsyncConnectionSource.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/AsyncConnectionSource.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.binding;
 
+import com.mongodb.ReadPreference;
 import com.mongodb.RequestContext;
 import com.mongodb.ServerApi;
 import com.mongodb.internal.async.SingleResultCallback;
@@ -51,6 +52,13 @@ public interface AsyncConnectionSource extends ReferenceCounted {
     ServerApi getServerApi();
 
     RequestContext getRequestContext();
+
+    /**
+     * Gets the read preference that was applied when selecting this source.
+     *
+     * @see AsyncReadBinding#getReadConnectionSource(int, ReadPreference, SingleResultCallback)
+     */
+    ReadPreference getReadPreference();
 
     /**
      * Gets a connection from this source.

--- a/driver-core/src/main/com/mongodb/internal/binding/AsyncReadBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/AsyncReadBinding.java
@@ -50,10 +50,23 @@ public interface AsyncReadBinding extends ReferenceCounted {
     RequestContext getRequestContext();
 
     /**
-     * Returns a connection source to a server that satisfies the specified read preference.
+     * Returns a connection source to a server that satisfies the read preference with which this instance is configured.
      * @param callback the to be passed the connection source
      */
     void getReadConnectionSource(SingleResultCallback<AsyncConnectionSource> callback);
+
+    /**
+     * Return a connection source that satisfies the read preference with which this instance is configured, if all connected servers have
+     * a maxWireVersion >= the given minWireVersion.  Otherwise, return a connection source that satisfied the given
+     * fallbackReadPreference.
+     *
+     * This is useful for operations that are able to execute on a secondary on later server versions, but must execute on the primary on
+     * earlier server versions.
+     *
+     * @see com.mongodb.internal.operation.AggregateToCollectionOperation
+     */
+    void getReadConnectionSource(int minWireVersion, ReadPreference fallbackReadPreference,
+            SingleResultCallback<AsyncConnectionSource> callback);
 
     @Override
     AsyncReadBinding retain();

--- a/driver-core/src/main/com/mongodb/internal/binding/ConnectionSource.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/ConnectionSource.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.binding;
 
+import com.mongodb.ReadPreference;
 import com.mongodb.RequestContext;
 import com.mongodb.ServerApi;
 import com.mongodb.connection.ServerDescription;
@@ -51,6 +52,13 @@ public interface ConnectionSource extends ReferenceCounted {
     ServerApi getServerApi();
 
     RequestContext getRequestContext();
+
+    /**
+     * Gets the read preference that was applied when selecting this source.
+     *
+     * @see ReadBinding#getReadConnectionSource(int, ReadPreference)
+     */
+    ReadPreference getReadPreference();
 
     /**
      * Gets a connection from this source.

--- a/driver-core/src/main/com/mongodb/internal/binding/ReadBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/ReadBinding.java
@@ -35,10 +35,22 @@ public interface ReadBinding extends ReferenceCounted {
     ReadPreference getReadPreference();
 
     /**
-     * Returns a connection source to a server that satisfies the specified read preference.
+     * Returns a connection source to a server that satisfies the read preference with which this instance is configured.
      * @return the connection source
      */
     ConnectionSource getReadConnectionSource();
+
+    /**
+     * Return a connection source that satisfies the read preference with which this instance is configured, if all connected servers have
+     * a maxWireVersion >= the given minWireVersion.  Otherwise, return a connection source that satisfied the given
+     * fallbackReadPreference.
+     *
+     * This is useful for operations that are able to execute on a secondary on later server versions, but must execute on the primary on
+     * earlier server versions.
+     *
+     * @see com.mongodb.internal.operation.AggregateToCollectionOperation
+     */
+    ConnectionSource getReadConnectionSource(int minWireVersion, ReadPreference fallbackReadPreference);
 
     /**
      * Gets the session context for this binding.

--- a/driver-core/src/main/com/mongodb/internal/binding/SingleServerBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/SingleServerBinding.java
@@ -74,6 +74,11 @@ public class SingleServerBinding extends AbstractReferenceCounted implements Rea
     }
 
     @Override
+    public ConnectionSource getReadConnectionSource(final int minWireVersion, final ReadPreference fallbackReadPreference) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public SessionContext getSessionContext() {
         return NoOpSessionContext.INSTANCE;
     }
@@ -122,6 +127,11 @@ public class SingleServerBinding extends AbstractReferenceCounted implements Rea
         @Override
         public RequestContext getRequestContext() {
             return requestContext;
+        }
+
+        @Override
+        public ReadPreference getReadPreference() {
+            return ReadPreference.primary();
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateToCollectionOperation.java
@@ -18,15 +18,14 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.internal.async.SingleResultCallback;
-import com.mongodb.internal.binding.AsyncWriteBinding;
-import com.mongodb.internal.binding.WriteBinding;
+import com.mongodb.internal.binding.AsyncReadBinding;
+import com.mongodb.internal.binding.ReadBinding;
 import com.mongodb.internal.client.model.AggregationLevel;
-import com.mongodb.internal.connection.AsyncConnection;
-import com.mongodb.internal.connection.Connection;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -34,28 +33,22 @@ import org.bson.BsonInt32;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
 import org.bson.BsonValue;
+import org.bson.codecs.BsonDocumentCodec;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommand;
-import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsync;
-import static com.mongodb.internal.operation.CommandOperationHelper.writeConcernErrorTransformer;
-import static com.mongodb.internal.operation.CommandOperationHelper.writeConcernErrorWriteTransformer;
-import static com.mongodb.internal.operation.OperationHelper.AsyncCallableWithConnection;
-import static com.mongodb.internal.operation.OperationHelper.CallableWithConnection;
-import static com.mongodb.internal.operation.OperationHelper.LOGGER;
-import static com.mongodb.internal.operation.OperationHelper.releasingCallback;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableRead;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeRetryableReadAsync;
 import static com.mongodb.internal.operation.OperationHelper.validateCollation;
-import static com.mongodb.internal.operation.OperationHelper.withAsyncConnection;
-import static com.mongodb.internal.operation.OperationHelper.withConnection;
+import static com.mongodb.internal.operation.ServerVersionHelper.FIVE_DOT_ZERO_WIRE_VERSION;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotFour;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotSix;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
+import static com.mongodb.internal.operation.WriteConcernHelper.throwOnWriteConcernError;
 
 /**
  * An operation that executes an aggregation that writes its results to a collection (which is what makes this a write operation rather than
@@ -64,7 +57,7 @@ import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConce
  * @mongodb.driver.manual reference/command/aggregate/ Aggregation
  * @since 3.0
  */
-public class AggregateToCollectionOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
+public class AggregateToCollectionOperation implements AsyncReadOperation<Void>, ReadOperation<Void> {
     private final MongoNamespace namespace;
     private final List<BsonDocument> pipeline;
     private final WriteConcern writeConcern;
@@ -129,20 +122,6 @@ public class AggregateToCollectionOperation implements AsyncWriteOperation<Void>
     public AggregateToCollectionOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline,
                                           final ReadConcern readConcern, final WriteConcern writeConcern) {
         this(namespace, pipeline, readConcern, writeConcern, AggregationLevel.COLLECTION);
-    }
-
-    /**
-     * Construct a new instance.
-     *
-     * @param namespace the database and collection namespace for the operation.
-     * @param pipeline the aggregation pipeline.
-     * @param writeConcern the write concern to apply
-     * @param aggregationLevel the aggregation level
-     * @since 3.10
-     */
-    public AggregateToCollectionOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline,
-                                          final WriteConcern writeConcern, final AggregationLevel aggregationLevel) {
-        this(namespace, pipeline, ReadConcern.DEFAULT, writeConcern, aggregationLevel);
     }
 
     /**
@@ -351,45 +330,35 @@ public class AggregateToCollectionOperation implements AsyncWriteOperation<Void>
     }
 
     @Override
-    public Void execute(final WriteBinding binding) {
-        return withConnection(binding, new CallableWithConnection<Void>() {
-            @Override
-            public Void call(final Connection connection) {
-                validateCollation(connection, collation);
-                return executeCommand(binding, namespace.getDatabaseName(), getCommand(connection.getDescription()),
-                        connection, writeConcernErrorTransformer());
-            }
-        });
+    public Void execute(final ReadBinding binding) {
+        return executeRetryableRead(binding,
+                () -> binding.getReadConnectionSource(FIVE_DOT_ZERO_WIRE_VERSION, ReadPreference.primary()),
+                namespace.getDatabaseName(),
+                (serverDescription, connectionDescription) -> getCommand(connectionDescription),
+                new BsonDocumentCodec(), (result, source, connection) -> {
+                    throwOnWriteConcernError(result, connection.getDescription().getServerAddress(),
+                            connection.getDescription().getMaxWireVersion());
+                    return null;
+                }, false);
     }
 
     @Override
-    public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
-        withAsyncConnection(binding, new AsyncCallableWithConnection() {
-            @Override
-            public void call(final AsyncConnection connection, final Throwable t) {
-                SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-                if (t != null) {
-                    errHandlingCallback.onResult(null, t);
-                } else {
-                    final SingleResultCallback<Void> wrappedCallback = releasingCallback(errHandlingCallback, connection);
-                    validateCollation(connection, collation, new AsyncCallableWithConnection() {
-                        @Override
-                        public void call(final AsyncConnection connection, final Throwable t) {
-                            if (t != null) {
-                                wrappedCallback.onResult(null, t);
-                            } else {
-                                executeCommandAsync(binding, namespace.getDatabaseName(),
-                                        getCommand(connection.getDescription()), connection, writeConcernErrorWriteTransformer(),
-                                        wrappedCallback);
-                            }
-                        }
-                    });
-                }
-            }
-        });
+    public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<Void> callback) {
+        executeRetryableReadAsync(binding,
+                (connectionSourceCallback) -> {
+                        binding.getReadConnectionSource(FIVE_DOT_ZERO_WIRE_VERSION, ReadPreference.primary(), connectionSourceCallback);
+                },
+                namespace.getDatabaseName(),
+                (serverDescription, connectionDescription) -> getCommand(connectionDescription),
+                new BsonDocumentCodec(), (result, source, connection) -> {
+                    throwOnWriteConcernError(result, connection.getDescription().getServerAddress(),
+                            connection.getDescription().getMaxWireVersion());
+                    return null;
+                }, false, callback);
     }
 
     private BsonDocument getCommand(final ConnectionDescription description) {
+        validateCollation(description, collation);
         BsonValue aggregationTarget = (aggregationLevel == AggregationLevel.DATABASE)
                 ? new BsonInt32(1) : new BsonString(namespace.getCollectionName());
 

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -120,7 +120,7 @@ public final class SyncOperations<TDocument> {
                 allowDiskUse, aggregationLevel);
     }
 
-    public WriteOperation<Void> aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
+    public ReadOperation<Void> aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
                                                       final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
                                                       final Collation collation, final Bson hint, final String comment,
                                                       final Bson variables, final AggregationLevel aggregationLevel) {

--- a/driver-core/src/main/com/mongodb/internal/selector/ReadPreferenceWithFallbackServerSelector.java
+++ b/driver-core/src/main/com/mongodb/internal/selector/ReadPreferenceWithFallbackServerSelector.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.selector;
+
+import com.mongodb.ReadPreference;
+import com.mongodb.connection.ClusterDescription;
+import com.mongodb.connection.ServerDescription;
+import com.mongodb.selector.ServerSelector;
+
+import java.util.List;
+
+public class ReadPreferenceWithFallbackServerSelector implements ServerSelector {
+
+    private final ReadPreference preferredReadPreference;
+    private final int minWireVersion;
+    private final ReadPreference fallbackReadPreference;
+    private ReadPreference appliedReadPreference;
+
+    public ReadPreferenceWithFallbackServerSelector(final ReadPreference preferredReadPreference, final int minWireVersion,
+            final ReadPreference fallbackReadPreference) {
+        this.preferredReadPreference = preferredReadPreference;
+        this.minWireVersion = minWireVersion;
+        this.fallbackReadPreference = fallbackReadPreference;
+    }
+
+
+    @Override
+    public List<ServerDescription> select(final ClusterDescription clusterDescription) {
+        if (maxWireVersion(clusterDescription) >= minWireVersion) {
+            appliedReadPreference = preferredReadPreference;
+            return new ReadPreferenceServerSelector(preferredReadPreference).select(clusterDescription);
+        } else {
+            appliedReadPreference = fallbackReadPreference;
+            return new ReadPreferenceServerSelector(fallbackReadPreference).select(clusterDescription);
+        }
+    }
+
+    public ReadPreference getAppliedReadPreference() {
+        return appliedReadPreference;
+    }
+
+    private int maxWireVersion(final ClusterDescription clusterDescription) {
+        return clusterDescription.getServerDescriptions().stream()
+                .map(ServerDescription::getMaxWireVersion)
+                .max(Integer::compareTo).orElse(0);
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
@@ -275,6 +275,7 @@ class OperationFunctionalSpecification extends Specification {
                 connection
             }
             getServerApi() >> null
+            getReadPreference() >> readPreference
             getServerDescription() >> {
                 def builder = ServerDescription.builder().address(Stub(ServerAddress)).state(ServerConnectionState.CONNECTED)
                 if (new ServerVersion(serverVersion).compareTo(new ServerVersion(3, 6)) >= 0) {
@@ -284,7 +285,7 @@ class OperationFunctionalSpecification extends Specification {
             }
         }
         def readBinding = Stub(ReadBinding) {
-            getReadConnectionSource() >> connectionSource
+            getReadConnectionSource(*_) >> connectionSource
             getReadPreference() >> readPreference
             getServerApi() >> null
             getSessionContext() >> Stub(SessionContext) {
@@ -353,6 +354,7 @@ class OperationFunctionalSpecification extends Specification {
 
         def connectionSource = Stub(AsyncConnectionSource) {
             getConnection(_) >> { it[0].onResult(connection, null) }
+            getReadPreference() >> readPreference
             getServerApi() >> null
             getServerDescription() >> {
                 def builder = ServerDescription.builder().address(Stub(ServerAddress)).state(ServerConnectionState.CONNECTED)
@@ -363,7 +365,7 @@ class OperationFunctionalSpecification extends Specification {
             }
         }
         def readBinding = Stub(AsyncReadBinding) {
-            getReadConnectionSource(_) >> { it[0].onResult(connectionSource, null) }
+            getReadConnectionSource(*_) >> { it.last().onResult(connectionSource, null) }
             getReadPreference() >> readPreference
             getServerApi() >> null
             getSessionContext() >> Stub(SessionContext) {

--- a/driver-core/src/test/functional/com/mongodb/internal/binding/AsyncSessionBinding.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/binding/AsyncSessionBinding.java
@@ -86,6 +86,22 @@ public final class AsyncSessionBinding implements AsyncReadWriteBinding {
         });
     }
 
+
+    @Override
+    public void getReadConnectionSource(final int minWireVersion, final ReadPreference fallbackReadPreference,
+            final SingleResultCallback<AsyncConnectionSource> callback) {
+        wrapped.getReadConnectionSource(minWireVersion, fallbackReadPreference, new SingleResultCallback<AsyncConnectionSource>() {
+            @Override
+            public void onResult(final AsyncConnectionSource result, final Throwable t) {
+                if (t != null) {
+                    callback.onResult(null, t);
+                } else {
+                    callback.onResult(new SessionBindingAsyncConnectionSource(result), null);
+                }
+            }
+        });
+    }
+
     @Override
     public int getCount() {
         return wrapped.getCount();
@@ -128,6 +144,11 @@ public final class AsyncSessionBinding implements AsyncReadWriteBinding {
         @Override
         public RequestContext getRequestContext() {
             return wrapped.getRequestContext();
+        }
+
+        @Override
+        public ReadPreference getReadPreference() {
+            return wrapped.getReadPreference();
         }
 
         @Override

--- a/driver-core/src/test/functional/com/mongodb/internal/binding/AsyncSingleConnectionBinding.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/binding/AsyncSingleConnectionBinding.java
@@ -190,6 +190,12 @@ public class AsyncSingleConnectionBinding extends AbstractReferenceCounted imple
     }
 
     @Override
+    public void getReadConnectionSource(final int minWireVersion, final ReadPreference fallbackReadPreference,
+            final SingleResultCallback<AsyncConnectionSource> callback) {
+        getReadConnectionSource(callback);
+    }
+
+    @Override
     public void getWriteConnectionSource(final SingleResultCallback<AsyncConnectionSource> callback) {
         isTrue("open", getCount() > 0);
         callback.onResult(new SingleAsyncConnectionSource(writeServerDescription, writeConnection), null);
@@ -234,6 +240,11 @@ public class AsyncSingleConnectionBinding extends AbstractReferenceCounted imple
         @Override
         public RequestContext getRequestContext() {
             return IgnorableRequestContext.INSTANCE;
+        }
+
+        @Override
+        public ReadPreference getReadPreference() {
+            return readPreference;
         }
 
         @Override

--- a/driver-core/src/test/functional/com/mongodb/internal/binding/SessionBinding.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/binding/SessionBinding.java
@@ -62,6 +62,11 @@ public class SessionBinding implements ReadWriteBinding {
     }
 
     @Override
+    public ConnectionSource getReadConnectionSource(final int minWireVersion, final ReadPreference fallbackReadPreference) {
+        return new SessionBindingConnectionSource(wrapped.getReadConnectionSource(minWireVersion, fallbackReadPreference));
+    }
+
+    @Override
     public SessionContext getSessionContext() {
         return sessionContext;
     }
@@ -107,6 +112,11 @@ public class SessionBinding implements ReadWriteBinding {
         @Override
         public RequestContext getRequestContext() {
             return wrapped.getRequestContext();
+        }
+
+        @Override
+        public ReadPreference getReadPreference() {
+            return wrapped.getReadPreference();
         }
 
         @Override

--- a/driver-core/src/test/functional/com/mongodb/internal/binding/SingleConnectionBinding.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/binding/SingleConnectionBinding.java
@@ -104,6 +104,11 @@ public class SingleConnectionBinding implements ReadWriteBinding {
     }
 
     @Override
+    public ConnectionSource getReadConnectionSource(final int minWireVersion, final ReadPreference fallbackReadPreference) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public SessionContext getSessionContext() {
         return NoOpSessionContext.INSTANCE;
     }
@@ -154,6 +159,11 @@ public class SingleConnectionBinding implements ReadWriteBinding {
         @Override
         public RequestContext getRequestContext() {
             return IgnorableRequestContext.INSTANCE;
+        }
+
+        @Override
+        public ReadPreference getReadPreference() {
+            return readPreference;
         }
 
         @Override

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateToCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateToCollectionOperationSpecification.groovy
@@ -279,7 +279,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         }
 
         then:
-        testOperation(operation, serverVersion, expectedCommand, false, BsonDocument.parse('{ok: 1}'),
+        testOperation(operation, serverVersion, expectedCommand, async, BsonDocument.parse('{ok: 1}'),
                 true, false, ReadPreference.primary(), false)
 
         where:

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ListCollectionsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ListCollectionsOperationSpecification.groovy
@@ -420,11 +420,12 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         disableMaxTimeFailPoint()
     }
 
-    def 'should use the ReadBindings readPreference to set secondaryOk'() {
+    def 'should use the readPreference to set secondaryOk'() {
         given:
         def connection = Mock(Connection)
         def connectionSource = Stub(ConnectionSource) {
             getServerApi() >> null
+            getReadPreference() >> readPreference
             getConnection() >> connection
         }
         def readBinding = Stub(ReadBinding) {
@@ -454,10 +455,11 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         readPreference << [ReadPreference.primary(), ReadPreference.secondary()]
     }
 
-    def 'should use the AsyncReadBindings readPreference to set secondaryOk'() {
+    def 'should use the readPreference to set secondaryOk in async'() {
         given:
         def connection = Mock(AsyncConnection)
         def connectionSource = Stub(AsyncConnectionSource) {
+            getReadPreference() >> readPreference
             getServerApi() >> null
             getConnection(_) >> { it[0].onResult(connection, null) }
         }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ListDatabasesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ListDatabasesOperationSpecification.groovy
@@ -112,10 +112,11 @@ class ListDatabasesOperationSpecification extends OperationFunctionalSpecificati
         disableMaxTimeFailPoint()
     }
 
-    def 'should use the ReadBindings readPreference to set secondaryOk'() {
+    def 'should use the readPreference to set secondaryOk'() {
         given:
         def connection = Mock(Connection)
         def connectionSource = Stub(ConnectionSource) {
+            getReadPreference() >> readPreference
             getServerApi() >> null
             getConnection() >> connection
         }
@@ -138,10 +139,11 @@ class ListDatabasesOperationSpecification extends OperationFunctionalSpecificati
         readPreference << [ReadPreference.primary(), ReadPreference.secondary()]
     }
 
-    def 'should use the AsyncReadBindings readPreference to set secondaryOk'() {
+    def 'should use the readPreference to set secondaryOk async'() {
         given:
         def connection = Mock(AsyncConnection)
         def connectionSource = Stub(AsyncConnectionSource) {
+            getReadPreference() >> readPreference
             getConnection(_) >> { it[0].onResult(connection, null) }
         }
         def readBinding = Stub(AsyncReadBinding) {

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ListIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ListIndexesOperationSpecification.groovy
@@ -251,11 +251,12 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
     }
 
 
-    def 'should use the ReadBindings readPreference to set secondaryOk'() {
+    def 'should use the readPreference to set secondaryOk'() {
         given:
         def connection = Mock(Connection)
         def connectionSource = Stub(ConnectionSource) {
             getServerApi() >> null
+            getReadPreference() >> readPreference
             getConnection() >> connection
         }
         def readBinding = Stub(ReadBinding) {
@@ -285,10 +286,11 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
         readPreference << [ReadPreference.primary(), ReadPreference.secondary()]
     }
 
-    def 'should use the AsyncReadBindings readPreference to set secondaryOk'() {
+    def 'should use the readPreference to set secondaryOk async'() {
         given:
         def connection = Mock(AsyncConnection)
         def connectionSource = Stub(AsyncConnectionSource) {
+            getReadPreference() >> readPreference
             getConnection(_) >> { it[0].onResult(connection, null) }
         }
         def readBinding = Stub(AsyncReadBinding) {

--- a/driver-core/src/test/resources/unified-test-format/crud/aggregate-write-readPreference.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/aggregate-write-readPreference.json
@@ -1,0 +1,457 @@
+{
+  "description": "aggregate-write-readPreference",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "readConcern": {
+      "level": "local"
+    },
+    "writeConcern": {
+      "w": 1
+    }
+  },
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "uriOptions": {
+          "readConcernLevel": "local",
+          "w": 1
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "db0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0",
+        "collectionOptions": {
+          "readPreference": {
+            "mode": "secondaryPreferred",
+            "maxStalenessSeconds": 600
+          }
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "db0",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    },
+    {
+      "collectionName": "coll1",
+      "databaseName": "db0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate with $out includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$out": "coll1"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$out": "coll1"
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $out omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$out": "coll1"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$out": "coll1"
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $merge includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll1"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll1"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $merge omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll1"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll1"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll1",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/db-aggregate-write-readPreference.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/db-aggregate-write-readPreference.json
@@ -1,0 +1,443 @@
+{
+  "description": "db-aggregate-write-readPreference",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "topologies": [
+        "replicaset"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "_yamlAnchors": {
+    "readConcern": {
+      "level": "local"
+    },
+    "writeConcern": {
+      "w": 1
+    }
+  },
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "uriOptions": {
+          "readConcernLevel": "local",
+          "w": 1
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "db0",
+        "databaseOptions": {
+          "readPreference": {
+            "mode": "secondaryPreferred",
+            "maxStalenessSeconds": 600
+          }
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "db0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Database-level aggregate with $out includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$out": "coll0"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$out": "coll0"
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Database-level aggregate with $out omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$out": "coll0"
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$out": "coll0"
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Database-level aggregate with $merge includes read preference for 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll0"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll0"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "mode": "secondaryPreferred",
+                    "maxStalenessSeconds": 600
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Database-level aggregate with $merge omits read preference for pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "database0",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "_id": 1
+                }
+              },
+              {
+                "$project": {
+                  "_id": 1
+                }
+              },
+              {
+                "$merge": {
+                  "into": "coll0"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    },
+                    {
+                      "$addFields": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": 1
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "coll0"
+                      }
+                    }
+                  ],
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "level": "local"
+                  },
+                  "writeConcern": {
+                    "w": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "db0",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/CommandOperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/CommandOperationHelperSpecification.groovy
@@ -243,7 +243,7 @@ class CommandOperationHelperSpecification extends Specification {
         callback.throwable.writeConcernError.code == -1
     }
 
-    def 'should use the ReadBindings readPreference'() {
+    def 'should use the ConnectionSource readPreference'() {
         given:
         def dbName = 'db'
         def command = new BsonDocument('fakeCommandName', BsonNull.VALUE)
@@ -253,10 +253,10 @@ class CommandOperationHelperSpecification extends Specification {
         def connection = Mock(Connection)
         def connectionSource = Stub(ConnectionSource) {
             getConnection() >> connection
+            getReadPreference() >> readPreference
         }
         def readBinding = Stub(ReadBinding) {
             getReadConnectionSource() >> connectionSource
-            getReadPreference() >> readPreference
             getServerApi() >> null
         }
         def connectionDescription = Stub(ConnectionDescription)
@@ -298,7 +298,7 @@ class CommandOperationHelperSpecification extends Specification {
 //        1 * connection.release()
     }
 
-    def 'should use the AsyncReadBindings readPreference'() {
+    def 'should use the AsyncConnectionSource readPreference'() {
         given:
         def dbName = 'db'
         def command = new BsonDocument('fakeCommandName', BsonNull.VALUE)
@@ -310,11 +310,11 @@ class CommandOperationHelperSpecification extends Specification {
         def connectionSource = Stub(AsyncConnectionSource) {
             getServerApi() >> null
             getConnection(_) >> { it[0].onResult(connection, null) }
+            getReadPreference() >> readPreference
         }
         def asyncReadBinding = Stub(AsyncReadBinding) {
             getServerApi() >> null
             getReadConnectionSource(_)  >> { it[0].onResult(connectionSource, null) }
-            getReadPreference() >> readPreference
         }
         def connectionDescription = Stub(ConnectionDescription)
 

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/OperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/OperationUnitSpecification.groovy
@@ -95,6 +95,7 @@ class OperationUnitSpecification extends Specification {
 
         def connectionSource = Stub(ConnectionSource) {
             getConnection() >> connection
+            getReadPreference() >> readPreference
             getServerApi() >> null
         }
         def readBinding = Stub(ReadBinding) {
@@ -148,6 +149,7 @@ class OperationUnitSpecification extends Specification {
 
         def connectionSource = Stub(AsyncConnectionSource) {
             getServerApi() >> null
+            getReadPreference() >> readPreference
             getConnection(_) >> { it[0].onResult(connection, null) }
         }
         def readBinding = Stub(AsyncReadBinding) {

--- a/driver-legacy/src/main/com/mongodb/DBCollection.java
+++ b/driver-legacy/src/main/com/mongodb/DBCollection.java
@@ -1225,7 +1225,7 @@ public class DBCollection {
                                                        .bypassDocumentValidation(options.getBypassDocumentValidation())
                                                        .collation(options.getCollation());
             try {
-                executor.execute(operation, getReadConcern());
+                executor.execute(operation, getReadPreference(), getReadConcern());
                 result = new DBCursor(database.getCollection(outCollection.asString().getValue()), new BasicDBObject(),
                         new DBCollectionFindOptions().readPreference(primary()).collation(options.getCollation()));
             } catch (MongoWriteConcernException e) {

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
@@ -666,21 +666,21 @@ class DBCollectionSpecification extends Specification {
         collection.aggregate(pipeline, AggregationOptions.builder().build())
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
                 bsonPipeline, collection.getReadConcern(), collection.getWriteConcern()))
 
         when: // Inherits from DB
         collection.aggregate(pipeline, AggregationOptions.builder().build())
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
                 bsonPipeline, collection.getReadConcern(), collection.getWriteConcern()))
 
         when:
         collection.aggregate(pipeline, AggregationOptions.builder().collation(collation).build())
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
                 bsonPipeline, collection.getReadConcern(), collection.getWriteConcern()).collation(collation))
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MapReducePublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MapReducePublisherImpl.java
@@ -196,7 +196,7 @@ final class MapReducePublisherImpl<T> extends BatchCursorPublisher<T> implements
             // initialBatchSize is ignored for map reduce operations.
             return createMapReduceInlineOperation();
         } else {
-            return new WriteOperationThenCursorReadOperation<>(createMapReduceToCollectionOperation(),
+            return new VoidWriteOperationThenCursorReadOperation<>(createMapReduceToCollectionOperation(),
                     createFindOperation(initialBatchSize));
         }
     }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/VoidReadOperationThenCursorReadOperation.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/VoidReadOperationThenCursorReadOperation.java
@@ -19,36 +19,33 @@ package com.mongodb.reactivestreams.client.internal;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
-import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.operation.AsyncReadOperation;
-import com.mongodb.internal.operation.AsyncWriteOperation;
 
-class WriteOperationThenCursorReadOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>> {
-    private final AsyncWriteOperation<Void> aggregateToCollectionOperation;
-    private final AsyncReadOperation<AsyncBatchCursor<T>> readOperation;
+class VoidReadOperationThenCursorReadOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>> {
+    private final AsyncReadOperation<Void> readOperation;
+    private final AsyncReadOperation<AsyncBatchCursor<T>> cursorReadOperation;
 
-    WriteOperationThenCursorReadOperation(final AsyncWriteOperation<Void> aggregateToCollectionOperation,
-                                                 final AsyncReadOperation<AsyncBatchCursor<T>> readOperation) {
-        this.aggregateToCollectionOperation = aggregateToCollectionOperation;
+    VoidReadOperationThenCursorReadOperation(final AsyncReadOperation<Void> readOperation,
+            final AsyncReadOperation<AsyncBatchCursor<T>> cursorReadOperation) {
         this.readOperation = readOperation;
+        this.cursorReadOperation = cursorReadOperation;
     }
 
-    public AsyncWriteOperation<Void> getAggregateToCollectionOperation() {
-        return aggregateToCollectionOperation;
-    }
-
-    public AsyncReadOperation<AsyncBatchCursor<T>> getReadOperation() {
+    public AsyncReadOperation<Void> getReadOperation() {
         return readOperation;
     }
 
+    public AsyncReadOperation<AsyncBatchCursor<T>> getCursorReadOperation() {
+        return cursorReadOperation;
+    }
+
     @Override
-    @SuppressWarnings("unchecked")
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        aggregateToCollectionOperation.executeAsync((AsyncWriteBinding) binding, (result, t) -> {
+        readOperation.executeAsync(binding, (result, t) -> {
             if (t != null) {
                 callback.onResult(null, t);
             } else {
-                readOperation.executeAsync(binding, callback);
+                cursorReadOperation.executeAsync(binding, callback);
             }
         });
     }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/VoidWriteOperationThenCursorReadOperation.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/VoidWriteOperationThenCursorReadOperation.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.internal;
+
+import com.mongodb.internal.async.AsyncBatchCursor;
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.binding.AsyncReadBinding;
+import com.mongodb.internal.binding.AsyncWriteBinding;
+import com.mongodb.internal.operation.AsyncReadOperation;
+import com.mongodb.internal.operation.AsyncWriteOperation;
+
+class VoidWriteOperationThenCursorReadOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>> {
+    private final AsyncWriteOperation<Void> writeOperation;
+    private final AsyncReadOperation<AsyncBatchCursor<T>> cursorReadOperation;
+
+    VoidWriteOperationThenCursorReadOperation(final AsyncWriteOperation<Void> writeOperation,
+                                              final AsyncReadOperation<AsyncBatchCursor<T>> cursorReadOperation) {
+        this.writeOperation = writeOperation;
+        this.cursorReadOperation = cursorReadOperation;
+    }
+
+    @Override
+    public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
+        writeOperation.executeAsync((AsyncWriteBinding) binding, (result, t) -> {
+            if (t != null) {
+                callback.onResult(null, t);
+            } else {
+                cursorReadOperation.executeAsync(binding, callback);
+            }
+        });
+    }
+}

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/CryptBinding.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/CryptBinding.java
@@ -84,6 +84,20 @@ public class CryptBinding implements AsyncClusterAwareReadWriteBinding {
         });
     }
 
+
+    @Override
+    public void getReadConnectionSource(final int minWireVersion, final ReadPreference fallbackReadPreference,
+            final SingleResultCallback<AsyncConnectionSource> callback) {
+        wrapped.getReadConnectionSource(minWireVersion, fallbackReadPreference, (result, t) -> {
+            if (t != null) {
+                callback.onResult(null, t);
+            } else {
+                callback.onResult(new CryptConnectionSource(result), null);
+            }
+        });
+    }
+
+
     @Override
     public void getConnectionSource(final ServerAddress serverAddress, final SingleResultCallback<AsyncConnectionSource> callback) {
         wrapped.getConnectionSource(serverAddress, (result, t) -> {
@@ -143,6 +157,11 @@ public class CryptBinding implements AsyncClusterAwareReadWriteBinding {
         @Override
         public RequestContext getRequestContext() {
             return wrapped.getRequestContext();
+        }
+
+        @Override
+        public ReadPreference getReadPreference() {
+            return wrapped.getReadPreference();
         }
 
         @Override

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoDatabase.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoDatabase.java
@@ -81,17 +81,17 @@ public class SyncMongoDatabase implements MongoDatabase {
 
     @Override
     public MongoDatabase withReadPreference(final ReadPreference readPreference) {
-        throw new UnsupportedOperationException();
+        return new SyncMongoDatabase(wrapped.withReadPreference(readPreference));
     }
 
     @Override
     public MongoDatabase withWriteConcern(final WriteConcern writeConcern) {
-        throw new UnsupportedOperationException();
+        return new SyncMongoDatabase(wrapped.withWriteConcern(writeConcern));
     }
 
     @Override
     public MongoDatabase withReadConcern(final ReadConcern readConcern) {
-        throw new UnsupportedOperationException();
+        return new SyncMongoDatabase(wrapped.withReadConcern(readConcern));
     }
 
     @Override

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/AggregatePublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/AggregatePublisherImplTest.java
@@ -111,9 +111,9 @@ public class AggregatePublisherImplTest extends TestHelper {
         // default input should be as expected
         Flux.from(publisher).blockFirst();
 
-        WriteOperationThenCursorReadOperation operation = (WriteOperationThenCursorReadOperation) executor.getReadOperation();
+        VoidReadOperationThenCursorReadOperation operation = (VoidReadOperationThenCursorReadOperation) executor.getReadOperation();
         assertEquals(ReadPreference.primary(), executor.getReadPreference());
-        assertOperationIsTheSameAs(expectedOperation, operation.getAggregateToCollectionOperation());
+        assertOperationIsTheSameAs(expectedOperation, operation.getReadOperation());
 
         // Should apply settings
         publisher
@@ -136,8 +136,8 @@ public class AggregatePublisherImplTest extends TestHelper {
 
         Flux.from(publisher).blockFirst();
         assertEquals(ReadPreference.primary(), executor.getReadPreference());
-        operation = (WriteOperationThenCursorReadOperation) executor.getReadOperation();
-        assertOperationIsTheSameAs(expectedOperation, operation.getAggregateToCollectionOperation());
+        operation = (VoidReadOperationThenCursorReadOperation) executor.getReadOperation();
+        assertOperationIsTheSameAs(expectedOperation, operation.getReadOperation());
 
         FindOperation<Document> expectedFindOperation =
                 new FindOperation<>(collectionNamespace, getDefaultCodecRegistry().get(Document.class))
@@ -148,7 +148,7 @@ public class AggregatePublisherImplTest extends TestHelper {
                         .maxTime(0, SECONDS)
                         .retryReads(true);
 
-        assertOperationIsTheSameAs(expectedFindOperation, operation.getReadOperation());
+        assertOperationIsTheSameAs(expectedFindOperation, operation.getCursorReadOperation());
 
         // Should handle database level aggregations
         publisher = new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.DATABASE);
@@ -156,9 +156,9 @@ public class AggregatePublisherImplTest extends TestHelper {
         expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline, ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED);
 
         Flux.from(publisher).blockFirst();
-        operation = (WriteOperationThenCursorReadOperation) executor.getReadOperation();
+        operation = (VoidReadOperationThenCursorReadOperation) executor.getReadOperation();
         assertEquals(ReadPreference.primary(), executor.getReadPreference());
-        assertOperationIsTheSameAs(expectedOperation, operation.getAggregateToCollectionOperation());
+        assertOperationIsTheSameAs(expectedOperation, operation.getReadOperation());
 
         // Should handle toCollection
         publisher = new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.COLLECTION);
@@ -167,7 +167,7 @@ public class AggregatePublisherImplTest extends TestHelper {
 
         // default input should be as expected
         Flux.from(publisher.toCollection()).blockFirst();
-        assertOperationIsTheSameAs(expectedOperation, executor.getWriteOperation());
+        assertOperationIsTheSameAs(expectedOperation, executor.getReadOperation());
     }
 
     @DisplayName("Should build the expected AggregateOperation for $out as document")
@@ -191,7 +191,7 @@ public class AggregatePublisherImplTest extends TestHelper {
                                                                                               WriteConcern.ACKNOWLEDGED);
 
         Flux.from(toCollectionPublisher).blockFirst();
-        assertOperationIsTheSameAs(expectedOperation, executor.getWriteOperation());
+        assertOperationIsTheSameAs(expectedOperation, executor.getReadOperation());
 
         // Should handle database level
         toCollectionPublisher =
@@ -199,7 +199,7 @@ public class AggregatePublisherImplTest extends TestHelper {
                         .toCollection();
 
         Flux.from(toCollectionPublisher).blockFirst();
-        assertOperationIsTheSameAs(expectedOperation, executor.getWriteOperation());
+        assertOperationIsTheSameAs(expectedOperation, executor.getReadOperation());
 
         // Should handle $out with namespace
         List<BsonDocument> pipelineWithNamespace = asList(BsonDocument.parse("{'$match': 1}"),
@@ -212,7 +212,7 @@ public class AggregatePublisherImplTest extends TestHelper {
                                                                WriteConcern.ACKNOWLEDGED);
 
         Flux.from(toCollectionPublisher).blockFirst();
-        assertOperationIsTheSameAs(expectedOperation, executor.getWriteOperation());
+        assertOperationIsTheSameAs(expectedOperation, executor.getReadOperation());
     }
 
     @DisplayName("Should build the expected AggregateOperation for $merge document")
@@ -234,9 +234,9 @@ public class AggregatePublisherImplTest extends TestHelper {
         // default input should be as expected
         Flux.from(publisher).blockFirst();
 
-        WriteOperationThenCursorReadOperation operation = (WriteOperationThenCursorReadOperation) executor.getReadOperation();
+        VoidReadOperationThenCursorReadOperation operation = (VoidReadOperationThenCursorReadOperation) executor.getReadOperation();
         assertEquals(ReadPreference.primary(), executor.getReadPreference());
-        assertOperationIsTheSameAs(expectedOperation, operation.getAggregateToCollectionOperation());
+        assertOperationIsTheSameAs(expectedOperation, operation.getReadOperation());
 
         // Should apply settings
         publisher
@@ -259,8 +259,8 @@ public class AggregatePublisherImplTest extends TestHelper {
 
         Flux.from(publisher).blockFirst();
         assertEquals(ReadPreference.primary(), executor.getReadPreference());
-        operation = (WriteOperationThenCursorReadOperation) executor.getReadOperation();
-        assertOperationIsTheSameAs(expectedOperation, operation.getAggregateToCollectionOperation());
+        operation = (VoidReadOperationThenCursorReadOperation) executor.getReadOperation();
+        assertOperationIsTheSameAs(expectedOperation, operation.getReadOperation());
 
         FindOperation<Document> expectedFindOperation =
                 new FindOperation<>(collectionNamespace, getDefaultCodecRegistry().get(Document.class))
@@ -271,7 +271,7 @@ public class AggregatePublisherImplTest extends TestHelper {
                         .maxTime(0, SECONDS)
                         .retryReads(true);
 
-        assertOperationIsTheSameAs(expectedFindOperation, operation.getReadOperation());
+        assertOperationIsTheSameAs(expectedFindOperation, operation.getCursorReadOperation());
 
         // Should handle database level aggregations
         publisher = new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.DATABASE);
@@ -279,9 +279,9 @@ public class AggregatePublisherImplTest extends TestHelper {
         expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline, ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED);
 
         Flux.from(publisher).blockFirst();
-        operation = (WriteOperationThenCursorReadOperation) executor.getReadOperation();
+        operation = (VoidReadOperationThenCursorReadOperation) executor.getReadOperation();
         assertEquals(ReadPreference.primary(), executor.getReadPreference());
-        assertOperationIsTheSameAs(expectedOperation, operation.getAggregateToCollectionOperation());
+        assertOperationIsTheSameAs(expectedOperation, operation.getReadOperation());
 
         // Should handle toCollection
         publisher = new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.COLLECTION);
@@ -290,7 +290,7 @@ public class AggregatePublisherImplTest extends TestHelper {
 
         // default input should be as expected
         Flux.from(publisher.toCollection()).blockFirst();
-        assertOperationIsTheSameAs(expectedOperation, executor.getWriteOperation());
+        assertOperationIsTheSameAs(expectedOperation, executor.getReadOperation());
     }
 
     @DisplayName("Should build the expected AggregateOperation for $merge string")
@@ -312,9 +312,9 @@ public class AggregatePublisherImplTest extends TestHelper {
         // default input should be as expected
         Flux.from(publisher).blockFirst();
 
-        WriteOperationThenCursorReadOperation operation = (WriteOperationThenCursorReadOperation) executor.getReadOperation();
+        VoidReadOperationThenCursorReadOperation operation = (VoidReadOperationThenCursorReadOperation) executor.getReadOperation();
         assertEquals(ReadPreference.primary(), executor.getReadPreference());
-        assertOperationIsTheSameAs(expectedOperation, operation.getAggregateToCollectionOperation());
+        assertOperationIsTheSameAs(expectedOperation, operation.getReadOperation());
 
         FindOperation<Document> expectedFindOperation =
                 new FindOperation<>(collectionNamespace, getDefaultCodecRegistry().get(Document.class))
@@ -322,7 +322,7 @@ public class AggregatePublisherImplTest extends TestHelper {
                 .batchSize(Integer.MAX_VALUE)
                 .retryReads(true);
 
-        assertOperationIsTheSameAs(expectedFindOperation, operation.getReadOperation());
+        assertOperationIsTheSameAs(expectedFindOperation, operation.getCursorReadOperation());
     }
 
     @DisplayName("Should handle error scenarios")

--- a/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
@@ -99,7 +99,7 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
         }
 
         getExecutor().execute(operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation, hint,
-                comment, variables, aggregationLevel), getReadConcern(), getClientSession());
+                comment, variables, aggregationLevel), getReadPreference(), getReadConcern(), getClientSession());
     }
 
     @Override
@@ -189,7 +189,7 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
         MongoNamespace outNamespace = getOutNamespace();
         if (outNamespace != null) {
             getExecutor().execute(operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation,
-                    hint, comment, variables, aggregationLevel), getReadConcern(), getClientSession());
+                    hint, comment, variables, aggregationLevel), getReadPreference(), getReadConcern(), getClientSession());
 
             FindOptions findOptions = new FindOptions().collation(collation);
             Integer batchSize = getBatchSize();

--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionBinding.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionBinding.java
@@ -88,6 +88,15 @@ public class ClientSessionBinding implements ReadWriteBinding {
         }
     }
 
+    @Override
+    public ConnectionSource getReadConnectionSource(final int minWireVersion, final ReadPreference fallbackReadPreference) {
+        if (isConnectionSourcePinningRequired()) {
+            return new SessionBindingConnectionSource(getPinnedConnectionSource(true));
+        } else {
+            return new SessionBindingConnectionSource(wrapped.getReadConnectionSource(minWireVersion, fallbackReadPreference));
+        }
+    }
+
     public ConnectionSource getWriteConnectionSource() {
         if (isConnectionSourcePinningRequired()) {
             return new SessionBindingConnectionSource(getPinnedConnectionSource(false));
@@ -156,6 +165,11 @@ public class ClientSessionBinding implements ReadWriteBinding {
         @Override
         public RequestContext getRequestContext() {
             return wrapped.getRequestContext();
+        }
+
+        @Override
+        public ReadPreference getReadPreference() {
+            return wrapped.getReadPreference();
         }
 
         @Override

--- a/driver-sync/src/main/com/mongodb/client/internal/CryptBinding.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/CryptBinding.java
@@ -49,6 +49,11 @@ class CryptBinding implements ClusterAwareReadWriteBinding {
     }
 
     @Override
+    public ConnectionSource getReadConnectionSource(final int minWireVersion, final ReadPreference fallbackReadPreference) {
+        return new CryptConnectionSource(wrapped.getReadConnectionSource(minWireVersion, fallbackReadPreference));
+    }
+
+    @Override
     public ConnectionSource getWriteConnectionSource() {
         return new CryptConnectionSource(wrapped.getWriteConnectionSource());
     }
@@ -120,6 +125,11 @@ class CryptBinding implements ClusterAwareReadWriteBinding {
         @Override
         public RequestContext getRequestContext() {
             return wrapped.getRequestContext();
+        }
+
+        @Override
+        public ReadPreference getReadPreference() {
+            return wrapped.getReadPreference();
         }
 
         @Override

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/Entities.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/Entities.java
@@ -413,12 +413,17 @@ public final class Entities {
     private void initDatabase(final BsonDocument entity, final String id) {
         MongoClient client = clients.get(entity.getString("client").getValue());
         MongoDatabase database = client.getDatabase(entity.getString("databaseName").getValue());
-        if (entity.containsKey("collectionOptions")) {
-            for (Map.Entry<String, BsonValue> entry : entity.getDocument("collectionOptions").entrySet()) {
-                //noinspection SwitchStatementWithTooFewBranches
+        if (entity.containsKey("databaseOptions")) {
+            for (Map.Entry<String, BsonValue> entry : entity.getDocument("databaseOptions").entrySet()) {
                 switch (entry.getKey()) {
                     case "readConcern":
                         database = database.withReadConcern(asReadConcern(entry.getValue().asDocument()));
+                        break;
+                    case "readPreference":
+                        database = database.withReadPreference(asReadPreference(entry.getValue().asDocument()));
+                        break;
+                    case "writeConcern":
+                        database = database.withWriteConcern(asWriteConcern(entry.getValue().asDocument()));
                         break;
                     default:
                         throw new UnsupportedOperationException("Unsupported database option: " + entry.getKey());

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
@@ -77,6 +77,7 @@ import org.bson.codecs.configuration.CodecRegistries;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -116,11 +117,14 @@ final class UnifiedCrudHelper {
     }
 
     public static ReadPreference asReadPreference(final BsonDocument readPreferenceDocument) {
-        if (readPreferenceDocument.size() > 1) {
-            throw new UnsupportedOperationException("Unsupported read preference properties");
+        if (readPreferenceDocument.size() == 1) {
+            return ReadPreference.valueOf(readPreferenceDocument.getString("mode").getValue());
+        } else if (readPreferenceDocument.size() == 2) {
+            return ReadPreference.valueOf(readPreferenceDocument.getString("mode").getValue(),
+                    Collections.emptyList(), readPreferenceDocument.getNumber("maxStalenessSeconds").intValue(), TimeUnit.SECONDS);
+        } else {
+            throw new UnsupportedOperationException("Unsupported read preference properties: " + readPreferenceDocument.toJson());
         }
-
-        return ReadPreference.valueOf(readPreferenceDocument.getString("mode").getValue());
     }
 
     private OperationResult resultOf(final Supplier<BsonValue> operationResult) {

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
@@ -115,7 +115,7 @@ class AggregateIterableSpecification extends Specification {
                 .hint(new Document('a', 1))
                 .comment('this is a comment').iterator()
 
-        def operation = executor.getWriteOperation() as AggregateToCollectionOperation
+        def operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then: 'should use the overrides'
         expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
@@ -148,7 +148,7 @@ class AggregateIterableSpecification extends Specification {
                 .hint(new Document('a', 1))
                 .comment('this is a comment').iterator()
 
-        operation = executor.getWriteOperation() as AggregateToCollectionOperation
+        operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then: 'should use the overrides'
         expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
@@ -182,7 +182,7 @@ class AggregateIterableSpecification extends Specification {
                 .comment('this is a comment')
                 .toCollection()
 
-        operation = executor.getWriteOperation() as AggregateToCollectionOperation
+        operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
         expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
@@ -213,7 +213,7 @@ class AggregateIterableSpecification extends Specification {
                 .hint(new Document('a', 1))
                 .comment('this is a comment').iterator()
 
-        def operation = executor.getWriteOperation() as AggregateToCollectionOperation
+        def operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then: 'should use the overrides'
         expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
@@ -248,7 +248,7 @@ class AggregateIterableSpecification extends Specification {
                 .hint(new Document('a', 1))
                 .comment('this is a comment').iterator()
 
-        operation = executor.getWriteOperation() as AggregateToCollectionOperation
+        operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then: 'should use the overrides'
         expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
@@ -284,7 +284,7 @@ class AggregateIterableSpecification extends Specification {
                 .hint(new Document('a', 1))
                 .comment('this is a comment').iterator()
 
-        operation = executor.getWriteOperation() as AggregateToCollectionOperation
+        operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then: 'should use the overrides'
         expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
@@ -318,7 +318,7 @@ class AggregateIterableSpecification extends Specification {
                 .comment('this is a comment')
                 .toCollection()
 
-        operation = executor.getWriteOperation() as AggregateToCollectionOperation
+        operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
         expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
@@ -343,7 +343,7 @@ class AggregateIterableSpecification extends Specification {
                 pipeline, AggregationLevel.COLLECTION, false)
                 .iterator()
 
-        def operation = executor.getWriteOperation() as AggregateToCollectionOperation
+        def operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
         expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace, pipeline, readConcern, writeConcern,
@@ -386,7 +386,7 @@ class AggregateIterableSpecification extends Specification {
                 readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false)
 
         aggregateIterable.toCollection()
-        def operation = executor.getWriteOperation() as AggregateToCollectionOperation
+        def operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
         expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
@@ -405,7 +405,7 @@ class AggregateIterableSpecification extends Specification {
                 readConcern, writeConcern, executor, pipeline, AggregationLevel.DATABASE, false)
         aggregateIterable.toCollection()
 
-        operation = executor.getWriteOperation() as AggregateToCollectionOperation
+        operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
         expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
@@ -424,7 +424,7 @@ class AggregateIterableSpecification extends Specification {
                 readConcern, writeConcern, executor, pipeline, AggregationLevel.COLLECTION, false)
         aggregateIterable.toCollection()
 
-        operation = executor.getWriteOperation() as AggregateToCollectionOperation
+        operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
         expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
@@ -442,7 +442,7 @@ class AggregateIterableSpecification extends Specification {
                 readConcern, writeConcern, executor, outWithDBpipeline, AggregationLevel.COLLECTION, false)
         aggregateIterable.toCollection()
 
-        operation = executor.getWriteOperation() as AggregateToCollectionOperation
+        operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
         expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,


### PR DESCRIPTION
JAVA-3994

This implementation uses the recommended approach from the specification:

> Drivers SHOULD use a custom server selector to consider server/wire version when matching a read preference and, if a pre-5.0 secondary would be selected, fall back to selecting a primary. With this approach, only a single server selection attempt is needed.

This required some minor surgery on the ReadBinding and ConnectionSource internal APIs.