### PR TITLE
Introduce and use `Cluster.withLock` to achieve cluster-wide locking

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE;
@@ -89,17 +91,17 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
 
     protected void initialize(final Collection<ServerAddress> serverAddresses) {
         ClusterDescription currentDescription = getCurrentDescription();
-        ClusterDescription newDescription;
+        AtomicReference<ClusterDescription> newDescription = new AtomicReference<>();
 
         // synchronizing this code because addServer registers a callback which is re-entrant to this instance.
         // In other words, we are leaking a reference to "this" from the constructor.
-        synchronized (this) {
+        withLock(() -> {
             for (final ServerAddress serverAddress : serverAddresses) {
                 addServer(serverAddress);
             }
-            newDescription = updateDescription();
-        }
-        fireChangeEvent(newDescription, currentDescription);
+            newDescription.set(updateDescription());
+        });
+        fireChangeEvent(newDescription.get(), currentDescription);
     }
 
     @Override
@@ -111,14 +113,14 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
 
     @Override
     public void close() {
-        synchronized (this) {
+        withLock(() -> {
             if (!isClosed()) {
                 for (final ServerTuple serverTuple : addressToServerTupleMap.values()) {
                     serverTuple.server.close();
                 }
             }
             super.close();
-        }
+        });
     }
 
     @Override
@@ -141,7 +143,7 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
     }
 
     void onChange(final Collection<ServerAddress> newHosts) {
-        synchronized (this) {
+        withLock(() -> {
             if (isClosed()) {
                 return;
             }
@@ -165,14 +167,14 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
             ClusterDescription newClusterDescription = updateDescription();
 
             fireChangeEvent(newClusterDescription, oldClusterDescription);
-        }
+        });
     }
 
     private void onChange(final ServerDescriptionChangedEvent event) {
-        ClusterDescription oldClusterDescription = null;
-        ClusterDescription newClusterDescription = null;
-        boolean shouldUpdateDescription = true;
-        synchronized (this) {
+        AtomicReference<ClusterDescription> oldClusterDescription = new AtomicReference<>();
+        AtomicReference<ClusterDescription> newClusterDescription = new AtomicReference<>();
+        AtomicBoolean shouldUpdateDescription = new AtomicBoolean(true);
+        withLock(() -> {
             if (isClosed()) {
                 return;
             }
@@ -203,27 +205,27 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
 
                 switch (clusterType) {
                     case REPLICA_SET:
-                        shouldUpdateDescription = handleReplicaSetMemberChanged(newDescription);
+                        shouldUpdateDescription.set(handleReplicaSetMemberChanged(newDescription));
                         break;
                     case SHARDED:
-                        shouldUpdateDescription = handleShardRouterChanged(newDescription);
+                        shouldUpdateDescription.set(handleShardRouterChanged(newDescription));
                         break;
                     case STANDALONE:
-                        shouldUpdateDescription = handleStandAloneChanged(newDescription);
+                        shouldUpdateDescription.set(handleStandAloneChanged(newDescription));
                         break;
                     default:
                         break;
                 }
             }
 
-            if (shouldUpdateDescription) {
+            if (shouldUpdateDescription.get()) {
                 serverTuple.description = newDescription;
-                oldClusterDescription = getCurrentDescription();
-                newClusterDescription = updateDescription();
+                oldClusterDescription.set(getCurrentDescription());
+                newClusterDescription.set(updateDescription());
             }
-        }
-        if (shouldUpdateDescription) {
-            fireChangeEvent(newClusterDescription, oldClusterDescription);
+        });
+        if (shouldUpdateDescription.get()) {
+            fireChangeEvent(newClusterDescription.get(), oldClusterDescription.get());
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
@@ -176,6 +176,7 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
         AtomicBoolean shouldUpdateDescription = new AtomicBoolean(true);
         withLock(() -> {
             if (isClosed()) {
+                shouldUpdateDescription.set(false);
                 return;
             }
 
@@ -192,6 +193,7 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
                     LOGGER.trace(format("Ignoring description changed event for removed server %s",
                                         newDescription.getAddress()));
                 }
+                shouldUpdateDescription.set(false);
                 return;
             }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -240,13 +240,15 @@ abstract class BaseCluster implements Cluster {
         return isClosed;
     }
 
-    protected synchronized void updateDescription(final ClusterDescription newDescription) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(format("Updating cluster description to  %s", newDescription.getShortDescription()));
-        }
+    protected void updateDescription(final ClusterDescription newDescription) {
+        withLock(() -> {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(format("Updating cluster description to  %s", newDescription.getShortDescription()));
+            }
 
-        description = newDescription;
-        updatePhase();
+            description = newDescription;
+            updatePhase();
+        });
     }
 
     protected void fireChangeEvent(final ClusterDescription newDescription, final ClusterDescription previousDescription) {
@@ -261,8 +263,13 @@ abstract class BaseCluster implements Cluster {
         return description;
     }
 
-    private synchronized void updatePhase() {
-        phase.getAndSet(new CountDownLatch(1)).countDown();
+    @Override
+    public synchronized void withLock(final Runnable action) {
+        action.run();
+    }
+
+    private void updatePhase() {
+        withLock(() -> phase.getAndSet(new CountDownLatch(1)).countDown());
     }
 
     private long getMaxWaitTimeNanos() {
@@ -381,8 +388,8 @@ abstract class BaseCluster implements Cluster {
 
     protected ClusterableServer createServer(final ServerAddress serverAddress,
                                              final ServerDescriptionChangedListener serverDescriptionChangedListener) {
-        return serverFactory.create(serverAddress, serverDescriptionChangedListener, createServerListener(serverFactory.getSettings()),
-                clusterClock);
+        return serverFactory.create(this, serverAddress, serverDescriptionChangedListener,
+                createServerListener(serverFactory.getSettings()), clusterClock);
     }
 
     private void throwIfIncompatible(final ClusterDescription curDescription) {
@@ -451,26 +458,30 @@ abstract class BaseCluster implements Cluster {
         }
     }
 
-    private synchronized void notifyWaitQueueHandler(final ServerSelectionRequest request) {
-        if (isClosed) {
-            return;
-        }
+    private void notifyWaitQueueHandler(final ServerSelectionRequest request) {
+        withLock(() -> {
+            if (isClosed) {
+                return;
+            }
 
-        waitQueue.add(request);
+            waitQueue.add(request);
 
-        if (waitQueueHandler == null) {
-            waitQueueHandler = new Thread(new WaitQueueHandler(), "cluster-" + clusterId.getValue());
-            waitQueueHandler.setDaemon(true);
-            waitQueueHandler.start();
-        } else {
-            updatePhase();
-        }
+            if (waitQueueHandler == null) {
+                waitQueueHandler = new Thread(new WaitQueueHandler(), "cluster-" + clusterId.getValue());
+                waitQueueHandler.setDaemon(true);
+                waitQueueHandler.start();
+            } else {
+                updatePhase();
+            }
+        });
     }
 
-    private synchronized void stopWaitQueueHandler() {
-        if (waitQueueHandler != null) {
-            waitQueueHandler.interrupt();
-        }
+    private void stopWaitQueueHandler() {
+        withLock(() -> {
+            if (waitQueueHandler != null) {
+                waitQueueHandler.interrupt();
+            }
+        });
     }
 
     private final class WaitQueueHandler implements Runnable {

--- a/driver-core/src/main/com/mongodb/internal/connection/Cluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/Cluster.java
@@ -92,4 +92,11 @@ public interface Cluster extends Closeable {
      * @return true if all the servers in this cluster have been closed
      */
     boolean isClosed();
+
+    /**
+     * Does the supplied {@code action} while holding a reentrant cluster-wide lock.
+     *
+     * @param action The action to {@linkplain Runnable#run() do}.
+     */
+    void withLock(Runnable action);
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/ClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ClusterableServerFactory.java
@@ -21,7 +21,7 @@ import com.mongodb.connection.ServerSettings;
 import com.mongodb.event.ServerListener;
 
 public interface ClusterableServerFactory {
-    ClusterableServer create(ServerAddress serverAddress, ServerDescriptionChangedListener serverDescriptionChangedListener,
+    ClusterableServer create(Cluster cluster, ServerAddress serverAddress, ServerDescriptionChangedListener serverDescriptionChangedListener,
                              ServerListener serverListener, ClusterClock clusterClock);
 
     ServerSettings getSettings();

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
@@ -75,7 +75,8 @@ public class DefaultClusterableServerFactory implements ClusterableServerFactory
     }
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress,
+    public ClusterableServer create(final Cluster cluster,
+                                    final ServerAddress serverAddress,
                                     final ServerDescriptionChangedListener serverDescriptionChangedListener,
                                     final ServerListener serverListener,
                                     final ClusterClock clusterClock) {
@@ -90,7 +91,7 @@ public class DefaultClusterableServerFactory implements ClusterableServerFactory
                 new InternalStreamConnectionFactory(clusterSettings.getMode(), streamFactory, credential, applicationName,
                         mongoDriverInformation, compressorList, commandListener, serverApi),
                 connectionPoolSettings, internalConnectionPoolSettings, sdamProvider);
-        SdamServerDescriptionManager sdam = new DefaultSdamServerDescriptionManager(serverId, serverDescriptionChangedListener,
+        SdamServerDescriptionManager sdam = new DefaultSdamServerDescriptionManager(cluster, serverId, serverDescriptionChangedListener,
                 serverListener, serverMonitor, connectionPool, clusterSettings.getMode());
         sdamProvider.initialize(sdam);
         serverMonitor.start();

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultSdamServerDescriptionManager.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultSdamServerDescriptionManager.java
@@ -24,9 +24,6 @@ import com.mongodb.connection.ServerType;
 import com.mongodb.event.ServerDescriptionChangedEvent;
 import com.mongodb.event.ServerListener;
 
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
 import static com.mongodb.assertions.Assertions.assertFalse;
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.assertTrue;
@@ -36,20 +33,22 @@ import static com.mongodb.internal.connection.ServerDescriptionHelper.unknownCon
 
 @ThreadSafe
 final class DefaultSdamServerDescriptionManager implements SdamServerDescriptionManager {
+    private final Cluster cluster;
     private final ServerId serverId;
     private final ServerDescriptionChangedListener serverDescriptionChangedListener;
     private final ServerListener serverListener;
     private final ServerMonitor serverMonitor;
     private final ConnectionPool connectionPool;
     private final ClusterConnectionMode connectionMode;
-    private final Lock lock;
     private volatile ServerDescription description;
 
-    DefaultSdamServerDescriptionManager(final ServerId serverId,
+    DefaultSdamServerDescriptionManager(final Cluster cluster,
+                                        final ServerId serverId,
                                         final ServerDescriptionChangedListener serverDescriptionChangedListener,
                                         final ServerListener serverListener, final ServerMonitor serverMonitor,
                                         final ConnectionPool connectionPool,
                                         final ClusterConnectionMode connectionMode) {
+        this.cluster = cluster;
         this.serverId = assertNotNull(serverId);
         this.serverDescriptionChangedListener = assertNotNull(serverDescriptionChangedListener);
         this.serverListener = assertNotNull(serverListener);
@@ -57,13 +56,11 @@ final class DefaultSdamServerDescriptionManager implements SdamServerDescription
         this.connectionPool = assertNotNull(connectionPool);
         this.connectionMode = assertNotNull(connectionMode);
         description = unknownConnectingServerDescription(serverId, null);
-        lock = new ReentrantLock();
     }
 
     @Override
     public void update(final ServerDescription candidateDescription) {
-        lock.lock();
-        try {
+        cluster.withLock(() -> {
             if (TopologyVersionHelper.newer(description.getTopologyVersion(), candidateDescription.getTopologyVersion())) {
                 return;
             }
@@ -84,29 +81,17 @@ final class DefaultSdamServerDescriptionManager implements SdamServerDescription
                 assertFalse(markedPoolReady);
                 connectionPool.invalidate();
             }
-        } finally {
-            lock.unlock();
-        }
+        });
     }
 
     @Override
     public void handleExceptionBeforeHandshake(final SdamIssue sdamIssue) {
-        lock.lock();
-        try {
-            handleException(sdamIssue, true);
-        } finally {
-            lock.unlock();
-        }
+        cluster.withLock(() -> handleException(sdamIssue, true));
     }
 
     @Override
     public void handleExceptionAfterHandshake(final SdamIssue sdamIssue) {
-        lock.lock();
-        try {
-            handleException(sdamIssue, false);
-        } finally {
-            lock.unlock();
-        }
+        cluster.withLock(() -> handleException(sdamIssue, false));
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedCluster.java
@@ -160,7 +160,7 @@ final class LoadBalancedCluster implements Cluster {
                         .address(host)
                         .build()),
                 settings, serverFactory.getSettings());
-        server = serverFactory.create(host, event -> { }, createServerListener(serverFactory.getSettings()), clusterClock);
+        server = serverFactory.create(this, host, event -> { }, createServerListener(serverFactory.getSettings()), clusterClock);
 
         clusterListener.clusterDescriptionChanged(new ClusterDescriptionChangedEvent(clusterId, description, initialDescription));
     }
@@ -281,6 +281,11 @@ final class LoadBalancedCluster implements Cluster {
     @Override
     public boolean isClosed() {
         return closed.get();
+    }
+
+    @Override
+    public void withLock(final Runnable action) {
+        fail();
     }
 
     private void handleServerSelectionRequest(final ServerSelectionRequest serverSelectionRequest) {

--- a/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedClusterableServerFactory.java
@@ -69,7 +69,8 @@ public class LoadBalancedClusterableServerFactory implements ClusterableServerFa
     }
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress,
+    public ClusterableServer create(final Cluster cluster,
+                                    final ServerAddress serverAddress,
                                     final ServerDescriptionChangedListener serverDescriptionChangedListener,
                                     final ServerListener serverListener, final ClusterClock clusterClock) {
         ConnectionPool connectionPool = new DefaultConnectionPool(new ServerId(clusterId, serverAddress),

--- a/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
@@ -29,6 +29,9 @@ import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.event.ServerDescriptionChangedEvent;
 
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.connection.ServerConnectionState.CONNECTING;
 import static java.lang.String.format;
@@ -41,7 +44,7 @@ import static java.util.Collections.singletonList;
 public final class SingleServerCluster extends BaseCluster {
     private static final Logger LOGGER = Loggers.getLogger("cluster");
 
-    private final ClusterableServer server;
+    private final AtomicReference<ClusterableServer> server;
 
     public SingleServerCluster(final ClusterId clusterId, final ClusterSettings settings, final ClusterableServerFactory serverFactory) {
         super(clusterId, settings, serverFactory);
@@ -52,30 +55,31 @@ public final class SingleServerCluster extends BaseCluster {
             LOGGER.info(format("Cluster created with settings %s", settings.getShortDescription()));
         }
 
+        server = new AtomicReference<>();
         // synchronized in the constructor because the change listener is re-entrant to this instance.
         // In other words, we are leaking a reference to "this" from the constructor.
-        synchronized (this) {
-            this.server = createServer(settings.getHosts().get(0), new DefaultServerDescriptionChangedListener());
+        withLock(() -> {
+            server.set(createServer(settings.getHosts().get(0), new DefaultServerDescriptionChangedListener()));
             publishDescription(ServerDescription.builder().state(CONNECTING).address(settings.getHosts().get(0))
                     .build());
-        }
+        });
     }
 
     @Override
     protected void connect() {
-        server.connect();
+        assertNotNull(server.get()).connect();
     }
 
     @Override
     public ClusterableServer getServer(final ServerAddress serverAddress) {
         isTrue("open", !isClosed());
-        return server;
+        return assertNotNull(server.get());
     }
 
     @Override
     public void close() {
         if (!isClosed()) {
-            server.close();
+            assertNotNull(server.get()).close();
             super.close();
         }
     }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
@@ -58,6 +58,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 import util.JsonPoweredTestHelper;
 
 import java.io.File;
@@ -85,6 +86,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 // Implementation of
@@ -181,8 +183,9 @@ public abstract class AbstractConnectionPoolTest {
                                 new TestCommandListener(),
                                 ClusterFixture.getServerApi()),
                         settings, internalSettings, sdamProvider));
-                sdamProvider.initialize(new DefaultSdamServerDescriptionManager(serverId, mock(ServerDescriptionChangedListener.class),
-                        mock(ServerListener.class), mock(ServerMonitor.class), pool, connectionMode));
+                sdamProvider.initialize(new DefaultSdamServerDescriptionManager(mockedCluster(), serverId,
+                        mock(ServerDescriptionChangedListener.class), mock(ServerListener.class), mock(ServerMonitor.class), pool,
+                        connectionMode));
                 setFailPoint();
                 break;
             }
@@ -517,6 +520,15 @@ public abstract class AbstractConnectionPoolTest {
             Thread.currentThread().interrupt();
             throw new MongoInterruptedException(null, e);
         }
+    }
+
+    private static Cluster mockedCluster() {
+        Cluster cluster = mock(Cluster.class);
+        Mockito.doAnswer(invocation -> {
+            invocation.getArgument(0, Runnable.class).run();
+            return null;
+        }).when(cluster).withLock(any(Runnable.class));
+        return cluster;
     }
 
     private enum Style {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultTestClusterableServerFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultTestClusterableServerFactory.java
@@ -43,7 +43,8 @@ public class DefaultTestClusterableServerFactory implements ClusterableServerFac
     }
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress,
+    public ClusterableServer create(final Cluster cluster,
+                                    final ServerAddress serverAddress,
                                     final ServerDescriptionChangedListener serverDescriptionChangedListener,
                                     final ServerListener ignored, final ClusterClock clusterClock) {
         ServerId serverId = new ServerId(clusterId, serverAddress);
@@ -56,7 +57,7 @@ public class DefaultTestClusterableServerFactory implements ClusterableServerFac
             serverAddressToServerMonitorMap.put(serverAddress, serverMonitor);
             ConnectionPool connectionPool = new TestConnectionPool();
             ServerListener serverListener = serverListenerFactory.create(serverAddress);
-            SdamServerDescriptionManager sdam = new DefaultSdamServerDescriptionManager(serverId, serverDescriptionChangedListener,
+            SdamServerDescriptionManager sdam = new DefaultSdamServerDescriptionManager(cluster, serverId, serverDescriptionChangedListener,
                     serverListener, serverMonitor, connectionPool, clusterConnectionMode);
             sdamProvider.initialize(sdam);
             serverMonitor.start();

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoadBalancedClusterTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoadBalancedClusterTest.java
@@ -338,7 +338,7 @@ public class LoadBalancedClusterTest {
         // close `cluster`, call `DnsSrvRecordInitializer.initialize` and check that it does not result in creating a `ClusterableServer`
         cluster.close();
         serverInitializerCaptor.getValue().initialize(Collections.singleton(new ServerAddress()));
-        verify(serverFactory, never()).create(any(), any(), any(), any());
+        verify(serverFactory, never()).create(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -347,12 +347,12 @@ public class LoadBalancedClusterTest {
         ClusterableServerFactory serverFactory = mock(ClusterableServerFactory.class);
         when(serverFactory.getSettings()).thenReturn(mock(ServerSettings.class));
         ClusterableServer server = mock(ClusterableServer.class);
-        when(serverFactory.create(any(), any(), any(), any())).thenReturn(server);
+        when(serverFactory.create(any(), any(), any(), any(), any())).thenReturn(server);
         // create `cluster` and check that it creates a `ClusterableServer`
         LoadBalancedCluster cluster = new LoadBalancedCluster(new ClusterId(),
                 ClusterSettings.builder().mode(ClusterConnectionMode.LOAD_BALANCED).build(), serverFactory,
                 mock(DnsSrvRecordMonitorFactory.class));
-        verify(serverFactory, times(1)).create(any(), any(), any(), any());
+        verify(serverFactory, times(1)).create(any(), any(), any(), any(), any());
         // close `cluster` and check that it closes `server`
         cluster.close();
         verify(server, atLeastOnce()).close();
@@ -492,7 +492,7 @@ public class LoadBalancedClusterTest {
     private ClusterableServerFactory mockServerFactory(final ServerAddress serverAddress, final ClusterableServer expectedServer) {
         ClusterableServerFactory serverFactory = mock(ClusterableServerFactory.class);
         when(serverFactory.getSettings()).thenReturn(ServerSettings.builder().build());
-        when(serverFactory.create(eq(serverAddress), any(), any(), any())).thenReturn(expectedServer);
+        when(serverFactory.create(any(), eq(serverAddress), any(), any(), any())).thenReturn(expectedServer);
         return serverFactory;
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/SrvPollingProseTests.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/SrvPollingProseTests.java
@@ -65,7 +65,7 @@ public class SrvPollingProseTests {
     @BeforeEach
     public void beforeEach() {
         when(serverFactory.getSettings()).thenReturn(ServerSettings.builder().build());
-        when(serverFactory.create(any(), any(), any(), any())).thenReturn(mock(ClusterableServer.class));
+        when(serverFactory.create(any(), any(), any(), any(), any())).thenReturn(mock(ClusterableServer.class));
     }
 
     @AfterEach

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestClusterableServerFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestClusterableServerFactory.java
@@ -37,7 +37,7 @@ public class TestClusterableServerFactory implements ClusterableServerFactory {
     private final Map<ServerAddress, TestServer> addressToServerMap = new HashMap<ServerAddress, TestServer>();
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress,
+    public ClusterableServer create(final Cluster cluster, final ServerAddress serverAddress,
                                     final ServerDescriptionChangedListener serverDescriptionChangedListener,
                                     final ServerListener serverListener,
                                     final ClusterClock clusterClock) {


### PR DESCRIPTION
This is a backport of https://github.com/mongodb/mongo-java-driver/pull/869.

JAVA-4471