### PR TITLE
Make maxConnecting configurable

### DIFF
--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -16,6 +16,7 @@
 
 package com.mongodb;
 
+import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.internal.dns.DefaultDnsResolver;
@@ -126,6 +127,7 @@ import static java.util.Collections.unmodifiableList;
  * <li>{@code maxPoolSize=n}: The maximum number of connections in the connection pool.</li>
  * <li>{@code waitQueueTimeoutMS=ms}: The maximum wait time in milliseconds that a thread may wait for a connection to
  * become available.</li>
+ * <li>{@code maxConnecting=n}: The maximum number of connections a pool may be establishing concurrently.</li>
  * </ul>
  * <p>Write concern configuration:</p>
  * <ul>
@@ -265,6 +267,7 @@ public class ConnectionString {
     private Integer maxWaitTime;
     private Integer maxConnectionIdleTime;
     private Integer maxConnectionLifeTime;
+    private Integer maxConnecting;
     private Integer connectTimeout;
     private Integer socketTimeout;
     private Boolean sslEnabled;
@@ -446,6 +449,7 @@ public class ConnectionString {
         GENERAL_OPTIONS_KEYS.add("connecttimeoutms");
         GENERAL_OPTIONS_KEYS.add("maxidletimems");
         GENERAL_OPTIONS_KEYS.add("maxlifetimems");
+        GENERAL_OPTIONS_KEYS.add("maxconnecting");
         GENERAL_OPTIONS_KEYS.add("sockettimeoutms");
 
         // Order matters here: Having tls after ssl means than the tls option will supersede the ssl option when both are set
@@ -542,6 +546,8 @@ public class ConnectionString {
                 maxConnectionIdleTime = parseInteger(value, "maxidletimems");
             } else if (key.equals("maxlifetimems")) {
                 maxConnectionLifeTime = parseInteger(value, "maxlifetimems");
+            } else if (key.equals("maxconnecting")) {
+                maxConnecting = parseInteger(value, "maxConnecting");
             } else if (key.equals("waitqueuetimeoutms")) {
                 maxWaitTime = parseInteger(value, "waitqueuetimeoutms");
             } else if (key.equals("connecttimeoutms")) {
@@ -1301,6 +1307,18 @@ public class ConnectionString {
     }
 
     /**
+     * Gets the maximum number of connections a pool may be establishing concurrently specified in the connection string.
+     * @return The maximum number of connections a pool may be establishing concurrently
+     * if the {@code maxConnecting} option is specified in the connection string, or {@code null} otherwise.
+     * @see ConnectionPoolSettings#getMaxConnecting()
+     * @since 4.4
+     */
+    @Nullable
+    public Integer getMaxConnecting() {
+        return maxConnecting;
+    }
+
+    /**
      * Gets the socket connect timeout specified in the connection string.
      * @return the socket connect timeout
      */
@@ -1445,6 +1463,7 @@ public class ConnectionString {
                 && Objects.equals(maxWaitTime, that.maxWaitTime)
                 && Objects.equals(maxConnectionIdleTime, that.maxConnectionIdleTime)
                 && Objects.equals(maxConnectionLifeTime, that.maxConnectionLifeTime)
+                && Objects.equals(maxConnecting, that.maxConnecting)
                 && Objects.equals(connectTimeout, that.connectTimeout)
                 && Objects.equals(socketTimeout, that.socketTimeout)
                 && Objects.equals(sslEnabled, that.sslEnabled)
@@ -1462,8 +1481,8 @@ public class ConnectionString {
     public int hashCode() {
         return Objects.hash(credential, isSrvProtocol, hosts, database, collection, directConnection, readPreference,
                 writeConcern, retryWrites, retryReads, readConcern, minConnectionPoolSize, maxConnectionPoolSize, maxWaitTime,
-                maxConnectionIdleTime, maxConnectionLifeTime, connectTimeout, socketTimeout, sslEnabled, sslInvalidHostnameAllowed,
-                requiredReplicaSetName, serverSelectionTimeout, localThreshold, heartbeatFrequency, applicationName, compressorList,
-                uuidRepresentation);
+                maxConnectionIdleTime, maxConnectionLifeTime, maxConnecting, connectTimeout, socketTimeout, sslEnabled,
+                sslInvalidHostnameAllowed, requiredReplicaSetName, serverSelectionTimeout, localThreshold, heartbeatFrequency,
+                applicationName, compressorList, uuidRepresentation);
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/ConnectionPoolSettings.java
+++ b/driver-core/src/main/com/mongodb/connection/ConnectionPoolSettings.java
@@ -371,7 +371,7 @@ public class ConnectionPoolSettings {
      * Establishment of a connection is a part of its life cycle
      * starting after a {@link ConnectionCreatedEvent} and ending before a {@link ConnectionReadyEvent}.
      * <p>
-     * Default is 2.
+     * Default is 2.</p>
      *
      * @return The maximum number of connections a pool may be establishing concurrently.
      * @see Builder#maxConnecting(int)

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -100,10 +100,6 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 @SuppressWarnings("deprecation")
 class DefaultConnectionPool implements ConnectionPool {
     private static final Logger LOGGER = Loggers.getLogger("connection");
-    /**
-     * Is package-access for the purpose of testing and must not be used for any other purpose outside of this class.
-     */
-    static final int MAX_CONNECTING = 2;
 
     private final ConcurrentPool<UsageTrackingInternalConnection> pool;
     private final ConnectionPoolSettings settings;
@@ -145,7 +141,7 @@ class DefaultConnectionPool implements ConnectionPool {
         this.connectionPoolListener = getConnectionPoolListener(settings);
         backgroundMaintenance = new BackgroundMaintenanceManager();
         connectionPoolCreated(connectionPoolListener, serverId, settings);
-        openConcurrencyLimiter = new OpenConcurrencyLimiter(MAX_CONNECTING);
+        openConcurrencyLimiter = new OpenConcurrencyLimiter(settings.getMaxConnecting());
         asyncWorkManager = new AsyncWorkManager(internalSettings.isPrestartAsyncWorkManager());
         stateAndGeneration = new StateAndGeneration();
         connectionGenerationSupplier = new ConnectionGenerationSupplier() {

--- a/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
@@ -200,6 +200,7 @@ class ConnectionStringSpecification extends Specification {
         connectionString.getMaxWaitTime() == 150;
         connectionString.getMaxConnectionIdleTime() == 200
         connectionString.getMaxConnectionLifeTime() == 300
+        connectionString.getMaxConnecting() == 1
         connectionString.getConnectTimeout() == 2500;
         connectionString.getSocketTimeout() == 5500;
         connectionString.getWriteConcern() == new WriteConcern(1, 2500);
@@ -215,7 +216,7 @@ class ConnectionStringSpecification extends Specification {
         where:
         connectionString <<
                 [new ConnectionString('mongodb://localhost/?minPoolSize=5&maxPoolSize=10&waitQueueTimeoutMS=150&'
-                                            + 'maxIdleTimeMS=200&maxLifeTimeMS=300&replicaSet=test&'
+                                            + 'maxIdleTimeMS=200&maxLifeTimeMS=300&maxConnecting=1&replicaSet=test&'
                                             + 'connectTimeoutMS=2500&socketTimeoutMS=5500&'
                                             + 'safe=false&w=1&wtimeout=2500&readPreference=primary&ssl=true&'
                                             + 'sslInvalidHostNameAllowed=true&'
@@ -224,7 +225,7 @@ class ConnectionStringSpecification extends Specification {
                                             + 'heartbeatFrequencyMS=20000&'
                                             + 'appName=app1'),
                  new ConnectionString('mongodb://localhost/?minPoolSize=5;maxPoolSize=10;waitQueueTimeoutMS=150;'
-                                            + 'maxIdleTimeMS=200;maxLifeTimeMS=300;replicaSet=test;'
+                                            + 'maxIdleTimeMS=200;maxLifeTimeMS=300;maxConnecting=1;replicaSet=test;'
                                             + 'connectTimeoutMS=2500;socketTimeoutMS=5500;'
                                             + 'safe=false;w=1;wtimeout=2500;readPreference=primary;ssl=true;'
                                             + 'sslInvalidHostNameAllowed=true;'
@@ -233,7 +234,7 @@ class ConnectionStringSpecification extends Specification {
                                             + 'heartbeatFrequencyMS=20000;'
                                             + 'appName=app1'),
                  new ConnectionString('mongodb://localhost/test?minPoolSize=5;maxPoolSize=10;waitQueueTimeoutMS=150;'
-                                            + 'maxIdleTimeMS=200&maxLifeTimeMS=300&replicaSet=test;'
+                                            + 'maxIdleTimeMS=200&maxLifeTimeMS=300&maxConnecting=1&replicaSet=test;'
                                             + 'connectTimeoutMS=2500;'
                                             + 'socketTimeoutMS=5500&'
                                             + 'safe=false&w=1;wtimeout=2500;readPreference=primary;ssl=true;'
@@ -419,6 +420,7 @@ class ConnectionStringSpecification extends Specification {
         then:
         connectionString.getMaxConnectionPoolSize() == null;
         connectionString.getMaxWaitTime() == null;
+        connectionString.getMaxConnecting() == null;
         connectionString.getConnectTimeout() == null;
         connectionString.getSocketTimeout() == null;
         connectionString.getWriteConcern() == null;
@@ -621,6 +623,7 @@ class ConnectionStringSpecification extends Specification {
                              + 'waitQueueTimeoutMS=150;'
                              + 'maxIdleTimeMS=200;'
                              + 'maxLifeTimeMS=300;replicaSet=test;'
+                             + 'maxConnecting=1;'
                              + 'connectTimeoutMS=2500;'
                              + 'socketTimeoutMS=5500;'
                              + 'safe=false;w=1;wtimeout=2500;'
@@ -630,7 +633,9 @@ class ConnectionStringSpecification extends Specification {
                                                                                              + 'maxPoolSize=10;'
                                                                                              + 'waitQueueTimeoutMS=150;'
                                                                                              + 'maxIdleTimeMS=200&maxLifeTimeMS=300'
-                                                                                             + '&replicaSet=test;connectTimeoutMS=2500;'
+                                                                                             + '&replicaSet=test;'
+                                                                                             + 'maxConnecting=1;'
+                                                                                             + 'connectTimeoutMS=2500;'
                                                                                              + 'socketTimeoutMS=5500&safe=false&w=1;'
                                                                                              + 'wtimeout=2500;fsync=true'
                                                                                              + '&directConnection=true'
@@ -655,11 +660,13 @@ class ConnectionStringSpecification extends Specification {
                            + '?readPreference=secondaryPreferred'
                            + '&readPreferenceTags=dc:ny,rack:1'
                            + '&readPreferenceTags=dc:ny'
-                           + '&readPreferenceTags=')                  | new ConnectionString('mongodb://localhost/'
+                           + '&readPreferenceTags='
+                           + '&maxConnecting=1')                | new ConnectionString('mongodb://localhost/'
                                                                                            + '?readPreference=secondaryPreferred'
                                                                                            + '&readPreferenceTags=dc:ny'
                                                                                            + '&readPreferenceTags=dc:ny, rack:1'
-                                                                                           + '&readPreferenceTags=')
+                                                                                           + '&readPreferenceTags='
+                                                                                           + '&maxConnecting=2')
         new ConnectionString('mongodb://ross:123@localhost/?'
                            + 'authMechanism=SCRAM-SHA-1')            | new ConnectionString('mongodb://ross:123@localhost/?'
                                                                                           + 'authMechanism=GSSAPI')

--- a/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
@@ -379,7 +379,7 @@ public class MongoClientOptions {
      * Establishment of a connection is a part of its life cycle
      * starting after a {@link ConnectionCreatedEvent} and ending before a {@link ConnectionReadyEvent}.
      * <p>
-     * Default is 2.
+     * Default is 2.</p>
      *
      * @return The maximum number of connections a pool may be establishing concurrently.
      * @see Builder#maxConnecting(int)

--- a/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
@@ -74,6 +74,7 @@ public class MongoClientOptions {
     private final int maxWaitTime;
     private final int maxConnectionIdleTime;
     private final int maxConnectionLifeTime;
+    private final int maxConnecting;
 
     private final int connectTimeout;
     private final int socketTimeout;
@@ -111,6 +112,7 @@ public class MongoClientOptions {
         maxWaitTime = builder.maxWaitTime;
         maxConnectionIdleTime = builder.maxConnectionIdleTime;
         maxConnectionLifeTime = builder.maxConnectionLifeTime;
+        maxConnecting = builder.maxConnecting;
         connectTimeout = builder.connectTimeout;
         socketTimeout = builder.socketTimeout;
         readPreference = builder.readPreference;
@@ -145,7 +147,7 @@ public class MongoClientOptions {
                 .maxWaitTime(getMaxWaitTime(), MILLISECONDS)
                 .maxConnectionIdleTime(getMaxConnectionIdleTime(), MILLISECONDS)
                 .maxConnectionLifeTime(getMaxConnectionLifeTime(), MILLISECONDS)
-                .maxConnecting(builder.maxConnecting);
+                .maxConnecting(getMaxConnecting());
 
         for (ConnectionPoolListener connectionPoolListener : builder.connectionPoolListeners) {
             connectionPoolSettingsBuilder.addConnectionPoolListener(connectionPoolListener);
@@ -387,7 +389,7 @@ public class MongoClientOptions {
      * @since 4.4
      */
     public int getMaxConnecting() {
-        return connectionPoolSettings.getMaxConnecting();
+        return maxConnecting;
     }
 
     /**
@@ -827,6 +829,9 @@ public class MongoClientOptions {
         if (maxConnectionLifeTime != that.maxConnectionLifeTime) {
             return false;
         }
+        if (maxConnecting != that.maxConnecting) {
+            return false;
+        }
         if (maxConnectionsPerHost != that.maxConnectionsPerHost) {
             return false;
         }
@@ -904,9 +909,7 @@ public class MongoClientOptions {
         if (serverApi != null ? !serverApi.equals(that.serverApi) : that.serverApi != null) {
             return false;
         }
-        if (!connectionPoolSettings.equals(that.connectionPoolSettings)) {
-            return false;
-        }
+
         return true;
     }
 
@@ -929,6 +932,7 @@ public class MongoClientOptions {
         result = 31 * result + maxWaitTime;
         result = 31 * result + maxConnectionIdleTime;
         result = 31 * result + maxConnectionLifeTime;
+        result = 31 * result + maxConnecting;
         result = 31 * result + connectTimeout;
         result = 31 * result + socketTimeout;
         result = 31 * result + (sslEnabled ? 1 : 0);
@@ -946,7 +950,6 @@ public class MongoClientOptions {
         result = 31 * result + compressorList.hashCode();
         result = 31 * result + (autoEncryptionSettings != null ? autoEncryptionSettings.hashCode() : 0);
         result = 31 * result + (serverApi != null ? serverApi.hashCode() : 0);
-        result = 31 * result + connectionPoolSettings.hashCode();
         return result;
     }
 

--- a/driver-legacy/src/main/com/mongodb/MongoClientURI.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientURI.java
@@ -107,6 +107,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  * <p>Connection pool configuration:</p>
  * <ul>
  * <li>{@code maxPoolSize=n}: The maximum number of connections in the connection pool.</li>
+ * <li>{@code maxConnecting=n}: The maximum number of connections a pool may be establishing concurrently.</li>
  * </ul>
  *
  * <p>Write concern configuration:</p>
@@ -372,6 +373,10 @@ public class MongoClientURI {
         Integer maxConnectionLifeTime = proxied.getMaxConnectionLifeTime();
         if (maxConnectionLifeTime != null) {
             builder.maxConnectionLifeTime(maxConnectionLifeTime);
+        }
+        Integer maxConnecting = proxied.getMaxConnecting();
+        if (maxConnecting != null) {
+            builder.maxConnecting(maxConnecting);
         }
         Integer socketTimeout = proxied.getSocketTimeout();
         if (socketTimeout != null) {

--- a/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
@@ -55,6 +55,7 @@ class MongoClientOptionsSpecification extends Specification {
         options.getUuidRepresentation() == UuidRepresentation.UNSPECIFIED
         options.getMinConnectionsPerHost() == 0
         options.getConnectionsPerHost() == 100
+        options.getMaxConnecting() == 2
         options.getConnectTimeout() == 10000
         options.getReadPreference() == ReadPreference.primary()
         options.getServerSelector() == null
@@ -185,6 +186,7 @@ class MongoClientOptionsSpecification extends Specification {
                                         .maxWaitTime(200)
                                         .maxConnectionIdleTime(300)
                                         .maxConnectionLifeTime(400)
+                                        .maxConnecting(1)
                                         .sslEnabled(true)
                                         .sslInvalidHostNameAllowed(true)
                                         .sslContext(SSLContext.getDefault())
@@ -220,6 +222,7 @@ class MongoClientOptionsSpecification extends Specification {
         options.getMaxWaitTime() == 200
         options.getMaxConnectionIdleTime() == 300
         options.getMaxConnectionLifeTime() == 400
+        options.getMaxConnecting() == 1
         options.getMinConnectionsPerHost() == 30
         options.getConnectionsPerHost() == 500
         options.getConnectTimeout() == 100
@@ -241,7 +244,8 @@ class MongoClientOptionsSpecification extends Specification {
 
         def connectionPoolSettings = ConnectionPoolSettings.builder().maxSize(500).minSize(30)
                 .maxWaitTime(200, MILLISECONDS).maxConnectionLifeTime(400, MILLISECONDS)
-                .maxConnectionIdleTime(300, MILLISECONDS).build()
+                .maxConnectionIdleTime(300, MILLISECONDS)
+                .maxConnecting(options.getMaxConnecting()).build()
         def socketSettings = SocketSettings.builder().connectTimeout(100, MILLISECONDS)
                 .readTimeout(700, MILLISECONDS)
                 .build()
@@ -320,6 +324,7 @@ class MongoClientOptionsSpecification extends Specification {
         optionsFromSettings.getMaxWaitTime() == 200
         optionsFromSettings.getMaxConnectionIdleTime() == 300
         optionsFromSettings.getMaxConnectionLifeTime() == 400
+        optionsFromSettings.getMaxConnecting() == settings.connectionPoolSettings.maxConnecting
         optionsFromSettings.getMinConnectionsPerHost() == 30
         optionsFromSettings.getConnectionsPerHost() == 500
         optionsFromSettings.getConnectTimeout() == 100
@@ -401,6 +406,7 @@ class MongoClientOptionsSpecification extends Specification {
                 .maxWaitTime(200)
                 .maxConnectionIdleTime(300)
                 .maxConnectionLifeTime(400)
+                .maxConnecting(1)
                 .sslEnabled(true)
                 .sslInvalidHostNameAllowed(true)
                 .sslContext(SSLContext.getDefault())
@@ -699,6 +705,7 @@ class MongoClientOptionsSpecification extends Specification {
                 .maxWaitTime(200)
                 .maxConnectionIdleTime(300)
                 .maxConnectionLifeTime(400)
+                .maxConnecting(1)
                 .sslEnabled(true)
                 .sslInvalidHostNameAllowed(true)
                 .sslContext(SSLContext.getDefault())
@@ -734,7 +741,8 @@ class MongoClientOptionsSpecification extends Specification {
         def expected = ['applicationName', 'autoEncryptionSettings', 'clusterListeners', 'codecRegistry', 'commandListeners',
                         'compressorList', 'connectTimeout', 'connectionPoolListeners', 'cursorFinalizerEnabled', 'dbDecoderFactory',
                         'dbEncoderFactory', 'heartbeatConnectTimeout', 'heartbeatFrequency', 'heartbeatSocketTimeout', 'localThreshold',
-                        'maxConnectionIdleTime', 'maxConnectionLifeTime', 'maxConnectionsPerHost', 'maxWaitTime', 'minConnectionsPerHost',
+                        'maxConnectionIdleTime', 'maxConnectionLifeTime', 'maxConnectionsPerHost', 'maxConnecting',
+                        'maxWaitTime', 'minConnectionsPerHost',
                         'minHeartbeatFrequency', 'readConcern', 'readPreference', 'requiredReplicaSetName', 'retryReads', 'retryWrites',
                         'serverApi', 'serverListeners', 'serverMonitorListeners', 'serverSelectionTimeout', 'serverSelector',
                         'socketTimeout', 'sslContext', 'sslEnabled', 'sslInvalidHostNameAllowed',

--- a/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
@@ -737,8 +737,8 @@ class MongoClientOptionsSpecification extends Specification {
     def 'should only have the following fields in the builder'() {
         when:
         // A regression test so that if any more methods are added then the builder(final MongoClientOptions options) should be updated
-        def actual = MongoClientOptions.Builder.declaredFields.grep { !it.synthetic } *.name.sort()
-        def expected = ['applicationName', 'autoEncryptionSettings', 'clusterListeners', 'codecRegistry', 'commandListeners',
+        def actual = new HashSet((MongoClientOptions.Builder.declaredFields.grep { !it.synthetic } *.name))
+        def expected = new HashSet(['applicationName', 'autoEncryptionSettings', 'clusterListeners', 'codecRegistry', 'commandListeners',
                         'compressorList', 'connectTimeout', 'connectionPoolListeners', 'cursorFinalizerEnabled', 'dbDecoderFactory',
                         'dbEncoderFactory', 'heartbeatConnectTimeout', 'heartbeatFrequency', 'heartbeatSocketTimeout', 'localThreshold',
                         'maxConnectionIdleTime', 'maxConnectionLifeTime', 'maxConnectionsPerHost', 'maxConnecting',
@@ -746,7 +746,7 @@ class MongoClientOptionsSpecification extends Specification {
                         'minHeartbeatFrequency', 'readConcern', 'readPreference', 'requiredReplicaSetName', 'retryReads', 'retryWrites',
                         'serverApi', 'serverListeners', 'serverMonitorListeners', 'serverSelectionTimeout', 'serverSelector',
                         'socketTimeout', 'sslContext', 'sslEnabled', 'sslInvalidHostNameAllowed',
-                        'uuidRepresentation', 'writeConcern']
+                        'uuidRepresentation', 'writeConcern'])
 
         then:
         actual == expected

--- a/driver-legacy/src/test/unit/com/mongodb/MongoClientURISpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoClientURISpecification.groovy
@@ -129,7 +129,7 @@ class MongoClientURISpecification extends Specification {
     def 'should correctly parse URI options for #type'() {
         given:
         def uri = new MongoClientURI('mongodb://localhost/?minPoolSize=5&maxPoolSize=10&waitQueueTimeoutMS=150&'
-                + 'maxIdleTimeMS=200&maxLifeTimeMS=300&replicaSet=test&'
+                + 'maxIdleTimeMS=200&maxLifeTimeMS=300&maxConnecting=1&replicaSet=test&'
                 + 'connectTimeoutMS=2500&socketTimeoutMS=5500&'
                 + 'safe=false&w=1&wtimeout=2500&ssl=true&readPreference=secondary&'
                 + 'sslInvalidHostNameAllowed=true&'
@@ -152,6 +152,7 @@ class MongoClientURISpecification extends Specification {
         options.getMaxWaitTime() == 150
         options.getMaxConnectionIdleTime() == 200
         options.getMaxConnectionLifeTime() == 300
+        options.getMaxConnecting() == 1
         options.getSocketTimeout() == 5500
         options.getConnectTimeout() == 2500
         options.getRequiredReplicaSetName() == 'test'
@@ -172,6 +173,7 @@ class MongoClientURISpecification extends Specification {
 
         then:
         options.getConnectionsPerHost() == 100
+        options.getMaxConnecting() == 2
         options.getMaxWaitTime() == 120000
         options.getConnectTimeout() == 10000
         options.getSocketTimeout() == 0
@@ -199,6 +201,7 @@ class MongoClientURISpecification extends Specification {
                 .maxWaitTime(200)
                 .maxConnectionIdleTime(300)
                 .maxConnectionLifeTime(400)
+                .maxConnecting(1)
                 .sslEnabled(true)
                 .sslInvalidHostNameAllowed(true)
                 .sslContext(SSLContext.getDefault())
@@ -224,6 +227,7 @@ class MongoClientURISpecification extends Specification {
         options.getMaxWaitTime() == 200
         options.getMaxConnectionIdleTime() == 300
         options.getMaxConnectionLifeTime() == 400
+        options.getMaxConnecting() == 1
         options.getMinConnectionsPerHost() == 30
         options.getConnectionsPerHost() == 500
         options.getConnectTimeout() == 100
@@ -346,6 +350,7 @@ class MongoClientURISpecification extends Specification {
                          + 'waitQueueTimeoutMS=150;'
                          + 'maxIdleTimeMS=200;'
                          + 'maxLifeTimeMS=300;replicaSet=test;'
+                         + 'maxConnecting=1;'
                          + 'connectTimeoutMS=2500;'
                          + 'socketTimeoutMS=5500;'
                          + 'safe=false;w=1;wtimeout=2500;'
@@ -353,7 +358,8 @@ class MongoClientURISpecification extends Specification {
                          + 'ssl=true')                               |  new MongoClientURI('mongodb://localhost/db.coll?minPoolSize=5;'
                                                                                          + 'maxPoolSize=10;'
                                                                                          + 'waitQueueTimeoutMS=150;'
-                                                                                         + 'maxIdleTimeMS=200&maxLifeTimeMS=300'
+                                                                                         + 'maxIdleTimeMS=200&maxLifeTimeMS=300;'
+                                                                                         + 'maxConnecting=1;'
                                                                                          + '&replicaSet=test;connectTimeoutMS=2500;'
                                                                                          + 'socketTimeoutMS=5500&safe=false&w=1;'
                                                                                          + 'wtimeout=2500;fsync=true'
@@ -378,11 +384,13 @@ class MongoClientURISpecification extends Specification {
                          + '?readPreference=secondaryPreferred'
                          + '&readPreferenceTags=dc:ny,rack:1'
                          + '&readPreferenceTags=dc:ny'
-                         + '&readPreferenceTags=')                  | new MongoClientURI('mongodb://localhost/'
+                         + '&readPreferenceTags='
+                         + '&maxConnecting=1')                  | new MongoClientURI('mongodb://localhost/'
                                                                                        + '?readPreference=secondaryPreferred'
                                                                                        + '&readPreferenceTags=dc:ny'
                                                                                        + '&readPreferenceTags=dc:ny, rack:1'
-                                                                                       + '&readPreferenceTags=')
+                                                                                       + '&readPreferenceTags='
+                                                                                       + '&maxConnecting=2')
         new MongoClientURI('mongodb://ross:123@localhost/?'
                          + 'authMechanism=SCRAM-SHA-1')            | new MongoClientURI('mongodb://ross:123@localhost/?'
                                                                                        + 'authMechanism=GSSAPI')
@@ -392,7 +400,8 @@ class MongoClientURISpecification extends Specification {
         when:
         MongoClientURI uri1 = new MongoClientURI('mongodb://user:pass@host1:1,host2:2,host3:3/bar?'
                                                         + 'maxPoolSize=10;waitQueueTimeoutMS=150;'
-                                                        + 'minPoolSize=7;maxIdleTimeMS=1000;maxLifeTimeMS=2000;replicaSet=test;'
+                                                        + 'minPoolSize=7;maxIdleTimeMS=1000;maxLifeTimeMS=2000;maxConnecting=1;'
+                                                        + 'replicaSet=test;'
                                                         + 'connectTimeoutMS=2500;socketTimeoutMS=5500;autoConnectRetry=true;'
                                                         + 'slaveOk=true;safe=false;w=1;wtimeout=2600')
 
@@ -402,6 +411,7 @@ class MongoClientURISpecification extends Specification {
                                                                .minConnectionsPerHost(7)
                                                                .maxConnectionIdleTime(1000)
                                                                .maxConnectionLifeTime(2000)
+                                                               .maxConnecting(1)
                                                                .requiredReplicaSetName('test')
                                                                .connectTimeout(2500)
                                                                .socketTimeout(5500)


### PR DESCRIPTION
The changes in this PR that affect public API are conditional on the reviewers of https://github.com/mongodb/specifications/pull/1098 accepting the `maxConnection` option name. This PR also does not include specification tests, which may appear in the aforementioned PR as a result of the review process. The PR is submitter prematurely in case we want to include it in release 4.4 despite the corresponding [DRIVERS-1943](https://jira.mongodb.org/browse/DRIVERS-1943) not being ready for implementation.

JAVA-4390