### PR TITLE
Set automatic module name for the legacy driver

### DIFF
--- a/driver-legacy/build.gradle
+++ b/driver-legacy/build.gradle
@@ -38,3 +38,8 @@ dependencies {
     testImplementation project(':driver-core').sourceSets.test.output
     testImplementation project(':driver-sync').sourceSets.test.output
 }
+
+afterEvaluate {
+    jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.driver.legacy.client'
+    jar.manifest.attributes['Bundle-SymbolicName'] = 'org.mongodb.driver-legacy'
+}


### PR DESCRIPTION
Currently on master the compiled jars manifest for the legacy driver has an automatic module name set to `org.mongodb.mongodb-driver-legacy`. A module name may not contain hyphens. 

This PR changes the module name to `org.mongodb.driver.legacy.client` which is consistent with the sync driver `org.mongodb.driver.sync.client`.