### PR TITLE
JAVA-4317: Add methods to override listeners in ClusterSettings, ServerSettings and ConnectionPoolSettings

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/ClusterSettings.java
+++ b/driver-core/src/main/com/mongodb/connection/ClusterSettings.java
@@ -269,6 +269,19 @@ public final class ClusterSettings {
         }
 
         /**
+         * Sets the cluster listeners.
+         *
+         * @param clusterListeners list of cluster listeners
+         * @return this
+         * @since 4.5
+         */
+        public Builder clusterListenerList(final List<ClusterListener> clusterListeners) {
+            notNull("clusterListeners", clusterListeners);
+            this.clusterListeners = new ArrayList<>(clusterListeners);
+            return this;
+        }
+
+        /**
          * Takes the settings from the given {@code ConnectionString} and applies them to the builder
          *
          * @param connectionString the connection string containing details of how to connect to MongoDB

--- a/driver-core/src/main/com/mongodb/connection/ConnectionPoolSettings.java
+++ b/driver-core/src/main/com/mongodb/connection/ConnectionPoolSettings.java
@@ -216,6 +216,19 @@ public class ConnectionPoolSettings {
         }
 
         /**
+         * Sets the connection pool listeners.
+         *
+         * @param connectionPoolListeners list of connection pool listeners
+         * @return this
+         * @since 4.5
+         */
+        public Builder connectionPoolListenerList(final List<ConnectionPoolListener> connectionPoolListeners) {
+            notNull("connectionPoolListeners", connectionPoolListeners);
+            this.connectionPoolListeners = new ArrayList<>(connectionPoolListeners);
+            return this;
+        }
+
+        /**
          * The maximum number of connections a pool may be establishing concurrently.
          *
          * @param maxConnecting The maximum number of connections a pool may be establishing concurrently. Must be positive.

--- a/driver-core/src/main/com/mongodb/connection/ServerSettings.java
+++ b/driver-core/src/main/com/mongodb/connection/ServerSettings.java
@@ -131,6 +131,19 @@ public class ServerSettings {
         }
 
         /**
+         * Sets the server listeners.
+         *
+         * @param serverListeners list of server listeners
+         * @return this
+         * @since 4.5
+         */
+        public Builder serverListenerList(final List<ServerListener> serverListeners) {
+            notNull("serverListeners", serverListeners);
+            this.serverListeners = new ArrayList<>(serverListeners);
+            return this;
+        }
+
+        /**
          * Adds a server monitor listener.
          *
          * @param serverMonitorListener the non-null server monitor listener
@@ -140,6 +153,19 @@ public class ServerSettings {
         public Builder addServerMonitorListener(final ServerMonitorListener serverMonitorListener) {
             notNull("serverMonitorListener", serverMonitorListener);
             serverMonitorListeners.add(serverMonitorListener);
+            return this;
+        }
+
+        /**
+         * Sets the server monitor listeners.
+         *
+         * @param serverMonitorListeners list of server monitor listeners
+         * @return this
+         * @since 4.5
+         */
+        public Builder serverMonitorListenerList(final List<ServerMonitorListener> serverMonitorListeners) {
+            notNull("serverMonitorListeners", serverMonitorListeners);
+            this.serverMonitorListeners = new ArrayList<>(serverMonitorListeners);
             return this;
         }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/ClusterSettingsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ClusterSettingsSpecification.groovy
@@ -48,6 +48,7 @@ class ClusterSettingsSpecification extends Specification {
         when:
         def listenerOne = Mock(ClusterListener)
         def listenerTwo = Mock(ClusterListener)
+        def listenerThree = Mock(ClusterListener)
         def settings = ClusterSettings.builder()
                                       .hosts(hosts)
                                       .mode(ClusterConnectionMode.MULTIPLE)
@@ -68,6 +69,12 @@ class ClusterSettingsSpecification extends Specification {
         settings.serverSelector == serverSelector
         settings.getServerSelectionTimeout(TimeUnit.MILLISECONDS) == 1000
         settings.clusterListeners == [listenerOne, listenerTwo]
+
+        when:
+        settings = ClusterSettings.builder(settings).clusterListenerList([listenerThree]).build()
+
+        then:
+        settings.clusterListeners == [listenerThree]
     }
 
     def 'should apply settings'() {

--- a/driver-core/src/test/unit/com/mongodb/connection/ConnectionPoolSettingsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ConnectionPoolSettingsSpecification.groovy
@@ -170,6 +170,7 @@ class ConnectionPoolSettingsSpecification extends Specification {
 
     def 'should apply settings'() {
         given:
+        def connectionPoolListener = Mock(ConnectionPoolListener)
         def defaultSettings = ConnectionPoolSettings.builder().build()
         def customSettings = ConnectionPoolSettings
                 .builder()
@@ -187,6 +188,12 @@ class ConnectionPoolSettingsSpecification extends Specification {
         expect:
         ConnectionPoolSettings.builder().applySettings(customSettings).build() == customSettings
         ConnectionPoolSettings.builder(customSettings).applySettings(defaultSettings).build() == defaultSettings
+
+        when:
+        customSettings = ConnectionPoolSettings.builder(customSettings).connectionPoolListenerList([connectionPoolListener]).build()
+
+        then:
+        customSettings.connectionPoolListeners == [connectionPoolListener]
     }
 
     def 'toString should be overridden'() {

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSettingsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSettingsSpecification.groovy
@@ -40,8 +40,10 @@ class ServerSettingsSpecification extends Specification {
         given:
         def serverListenerOne = new ServerListenerAdapter() { }
         def serverListenerTwo = new ServerListenerAdapter() { }
+        def serverListenerThree = new ServerListenerAdapter() { }
         def serverMonitorListenerOne = new ServerMonitorListenerAdapter() { }
         def serverMonitorListenerTwo = new ServerMonitorListenerAdapter() { }
+        def serverMonitorListenerThree = new ServerMonitorListenerAdapter() { }
 
         when:
         def settings = ServerSettings.builder()
@@ -59,6 +61,15 @@ class ServerSettingsSpecification extends Specification {
         settings.getMinHeartbeatFrequency(MILLISECONDS) == 1000
         settings.serverListeners == [serverListenerOne, serverListenerTwo]
         settings.serverMonitorListeners == [serverMonitorListenerOne, serverMonitorListenerTwo]
+
+        when:
+        settings = ServerSettings.builder()
+                .serverListenerList([serverListenerThree])
+                .serverMonitorListenerList([serverMonitorListenerThree]).build()
+
+        then:
+        settings.serverListeners == [serverListenerThree]
+        settings.serverMonitorListeners == [serverMonitorListenerThree]
     }
 
     def 'when connection string is applied to builder, all properties should be set'() {


### PR DESCRIPTION
[JAVA-4317](https://jira.mongodb.org/browse/JAVA-4317)

This PR adds the ability to override listeners in `ClusterSettings`, `ServerSettings` and `ConnectionPoolSettings` by allowing the user to provide a list of listeners. These changes have been modeled after `MongoClientSettings.Builder#commandListenerList`.

QA Performed: Amended unit tests where appropriate.