### PR TITLE
Support codec for Java records

### DIFF
--- a/bson-record-codec/build.gradle
+++ b/bson-record-codec/build.gradle
@@ -14,15 +14,23 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':bson-record-codec'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include 'util:spock'
-include 'util:taglets'
+archivesBaseName = 'bson-record-codec'
+description = 'The BSON Codec for Java records'
+
+ext {
+    pomName = 'BSON Record Codec'
+}
+
+dependencies {
+    api project(path: ':bson', configuration: 'default')
+    testImplementation project(':bson').sourceSets.test.output
+}
+
+afterEvaluate {
+    jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.bson.record.codec'
+    jar.manifest.attributes['Bundle-SymbolicName'] = 'org.mongodb.bson-record-codec'
+    jar.manifest.attributes['Import-Package'] = [
+            'org.slf4j.*;resolution:=optional',
+            '*',
+    ].join(',')
+}

--- a/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
@@ -165,9 +165,10 @@ final class RecordCodec<T extends Record> implements Codec<T> {
     }
 
     private static <T> List<ComponentModel> getComponentModels(final Class<T> clazz, final CodecRegistry codecRegistry) {
-        var componentModels = new ArrayList<ComponentModel>(clazz.getRecordComponents().length);
-        for (int i = 0; i < clazz.getRecordComponents().length; i++) {
-            componentModels.add(new ComponentModel(clazz.getRecordComponents()[i], codecRegistry, i));
+        var recordComponents = clazz.getRecordComponents();
+        var componentModels = new ArrayList<ComponentModel>(recordComponents.length);
+        for (int i = 0; i < recordComponents.length; i++) {
+            componentModels.add(new ComponentModel(recordComponents[i], codecRegistry, i));
         }
         return componentModels;
     }

--- a/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record;
+
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.RepresentationConfigurable;
+import org.bson.codecs.configuration.CodecConfigurationException;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.record.annotations.BsonProperty;
+import org.bson.codecs.record.annotations.BsonId;
+import org.bson.codecs.record.annotations.BsonRepresentation;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static org.bson.assertions.Assertions.notNull;
+
+final class RecordCodec<T extends Record> implements Codec<T> {
+    private final Class<T> clazz;
+    private final Constructor<?> canonicalConstructor;
+    private final List<ComponentModel> componentModels;
+    private final ComponentModel componentModelForId;
+    private final Map<String, ComponentModel> fieldNameToComponentModel;
+
+    private static final class ComponentModel {
+        private final RecordComponent component;
+        private final Codec<?> codec;
+        private final int index;
+        private final String fieldName;
+
+        private ComponentModel(final RecordComponent component, final CodecRegistry codecRegistry, final int index) {
+            this.component = component;
+            this.codec = computeCodec(component, codecRegistry);
+            this.index = index;
+            this.fieldName = computeFieldName(component);
+        }
+
+        String getComponentName() {
+            return component.getName();
+        }
+
+        String getFieldName() {
+            return fieldName;
+        }
+
+        Object getValue(final Record record) throws InvocationTargetException, IllegalAccessException {
+            return component.getAccessor().invoke(record);
+        }
+
+        private static Codec<?> computeCodec(final RecordComponent component, final CodecRegistry codecRegistry) {
+            var codec = codecRegistry.get(toWrapper(component.getType()));
+            var bsonRepresentationAnnotation = component.getAnnotation(BsonRepresentation.class);
+            if (bsonRepresentationAnnotation != null) {
+                if (codec instanceof RepresentationConfigurable<?> representationConfigurable) {
+                    codec = representationConfigurable.withRepresentation(bsonRepresentationAnnotation.value());
+                } else {
+                    throw new CodecConfigurationException(
+                            format("Codec for %s must implement RepresentationConfigurable to support BsonRepresentation",
+                                    codec.getEncoderClass()));
+                }
+            }
+            return codec;
+        }
+
+        private static String computeFieldName(final RecordComponent component) {
+            if (component.isAnnotationPresent(BsonId.class)) {
+                return "_id";
+            } else if (component.isAnnotationPresent(BsonProperty.class)) {
+                return component.getAnnotation(BsonProperty.class).value();
+            }
+            return component.getName();
+        }
+    }
+
+    RecordCodec(final Class<T> clazz, final CodecRegistry codecRegistry) {
+        this.clazz = notNull("class", clazz);
+        canonicalConstructor = notNull("canonicalConstructor", getCanonicalConstructor(clazz));
+        componentModels = getComponentModels(clazz, codecRegistry);
+        fieldNameToComponentModel = componentModels.stream()
+                .collect(Collectors.toMap(ComponentModel::getFieldName, Function.identity()));
+        componentModelForId = getComponentModelForId(clazz, componentModels);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public T decode(final BsonReader reader, final DecoderContext decoderContext) {
+        reader.readStartDocument();
+
+        Object[] constructorArguments = new Object[componentModels.size()];
+        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+            var fieldName = reader.readName();
+            var componentModel = fieldNameToComponentModel.get(fieldName);
+            constructorArguments[componentModel.index] = decoderContext.decodeWithChildContext(componentModel.codec, reader);
+        }
+        reader.readEndDocument();
+
+        try {
+            return (T) canonicalConstructor.newInstance(constructorArguments);
+        } catch (ReflectiveOperationException e) {
+            throw new CodecConfigurationException(format("Unable to invoke canonical constructor of record class %s", clazz.getName()), e);
+        }
+    }
+
+    @Override
+    public void encode(final BsonWriter writer, final T record, final EncoderContext encoderContext) {
+        writer.writeStartDocument();
+        if (componentModelForId != null) {
+            writeComponent(writer, record, componentModelForId);
+        }
+        for (var componentModel : componentModels) {
+            if (componentModel == componentModelForId) {
+                continue;
+            }
+            writeComponent(writer, record, componentModel);
+        }
+        writer.writeEndDocument();
+
+    }
+
+    @Override
+    public Class<T> getEncoderClass() {
+        return clazz;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void writeComponent(final BsonWriter writer, final T record, final ComponentModel componentModel) {
+        try {
+            Object componentValue = componentModel.getValue(record);
+            if (componentValue != null) {
+                writer.writeName(componentModel.getFieldName());
+                ((Codec) componentModel.codec).encode(writer, componentValue, EncoderContext.builder().build());
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new CodecConfigurationException(
+                    format("Unable to access value of component %s for record %s", componentModel.getComponentName(), clazz.getName()), e);
+        }
+    }
+
+    private static <T> List<ComponentModel> getComponentModels(final Class<T> clazz, final CodecRegistry codecRegistry) {
+        var componentModels = new ArrayList<ComponentModel>(clazz.getRecordComponents().length);
+        for (int i = 0; i < clazz.getRecordComponents().length; i++) {
+            componentModels.add(new ComponentModel(clazz.getRecordComponents()[i], codecRegistry, i));
+        }
+        return componentModels;
+    }
+
+    @Nullable
+    private static <T> ComponentModel getComponentModelForId(final Class<T> clazz, final List<ComponentModel> componentModels) {
+        List<ComponentModel> componentModelsForId = componentModels.stream()
+                .filter(componentModel -> componentModel.getFieldName().equals("_id")).toList();
+        if (componentModelsForId.size() > 1) {
+            throw new CodecConfigurationException(format("Record %s has more than one _id component", clazz.getName()));
+        } else {
+            return componentModelsForId.stream().findFirst().orElse(null);
+        }
+    }
+
+    private static <T> Constructor<?> getCanonicalConstructor(final Class<T> clazz) {
+        Class<?>[] recordComponentTypes = Arrays.stream(clazz.getRecordComponents()).map(RecordComponent::getType).toArray(Class<?>[]::new);
+        for (var constructor : clazz.getConstructors()) {
+            if (Arrays.equals(constructor.getParameterTypes(), recordComponentTypes)) {
+                return constructor;
+            }
+        }
+        throw new AssertionError(format("Could not find canonical constructor for record %s", clazz.getName()));
+    }
+
+    private static Class<?> toWrapper(final Class<?> clazz) {
+        if (clazz == Integer.TYPE) {
+            return Integer.class;
+        } else if (clazz == Long.TYPE) {
+            return Long.class;
+        } else if (clazz == Boolean.TYPE) {
+            return Boolean.class;
+        } else if (clazz == Byte.TYPE) {
+            return Byte.class;
+        } else if (clazz == Character.TYPE) {
+            return Character.class;
+        } else if (clazz == Float.TYPE) {
+            return Float.class;
+        } else if (clazz == Double.TYPE) {
+            return Double.class;
+        } else if (clazz == Short.TYPE) {
+            return Short.class;
+        } else {
+            return clazz;
+        }
+    }
+}

--- a/bson-record-codec/src/main/org/bson/codecs/record/RecordCodecProvider.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/RecordCodecProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record;
+
+import org.bson.codecs.Codec;
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+
+/**
+ * Provides Codec instances for Java records.
+ *
+ * @since 4.XXXXX
+ * @see Record
+ */
+public final class RecordCodecProvider implements CodecProvider {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
+        if (!clazz.isRecord()) {
+            return null;
+        }
+
+        return (Codec<T>) new RecordCodec(clazz, registry);
+    }
+}

--- a/bson-record-codec/src/main/org/bson/codecs/record/annotations/BsonId.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/annotations/BsonId.java
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':bson-record-codec'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include 'util:spock'
-include 'util:taglets'
+package org.bson.codecs.record.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation that configures the record component as the _id field of the document
+ *
+ * @since 4.XXX
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.RECORD_COMPONENT})
+public @interface BsonId {
+}

--- a/bson-record-codec/src/main/org/bson/codecs/record/annotations/BsonProperty.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/annotations/BsonProperty.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation that configures a record component.
+ *
+ * @since 4.XXX
+ */
+@Documented
+@Target({ElementType.RECORD_COMPONENT})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BsonProperty {
+    /**
+     * The field name of the record component.
+     *
+     * @return the field name to use for the record component
+     */
+    String value() default "";
+
+//    /**
+//     * TODO: is this needed?  If so, needs to be tested and implemented
+//     *
+//     * @return whether to include a discriminator when serializing nested records.
+//     */
+//    boolean useDiscriminator() default false;
+}

--- a/bson-record-codec/src/main/org/bson/codecs/record/annotations/BsonRepresentation.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/annotations/BsonRepresentation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.annotations;
+
+import org.bson.BsonType;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation that specifies what type the record component is stored as in the database.
+ *
+ * @since 4.XXX
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.RECORD_COMPONENT})
+public @interface BsonRepresentation {
+    /**
+     * The type that the property is stored as in the database.
+     *
+     * @return the type that the property should be stored as.
+     */
+    BsonType value();
+}

--- a/bson-record-codec/src/main/org/bson/codecs/record/annotations/package-info.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/annotations/package-info.java
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':bson-record-codec'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include 'util:spock'
-include 'util:taglets'
+/**
+ * This package contains annotations for encoding and decoding Java records.
+ */
+package org.bson.codecs.record.annotations;

--- a/bson-record-codec/src/main/org/bson/codecs/record/package-info.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/package-info.java
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 
-include ':bson'
-include ':bson-record-codec'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-scala'
-include ':driver-scala'
-include 'util:spock'
-include 'util:taglets'
+/**
+ * This package contains classes for encoding and decoding Java records.
+ */
+package org.bson.codecs.record;

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecProviderTest.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecProviderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record;
+
+import org.bson.codecs.record.samples.TestRecord;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class RecordCodecProviderTest {
+
+    @Test
+    public void shouldReturnNullForNonRecord() {
+        var provider = new RecordCodecProvider();
+
+        // expect
+        assertNull(provider.get(String.class, Bson.DEFAULT_CODEC_REGISTRY));
+    }
+
+    @Test
+    public void shouldReturnRecordCodecForRecord() {
+        var provider = new RecordCodecProvider();
+
+        // when
+        var codec = provider.get(TestRecord.class, Bson.DEFAULT_CODEC_REGISTRY);
+
+        // then
+        assertTrue(codec instanceof RecordCodec);
+        var recordCodec = (RecordCodec<TestRecord>) codec;
+        assertEquals(TestRecord.class, recordCodec.getEncoderClass());
+    }
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonDocumentWriter;
+import org.bson.BsonInt32;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.record.samples.TestRecord;
+import org.bson.conversions.Bson;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RecordCodecTest {
+    private final RecordCodec<TestRecord> codec = new RecordCodec<>(TestRecord.class, Bson.DEFAULT_CODEC_REGISTRY);
+
+    @Test
+    public void testSimpleRecord() {
+        var identifier = new ObjectId();
+        var testRecord = new TestRecord("Lucas", 14, List.of("soccer", "basketball"), identifier.toHexString());
+
+        var document = new BsonDocument();
+        var writer = new BsonDocumentWriter(document);
+
+        // when
+        codec.encode(writer, testRecord, EncoderContext.builder().build());
+
+        // then
+        assertEquals(
+                new BsonDocument("_id", new BsonObjectId(identifier))
+                        .append("name", new BsonString("Lucas"))
+                        .append("hobbies", new BsonArray(List.of(new BsonString("soccer"), new BsonString("basketball"))))
+                        .append("a", new BsonInt32(14)),
+                document);
+        assertEquals("_id", document.getFirstKey());
+
+        // when
+        var decoded = codec.decode(new BsonDocumentReader(document), DecoderContext.builder().build());
+
+        // then
+        assertEquals(testRecord, decoded);
+    }
+
+    @Test
+    public void testSimpleRecordWithNulls() {
+        var identifier = new ObjectId();
+        var testRecord = new TestRecord(null, 14, null, identifier.toHexString());
+
+        var document = new BsonDocument();
+        var writer = new BsonDocumentWriter(document);
+
+        // when
+        codec.encode(writer, testRecord, EncoderContext.builder().build());
+
+        // then
+        assertEquals(
+                new BsonDocument("_id", new BsonObjectId(identifier))
+                        .append("a", new BsonInt32(14)),
+                document);
+
+        // when
+        var decoded = codec.decode(new BsonDocumentReader(document), DecoderContext.builder().build());
+
+        // then
+        assertEquals(testRecord, decoded);
+    }
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecord.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecord.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.BsonType;
+import org.bson.codecs.record.annotations.BsonId;
+import org.bson.codecs.record.annotations.BsonProperty;
+import org.bson.codecs.record.annotations.BsonRepresentation;
+
+import java.util.List;
+
+public record TestRecord(String name,
+                         @BsonProperty("a") int age,
+                         List<String> hobbies,
+                         @BsonRepresentation(BsonType.OBJECT_ID) @BsonId String identifier) {
+
+    // To test that the default constructor is always used for decoding
+    public TestRecord(final String identifier) {
+        this("Adrian", 17, List.of("soccer", "music"), identifier);
+    }
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecord.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecord.java
@@ -28,7 +28,7 @@ public record TestRecord(String name,
                          List<String> hobbies,
                          @BsonRepresentation(BsonType.OBJECT_ID) @BsonId String identifier) {
 
-    // To test that the default constructor is always used for decoding
+    // To test that the canonical constructor is always used for decoding
     public TestRecord(final String identifier) {
         this("Adrian", 17, List.of("soccer", "music"), identifier);
     }

--- a/gradle/javaToolchain.gradle
+++ b/gradle/javaToolchain.gradle
@@ -31,7 +31,12 @@ allprojects {
         }
     }
 
-    if (project in javaMainProjects) {
+    if (project == project(":bson-record-codec")) {
+        tasks.withType(JavaCompile) {
+            options.encoding = "UTF-8"
+            options.release.set(17)
+        }
+    } else if (project in javaMainProjects) {
         tasks.withType(JavaCompile) {
             options.encoding = "UTF-8"
             options.release.set(8)


### PR DESCRIPTION
JAVA-3567

This is a draft pull request to get feedback on the approach.  Of note:

1. It's implemented as a separate module, bson-record-codec, with a minimum release dependency of Java 17
2. It is not dependent on any POJO Codec support classes.  
3. There is no support for conventions.  The provider is implicitly automatic.  It supports all record types.
4. There is no automatic conversion of "id" to "_id".  You have to either name the field "_id" or annotate with BsonId.  
5. It redefines the annotations so that they can be added to the record component and only the record component.  Also, I can't think of a straightforward way to add `ElementType.RECORD_COMPONENT` to `@Target` of the existing annotations, since that requires Java 17. 
6. It doesn't support generics at all, even for nested records.  It's not clear if they are needed, but probably some users will have a use case for it.
7. It doesn't support discriminators at all,  It's not clear if they are needed, but again, they probably are.  It's just a bit weird because records are final and so the only base type would be an interface they is implemented by multiple record types.
8. It does not serialize null values. It just leaves the field out entirely (I think PojoCodec is the same).
9. The tests don't run properly in Evergreen yet because it requires Java 17.
10. Javadoc generation is failing on Evergreen for some reason I don't understand.  It works locally.