### PR TITLE
JAVA-4427: Add throws exception tag to javadoc for createIndex

### DIFF
--- a/driver-legacy/src/main/com/mongodb/DBCollection.java
+++ b/driver-legacy/src/main/com/mongodb/DBCollection.java
@@ -1372,6 +1372,7 @@ public class DBCollection {
      *
      * @param keys    a document that contains pairs with the name of the field or fields to index and order of the index
      * @param options a document that controls the creation of the index.
+     * @throws MongoException if the operation failed
      * @mongodb.driver.manual /administration/indexes-creation/ Index Creation Tutorials
      */
     public void createIndex(final DBObject keys, final DBObject options) {


### PR DESCRIPTION
[JAVA-4427](https://jira.mongodb.org/browse/JAVA-4427)