### PR TITLE
Add command monitoring unified tests for serverConnectionId

### DIFF
--- a/driver-core/src/test/resources/unified-test-format/command-monitoring/pre-42-server-connection-id.json
+++ b/driver-core/src/test/resources/unified-test-format/command-monitoring/pre-42-server-connection-id.json
@@ -1,0 +1,101 @@
+{
+  "description": "pre-42-server-connection-id",
+  "schemaVersion": "1.6",
+  "runOnRequirements": [
+    {
+      "maxServerVersion": "4.0.99"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "server-connection-id-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "server-connection-id-tests",
+      "collectionName": "coll",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command events do not include server connection id",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": false
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/command-monitoring/server-connection-id.json
+++ b/driver-core/src/test/resources/unified-test-format/command-monitoring/server-connection-id.json
@@ -1,0 +1,101 @@
+{
+  "description": "server-connection-id",
+  "schemaVersion": "1.6",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.2"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "server-connection-id-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "server-connection-id-tests",
+      "collectionName": "coll",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command events include server connection id",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/CommandMonitoringTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/CommandMonitoringTest.java
@@ -25,12 +25,17 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
+import static org.junit.Assume.assumeFalse;
+
 public class CommandMonitoringTest extends UnifiedReactiveStreamsTest {
     public CommandMonitoringTest(@SuppressWarnings("unused") final String fileDescription,
                                  @SuppressWarnings("unused") final String testDescription,
                                  final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
                                  final BsonArray initialData, final BsonDocument definition) {
         super(schemaVersion, runOnRequirements, entities, initialData, definition);
+        // The driver has a hack where getLastError command is executed as part of the handshake in order to get a connectionId
+        // even when the hello command response doesn't contain it.
+        assumeFalse(fileDescription.equals("pre-42-server-connection-id"));
     }
 
     @Parameterized.Parameters(name = "{0}: {1}")

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/CommandMonitoringTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/CommandMonitoringTest.java
@@ -38,6 +38,9 @@ public class CommandMonitoringTest extends UnifiedSyncTest {
                                  final BsonDocument definition) {
         super(schemaVersion, runOnRequirements, entities, initialData, definition);
         assumeFalse(isServerlessTest());
+        // The driver has a hack where getLastError command is executed as part of the handshake in order to get a connectionId
+        // even when the hello command response doesn't contain it.
+        assumeFalse(fileDescription.equals("pre-42-server-connection-id"));
     }
 
     @Parameterized.Parameters(name = "{0}: {1}")

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/EventMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/EventMatcher.java
@@ -68,6 +68,16 @@ final class EventMatcher {
                 }
             }
 
+            if (expected.containsKey("hasServerConnectionId")) {
+                boolean hasServerConnectionId = expected.getBoolean("hasServerConnectionId").getValue();
+                Integer serverConnectionId = actual.getConnectionDescription().getConnectionId().getServerValue();
+                if (hasServerConnectionId) {
+                    assertNotNull(context.getMessage("Expected serverConnectionId"), serverConnectionId);
+                } else {
+                    assertNull(context.getMessage("Expected no serverConnectionId"), serverConnectionId);
+                }
+            }
+
             if (actual.getClass().equals(CommandStartedEvent.class)) {
                 assertEquals(context.getMessage("Expected CommandStartedEvent"), eventType, "commandStartedEvent");
                 CommandStartedEvent actualCommandStartedEvent = (CommandStartedEvent) actual;

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -143,7 +143,8 @@ public abstract class UnifiedTest {
                 || schemaVersion.startsWith("1.2")
                 || schemaVersion.startsWith("1.3")
                 || schemaVersion.startsWith("1.4")
-                || schemaVersion.startsWith("1.5"));
+                || schemaVersion.startsWith("1.5")
+                || schemaVersion.startsWith("1.6"));
         if (runOnRequirements != null) {
             assumeTrue("Run-on requirements not met",
                     runOnRequirementsMet(runOnRequirements, getMongoClientSettings(), getServerVersion()));


### PR DESCRIPTION
The driver already supports the feature, so this is just test changes.
It includes support for version 1.6 of the unified test format.

JAVA-4238