### PR TITLE
Make ClusterConnectionMode required in CommandMessage

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/Authenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/Authenticator.java
@@ -19,17 +19,23 @@ package com.mongodb.internal.connection;
 import com.mongodb.MongoCredential;
 import com.mongodb.MongoInternalException;
 import com.mongodb.ServerApi;
+import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.lang.NonNull;
 import com.mongodb.lang.Nullable;
 
+import static com.mongodb.assertions.Assertions.notNull;
+
 public abstract class Authenticator {
     private final MongoCredentialWithCache credential;
+    private final ClusterConnectionMode clusterConnectionMode;
     private final ServerApi serverApi;
 
-    Authenticator(@NonNull final MongoCredentialWithCache credential, @Nullable final ServerApi serverApi) {
+    Authenticator(@NonNull final MongoCredentialWithCache credential, final ClusterConnectionMode clusterConnectionMode,
+            @Nullable final ServerApi serverApi) {
         this.credential = credential;
+        this.clusterConnectionMode = notNull("clusterConnectionMode", clusterConnectionMode);
         this.serverApi = serverApi;
     }
 
@@ -41,6 +47,10 @@ public abstract class Authenticator {
     @NonNull
     MongoCredential getMongoCredential() {
         return credential.getCredential();
+    }
+
+    ClusterConnectionMode getClusterConnectionMode() {
+        return clusterConnectionMode;
     }
 
     @Nullable

--- a/driver-core/src/main/com/mongodb/internal/connection/AwsAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AwsAuthenticator.java
@@ -23,6 +23,7 @@ import com.mongodb.MongoException;
 import com.mongodb.MongoInternalException;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerApi;
+import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.lang.NonNull;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonBinary;
@@ -63,8 +64,9 @@ public class AwsAuthenticator extends SaslAuthenticator {
     private static final String MONGODB_AWS_MECHANISM_NAME = "MONGODB-AWS";
     private static final int RANDOM_LENGTH = 32;
 
-    public AwsAuthenticator(final MongoCredentialWithCache credential, final @Nullable ServerApi serverApi) {
-        super(credential, serverApi);
+    public AwsAuthenticator(final MongoCredentialWithCache credential, final ClusterConnectionMode clusterConnectionMode,
+            final @Nullable ServerApi serverApi) {
+        super(credential, clusterConnectionMode, serverApi);
 
         if (getMongoCredential().getAuthenticationMechanism() != MONGODB_AWS) {
             throw new MongoException("Incorrect mechanism: " + getMongoCredential().getMechanism());

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
@@ -46,7 +46,7 @@ import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.ReadPreference.primaryPreferred;
 import static com.mongodb.assertions.Assertions.assertFalse;
 import static com.mongodb.assertions.Assertions.isTrue;
-import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE;
+import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE;
 import static com.mongodb.connection.ServerType.SHARD_ROUTER;
 import static com.mongodb.connection.ServerType.STANDALONE;
@@ -72,16 +72,17 @@ public final class CommandMessage extends RequestMessage {
     private final ServerApi serverApi;
 
     CommandMessage(final MongoNamespace namespace, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
-                   final ReadPreference readPreference, final MessageSettings settings, final @Nullable ServerApi serverApi) {
+            final ReadPreference readPreference, final MessageSettings settings, final ClusterConnectionMode clusterConnectionMode,
+            final @Nullable ServerApi serverApi) {
         this(namespace, command, commandFieldNameValidator, readPreference, settings, true, null, null,
-                MULTIPLE, serverApi);
+                clusterConnectionMode, serverApi);
     }
 
     CommandMessage(final MongoNamespace namespace, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
-                   final ReadPreference readPreference, final MessageSettings settings, final boolean exhaustAllowed,
-                   final @Nullable ServerApi serverApi) {
+            final ReadPreference readPreference, final MessageSettings settings, final boolean exhaustAllowed,
+            final ClusterConnectionMode clusterConnectionMode, final @Nullable ServerApi serverApi) {
         this(namespace, command, commandFieldNameValidator, readPreference, settings, true, exhaustAllowed, null, null,
-                MULTIPLE, serverApi);
+                clusterConnectionMode, serverApi);
     }
 
     CommandMessage(final MongoNamespace namespace, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
@@ -106,7 +107,7 @@ public final class CommandMessage extends RequestMessage {
         this.exhaustAllowed = exhaustAllowed;
         this.payload = payload;
         this.payloadFieldNameValidator = payloadFieldNameValidator;
-        this.clusterConnectionMode = clusterConnectionMode;
+        this.clusterConnectionMode = notNull("clusterConnectionMode", clusterConnectionMode);
         this.serverApi = serverApi;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
@@ -79,7 +79,7 @@ public class DefaultClusterableServerFactory implements ClusterableServerFactory
                 // no credentials, compressor list, or command listener for the server monitor factory
                 new InternalStreamConnectionFactory(clusterMode, heartbeatStreamFactory, null, applicationName,
                         mongoDriverInformation, emptyList(), null, serverApi),
-                serverApi, sdamProvider);
+                clusterMode, serverApi, sdamProvider);
         ConnectionPool connectionPool = new DefaultConnectionPool(serverId,
                 new InternalStreamConnectionFactory(clusterMode, streamFactory, credential, applicationName,
                         mongoDriverInformation, compressorList, commandListener, serverApi),

--- a/driver-core/src/main/com/mongodb/internal/connection/GSSAPIAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/GSSAPIAuthenticator.java
@@ -23,6 +23,7 @@ import com.mongodb.MongoSecurityException;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerApi;
 import com.mongodb.SubjectProvider;
+import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.lang.NonNull;
 import com.mongodb.lang.Nullable;
 import org.ietf.jgss.GSSCredential;
@@ -50,8 +51,9 @@ class GSSAPIAuthenticator extends SaslAuthenticator {
     private static final String SERVICE_NAME_DEFAULT_VALUE = "mongodb";
     private static final Boolean CANONICALIZE_HOST_NAME_DEFAULT_VALUE = false;
 
-    GSSAPIAuthenticator(final MongoCredentialWithCache credential, final @Nullable ServerApi serverApi) {
-        super(credential, serverApi);
+    GSSAPIAuthenticator(final MongoCredentialWithCache credential, final ClusterConnectionMode clusterConnectionMode,
+            final @Nullable ServerApi serverApi) {
+        super(credential, clusterConnectionMode, serverApi);
 
         if (getMongoCredential().getAuthenticationMechanism() != GSSAPI) {
             throw new MongoException("Incorrect mechanism: " + getMongoCredential().getMechanism());

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionFactory.java
@@ -65,21 +65,21 @@ class InternalStreamConnectionFactory implements InternalConnectionFactory {
 
     private Authenticator createAuthenticator(final MongoCredentialWithCache credential) {
         if (credential.getAuthenticationMechanism() == null) {
-            return new DefaultAuthenticator(credential, serverApi);
+            return new DefaultAuthenticator(credential, clusterConnectionMode, serverApi);
         }
 
         switch (credential.getAuthenticationMechanism()) {
             case GSSAPI:
-                return new GSSAPIAuthenticator(credential, serverApi);
+                return new GSSAPIAuthenticator(credential, clusterConnectionMode, serverApi);
             case PLAIN:
-                return new PlainAuthenticator(credential, serverApi);
+                return new PlainAuthenticator(credential, clusterConnectionMode, serverApi);
             case MONGODB_X509:
-                return new X509Authenticator(credential, serverApi);
+                return new X509Authenticator(credential, clusterConnectionMode, serverApi);
             case SCRAM_SHA_1:
             case SCRAM_SHA_256:
-                return new ScramShaAuthenticator(credential, serverApi);
+                return new ScramShaAuthenticator(credential, clusterConnectionMode, serverApi);
             case MONGODB_AWS:
-                return new AwsAuthenticator(credential, serverApi);
+                return new AwsAuthenticator(credential, clusterConnectionMode, serverApi);
             default:
                 throw new IllegalArgumentException("Unsupported authentication mechanism " + credential.getAuthenticationMechanism());
         }

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
@@ -86,8 +86,8 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
     public void startHandshakeAsync(final InternalConnection internalConnection,
                                     final SingleResultCallback<InternalConnectionInitializationDescription> callback) {
         final long startTime = System.nanoTime();
-        executeCommandAsync("admin", createHelloCommand(authenticator, internalConnection), serverApi, internalConnection,
-                new SingleResultCallback<BsonDocument>() {
+        executeCommandAsync("admin", createHelloCommand(authenticator, internalConnection), clusterConnectionMode, serverApi,
+                internalConnection, new SingleResultCallback<BsonDocument>() {
                     @Override
                     public void onResult(final BsonDocument helloResult, final Throwable t) {
                         if (t != null) {
@@ -128,7 +128,7 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
 
         long start = System.nanoTime();
         try {
-            helloResult = executeCommand("admin", helloCommandDocument, serverApi, internalConnection);
+            helloResult = executeCommand("admin", helloCommandDocument, clusterConnectionMode, serverApi, internalConnection);
         } catch (MongoException e) {
             throw mapHelloException(e);
         }
@@ -197,7 +197,7 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
         }
 
         return applyGetLastErrorResult(executeCommandWithoutCheckingForFailure("admin",
-                new BsonDocument("getlasterror", new BsonInt32(1)), serverApi,
+                new BsonDocument("getlasterror", new BsonInt32(1)), clusterConnectionMode, serverApi,
                 internalConnection),
                 description);
     }
@@ -225,7 +225,7 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
             return;
         }
 
-        executeCommandAsync("admin", new BsonDocument("getlasterror", new BsonInt32(1)), serverApi,
+        executeCommandAsync("admin", new BsonDocument("getlasterror", new BsonInt32(1)), clusterConnectionMode, serverApi,
                 internalConnection,
                 new SingleResultCallback<BsonDocument>() {
                     @Override

--- a/driver-core/src/main/com/mongodb/internal/connection/PlainAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/PlainAuthenticator.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoCredential;
 import com.mongodb.MongoSecurityException;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerApi;
+import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.lang.Nullable;
 
 import javax.security.auth.callback.Callback;
@@ -38,8 +39,9 @@ import static com.mongodb.assertions.Assertions.isTrue;
 class PlainAuthenticator extends SaslAuthenticator {
     private static final String DEFAULT_PROTOCOL = "mongodb";
 
-    PlainAuthenticator(final MongoCredentialWithCache credential, final @Nullable ServerApi serverApi) {
-        super(credential, serverApi);
+    PlainAuthenticator(final MongoCredentialWithCache credential, final ClusterConnectionMode clusterConnectionMode,
+            final @Nullable ServerApi serverApi) {
+        super(credential, clusterConnectionMode, serverApi);
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/connection/SaslAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SaslAuthenticator.java
@@ -22,6 +22,7 @@ import com.mongodb.MongoSecurityException;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerApi;
 import com.mongodb.SubjectProvider;
+import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
@@ -49,8 +50,9 @@ abstract class SaslAuthenticator extends Authenticator implements SpeculativeAut
     public static final Logger LOGGER = Loggers.getLogger("authenticator");
     private static final String SUBJECT_PROVIDER_CACHE_KEY = "SUBJECT_PROVIDER";
 
-    SaslAuthenticator(final MongoCredentialWithCache credential, final @Nullable ServerApi serverApi) {
-        super(credential, serverApi);
+    SaslAuthenticator(final MongoCredentialWithCache credential, final ClusterConnectionMode clusterConnectionMode,
+            final @Nullable ServerApi serverApi) {
+        super(credential, clusterConnectionMode, serverApi);
     }
 
     public void authenticate(final InternalConnection connection, final ConnectionDescription connectionDescription) {
@@ -225,25 +227,26 @@ abstract class SaslAuthenticator extends Authenticator implements SpeculativeAut
     private BsonDocument sendSaslStart(final byte[] outToken, final InternalConnection connection) {
         BsonDocument startDocument = createSaslStartCommandDocument(outToken);
         appendSaslStartOptions(startDocument);
-        return executeCommand(getMongoCredential().getSource(), startDocument, getServerApi(), connection);
+        return executeCommand(getMongoCredential().getSource(), startDocument, getClusterConnectionMode(), getServerApi(), connection);
     }
 
     private BsonDocument sendSaslContinue(final BsonInt32 conversationId, final byte[] outToken, final InternalConnection connection) {
-        return executeCommand(getMongoCredential().getSource(), createSaslContinueDocument(conversationId, outToken), getServerApi(),
-                connection);
+        return executeCommand(getMongoCredential().getSource(), createSaslContinueDocument(conversationId, outToken),
+                getClusterConnectionMode(), getServerApi(), connection);
     }
 
     private void sendSaslStartAsync(final byte[] outToken, final InternalConnection connection,
                                     final SingleResultCallback<BsonDocument> callback) {
         BsonDocument startDocument = createSaslStartCommandDocument(outToken);
         appendSaslStartOptions(startDocument);
-        executeCommandAsync(getMongoCredential().getSource(), startDocument, getServerApi(), connection, callback);
+        executeCommandAsync(getMongoCredential().getSource(), startDocument, getClusterConnectionMode(), getServerApi(), connection,
+                callback);
     }
 
     private void sendSaslContinueAsync(final BsonInt32 conversationId, final byte[] outToken, final InternalConnection connection,
                                        final SingleResultCallback<BsonDocument> callback) {
-        executeCommandAsync(getMongoCredential().getSource(), createSaslContinueDocument(conversationId, outToken), getServerApi(),
-                connection, callback);
+        executeCommandAsync(getMongoCredential().getSource(), createSaslContinueDocument(conversationId, outToken),
+                getClusterConnectionMode(), getServerApi(), connection, callback);
     }
 
     protected BsonDocument createSaslStartCommandDocument(final byte[] outToken) {

--- a/driver-core/src/main/com/mongodb/internal/connection/ScramShaAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ScramShaAuthenticator.java
@@ -20,6 +20,7 @@ import com.mongodb.AuthenticationMechanism;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerApi;
+import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.internal.authentication.SaslPrep;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonBoolean;
@@ -55,18 +56,16 @@ class ScramShaAuthenticator extends SaslAuthenticator {
     private static final int RANDOM_LENGTH = 24;
     private static final byte[] INT_1 = {0, 0, 0, 1};
 
-    ScramShaAuthenticator(final MongoCredentialWithCache credential, @Nullable final ServerApi serverApi) {
+    ScramShaAuthenticator(final MongoCredentialWithCache credential, final ClusterConnectionMode clusterConnectionMode,
+            @Nullable final ServerApi serverApi) {
         this(credential, new DefaultRandomStringGenerator(), getAuthenicationHashGenerator(credential.getAuthenticationMechanism()),
-                serverApi);
-    }
-
-    ScramShaAuthenticator(final MongoCredentialWithCache credential, final RandomStringGenerator randomStringGenerator) {
-        this(credential, randomStringGenerator, getAuthenicationHashGenerator(credential.getAuthenticationMechanism()), null);
+                clusterConnectionMode, serverApi);
     }
 
     ScramShaAuthenticator(final MongoCredentialWithCache credential, final RandomStringGenerator randomStringGenerator,
-                          final AuthenticationHashGenerator authenticationHashGenerator, @Nullable final ServerApi serverApi) {
-        super(credential, serverApi);
+                          final AuthenticationHashGenerator authenticationHashGenerator, final ClusterConnectionMode clusterConnectionMode,
+                          @Nullable final ServerApi serverApi) {
+        super(credential, clusterConnectionMode, serverApi);
         this.randomStringGenerator = randomStringGenerator;
         this.authenticationHashGenerator = authenticationHashGenerator;
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/X509Authenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/X509Authenticator.java
@@ -20,6 +20,7 @@ import com.mongodb.AuthenticationMechanism;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoSecurityException;
 import com.mongodb.ServerApi;
+import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
@@ -38,8 +39,9 @@ class X509Authenticator extends Authenticator implements SpeculativeAuthenticato
     public static final Logger LOGGER = Loggers.getLogger("authenticator");
     private BsonDocument speculativeAuthenticateResponse;
 
-    X509Authenticator(final MongoCredentialWithCache credential, final @Nullable ServerApi serverApi) {
-        super(credential, serverApi);
+    X509Authenticator(final MongoCredentialWithCache credential, final ClusterConnectionMode clusterConnectionMode,
+            final @Nullable ServerApi serverApi) {
+        super(credential, clusterConnectionMode, serverApi);
     }
 
     @Override
@@ -50,7 +52,7 @@ class X509Authenticator extends Authenticator implements SpeculativeAuthenticato
         try {
             validateUserName(connectionDescription);
             BsonDocument authCommand = getAuthCommand(getMongoCredential().getUserName());
-            executeCommand(getMongoCredential().getSource(), authCommand, getServerApi(), connection);
+            executeCommand(getMongoCredential().getSource(), authCommand, getClusterConnectionMode(), getServerApi(), connection);
         } catch (MongoCommandException e) {
             throw new MongoSecurityException(getMongoCredential(), "Exception authenticating", e);
         }
@@ -66,7 +68,7 @@ class X509Authenticator extends Authenticator implements SpeculativeAuthenticato
             try {
                 validateUserName(connectionDescription);
                 executeCommandAsync(getMongoCredential().getSource(), getAuthCommand(getMongoCredential().getUserName()),
-                        getServerApi(), connection,
+                        getClusterConnectionMode(), getServerApi(), connection,
                         new SingleResultCallback<BsonDocument>() {
                             @Override
                             public void onResult(final BsonDocument nonceResult, final Throwable t) {

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -259,6 +259,10 @@ public final class ClusterFixture {
         }
     }
 
+    public static ClusterConnectionMode getClusterConnectionMode() {
+        return getCluster().getCurrentDescription().getConnectionMode();
+    }
+
     @Nullable
     public static ServerApi getServerApi() {
          if (System.getProperty(MONGODB_API_VERSION) == null) {

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncStreamTimeoutsSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncStreamTimeoutsSpecification.groovy
@@ -34,6 +34,7 @@ import util.spock.annotations.Slow
 
 import java.util.concurrent.TimeUnit
 
+import static com.mongodb.ClusterFixture.getClusterConnectionMode
 import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getServerApi
@@ -74,7 +75,7 @@ class AsyncStreamTimeoutsSpecification extends OperationFunctionalSpecification 
         countCommand.put('query', new BsonDocument('$where', new BsonString('sleep(5050); return true;')))
 
         when:
-        executeCommand(getDatabaseName(), countCommand, getServerApi(), connection)
+        executeCommand(getDatabaseName(), countCommand,  getClusterConnectionMode(), getServerApi(), connection)
 
         then:
         thrown(MongoSocketReadTimeoutException)
@@ -110,7 +111,7 @@ class AsyncStreamTimeoutsSpecification extends OperationFunctionalSpecification 
         countCommand.put('query', new BsonDocument('$where', new BsonString('sleep(5050); return true;')))
 
         when:
-        executeCommand(getDatabaseName(), countCommand, getServerApi(), connection)
+        executeCommand(getDatabaseName(), countCommand, getClusterConnectionMode(), getServerApi(), connection)
 
         then:
         thrown(MongoSocketReadTimeoutException)

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/CommandHelperSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/CommandHelperSpecification.groovy
@@ -34,6 +34,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.CountDownLatch
 
+import static com.mongodb.ClusterFixture.getClusterConnectionMode
 import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getServerApi
@@ -67,7 +68,8 @@ class CommandHelperSpecification extends Specification {
         clusterClock.advance(new BsonDocument('clusterTime', new BsonTimestamp(42L)))
 
         when:
-        executeCommand('admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)), clusterClock, getServerApi(), connection)
+        executeCommand('admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)), clusterClock, getClusterConnectionMode(),
+                getServerApi(), connection)
 
         then:
         1 * connection.sendAndReceive(_, _, _ as ClusterClockAdvancingSessionContext, _)
@@ -79,7 +81,8 @@ class CommandHelperSpecification extends Specification {
         BsonDocument receivedDocument = null
         Throwable receivedException = null
         def latch1 = new CountDownLatch(1)
-        executeCommandAsync('admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)), getServerApi(), connection)
+        executeCommandAsync('admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)), getClusterConnectionMode(),
+                getServerApi(), connection)
                 { document, exception -> receivedDocument = document; receivedException = exception; latch1.countDown() }
         latch1.await()
 
@@ -90,7 +93,8 @@ class CommandHelperSpecification extends Specification {
 
         when:
         def latch2 = new CountDownLatch(1)
-        executeCommandAsync('admin', new BsonDocument('non-existent-command', new BsonInt32(1)), getServerApi(), connection)
+        executeCommandAsync('admin', new BsonDocument('non-existent-command', new BsonInt32(1)), getClusterConnectionMode(),
+                getServerApi(), connection)
                 { document, exception -> receivedDocument = document; receivedException = exception; latch2.countDown() }
         latch2.await()
 

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/GSSAPIAuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/GSSAPIAuthenticationSpecification.groovy
@@ -56,7 +56,8 @@ class GSSAPIAuthenticationSpecification extends Specification {
 
         when:
         openConnection(connection, async)
-        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')), null, connection)
+        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
+                getClusterConnectionMode(), null, connection)
 
         then:
         thrown(MongoCommandException)
@@ -74,7 +75,8 @@ class GSSAPIAuthenticationSpecification extends Specification {
 
         when:
         openConnection(connection, async)
-        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')), null, connection)
+        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
+                getClusterConnectionMode(), null, connection)
 
         then:
         true
@@ -95,7 +97,8 @@ class GSSAPIAuthenticationSpecification extends Specification {
 
         when:
         openConnection(connection, async)
-        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')), null, connection)
+        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
+                getClusterConnectionMode(), null, connection)
 
         then:
         thrown(MongoSecurityException)
@@ -126,7 +129,8 @@ class GSSAPIAuthenticationSpecification extends Specification {
         when:
         def connection = createConnection(async, getMongoCredential(subject))
         openConnection(connection, async)
-        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')), null, connection)
+        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
+                getClusterConnectionMode(), null, connection)
 
         then:
         true
@@ -169,7 +173,8 @@ class GSSAPIAuthenticationSpecification extends Specification {
         when:
         def connection = createConnection(async, getMongoCredential(saslClientProperties))
         openConnection(connection, async)
-        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')), null, connection)
+        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
+                getClusterConnectionMode(), null, connection)
 
         then:
         true
@@ -206,7 +211,7 @@ class GSSAPIAuthenticationSpecification extends Specification {
     }
 
     private static Authenticator createAuthenticator(final MongoCredential credential) {
-        credential == null ? null : new GSSAPIAuthenticator(new MongoCredentialWithCache(credential), null)
+        credential == null ? null : new GSSAPIAuthenticator(new MongoCredentialWithCache(credential), getClusterConnectionMode(), null)
     }
 
     private static void openConnection(final InternalConnection connection, final boolean async) {

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/PlainAuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/PlainAuthenticationSpecification.groovy
@@ -33,6 +33,7 @@ import spock.lang.IgnoreIf
 import spock.lang.Specification
 
 import static com.mongodb.AuthenticationMechanism.PLAIN
+import static com.mongodb.ClusterFixture.getClusterConnectionMode
 import static com.mongodb.ClusterFixture.getConnectionString
 import static com.mongodb.ClusterFixture.getCredential
 import static com.mongodb.ClusterFixture.getSslSettings
@@ -50,7 +51,8 @@ class PlainAuthenticationSpecification extends Specification {
 
         when:
         openConnection(connection, async)
-        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')), null, connection)
+        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
+                etClusterConnectionMode(), null, connection)
 
         then:
         thrown(MongoCommandException)
@@ -68,7 +70,8 @@ class PlainAuthenticationSpecification extends Specification {
 
         when:
         openConnection(connection, async)
-        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')), null, connection)
+        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
+                getClusterConnectionMode(), null, connection)
 
         then:
         true
@@ -86,7 +89,8 @@ class PlainAuthenticationSpecification extends Specification {
 
         when:
         openConnection(connection, async)
-        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')), null, connection)
+        executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
+                getClusterConnectionMode(), null, connection)
 
         then:
         thrown(MongoSecurityException)
@@ -112,7 +116,7 @@ class PlainAuthenticationSpecification extends Specification {
     }
 
     private static Authenticator createAuthenticator(final MongoCredential credential) {
-        credential == null ? null : new PlainAuthenticator(new MongoCredentialWithCache(credential), null)
+        credential == null ? null : new PlainAuthenticator(new MongoCredentialWithCache(credential), clusterConnectionMode, null)
     }
 
     private static void openConnection(final InternalConnection connection, final boolean async) {

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/PlainAuthenticatorTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/PlainAuthenticatorTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 
+import static com.mongodb.ClusterFixture.getClusterConnectionMode;
 import static com.mongodb.ClusterFixture.getServerApi;
 import static com.mongodb.ClusterFixture.getSslSettings;
 
@@ -66,14 +67,14 @@ public class PlainAuthenticatorTest {
     @Test
     public void testSuccessfulAuthentication() {
         PlainAuthenticator authenticator = new PlainAuthenticator(getCredentialWithCache(userName, source, password.toCharArray()),
-                getServerApi());
+                getClusterConnectionMode(), getServerApi());
         authenticator.authenticate(internalConnection, connectionDescription);
     }
 
     @Test(expected = MongoSecurityException.class)
     public void testUnsuccessfulAuthentication() {
         PlainAuthenticator authenticator = new PlainAuthenticator(getCredentialWithCache(userName, source, "wrong".toCharArray()),
-                getServerApi());
+                getClusterConnectionMode(), getServerApi());
         authenticator.authenticate(internalConnection, connectionDescription);
     }
 

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/ServerMonitorSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/ServerMonitorSpecification.groovy
@@ -34,6 +34,7 @@ import org.bson.types.ObjectId
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+import static com.mongodb.ClusterFixture.getClusterConnectionMode
 import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getServerApi
@@ -223,8 +224,9 @@ class ServerMonitorSpecification extends OperationFunctionalSpecification {
                 new InternalStreamConnectionFactory(SINGLE, new SocketStreamFactory(SocketSettings.builder()
                         .connectTimeout(500, TimeUnit.MILLISECONDS)
                         .build(),
-                        getSslSettings()), getCredentialWithCache(), null, null, [], null, getServerApi()),
-                getServerApi(), SameObjectProvider.initialized(sdam))
+                        getSslSettings()), getCredentialWithCache(), null, null, [], null,
+                        getServerApi()),
+                        getClusterConnectionMode(), getServerApi(), SameObjectProvider.initialized(sdam))
         serverMonitor.start()
         serverMonitor
     }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerMonitorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerMonitorSpecification.groovy
@@ -18,6 +18,7 @@ package com.mongodb.internal.connection
 
 import com.mongodb.MongoSocketReadTimeoutException
 import com.mongodb.ServerAddress
+import com.mongodb.connection.ClusterConnectionMode
 import com.mongodb.connection.ClusterId
 import com.mongodb.connection.ConnectionDescription
 import com.mongodb.connection.ServerConnectionState
@@ -83,7 +84,7 @@ class DefaultServerMonitorSpecification extends Specification {
             }
         }
         monitor = new DefaultServerMonitor(new ServerId(new ClusterId(), new ServerAddress()), ServerSettings.builder().build(),
-                new ClusterClock(), internalConnectionFactory, null, SameObjectProvider.initialized(sdam))
+                new ClusterClock(), internalConnectionFactory, ClusterConnectionMode.SINGLE, null, SameObjectProvider.initialized(sdam))
         monitor.start()
 
         when:
@@ -168,7 +169,7 @@ class DefaultServerMonitorSpecification extends Specification {
         }
         monitor = new DefaultServerMonitor(new ServerId(new ClusterId(), new ServerAddress()),
                 ServerSettings.builder().heartbeatFrequency(1, TimeUnit.SECONDS).addServerMonitorListener(serverMonitorListener).build(),
-                new ClusterClock(), internalConnectionFactory, null, mockSdamProvider())
+                new ClusterClock(), internalConnectionFactory, ClusterConnectionMode.SINGLE, null, mockSdamProvider())
 
         when:
         monitor.start()
@@ -249,7 +250,7 @@ class DefaultServerMonitorSpecification extends Specification {
         }
         monitor = new DefaultServerMonitor(new ServerId(new ClusterId(), new ServerAddress()),
                 ServerSettings.builder().heartbeatFrequency(1, TimeUnit.SECONDS).addServerMonitorListener(serverMonitorListener).build(),
-                new ClusterClock(), internalConnectionFactory, null, mockSdamProvider())
+                new ClusterClock(), internalConnectionFactory, ClusterConnectionMode.SINGLE, null, mockSdamProvider())
 
         when:
         monitor.start()

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionInitializerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionInitializerSpecification.groovy
@@ -290,10 +290,10 @@ class InternalStreamConnectionInitializerSpecification extends Specification {
     def 'should speculatively authenticate with default authenticator'() {
         given:
         def credential = new MongoCredentialWithCache(createCredential('user', 'database', 'pencil' as char[]))
-        def authenticator = Spy(DefaultAuthenticator, constructorArgs: [credential, null])
+        def authenticator = Spy(DefaultAuthenticator, constructorArgs: [credential, SINGLE, null])
         def scramShaAuthenticator = Spy(ScramShaAuthenticator,
                 constructorArgs: [credential.withMechanism(AuthenticationMechanism.SCRAM_SHA_256),
-                                  { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, null])
+                                  { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, SINGLE, null])
         def initializer = new InternalStreamConnectionInitializer(SINGLE, authenticator, null, [], null)
         authenticator.getAuthenticatorForHello() >> scramShaAuthenticator
         def serverResponse = 'r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096'
@@ -324,7 +324,8 @@ class InternalStreamConnectionInitializerSpecification extends Specification {
     def 'should speculatively authenticate with SCRAM-SHA-256 authenticator'() {
         given:
         def credential = new MongoCredentialWithCache(createScramSha256Credential('user', 'database', 'pencil' as char[]))
-        def authenticator = Spy(ScramShaAuthenticator, constructorArgs: [credential, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, null])
+        def authenticator = Spy(ScramShaAuthenticator, constructorArgs: [credential, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, SINGLE,
+                                                                         null])
         def initializer = new InternalStreamConnectionInitializer(SINGLE, authenticator, null, [], null)
         def serverResponse = 'r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096'
         def speculativeAuthenticateResponse =
@@ -354,7 +355,8 @@ class InternalStreamConnectionInitializerSpecification extends Specification {
     def 'should speculatively authenticate with SCRAM-SHA-1 authenticator'() {
         given:
         def credential = new MongoCredentialWithCache(createScramSha1Credential('user', 'database', 'pencil' as char[]))
-        def authenticator = Spy(ScramShaAuthenticator, constructorArgs: [credential, { 'fyko+d2lbbFgONRv9qkxdawL' }, { 'pencil' }, null])
+        def authenticator = Spy(ScramShaAuthenticator, constructorArgs: [credential, { 'fyko+d2lbbFgONRv9qkxdawL' }, { 'pencil' },
+                                                                         SINGLE, null])
         def initializer = new InternalStreamConnectionInitializer(SINGLE, authenticator, null, [], null)
         def serverResponse = 'r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096'
         def speculativeAuthenticateResponse =
@@ -384,7 +386,7 @@ class InternalStreamConnectionInitializerSpecification extends Specification {
     def 'should speculatively authenticate with X509 authenticator'() {
         given:
         def credential = new MongoCredentialWithCache(createMongoX509Credential())
-        def authenticator = Spy(X509Authenticator, constructorArgs: [credential, null])
+        def authenticator = Spy(X509Authenticator, constructorArgs: [credential, SINGLE, null])
         def initializer = new InternalStreamConnectionInitializer(SINGLE, authenticator, null, [], null)
         def speculativeAuthenticateResponse =
                 BsonDocument.parse('{ dbname: "$external", user: "CN=client,OU=KernelUser,O=MongoDB,L=New York City,ST=New York,C=US"}')
@@ -412,7 +414,7 @@ class InternalStreamConnectionInitializerSpecification extends Specification {
     def 'should not speculatively authenticate with Plain authenticator'() {
         given:
         def credential = new MongoCredentialWithCache(createPlainCredential('user', 'database', 'pencil' as char[]))
-        def authenticator = Spy(PlainAuthenticator, constructorArgs: [credential, null])
+        def authenticator = Spy(PlainAuthenticator, constructorArgs: [credential, SINGLE, null])
         def initializer = new InternalStreamConnectionInitializer(SINGLE, authenticator, null, [], null)
 
         when:

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
@@ -59,6 +59,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 import static com.mongodb.ReadPreference.primary
+import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.connection.ConnectionDescription.getDefaultMaxMessageSize
 import static com.mongodb.connection.ConnectionDescription.getDefaultMaxWriteBatchSize
@@ -413,7 +414,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         def response = '{ok : 0, errmsg : "failed"}'
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, 0) >> helper.messageHeader(commandMessage.getId(), response)
@@ -431,7 +433,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         def callback = new FutureResultCallback()
         def response = '{ok : 0, errmsg : "failed"}'
 
@@ -494,7 +497,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, 0) >> helper.defaultMessageHeader(commandMessage.getId())
         stream.read(90, 0) >> helper.defaultReply()
@@ -514,7 +518,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, 0) >> helper.defaultMessageHeader(commandMessage.getId())
         stream.read(90, 0) >> helper.defaultReply()
@@ -537,7 +542,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         def response = '''{
                             ok : 1,
                             operationTime : { $timestamp : { "t" : 40, "i" : 20 } },
@@ -563,7 +569,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         def callback = new FutureResultCallback()
         def response = '''{
                             ok : 1,
@@ -598,7 +605,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.write(_) >> { throw new MongoSocketWriteException('Failed to write', serverAddress, new IOException()) }
 
@@ -617,7 +625,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, 0) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
 
@@ -636,7 +645,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, 0) >> helper.defaultMessageHeader(commandMessage.getId())
         stream.read(90, 0) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
@@ -656,7 +666,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         def response = '{ok : 0, errmsg : "failed"}'
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, 0) >> helper.messageHeader(commandMessage.getId(), response)
@@ -678,7 +689,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def securitySensitiveCommandName = securitySensitiveCommand.keySet().iterator().next()
         def connection = getOpenedConnection()
         def commandMessage = new CommandMessage(cmdNamespace, securitySensitiveCommand, fieldNameValidator, primary(), messageSettings,
-                null)
+                MULTIPLE, null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, 0) >> helper.defaultMessageHeader(commandMessage.getId())
         stream.read(90, 0) >> helper.defaultReply()
@@ -714,7 +725,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def commandMessage = new CommandMessage(cmdNamespace, securitySensitiveCommand, fieldNameValidator, primary(), messageSettings,
-                null)
+                MULTIPLE, null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, 0) >> helper.defaultMessageHeader(commandMessage.getId())
         stream.read(_, 0) >> helper.reply('{ok : 0, errmsg : "failed"}')
@@ -750,7 +761,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -781,7 +793,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -815,7 +828,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -840,7 +854,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -868,7 +883,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -899,7 +915,8 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, null)
+        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+                null)
         def callback = new FutureResultCallback()
         def response = '{ok : 0, errmsg : "failed"}'
 
@@ -932,7 +949,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def securitySensitiveCommandName = securitySensitiveCommand.keySet().iterator().next()
         def connection = getOpenedConnection()
         def commandMessage = new CommandMessage(cmdNamespace, securitySensitiveCommand, fieldNameValidator, primary(), messageSettings,
-                null)
+                MULTIPLE, null)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
@@ -36,6 +36,8 @@ import org.bson.BsonInt32
 import org.bson.BsonString
 import spock.lang.Specification
 
+import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
+import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.internal.operation.ServerVersionHelper.THREE_DOT_SIX_WIRE_VERSION
 
 class LoggingCommandEventSenderSpecification extends Specification {
@@ -50,7 +52,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def replyDocument = new BsonDocument('ok', new BsonInt32(1))
         def failureException = new MongoInternalException('failure!')
         def message = new CommandMessage(namespace, commandDocument,
-                new NoOpFieldNameValidator(), ReadPreference.primary(), messageSettings, null)
+                new NoOpFieldNameValidator(), ReadPreference.primary(), messageSettings, MULTIPLE, null)
         def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
         message.encode(bsonOutput, NoOpSessionContext.INSTANCE)
         def logger = Stub(Logger) {
@@ -90,7 +92,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def replyDocument = new BsonDocument('ok', new BsonInt32(1))
         def failureException = new MongoInternalException('failure!')
         def message = new CommandMessage(namespace, commandDocument, new NoOpFieldNameValidator(), ReadPreference.primary(),
-                messageSettings, null)
+                messageSettings, MULTIPLE, null)
         def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
         message.encode(bsonOutput, NoOpSessionContext.INSTANCE)
         def logger = Mock(Logger) {
@@ -138,7 +140,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def messageSettings = MessageSettings.builder().maxWireVersion(THREE_DOT_SIX_WIRE_VERSION).build()
         def commandDocument = new BsonDocument('fake', new BsonBinary(new byte[2048]))
         def message = new CommandMessage(namespace, commandDocument, new NoOpFieldNameValidator(), ReadPreference.primary(),
-                messageSettings, null)
+                messageSettings, SINGLE, null)
         def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
         message.encode(bsonOutput, NoOpSessionContext.INSTANCE)
         def logger = Mock(Logger) {
@@ -165,7 +167,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def messageSettings = MessageSettings.builder().maxWireVersion(THREE_DOT_SIX_WIRE_VERSION).build()
         def commandDocument = new BsonDocument('createUser', new BsonString('private'))
         def message = new CommandMessage(namespace, commandDocument, new NoOpFieldNameValidator(), ReadPreference.primary(),
-                messageSettings, null)
+                messageSettings, SINGLE, null)
         def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
         message.encode(bsonOutput, NoOpSessionContext.INSTANCE)
         def logger = Mock(Logger) {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/NativeAuthenticatorUnitTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/NativeAuthenticatorUnitTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static com.mongodb.ClusterFixture.getClusterConnectionMode;
 import static com.mongodb.ClusterFixture.getServerApi;
 import static com.mongodb.internal.connection.MessageHelper.buildSuccessfulReply;
 import static com.mongodb.internal.connection.MessageHelper.getApiVersionField;
@@ -48,7 +49,7 @@ public class NativeAuthenticatorUnitTest {
         connectionDescription = new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress()));
         MongoCredential credential = MongoCredential.createCredential("\u53f0\u5317", "database",
                 "Ta\u0301ibe\u030Ci".toCharArray());
-        subject = new NativeAuthenticator(new MongoCredentialWithCache(credential), getServerApi());
+        subject = new NativeAuthenticator(new MongoCredentialWithCache(credential), getClusterConnectionMode(), getServerApi());
     }
 
     @Test

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/PlainAuthenticatorUnitTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/PlainAuthenticatorUnitTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import static com.mongodb.ClusterFixture.getClusterConnectionMode;
 import static com.mongodb.ClusterFixture.getServerApi;
 import static com.mongodb.internal.connection.MessageHelper.getApiVersionField;
 import static com.mongodb.internal.connection.MessageHelper.getDbField;
@@ -45,7 +46,7 @@ public class PlainAuthenticatorUnitTest {
         connection = new TestInternalConnection(new ServerId(new ClusterId(), new ServerAddress("localhost", 27017)));
         connectionDescription = new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress()));
         credential = MongoCredential.createPlainCredential("user", "$external", "pencil".toCharArray());
-        subject = new PlainAuthenticator(new MongoCredentialWithCache(credential), getServerApi());
+        subject = new PlainAuthenticator(new MongoCredentialWithCache(credential), getClusterConnectionMode(), getServerApi());
     }
 
     @Test

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ScramShaAuthenticatorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ScramShaAuthenticatorSpecification.groovy
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit
 
 import static com.mongodb.MongoCredential.createScramSha1Credential
 import static com.mongodb.MongoCredential.createScramSha256Credential
+import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.internal.connection.MessageHelper.buildSuccessfulReply
 import static org.junit.Assert.assertEquals
 
@@ -56,7 +57,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
 
         when:
         def credential = new MongoCredentialWithCache(createScramSha1Credential(user, 'database', password as char[]))
-        def authenticator = new ScramShaAuthenticator(credential, { 'fyko+d2lbbFgONRv9qkxdawL' }, { preppedPassword }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'fyko+d2lbbFgONRv9qkxdawL' }, { preppedPassword }, SINGLE, null)
 
         then:
         validateAuthentication(payloads, authenticator, async, emptyExchange)
@@ -84,7 +85,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
 
         when:
         def credential = new MongoCredentialWithCache(createScramSha1Credential(user, 'database', password as char[]))
-        def authenticator = new ScramShaAuthenticator(credential, { 'fyko+d2lbbFgONRv9qkxdawL' }, { preppedPassword }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'fyko+d2lbbFgONRv9qkxdawL' }, { preppedPassword }, SINGLE, null)
 
         then:
         def speculativeAuthenticateCommand =
@@ -110,7 +111,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
 
         when:
         def credential = new MongoCredentialWithCache(createScramSha256Credential(user, 'database', password as char[]))
-        def authenticator = new ScramShaAuthenticator(credential, { 'rOprNGfwEbeRWgbNEkqO' }, { preppedPassword }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'rOprNGfwEbeRWgbNEkqO' }, { preppedPassword }, SINGLE, null)
 
         then:
         validateAuthentication(payloads, authenticator, async, emptyExchange)
@@ -138,7 +139,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
 
         when:
         def credential = new MongoCredentialWithCache(createScramSha256Credential(user, 'database', password as char[]))
-        def authenticator = new ScramShaAuthenticator(credential, { 'rOprNGfwEbeRWgbNEkqO' }, { preppedPassword }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'rOprNGfwEbeRWgbNEkqO' }, { preppedPassword }, SINGLE, null)
 
         then:
         def speculativeAuthenticateCommand =
@@ -164,7 +165,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
 
         when:
         def credential = new MongoCredentialWithCache(createScramSha1Credential(user, 'database', password as char[]))
-        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, SINGLE, null)
 
         then:
         validateAuthentication(payloads, authenticator, async, emptyExchange)
@@ -187,7 +188,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
 
         when:
         def credential = new MongoCredentialWithCache(createScramSha1Credential(user, 'database', password as char[]))
-        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, SINGLE, null)
 
         then:
         validateAuthentication(payloads, authenticator, async, emptyExchange)
@@ -210,7 +211,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
 
         when:
         def credential = new MongoCredentialWithCache(createScramSha1Credential(user, 'database', password as char[]))
-        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, SINGLE, null)
 
         then:
         validateAuthentication(payloads, authenticator, async, emptyExchange)
@@ -233,7 +234,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
 
         when:
         def credential = new MongoCredentialWithCache(createScramSha256Credential(user, 'database', password as char[]))
-        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, SINGLE, null)
 
         then:
         validateAuthentication(payloads, authenticator, async, emptyExchange)
@@ -256,7 +257,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
 
         when:
         def credential = new MongoCredentialWithCache(createScramSha256Credential(user, 'database', password as char[]))
-        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, SINGLE, null)
 
         then:
         validateAuthentication(payloads, authenticator, async, emptyExchange)
@@ -279,7 +280,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
 
         when:
         def credential = new MongoCredentialWithCache(createScramSha256Credential(user, 'database', password as char[]))
-        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, SINGLE, null)
 
         then:
         validateAuthentication(payloads, authenticator, async, emptyExchange)
@@ -302,7 +303,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
 
         when:
         def credential = new MongoCredentialWithCache(createScramSha256Credential(user, 'database', password as char[]))
-        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, SINGLE, null)
 
         then:
         validateAuthentication(payloads, authenticator, async, emptyExchange)
@@ -325,7 +326,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
 
         when:
         def credential = new MongoCredentialWithCache(createScramSha256Credential(user, 'database', password as char[]))
-        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'clientNONCE' }, { preppedPassword }, SINGLE, null)
 
         then:
         validateAuthentication(payloads, authenticator, async, emptyExchange)
@@ -337,7 +338,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
     def 'should throw if invalid r value from server'() {
         when:
         def serverResponses = ['r=InvalidRValue,s=MYSALT,i=4096']
-        def authenticator = new ScramShaAuthenticator(credential, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, SINGLE, null)
         authenticate(createConnection(serverResponses), authenticator, async)
 
         then:
@@ -352,7 +353,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
     def 'should throw if iteration count is below the minimium allowed count'() {
         when:
         def serverResponses = createMessages('S: r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=QSXCR+Q6sek8bf92,i=4095').last()
-        def authenticator = new ScramShaAuthenticator(credential, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, SINGLE, null)
         authenticate(createConnection(serverResponses), authenticator, async)
 
         then:
@@ -370,7 +371,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
             S: r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=QSXCR+Q6sek8bf92,i=4096
             S: v=InvalidServerSignature
         ''').last()
-        def authenticator = new ScramShaAuthenticator(credential, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, null)
+        def authenticator = new ScramShaAuthenticator(credential, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, SINGLE, null)
         authenticate(createConnection(serverResponses), authenticator, async)
 
         then:
@@ -389,7 +390,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
             S: v=rmF9pqV8S7suAoZWja4dJRkFsKQ=
             S: z=ExtraStep
         ''').last()
-        def authenticator = new ScramShaAuthenticator(SHA1_CREDENTIAL, { 'fyko+d2lbbFgONRv9qkxdawL' }, { 'pencil' }, null)
+        def authenticator = new ScramShaAuthenticator(SHA1_CREDENTIAL, { 'fyko+d2lbbFgONRv9qkxdawL' }, { 'pencil' }, SINGLE, null)
         authenticate(createConnection(serverResponses), authenticator, async)
 
         then:
@@ -408,7 +409,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
             S: v=6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4=
             S: z=ExtraStep
         ''', true).last()
-        def authenticator = new ScramShaAuthenticator(SHA256_CREDENTIAL, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, null)
+        def authenticator = new ScramShaAuthenticator(SHA256_CREDENTIAL, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, SINGLE, null)
         authenticate(createConnection(serverResponses), authenticator, async)
 
         then:
@@ -426,7 +427,8 @@ class ScramShaAuthenticatorSpecification extends Specification {
             S: r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096
             S: v=6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4=
         ''').last()
-        def authenticator = new ScramShaAuthenticator(SHA256_CREDENTIAL, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, null)
+        def authenticator = new ScramShaAuthenticator(SHA256_CREDENTIAL, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' },
+                SINGLE, null)
 
         when:
         // server sends done=true on first response, client is not complete after processing response
@@ -453,7 +455,7 @@ class ScramShaAuthenticatorSpecification extends Specification {
             S: r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096
             S: v=invalidResponse
         ''').last()
-        def authenticator = new ScramShaAuthenticator(SHA256_CREDENTIAL, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, null)
+        def authenticator = new ScramShaAuthenticator(SHA256_CREDENTIAL, { 'rOprNGfwEbeRWgbNEkqO' }, { 'pencil' }, SINGLE, null)
 
         when:
         // server sends done=true on second response, client throws exception on invalid server response

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/StreamHelper.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/StreamHelper.groovy
@@ -36,6 +36,7 @@ import java.nio.ByteOrder
 import java.security.SecureRandom
 
 import static com.mongodb.MongoNamespace.COMMAND_COLLECTION_NAME
+import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.internal.connection.MessageHelper.LEGACY_HELLO
 
 class StreamHelper {
@@ -165,7 +166,7 @@ class StreamHelper {
     static hello() {
         CommandMessage command = new CommandMessage(new MongoNamespace('admin', COMMAND_COLLECTION_NAME),
                 new BsonDocument(LEGACY_HELLO, new BsonInt32(1)), new NoOpFieldNameValidator(), ReadPreference.primary(),
-                MessageSettings.builder().build(), null)
+                MessageSettings.builder().build(), SINGLE, null)
         OutputBuffer outputBuffer = new BasicOutputBuffer()
         command.encode(outputBuffer, NoOpSessionContext.INSTANCE)
         nextMessageId++

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/UsageTrackingConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/UsageTrackingConnectionSpecification.groovy
@@ -30,6 +30,7 @@ import org.bson.codecs.BsonDocumentCodec
 import spock.lang.Specification
 
 import static com.mongodb.ReadPreference.primary
+import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 
 class UsageTrackingConnectionSpecification extends Specification {
     private static final ServerId SERVER_ID = new ServerId(new ClusterId(), new ServerAddress())
@@ -173,7 +174,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         when:
         connection.sendAndReceive(new CommandMessage(new MongoNamespace('test.coll'),
                 new BsonDocument('ping', new BsonInt32(1)), new NoOpFieldNameValidator(), primary(),
-                MessageSettings.builder().build(), null),
+                MessageSettings.builder().build(), SINGLE, null),
                 new BsonDocumentCodec(), NoOpSessionContext.INSTANCE, IgnorableRequestContext.INSTANCE)
 
         then:
@@ -191,7 +192,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         when:
         connection.sendAndReceiveAsync(new CommandMessage(new MongoNamespace('test.coll'),
                 new BsonDocument('ping', new BsonInt32(1)), new NoOpFieldNameValidator(), primary(),
-                MessageSettings.builder().build(), null),
+                MessageSettings.builder().build(), SINGLE, null),
                 new BsonDocumentCodec(), NoOpSessionContext.INSTANCE, IgnorableRequestContext.INSTANCE, futureResultCallback)
         futureResultCallback.get()
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorNoUserNameTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorNoUserNameTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static com.mongodb.ClusterFixture.getServerApi;
+import static com.mongodb.connection.ClusterConnectionMode.SINGLE;
 import static com.mongodb.internal.connection.MessageHelper.buildSuccessfulReply;
 import static com.mongodb.internal.connection.MessageHelper.getApiVersionField;
 import static com.mongodb.internal.connection.MessageHelper.getDbField;
@@ -60,7 +61,7 @@ public class X509AuthenticatorNoUserNameTest {
     public void testSuccessfulAuthentication() {
         enqueueSuccessfulAuthenticationReply();
 
-        new X509Authenticator(getCredentialWithCache(), getServerApi()).authenticate(connection, connectionDescriptionThreeFour);
+        new X509Authenticator(getCredentialWithCache(), SINGLE, getServerApi()).authenticate(connection, connectionDescriptionThreeFour);
 
         validateMessages();
     }
@@ -68,7 +69,7 @@ public class X509AuthenticatorNoUserNameTest {
     @Test
     public void testUnsuccessfulAuthenticationWhenServerVersionLessThanThreeFour() {
         try {
-            new X509Authenticator(getCredentialWithCache(), getServerApi()).authenticate(connection, connectionDescriptionThreeTwo);
+            new X509Authenticator(getCredentialWithCache(), SINGLE, getServerApi()).authenticate(connection, connectionDescriptionThreeTwo);
             fail();
         } catch (MongoSecurityException e) {
             assertEquals("User name is required for the MONGODB-X509 authentication mechanism on server versions less than 3.4",
@@ -81,8 +82,8 @@ public class X509AuthenticatorNoUserNameTest {
         enqueueSuccessfulAuthenticationReply();
 
         FutureResultCallback<Void> futureCallback = new FutureResultCallback<Void>();
-        new X509Authenticator(getCredentialWithCache(), getServerApi()).authenticateAsync(connection, connectionDescriptionThreeFour,
-                futureCallback);
+        new X509Authenticator(getCredentialWithCache(), SINGLE, getServerApi()).authenticateAsync(connection,
+                connectionDescriptionThreeFour, futureCallback);
 
         futureCallback.get();
 
@@ -92,7 +93,7 @@ public class X509AuthenticatorNoUserNameTest {
     @Test
     public void testUnsuccessfulAuthenticationWhenServerVersionLessThanThreeFourAsync() throws ExecutionException, InterruptedException {
         FutureResultCallback<Void> futureCallback = new FutureResultCallback<Void>();
-        new X509Authenticator(getCredentialWithCache(), getServerApi()).authenticateAsync(connection, connectionDescriptionThreeTwo,
+        new X509Authenticator(getCredentialWithCache(), SINGLE, getServerApi()).authenticateAsync(connection, connectionDescriptionThreeTwo,
                 futureCallback);
 
         try {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorUnitTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorUnitTest.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoCredential;
 import com.mongodb.MongoSecurityException;
 import com.mongodb.ServerAddress;
 import com.mongodb.async.FutureResultCallback;
+import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.connection.ClusterId;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerId;
@@ -49,7 +50,7 @@ public class X509AuthenticatorUnitTest {
         connection = new TestInternalConnection(new ServerId(new ClusterId(), new ServerAddress("localhost", 27017)));
         connectionDescription = new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress()));
         credential = MongoCredential.createMongoX509Credential("CN=client,OU=kerneluser,O=10Gen,L=New York City,ST=New York,C=US");
-        subject = new X509Authenticator(new MongoCredentialWithCache(credential), getServerApi());
+        subject = new X509Authenticator(new MongoCredentialWithCache(credential), ClusterConnectionMode.SINGLE, getServerApi());
     }
 
     @Test


### PR DESCRIPTION
JAVA-4447

This is a pre-cursor to the work to actually ensure that OP_MSG is used when the connection mode is load-balanced.  Before we can do that we have to ensure that ClusterConnectionMode is consistently passed all the way down to CommandMessage, which is where that decision is made.

The majority of this work was done using Change Message Signature refactoring in IntelliJ.