### PR TITLE
Iteration should throw if cursor is closed

### DIFF
--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoBatchCursorAdapterSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoBatchCursorAdapterSpecification.groovy
@@ -62,6 +62,31 @@ class MongoBatchCursorAdapterSpecification extends Specification {
         1 * batchCursor.close()
     }
 
+    def 'should throw if closed'() {
+        given:
+        def batchCursor = Mock(BatchCursor)
+        def cursor = new MongoBatchCursorAdapter(batchCursor)
+        cursor.close()
+
+        when:
+        cursor.hasNext()
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        cursor.next()
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        cursor.tryNext()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
     def 'next should throw if there is no next'() {
         given:
         def batchCursor = Stub(BatchCursor)

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoChangeStreamCursorSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoChangeStreamCursorSpecification.groovy
@@ -19,6 +19,7 @@ package com.mongodb.client.internal
 import com.mongodb.ServerAddress
 import com.mongodb.ServerCursor
 import com.mongodb.internal.operation.AggregateResponseBatchCursor
+import com.mongodb.internal.operation.BatchCursor
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.RawBsonDocument
@@ -69,6 +70,32 @@ class MongoChangeStreamCursorSpecification extends Specification {
 
         then:
         1 * batchCursor.close()
+    }
+
+
+    def 'should throw if closed'() {
+        given:
+        def batchCursor = Mock(AggregateResponseBatchCursor)
+        def cursor = new MongoBatchCursorAdapter(batchCursor)
+        cursor.close()
+
+        when:
+        cursor.hasNext()
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        cursor.next()
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        cursor.tryNext()
+
+        then:
+        thrown(IllegalStateException)
     }
 
     def 'next should throw if there is no next'() {

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoChangeStreamCursorSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoChangeStreamCursorSpecification.groovy
@@ -19,7 +19,6 @@ package com.mongodb.client.internal
 import com.mongodb.ServerAddress
 import com.mongodb.ServerCursor
 import com.mongodb.internal.operation.AggregateResponseBatchCursor
-import com.mongodb.internal.operation.BatchCursor
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.RawBsonDocument


### PR DESCRIPTION
This changes the behavior of the cursor implementations in the CRUD API
such that attempts to iterate the cursor with hasNext/next/tryNext will
throw IllegalStateException instead of returning already-cached results
from previous iteration.

JAVA-4368