### PR TITLE
Add MongoCursor#available

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/BatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/BatchCursor.java
@@ -66,6 +66,13 @@ public interface BatchCursor<T> extends Iterator<List<T>>, Closeable {
     List<T> next();
 
     /**
+     * Gets the number of results available locally without blocking,which may be 0, or 0 when the cursor is exhausted or closed.
+     *
+     * @return the number of results available locally without blocking
+     */
+    int available();
+
+    /**
      * Sets the batch size to use when requesting the next batch.  This is the number of documents to request in the next batch.
      *
      * @param batchSize the non-negative batch size.  0 means to use the server default.

--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursor.java
@@ -94,6 +94,11 @@ final class ChangeStreamBatchCursor<T> implements AggregateResponseBatchCursor<T
     }
 
     @Override
+    public int available() {
+        return wrapped.available();
+    }
+
+    @Override
     public List<T> tryNext() {
         return resumeableOperation(new Function<AggregateResponseBatchCursor<RawBsonDocument>, List<T>>() {
             @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
@@ -423,6 +423,11 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
         }
 
         @Override
+        public int available() {
+            return delegate.available();
+        }
+
+        @Override
         public void setBatchSize(final int batchSize) {
             delegate.setBatchSize(batchSize);
         }

--- a/driver-core/src/main/com/mongodb/internal/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/QueryBatchCursor.java
@@ -171,6 +171,11 @@ class QueryBatchCursor<T> implements AggregateResponseBatchCursor<T> {
         return assertNotNull(resourceManager.execute(MESSAGE_IF_CLOSED_AS_ITERATOR, this::doNext));
     }
 
+    @Override
+    public int available() {
+        return !resourceManager.operable() || nextBatch == null ? 0 : nextBatch.size();
+    }
+
     private List<T> doNext() {
         if (!doHasNext()) {
             throw new NoSuchElementException();

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/QueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/QueryBatchCursorFunctionalSpecification.groovy
@@ -554,6 +554,53 @@ class QueryBatchCursorFunctionalSpecification extends OperationFunctionalSpecifi
         }
     }
 
+    def 'should report available documents'() {
+        given:
+        def firstBatch = executeQuery(3)
+
+        when:
+        cursor = new QueryBatchCursor<Document>(firstBatch, 0, 2, new DocumentCodec(), connectionSource)
+
+        then:
+        cursor.available() == 3
+
+        when:
+        cursor.hasNext()
+
+        then:
+        cursor.available() == 3
+
+        when:
+        cursor.next()
+
+        then:
+        cursor.available() == 0
+
+        when:
+        cursor.hasNext()
+
+        then:
+        cursor.available() == 2
+
+        when:
+        cursor.next()
+
+        then:
+        cursor.available() == 0
+
+        when:
+        cursor.hasNext()
+
+        then:
+        cursor.available() == 2
+
+        when:
+        cursor.close()
+
+        then:
+        cursor.available() == 0
+    }
+
     private QueryResult<Document> executeQuery() {
         executeQuery(0)
     }

--- a/driver-legacy/src/test/functional/com/mongodb/DBCursorFunctionalSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCursorFunctionalSpecification.groovy
@@ -232,6 +232,11 @@ class DBCursorFunctionalSpecification extends FunctionalSpecification {
                     List<DBObject> next() { null }
 
                     @Override
+                    int available() {
+                        0
+                    }
+
+                    @Override
                     void setBatchSize(final int batchSize) { }
 
                     @Override

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncChangeStreamIterable.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncChangeStreamIterable.java
@@ -66,6 +66,11 @@ class SyncChangeStreamIterable<T> extends SyncMongoIterable<ChangeStreamDocument
             }
 
             @Override
+            public int available() {
+                return wrapped.available();
+            }
+
+            @Override
             public ChangeStreamDocument<T> tryNext() {
                 return wrapped.tryNext();
             }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCursor.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCursor.java
@@ -149,6 +149,11 @@ class SyncMongoCursor<T> implements MongoCursor<T> {
     }
 
     @Override
+    public int available() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void remove() {
         throw new UnsupportedOperationException();
     }

--- a/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncChangeStreamIterable.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncChangeStreamIterable.scala
@@ -36,6 +36,7 @@ case class SyncChangeStreamIterable[T](wrapped: ChangeStreamObservable[T])
       def close(): Unit = wrapped.close()
       def hasNext: Boolean = wrapped.hasNext
       def next: ChangeStreamDocument[T] = wrapped.next
+      override def available(): Int = wrapped.available
       def tryNext: ChangeStreamDocument[T] = wrapped.tryNext
       def getServerCursor: ServerCursor = wrapped.getServerCursor
       def getServerAddress: ServerAddress = wrapped.getServerAddress

--- a/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncChangeStreamIterable.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncChangeStreamIterable.scala
@@ -36,7 +36,7 @@ case class SyncChangeStreamIterable[T](wrapped: ChangeStreamObservable[T])
       def close(): Unit = wrapped.close()
       def hasNext: Boolean = wrapped.hasNext
       def next: ChangeStreamDocument[T] = wrapped.next
-      override def available(): Int = wrapped.available
+      def available(): Int = wrapped.available
       def tryNext: ChangeStreamDocument[T] = wrapped.tryNext
       def getServerCursor: ServerCursor = wrapped.getServerCursor
       def getServerAddress: ServerAddress = wrapped.getServerAddress

--- a/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncMongoCursor.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncMongoCursor.scala
@@ -89,6 +89,8 @@ case class SyncMongoCursor[T](val observable: Observable[T]) extends MongoCursor
     retVal
   }
 
+  override def available(): Int = throw new UnsupportedOperationException
+
   override def remove(): Unit = throw new UnsupportedOperationException
 
   def tryNext = throw new UnsupportedOperationException // No good way to fulfill this contract with a Publisher<T>

--- a/driver-sync/src/main/com/mongodb/client/MongoCursor.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoCursor.java
@@ -58,6 +58,14 @@ public interface MongoCursor<TResult> extends Iterator<TResult>, Closeable {
     TResult next();
 
     /**
+     * Gets the number of results available locally without blocking,which may be 0, or 0 when the cursor is exhausted or closed.
+     *
+     * @return the number of results available locally without blocking
+     * @since 4.4
+     */
+    int available();
+
+    /**
      * A special {@code next()} case that returns the next element in the iteration if available or null.
      *
      * <p>Tailable cursors are an example where this is useful. A call to {@code tryNext()} may return null, but in the future calling

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoBatchCursorAdapter.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoBatchCursorAdapter.java
@@ -67,6 +67,15 @@ public class MongoBatchCursorAdapter<T> implements MongoCursor<T> {
         return getNextInBatch();
     }
 
+    @Override
+    public int available() {
+        int available = batchCursor.available();
+        if (curBatch != null) {
+            available += (curBatch.size() - curPos);
+        }
+        return available;
+    }
+
     @Nullable
     @Override
     public T tryNext() {

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoChangeStreamCursorImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoChangeStreamCursorImpl.java
@@ -71,6 +71,15 @@ public class MongoChangeStreamCursorImpl<T> implements MongoChangeStreamCursor<T
         return getNextInBatch();
     }
 
+    @Override
+    public int available() {
+        int available = batchCursor.available();
+        if (curBatch != null) {
+            available += (curBatch.size() - curPos);
+        }
+        return available;
+    }
+
     @Nullable
     @Override
     public T tryNext() {

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoMappingCursor.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoMappingCursor.java
@@ -48,6 +48,11 @@ class MongoMappingCursor<T, U> implements MongoCursor<U> {
         return mapper.apply(proxied.next());
     }
 
+    @Override
+    public int available() {
+        return proxied.available();
+    }
+
     @Nullable
     @Override
     public U tryNext() {

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoBatchCursorAdapterSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoBatchCursorAdapterSpecification.groovy
@@ -118,4 +118,70 @@ class MongoBatchCursorAdapterSpecification extends Specification {
         cursor.tryNext() == secondBatch[0]
         cursor.tryNext() == null
     }
+
+    def 'should report available documents'() {
+        given:
+        def firstBatch = [new Document('x', 1), new Document('x', 1)]
+        def secondBatch = [new Document('x', 2)]
+
+        def batchCursor = Stub(BatchCursor)
+
+        batchCursor.hasNext() >>> [true, true, true, true, false]
+        batchCursor.next() >>> [firstBatch, secondBatch]
+        batchCursor.available() >>> [2, 2, 0, 0, 0, 1, 0, 0, 0]
+
+        when:
+        def cursor = new MongoBatchCursorAdapter(batchCursor)
+
+        then:
+        cursor.available() == 2
+
+        when:
+        cursor.hasNext()
+
+        then:
+        cursor.available() == 2
+
+        when:
+        cursor.next()
+
+        then:
+        cursor.available() == 1
+
+        when:
+        cursor.hasNext()
+
+        then:
+        cursor.available() == 1
+
+        when:
+        cursor.next()
+
+        then:
+        cursor.available() == 0
+
+        when:
+        cursor.hasNext()
+
+        then:
+        cursor.available() == 1
+
+        when:
+        cursor.next()
+
+        then:
+        cursor.available() == 0    // fail
+
+        when:
+        cursor.hasNext()
+
+        then:
+        cursor.available() == 0
+
+        when:
+        cursor.close()
+
+        then:
+        cursor.available() == 0
+    }
 }

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoChangeStreamCursorSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoChangeStreamCursorSpecification.groovy
@@ -200,4 +200,72 @@ class MongoChangeStreamCursorSpecification extends Specification {
         cursor.tryNext() == null
         cursor.getResumeToken() == new BsonDocument('_data', new BsonInt32(3))
     }
+
+
+    def 'should report available documents'() {
+        given:
+        def firstBatch = [RawBsonDocument.parse('{ _id: { _data: 1 }, x: 1 }'),
+                          RawBsonDocument.parse('{ _id: { _data: 2 }, x: 1 }')]
+        def secondBatch = [RawBsonDocument.parse('{ _id: { _data: 3 }, x: 2 }')]
+
+        def batchCursor = Stub(AggregateResponseBatchCursor)
+
+        batchCursor.hasNext() >>> [true, true, true, true, false]
+        batchCursor.next() >>> [firstBatch, secondBatch]
+        batchCursor.available() >>> [2, 2, 0, 0, 0, 1, 0, 0, 0]
+
+        when:
+        def cursor = new MongoChangeStreamCursorImpl(batchCursor, new RawBsonDocumentCodec(), new BsonDocument('_data', new BsonInt32(1)))
+
+        then:
+        cursor.available() == 2
+
+        when:
+        cursor.hasNext()
+
+        then:
+        cursor.available() == 2
+
+        when:
+        cursor.next()
+
+        then:
+        cursor.available() == 1
+
+        when:
+        cursor.hasNext()
+
+        then:
+        cursor.available() == 1
+
+        when:
+        cursor.next()
+
+        then:
+        cursor.available() == 0
+
+        when:
+        cursor.hasNext()
+
+        then:
+        cursor.available() == 1
+
+        when:
+        cursor.next()
+
+        then:
+        cursor.available() == 0    // fail
+
+        when:
+        cursor.hasNext()
+
+        then:
+        cursor.available() == 0
+
+        when:
+        cursor.close()
+
+        then:
+        cursor.available() == 0
+    }
 }


### PR DESCRIPTION
JAVA-4167

Putting this in draft review to get feedback on the API, before writing any tests.  I went with adding an `available` method, as mentioned in my last comment on the ticket:

> Maybe instead of a new method to get documents from the cursor, we can have a new method that reports how many are currently available. This would be similar to the java.io.InputStream#available method in the JDK.

Here's what the reporter's code would look like with this API:

```
    public static List<ChangeStreamDocument<Document>> getThingsToDo(MongoCollection<Document> collection) {
        var changeStreamIterable = collection
                .watch()
                .batchSize(100)
                .maxAwaitTime(5000, TimeUnit.MILLISECONDS);

        List<ChangeStreamDocument<Document>> thingsToDo = new ArrayList<>();
        try (var cursor = changeStreamIterable.cursor()) {
            var work = cursor.tryNext();
            if (work == null)
                return Collections.emptyList();

            thingsToDo.add(work);
            while (cursor.available() > 0) {
                // drain everything we've fetched, but don't fetch any more
                thingsToDo.add(cursor.next());
            }

            return thingsToDo;
        }
    }
```

Not bad. I think it's cleaner than the API suggested by the user in that you no longer need an infinite loop.