### PR TITLE
Add codec provider for enums

### DIFF
--- a/bson/src/main/org/bson/codecs/EnumCodec.java
+++ b/bson/src/main/org/bson/codecs/EnumCodec.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008 - 2013 10gen, Inc. <http://10gen.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.bson.codecs;
+
+import org.bson.BsonReader;
+import org.bson.BsonWriter;
+
+/**
+ * A codec for classes that extends {@link Enum}
+ *
+ * @param <T> The enum type
+ * @since 4.5
+ */
+public final class EnumCodec<T extends Enum<T>> implements Codec<T> {
+    private final Class<T> clazz;
+
+    public EnumCodec(final Class<T> clazz) {
+        this.clazz = clazz;
+    }
+
+    @Override
+    public T decode(final BsonReader reader, final DecoderContext decoderContext) {
+        return Enum.valueOf(clazz, reader.readString());
+    }
+
+    @Override
+    public void encode(final BsonWriter writer, final T value, final EncoderContext encoderContext) {
+        writer.writeString(value.name());
+    }
+
+    @Override
+    public Class<T> getEncoderClass() {
+        return clazz;
+    }
+}

--- a/bson/src/main/org/bson/codecs/EnumCodec.java
+++ b/bson/src/main/org/bson/codecs/EnumCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008 - 2013 10gen, Inc. <http://10gen.com>
+ * Copyright 2008-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.bson.codecs;

--- a/bson/src/main/org/bson/codecs/EnumCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/EnumCodecProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008 - 2013 10gen, Inc. <http://10gen.com>
+ * Copyright 2008-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.bson.codecs;

--- a/bson/src/main/org/bson/codecs/EnumCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/EnumCodecProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008 - 2013 10gen, Inc. <http://10gen.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.bson.codecs;
+
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+
+/**
+ * A codec provider for classes that extend {@link Enum}.
+ *
+ * @since 4.5
+ */
+public final class EnumCodecProvider implements CodecProvider {
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
+        if (Enum.class.isAssignableFrom(clazz)) {
+            return (Codec<T>) new EnumCodec(clazz);
+        }
+        return null;
+    }
+}

--- a/bson/src/main/org/bson/codecs/pojo/EnumPropertyCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/pojo/EnumPropertyCodecProvider.java
@@ -16,11 +16,8 @@
 
 package org.bson.codecs.pojo;
 
-import org.bson.BsonReader;
-import org.bson.BsonWriter;
 import org.bson.codecs.Codec;
-import org.bson.codecs.DecoderContext;
-import org.bson.codecs.EncoderContext;
+import org.bson.codecs.EnumCodec;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.configuration.CodecRegistry;
 
@@ -45,28 +42,4 @@ final class EnumPropertyCodecProvider implements PropertyCodecProvider {
         }
         return null;
     }
-
-    private static class EnumCodec<T extends Enum<T>> implements Codec<T> {
-        private final Class<T> clazz;
-
-        EnumCodec(final Class<T> clazz) {
-            this.clazz = clazz;
-        }
-
-        @Override
-        public void encode(final BsonWriter writer, final T value, final EncoderContext encoderContext) {
-            writer.writeString(value.name());
-        }
-
-        @Override
-        public Class<T> getEncoderClass() {
-            return clazz;
-        }
-
-        @Override
-        public T decode(final BsonReader reader, final DecoderContext decoderContext) {
-            return Enum.valueOf(clazz, reader.readString());
-        }
-    }
-
 }

--- a/bson/src/main/org/bson/conversions/Bson.java
+++ b/bson/src/main/org/bson/conversions/Bson.java
@@ -20,6 +20,7 @@ import org.bson.BsonDocument;
 import org.bson.codecs.BsonCodecProvider;
 import org.bson.codecs.BsonValueCodecProvider;
 import org.bson.codecs.DocumentCodecProvider;
+import org.bson.codecs.EnumCodecProvider;
 import org.bson.codecs.IterableCodecProvider;
 import org.bson.codecs.JsonObjectCodecProvider;
 import org.bson.codecs.MapCodecProvider;
@@ -47,6 +48,7 @@ public interface Bson {
      *     <li>{@link Jsr310CodecProvider}</li>
      *     <li>{@link JsonObjectCodecProvider}</li>
      *     <li>{@link BsonCodecProvider}</li>
+     *     <li>{@link EnumCodecProvider}</li>
      * </ul>
      * <p>
      * Additional providers may be added in a future release.
@@ -63,7 +65,8 @@ public interface Bson {
                     new MapCodecProvider(),
                     new Jsr310CodecProvider(),
                     new JsonObjectCodecProvider(),
-                    new BsonCodecProvider()));
+                    new BsonCodecProvider(),
+                    new EnumCodecProvider()));
 
     /**
      * Render into a BsonDocument.

--- a/bson/src/test/unit/org/bson/codecs/CodecTestCase.java
+++ b/bson/src/test/unit/org/bson/codecs/CodecTestCase.java
@@ -48,7 +48,7 @@ abstract class CodecTestCase {
         return fromProviders(asList(new ValueCodecProvider(), getDocumentCodecProvider()));
     }
 
-    <T> T getDecodedValue(BsonValue bsonValue, Decoder<T> decoder) {
+    <T> T getDecodedValue(final BsonValue bsonValue, final Decoder<T> decoder) {
         BsonDocument document = new BsonDocument("val", bsonValue);
         BsonDocumentReader reader = new BsonDocumentReader(document);
         reader.readStartDocument();
@@ -56,7 +56,7 @@ abstract class CodecTestCase {
         return decoder.decode(reader, DecoderContext.builder().build());
     }
 
-    <T> BsonValue getEncodedValue(T value, Encoder<T> encoder) {
+    <T> BsonValue getEncodedValue(final T value, final Encoder<T> encoder) {
         BsonDocumentWriter writer = new BsonDocumentWriter(new BsonDocument());
         writer.writeStartDocument();
         writer.writeName("val");

--- a/bson/src/test/unit/org/bson/codecs/CodecTestCase.java
+++ b/bson/src/test/unit/org/bson/codecs/CodecTestCase.java
@@ -18,7 +18,11 @@ package org.bson.codecs;
 
 import org.bson.BsonBinaryReader;
 import org.bson.BsonBinaryWriter;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonDocumentWriter;
 import org.bson.BsonType;
+import org.bson.BsonValue;
 import org.bson.BsonWriter;
 import org.bson.ByteBufNIO;
 import org.bson.Document;
@@ -42,6 +46,23 @@ abstract class CodecTestCase {
 
     CodecRegistry getRegistry() {
         return fromProviders(asList(new ValueCodecProvider(), getDocumentCodecProvider()));
+    }
+
+    <T> T getDecodedValue(BsonValue bsonValue, Decoder<T> decoder) {
+        BsonDocument document = new BsonDocument("val", bsonValue);
+        BsonDocumentReader reader = new BsonDocumentReader(document);
+        reader.readStartDocument();
+        reader.readName("val");
+        return decoder.decode(reader, DecoderContext.builder().build());
+    }
+
+    <T> BsonValue getEncodedValue(T value, Encoder<T> encoder) {
+        BsonDocumentWriter writer = new BsonDocumentWriter(new BsonDocument());
+        writer.writeStartDocument();
+        writer.writeName("val");
+        encoder.encode(writer, value, EncoderContext.builder().build());
+        writer.writeEndDocument();
+        return writer.getDocument().get("val");
     }
 
     <T> void roundTrip(final T value) {

--- a/bson/src/test/unit/org/bson/codecs/EnumCodecProviderTest.java
+++ b/bson/src/test/unit/org/bson/codecs/EnumCodecProviderTest.java
@@ -17,7 +17,6 @@
 package org.bson.codecs;
 
 import org.bson.codecs.configuration.CodecRegistries;
-import org.bson.codecs.pojo.entities.SimpleEnum;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/bson/src/test/unit/org/bson/codecs/EnumCodecProviderTest.java
+++ b/bson/src/test/unit/org/bson/codecs/EnumCodecProviderTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.codecs.configuration.CodecRegistries;
+import org.bson.codecs.pojo.entities.SimpleEnum;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class EnumCodecProviderTest {
+    @Test
+    public void shouldProvideCodecForEnum() {
+        EnumCodecProvider provider = new EnumCodecProvider();
+        Codec<SimpleEnum> codec = provider.get(SimpleEnum.class, CodecRegistries.fromProviders(provider));
+        assertNotNull(codec);
+        assertEquals(EnumCodec.class, codec.getClass());
+    }
+
+    @Test
+    public void shouldNotProvideCodecForNonEnum() {
+        EnumCodecProvider provider = new EnumCodecProvider();
+        Codec<String> codec = provider.get(String.class, CodecRegistries.fromProviders(provider));
+        assertNull(codec);
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/EnumCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/EnumCodecTest.java
@@ -18,7 +18,6 @@ package org.bson.codecs;
 
 import org.bson.BsonString;
 import org.bson.BsonValue;
-import org.bson.codecs.pojo.entities.SimpleEnum;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/bson/src/test/unit/org/bson/codecs/EnumCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/EnumCodecTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.codecs.pojo.entities.SimpleEnum;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EnumCodecTest extends CodecTestCase {
+    @Test
+    public void shouldEncodeEnum() {
+        Codec<SimpleEnum> codec = new EnumCodec<>(SimpleEnum.class);
+        BsonValue encodedValue = getEncodedValue(SimpleEnum.BRAVO, codec);
+        assertEquals(SimpleEnum.BRAVO.name(), encodedValue.asString().getValue());
+    }
+
+    @Test
+    public void shouldDecodeEnum() {
+        Codec<SimpleEnum> codec = new EnumCodec<>(SimpleEnum.class);
+        SimpleEnum decodedValue = getDecodedValue(new BsonString(SimpleEnum.BRAVO.name()), codec);
+        assertEquals(SimpleEnum.BRAVO, decodedValue);
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/SimpleEnum.java
+++ b/bson/src/test/unit/org/bson/codecs/SimpleEnum.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.bson.codecs.pojo.entities;
+package org.bson.codecs;
 
 public enum SimpleEnum {
     ALPHA,

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -55,7 +55,7 @@ import org.bson.codecs.pojo.entities.OptionalPropertyCodecProvider;
 import org.bson.codecs.pojo.entities.PrimitivesModel;
 import org.bson.codecs.pojo.entities.PrivateSetterFieldModel;
 import org.bson.codecs.pojo.entities.PropertyWithMultipleTypeParamsModel;
-import org.bson.codecs.pojo.entities.SimpleEnum;
+import org.bson.codecs.SimpleEnum;
 import org.bson.codecs.pojo.entities.SimpleEnumModel;
 import org.bson.codecs.pojo.entities.SimpleGenericsModel;
 import org.bson.codecs.pojo.entities.SimpleIdImmutableModel;

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -352,9 +352,17 @@ public final class PojoCustomTest extends PojoTestCase {
 
     @Test
     public void testEnumSupportWithCustomCodec() {
-        CodecRegistry registry = fromRegistries(getCodecRegistry(getPojoCodecProviderBuilder(SimpleEnumModel.class)),
-                fromCodecs(new SimpleEnumCodec()));
+        CodecRegistry registry = fromRegistries(fromCodecs(new SimpleEnumCodec()),
+                getCodecRegistry(getPojoCodecProviderBuilder(SimpleEnumModel.class)));
         roundTrip(registry, new SimpleEnumModel(SimpleEnum.BRAVO), "{ 'myEnum': 1 }");
+    }
+
+    @Test
+    public void testEnumSupportWithFallback() {
+        // Create a registry without EnumCodecProvider, to test the fallback in EnumPropertyCodecProvider#get
+        CodecRegistry registry = fromRegistries(fromProviders(new ValueCodecProvider(),
+                getPojoCodecProviderBuilder(SimpleEnumModel.class).build()));
+        roundTrip(registry, new SimpleEnumModel(SimpleEnum.BRAVO), "{ 'myEnum': 'BRAVO' }");
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
@@ -66,7 +66,7 @@ import org.bson.codecs.pojo.entities.ShapeHolderModel;
 import org.bson.codecs.pojo.entities.ShapeModelAbstract;
 import org.bson.codecs.pojo.entities.ShapeModelCircle;
 import org.bson.codecs.pojo.entities.ShapeModelRectangle;
-import org.bson.codecs.pojo.entities.SimpleEnum;
+import org.bson.codecs.SimpleEnum;
 import org.bson.codecs.pojo.entities.SimpleEnumModel;
 import org.bson.codecs.pojo.entities.SimpleGenericsModel;
 import org.bson.codecs.pojo.entities.SimpleIdImmutableModel;

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoTestCase.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoTestCase.java
@@ -27,6 +27,7 @@ import org.bson.codecs.BsonValueCodecProvider;
 import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
+import org.bson.codecs.EnumCodecProvider;
 import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.jsr310.Jsr310CodecProvider;
@@ -223,7 +224,9 @@ abstract class PojoTestCase {
     }
 
     CodecRegistry getCodecRegistry(final PojoCodecProvider.Builder builder) {
-        return fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider(), new Jsr310CodecProvider(), builder.build());
+        return fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider(), new Jsr310CodecProvider(),
+                new EnumCodecProvider(),
+                builder.build());
     }
 
     static SimpleModel getSimpleModel() {

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoTestCase.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoTestCase.java
@@ -51,7 +51,7 @@ import org.bson.codecs.pojo.entities.ReusedGenericsModel;
 import org.bson.codecs.pojo.entities.SelfReferentialGenericModel;
 import org.bson.codecs.pojo.entities.ShapeModelCircle;
 import org.bson.codecs.pojo.entities.ShapeModelRectangle;
-import org.bson.codecs.pojo.entities.SimpleEnum;
+import org.bson.codecs.SimpleEnum;
 import org.bson.codecs.pojo.entities.SimpleGenericsModel;
 import org.bson.codecs.pojo.entities.SimpleModel;
 import org.bson.codecs.pojo.entities.SimpleNestedPojoModel;

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/SimpleEnumModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/SimpleEnumModel.java
@@ -16,6 +16,8 @@
 
 package org.bson.codecs.pojo.entities;
 
+import org.bson.codecs.SimpleEnum;
+
 public final class SimpleEnumModel {
 
     private SimpleEnum myEnum;

--- a/driver-core/src/main/com/mongodb/MongoClientSettings.java
+++ b/driver-core/src/main/com/mongodb/MongoClientSettings.java
@@ -32,6 +32,7 @@ import org.bson.UuidRepresentation;
 import org.bson.codecs.BsonCodecProvider;
 import org.bson.codecs.BsonValueCodecProvider;
 import org.bson.codecs.DocumentCodecProvider;
+import org.bson.codecs.EnumCodecProvider;
 import org.bson.codecs.IterableCodecProvider;
 import org.bson.codecs.JsonObjectCodecProvider;
 import org.bson.codecs.MapCodecProvider;
@@ -71,7 +72,8 @@ public final class MongoClientSettings {
                     new GridFSFileCodecProvider(),
                     new Jsr310CodecProvider(),
                     new JsonObjectCodecProvider(),
-                    new BsonCodecProvider()));
+                    new BsonCodecProvider(),
+                    new EnumCodecProvider()));
 
     private final ReadPreference readPreference;
     private final WriteConcern writeConcern;
@@ -116,7 +118,12 @@ public final class MongoClientSettings {
      * <li>{@link org.bson.codecs.jsr310.Jsr310CodecProvider}</li>
      * <li>{@link org.bson.codecs.JsonObjectCodecProvider}</li>
      * <li>{@link org.bson.codecs.BsonCodecProvider}</li>
+     * <li>{@link org.bson.codecs.EnumCodecProvider}</li>
      * </ul>
+     *
+     * <p>
+     * Additional providers may be added in a future release.
+     * </p>
      *
      * @return the default codec registry
      */


### PR DESCRIPTION
JAVA-4440

One question I have is whether to keep `org.bson.codecs.pojo.EnumPropertyCodecProvider` around, or just remove it.  I'm comfortable with leaving it, but wonder what others think.