### PR TITLE
Write the type of ADTs with only one subclass

### DIFF
--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/MacroCodec.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/MacroCodec.scala
@@ -80,7 +80,7 @@ trait MacroCodec[T] extends Codec[T] {
    * The field used to save the class name when saving sealed case classes.
    */
   val classFieldName = "_t"
-  lazy val hasClassFieldName: Boolean = caseClassesMap.size > 1
+  lazy val hasClassFieldName: Boolean = caseClassesMapInv.keySet != Set(encoderClass)
   lazy val caseClassesMapInv: Map[Class[_], String] = caseClassesMap.map(_.swap)
   protected val registry: CodecRegistry =
     CodecRegistries.fromRegistries(List(codecRegistry, CodecRegistries.fromCodecs(this)).asJava)

--- a/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
+++ b/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
@@ -179,6 +179,15 @@ class MacrosSpec extends BaseSpec {
   case class SealedTraitB(intField: Int) extends SealedTrait
   case class ContainsSealedTrait(list: List[SealedTrait])
 
+  sealed class SingleSealedClass
+  case class SingleSealedClassImpl() extends SingleSealedClass
+
+  sealed abstract class SingleSealedAbstractClass
+  case class SingleSealedAbstractClassImpl() extends SingleSealedAbstractClass
+
+  sealed trait SingleSealedTrait
+  case class SingleSealedTraitImpl() extends SingleSealedTrait
+
   object CaseObjectEnumCodecProvider extends CodecProvider {
     def isCaseObjectEnum[T](clazz: Class[T]): Boolean = {
       clazz.isInstance(CaseObjectEnum.Alpha) || clazz.isInstance(CaseObjectEnum.Bravo) || clazz.isInstance(
@@ -518,6 +527,16 @@ class MacrosSpec extends BaseSpec {
       classOf[ContainsNestedSeqADT],
       classOf[Tree]
     )
+  }
+
+  it should "write the type of sealed classes and traits with only one subclass" in {
+    roundTrip(SingleSealedClassImpl(), """{ "_t" : "SingleSealedClassImpl" }""".stripMargin, classOf[SingleSealedClass])
+    roundTrip(
+      SingleSealedAbstractClassImpl(),
+      """{ "_t" : "SingleSealedAbstractClassImpl" }""".stripMargin,
+      classOf[SingleSealedAbstractClass]
+    )
+    roundTrip(SingleSealedTraitImpl(), """{ "_t" : "SingleSealedTraitImpl" }""".stripMargin, classOf[SingleSealedTrait])
   }
 
   it should "support optional values in ADT sealed classes" in {


### PR DESCRIPTION
Original PR: mongodb/mongo-scala-driver#67

JAVA-4300