### PR TITLE
Run serverless tests against a load balancer

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -259,6 +259,7 @@ functions:
           SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
           SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
           SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
+          LOADBALANCED=ON \
             bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
     - command: expansions.update
       params:
@@ -325,7 +326,8 @@ functions:
         script: |
           ${PREPARE_SHELL}
           JDK="${JDK}" \
-          MONGODB_URI="${MONGODB_URI}" \
+          SINGLE_ATLASPROXY_SERVERLESS_URI="${SINGLE_ATLASPROXY_SERVERLESS_URI}" \
+          MULTI_ATLASPROXY_SERVERLESS_URI="${MULTI_ATLASPROXY_SERVERLESS_URI}" \
           SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}" \
           SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}" \
             .evergreen/run-serverless-tests.sh

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -21,14 +21,11 @@ echo "Running serverless tests with ${JDK}"
 
 export JAVA_HOME="/opt/java/jdk11"
 
-MONGODB_URI_SINGLE_HOST=${MONGODB_URI%%,*}
-SINGLE_HOST=${MONGODB_URI_SINGLE_HOST:10}
-
-MONGODB_URI_FINAL="mongodb://${SERVERLESS_ATLAS_USER}:${SERVERLESS_ATLAS_PASSWORD}@${SINGLE_HOST}/?tls=true"
-
-echo ${MONGODB_URI_FINAL}
+# assume "mongodb" protocol for single server, and "mongodb+srv" protocol for multi server
+SINGLE_SERVER_URI="mongodb://${SERVERLESS_ATLAS_USER}:${SERVERLESS_ATLAS_PASSWORD}@${SINGLE_ATLASPROXY_SERVERLESS_URI:10}"
+MULTI_SERVER_URI="mongodb+srv://${SERVERLESS_ATLAS_USER}:${SERVERLESS_ATLAS_PASSWORD}@${MULTI_ATLASPROXY_SERVERLESS_URI:14}"
 
 ./gradlew -version
 
-./gradlew -PjdkHome=/opt/java/${JDK} -Dorg.mongodb.test.uri=${MONGODB_URI_FINAL} -Dorg.mongodb.test.serverless=true \
-   --stacktrace --info --continue driver-sync:test
+./gradlew -PjdkHome=/opt/java/${JDK} -Dorg.mongodb.test.uri=${SINGLE_SERVER_URI}  -Dorg.mongodb.test.transaction.uri=${MULTI_SERVER_URI} \
+   -Dorg.mongodb.test.serverless=true --stacktrace --info --continue driver-sync:test

--- a/driver-core/src/test/resources/unified-test-format/load-balancers/cursors.json
+++ b/driver-core/src/test/resources/unified-test-format/load-balancers/cursors.json
@@ -902,6 +902,11 @@
     },
     {
       "description": "listCollections pins the cursor to a connection",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "listCollections",
@@ -991,6 +996,11 @@
     },
     {
       "description": "listIndexes pins the cursor to a connection",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "createIndex",
@@ -1151,6 +1161,11 @@
     },
     {
       "description": "change streams pin to a connection",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "createChangeStream",

--- a/driver-core/src/test/resources/unified-test-format/load-balancers/sdam-error-handling.json
+++ b/driver-core/src/test/resources/unified-test-format/load-balancers/sdam-error-handling.json
@@ -127,6 +127,11 @@
   "tests": [
     {
       "description": "only connections for a specific serviceId are closed when pools are cleared",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "createFindCursor",
@@ -255,7 +260,7 @@
       ]
     },
     {
-      "description": "errors during the initial connection hello are ignore",
+      "description": "errors during the initial connection hello are ignored",
       "runOnRequirements": [
         {
           "minServerVersion": "4.9"
@@ -274,7 +279,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "closeConnection": true,
                 "appName": "lbSDAMErrorTestClient"

--- a/driver-core/src/test/resources/unified-test-format/load-balancers/transactions.json
+++ b/driver-core/src/test/resources/unified-test-format/load-balancers/transactions.json
@@ -607,6 +607,11 @@
     },
     {
       "description": "pinned connection is released after a transient non-network CRUD error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -715,6 +720,11 @@
     },
     {
       "description": "pinned connection is released after a transient network CRUD error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -831,6 +841,11 @@
     },
     {
       "description": "pinned connection is released after a transient non-network commit error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/driver-sync/src/test/functional/com/mongodb/client/Fixture.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/Fixture.java
@@ -16,13 +16,11 @@
 
 package com.mongodb.client;
 
-import com.mongodb.Block;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.internal.MongoClientImpl;
 import com.mongodb.connection.ServerDescription;
-import com.mongodb.connection.ServerSettings;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/driver-sync/src/test/functional/com/mongodb/client/InitialDnsSeedlistDiscoveryTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/InitialDnsSeedlistDiscoveryTest.java
@@ -191,7 +191,7 @@ public class InitialDnsSeedlistDiscoveryTest {
     @Test
     public void shouldDiscoverSrvRecord() throws InterruptedException {
         assumeFalse(isServerlessTest());
-        
+
         if (seeds.isEmpty()) {
             return;
         }

--- a/driver-sync/src/test/functional/com/mongodb/client/InitialDnsSeedlistDiscoveryTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/InitialDnsSeedlistDiscoveryTest.java
@@ -56,9 +56,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.mongodb.ClusterFixture.getSslSettings;
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isLoadBalanced;
+import static com.mongodb.ClusterFixture.isServerlessTest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 // See https://github.com/mongodb/specifications/tree/master/source/initial-dns-seedlist-discovery/tests
@@ -188,6 +190,8 @@ public class InitialDnsSeedlistDiscoveryTest {
 
     @Test
     public void shouldDiscoverSrvRecord() throws InterruptedException {
+        assumeFalse(isServerlessTest());
+        
         if (seeds.isEmpty()) {
             return;
         }

--- a/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeoutException;
 
 import static com.mongodb.ClusterFixture.getServerStatus;
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
+import static com.mongodb.ClusterFixture.isServerlessTest;
 import static com.mongodb.ClusterFixture.isSharded;
 import static com.mongodb.ClusterFixture.isStandalone;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
@@ -54,6 +55,7 @@ import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -117,6 +119,7 @@ public class RetryableWritesProseTest extends DatabaseTestCase {
             final Function<MongoCollection<Document>, R> operation, final String operationName, final boolean write)
             throws InterruptedException, ExecutionException, TimeoutException {
         assumeTrue(serverVersionAtLeast(4, 3) && !(write && isStandalone()));
+        assumeFalse(isServerlessTest());
         TestConnectionPoolListener connectionPoolListener = new TestConnectionPoolListener(asList(
                 "connectionCheckedOutEvent",
                 "poolClearedEvent",

--- a/driver-sync/src/test/functional/com/mongodb/client/ServerDiscoveryAndMonitoringProseTests.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ServerDiscoveryAndMonitoringProseTests.java
@@ -168,6 +168,7 @@ public class ServerDiscoveryAndMonitoringProseTests {
     @SuppressWarnings("try")
     public void testConnectionPoolManagement() throws InterruptedException {
         assumeTrue(serverVersionAtLeast(4, 3));
+        assumeFalse(isServerlessTest());
         BlockingQueue<Object> events = new SynchronousQueue<>(true);
         ServerMonitorListener serverMonitorListener = new ServerMonitorListener() {
             @Override


### PR DESCRIPTION
JAVA-4279

I disabled a few prose spec tests that don't properly run in serverless.  I think some of them could be made to run given the time none of them seem like they are testing anything that is necessary to prove serverless is working.

There is also one change to the unified test runner, which required a change to the Fixture class.  I'll discuss that in an inline comment.