### PR TITLE
Load Zstandard library during connection creation time

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/ZstdCompressor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ZstdCompressor.java
@@ -29,9 +29,11 @@ import java.util.List;
 class ZstdCompressor extends Compressor {
     ZstdCompressor() {
         try {
-            Class.forName("com.github.luben.zstd.Zstd");
+            // Trigger static class initialization so that associated blocking
+            // operations don't happen on `#compress`-invoking threads.
+            Class.forName(Zstd.class.getName());
         } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to initialize Zstd", e);
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/ZstdCompressor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ZstdCompressor.java
@@ -27,6 +27,14 @@ import java.io.InputStream;
 import java.util.List;
 
 class ZstdCompressor extends Compressor {
+    ZstdCompressor() {
+        try {
+            Class.forName("com.github.luben.zstd.Zstd");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     public String getName() {
         return "zstd";

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ZstdCompressorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ZstdCompressorTest.java
@@ -1,0 +1,22 @@
+package com.mongodb.internal.connection;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.luben.zstd.util.Native;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+final class ZstdCompressorTest {
+    @Test
+    void zstdClassInitializer() throws NoSuchFieldException, IllegalAccessException {
+        Field loaded = Native.class.getDeclaredField("loaded");
+        loaded.setAccessible(true);
+        assertFalse((Boolean) loaded.get(null));
+
+        @SuppressWarnings("unused") ZstdCompressor zstdCompressor = new ZstdCompressor();
+        assertTrue((Boolean) loaded.get(null));
+    }
+}


### PR DESCRIPTION
[JAVA-4402](https://jira.mongodb.org/browse/JAVA-4402)

Currently, the Zstandard library loading only happens when `ZstdCompressor#compress` is called. This can be problematic when the caller thread cannot do a blocking call. In our case, it's Netty's event loop thread, and [BlockHound](https://github.com/reactor/BlockHound) throws a `BlockingOperationError`.

This change loads the class when the `ZstdCompressor` instance is created.

Open question: Should I also apply the same pattern for other `Compressor`s?

The stacktrace we get, if that helps:

```
WARN 1 --- [ntLoopGroup-2-3] t.p.r.blockhound.BlockHoundConfigurer    () : reactor.blockhound.BlockingOperationError: Blocking call! java.io.RandomAccessFile#readBytes
	at tech.picnic.reactive.blockhound.PicnicBlockHoundIntegration.onBlockingCall(PicnicBlockHoundIntegration.java:58)
	at reactor.blockhound.BlockHound$Builder.lambda$install$8(BlockHound.java:427)
	at reactor.blockhound.BlockHoundRuntime.checkBlocking(BlockHoundRuntime.java:89)
	at java.base/java.io.RandomAccessFile.readBytes(RandomAccessFile.java)
	at java.base/java.io.RandomAccessFile.read(RandomAccessFile.java:405)
	at org.springframework.boot.loader.data.RandomAccessDataFile$FileAccess.read(RandomAccessDataFile.java:222)
	at org.springframework.boot.loader.data.RandomAccessDataFile$FileAccess.access$400(RandomAccessDataFile.java:205)
	at org.springframework.boot.loader.data.RandomAccessDataFile.read(RandomAccessDataFile.java:117)
	at org.springframework.boot.loader.data.RandomAccessDataFile.read(RandomAccessDataFile.java:102)
	at org.springframework.boot.loader.jar.CentralDirectoryFileHeader.load(CentralDirectoryFileHeader.java:84)
	at org.springframework.boot.loader.jar.CentralDirectoryFileHeader.fromRandomAccessData(CentralDirectoryFileHeader.java:211)
	at org.springframework.boot.loader.jar.JarFileEntries.getEntry(JarFileEntries.java:316)
	at org.springframework.boot.loader.jar.JarFileEntries.getEntry(JarFileEntries.java:301)
	at org.springframework.boot.loader.jar.JarFileEntries.doGetEntry(JarFileEntries.java:289)
	at org.springframework.boot.loader.jar.JarFileEntries.getEntry(JarFileEntries.java:244)
	at org.springframework.boot.loader.jar.JarFileEntries.containsEntry(JarFileEntries.java:200)
	at org.springframework.boot.loader.jar.JarFile.containsEntry(JarFile.java:247)
	at org.springframework.boot.loader.jar.JarURLConnection.get(JarURLConnection.java:263)
	at org.springframework.boot.loader.jar.Handler.openConnection(Handler.java:89)
	at java.base/java.net.URL.openConnection(URL.java:1094)
	at java.base/jdk.internal.loader.URLClassPath$Loader.findResource(URLClassPath.java:618)
	at java.base/jdk.internal.loader.URLClassPath.findResource(URLClassPath.java:295)
	at java.base/java.net.URLClassLoader$2.run(URLClassLoader.java:624)
	at java.base/java.net.URLClassLoader$2.run(URLClassLoader.java:622)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.net.URLClassLoader.findResource(URLClassLoader.java:621)
	at org.springframework.boot.loader.LaunchedURLClassLoader.findResource(LaunchedURLClassLoader.java:100)
	at java.base/java.lang.ClassLoader.getResource(ClassLoader.java:1403)
	at java.base/java.net.URLClassLoader.getResourceAsStream(URLClassLoader.java:290)
	at java.base/java.lang.Class.getResourceAsStream(Class.java:2850)
	at com.github.luben.zstd.util.Native.load(Native.java:82)
	at com.github.luben.zstd.util.Native.load(Native.java:55)
	at com.github.luben.zstd.Zstd.(Zstd.java:13)
	at com.mongodb.internal.connection.ZstdCompressor.compress(ZstdCompressor.java:48)
	at com.mongodb.internal.connection.CompressedMessage.encodeMessageBodyWithMetadata(CompressedMessage.java:49)
	at com.mongodb.internal.connection.RequestMessage.encode(RequestMessage.java:138)
	at com.mongodb.internal.connection.InternalStreamConnection.sendAndReceiveAsync(InternalStreamConnection.java:450)
	at com.mongodb.internal.connection.UsageTrackingInternalConnection.sendAndReceiveAsync(UsageTrackingInternalConnection.java:159)
	at com.mongodb.internal.connection.DefaultConnectionPool$PooledConnection.sendAndReceiveAsync(DefaultConnectionPool.java:640)
	at com.mongodb.internal.connection.CommandProtocolImpl.executeAsync(CommandProtocolImpl.java:87)
	at com.mongodb.internal.connection.DefaultServer$DefaultServerProtocolExecutor.executeAsync(DefaultServer.java:270)
	at com.mongodb.internal.connection.DefaultServerConnection.executeProtocolAsync(DefaultServerConnection.java:230)
	at com.mongodb.internal.connection.DefaultServerConnection.commandAsync(DefaultServerConnection.java:142)
	at com.mongodb.internal.connection.DefaultServerConnection.commandAsync(DefaultServerConnection.java:132)
	at com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsyncWithConnection(CommandOperationHelper.java:432)
	at com.mongodb.internal.operation.FindOperation$2.call(FindOperation.java:702)
	at com.mongodb.internal.operation.OperationHelper$9.onResult(OperationHelper.java:734)
	at com.mongodb.internal.operation.OperationHelper$9.onResult(OperationHelper.java:731)
	at com.mongodb.internal.connection.DefaultServer$1.onResult(DefaultServer.java:116)
	at com.mongodb.internal.connection.DefaultServer$1.onResult(DefaultServer.java:105)
	at com.mongodb.internal.async.ErrorHandlingResultCallback.onResult(ErrorHandlingResultCallback.java:48)
	at com.mongodb.internal.connection.DefaultConnectionPool.lambda$getAsync$0(DefaultConnectionPool.java:174)
	at com.mongodb.internal.connection.DefaultConnectionPool$OpenConcurrencyLimiter.lambda$openAsyncOrGetAvailable$0(DefaultConnectionPool.java:893)
	at com.mongodb.internal.connection.DefaultConnectionPool$PooledConnection.lambda$openAsync$0(DefaultConnectionPool.java:513)
	at com.mongodb.internal.connection.UsageTrackingInternalConnection$1.onResult(UsageTrackingInternalConnection.java:74)
	at com.mongodb.internal.connection.UsageTrackingInternalConnection$1.onResult(UsageTrackingInternalConnection.java:63)
	at com.mongodb.internal.connection.InternalStreamConnection$1.lambda$completed$0(InternalStreamConnection.java:204)
	at com.mongodb.internal.connection.InternalStreamConnectionInitializer.completeConnectionDescriptionInitializationAsync(InternalStreamConnectionInitializer.java:222)
	at com.mongodb.internal.connection.InternalStreamConnectionInitializer.access$300(InternalStreamConnectionInitializer.java:48)
	at com.mongodb.internal.connection.InternalStreamConnectionInitializer$2.onResult(InternalStreamConnectionInitializer.java:116)
	at com.mongodb.internal.connection.InternalStreamConnectionInitializer$2.onResult(InternalStreamConnectionInitializer.java:110)
	at com.mongodb.internal.async.ErrorHandlingResultCallback.onResult(ErrorHandlingResultCallback.java:48)
	at com.mongodb.internal.connection.SaslAuthenticator.verifySaslClientComplete(SaslAuthenticator.java:178)
	at com.mongodb.internal.connection.SaslAuthenticator.access$500(SaslAuthenticator.java:48)
	at com.mongodb.internal.connection.SaslAuthenticator$Continuator.onResult(SaslAuthenticator.java:306)
	at com.mongodb.internal.connection.SaslAuthenticator$Continuator.onResult(SaslAuthenticator.java:286)
	at com.mongodb.internal.connection.CommandHelper$1.onResult(CommandHelper.java:63)
	at com.mongodb.internal.connection.CommandHelper$1.onResult(CommandHelper.java:57)
	at com.mongodb.internal.connection.InternalStreamConnection$2$1.onResult(InternalStreamConnection.java:508)
	at com.mongodb.internal.connection.InternalStreamConnection$2$1.onResult(InternalStreamConnection.java:485)
	at com.mongodb.internal.connection.InternalStreamConnection$MessageHeaderCallback$MessageCallback.onResult(InternalStreamConnection.java:791)
	at com.mongodb.internal.connection.InternalStreamConnection$MessageHeaderCallback$MessageCallback.onResult(InternalStreamConnection.java:758)
	at com.mongodb.internal.connection.InternalStreamConnection$5.completed(InternalStreamConnection.java:627)
	at com.mongodb.internal.connection.InternalStreamConnection$5.completed(InternalStreamConnection.java:624)
	at com.mongodb.connection.netty.NettyStream.readAsync(NettyStream.java:319)
	at com.mongodb.connection.netty.NettyStream.readAsync(NettyStream.java:266)
	at com.mongodb.internal.connection.InternalStreamConnection.readAsync(InternalStreamConnection.java:624)
	at com.mongodb.internal.connection.InternalStreamConnection.access$600(InternalStreamConnection.java:81)
	at com.mongodb.internal.connection.InternalStreamConnection$MessageHeaderCallback.onResult(InternalStreamConnection.java:748)
	at com.mongodb.internal.connection.InternalStreamConnection$MessageHeaderCallback.onResult(InternalStreamConnection.java:733)
	at com.mongodb.internal.connection.InternalStreamConnection$5.completed(InternalStreamConnection.java:627)
	at com.mongodb.internal.connection.InternalStreamConnection$5.completed(InternalStreamConnection.java:624)
	at com.mongodb.connection.netty.NettyStream.readAsync(NettyStream.java:319)
	at com.mongodb.connection.netty.NettyStream.handleReadResponse(NettyStream.java:347)
	at com.mongodb.connection.netty.NettyStream.access$1100(NettyStream.java:105)
	at com.mongodb.connection.netty.NettyStream$InboundBufferHandler.channelRead0(NettyStream.java:421)
	at com.mongodb.connection.netty.NettyStream$InboundBufferHandler.channelRead0(NettyStream.java:418)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1372)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1235)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1284)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:507)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:446)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581)
	at io.netty.channel.nio.NioEventLoop.run(Unknown Source)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Unknown Source)
```