### PR TITLE
Update performance benchmarks to use perf.send

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -769,9 +769,8 @@ functions:
           PROJECT_DIRECTORY=${PROJECT_DIRECTORY} .evergreen/run-perf-tests.sh
 
   "send dashboard data":
-    - command: json.send
+    - command: perf.send
       params:
-        name: perf
         file: src/results.json
 
 # Anchors

--- a/driver-benchmarks/src/main/com/mongodb/benchmark/framework/EvergreenBenchmarkResultWriter.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/framework/EvergreenBenchmarkResultWriter.java
@@ -22,40 +22,44 @@ import org.bson.json.JsonWriterSettings;
 
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.Writer;
+import java.io.StringWriter;
 
 public class EvergreenBenchmarkResultWriter implements BenchmarkResultWriter {
 
     private static final String OUTPUT_FILE_SYSTEM_PROPERTY = "org.mongodb.benchmarks.output";
 
-    private final Writer writer;
+    private final StringWriter writer;
     private final JsonWriter jsonWriter;
 
     public EvergreenBenchmarkResultWriter()  {
-        try {
-            writer = new FileWriter(System.getProperty(OUTPUT_FILE_SYSTEM_PROPERTY));
-            jsonWriter = new JsonWriter(writer,
-                    JsonWriterSettings.builder().outputMode(JsonMode.RELAXED).indent(true).build());;
-            jsonWriter.writeStartDocument();
-            jsonWriter.writeStartArray("results");
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        writer = new StringWriter();
+        jsonWriter = new JsonWriter(writer, JsonWriterSettings.builder().outputMode(JsonMode.RELAXED).indent(true).build());
+        jsonWriter.writeStartDocument();
+        jsonWriter.writeStartArray("results");
     }
 
     @Override
     public void write(final BenchmarkResult benchmarkResult) {
         jsonWriter.writeStartDocument();
-        jsonWriter.writeString("name", benchmarkResult.getName());
-        jsonWriter.writeStartDocument("results");
-        jsonWriter.writeStartDocument("1");
 
-        jsonWriter.writeDouble("ops_per_sec",
+        jsonWriter.writeStartDocument("info");
+        jsonWriter.writeString("test_name", benchmarkResult.getName());
+
+        jsonWriter.writeStartDocument("args");
+        jsonWriter.writeInt32("threads", 1);
+        jsonWriter.writeEndDocument();
+        jsonWriter.writeEndDocument();
+
+        jsonWriter.writeStartArray("metrics");
+
+        jsonWriter.writeStartDocument();
+        jsonWriter.writeString("name","ops_per_sec" );
+        jsonWriter.writeDouble("value",
                 (benchmarkResult.getBytesPerIteration() / 1000000d) /
                         (benchmarkResult.getElapsedTimeNanosAtPercentile(50) / 1000000000d));
+        jsonWriter.writeEndDocument();
 
-        jsonWriter.writeEndDocument();
-        jsonWriter.writeEndDocument();
+        jsonWriter.writeEndArray();
         jsonWriter.writeEndDocument();
     }
 
@@ -63,12 +67,16 @@ public class EvergreenBenchmarkResultWriter implements BenchmarkResultWriter {
     public void close() throws IOException {
         jsonWriter.writeEndArray();
         jsonWriter.writeEndDocument();
-        jsonWriter.close();
-        writer.close();
-        System.out.println("DONE");
+
+        try (FileWriter fileWriter = new FileWriter(System.getProperty(OUTPUT_FILE_SYSTEM_PROPERTY))) {
+            fileWriter.write(getJsonResultsArrayFromJsonDocument());
+        }
     }
 
-    public String getResults() {
-        return writer.toString();
+    private String getJsonResultsArrayFromJsonDocument() {
+        String jsonDocument = writer.toString();
+        int startArrayIndex = jsonDocument.indexOf('[');
+        int endArrayIndex = jsonDocument.lastIndexOf(']');
+        return writer.toString().substring(startArrayIndex, endArrayIndex + 1) + "\n";
     }
 }


### PR DESCRIPTION
Evergreen had deprecated json.send in favor of perf.send. See
https://github.com/evergreen-ci/evergreen/wiki/Project-Commands#perf-send.

JAVA-4323