### PR TITLE
[JAVA-4319] Include default match statement to CaseClassCodec macro

### DIFF
--- a/bson-scala/src/main/scala-2.13+/org/mongodb/scala/bson/collection/mutable/Document.scala
+++ b/bson-scala/src/main/scala-2.13+/org/mongodb/scala/bson/collection/mutable/Document.scala
@@ -232,7 +232,7 @@ case class Document(protected[scala] val underlying: BsonDocument)
    *  @param xs   the iterator producing the elements to remove.
    *  @return the document itself
    */
-  def --=(xs: IterableOnce[String]): Document = { xs foreach -=; this }
+  def --=(xs: IterableOnce[String]): Document = { xs.iterator foreach -=; this }
   // scalastyle:on method.name
 
   /**

--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/BsonTransformer.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/BsonTransformer.scala
@@ -19,7 +19,7 @@ package org.mongodb.scala.bson
 import java.util.Date
 
 import scala.annotation.implicitNotFound
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.matching.Regex
 
 import org.mongodb.scala.bson.collection.immutable.{ Document => IDocument }
@@ -168,12 +168,8 @@ trait DefaultBsonTransformers extends LowPrio {
    * Transforms `Option[T]` to `BsonValue`
    */
   implicit def transformOption[T](implicit transformer: BsonTransformer[T]): BsonTransformer[Option[T]] = {
-    new BsonTransformer[Option[T]] {
-      def apply(value: Option[T]): BsonValue = value match {
-        case Some(transformable) => transformer(transformable)
-        case None                => BsonNull()
-      }
-    }
+    case Some(transformable) => transformer(transformable)
+    case None                => BsonNull()
   }
 
 }
@@ -203,11 +199,9 @@ trait LowPrio {
    */
   implicit def transformKeyValuePairs[T](
       implicit transformer: BsonTransformer[T]
-  ): BsonTransformer[Seq[(String, T)]] = {
-    new BsonTransformer[Seq[(String, T)]] {
-      def apply(values: Seq[(String, T)]): BsonDocument = {
-        BsonDocument(values.map(kv => (kv._1, transformer(kv._2))).toList)
-      }
+  ): BsonTransformer[Seq[(String, T)]] = { (values: Seq[(String, T)]) =>
+    {
+      BsonDocument(values.map(kv => (kv._1, transformer(kv._2))).toList)
     }
   }
 
@@ -219,10 +213,9 @@ trait LowPrio {
    * @return a BsonArray containing all the values
    */
   implicit def transformSeq[T](implicit transformer: BsonTransformer[T]): BsonTransformer[Seq[T]] = {
-    new BsonTransformer[Seq[T]] {
-      def apply(values: Seq[T]): BsonValue = {
+    (values: Seq[T]) =>
+      {
         new BsonArray(values.map(transformer.apply).toList.asJava)
       }
-    }
   }
 }

--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/BsonValue.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/BsonValue.scala
@@ -18,7 +18,7 @@ package org.mongodb.scala.bson
 
 import java.util.Date
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.matching.Regex
 
 import org.bson.{ BsonDocument => JBsonDocument }
@@ -176,7 +176,7 @@ object BsonDocument {
    * @param elems a traversable of key, value pairs
    * @return the BsonDocument
    */
-  def apply(elems: Traversable[(String, BsonValue)]): BsonDocument = {
+  def apply(elems: Iterable[(String, BsonValue)]): BsonDocument = {
     val bsonDocument = new JBsonDocument()
     elems.foreach(kv => bsonDocument.put(kv._1, kv._2))
     bsonDocument
@@ -296,7 +296,7 @@ object BsonJavaScriptWithScope {
    * @param scope the function scope
    * @return the BsonJavaScript
    */
-  def apply(value: String, scope: Traversable[(String, BsonValue)]): BsonJavaScriptWithScope =
+  def apply(value: String, scope: Iterable[(String, BsonValue)]): BsonJavaScriptWithScope =
     new BsonJavaScriptWithScope(value, BsonDocument(scope))
 }
 

--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/CaseClassCodec.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/CaseClassCodec.scala
@@ -350,7 +350,7 @@ private[codecs] object CaseClassCodec {
                   val instanceValue = value.asInstanceOf[${classType}]
                   ..${writeClassValues(fields, ignoredFields(classType))}"""
         }.toSeq
-      }
+      } :+ cq"""_ => throw new BsonInvalidOperationException("Unexpected class type: " + className)"""
       q"""
         writer.writeStartDocument()
         this.writeClassFieldName(writer, className, encoderContext)

--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/MacroCodec.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/MacroCodec.scala
@@ -16,7 +16,7 @@
 
 package org.mongodb.scala.bson.codecs.macrocodecs
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 import org.bson._
@@ -217,8 +217,8 @@ trait MacroCodec[T] extends Codec[T] {
       list.toSet.asInstanceOf[V]
     } else if (classOf[Vector[_]].isAssignableFrom(clazz)) {
       list.toVector.asInstanceOf[V]
-    } else if (classOf[Stream[_]].isAssignableFrom(clazz)) {
-      list.toStream.asInstanceOf[V]
+    } else if (classOf[LazyList[_]].isAssignableFrom(clazz)) {
+      list.to(LazyList).asInstanceOf[V]
     } else {
       list.toList.asInstanceOf[V]
     }

--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/collection/BaseDocument.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/collection/BaseDocument.scala
@@ -16,8 +16,8 @@
 
 package org.mongodb.scala.bson.collection
 
-import scala.collection.JavaConverters._
-import scala.collection.{ GenTraversableOnce, Traversable }
+import scala.jdk.CollectionConverters._
+import scala.collection.{ Iterable, IterableOnce }
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success, Try }
 
@@ -38,7 +38,7 @@ import org.mongodb.scala.bson.BsonMagnets
  *
  * @tparam T The concrete Document implementation
  */
-private[bson] trait BaseDocument[T] extends Traversable[(String, BsonValue)] with Bson {
+private[bson] trait BaseDocument[T] extends Iterable[(String, BsonValue)] with Bson {
 
   import BsonMagnets._
 
@@ -117,8 +117,8 @@ private[bson] trait BaseDocument[T] extends Traversable[(String, BsonValue)] wit
    * @param xs      the traversable object consisting of key-value pairs.
    * @return        a new document with the bindings of this document and those from `xs`.
    */
-  def --(xs: GenTraversableOnce[String]): T = {
-    val keysToIgnore = xs.toList
+  def --(xs: IterableOnce[String]): T = {
+    val keysToIgnore = xs.iterator.to(List)
     val newUnderlying = new BsonDocument()
     for ((k, v) <- iterator if !keysToIgnore.contains(k)) {
       newUnderlying.put(k, v)
@@ -209,7 +209,7 @@ private[bson] trait BaseDocument[T] extends Traversable[(String, BsonValue)] wit
    *
    * @return an iterator over all keys.
    */
-  def keysIterator: Iterator[String] = keySet.toIterator
+  def keysIterator: Iterator[String] = keySet.iterator
 
   /**
    * Collects all values of this document in an iterable collection.
@@ -223,7 +223,7 @@ private[bson] trait BaseDocument[T] extends Traversable[(String, BsonValue)] wit
    *
    * @return an iterator over all values that are associated with some key in this document.
    */
-  def valuesIterator: Iterator[BsonValue] = values.toIterator
+  def valuesIterator: Iterator[BsonValue] = values.iterator
 
   /**
    * Gets a JSON representation of this document

--- a/bson-scala/src/test/scala/org/mongodb/scala/bson/BsonValueSpec.scala
+++ b/bson-scala/src/test/scala/org/mongodb/scala/bson/BsonValueSpec.scala
@@ -18,7 +18,7 @@ package org.mongodb.scala.bson
 
 import java.util.Date
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class BsonValueSpec extends BaseSpec {
 

--- a/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/ImmutableDocumentCodecSpec.scala
+++ b/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/ImmutableDocumentCodecSpec.scala
@@ -28,7 +28,7 @@ import org.mongodb.scala.bson.BaseSpec
 import org.mongodb.scala.bson.codecs.Registry.DEFAULT_CODEC_REGISTRY
 import org.mongodb.scala.bson.collection.immutable.Document
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ImmutableDocumentCodecSpec extends BaseSpec {
 
@@ -56,7 +56,7 @@ class ImmutableDocumentCodecSpec extends BaseSpec {
     ImmutableDocumentCodec(registry).encode(writer, original, EncoderContext.builder().build())
 
     info("decoding")
-    val buffer: BasicOutputBuffer = writer.getBsonOutput().asInstanceOf[BasicOutputBuffer];
+    val buffer: BasicOutputBuffer = writer.getBsonOutput.asInstanceOf[BasicOutputBuffer]
     val reader: BsonBinaryReader = new BsonBinaryReader(
       new ByteBufferBsonInput(
         new ByteBufNIO(ByteBuffer.wrap(buffer.toByteArray))
@@ -85,7 +85,7 @@ class ImmutableDocumentCodecSpec extends BaseSpec {
     )
 
     info("decoding")
-    val buffer: BasicOutputBuffer = writer.getBsonOutput().asInstanceOf[BasicOutputBuffer];
+    val buffer: BasicOutputBuffer = writer.getBsonOutput.asInstanceOf[BasicOutputBuffer]
     val reader: BsonBinaryReader =
       new BsonBinaryReader(new ByteBufferBsonInput(new ByteBufNIO(ByteBuffer.wrap(buffer.toByteArray))))
 
@@ -93,12 +93,12 @@ class ImmutableDocumentCodecSpec extends BaseSpec {
 
     decodedDocument shouldBe a[Document]
     original should equal(decodedDocument)
-    decodedDocument.keys.toList should contain theSameElementsInOrderAs (List("_id", "a", "nested"))
+    decodedDocument.keys.toList should contain theSameElementsInOrderAs List("_id", "a", "nested")
 
-    Document(decodedDocument[BsonDocument]("nested")).keys.toList should contain theSameElementsInOrderAs (List(
+    Document(decodedDocument[BsonDocument]("nested")).keys.toList should contain theSameElementsInOrderAs List(
       "a",
       "_id"
-    ))
+    )
   }
 
   it should "encoder class should work as expected" in {

--- a/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
+++ b/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
@@ -31,7 +31,7 @@ import org.mongodb.scala.bson.codecs.Macros.{ createCodecProvider, createCodecPr
 import org.mongodb.scala.bson.codecs.Registry.DEFAULT_CODEC_REGISTRY
 import org.mongodb.scala.bson.collection.immutable.Document
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
 //scalastyle:off
@@ -90,7 +90,7 @@ class MacrosSpec extends BaseSpec {
   case class ContainsSet(name: String, friends: Set[String])
   case class ContainsVector(name: String, friends: Vector[String])
   case class ContainsList(name: String, friends: List[String])
-  case class ContainsStream(name: String, friends: Stream[String])
+  case class ContainsStream(name: String, friends: LazyList[String])
 
   case class CaseClassWithVal(_id: ObjectId, name: String) {
     val id: String = _id.toString
@@ -234,7 +234,7 @@ class MacrosSpec extends BaseSpec {
       Macros.createCodecProvider(classOf[ContainsList])
     )
     roundTrip(
-      ContainsStream("Bob", Stream("Tom", "Charlie")),
+      ContainsStream("Bob", LazyList("Tom", "Charlie")),
       """{name: "Bob", friends: ["Tom","Charlie"]}""",
       Macros.createCodecProvider(classOf[ContainsStream])
     )

--- a/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/MutableDocumentCodecSpec.scala
+++ b/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/MutableDocumentCodecSpec.scala
@@ -29,7 +29,7 @@ import org.mongodb.scala.bson.codecs.Registry.DEFAULT_CODEC_REGISTRY
 import org.mongodb.scala.bson.collection.mutable
 import org.mongodb.scala.bson.collection.mutable.Document
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class MutableDocumentCodecSpec extends BaseSpec {
 
@@ -57,7 +57,7 @@ class MutableDocumentCodecSpec extends BaseSpec {
     MutableDocumentCodec(registry).encode(writer, original, EncoderContext.builder().build())
 
     info("decoding")
-    val buffer: BasicOutputBuffer = writer.getBsonOutput().asInstanceOf[BasicOutputBuffer];
+    val buffer: BasicOutputBuffer = writer.getBsonOutput.asInstanceOf[BasicOutputBuffer]
     val reader: BsonBinaryReader =
       new BsonBinaryReader(new ByteBufferBsonInput(new ByteBufNIO(ByteBuffer.wrap(buffer.toByteArray))))
 
@@ -83,7 +83,7 @@ class MutableDocumentCodecSpec extends BaseSpec {
     )
 
     info("decoding")
-    val buffer: BasicOutputBuffer = writer.getBsonOutput().asInstanceOf[BasicOutputBuffer];
+    val buffer: BasicOutputBuffer = writer.getBsonOutput.asInstanceOf[BasicOutputBuffer]
     val reader: BsonBinaryReader =
       new BsonBinaryReader(new ByteBufferBsonInput(new ByteBufNIO(ByteBuffer.wrap(buffer.toByteArray))))
 
@@ -91,12 +91,12 @@ class MutableDocumentCodecSpec extends BaseSpec {
 
     decodedDocument shouldBe a[mutable.Document]
     original should equal(decodedDocument)
-    decodedDocument.keys.toList should contain theSameElementsInOrderAs (List("_id", "a", "nested"))
+    decodedDocument.keys.toList should contain theSameElementsInOrderAs List("_id", "a", "nested")
 
-    Document(decodedDocument[BsonDocument]("nested")).keys.toList should contain theSameElementsInOrderAs (List(
+    Document(decodedDocument[BsonDocument]("nested")).keys.toList should contain theSameElementsInOrderAs List(
       "a",
       "_id"
-    ))
+    )
   }
 
   it should "encoder class should work as expected" in {

--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,13 @@ configure(scalaProjects) {
 
     tasks.withType(ScalaCompile) {
         scalaCompileOptions.deprecation = false
+        scalaCompileOptions.additionalParameters = [
+                "-feature",
+                "-unchecked",
+                "-language:reflectiveCalls",
+                "-Wconf:cat=deprecation:ws,any:e",
+                "-Xlint:strict-unsealed-patmat"
+        ]
     }
 
     tasks.withType(GenerateModuleMetadata) {

--- a/driver-scala/src/main/scala/org/mongodb/scala/CreateIndexCommitQuorum.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/CreateIndexCommitQuorum.scala
@@ -16,7 +16,7 @@
 
 package org.mongodb.scala
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.Duration
 import com.mongodb.{ CreateIndexCommitQuorum => JCreateIndexCommitQuorum }
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoClient.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoClient.scala
@@ -26,7 +26,7 @@ import org.mongodb.scala.bson.DefaultHelper.DefaultsTo
 import org.mongodb.scala.bson.codecs.{ DocumentCodecProvider, IterableCodecProvider }
 import org.mongodb.scala.bson.conversions.Bson
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
 /**

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoCollection.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoCollection.scala
@@ -26,7 +26,7 @@ import org.mongodb.scala.model._
 import org.mongodb.scala.result._
 import org.reactivestreams.Publisher
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
 // scalastyle:off number.of.methods file.size.limit

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoDatabase.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoDatabase.scala
@@ -22,7 +22,7 @@ import org.bson.codecs.configuration.CodecRegistry
 import org.mongodb.scala.bson.DefaultHelper.DefaultsTo
 import org.mongodb.scala.bson.conversions.Bson
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
 /**

--- a/driver-scala/src/main/scala/org/mongodb/scala/ReadPreference.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/ReadPreference.scala
@@ -18,7 +18,7 @@ package org.mongodb.scala
 
 import java.util.concurrent.TimeUnit.MILLISECONDS
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.Duration
 
 import com.mongodb.{ ReadPreference => JReadPreference }

--- a/driver-scala/src/main/scala/org/mongodb/scala/TagSet.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/TagSet.scala
@@ -16,7 +16,7 @@
 
 package org.mongodb.scala
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.mongodb.{ TagSet => JTagSet }
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Accumulators.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Accumulators.scala
@@ -16,7 +16,7 @@
 
 package org.mongodb.scala.model
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import com.mongodb.client.model.{ Accumulators => JAccumulators }
 import org.mongodb.scala.bson.conversions.Bson
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
@@ -18,7 +18,7 @@ package org.mongodb.scala.model
 
 import com.mongodb.annotations.Beta
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import com.mongodb.client.model.{ Aggregates => JAggregates }
 import org.mongodb.scala.MongoNamespace
 import org.mongodb.scala.bson.conversions.Bson

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Filters.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Filters.scala
@@ -18,7 +18,7 @@ package org.mongodb.scala.model
 
 import java.lang
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.matching.Regex
 
 import org.bson._

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Indexes.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Indexes.scala
@@ -16,7 +16,7 @@
 
 package org.mongodb.scala.model
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.mongodb.client.model.{ Indexes => JIndexes }
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/MergeOptions.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/MergeOptions.scala
@@ -16,7 +16,7 @@
 
 package org.mongodb.scala.model
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.mongodb.scala.bson.conversions.Bson
 
 import com.mongodb.client.model.{ MergeOptions => JMergeOptions }

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Projections.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Projections.scala
@@ -16,7 +16,7 @@
 
 package org.mongodb.scala.model
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.mongodb.client.model.{ Projections => JProjections }
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Sorts.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Sorts.scala
@@ -16,7 +16,7 @@
 
 package org.mongodb.scala.model
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.mongodb.client.model.{ Sorts => JSorts }
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Updates.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Updates.scala
@@ -16,7 +16,7 @@
 
 package org.mongodb.scala.model
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import com.mongodb.client.model.{ PushOptions => JPushOptions, Updates => JUpdates }
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/geojson/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/geojson/package.scala
@@ -16,7 +16,7 @@
 
 package org.mongodb.scala.model
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import com.mongodb.client.model.{ geojson => Jgeojson }

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/package.scala
@@ -18,7 +18,7 @@ package org.mongodb.scala
 
 import com.mongodb.annotations.Beta
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import com.mongodb.client.model.{ MongoTimeUnit => JMongoTimeUnit }
 import org.mongodb.scala.bson.conversions.Bson
 


### PR DESCRIPTION
[JAVA-4319](https://jira.mongodb.org/browse/JAVA-4319)

Inserted a default statement for the case class macro, like there is on CaseClassCodec:390

This allows for the `-Xlint:strict-unsealed-patmat` scalac option to be included with Scala Versions >= 2.13.4.