### PR TITLE
JAVA-4028 Provide explicit guidance on handling command errors that occur before the handshake completes during operation execution

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/JsonTestServerVersionChecker.java
+++ b/driver-core/src/test/functional/com/mongodb/JsonTestServerVersionChecker.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import static com.mongodb.ClusterFixture.getServerVersion;
 import static com.mongodb.ClusterFixture.getVersionList;
+import static com.mongodb.ClusterFixture.isAuthenticated;
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isLoadBalanced;
 import static com.mongodb.ClusterFixture.isSharded;
@@ -57,6 +58,9 @@ public final class JsonTestServerVersionChecker {
             return false;
         }
         if (document.containsKey("topology") && !topologyMatches(document.getArray("topology"))) {
+            return false;
+        }
+        if (document.containsKey("authEnabled") && (isAuthenticated() != document.getBoolean("authEnabled").getValue())) {
             return false;
         }
 

--- a/driver-core/src/test/resources/server-discovery-and-monitoring-integration/auth-error.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring-integration/auth-error.json
@@ -1,0 +1,140 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4",
+      "authEnabled": true
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "auth-error",
+  "data": [
+    {
+      "_id": 1
+    },
+    {
+      "_id": 2
+    }
+  ],
+  "tests": [
+    {
+      "description": "Reset server and pool after AuthenticationFailure error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "saslContinue"
+          ],
+          "appName": "authErrorTest",
+          "errorCode": 18
+        }
+      },
+      "clientOptions": {
+        "retryWrites": false,
+        "appname": "authErrorTest"
+      },
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          },
+          "error": true
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 5
+              },
+              {
+                "_id": 6
+              }
+            ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "auth-error",
+              "documents": [
+                {
+                  "_id": 5
+                },
+                {
+                  "_id": 6
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 5
+            },
+            {
+              "_id": 6
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/server-discovery-and-monitoring-integration/auth-misc-command-error.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring-integration/auth-misc-command-error.json
@@ -1,0 +1,140 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4",
+      "authEnabled": true
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "auth-misc-error",
+  "data": [
+    {
+      "_id": 1
+    },
+    {
+      "_id": 2
+    }
+  ],
+  "tests": [
+    {
+      "description": "Reset server and pool after misc command error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "saslContinue"
+          ],
+          "appName": "authMiscErrorTest",
+          "errorCode": 1
+        }
+      },
+      "clientOptions": {
+        "retryWrites": false,
+        "appname": "authMiscErrorTest"
+      },
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          },
+          "error": true
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 5
+              },
+              {
+                "_id": 6
+              }
+            ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "auth-misc-error",
+              "documents": [
+                {
+                  "_id": 5
+                },
+                {
+                  "_id": 6
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 5
+            },
+            {
+              "_id": 6
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/server-discovery-and-monitoring-integration/auth-network-error.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring-integration/auth-network-error.json
@@ -1,0 +1,140 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4",
+      "authEnabled": true
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "auth-network-error",
+  "data": [
+    {
+      "_id": 1
+    },
+    {
+      "_id": 2
+    }
+  ],
+  "tests": [
+    {
+      "description": "Reset server and pool after network error during authentication",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "saslContinue"
+          ],
+          "closeConnection": true,
+          "appName": "authNetworkErrorTest"
+        }
+      },
+      "clientOptions": {
+        "retryWrites": false,
+        "appname": "authNetworkErrorTest"
+      },
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          },
+          "error": true
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 5
+              },
+              {
+                "_id": 6
+              }
+            ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "auth-network-error",
+              "documents": [
+                {
+                  "_id": 5
+                },
+                {
+                  "_id": 6
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 5
+            },
+            {
+              "_id": 6
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/server-discovery-and-monitoring-integration/auth-network-timeout-error.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring-integration/auth-network-timeout-error.json
@@ -1,0 +1,143 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4",
+      "authEnabled": true
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "auth-network-timeout-error",
+  "data": [
+    {
+      "_id": 1
+    },
+    {
+      "_id": 2
+    }
+  ],
+  "tests": [
+    {
+      "description": "Reset server and pool after network timeout error during authentication",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "saslContinue"
+          ],
+          "blockConnection": true,
+          "blockTimeMS": 500,
+          "appName": "authNetworkTimeoutErrorTest"
+        }
+      },
+      "clientOptions": {
+        "retryWrites": false,
+        "appname": "authNetworkTimeoutErrorTest",
+        "connectTimeoutMS": 250,
+        "socketTimeoutMS": 250
+      },
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          },
+          "error": true
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 5
+              },
+              {
+                "_id": 6
+              }
+            ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "auth-network-timeout-error",
+              "documents": [
+                {
+                  "_id": 5
+                },
+                {
+                  "_id": 6
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 5
+            },
+            {
+              "_id": 6
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/server-discovery-and-monitoring-integration/auth-shutdown-error.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring-integration/auth-shutdown-error.json
@@ -1,0 +1,140 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4",
+      "authEnabled": true
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "auth-shutdown-error",
+  "data": [
+    {
+      "_id": 1
+    },
+    {
+      "_id": 2
+    }
+  ],
+  "tests": [
+    {
+      "description": "Reset server and pool after shutdown error during authentication",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "saslContinue"
+          ],
+          "appName": "authShutdownErrorTest",
+          "errorCode": 91
+        }
+      },
+      "clientOptions": {
+        "retryWrites": false,
+        "appname": "authShutdownErrorTest"
+      },
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          },
+          "error": true
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 5
+              },
+              {
+                "_id": 6
+              }
+            ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "auth-shutdown-error",
+              "documents": [
+                {
+                  "_id": 5
+                },
+                {
+                  "_id": 6
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 5
+            },
+            {
+              "_id": 6
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/server-discovery-and-monitoring-integration/find-network-timeout-error.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring-integration/find-network-timeout-error.json
@@ -1,0 +1,119 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4"
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "find-network-timeout-error",
+  "data": [
+    {
+      "_id": 1
+    },
+    {
+      "_id": 2
+    }
+  ],
+  "tests": [
+    {
+      "description": "Ignore network timeout error on find",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "find"
+          ],
+          "blockConnection": true,
+          "blockTimeMS": 500,
+          "appName": "findNetworkTimeoutErrorTest"
+        }
+      },
+      "clientOptions": {
+        "retryWrites": false,
+        "retryReads": false,
+        "appname": "findNetworkTimeoutErrorTest",
+        "socketTimeoutMS": 250
+      },
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "error": true
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 3
+            }
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 0
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "find-network-timeout-error"
+            },
+            "command_name": "find",
+            "database_name": "sdam-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "find-network-timeout-error",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/server-discovery-and-monitoring-integration/minPoolSize-error.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring-integration/minPoolSize-error.json
@@ -17,8 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster",
-            "hello"
+            "hello",
+            "isMaster"
           ],
           "appName": "SDAMminPoolSizeError",
           "closeConnection": true

--- a/driver-core/src/test/resources/server-discovery-and-monitoring-integration/pool-cleared-error.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring-integration/pool-cleared-error.json
@@ -1,0 +1,307 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.9",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "pool-cleared-error",
+  "data": [],
+  "tests": [
+    {
+      "description": "PoolClearedError does not mark server unknown",
+      "clientOptions": {
+        "retryWrites": true,
+        "maxPoolSize": 1,
+        "appname": "poolClearedErrorTest"
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        },
+        {
+          "name": "configureFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "blockConnection": true,
+                "blockTimeMS": 100,
+                "closeConnection": true,
+                "appName": "poolClearedErrorTest"
+              }
+            }
+          }
+        },
+        {
+          "name": "startThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread1"
+          }
+        },
+        {
+          "name": "startThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread2"
+          }
+        },
+        {
+          "name": "startThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread3"
+          }
+        },
+        {
+          "name": "startThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread4"
+          }
+        },
+        {
+          "name": "startThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread5"
+          }
+        },
+        {
+          "name": "startThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread6"
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread1",
+            "operation": {
+              "name": "insertOne",
+              "object": "collection",
+              "arguments": {
+                "document": {
+                  "_id": 2
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread2",
+            "operation": {
+              "name": "insertOne",
+              "object": "collection",
+              "arguments": {
+                "document": {
+                  "_id": 3
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread3",
+            "operation": {
+              "name": "insertOne",
+              "object": "collection",
+              "arguments": {
+                "document": {
+                  "_id": 4
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread4",
+            "operation": {
+              "name": "insertOne",
+              "object": "collection",
+              "arguments": {
+                "document": {
+                  "_id": 5
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread5",
+            "operation": {
+              "name": "insertOne",
+              "object": "collection",
+              "arguments": {
+                "document": {
+                  "_id": 6
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread6",
+            "operation": {
+              "name": "insertOne",
+              "object": "collection",
+              "arguments": {
+                "document": {
+                  "_id": 7
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread1"
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread2"
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread3"
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread4"
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread5"
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "name": "thread6"
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 8
+            }
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            },
+            {
+              "_id": 5
+            },
+            {
+              "_id": 6
+            },
+            {
+              "_id": 7
+            },
+            {
+              "_id": 8
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractUnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractUnifiedTest.java
@@ -48,6 +48,7 @@ import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
+import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.Document;
@@ -80,6 +81,7 @@ import static com.mongodb.client.CommandMonitoringTestHelper.assertEventsEqualit
 import static com.mongodb.client.CommandMonitoringTestHelper.getExpectedEvents;
 import static com.mongodb.client.Fixture.getMongoClient;
 import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
+import static java.lang.Math.toIntExact;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -208,7 +210,8 @@ public abstract class AbstractUnifiedTest {
                 .applyToSocketSettings(new Block<SocketSettings.Builder>() {
                     @Override
                     public void apply(final SocketSettings.Builder builder) {
-                        builder.readTimeout(5, SECONDS);
+                        builder.readTimeout(clientOptions.getInt32(
+                                "socketTimeoutMS", new BsonInt32(toIntExact(SECONDS.toMillis(5)))).getValue(), MILLISECONDS);
                         if (clientOptions.containsKey("connectTimeoutMS")) {
                             builder.connectTimeout(clientOptions.getNumber("connectTimeoutMS").intValue(), MILLISECONDS);
                         }


### PR DESCRIPTION
This PR synchronizes [`server-discovery-and-monitoring/tests/integration`](https://github.com/mongodb/specifications/tree/master/source/server-discovery-and-monitoring/tests/integration) tests (as per [JAVA-4028](https://jira.mongodb.org/browse/JAVA-4028)), which also includes changes from JAVA-4139, with accordance to the "has to be finished together with" link in Jira. The only test excluded from the synchronization is [`rediscover-quickly-after-step-down.json`](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.json). The reason is that there was made a conscious decision to introduce a discrepancy between the original specification tests and their copy in the Java driver repo by ignoring changes in [DRIVERS-1290](https://jira.mongodb.org/browse/DRIVERS-1290) (see [JAVA-3765](https://jira.mongodb.org/browse/JAVA-3765)), and we will have to live with and continue bumping into it.

I did not discover new behavior that we need to add to the Java driver as a result of the changes in [DRIVERS-1476](https://jira.mongodb.org/browse/DRIVERS-1476) (a task that caused [JAVA-4028](https://jira.mongodb.org/browse/JAVA-4028)).

JAVA-4028