### PR TITLE
Add #available method to legacy cursor API

### DIFF
--- a/driver-legacy/src/main/com/mongodb/Cursor.java
+++ b/driver-legacy/src/main/com/mongodb/Cursor.java
@@ -28,7 +28,12 @@ import java.util.Iterator;
 public interface Cursor extends Iterator<DBObject>, Closeable {
 
     /**
-     * Gets the number of results available locally without blocking, which may be 0, or 0 when the cursor is exhausted or closed.
+     * Gets the number of results available locally without blocking, which may be 0.
+     *
+     * <p>
+     * If the cursor is known to be exhausted, returns 0.  If the cursor is closed before it's been exhausted, it may return a non-zero
+     * value.
+     * </p>
      *
      * @return the number of results available locally without blocking
      * @since 4.5

--- a/driver-legacy/src/main/com/mongodb/Cursor.java
+++ b/driver-legacy/src/main/com/mongodb/Cursor.java
@@ -28,7 +28,7 @@ import java.util.Iterator;
 public interface Cursor extends Iterator<DBObject>, Closeable {
 
     /**
-     * Gets the number of results available locally without blocking,which may be 0, or 0 when the cursor is exhausted or closed.
+     * Gets the number of results available locally without blocking, which may be 0, or 0 when the cursor is exhausted or closed.
      *
      * @return the number of results available locally without blocking
      * @since 4.5

--- a/driver-legacy/src/main/com/mongodb/Cursor.java
+++ b/driver-legacy/src/main/com/mongodb/Cursor.java
@@ -28,6 +28,14 @@ import java.util.Iterator;
 public interface Cursor extends Iterator<DBObject>, Closeable {
 
     /**
+     * Gets the number of results available locally without blocking,which may be 0, or 0 when the cursor is exhausted or closed.
+     *
+     * @return the number of results available locally without blocking
+     * @since 4.5
+     */
+    int available();
+
+    /**
      * Gets the server's identifier for this Cursor.
      *
      * @return the cursor's ID, or 0 if there is no active cursor.

--- a/driver-legacy/src/main/com/mongodb/DBCursor.java
+++ b/driver-legacy/src/main/com/mongodb/DBCursor.java
@@ -189,7 +189,7 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
     }
 
     /**
-     * Gets the number of results available locally without blocking,which may be 0, or 0 when the cursor is exhausted or closed.
+     * Gets the number of results available locally without blocking, which may be 0, or 0 when the cursor is exhausted or closed.
      *
      * @return the number of results available locally without blocking
      * @since 4.5

--- a/driver-legacy/src/main/com/mongodb/DBCursor.java
+++ b/driver-legacy/src/main/com/mongodb/DBCursor.java
@@ -189,6 +189,16 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
     }
 
     /**
+     * Gets the number of results available locally without blocking,which may be 0, or 0 when the cursor is exhausted or closed.
+     *
+     * @return the number of results available locally without blocking
+     * @since 4.5
+     */
+    public int available() {
+        return cursor != null ? cursor.available() : 0;
+    }
+
+    /**
      * Non blocking check for tailable cursors to see if another object is available.
      *
      * <p>Returns the object the cursor is at and moves the cursor ahead by one or

--- a/driver-legacy/src/main/com/mongodb/DBCursor.java
+++ b/driver-legacy/src/main/com/mongodb/DBCursor.java
@@ -189,7 +189,12 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
     }
 
     /**
-     * Gets the number of results available locally without blocking, which may be 0, or 0 when the cursor is exhausted or closed.
+     * Gets the number of results available locally without blocking, which may be 0.
+     *
+     * <p>
+     * If the cursor is known to be exhausted, returns 0.  If the cursor is closed before it's been exhausted, it may return a non-zero
+     * value.
+     * </p>
      *
      * @return the number of results available locally without blocking
      * @since 4.5

--- a/driver-legacy/src/main/com/mongodb/MongoCursorAdapter.java
+++ b/driver-legacy/src/main/com/mongodb/MongoCursorAdapter.java
@@ -27,6 +27,11 @@ class MongoCursorAdapter implements Cursor {
     }
 
     @Override
+    public int available() {
+        return cursor.available();
+    }
+
+    @Override
     public long getCursorId() {
         ServerCursor serverCursor = cursor.getServerCursor();
         if (serverCursor == null) {

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionAggregationTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionAggregationTest.java
@@ -146,6 +146,22 @@ public class DBCollectionAggregationTest extends DatabaseTestCase {
         }
     }
 
+    @Test
+    public void testAvailable() {
+        prepareData();
+        Cursor cursor = collection.aggregate(asList(new BasicDBObject("$match", new BasicDBObject())),
+                AggregationOptions.builder().build());
+
+        assertEquals(3, cursor.available());
+
+        cursor.next();
+        assertEquals(2, cursor.available());
+
+        cursor.next();
+        assertEquals(1, cursor.available());
+    }
+
+
     private void verify(final List<DBObject> pipeline, final AggregationOptions options) {
         verify(pipeline, options, ReadPreference.primary());
     }

--- a/driver-legacy/src/test/functional/com/mongodb/DBCursorTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCursorTest.java
@@ -62,6 +62,27 @@ public class DBCursorTest extends DatabaseTestCase {
     }
 
     @Test
+    public void testAvailable() {
+        cursor.batchSize(3);
+        assertEquals(0, cursor.available());
+
+        cursor.next();
+        assertEquals(2, cursor.available());
+
+        cursor.next();
+        assertEquals(1, cursor.available());
+
+        cursor.next();
+        assertEquals(0, cursor.available());
+
+        cursor.next();
+        assertEquals(2, cursor.available());
+
+        cursor.close();
+        assertEquals(0, cursor.available());
+    }
+
+    @Test
     public void testNextHasNext() {
         cursor.sort(new BasicDBObject("_id", 1));
         int i = 0;

--- a/driver-sync/src/main/com/mongodb/client/MongoCursor.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoCursor.java
@@ -58,7 +58,12 @@ public interface MongoCursor<TResult> extends Iterator<TResult>, Closeable {
     TResult next();
 
     /**
-     * Gets the number of results available locally without blocking,which may be 0, or 0 when the cursor is exhausted or closed.
+     * Gets the number of results available locally without blocking, which may be 0.
+     *
+     * <p>
+     * If the cursor is known to be exhausted, returns 0.  If the cursor is closed before it's been exhausted, it may return a non-zero
+     * value.
+     * </p>
      *
      * @return the number of results available locally without blocking
      * @since 4.4


### PR DESCRIPTION
The new methods are

* com.mongodb.DBCursor#available
* com.mongodb.Cursor#available

with the same semantics as the recently added

* com.mongodb.client.MongoCursor#available

JAVA-4422