### PR TITLE
Support `authorizedCollections` option for `listCollections` helpers

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -542,11 +542,13 @@ public final class Operations<TDocument> {
 
     public <TResult> ListCollectionsOperation<TResult> listCollections(final String databaseName, final Class<TResult> resultClass,
                                                                 final Bson filter, final boolean collectionNamesOnly,
+                                                                final boolean authorizedCollections,
                                                                 final Integer batchSize, final long maxTimeMS) {
         return new ListCollectionsOperation<TResult>(databaseName, codecRegistry.get(resultClass))
                 .retryReads(retryReads)
                 .filter(toBsonDocumentOrNull(filter))
                 .nameOnly(collectionNamesOnly)
+                .authorizedCollections(authorizedCollections)
                 .batchSize(batchSize == null ? 0 : batchSize)
                 .maxTime(maxTimeMS, MILLISECONDS);
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -240,8 +240,10 @@ public final class SyncOperations<TDocument> {
 
     public <TResult> ReadOperation<BatchCursor<TResult>> listCollections(final String databaseName, final Class<TResult> resultClass,
                                                                          final Bson filter, final boolean collectionNamesOnly,
+                                                                         final boolean authorizedCollections,
                                                                          final Integer batchSize, final long maxTimeMS) {
-        return operations.listCollections(databaseName, resultClass, filter, collectionNamesOnly, batchSize, maxTimeMS);
+        return operations.listCollections(databaseName, resultClass, filter, collectionNamesOnly, authorizedCollections,
+                batchSize, maxTimeMS);
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> listDatabases(final Class<TResult> resultClass, final Bson filter,

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ListCollectionsPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ListCollectionsPublisher.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <TResult> The type of the result.
  * @since 1.0
+ * @mongodb.driver.manual reference/command/listCollections/ listCollections
  */
 public interface ListCollectionsPublisher<TResult> extends Publisher<TResult> {
 
@@ -38,6 +39,21 @@ public interface ListCollectionsPublisher<TResult> extends Publisher<TResult> {
      * @mongodb.driver.manual reference/method/db.collection.find/ Filter
      */
     ListCollectionsPublisher<TResult> filter(@Nullable Bson filter);
+
+    /**
+     * Sets the {@code authorizedCollections} field of the {@code listCollections} command.
+     * This method is ignored if called on a {@link ListCollectionsPublisher} obtained not via any of the
+     * {@link MongoDatabase#listCollectionNames() MongoDatabase.listCollectionNames} methods.
+     *
+     * @param authorizedCollections If {@code true}, allows executing the {@code listCollections} command,
+     * which has the {@code nameOnly} field set to {@code true}, without having the
+     * <a href="https://docs.mongodb.com/manual/reference/privilege-actions/#mongodb-authaction-listCollections">
+     * {@code listCollections} privilege</a> on the corresponding database resource.
+     * @return {@code this}.
+     * @since 4.5
+     * @mongodb.server.release 4.0
+     */
+    ListCollectionsPublisher<TResult> authorizedCollections(boolean authorizedCollections);
 
     /**
      * Sets the maximum execution time on the server for this operation.

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoDatabase.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoDatabase.java
@@ -237,18 +237,20 @@ public interface MongoDatabase {
      * Gets the names of all the collections in this database.
      *
      * @return a publisher with all the names of all the collections in this database
+     * @mongodb.driver.manual reference/command/listCollections listCollections
      */
-    Publisher<String> listCollectionNames();
+    ListCollectionsPublisher<String> listCollectionNames();
 
     /**
      * Gets the names of all the collections in this database.
      *
      * @param clientSession the client session with which to associate this operation
      * @return a publisher with all the names of all the collections in this database
+     * @mongodb.driver.manual reference/command/listCollections listCollections
      * @mongodb.server.release 3.6
      * @since 1.7
      */
-    Publisher<String> listCollectionNames(ClientSession clientSession);
+    ListCollectionsPublisher<String> listCollectionNames(ClientSession clientSession);
 
     /**
      * Finds all the collections in this database.

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImpl.java
@@ -17,21 +17,29 @@
 package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.ReadConcern;
+import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ClientSession;
 import com.mongodb.reactivestreams.client.ListCollectionsPublisher;
 import org.bson.conversions.Bson;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 final class ListCollectionsPublisherImpl<T> extends BatchCursorPublisher<T> implements ListCollectionsPublisher<T> {
 
     private final boolean collectionNamesOnly;
+    private boolean authorizedCollections;
     private Bson filter;
     private long maxTimeMS;
 
@@ -59,8 +67,72 @@ final class ListCollectionsPublisherImpl<T> extends BatchCursorPublisher<T> impl
         return this;
     }
 
+    @Override
+    public ListCollectionsPublisherImpl<T> authorizedCollections(final boolean authorizedCollections) {
+        this.authorizedCollections = authorizedCollections;
+        return this;
+    }
+
     AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
         return getOperations().listCollections(getNamespace().getDatabaseName(), getDocumentClass(), filter, collectionNamesOnly,
-                initialBatchSize, maxTimeMS);
+                authorizedCollections, initialBatchSize, maxTimeMS);
+    }
+
+    <U> ListCollectionsPublisher<U> map(final Function<T, U> mapper) {
+        return new Mapping<>(this, mapper);
+    }
+
+    private static final class Mapping<T, U> implements ListCollectionsPublisher<U> {
+        private final ListCollectionsPublisher<T> wrapped;
+        private final Publisher<U> mappingPublisher;
+        private final Function<T, U> mapper;
+
+        Mapping(final ListCollectionsPublisher<T> publisher, final Function<T, U> mapper) {
+            this.wrapped = publisher;
+            mappingPublisher = Flux.from(publisher).map(mapper);
+            this.mapper = mapper;
+        }
+
+        @Override
+        public ListCollectionsPublisher<U> filter(@Nullable final Bson filter) {
+            wrapped.filter(filter);
+            return this;
+        }
+
+        @Override
+        public ListCollectionsPublisher<U> authorizedCollections(final boolean authorizedCollections) {
+            wrapped.authorizedCollections(authorizedCollections);
+            return this;
+        }
+
+        @Override
+        public ListCollectionsPublisher<U> maxTime(final long maxTime, final TimeUnit timeUnit) {
+            wrapped.maxTime(maxTime, timeUnit);
+            return this;
+        }
+
+        @Override
+        public ListCollectionsPublisher<U> batchSize(final int batchSize) {
+            wrapped.batchSize(batchSize);
+            return this;
+        }
+
+        @Override
+        public Publisher<U> first() {
+            return Mono.from(wrapped.first()).map(mapper);
+        }
+
+        @Override
+        public void subscribe(final Subscriber<? super U> s) {
+            mappingPublisher.subscribe(s);
+        }
+
+        /**
+         * This method is used in tests via the reflection API.
+         */
+        @VisibleForTesting(otherwise = PRIVATE)
+        ListCollectionsPublisher<T> getMapped() {
+            return wrapped;
+        }
     }
 }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoDatabaseImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoDatabaseImpl.java
@@ -34,7 +34,6 @@ import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
 
 import java.util.Collections;
 import java.util.List;
@@ -168,14 +167,14 @@ public final class MongoDatabaseImpl implements MongoDatabase {
     }
 
     @Override
-    public Publisher<String> listCollectionNames() {
-        return Flux.from(new ListCollectionsPublisherImpl<>(null, mongoOperationPublisher, true))
+    public ListCollectionsPublisher<String> listCollectionNames() {
+        return new ListCollectionsPublisherImpl<>(null, mongoOperationPublisher, true)
                 .map(d -> d.getString("name"));
     }
 
     @Override
-    public Publisher<String> listCollectionNames(final ClientSession clientSession) {
-        return Flux.from(new ListCollectionsPublisherImpl<>(notNull("clientSession", clientSession), mongoOperationPublisher, true))
+    public ListCollectionsPublisher<String> listCollectionNames(final ClientSession clientSession) {
+        return new ListCollectionsPublisherImpl<>(notNull("clientSession", clientSession), mongoOperationPublisher, true)
                 .map(d -> d.getString("name"));
     }
 

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncListCollectionsIterable.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncListCollectionsIterable.java
@@ -38,6 +38,12 @@ class SyncListCollectionsIterable<T> extends SyncMongoIterable<T> implements Lis
     }
 
     @Override
+    public ListCollectionsIterable<T> authorizedCollections(final boolean authorizedCollections) {
+        wrapped.authorizedCollections(authorizedCollections);
+        return this;
+    }
+
+    @Override
     public ListCollectionsIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
         wrapped.maxTime(maxTime, timeUnit);
         return this;

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoDatabase.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoDatabase.java
@@ -25,7 +25,6 @@ import com.mongodb.client.ClientSession;
 import com.mongodb.client.ListCollectionsIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.MongoIterable;
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.CreateViewOptions;
 import org.bson.Document;
@@ -157,7 +156,7 @@ public class SyncMongoDatabase implements MongoDatabase {
     }
 
     @Override
-    public MongoIterable<String> listCollectionNames() {
+    public ListCollectionsIterable<String> listCollectionNames() {
         throw new UnsupportedOperationException();
     }
 
@@ -172,7 +171,7 @@ public class SyncMongoDatabase implements MongoDatabase {
     }
 
     @Override
-    public MongoIterable<String> listCollectionNames(final ClientSession clientSession) {
+    public ListCollectionsIterable<String> listCollectionNames(final ClientSession clientSession) {
         throw new UnsupportedOperationException();
     }
 

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImplTest.java
@@ -40,12 +40,15 @@ public class ListCollectionsPublisherImplTest extends TestHelper {
     void shouldBuildTheExpectedOperation() {
         TestOperationExecutor executor = createOperationExecutor(asList(getBatchCursor(), getBatchCursor()));
         ListCollectionsPublisher<String> publisher = new ListCollectionsPublisherImpl<>(null, createMongoOperationPublisher(executor)
-                .withDocumentClass(String.class), true);
+                .withDocumentClass(String.class), true)
+                .authorizedCollections(true);
 
         ListCollectionsOperation<String> expectedOperation = new ListCollectionsOperation<>(DATABASE_NAME,
                                                                                             getDefaultCodecRegistry().get(String.class))
                 .batchSize(Integer.MAX_VALUE)
-                .nameOnly(true).retryReads(true);
+                .nameOnly(true)
+                .authorizedCollections(true)
+                .retryReads(true);
 
         // default input should be as expected
         Flux.from(publisher).blockFirst();

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoDatabaseImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoDatabaseImplTest.java
@@ -136,6 +136,13 @@ public class MongoDatabaseImplTest extends TestHelper {
                   },
                   () -> {
                       ListCollectionsPublisher<Document> expected =
+                              new ListCollectionsPublisherImpl<>(null, mongoOperationPublisher, true)
+                                      .authorizedCollections(true);
+                      assertPublisherIsTheSameAs(expected, database.listCollectionNames().authorizedCollections(true),
+                              "nameOnly & authorizedCollections");
+                  },
+                  () -> {
+                      ListCollectionsPublisher<Document> expected =
                               new ListCollectionsPublisherImpl<>(clientSession, mongoOperationPublisher, true);
                       assertPublisherIsTheSameAs(expected, database.listCollectionNames(clientSession), "With client session");
                   }

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/TestHelper.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/TestHelper.java
@@ -44,6 +44,7 @@ import reactor.core.Scannable;
 import reactor.core.publisher.Mono;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -52,6 +53,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.stream.Collectors.toList;
@@ -190,21 +192,23 @@ public class TestHelper {
     }
 
     private static Publisher<?> getRootSource(final Publisher<?> publisher) {
-        Optional<Publisher<?>> sourcePublisher = Optional.of(publisher);
+        Publisher<?> sourcePublisher = publisher;
         // Uses reflection to find the root / source publisher
         if (publisher instanceof Scannable) {
             Scannable scannable = (Scannable) publisher;
             List<? extends Scannable> parents = scannable.parents().collect(toList());
             if (parents.isEmpty()) {
-                sourcePublisher = getSource(scannable);
+                sourcePublisher = getSource(scannable).orElse(publisher);
             } else {
                 sourcePublisher = parents.stream().map(TestHelper::getSource)
                         .filter(Optional::isPresent)
                         .reduce((first, second) -> second)
-                        .orElse(Optional.empty());
+                        .flatMap(Function.identity())
+                        .orElse(publisher);
             }
         }
-        return sourcePublisher.orElse(publisher);
+        sourcePublisher = getMapped(sourcePublisher).orElse(sourcePublisher);
+        return sourcePublisher;
     }
 
     private static Optional<Publisher<?>> getSource(final Scannable scannable) {
@@ -214,6 +218,19 @@ public class TestHelper {
         } else {
             return getScannableArray(scannable);
         }
+    }
+
+    private static Optional<Publisher<?>> getMapped(final Publisher<?> maybeMappingPublisher) {
+        return Stream.of(maybeMappingPublisher.getClass().getDeclaredMethods())
+                .filter(m -> m.getName().equals("getMapped"))
+                .findFirst()
+                .map(m -> {
+                    try {
+                        return (Publisher<?>) m.invoke(maybeMappingPublisher);
+                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
     }
 
     private static Optional<Publisher<?>> getScannableSource(final Scannable scannable) {

--- a/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncListCollectionsIterable.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncListCollectionsIterable.scala
@@ -29,6 +29,11 @@ case class SyncListCollectionsIterable[T](wrapped: ListCollectionsObservable[T])
     this
   }
 
+  override def authorizedCollections(authorizedCollections: Boolean): ListCollectionsIterable[T] = {
+    wrapped.authorizedCollections(authorizedCollections)
+    this
+  }
+
   override def maxTime(maxTime: Long, timeUnit: TimeUnit): ListCollectionsIterable[T] = {
     wrapped.maxTime(maxTime, timeUnit)
     this

--- a/driver-scala/src/main/scala/org/mongodb/scala/ListCollectionsObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/ListCollectionsObservable.scala
@@ -45,6 +45,23 @@ case class ListCollectionsObservable[TResult](wrapped: ListCollectionsPublisher[
   }
 
   /**
+   * Sets the `authorizedCollections` field of the `istCollections` command.
+   * This method is ignored if called on a [[ListCollectionsObservable]] obtained not via any of the
+   * `MongoDatabase.listCollectionNames` methods.
+   *
+   * @param authorizedCollections If `true`, allows executing the `listCollections` command,
+   * which has the `nameOnly` field set to `true`, without having the
+   * <a href="https://docs.mongodb.com/manual/reference/privilege-actions/#mongodb-authaction-listCollections">
+   * `listCollections` privilege</a> on the corresponding database resource.
+   * @return `this`.
+   * @since 4.5
+   */
+  def authorizedCollections(authorizedCollections: Boolean): ListCollectionsObservable[TResult] = {
+    wrapped.authorizedCollections(authorizedCollections)
+    this
+  }
+
+  /**
    * Sets the maximum execution time on the server for this operation.
    *
    * [[http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS/ Max Time]]

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoDatabase.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoDatabase.scala
@@ -203,7 +203,8 @@ case class MongoDatabase(private[scala] val wrapped: JMongoDatabase) {
    *
    * @return a Observable with all the names of all the collections in this database
    */
-  def listCollectionNames(): Observable[String] = wrapped.listCollectionNames()
+  def listCollectionNames(): ListCollectionsObservable[String] =
+    ListCollectionsObservable(wrapped.listCollectionNames())
 
   /**
    * Finds all the collections in this database.
@@ -226,7 +227,8 @@ case class MongoDatabase(private[scala] val wrapped: JMongoDatabase) {
    * @since 2.2
    * @note Requires MongoDB 3.6 or greater
    */
-  def listCollectionNames(clientSession: ClientSession): Observable[String] = wrapped.listCollectionNames(clientSession)
+  def listCollectionNames(clientSession: ClientSession): ListCollectionsObservable[String] =
+    ListCollectionsObservable(wrapped.listCollectionNames(clientSession))
 
   /**
    * Finds all the collections in this database.

--- a/driver-sync/src/main/com/mongodb/client/ListCollectionsIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/ListCollectionsIterable.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <TResult> The type of the result.
  * @since 3.0
+ * @mongodb.driver.manual reference/command/listCollections/ listCollections
  */
 public interface ListCollectionsIterable<TResult> extends MongoIterable<TResult> {
 
@@ -37,6 +38,21 @@ public interface ListCollectionsIterable<TResult> extends MongoIterable<TResult>
      * @mongodb.driver.manual reference/method/db.collection.find/ Filter
      */
     ListCollectionsIterable<TResult> filter(@Nullable Bson filter);
+
+    /**
+     * Sets the {@code authorizedCollections} field of the {@code listCollections} command.
+     * This method is ignored if called on a {@link ListCollectionsIterable} obtained not via any of the
+     * {@link MongoDatabase#listCollectionNames() MongoDatabase.listCollectionNames} methods.
+     *
+     * @param authorizedCollections If {@code true}, allows executing the {@code listCollections} command,
+     * which has the {@code nameOnly} field set to {@code true}, without having the
+     * <a href="https://docs.mongodb.com/manual/reference/privilege-actions/#mongodb-authaction-listCollections">
+     * {@code listCollections} privilege</a> on the corresponding database resource.
+     * @return {@code this}.
+     * @since 4.5
+     * @mongodb.server.release 4.0
+     */
+    ListCollectionsIterable<TResult> authorizedCollections(boolean authorizedCollections);
 
     /**
      * Sets the maximum execution time on the server for this operation.

--- a/driver-sync/src/main/com/mongodb/client/MongoDatabase.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoDatabase.java
@@ -240,8 +240,9 @@ public interface MongoDatabase {
      * Gets the names of all the collections in this database.
      *
      * @return an iterable containing all the names of all the collections in this database
+     * @mongodb.driver.manual reference/command/listCollections listCollections
      */
-    MongoIterable<String> listCollectionNames();
+    ListCollectionsIterable<String> listCollectionNames();
 
     /**
      * Finds all the collections in this database.
@@ -268,8 +269,9 @@ public interface MongoDatabase {
      * @return an iterable containing all the names of all the collections in this database
      * @since 3.6
      * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/listCollections listCollections
      */
-    MongoIterable<String> listCollectionNames(ClientSession clientSession);
+    ListCollectionsIterable<String> listCollectionNames(ClientSession clientSession);
 
     /**
      * Finds all the collections in this database.

--- a/driver-sync/src/main/com/mongodb/client/internal/ListCollectionsIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ListCollectionsIterableImpl.java
@@ -44,12 +44,6 @@ class ListCollectionsIterableImpl<TResult> extends MongoIterableImpl<TResult> im
 
     ListCollectionsIterableImpl(@Nullable final ClientSession clientSession, final String databaseName, final boolean collectionNamesOnly,
                                 final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                                final OperationExecutor executor) {
-        this(clientSession, databaseName, collectionNamesOnly, resultClass, codecRegistry, readPreference, executor, true);
-    }
-
-    ListCollectionsIterableImpl(@Nullable final ClientSession clientSession, final String databaseName, final boolean collectionNamesOnly,
-                                final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
                                 final OperationExecutor executor, final boolean retryReads) {
         super(clientSession, executor, ReadConcern.DEFAULT, readPreference, retryReads); // TODO: read concern?
         this.collectionNamesOnly = collectionNamesOnly;

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
@@ -28,7 +28,6 @@ import com.mongodb.client.ClientSession;
 import com.mongodb.client.ListCollectionsIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.MongoIterable;
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.CreateViewOptions;
 import com.mongodb.client.model.IndexOptionDefaults;
@@ -212,17 +211,17 @@ public class MongoDatabaseImpl implements MongoDatabase {
     }
 
     @Override
-    public MongoIterable<String> listCollectionNames() {
+    public ListCollectionsIterable<String> listCollectionNames() {
         return createListCollectionNamesIterable(null);
     }
 
     @Override
-    public MongoIterable<String> listCollectionNames(final ClientSession clientSession) {
+    public ListCollectionsIterable<String> listCollectionNames(final ClientSession clientSession) {
         notNull("clientSession", clientSession);
         return createListCollectionNamesIterable(clientSession);
     }
 
-    private MongoIterable<String> createListCollectionNamesIterable(@Nullable final ClientSession clientSession) {
+    private ListCollectionsIterable<String> createListCollectionNamesIterable(@Nullable final ClientSession clientSession) {
         return createListCollectionsIterable(clientSession, BsonDocument.class, true)
                 .map(new Function<BsonDocument, String>() {
                     @Override
@@ -253,7 +252,7 @@ public class MongoDatabaseImpl implements MongoDatabase {
         return createListCollectionsIterable(clientSession, resultClass, false);
     }
 
-    private <TResult> ListCollectionsIterable<TResult> createListCollectionsIterable(@Nullable final ClientSession clientSession,
+    private <TResult> ListCollectionsIterableImpl<TResult> createListCollectionsIterable(@Nullable final ClientSession clientSession,
                                                                                      final Class<TResult> resultClass,
                                                                                      final boolean collectionNamesOnly) {
         return new ListCollectionsIterableImpl<>(clientSession, name, collectionNamesOnly, resultClass, codecRegistry,

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ListCollectionsIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ListCollectionsIterableSpecification.groovy
@@ -48,12 +48,12 @@ class ListCollectionsIterableSpecification extends Specification {
         given:
         def executor = new TestOperationExecutor([null, null, null]);
         def listCollectionIterable = new ListCollectionsIterableImpl<Document>(null, 'db', false, Document, codecRegistry,
-                readPreference, executor)
+                readPreference, executor, true)
                 .filter(new Document('filter', 1))
                 .batchSize(100)
                 .maxTime(1000, MILLISECONDS)
         def listCollectionNamesIterable = new ListCollectionsIterableImpl<Document>(null, 'db', true, Document, codecRegistry,
-                readPreference, executor)
+                readPreference, executor, true)
 
         when: 'default input should be as expected'
         listCollectionIterable.iterator()
@@ -94,7 +94,7 @@ class ListCollectionsIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([batchCursor, batchCursor]);
         def listCollectionIterable = new ListCollectionsIterableImpl<Document>(clientSession, 'db', false, Document, codecRegistry,
-                readPreference, executor)
+                readPreference, executor, true)
 
         when:
         listCollectionIterable.first()
@@ -134,7 +134,7 @@ class ListCollectionsIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]);
         def mongoIterable = new ListCollectionsIterableImpl<Document>(null, 'db', false, Document, codecRegistry, readPreference,
-                executor)
+                executor, true)
 
         when:
         def results = mongoIterable.first()
@@ -178,7 +178,7 @@ class ListCollectionsIterableSpecification extends Specification {
         when:
         def batchSize = 5
         def mongoIterable = new ListCollectionsIterableImpl<Document>(null, 'db', false, Document, codecRegistry, readPreference,
-                Stub(OperationExecutor))
+                Stub(OperationExecutor), true)
 
         then:
         mongoIterable.getBatchSize() == null

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ListCollectionsIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ListCollectionsIterableSpecification.groovy
@@ -46,7 +46,7 @@ class ListCollectionsIterableSpecification extends Specification {
 
     def 'should build the expected listCollectionOperation'() {
         given:
-        def executor = new TestOperationExecutor([null, null, null]);
+        def executor = new TestOperationExecutor([null, null, null, null]);
         def listCollectionIterable = new ListCollectionsIterableImpl<Document>(null, 'db', false, Document, codecRegistry,
                 readPreference, executor, true)
                 .filter(new Document('filter', 1))
@@ -54,6 +54,9 @@ class ListCollectionsIterableSpecification extends Specification {
                 .maxTime(1000, MILLISECONDS)
         def listCollectionNamesIterable = new ListCollectionsIterableImpl<Document>(null, 'db', true, Document, codecRegistry,
                 readPreference, executor, true)
+        def listAuthorizedCollectionNamesIterable = new ListCollectionsIterableImpl<Document>(null, 'db', true, Document,
+                codecRegistry, readPreference, executor, true)
+                .authorizedCollections(true)
 
         when: 'default input should be as expected'
         listCollectionIterable.iterator()
@@ -84,6 +87,16 @@ class ListCollectionsIterableSpecification extends Specification {
 
         then: 'should create operation with nameOnly'
         expect operation, isTheSameAs(new ListCollectionsOperation<Document>('db', new DocumentCodec()).nameOnly(true)
+                .retryReads(true))
+
+        when: 'requesting authorized collection names only'
+        listAuthorizedCollectionNamesIterable.iterator()
+        operation = executor.getReadOperation() as ListCollectionsOperation<Document>
+
+        then: 'should create operation with `nameOnly` and `authorizedCollections`'
+        expect operation, isTheSameAs(new ListCollectionsOperation<Document>('db', new DocumentCodec())
+                .nameOnly(true)
+                .authorizedCollections(true)
                 .retryReads(true))
     }
 


### PR DESCRIPTION
This PR changes API in the following interfaces:

- `com.mongodb.client.ListCollectionsIterable`
- `com.mongodb.reactivestreams.client.ListCollectionsPublisher`
- `com.mongodb.client.MongoDatabase`
- `com.mongodb.reactivestreams.client.MongoDatabase`

in a way that is backward-compatible from the perspective of the API users, and is breaking from the perspective of API implementors.

You may see a few methods marked as `@VisibleForTesting`, which are used reflectively either from Java tests, or from Groovy. The code that effectively required the presence of these methods was already in the tests, I simply made the changes to fit into existing test infrastructure.

JAVA-4353