### PR TITLE
Add error labels to MongoWriteConcernException

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/WriteConcernHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/WriteConcernHelper.java
@@ -61,9 +61,12 @@ public final class WriteConcernHelper {
     }
 
     public static MongoWriteConcernException createWriteConcernException(final BsonDocument result, final ServerAddress serverAddress) {
-        return new MongoWriteConcernException(
+        MongoWriteConcernException writeConcernException = new MongoWriteConcernException(
                 createWriteConcernError(result.getDocument("writeConcernError")),
                 WriteConcernResult.acknowledged(0, false, null), serverAddress);
+        result.getArray("errorLabels", new BsonArray()).stream().map(i -> i.asString().getValue())
+                .forEach(writeConcernException::addLabel);
+        return writeConcernException;
     }
 
     public static WriteConcernError createWriteConcernError(final BsonDocument writeConcernErrorDocument) {


### PR DESCRIPTION
The error labels are at the top level of the response
document, and the code was assuming that they were
embedded in the writeConcernError document.  This fix
ensures that error labels at the top level are properly
added to MongoWriteConcernException

JAVA-4419

Note: this change is tested in scope of JAVA-4382 spec test changes, which will follow in a separate PR