### PR TITLE
Introduce and use `Cluster.withLock` to achieve cluster-wide locking

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -240,13 +240,15 @@ abstract class BaseCluster implements Cluster {
         return isClosed;
     }
 
-    protected synchronized void updateDescription(final ClusterDescription newDescription) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(format("Updating cluster description to  %s", newDescription.getShortDescription()));
-        }
+    protected void updateDescription(final ClusterDescription newDescription) {
+        withLock(() -> {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(format("Updating cluster description to  %s", newDescription.getShortDescription()));
+            }
 
-        description = newDescription;
-        updatePhase();
+            description = newDescription;
+            updatePhase();
+        });
     }
 
     /**
@@ -265,8 +267,13 @@ abstract class BaseCluster implements Cluster {
         return description;
     }
 
-    private synchronized void updatePhase() {
-        phase.getAndSet(new CountDownLatch(1)).countDown();
+    @Override
+    public synchronized void withLock(final Runnable action) {
+        action.run();
+    }
+
+    private void updatePhase() {
+        withLock(() -> phase.getAndSet(new CountDownLatch(1)).countDown());
     }
 
     private long getMaxWaitTimeNanos() {
@@ -387,7 +394,7 @@ abstract class BaseCluster implements Cluster {
 
     protected ClusterableServer createServer(final ServerAddress serverAddress,
                                              final ServerDescriptionChangedListener serverDescriptionChangedListener) {
-        return serverFactory.create(serverAddress, serverDescriptionChangedListener, clusterClock);
+        return serverFactory.create(this, serverAddress, serverDescriptionChangedListener, clusterClock);
     }
 
     private void throwIfIncompatible(final ClusterDescription curDescription) {
@@ -456,26 +463,30 @@ abstract class BaseCluster implements Cluster {
         }
     }
 
-    private synchronized void notifyWaitQueueHandler(final ServerSelectionRequest request) {
-        if (isClosed) {
-            return;
-        }
+    private void notifyWaitQueueHandler(final ServerSelectionRequest request) {
+        withLock(() -> {
+            if (isClosed) {
+                return;
+            }
 
-        waitQueue.add(request);
+            waitQueue.add(request);
 
-        if (waitQueueHandler == null) {
-            waitQueueHandler = new Thread(new WaitQueueHandler(), "cluster-" + clusterId.getValue());
-            waitQueueHandler.setDaemon(true);
-            waitQueueHandler.start();
-        } else {
-            updatePhase();
-        }
+            if (waitQueueHandler == null) {
+                waitQueueHandler = new Thread(new WaitQueueHandler(), "cluster-" + clusterId.getValue());
+                waitQueueHandler.setDaemon(true);
+                waitQueueHandler.start();
+            } else {
+                updatePhase();
+            }
+        });
     }
 
-    private synchronized void stopWaitQueueHandler() {
-        if (waitQueueHandler != null) {
-            waitQueueHandler.interrupt();
-        }
+    private void stopWaitQueueHandler() {
+        withLock(() -> {
+            if (waitQueueHandler != null) {
+                waitQueueHandler.interrupt();
+            }
+        });
     }
 
     private final class WaitQueueHandler implements Runnable {

--- a/driver-core/src/main/com/mongodb/internal/connection/Cluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/Cluster.java
@@ -92,4 +92,11 @@ public interface Cluster extends Closeable {
      * @return true if all the servers in this cluster have been closed
      */
     boolean isClosed();
+
+    /**
+     * Does the supplied {@code action} while holding a reentrant cluster-wide lock.
+     *
+     * @param action The action to {@linkplain Runnable#run() do}.
+     */
+    void withLock(Runnable action);
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/ClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ClusterableServerFactory.java
@@ -20,8 +20,8 @@ import com.mongodb.ServerAddress;
 import com.mongodb.connection.ServerSettings;
 
 public interface ClusterableServerFactory {
-    ClusterableServer create(ServerAddress serverAddress, ServerDescriptionChangedListener serverDescriptionChangedListener,
-            ClusterClock clusterClock);
+    ClusterableServer create(Cluster cluster, ServerAddress serverAddress,
+            ServerDescriptionChangedListener serverDescriptionChangedListener, ClusterClock clusterClock);
 
     ServerSettings getSettings();
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
@@ -76,7 +76,7 @@ public class DefaultClusterableServerFactory implements ClusterableServerFactory
     }
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress,
+    public ClusterableServer create(final Cluster cluster, final ServerAddress serverAddress,
             final ServerDescriptionChangedListener serverDescriptionChangedListener,
             final ClusterClock clusterClock) {
         ServerId serverId = new ServerId(clusterId, serverAddress);
@@ -91,7 +91,7 @@ public class DefaultClusterableServerFactory implements ClusterableServerFactory
                         mongoDriverInformation, compressorList, commandListener, serverApi),
                 connectionPoolSettings, internalConnectionPoolSettings, sdamProvider);
         ServerListener serverListener = singleServerListener(serverSettings);
-        SdamServerDescriptionManager sdam = new DefaultSdamServerDescriptionManager(serverId, serverDescriptionChangedListener,
+        SdamServerDescriptionManager sdam = new DefaultSdamServerDescriptionManager(cluster, serverId, serverDescriptionChangedListener,
                 serverListener, serverMonitor, connectionPool, clusterSettings.getMode());
         sdamProvider.initialize(sdam);
         serverMonitor.start();

--- a/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedCluster.java
@@ -159,7 +159,7 @@ final class LoadBalancedCluster implements Cluster {
                         .address(host)
                         .build()),
                 settings, serverFactory.getSettings());
-        server = serverFactory.create(host, event -> { }, clusterClock);
+        server = serverFactory.create(this, host, event -> { }, clusterClock);
 
         clusterListener.clusterDescriptionChanged(new ClusterDescriptionChangedEvent(clusterId, description, initialDescription));
     }
@@ -280,6 +280,11 @@ final class LoadBalancedCluster implements Cluster {
     @Override
     public boolean isClosed() {
         return closed.get();
+    }
+
+    @Override
+    public void withLock(final Runnable action) {
+        fail();
     }
 
     private void handleServerSelectionRequest(final ServerSelectionRequest serverSelectionRequest) {

--- a/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedClusterableServerFactory.java
@@ -70,7 +70,7 @@ public class LoadBalancedClusterableServerFactory implements ClusterableServerFa
     }
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress,
+    public ClusterableServer create(final Cluster cluster, final ServerAddress serverAddress,
             final ServerDescriptionChangedListener serverDescriptionChangedListener,
             final ClusterClock clusterClock) {
         ConnectionPool connectionPool = new DefaultConnectionPool(new ServerId(clusterId, serverAddress),

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
@@ -58,6 +58,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 import util.JsonPoweredTestHelper;
 
 import java.io.File;
@@ -85,6 +86,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 // Implementation of
@@ -184,8 +186,9 @@ public abstract class AbstractConnectionPoolTest {
                                 new TestCommandListener(),
                                 ClusterFixture.getServerApi()),
                         settings, internalSettings, sdamProvider));
-                sdamProvider.initialize(new DefaultSdamServerDescriptionManager(serverId, mock(ServerDescriptionChangedListener.class),
-                        mock(ServerListener.class), mock(ServerMonitor.class), pool, connectionMode));
+                sdamProvider.initialize(new DefaultSdamServerDescriptionManager(mockedCluster(), serverId,
+                        mock(ServerDescriptionChangedListener.class), mock(ServerListener.class), mock(ServerMonitor.class), pool,
+                        connectionMode));
                 setFailPoint();
                 break;
             }
@@ -520,6 +523,15 @@ public abstract class AbstractConnectionPoolTest {
             Thread.currentThread().interrupt();
             throw new MongoInterruptedException(null, e);
         }
+    }
+
+    private static Cluster mockedCluster() {
+        Cluster cluster = mock(Cluster.class);
+        Mockito.doAnswer(invocation -> {
+            invocation.getArgument(0, Runnable.class).run();
+            return null;
+        }).when(cluster).withLock(any(Runnable.class));
+        return cluster;
     }
 
     private enum Style {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
@@ -34,6 +34,7 @@ import com.mongodb.async.FutureResultCallback
 import com.mongodb.client.syncadapter.SupplyingCallback
 import com.mongodb.connection.ClusterConnectionMode
 import com.mongodb.connection.ClusterId
+import com.mongodb.connection.ClusterSettings
 import com.mongodb.connection.ConnectionDescription
 import com.mongodb.connection.ConnectionId
 import com.mongodb.connection.ServerConnectionState
@@ -146,7 +147,7 @@ class DefaultServerSpecification extends Specification {
         def connectionPool = Mock(ConnectionPool)
         def sdamProvider = SameObjectProvider.<SdamServerDescriptionManager>uninitialized()
         def serverMonitor = new TestServerMonitor(sdamProvider)
-        sdamProvider.initialize(new DefaultSdamServerDescriptionManager(serverId, Mock(ServerDescriptionChangedListener),
+        sdamProvider.initialize(new DefaultSdamServerDescriptionManager(mockCluster(), serverId, Mock(ServerDescriptionChangedListener),
                 serverListener, serverMonitor, connectionPool, ClusterConnectionMode.MULTIPLE))
         def server = defaultServer(Mock(ConnectionPool), serverMonitor, serverListener, sdamProvider.get(), Mock(CommandListener))
         serverMonitor.updateServerDescription(ServerDescription.builder()
@@ -498,7 +499,7 @@ class DefaultServerSpecification extends Specification {
     private DefaultServer defaultServer(final ConnectionPool connectionPool, final ServerMonitor serverMonitor) {
         def serverListener = Mock(ServerListener)
         defaultServer(connectionPool, serverMonitor, serverListener,
-                new DefaultSdamServerDescriptionManager(
+                new DefaultSdamServerDescriptionManager(mockCluster(),
                         serverId, Mock(ServerDescriptionChangedListener), serverListener, serverMonitor, connectionPool,
                         ClusterConnectionMode.MULTIPLE),
                 Mock(CommandListener))
@@ -569,6 +570,19 @@ class DefaultServerSpecification extends Specification {
             sessionContext.advanceClusterTime(responseDocument.getDocument('$clusterTime'))
             sessionContext.advanceOperationTime(responseDocument.getTimestamp('operationTime'))
             this
+        }
+    }
+
+    private Cluster mockCluster() {
+        new BaseCluster(new ClusterId(), ClusterSettings.builder().build(), Mock(ClusterableServerFactory)) {
+            @Override
+            protected void connect() {
+            }
+
+            @Override
+            ClusterableServer getServer(final ServerAddress serverAddress) {
+                null
+            }
         }
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultTestClusterableServerFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultTestClusterableServerFactory.java
@@ -43,7 +43,8 @@ public class DefaultTestClusterableServerFactory implements ClusterableServerFac
     }
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress,
+    public ClusterableServer create(final Cluster cluster,
+                                    final ServerAddress serverAddress,
                                     final ServerDescriptionChangedListener serverDescriptionChangedListener,
                                     final ClusterClock clusterClock) {
         ServerId serverId = new ServerId(clusterId, serverAddress);
@@ -56,7 +57,7 @@ public class DefaultTestClusterableServerFactory implements ClusterableServerFac
             serverAddressToServerMonitorMap.put(serverAddress, serverMonitor);
             ConnectionPool connectionPool = new TestConnectionPool();
             ServerListener serverListener = serverListenerFactory.create(serverAddress);
-            SdamServerDescriptionManager sdam = new DefaultSdamServerDescriptionManager(serverId, serverDescriptionChangedListener,
+            SdamServerDescriptionManager sdam = new DefaultSdamServerDescriptionManager(cluster, serverId, serverDescriptionChangedListener,
                     serverListener, serverMonitor, connectionPool, clusterConnectionMode);
             sdamProvider.initialize(sdam);
             serverMonitor.start();

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoadBalancedClusterTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoadBalancedClusterTest.java
@@ -337,7 +337,7 @@ public class LoadBalancedClusterTest {
         // close `cluster`, call `DnsSrvRecordInitializer.initialize` and check that it does not result in creating a `ClusterableServer`
         cluster.close();
         serverInitializerCaptor.getValue().initialize(Collections.singleton(new ServerAddress()));
-        verify(serverFactory, never()).create(any(), any(), any());
+        verify(serverFactory, never()).create(any(), any(), any(), any());
     }
 
     @Test
@@ -346,12 +346,12 @@ public class LoadBalancedClusterTest {
         ClusterableServerFactory serverFactory = mock(ClusterableServerFactory.class);
         when(serverFactory.getSettings()).thenReturn(mock(ServerSettings.class));
         ClusterableServer server = mock(ClusterableServer.class);
-        when(serverFactory.create(any(), any(), any())).thenReturn(server);
+        when(serverFactory.create(any(), any(), any(), any())).thenReturn(server);
         // create `cluster` and check that it creates a `ClusterableServer`
         LoadBalancedCluster cluster = new LoadBalancedCluster(new ClusterId(),
                 ClusterSettings.builder().mode(ClusterConnectionMode.LOAD_BALANCED).build(), serverFactory,
                 mock(DnsSrvRecordMonitorFactory.class));
-        verify(serverFactory, times(1)).create(any(), any(), any());
+        verify(serverFactory, times(1)).create(any(), any(), any(), any());
         // close `cluster` and check that it closes `server`
         cluster.close();
         verify(server, atLeastOnce()).close();
@@ -491,7 +491,7 @@ public class LoadBalancedClusterTest {
     private ClusterableServerFactory mockServerFactory(final ServerAddress serverAddress, final ClusterableServer expectedServer) {
         ClusterableServerFactory serverFactory = mock(ClusterableServerFactory.class);
         when(serverFactory.getSettings()).thenReturn(ServerSettings.builder().build());
-        when(serverFactory.create(eq(serverAddress), any(), any())).thenReturn(expectedServer);
+        when(serverFactory.create(any(), eq(serverAddress), any(), any())).thenReturn(expectedServer);
         return serverFactory;
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/SrvPollingProseTests.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/SrvPollingProseTests.java
@@ -66,7 +66,7 @@ public class SrvPollingProseTests {
     @BeforeEach
     public void beforeEach() {
         when(serverFactory.getSettings()).thenReturn(ServerSettings.builder().build());
-        when(serverFactory.create(any(), any(), any())).thenReturn(mock(ClusterableServer.class));
+        when(serverFactory.create(any(), any(), any(), any())).thenReturn(mock(ClusterableServer.class));
     }
 
     @AfterEach

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestClusterableServerFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestClusterableServerFactory.java
@@ -38,7 +38,7 @@ public class TestClusterableServerFactory implements ClusterableServerFactory {
     private final Map<ServerAddress, TestServer> addressToServerMap = new HashMap<ServerAddress, TestServer>();
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress,
+    public ClusterableServer create(final Cluster cluster, final ServerAddress serverAddress,
                                     final ServerDescriptionChangedListener serverDescriptionChangedListener,
                                     final ClusterClock clusterClock) {
         addressToServerMap.put(serverAddress, new TestServer(serverAddress, serverDescriptionChangedListener, NO_OP_SERVER_LISTENER));


### PR DESCRIPTION
See this [comment](https://jira.mongodb.org/browse/JAVA-4471?focusedCommentId=4336655&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4336655) for the details on what this PR fixes. The idea is to guard the action of pausing/unpausing a pool with the same cluster-wide lock that is used to guard the cluster state.

There will be one more PR that tries to get rid of some fields and params that duplicate the information that can be accessed via `Cluster`.

JAVA-4471