### PR TITLE
Build: Fix Manifest for jdk.net

### DIFF
--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -66,6 +66,7 @@ afterEvaluate {
     jar.manifest.attributes['Import-Package'] = [
             '!sun.misc.*',  // Used by DirectBufferDeallocator only for java 8
             '!sun.nio.ch.*',  // Used by DirectBufferDeallocator only for java 8
+            '!jdk.net.*', // Used by SocketStreamHelper depends on JDK version
             'io.netty.*;resolution:=optional',
             'org.xerial.snappy.*;resolution:=optional',
             'com.github.luben.zstd.*;resolution:=optional',


### PR DESCRIPTION
JAVA-4399

Simple fix - I checked all other calls to `Class.forName` and didn't find any others that should be removed from the manifest.