### PR TITLE
Rename test system property to better reflect its current usage

### DIFF
--- a/.evergreen/run-load-balancer-tests.sh
+++ b/.evergreen/run-load-balancer-tests.sh
@@ -48,7 +48,7 @@ set +o errexit
 
 ./gradlew -PjdkHome=/opt/java/${JDK} \
   -Dorg.mongodb.test.uri=${SINGLE_MONGOS_LB_URI} \
-  -Dorg.mongodb.test.transaction.uri=${MULTI_MONGOS_LB_URI} \
+  -Dorg.mongodb.test.multi.mongos.uri=${MULTI_MONGOS_LB_URI} \
   ${GRADLE_EXTRA_VARS} --stacktrace --info --continue driver-sync:test \
   --tests LoadBalancerTest \
   --tests RetryableReadsTest \
@@ -63,7 +63,7 @@ echo $first
 
 ./gradlew -PjdkHome=/opt/java/${JDK} \
   -Dorg.mongodb.test.uri=${SINGLE_MONGOS_LB_URI} \
-  -Dorg.mongodb.test.transaction.uri=${MULTI_MONGOS_LB_URI} \
+  -Dorg.mongodb.test.multi.mongos.uri=${MULTI_MONGOS_LB_URI} \
   ${GRADLE_EXTRA_VARS} --stacktrace --info --continue driver-reactive-stream:test \
   --tests LoadBalancerTest \
   --tests RetryableReadsTest \
@@ -78,7 +78,7 @@ echo $second
 
 ./gradlew -PjdkHome=/opt/java/${JDK} \
   -Dorg.mongodb.test.uri=${SINGLE_MONGOS_LB_URI} \
-  -Dorg.mongodb.test.transaction.uri=${MULTI_MONGOS_LB_URI} \
+  -Dorg.mongodb.test.multi.mongos.uri=${MULTI_MONGOS_LB_URI} \
   ${GRADLE_EXTRA_VARS} --stacktrace --info --continue driver-core:test \
   --tests QueryBatchCursorFunctionalSpecification
 third=$?

--- a/.evergreen/run-scala-tests.sh
+++ b/.evergreen/run-scala-tests.sh
@@ -28,10 +28,10 @@ if [ "$AUTH" != "noauth" ]; then
 fi
 
 if [ "$SAFE_FOR_MULTI_MONGOS" == "true" ]; then
-    export TRANSACTION_URI="-Dorg.mongodb.test.transaction.uri=${MONGODB_URI}"
+    export MULTI_MONGOS_URI_SYSTEM_PROPERTY="-Dorg.mongodb.test.multi.mongos.uri=${MONGODB_URI}"
 fi
 
 echo "Running scala tests with Scala $SCALA"
 
 ./gradlew -version
-./gradlew -PscalaVersion=$SCALA --stacktrace --info :bson-scala:test :driver-scala:test :driver-scala:integrationTest -Dorg.mongodb.test.uri=${MONGODB_URI} ${TRANSACTION_URI}
+./gradlew -PscalaVersion=$SCALA --stacktrace --info :bson-scala:test :driver-scala:test :driver-scala:integrationTest -Dorg.mongodb.test.uri=${MONGODB_URI} ${MULTI_MONGOS_URI_SYSTEM_PROPERTY}

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -27,5 +27,5 @@ MULTI_SERVER_URI="mongodb+srv://${SERVERLESS_ATLAS_USER}:${SERVERLESS_ATLAS_PASS
 
 ./gradlew -version
 
-./gradlew -PjdkHome=/opt/java/${JDK} -Dorg.mongodb.test.uri=${SINGLE_SERVER_URI}  -Dorg.mongodb.test.transaction.uri=${MULTI_SERVER_URI} \
+./gradlew -PjdkHome=/opt/java/${JDK} -Dorg.mongodb.test.uri=${SINGLE_SERVER_URI}  -Dorg.mongodb.test.multi.mongos.uri=${MULTI_SERVER_URI} \
    -Dorg.mongodb.test.serverless=true --stacktrace --info --continue driver-sync:test

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -62,12 +62,12 @@ provision_ssl () {
   if [ "$AUTH" != "noauth" ] || [ "$TOPOLOGY" == "replica_set" ]; then
     export MONGODB_URI="${MONGODB_URI}&ssl=true&sslInvalidHostNameAllowed=true"
     if [ "$SAFE_FOR_MULTI_MONGOS" == "true" ]; then
-        export TRANSACTION_URI="${TRANSACTION_URI}&ssl=true&sslInvalidHostNameAllowed=true"
+        export MULTI_MONGOS_URI="${MULTI_MONGOS_URI}&ssl=true&sslInvalidHostNameAllowed=true"
     fi
   else
     export MONGODB_URI="${MONGODB_URI}/?ssl=true&sslInvalidHostNameAllowed=true"
     if [ "$SAFE_FOR_MULTI_MONGOS" == "true" ]; then
-        export TRANSACTION_URI="${TRANSACTION_URI}/?ssl=true&sslInvalidHostNameAllowed=true"
+        export MULTI_MONGOS_URI="${MULTI_MONGOS_URI}/?ssl=true&sslInvalidHostNameAllowed=true"
     fi
   fi
 }
@@ -80,9 +80,9 @@ provision_ssl () {
 if [ "$TOPOLOGY" == "sharded_cluster" ]; then
     if [ "$SAFE_FOR_MULTI_MONGOS" == "true" ]; then
         if [ "$AUTH" = "auth" ]; then
-            export TRANSACTION_URI="mongodb://bob:pwd123@localhost:27017,localhost:27018/?authSource=admin"
+            export MULTI_MONGOS_URI="mongodb://bob:pwd123@localhost:27017,localhost:27018/?authSource=admin"
         else
-            export TRANSACTION_URI="${MONGODB_URI}"
+            export MULTI_MONGOS_URI="${MONGODB_URI}"
         fi
     fi
 
@@ -101,10 +101,10 @@ if [ "$COMPRESSOR" != "" ]; then
      fi
 
      if [ "$SAFE_FOR_MULTI_MONGOS" == "true" ]; then
-         if [[ "$TRANSACTION_URI" == *"?"* ]]; then
-             export TRANSACTION_URI="${TRANSACTION_URI}&compressors=${COMPRESSOR}"
+         if [[ "$MULTI_MONGOS_URI" == *"?"* ]]; then
+             export MULTI_MONGOS_URI="${MULTI_MONGOS_URI}&compressors=${COMPRESSOR}"
          else
-             export TRANSACTION_URI="${TRANSACTION_URI}/?compressors=${COMPRESSOR}"
+             export MULTI_MONGOS_URI="${MULTI_MONGOS_URI}/?compressors=${COMPRESSOR}"
          fi
      fi
 fi
@@ -114,7 +114,7 @@ if [ "$SSL" != "nossl" ]; then
 fi
 
 if [ "$SAFE_FOR_MULTI_MONGOS" == "true" ]; then
-    export TRANSACTION_URI="-Dorg.mongodb.test.transaction.uri=${TRANSACTION_URI}"
+    export MULTI_MONGOS_URI_SYSTEM_PROPERTY="-Dorg.mongodb.test.multi.mongos.uri=${MULTI_MONGOS_URI}"
 fi
 
 # For now it's sufficient to hard-code the API version to "1", since it's the only API version
@@ -129,7 +129,7 @@ echo "Running tests with ${JDK}"
 
 if [ "$SLOW_TESTS_ONLY" == "true" ]; then
     ./gradlew -PjdkHome=/opt/java/${JDK} -Dorg.mongodb.test.uri=${MONGODB_URI} \
-              ${TRANSACTION_URI} ${GRADLE_EXTRA_VARS} ${ASYNC_TYPE} \
+              ${MULTI_MONGOS_URI_SYSTEM_PROPERTY} ${GRADLE_EXTRA_VARS} ${ASYNC_TYPE} \
               ${JAVA_SYSPROP_NETTY_SSL_PROVIDER} \
               --stacktrace --info testSlowOnly
 else
@@ -138,7 +138,7 @@ else
               -Dorg.mongodb.test.tmpAwsAccessKeyId=${AWS_TEMP_ACCESS_KEY_ID} -Dorg.mongodb.test.tmpAwsSecretAccessKey=${AWS_TEMP_SECRET_ACCESS_KEY} -Dorg.mongodb.test.tmpAwsSessionToken=${AWS_TEMP_SESSION_TOKEN} \
               -Dorg.mongodb.test.azureTenantId=${AZURE_TENANT_ID} -Dorg.mongodb.test.azureClientId=${AZURE_CLIENT_ID} -Dorg.mongodb.test.azureClientSecret=${AZURE_CLIENT_SECRET} \
               -Dorg.mongodb.test.gcpEmail=${GCP_EMAIL} -Dorg.mongodb.test.gcpPrivateKey=${GCP_PRIVATE_KEY} \
-              ${TRANSACTION_URI} ${API_VERSION} ${GRADLE_EXTRA_VARS} ${ASYNC_TYPE} \
+              ${MULTI_MONGOS_URI_SYSTEM_PROPERTY} ${API_VERSION} ${GRADLE_EXTRA_VARS} ${ASYNC_TYPE} \
               ${JAVA_SYSPROP_NETTY_SSL_PROVIDER} \
               --stacktrace --info --continue test
 fi

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -104,7 +104,7 @@ public final class ClusterFixture {
     public static final String DEFAULT_URI = "mongodb://localhost:27017";
     public static final String MONGODB_URI_SYSTEM_PROPERTY_NAME = "org.mongodb.test.uri";
     public static final String MONGODB_API_VERSION = "org.mongodb.test.api.version";
-    public static final String MONGODB_TRANSACTION_URI_SYSTEM_PROPERTY_NAME = "org.mongodb.test.transaction.uri";
+    public static final String MONGODB_MULTI_MONGOS_URI_SYSTEM_PROPERTY_NAME = "org.mongodb.test.multi.mongos.uri";
     public static final String SERVERLESS_TEST_SYSTEM_PROPERTY_NAME = "org.mongodb.test.serverless";
     public static final String DATA_LAKE_TEST_SYSTEM_PROPERTY_NAME = "org.mongodb.test.data.lake";
     private static final String MONGODB_OCSP_SHOULD_SUCCEED = "org.mongodb.test.ocsp.tls.should.succeed";
@@ -222,7 +222,7 @@ public final class ClusterFixture {
 
     @Nullable
     public static synchronized ConnectionString getMultiMongosConnectionString() {
-        return getConnectionStringFromSystemProperty(MONGODB_TRANSACTION_URI_SYSTEM_PROPERTY_NAME);
+        return getConnectionStringFromSystemProperty(MONGODB_MULTI_MONGOS_URI_SYSTEM_PROPERTY_NAME);
     }
 
     public static boolean isServerlessTest() {

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsTest.java
@@ -126,7 +126,7 @@ public abstract class AbstractRetryableReadsTest {
         if (useMultipleMongoses) {
             assumeTrue(isSharded());
             connectionString = getMultiMongosConnectionString();
-            assumeTrue("The system property org.mongodb.test.transaction.uri is not set.", connectionString != null);
+            assumeTrue("The system property org.mongodb.test.multi.mongos.uri is not set.", connectionString != null);
         }
 
         MongoClientSettings settings = getMongoClientSettingsBuilder()


### PR DESCRIPTION
Rename org.mongodb.test.transaction.uri to org.mongodb.test.multi.mongos.uri,
along with associated shell script variables.

JAVA-4333