### PR TITLE
Add support for attaching elements to the DecoderContext

### DIFF
--- a/bson/src/main/org/bson/codecs/DecoderContext.java
+++ b/bson/src/main/org/bson/codecs/DecoderContext.java
@@ -42,9 +42,7 @@ public final class DecoderContext {
      * @return the new DecoderContext
      */
     public DecoderContext attach(String key, Object object) {
-        return builder()
-                .attachments(attachments)
-                .checkedDiscriminator(checkedDiscriminator)
+        return builder(this)
                 .attach(key, object)
                 .build();
     }
@@ -66,6 +64,7 @@ public final class DecoderContext {
     public <T> T attachment(String key) {
         return (T) attachments.get(key);
     }
+
     /**
      * Create a builder.
      *
@@ -73,6 +72,17 @@ public final class DecoderContext {
      */
     public static Builder builder() {
         return new Builder();
+    }
+
+    /**
+     * Create a builder.
+     *
+     * @return the builder
+     */
+    public static Builder builder(DecoderContext original) {
+        return new Builder()
+                .attachments(original.attachments)
+                .checkedDiscriminator(original.checkedDiscriminator);
     }
 
     /**

--- a/bson/src/main/org/bson/codecs/DecoderContext.java
+++ b/bson/src/main/org/bson/codecs/DecoderContext.java
@@ -18,6 +18,9 @@ package org.bson.codecs;
 
 import org.bson.BsonReader;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.bson.assertions.Assertions.notNull;
 
 /**
@@ -29,7 +32,22 @@ import static org.bson.assertions.Assertions.notNull;
 public final class DecoderContext {
     private static final DecoderContext DEFAULT_CONTEXT = DecoderContext.builder().build();
     private final boolean checkedDiscriminator;
+    private final Map<String, Object> attachments;
 
+    /**
+     * Attaches an item to this context with the given name.  Returns a new modified context.
+     *
+     * @param key the key for the attachment
+     * @param object the item to attach
+     * @return the new DecoderContext
+     */
+    public DecoderContext attach(String key, Object object) {
+        return builder()
+                .attachments(attachments)
+                .checkedDiscriminator(checkedDiscriminator)
+                .attach(key, object)
+                .build();
+    }
     /**
      * @return true if the discriminator has been checked
      */
@@ -37,6 +55,17 @@ public final class DecoderContext {
         return checkedDiscriminator;
     }
 
+    /**
+     * Fetches the named attachment.  Will return null if that name doesn't have an attachment.
+     *
+     * @param key the name of the attachment
+     * @param <T> the type of the attachment
+     * @return the attachment
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T attachment(String key) {
+        return (T) attachments.get(key);
+    }
     /**
      * Create a builder.
      *
@@ -53,7 +82,22 @@ public final class DecoderContext {
         private Builder() {
         }
 
+        private final Map<String, Object> attachments = new HashMap<>();
         private boolean checkedDiscriminator;
+
+        public Map<String, Object> attachments() {
+            return attachments;
+        }
+
+        public Builder attach(String key, Object attachment) {
+            this.attachments.put(key, attachment);
+            return this;
+        }
+
+        public Builder attachments(Map<String, Object> attachments) {
+            this.attachments.putAll(attachments);
+            return this;
+        }
 
         /**
          * @return true if the discriminator has been checked
@@ -97,6 +141,7 @@ public final class DecoderContext {
     }
 
     private DecoderContext(final Builder builder) {
+        this.attachments = builder.attachments();
         this.checkedDiscriminator = builder.hasCheckedDiscriminator();
     }
 }

--- a/bson/src/main/org/bson/codecs/EncoderContext.java
+++ b/bson/src/main/org/bson/codecs/EncoderContext.java
@@ -18,6 +18,9 @@ package org.bson.codecs;
 
 import org.bson.BsonWriter;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * The context for encoding values to BSON.
  *
@@ -30,6 +33,33 @@ public final class EncoderContext {
 
     private final boolean encodingCollectibleDocument;
 
+    private final Map<String, Object> attachments;
+
+    /**
+     * Attaches an item to this context with the given name.  Returns a new modified context.
+     *
+     * @param key the key for the attachment
+     * @param object the item to attach
+     * @return the new DecoderContext
+     */
+    public EncoderContext attach(String key, Object object) {
+        return builder(this)
+                .attach(key, object)
+                .build();
+    }
+
+    /**
+     * Fetches the named attachment.  Will return null if that name doesn't have an attachment.
+     *
+     * @param key the name of the attachment
+     * @param <T> the type of the attachment
+     * @return the attachment
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T attachment(String key) {
+        return (T) attachments.get(key);
+    }
+
     /**
      * Create a builder.
      *
@@ -40,12 +70,39 @@ public final class EncoderContext {
     }
 
     /**
+     * Create a builder.
+     *
+     * @return the builder
+     */
+    public static Builder builder(EncoderContext original) {
+        return new Builder()
+                .attachments(original.attachments)
+                .isEncodingCollectibleDocument(original.encodingCollectibleDocument);
+    }
+
+    /**
      * A builder for {@code EncoderContext} instances.
      */
     public static final class Builder {
         private boolean encodingCollectibleDocument;
+        private final Map<String, Object> attachments = new HashMap<>();
 
         private Builder() {
+        }
+
+
+        public Map<String, Object> attachments() {
+            return attachments;
+        }
+
+        public Builder attach(String key, Object attachment) {
+            this.attachments.put(key, attachment);
+            return this;
+        }
+
+        public Builder attachments(Map<String, Object> attachments) {
+            this.attachments.putAll(attachments);
+            return this;
         }
 
         /**
@@ -101,6 +158,7 @@ public final class EncoderContext {
     }
 
     private EncoderContext(final Builder builder) {
+        attachments = builder.attachments;
         encodingCollectibleDocument = builder.encodingCollectibleDocument;
     }
 }


### PR DESCRIPTION
I would like to discuss adding something like this to the DecoderContext.  This would allow me to attach a cache in Morphia so that when I'm fetching referenced documents, I can cache them and reuse the hydrated objects rather than reprocessing them all over and over.  The precise shape of this API could no doubt use some fine tuning but this is the general idea.