### PR TITLE
Add hint string support back to legacy API

### DIFF
--- a/driver-legacy/src/main/com/mongodb/DBCursor.java
+++ b/driver-legacy/src/main/com/mongodb/DBCursor.java
@@ -25,6 +25,7 @@ import com.mongodb.client.model.DBCollectionCountOptions;
 import com.mongodb.client.model.DBCollectionFindOptions;
 import com.mongodb.internal.operation.FindOperation;
 import com.mongodb.lang.Nullable;
+import org.bson.BsonString;
 import org.bson.codecs.Decoder;
 
 import java.util.ArrayList;
@@ -309,6 +310,19 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
     }
 
     /**
+     * Informs the database of an indexed field of the collection in order to improve performance.
+     *
+     * @param indexName the name of an index
+     * @return same DBCursor for chaining operations
+     * @since 4.4
+     * @mongodb.driver.manual reference/operator/meta/hint/ $hint
+     */
+    public DBCursor hint(final String indexName) {
+        findOptions.hintString(indexName);
+        return this;
+    }
+
+    /**
      * Set the maximum execution time for operations on this cursor.
      *
      * @param maxTime  the maximum time that the server will allow the query to run, before killing the operation.
@@ -409,7 +423,10 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
                                                 .sort(collection.wrapAllowNull(findOptions.getSort()))
                                                 .collation(findOptions.getCollation())
                                                 .comment(findOptions.getComment())
-                                                .hint(collection.wrapAllowNull(findOptions.getHint()))
+                                                .hint(findOptions.getHint() != null
+                                                        ? collection.wrapAllowNull(findOptions.getHint())
+                                                        : (findOptions.getHintString() != null
+                                                        ? new BsonString(findOptions.getHintString()) : null))
                                                 .min(collection.wrapAllowNull(findOptions.getMin()))
                                                 .max(collection.wrapAllowNull(findOptions.getMax()))
                                                 .cursorType(findOptions.getCursorType())
@@ -876,6 +893,7 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
                 .readConcern(getReadConcern())
                 .collation(getCollation())
                 .maxTime(findOptions.getMaxTime(MILLISECONDS), MILLISECONDS)
-                .hint(findOptions.getHint());
+                .hint(findOptions.getHint())
+                .hintString(findOptions.getHintString());
     }
 }

--- a/driver-legacy/src/main/com/mongodb/client/model/DBCollectionFindOptions.java
+++ b/driver-legacy/src/main/com/mongodb/client/model/DBCollectionFindOptions.java
@@ -51,6 +51,7 @@ public final class DBCollectionFindOptions {
     private Collation collation;
     private String comment;
     private DBObject hint;
+    private String hintString;
     private DBObject max;
     private DBObject min;
     private boolean returnKey;
@@ -85,6 +86,7 @@ public final class DBCollectionFindOptions {
         copiedOptions.collation(collation);
         copiedOptions.comment(comment);
         copiedOptions.hint(hint);
+        copiedOptions.hintString(hintString);
         copiedOptions.max(max);
         copiedOptions.min(min);
         copiedOptions.returnKey(returnKey);
@@ -458,6 +460,17 @@ public final class DBCollectionFindOptions {
     }
 
     /**
+     * Returns the hint string for the name of the index to use. The default is not to set a hint.
+     *
+     * @return the hint string
+     * @since 4.4
+     */
+    @Nullable
+    public String getHintString() {
+        return hintString;
+    }
+
+    /**
      * Sets the hint for which index to use. A null value means no hint is set.
      *
      * @param hint the hint
@@ -469,6 +482,17 @@ public final class DBCollectionFindOptions {
         return this;
     }
 
+    /**
+     * Sets the hint for the name of the index to use. A null value means no hint is set.
+     *
+     * @param hintString the hint string
+     * @return this
+     * @since 4.4
+     */
+    public DBCollectionFindOptions hintString(@Nullable final String hintString) {
+        this.hintString = hintString;
+        return this;
+    }
     /**
      * Returns the exclusive upper bound for a specific index. By default there is no max bound.
      *

--- a/driver-legacy/src/test/unit/com/mongodb/client/model/DBCollectionCountOptionsSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/client/model/DBCollectionCountOptionsSpecification.groovy
@@ -32,6 +32,7 @@ class DBCollectionCountOptionsSpecification extends Specification {
         then:
         options.getCollation() == null
         options.getHint() == null
+        options.getHintString() == null
         options.getLimit() == 0
         options.getMaxTime(TimeUnit.MILLISECONDS) == 0
         options.getReadConcern() == null
@@ -45,11 +46,13 @@ class DBCollectionCountOptionsSpecification extends Specification {
         def readConcern = ReadConcern.LOCAL
         def readPreference = ReadPreference.nearest()
         def hint = BasicDBObject.parse('{a: 1}')
+        def hintString = 'a_1'
 
         when:
         def options = new DBCollectionCountOptions()
                 .collation(collation)
                 .hint(hint)
+                .hintString(hintString)
                 .limit(1)
                 .maxTime(1, TimeUnit.MILLISECONDS)
                 .readConcern(readConcern)
@@ -59,6 +62,7 @@ class DBCollectionCountOptionsSpecification extends Specification {
         then:
         options.getCollation() == collation
         options.getHint() == hint
+        options.getHintString() == hintString
         options.getLimit() == 1
         options.getMaxTime(TimeUnit.MILLISECONDS) == 1
         options.getReadConcern() == readConcern

--- a/driver-legacy/src/test/unit/com/mongodb/client/model/DBCollectionFindOptionsSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/client/model/DBCollectionFindOptionsSpecification.groovy
@@ -47,6 +47,7 @@ class DBCollectionFindOptionsSpecification extends Specification {
         options.getSort() == null
         options.getComment() == null
         options.getHint() == null
+        options.getHintString() == null
         options.getMax() == null
         options.getMin() == null
         !options.isReturnKey()
@@ -63,6 +64,7 @@ class DBCollectionFindOptionsSpecification extends Specification {
         def readPreference = ReadPreference.nearest()
         def comment = 'comment'
         def hint = BasicDBObject.parse('{x : 1}')
+        def hintString = 'a_1'
         def min = BasicDBObject.parse('{y : 1}')
         def max = BasicDBObject.parse('{y : 100}')
 
@@ -84,6 +86,7 @@ class DBCollectionFindOptionsSpecification extends Specification {
                 .sort(sort)
                 .comment(comment)
                 .hint(hint)
+                .hintString(hintString)
                 .max(max)
                 .min(min)
                 .returnKey(true)
@@ -106,6 +109,7 @@ class DBCollectionFindOptionsSpecification extends Specification {
         options.isPartial()
         options.getComment() == comment
         options.getHint() == hint
+        options.getHintString() == hintString
         options.getMax() == max
         options.getMin() == min
         options.isReturnKey()
@@ -122,6 +126,7 @@ class DBCollectionFindOptionsSpecification extends Specification {
         def readPreference = ReadPreference.nearest()
         def comment = 'comment'
         def hint = BasicDBObject.parse('{x : 1}')
+        def hintString = 'a_1'
         def min = BasicDBObject.parse('{y : 1}')
         def max = BasicDBObject.parse('{y : 100}')
 
@@ -143,6 +148,7 @@ class DBCollectionFindOptionsSpecification extends Specification {
                 .sort(sort)
                 .comment(comment)
                 .hint(hint)
+                .hintString(hintString)
                 .max(max)
                 .min(min)
                 .returnKey(true)
@@ -169,6 +175,7 @@ class DBCollectionFindOptionsSpecification extends Specification {
         options.isPartial()
         options.getComment() == comment
         options.getHint() == hint
+        options.getHintString() == hintString
         options.getMax() == max
         options.getMin() == min
         options.isReturnKey()


### PR DESCRIPTION
* DBCursor.hint(String)
* DBCollectionFindOptions.hintString(String)

These methods were removed in 4.0.  Adding them back to help dependent libraries upgrade to 4.x.

JAVA-4381