### PR TITLE
Add missing Javadoc

### DIFF
--- a/bson/src/main/org/bson/AbstractBsonReader.java
+++ b/bson/src/main/org/bson/AbstractBsonReader.java
@@ -771,6 +771,9 @@ public abstract class AbstractBsonReader implements BsonReader {
         }
     }
 
+    /**
+     * An implementation of {@code BsonReaderMark}.
+     */
     protected class Mark implements BsonReaderMark {
         private final State state;
         private final Context parentContext;
@@ -778,14 +781,27 @@ public abstract class AbstractBsonReader implements BsonReader {
         private final BsonType currentBsonType;
         private final String currentName;
 
+        /**
+         * Gets the parent context.
+         *
+         * @return the parent context
+         */
         protected Context getParentContext() {
             return parentContext;
         }
 
+        /**
+         * Gets the context type.
+         *
+         * @return the context type
+         */
         protected BsonContextType getContextType() {
             return contextType;
         }
 
+        /**
+         * Construct an instance.
+         */
         protected Mark() {
             state = AbstractBsonReader.this.state;
             parentContext = AbstractBsonReader.this.context.parentContext;
@@ -794,6 +810,7 @@ public abstract class AbstractBsonReader implements BsonReader {
             currentName = AbstractBsonReader.this.currentName;
         }
 
+        @Override
         public void reset() {
             AbstractBsonReader.this.state = state;
             AbstractBsonReader.this.currentBsonType = currentBsonType;

--- a/bson/src/main/org/bson/BSONException.java
+++ b/bson/src/main/org/bson/BSONException.java
@@ -18,6 +18,7 @@ package org.bson;
 
 /**
  * A general runtime exception raised in BSON processing.
+ * @serial exclude
  */
 public class BSONException extends RuntimeException {
 

--- a/bson/src/main/org/bson/BsonBinaryReader.java
+++ b/bson/src/main/org/bson/BsonBinaryReader.java
@@ -394,11 +394,17 @@ public class BsonBinaryReader extends AbstractBsonReader {
         return new Mark();
     }
 
+    /**
+     * An implementation of {@code AbstractBsonReader.Mark}.
+     */
     protected class Mark extends AbstractBsonReader.Mark {
         private final int startPosition;
         private final int size;
         private final BsonInputMark bsonInputMark;
 
+        /**
+         * Construct an instance.
+         */
         protected Mark() {
             super();
             startPosition = BsonBinaryReader.this.getContext().startPosition;
@@ -406,12 +412,17 @@ public class BsonBinaryReader extends AbstractBsonReader {
             bsonInputMark = BsonBinaryReader.this.bsonInput.getMark(Integer.MAX_VALUE);
         }
 
+        @Override
         public void reset() {
             super.reset();
             bsonInputMark.reset();
             BsonBinaryReader.this.setContext(new Context((Context) getParentContext(), getContextType(), startPosition, size));
         }
     }
+
+    /**
+     * An implementation of {@code AbstractBsonReader.Context}.
+     */
     protected class Context extends AbstractBsonReader.Context {
         private final int startPosition;
         private final int size;

--- a/bson/src/main/org/bson/BsonBinaryWriter.java
+++ b/bson/src/main/org/bson/BsonBinaryWriter.java
@@ -420,6 +420,9 @@ public class BsonBinaryWriter extends AbstractBsonWriter {
         }
     }
 
+    /**
+     * An implementation of {@code AbstractBsonWriter.Context}.
+     */
     protected class Context extends AbstractBsonWriter.Context {
         private final int startPosition;
         private int index; // used when contextType is an array
@@ -458,6 +461,9 @@ public class BsonBinaryWriter extends AbstractBsonWriter {
         }
     }
 
+    /**
+     * An implementation of {@code AbstractBsonWriter.Mark}.
+     */
     protected class Mark extends AbstractBsonWriter.Mark {
         private final int position;
 

--- a/bson/src/main/org/bson/BsonBoolean.java
+++ b/bson/src/main/org/bson/BsonBoolean.java
@@ -25,8 +25,14 @@ public final class BsonBoolean extends BsonValue implements Comparable<BsonBoole
 
     private final boolean value;
 
+    /**
+     * The true value.
+     */
     public static final BsonBoolean TRUE = new BsonBoolean(true);
 
+    /**
+     * The false value.
+     */
     public static final BsonBoolean FALSE = new BsonBoolean(false);
 
     /**

--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -885,8 +885,6 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, C
         }
     }
 
-    //
-
     /**
      * Write the replacement object.
      *
@@ -901,7 +899,7 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, C
     }
 
     /**
-     * Prevent normal serialization.
+     * Prevent normal deserialization.
      *
      * <p>
      * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html

--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -49,6 +49,9 @@ import static java.lang.String.format;
 public class BsonDocument extends BsonValue implements Map<String, BsonValue>, Cloneable, Bson, Serializable {
     private static final long serialVersionUID = 1L;
 
+    /**
+     * The underlying map.
+     */
     private final Map<String, BsonValue> map;
 
     /**
@@ -882,12 +885,31 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, C
         }
     }
 
-    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
+    //
+
+    /**
+     * Write the replacement object.
+     *
+     * <p>
+     * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
+     * </p>
+     *
+     * @return a proxy for the document
+     */
     private Object writeReplace() {
         return new SerializationProxy(this);
     }
 
-    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
+    /**
+     * Prevent normal serialization.
+     *
+     * <p>
+     * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
+     * </p>
+     *
+     * @param stream the stream
+     * @throws InvalidObjectException in all cases
+     */
     private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
         throw new InvalidObjectException("Proxy required");
     }

--- a/bson/src/main/org/bson/BsonDocumentReader.java
+++ b/bson/src/main/org/bson/BsonDocumentReader.java
@@ -243,10 +243,17 @@ public class BsonDocumentReader extends AbstractBsonReader {
     protected Context getContext() {
         return (Context) super.getContext();
     }
+
+    /**
+     * An implementation of {@code AbstractBsonReader.Mark}.
+     */
     protected class Mark extends AbstractBsonReader.Mark {
         private final BsonValue currentValue;
         private final Context context;
 
+        /**
+         * Construct an instance.
+         */
         protected Mark() {
             super();
             currentValue = BsonDocumentReader.this.currentValue;
@@ -254,6 +261,7 @@ public class BsonDocumentReader extends AbstractBsonReader {
             context.mark();
         }
 
+        @Override
         public void reset() {
             super.reset();
             BsonDocumentReader.this.currentValue = currentValue;
@@ -325,21 +333,43 @@ public class BsonDocumentReader extends AbstractBsonReader {
         }
     }
 
+    /**
+     * An implementation of {@code AbstractBsonReader.Context}.
+     */
     protected class Context extends AbstractBsonReader.Context {
 
         private BsonDocumentMarkableIterator<Map.Entry<String, BsonValue>> documentIterator;
         private BsonDocumentMarkableIterator<BsonValue> arrayIterator;
 
+        /**
+         * Construct an instance.
+         *
+         * @param parentContext the parent context
+         * @param contextType the context type
+         * @param array the array context
+         */
         protected Context(final Context parentContext, final BsonContextType contextType, final BsonArray array) {
             super(parentContext, contextType);
             arrayIterator = new BsonDocumentMarkableIterator<BsonValue>(array.iterator());
         }
 
+        /**
+         * Construct an instance.
+         *
+         * @param parentContext the parent context
+         * @param contextType the context type
+         * @param document the document context
+         */
         protected Context(final Context parentContext, final BsonContextType contextType, final BsonDocument document) {
             super(parentContext, contextType);
             documentIterator = new BsonDocumentMarkableIterator<Map.Entry<String, BsonValue>>(document.entrySet().iterator());
         }
 
+        /**
+         * Gets the next element.
+         *
+         * @return the next element, which may be null
+         */
         public Map.Entry<String, BsonValue> getNextElement() {
             if (documentIterator.hasNext()) {
                 return documentIterator.next();
@@ -347,6 +377,10 @@ public class BsonDocumentReader extends AbstractBsonReader {
                 return null;
             }
         }
+
+        /**
+         * Create a mark.
+         */
         protected void mark() {
             if (documentIterator != null) {
                 documentIterator.mark();
@@ -359,6 +393,9 @@ public class BsonDocumentReader extends AbstractBsonReader {
             }
         }
 
+        /**
+         * Reset the context.
+         */
         protected void reset() {
             if (documentIterator != null) {
                 documentIterator.reset();
@@ -371,6 +408,11 @@ public class BsonDocumentReader extends AbstractBsonReader {
             }
         }
 
+        /**
+         * Gets the next value.
+         *
+         * @return the next value, which may be null
+         */
         public BsonValue getNextValue() {
             if (arrayIterator.hasNext()) {
                 return arrayIterator.next();

--- a/bson/src/main/org/bson/BsonDocumentWrapper.java
+++ b/bson/src/main/org/bson/BsonDocumentWrapper.java
@@ -216,7 +216,7 @@ public final class BsonDocumentWrapper<T> extends BsonDocument {
     }
 
     /**
-     * Prevent normal serialization.
+     * Prevent normal deserialization.
      *
      * <p>
      * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html

--- a/bson/src/main/org/bson/BsonDocumentWrapper.java
+++ b/bson/src/main/org/bson/BsonDocumentWrapper.java
@@ -41,6 +41,10 @@ public final class BsonDocumentWrapper<T> extends BsonDocument {
 
     private final transient T wrappedDocument;
     private final transient Encoder<T> encoder;
+
+    /**
+     * The unwrapped document, which may be null
+     */
     private BsonDocument unwrapped;
 
     /**
@@ -198,12 +202,29 @@ public final class BsonDocumentWrapper<T> extends BsonDocument {
         return unwrapped;
     }
 
-    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
+    /**
+     * Write the replacement object.
+     *
+     * <p>
+     * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
+     * </p>
+     *
+     * @return a proxy for the document
+     */
     private Object writeReplace() {
         return getUnwrapped();
     }
 
-    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
+    /**
+     * Prevent normal serialization.
+     *
+     * <p>
+     * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
+     * </p>
+     *
+     * @param stream the stream
+     * @throws InvalidObjectException in all cases
+     */
     private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
         throw new InvalidObjectException("Proxy required");
     }

--- a/bson/src/main/org/bson/BsonNull.java
+++ b/bson/src/main/org/bson/BsonNull.java
@@ -23,6 +23,9 @@ package org.bson;
  */
 public final class BsonNull extends BsonValue {
 
+    /**
+     * A singleton instance of the null value.
+     */
     public static final BsonNull VALUE = new BsonNull();
 
     @Override

--- a/bson/src/main/org/bson/Document.java
+++ b/bson/src/main/org/bson/Document.java
@@ -69,6 +69,9 @@ public class Document implements Map<String, Object>, Serializable, Bson {
 
     private static final long serialVersionUID = 6297731997167536582L;
 
+    /**
+     * The map of keys to values.
+     */
     private final LinkedHashMap<String, Object> documentAsMap;
 
     /**

--- a/bson/src/main/org/bson/RawBsonArray.java
+++ b/bson/src/main/org/bson/RawBsonArray.java
@@ -155,7 +155,7 @@ public class RawBsonArray extends BsonArray implements Serializable {
     }
 
     /**
-     * Prevent normal serialization.
+     * Prevent normal deserialization.
      *
      * <p>
      * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html

--- a/bson/src/main/org/bson/RawBsonArray.java
+++ b/bson/src/main/org/bson/RawBsonArray.java
@@ -141,12 +141,29 @@ public class RawBsonArray extends BsonArray implements Serializable {
         return super.hashCode();
     }
 
-    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
+    /**
+     * Write the replacement object.
+     *
+     * <p>
+     * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
+     * </p>
+     *
+     * @return a proxy for the document
+     */
     private Object writeReplace() {
         return new SerializationProxy(delegate.bytes, delegate.offset, delegate.length);
     }
 
-    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
+    /**
+     * Prevent normal serialization.
+     *
+     * <p>
+     * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
+     * </p>
+     *
+     * @param stream the stream
+     * @throws InvalidObjectException in all cases
+     */
     private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
         throw new InvalidObjectException("Proxy required");
     }

--- a/bson/src/main/org/bson/RawBsonDocument.java
+++ b/bson/src/main/org/bson/RawBsonDocument.java
@@ -52,8 +52,19 @@ public final class RawBsonDocument extends BsonDocument {
     private static final long serialVersionUID = 1L;
     private static final int MIN_BSON_DOCUMENT_SIZE = 5;
 
+    /**
+     * The raw bytes.
+     */
     private final byte[] bytes;
+
+    /**
+     * The offset into bytes, which much be less than {@code bytes.length}.
+     */
     private final int offset;
+
+    /**
+     * The length, which much be less than {@code offset + bytes.length}.
+     */
     private final int length;
 
     /**
@@ -359,12 +370,29 @@ public final class RawBsonDocument extends BsonDocument {
         }
     }
 
-    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
+    /**
+     * Write the replacement object.
+     *
+     * <p>
+     * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
+     * </p>
+     *
+     * @return a proxy for the document
+     */
     private Object writeReplace() {
         return new SerializationProxy(this.bytes, offset, length);
     }
 
-    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
+    /**
+     * Prevent normal serialization.
+     *
+     * <p>
+     * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
+     * </p>
+     *
+     * @param stream the stream
+     * @throws InvalidObjectException in all cases
+     */
     private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
         throw new InvalidObjectException("Proxy required");
     }

--- a/bson/src/main/org/bson/RawBsonDocument.java
+++ b/bson/src/main/org/bson/RawBsonDocument.java
@@ -58,12 +58,12 @@ public final class RawBsonDocument extends BsonDocument {
     private final byte[] bytes;
 
     /**
-     * The offset into bytes, which much be less than {@code bytes.length}.
+     * The offset into bytes, which must be less than {@code bytes.length}.
      */
     private final int offset;
 
     /**
-     * The length, which much be less than {@code offset + bytes.length}.
+     * The length, which must be less than {@code offset + bytes.length}.
      */
     private final int length;
 
@@ -384,7 +384,7 @@ public final class RawBsonDocument extends BsonDocument {
     }
 
     /**
-     * Prevent normal serialization.
+     * Prevent normal deserialization.
      *
      * <p>
      * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html

--- a/bson/src/main/org/bson/codecs/pojo/IdGenerators.java
+++ b/bson/src/main/org/bson/codecs/pojo/IdGenerators.java
@@ -59,6 +59,9 @@ public final class IdGenerators {
         }
     };
 
+    /**
+     * A IdGenerator for {@code String}
+     */
     public static final IdGenerator<String> STRING_ID_GENERATOR = new IdGenerator<String>() {
         @Override
         public String generate() {

--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -1349,11 +1349,17 @@ public class JsonReader extends AbstractBsonReader {
         return (Context) super.getContext();
     }
 
+    /**
+     * An implementation of {@code AbstractBsonReader.Mark}.
+     */
     protected class Mark extends AbstractBsonReader.Mark {
         private final JsonToken pushedToken;
         private final Object currentValue;
         private final int markPos;
 
+        /**
+         * Construct an instance.
+         */
         protected Mark() {
             super();
             pushedToken = JsonReader.this.pushedToken;
@@ -1361,6 +1367,7 @@ public class JsonReader extends AbstractBsonReader {
             markPos = JsonReader.this.scanner.mark();
         }
 
+        @Override
         public void reset() {
             super.reset();
             JsonReader.this.pushedToken = pushedToken;
@@ -1369,21 +1376,35 @@ public class JsonReader extends AbstractBsonReader {
             JsonReader.this.setContext(new Context(getParentContext(), getContextType()));
         }
 
+        /**
+         * Discard the mark.
+         */
         public void discard() {
             JsonReader.this.scanner.discard(markPos);
         }
     }
 
 
+    /**
+     * An implementation of {@code AbstractBsonReader.Context}/
+     */
     protected class Context extends AbstractBsonReader.Context {
+        /**
+         * Construct an instance.
+         *
+         * @param parentContext the parent context
+         * @param contextType the context type
+         */
         protected Context(final AbstractBsonReader.Context parentContext, final BsonContextType contextType) {
             super(parentContext, contextType);
         }
 
+        @Override
         protected Context getParentContext() {
             return (Context) super.getParentContext();
         }
 
+        @Override
         protected BsonContextType getContextType() {
             return super.getContextType();
         }

--- a/bson/src/main/org/bson/types/BSONTimestamp.java
+++ b/bson/src/main/org/bson/types/BSONTimestamp.java
@@ -29,7 +29,13 @@ public final class BSONTimestamp implements Comparable<BSONTimestamp>, Serializa
 
     private static final long serialVersionUID = -3268482672267936464L;
 
+    /**
+     * The millisecond increment within the second.
+     */
     private final int inc;
+    /**
+     * The time, in seconds
+     */
     private final Date time;
 
     /**

--- a/bson/src/main/org/bson/types/Binary.java
+++ b/bson/src/main/org/bson/types/Binary.java
@@ -27,7 +27,14 @@ import java.util.Arrays;
 public class Binary implements Serializable {
     private static final long serialVersionUID = 7902997490338209467L;
 
+    /**
+     * The binary sub-type.
+     */
     private final byte type;
+
+    /**
+     * The binary data.
+     */
     private final byte[] data;
 
     /**

--- a/bson/src/main/org/bson/types/Code.java
+++ b/bson/src/main/org/bson/types/Code.java
@@ -27,6 +27,9 @@ public class Code implements Serializable {
 
     private static final long serialVersionUID = 475535263314046697L;
 
+    /**
+     * The JavaScript code string.
+     */
     private final String code;
 
     /**

--- a/bson/src/main/org/bson/types/CodeWScope.java
+++ b/bson/src/main/org/bson/types/CodeWScope.java
@@ -25,6 +25,9 @@ import org.bson.BSONObject;
  */
 public class CodeWScope extends Code {
 
+    /**
+     * The scope document.
+     */
     private final BSONObject scope;
 
     private static final long serialVersionUID = -6284832275113680002L;

--- a/bson/src/main/org/bson/types/CodeWithScope.java
+++ b/bson/src/main/org/bson/types/CodeWithScope.java
@@ -25,6 +25,9 @@ import org.bson.Document;
  */
 public class CodeWithScope extends Code {
 
+    /**
+     * The scope document.
+     */
     private final Document scope;
 
     private static final long serialVersionUID = -6284832275113680002L;

--- a/bson/src/main/org/bson/types/Decimal128.java
+++ b/bson/src/main/org/bson/types/Decimal128.java
@@ -94,7 +94,13 @@ public final class Decimal128 extends Number implements Comparable<Decimal128> {
      */
     public static final Decimal128 NEGATIVE_ZERO = fromIEEE754BIDEncoding(0xb040000000000000L, 0x0000000000000000L);
 
+    /**
+     * The high bits.
+     */
     private final long high;
+    /**
+     * The low bits.
+     */
     private final long low;
 
     /**

--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -377,7 +377,7 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
     }
 
     /**
-     * Prevent normal serialization.
+     * Prevent normal deserialization.
      *
      * <p>
      * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html

--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -63,9 +63,21 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
             '0', '1', '2', '3', '4', '5', '6', '7',
             '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
+    /**
+     * The timestamp
+     */
     private final int timestamp;
+    /**
+     * The counter.
+     */
     private final int counter;
+    /**
+     * the first four bits of randomness.
+     */
     private final int randomValue1;
+    /**
+     * The last two bits of randomness.
+     */
     private final short randomValue2;
 
     /**
@@ -351,12 +363,29 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
         return toHexString();
     }
 
-    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
+    /**
+     * Write the replacement object.
+     *
+     * <p>
+     * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
+     * </p>
+     *
+     * @return a proxy for the document
+     */
     private Object writeReplace() {
         return new SerializationProxy(this);
     }
 
-    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
+    /**
+     * Prevent normal serialization.
+     *
+     * <p>
+     * See https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
+     * </p>
+     *
+     * @param stream the stream
+     * @throws InvalidObjectException in all cases
+     */
     private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
         throw new InvalidObjectException("Proxy required");
     }

--- a/bson/src/main/org/bson/types/Symbol.java
+++ b/bson/src/main/org/bson/types/Symbol.java
@@ -27,6 +27,9 @@ public class Symbol implements Serializable {
 
     private static final long serialVersionUID = 1326269319883146072L;
 
+    /**
+     * The symbol string.
+     */
     private final String symbol;
 
     /**

--- a/driver-core/src/main/com/mongodb/BasicDBList.java
+++ b/driver-core/src/main/com/mongodb/BasicDBList.java
@@ -58,5 +58,8 @@ public class BasicDBList extends BasicBSONList implements DBObject {
         return newobj;
     }
 
+    /**
+     * Whether the object is partial
+     */
     private boolean _isPartialObject;
 }

--- a/driver-core/src/main/com/mongodb/BasicDBObject.java
+++ b/driver-core/src/main/com/mongodb/BasicDBObject.java
@@ -65,6 +65,9 @@ public class BasicDBObject extends BasicBSONObject implements DBObject, Bson {
                     UuidRepresentation.STANDARD)
                     .get(BasicDBObject.class);
 
+    /**
+     * Whether the object is partial
+     */
     private boolean isPartialObject;
 
     /**

--- a/driver-core/src/main/com/mongodb/DBRef.java
+++ b/driver-core/src/main/com/mongodb/DBRef.java
@@ -42,7 +42,7 @@ public class DBRef implements Serializable {
      */
     private final String collectionName;
     /**
-     * The database name, which mayt be null.
+     * The database name, which may be null.
      */
     private final String databaseName;
 

--- a/driver-core/src/main/com/mongodb/DBRef.java
+++ b/driver-core/src/main/com/mongodb/DBRef.java
@@ -33,8 +33,17 @@ public class DBRef implements Serializable {
 
     private static final long serialVersionUID = -849581217713362618L;
 
+    /**
+     * The id.
+     */
     private final Object id;
+    /**
+     * The collection name.
+     */
     private final String collectionName;
+    /**
+     * The database name, which mayt be null.
+     */
     private final String databaseName;
 
     /**

--- a/driver-core/src/main/com/mongodb/MongoBulkWriteException.java
+++ b/driver-core/src/main/com/mongodb/MongoBulkWriteException.java
@@ -29,6 +29,7 @@ import java.util.Set;
  * An exception that represents all errors associated with a bulk write operation.
  *
  * @since 3.0
+ * @serial exclude
  */
 public class MongoBulkWriteException extends MongoServerException {
 

--- a/driver-core/src/main/com/mongodb/MongoCommandException.java
+++ b/driver-core/src/main/com/mongodb/MongoCommandException.java
@@ -32,6 +32,7 @@ import static java.lang.String.format;
  * An exception indicating that a command sent to a MongoDB server returned a failure.
  *
  * @since 2.13
+ * @serial exclude
  */
 public class MongoCommandException extends MongoServerException {
     private static final long serialVersionUID = 8160676451944215078L;

--- a/driver-core/src/main/com/mongodb/MongoCursorNotFoundException.java
+++ b/driver-core/src/main/com/mongodb/MongoCursorNotFoundException.java
@@ -20,6 +20,7 @@ package com.mongodb;
  * Subclass of {@link MongoException} representing a cursor-not-found exception.
  *
  * @since 2.12
+ * @serial exclude
  */
 public class MongoCursorNotFoundException extends MongoQueryException {
 

--- a/driver-core/src/main/com/mongodb/MongoException.java
+++ b/driver-core/src/main/com/mongodb/MongoException.java
@@ -30,6 +30,7 @@ import static com.mongodb.assertions.Assertions.notNull;
 
 /**
  * Top level Exception for all Exceptions, server-side or client-side, that come from the driver.
+ * @serial exclude
  */
 public class MongoException extends RuntimeException {
 
@@ -190,12 +191,22 @@ public class MongoException extends RuntimeException {
         return errorLabels.contains(errorLabel);
     }
 
+    /**
+     * Add labels.
+     *
+     * @param labels the labels
+     */
     protected void addLabels(final BsonArray labels) {
         for (final BsonValue errorLabel : labels) {
             addLabel(errorLabel.asString().getValue());
         }
     }
 
+    /**
+     * Add labels.
+     *
+     * @param labels the labels
+     */
     protected void addLabels(final Collection<String> labels) {
         for (final String errorLabel : labels) {
             addLabel(errorLabel);

--- a/driver-core/src/main/com/mongodb/MongoIncompatibleDriverException.java
+++ b/driver-core/src/main/com/mongodb/MongoIncompatibleDriverException.java
@@ -23,6 +23,7 @@ import com.mongodb.connection.ClusterDescription;
  * connected to.
  *
  * @since 2.12.0
+ * @serial exclude
  */
 public class MongoIncompatibleDriverException extends MongoException {
     private static final long serialVersionUID = -5213381354402601890L;

--- a/driver-core/src/main/com/mongodb/MongoNamespace.java
+++ b/driver-core/src/main/com/mongodb/MongoNamespace.java
@@ -35,6 +35,9 @@ import static java.util.Arrays.asList;
  */
 @Immutable
 public final class MongoNamespace {
+    /**
+     * The collection name in which to execute a command.
+     */
     public static final String COMMAND_COLLECTION_NAME = "$cmd";
 
     private static final Set<Character> PROHIBITED_CHARACTERS_IN_DATABASE_NAME =

--- a/driver-core/src/main/com/mongodb/MongoQueryException.java
+++ b/driver-core/src/main/com/mongodb/MongoQueryException.java
@@ -22,6 +22,7 @@ import static java.lang.String.format;
  * An exception indicating that a query operation failed on the server.
  *
  * @since 3.0
+ * @serial exclude
  */
 public class MongoQueryException extends MongoServerException {
     private static final long serialVersionUID = -5113350133297015801L;

--- a/driver-core/src/main/com/mongodb/MongoSecurityException.java
+++ b/driver-core/src/main/com/mongodb/MongoSecurityException.java
@@ -20,6 +20,7 @@ package com.mongodb;
  * This exception is thrown when there is an error reported by the underlying client authentication mechanism.
  *
  * @since 3.0
+ * @serial exclude
  */
 public class MongoSecurityException extends MongoClientException {
     private static final long serialVersionUID = -7044790409935567275L;

--- a/driver-core/src/main/com/mongodb/MongoServerException.java
+++ b/driver-core/src/main/com/mongodb/MongoServerException.java
@@ -20,6 +20,7 @@ package com.mongodb;
  * An exception indicating that some error has been raised by a MongoDB server in response to an operation.
  *
  * @since 2.13
+ * @serial exclude
  */
 public abstract class MongoServerException extends MongoException {
     private static final long serialVersionUID = -5213859742051776206L;

--- a/driver-core/src/main/com/mongodb/MongoSocketException.java
+++ b/driver-core/src/main/com/mongodb/MongoSocketException.java
@@ -20,6 +20,7 @@ package com.mongodb;
  * Subclass of {@link MongoException} representing a network-related exception
  *
  * @since 2.12
+ * @serial exclude
  */
 public class MongoSocketException extends MongoException {
 

--- a/driver-core/src/main/com/mongodb/MongoWriteConcernException.java
+++ b/driver-core/src/main/com/mongodb/MongoWriteConcernException.java
@@ -27,6 +27,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  * @see com.mongodb.WriteConcern
  *
  * @since 3.0
+ * @serial exclude
  */
 public class MongoWriteConcernException extends MongoServerException {
     private static final long serialVersionUID = 4577579466973523211L;

--- a/driver-core/src/main/com/mongodb/MongoWriteException.java
+++ b/driver-core/src/main/com/mongodb/MongoWriteException.java
@@ -20,6 +20,7 @@ package com.mongodb;
  * An exception indicating the failure of a write operation.
  *
  * @since 3.0
+ * @serial exclude
  */
 public class MongoWriteException extends MongoServerException {
 

--- a/driver-core/src/main/com/mongodb/ReadPreference.java
+++ b/driver-core/src/main/com/mongodb/ReadPreference.java
@@ -154,8 +154,20 @@ public abstract class ReadPreference {
         }
     }
 
+    /**
+     * Choose for non-replica sets.
+     *
+     * @param clusterDescription the cluster description
+     * @return the list of matching server descriptions
+     */
     protected abstract List<ServerDescription> chooseForNonReplicaSet(ClusterDescription clusterDescription);
 
+    /**
+     * Choose for replica sets.
+     *
+     * @param clusterDescription the cluster description
+     * @return the list of matching server descriptions
+     */
     protected abstract List<ServerDescription> chooseForReplicaSet(ClusterDescription clusterDescription);
 
     /**

--- a/driver-core/src/main/com/mongodb/ServerAddress.java
+++ b/driver-core/src/main/com/mongodb/ServerAddress.java
@@ -33,7 +33,13 @@ import java.util.List;
 public class ServerAddress implements Serializable {
     private static final long serialVersionUID = 4027873363095395504L;
 
+    /**
+     * The host.
+     */
     private final String host;
+    /**
+     * The port.
+     */
     private final int port;
 
     /**

--- a/driver-core/src/main/com/mongodb/ServerCursor.java
+++ b/driver-core/src/main/com/mongodb/ServerCursor.java
@@ -31,7 +31,13 @@ public final class ServerCursor implements Serializable {
 
     private static final long serialVersionUID = -7013636754565190109L;
 
+    /**
+     * The cursor id.
+     */
     private final long id;
+    /**
+     * The server address.
+     */
     private final ServerAddress address;
 
     /**

--- a/driver-core/src/main/com/mongodb/TaggableReadPreference.java
+++ b/driver-core/src/main/com/mongodb/TaggableReadPreference.java
@@ -205,8 +205,8 @@ public abstract class TaggableReadPreference extends ReadPreference {
         return selectFreshServers(clusterDescription, getAny(clusterDescription));
     }
 
-    protected static ClusterDescription copyClusterDescription(final ClusterDescription clusterDescription,
-                                                               final List<ServerDescription> selectedServers) {
+    static ClusterDescription copyClusterDescription(final ClusterDescription clusterDescription,
+                                                     final List<ServerDescription> selectedServers) {
         return new ClusterDescription(clusterDescription.getConnectionMode(),
                                              clusterDescription.getType(),
                                              selectedServers,
@@ -214,8 +214,8 @@ public abstract class TaggableReadPreference extends ReadPreference {
                                              clusterDescription.getServerSettings());
     }
 
-    protected List<ServerDescription> selectFreshServers(final ClusterDescription clusterDescription,
-                                                         final List<ServerDescription> servers) {
+    List<ServerDescription> selectFreshServers(final ClusterDescription clusterDescription,
+                                               final List<ServerDescription> servers) {
         Long maxStaleness = getMaxStaleness(MILLISECONDS);
         if (maxStaleness == null) {
             return servers;

--- a/driver-core/src/main/com/mongodb/WriteConcern.java
+++ b/driver-core/src/main/com/mongodb/WriteConcern.java
@@ -70,10 +70,19 @@ public class WriteConcern implements Serializable {
     // map of the constants from above for use by fromString
     private static final Map<String, WriteConcern> NAMED_CONCERNS;
 
+    /**
+     * The w value.
+     */
     private final Object w;
 
+    /**
+     * The w timeout value.
+     */
     private final Integer wTimeoutMS;
 
+    /**
+     * The journal value.
+     */
     private final Boolean journal;
 
     /**

--- a/driver-core/src/main/com/mongodb/WriteConcernException.java
+++ b/driver-core/src/main/com/mongodb/WriteConcernException.java
@@ -39,6 +39,7 @@ import static java.lang.String.format;
  * </ul>
  * @see MongoWriteConcernException
  * @see MongoBulkWriteException
+ * @serial exclude
  */
 public class WriteConcernException extends MongoServerException {
 

--- a/driver-core/src/main/com/mongodb/client/model/BucketGranularity.java
+++ b/driver-core/src/main/com/mongodb/client/model/BucketGranularity.java
@@ -25,18 +25,57 @@ package com.mongodb.client.model;
  * @since 3.4
  */
 public enum BucketGranularity {
+    /**
+     * R5
+     */
     R5,
+    /**
+     * R10
+     */
     R10,
+    /**
+     * R20
+     */
     R20,
+    /**
+     * R40
+     */
     R40,
+    /**
+     * R80
+     */
     R80,
+    /**
+     * SERIES_125
+     */
     SERIES_125("1-2-5"),
+    /**
+     * E6
+     */
     E6,
+    /**
+     * E12
+     */
     E12,
+    /**
+     * E24
+     */
     E24,
+    /**
+     * E48
+     */
     E48,
+    /**
+     * E96
+     */
     E96,
+    /**
+     * E192
+     */
     E192,
+    /**
+     * POWERSOF2
+     */
     POWERSOF2;
 
     private final String value;

--- a/driver-core/src/main/com/mongodb/client/model/MongoTimeUnit.java
+++ b/driver-core/src/main/com/mongodb/client/model/MongoTimeUnit.java
@@ -26,14 +26,41 @@ import com.mongodb.annotations.Beta;
  */
 @Beta
 public enum MongoTimeUnit {
+    /**
+     * YEAR
+     */
     YEAR("year", false),
+    /**
+     * QUARTER
+     */
     QUARTER("quarter", false),
+    /**
+     * MONTH
+     */
     MONTH("month", false),
+    /**
+     * WEEK
+     */
     WEEK("week", true),
+    /**
+     * DAY
+     */
     DAY("day", true),
+    /**
+     * HOUR
+     */
     HOUR("hour", true),
+    /**
+     * MINUTE
+     */
     MINUTE("minute", true),
+    /**
+     * SECOND
+     */
     SECOND("second", true),
+    /**
+     * MILLISECOND
+     */
     MILLISECOND("millisecond", true);
 
     private final String value;

--- a/driver-core/src/main/com/mongodb/client/model/vault/DataKeyOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/vault/DataKeyOptions.java
@@ -100,7 +100,6 @@ public class DataKeyOptions {
      *   <li>endpoint: an optional String, with the host with optional port. Defaults to "cloudkms.googleapis.com".</li>
      * </ul>
      * <p>
-     * <p>
      *     If the kmsProvider is "kmip" the master key is required and must contain the following fields:
      * </p>
      * <ul>

--- a/driver-legacy/src/main/com/mongodb/BulkWriteException.java
+++ b/driver-legacy/src/main/com/mongodb/BulkWriteException.java
@@ -25,6 +25,7 @@ import java.util.List;
  *
  * @mongodb.driver.manual reference/method/BulkWriteResult/#BulkWriteResult.writeErrors BulkWriteResult.writeErrors
  * @since 2.12
+ * @serial exclude
  */
 public class BulkWriteException extends MongoServerException {
     private static final long serialVersionUID = -1505950263354313025L;

--- a/driver-legacy/src/main/com/mongodb/CommandResult.java
+++ b/driver-legacy/src/main/com/mongodb/CommandResult.java
@@ -29,7 +29,14 @@ import static com.mongodb.assertions.Assertions.notNull;
  */
 public class CommandResult extends BasicDBObject {
     private static final long serialVersionUID = 5907909423864204060L;
+
+    /**
+     * The response document.
+     */
     private final BsonDocument response;
+    /**
+     * The server address.
+     */
     private final ServerAddress address;
 
     CommandResult(final BsonDocument response) {

--- a/driver-legacy/src/main/com/mongodb/DBCollection.java
+++ b/driver-legacy/src/main/com/mongodb/DBCollection.java
@@ -125,6 +125,9 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 @ThreadSafe
 @SuppressWarnings({"rawtypes", "deprecation"})
 public class DBCollection {
+    /**
+     * The name of the field that uniquely identifies each document in a collection.
+     */
     public static final String ID_FIELD_NAME = "_id";
     private final String name;
     private final DB database;

--- a/driver-legacy/src/main/com/mongodb/DefaultDBCallback.java
+++ b/driver-legacy/src/main/com/mongodb/DefaultDBCallback.java
@@ -74,6 +74,9 @@ public class DefaultDBCallback extends BasicBSONCallback implements DBCallback {
         return document;
     }
 
+    /**
+     * The {@code DBCallbackFactory} for {@code DefaultDBCallback} instances.
+     */
     public static final DBCallbackFactory FACTORY = new DBCallbackFactory() {
         @Override
         public DBCallback create(final DBCollection collection) {

--- a/driver-legacy/src/main/com/mongodb/DefaultDBDecoder.java
+++ b/driver-legacy/src/main/com/mongodb/DefaultDBDecoder.java
@@ -50,6 +50,9 @@ public class DefaultDBDecoder extends BasicBSONDecoder implements DBDecoder {
         return String.format("DBDecoder{class=%s}", getClass().getName());
     }
 
+    /**
+     * The {@code DBDecoderFactory} for {@code DefaultDBDecoder} instances.
+     */
     public static final DBDecoderFactory FACTORY = new DBDecoderFactory() {
         @Override
         public DBDecoder create() {

--- a/driver-legacy/src/main/com/mongodb/DefaultDBEncoder.java
+++ b/driver-legacy/src/main/com/mongodb/DefaultDBEncoder.java
@@ -63,6 +63,9 @@ public class DefaultDBEncoder extends BasicBSONEncoder implements DBEncoder {
         return String.format("DBEncoder{class=%s}", getClass().getName());
     }
 
+    /**
+     * The {@code DBEncoderFactory} for {@code DefaultDBEncoder} instances.
+     */
     public static final DBEncoderFactory FACTORY = new DBEncoderFactory() {
         @Override
         public DBEncoder create() {

--- a/driver-legacy/src/main/com/mongodb/LazyDBDecoder.java
+++ b/driver-legacy/src/main/com/mongodb/LazyDBDecoder.java
@@ -55,6 +55,9 @@ public class LazyDBDecoder extends LazyBSONDecoder implements DBDecoder {
         return (DBObject) callback.get();
     }
 
+    /**
+     * The {@code DBDecoderFactory} for {@code LazyDBDecoder} instances.
+     */
     public static final DBDecoderFactory FACTORY = new DBDecoderFactory() {
         @Override
         public DBDecoder create() {

--- a/driver-legacy/src/main/com/mongodb/QueryOperators.java
+++ b/driver-legacy/src/main/com/mongodb/QueryOperators.java
@@ -22,44 +22,139 @@ package com.mongodb;
  * @mongodb.driver.manual reference/operator/query/ Query Operators
  */
 public class QueryOperators {
+    /**
+     * OR
+     */
     public static final String OR = "$or";
+    /**
+     * AND
+     */
     public static final String AND = "$and";
 
+    /**
+     * GT
+     */
     public static final String GT = "$gt";
+    /**
+     * GTE
+     */
     public static final String GTE = "$gte";
+    /**
+     * LT
+     */
     public static final String LT = "$lt";
+    /**
+     * LTE
+     */
     public static final String LTE = "$lte";
 
+    /**
+     * NE
+     */
     public static final String NE = "$ne";
+    /**
+     * IN
+     */
     public static final String IN = "$in";
+    /**
+     * NIN
+     */
     public static final String NIN = "$nin";
+    /**
+     * MOD
+     */
     public static final String MOD = "$mod";
+    /**
+     * ALL
+     */
     public static final String ALL = "$all";
+    /**
+     * SIZE
+     */
     public static final String SIZE = "$size";
+    /**
+     * EXISTS
+     */
     public static final String EXISTS = "$exists";
+    /**
+     * ELEM_MATCH
+     */
     public static final String ELEM_MATCH = "$elemMatch";
 
     // (to be implemented in QueryBuilder)
+
+    /**
+     * WHERE
+     */
     public static final String WHERE = "$where";
+    /**
+     * NOR
+     */
     public static final String NOR = "$nor";
+    /**
+     * TYPE
+     */
     public static final String TYPE = "$type";
+    /**
+     * NOT
+     */
     public static final String NOT = "$not";
 
     // geo operators
+
+    /**
+     * WITHIN
+     */
     public static final String WITHIN = "$within";
+    /**
+     * NEAR
+     */
     public static final String NEAR = "$near";
+    /**
+     * NEAR_SPHERE
+     */
     public static final String NEAR_SPHERE = "$nearSphere";
+    /**
+     * BOX
+     */
     public static final String BOX = "$box";
+    /**
+     * CENTER
+     */
     public static final String CENTER = "$center";
+    /**
+     * POLYGON
+     */
     public static final String POLYGON = "$polygon";
+    /**
+     * CENTER_SPHERE
+     */
     public static final String CENTER_SPHERE = "$centerSphere";
+
     // (to be implemented in QueryBuilder)
+
+    /**
+     * MAX_DISTANCE
+     */
     public static final String MAX_DISTANCE = "$maxDistance";
+    /**
+     * UNIQUE_DOCS
+     */
     public static final String UNIQUE_DOCS = "$uniqueDocs";
 
     // text operators
+
+    /**
+     * TEXT
+     */
     public static final String TEXT = "$text";
+    /**
+     * SEARCH
+     */
     public static final String SEARCH = "$search";
+    /**
+     * LANGUAGE
+     */
     public static final String LANGUAGE = "$language";
 
     private QueryOperators() {


### PR DESCRIPTION
JAVA-4430

Note: I was not trying to make these informative, as most of the them would be rarely used at this point.  This was just about shutting up the javadoc compiler.

I added `@serial exclude` to all the javadoc for exceptions, as we don't particularly want these to be serializable.