### PR TITLE
Use CodecRegistry in DocumentCodec for Iterable and Map instances

### DIFF
--- a/bson/src/main/org/bson/Document.java
+++ b/bson/src/main/org/bson/Document.java
@@ -24,6 +24,8 @@ import org.bson.codecs.DocumentCodec;
 import org.bson.codecs.DocumentCodecProvider;
 import org.bson.codecs.Encoder;
 import org.bson.codecs.EncoderContext;
+import org.bson.codecs.IterableCodecProvider;
+import org.bson.codecs.MapCodecProvider;
 import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
@@ -60,7 +62,8 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 public class Document implements Map<String, Object>, Serializable, Bson {
     private static final Codec<Document> DEFAULT_CODEC =
             CodecRegistryHelper.createRegistry(
-                    fromProviders(asList(new ValueCodecProvider(), new BsonValueCodecProvider(), new DocumentCodecProvider())),
+                    fromProviders(asList(new ValueCodecProvider(), new IterableCodecProvider(),
+                            new BsonValueCodecProvider(), new DocumentCodecProvider(), new MapCodecProvider())),
                     UuidRepresentation.STANDARD)
                     .get(Document.class);
 

--- a/bson/src/main/org/bson/codecs/ContainerCodecHelper.java
+++ b/bson/src/main/org/bson/codecs/ContainerCodecHelper.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.Transformer;
+import org.bson.UuidRepresentation;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import java.util.UUID;
+
+/**
+ * Helper methods for Codec implementations for containers, e.g. {@code Map} and {@code Iterable}.
+ */
+final class ContainerCodecHelper {
+
+    static Object readValue(final BsonReader reader, final DecoderContext decoderContext,
+            final BsonTypeCodecMap bsonTypeCodecMap, final UuidRepresentation uuidRepresentation,
+            final CodecRegistry registry, final Transformer valueTransformer) {
+
+        BsonType bsonType = reader.getCurrentBsonType();
+        if (bsonType == BsonType.NULL) {
+            reader.readNull();
+            return null;
+        } else {
+            Codec<?> codec = bsonTypeCodecMap.get(bsonType);
+
+            if (bsonType == BsonType.BINARY && reader.peekBinarySize() == 16) {
+                switch (reader.peekBinarySubType()) {
+                    case 3:
+                        if (uuidRepresentation == UuidRepresentation.JAVA_LEGACY
+                                || uuidRepresentation == UuidRepresentation.C_SHARP_LEGACY
+                                || uuidRepresentation == UuidRepresentation.PYTHON_LEGACY) {
+                            codec = registry.get(UUID.class);
+                        }
+                        break;
+                    case 4:
+                        if (uuidRepresentation == UuidRepresentation.STANDARD) {
+                            codec = registry.get(UUID.class);
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+            return valueTransformer.transform(codec.decode(reader, decoderContext));
+        }
+    }
+
+    private ContainerCodecHelper() {
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/DocumentCodecSpecification.groovy
+++ b/bson/src/test/unit/org/bson/codecs/DocumentCodecSpecification.groovy
@@ -62,7 +62,8 @@ import static org.bson.codecs.configuration.CodecRegistries.fromRegistries
 
 class DocumentCodecSpecification extends Specification {
     static final CodecRegistry REGISTRY = fromRegistries(fromCodecs(new UuidCodec(STANDARD)),
-            fromProviders(asList(new ValueCodecProvider(), new BsonValueCodecProvider(), new DocumentCodecProvider())))
+            fromProviders(asList(new ValueCodecProvider(), new IterableCodecProvider(),
+                    new BsonValueCodecProvider(), new DocumentCodecProvider(), new MapCodecProvider())))
 
     @Shared
     BsonDocument bsonDoc = new BsonDocument()


### PR DESCRIPTION
* Instead of using private methods within DocumentCodec to encode instances
of Iterable and Map, instead look up the Codec in the registry as with
any other instance.
* Instead of using a private method within DocumentCodec to decode BSON arrays,
instead lookup up the Codec in the registry according to the type mapped to
array in the BsonTypeClassMap.

JAVA-3925

I added a second commit as well to deduplicate the horrendous UUID-related code that exists in the three affected Codec implementations.