### PR TITLE
Fixed javadoc for ObjectId(timestamp, counter) and exception message for ObjectId(timestamp, randomValue1, randomValue2, counter)

### DIFF
--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -167,7 +167,7 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
     }
 
     /**
-     * Creates an ObjectId using the given time, machine identifier, process identifier, and counter.
+     * Creates an ObjectId using the given time and counter.
      *
      * @param timestamp the time in seconds
      * @param counter   the counter
@@ -184,7 +184,7 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
     private ObjectId(final int timestamp, final int randomValue1, final short randomValue2, final int counter,
                      final boolean checkCounter) {
         if ((randomValue1 & 0xff000000) != 0) {
-            throw new IllegalArgumentException("The machine identifier must be between 0 and 16777215 (it must fit in three bytes).");
+            throw new IllegalArgumentException("The random value must be between 0 and 16777215 (it must fit in three bytes).");
         }
         if (checkCounter && ((counter & 0xff000000) != 0)) {
             throw new IllegalArgumentException("The counter must be between 0 and 16777215 (it must fit in three bytes).");


### PR DESCRIPTION
The javadoc for `ObjectId(timestamp, counter)` states that it "Creates an ObjectId using the given time, machine identifier, process identifier, and counter", but the constructor only takes two parameters, `timestamp` and `counter`.
The exception message in ObjectId(timestamp, randomValue1, randomValue2, counter) states that "The machine identifier must be between 0 and 16777215", although the exception is thrown when `(randomValue1 & 0xff000000) != 0`.

When running tests the following two failed: 
```
> Task :driver-scala:integrationTest
Running Test task using scala version: 2.13.6

org.mongodb.scala.gridfs.GridFSObservableSpec > The Scala driver should not create indexes if the files collection is not empty FAILED
    org.scalatest.concurrent.Futures$FutureConcept$$anon$1 at GridFSObservableSpec.scala:280

org.mongodb.scala.gridfs.GridFSObservableSpec > The Scala driver should use the user provided codec registries for encoding / decoding data FAILED
    org.scalatest.concurrent.Futures$FutureConcept$$anon$1 at GridFSObservableSpec.scala:304
<=========----> 75% EXECUTING [17m 19s]
> :driver-scala:integrationTest > Executing test org.mongodb.scala.gridfs.GridFSObservableSpec
> IDLE
> :driver-scala:integrationTest > 986 tests completed, 2 failed, 593 skipped
```
However, these failures seem to be related to this issue: https://jira.mongodb.org/browse/JAVA-4126, and not to the changes, which were only made to the javadoc and exception message.