### PR TITLE
Always specify the known cause when calling `ConnectionPool.invalidate`

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/ConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ConnectionPool.java
@@ -26,7 +26,7 @@ import java.io.Closeable;
 import java.util.concurrent.TimeUnit;
 
 /**
- * An instance of an implementation must be created in the {@linkplain #invalidate() paused} state.
+ * An instance of an implementation must be created in the {@linkplain #invalidate(Throwable) paused} state.
  */
 interface ConnectionPool extends Closeable {
     /**
@@ -36,13 +36,13 @@ interface ConnectionPool extends Closeable {
 
     /**
      * @param timeout See {@link com.mongodb.internal.Timeout#startNow(long, TimeUnit)}.
-     * @throws MongoConnectionPoolClearedException If detects that the pool is {@linkplain #invalidate() paused}.
+     * @throws MongoConnectionPoolClearedException If detects that the pool is {@linkplain #invalidate(Throwable) paused}.
      */
     InternalConnection get(long timeout, TimeUnit timeUnit) throws MongoConnectionPoolClearedException;
 
     /**
      * Completes the {@code callback} with a {@link MongoConnectionPoolClearedException}
-     * if detects that the pool is {@linkplain #invalidate() paused}.
+     * if detects that the pool is {@linkplain #invalidate(Throwable) paused}.
      */
     void getAsync(SingleResultCallback<InternalConnection> callback);
 
@@ -50,23 +50,16 @@ interface ConnectionPool extends Closeable {
      * Mark the pool as paused, unblock all threads waiting in {@link #get() get…} methods, unless they are blocked
      * doing an IO operation, increment {@linkplain #getGeneration() generation} to lazily clear all connections managed by the pool
      * (this is done via {@link #get() get…} and {@linkplain InternalConnection#close() check in} methods, and may also be done
-     * by a background task). In the {@linkplain #invalidate() paused} state, connections can be created neither in the background
+     * by a background task). In the paused state, connections can be created neither in the background
      * nor via {@link #get() get…} methods.
-     * If the pool is {@linkplain #invalidate() paused}, the method does nothing except for recording the specified {@code cause}.
+     * If the pool is paused, the method does nothing except for recording the specified {@code cause}.
      *
      * @see #ready()
      */
     void invalidate(@Nullable Throwable cause);
 
     /**
-     * Is equivalent to {@link #invalidate(Throwable)} called with {@code null}.
-     *
-     * @see #invalidate(Throwable)
-     */
-    void invalidate();
-
-    /**
-     * Unlike {@link #invalidate()}, this method neither marks the pool as paused,
+     * Unlike {@link #invalidate(Throwable)}, this method neither marks the pool as paused,
      * nor affects the {@linkplain #getGeneration() generation}.
      *
      * @param generation The expected service-specific generation.

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -262,11 +262,6 @@ class DefaultConnectionPool implements ConnectionPool {
     }
 
     @Override
-    public void invalidate() {
-        invalidate(null);
-    }
-
-    @Override
     public void ready() {
         if (stateAndGeneration.ready()) {
             LOGGER.debug("Marking the connection pool for " + serverId +  " as 'ready'");

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultSdamServerDescriptionManager.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultSdamServerDescriptionManager.java
@@ -79,10 +79,11 @@ final class DefaultSdamServerDescriptionManager implements SdamServerDescription
                 markedPoolReady = true;
             }
             updateDescription(candidateDescription);
-            if (candidateDescription.getException() != null) {
+            Throwable candidateDescriptionException = candidateDescription.getException();
+            if (candidateDescriptionException != null) {
                 assertTrue(newServerType == UNKNOWN);
                 assertFalse(markedPoolReady);
-                connectionPool.invalidate();
+                connectionPool.invalidate(candidateDescriptionException);
             }
         } finally {
             lock.unlock();

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
@@ -465,11 +465,11 @@ public class DefaultConnectionPoolTest {
         assertTrue(invalidateAndReadyProb >= 0 && invalidateAndReadyProb <= 1);
         Runnable spontaneouslyInvalidateReady = () -> {
             if (ThreadLocalRandom.current().nextFloat() < invalidateAndReadyProb) {
-                pool.invalidate();
+                pool.invalidate(null);
                 pool.ready();
             }
             if (ThreadLocalRandom.current().nextFloat() < invalidateProb) {
-                pool.invalidate();
+                pool.invalidate(null);
             }
             if (ThreadLocalRandom.current().nextFloat() < readyProb) {
                 pool.ready();

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
@@ -239,7 +239,7 @@ public abstract class AbstractConnectionPoolTest {
                             .longValue();
                     listener.waitForEvent(eventClass, operation.getNumber("count").intValue(), timeoutMillis, TimeUnit.MILLISECONDS);
                 } else if (name.equals("clear")) {
-                    pool.invalidate();
+                    pool.invalidate(null);
                 } else if (name.equals("ready")) {
                     pool.ready();
                 } else if (name.equals("close")) {
@@ -580,11 +580,6 @@ public abstract class AbstractConnectionPoolTest {
         @Override
         public void invalidate(@Nullable final Throwable cause) {
             pool.invalidate(cause);
-        }
-
-        @Override
-        public void invalidate() {
-            pool.invalidate();
         }
 
         @Override

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultConnectionPoolSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultConnectionPoolSpecification.groovy
@@ -152,7 +152,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         connectionFactory.createdConnections.get(0).opened()  // if the first one is opened, they all should be
 
         when: 'the pool is invalidated and the maintenance tasks runs'
-        pool.invalidate()
+        pool.invalidate(null)
         pool.ready()
         pool.doMaintenance()
         //not cool - but we have no way of being notified that the maintenance task has finished
@@ -410,7 +410,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         when:
         pool.ready()
         pool.ready()
-        pool.invalidate()
+        pool.invalidate(null)
         pool.invalidate(new RuntimeException())
 
         then:
@@ -504,7 +504,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         pool.close()
 
         when:
-        pool.invalidate()
+        pool.invalidate(null)
 
         then:
         noExceptionThrown()

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
@@ -179,7 +179,7 @@ class DefaultServerSpecification extends Specification {
         server.invalidate()
 
         then:
-        0 * connectionPool.invalidate()
+        0 * connectionPool.invalidate(null)
         0 * serverMonitor.connect()
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestConnectionPool.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestConnectionPool.java
@@ -160,11 +160,6 @@ public class TestConnectionPool implements ConnectionPool {
     }
 
     @Override
-    public void invalidate() {
-        invalidate(null);
-    }
-
-    @Override
     public void invalidate(final ObjectId serviceId, final int generation) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
After this [Slack discussion](https://mongodb.slack.com/archives/G016S9LLKU2/p1638376906000700), I realized that there is no reason for us to have both `ConnectionPool.invalidate()` and `ConnectionPool.invalidate(Throwable)`. Moreover, I noticed that there are situations when `DefaultSdamServerDescriptionManager` calls `invalidate` without specifying the cause despite it being known. This PR fixes the discovered issue and removes the unnecessary method.