### PR TITLE
Ensure callback using cluster description is guarded

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionBinding.java
@@ -150,7 +150,7 @@ public class ClientSessionBinding extends AbstractReferenceCounted implements As
     private void isConnectionSourcePinningRequired(final SingleResultCallback<Boolean> callback) {
         try {
             callback.onResult(isConnectionSourcePinningRequired(), null);
-        } catch (MongoException e) {
+        } catch (RuntimeException e) {
             callback.onResult(null, e);
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionBinding.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.async.client;
 
-import com.mongodb.MongoException;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.RequestContext;

--- a/driver-core/src/main/com/mongodb/internal/connection/Cluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/Cluster.java
@@ -51,6 +51,7 @@ public interface Cluster extends Closeable {
      *
      * @return a ClusterDescription representing the current state of the cluster
      * @throws com.mongodb.MongoTimeoutException if the timeout has been reached before the cluster type is known
+     * @throws com.mongodb.MongoInterruptedException if interrupted when getting the cluster description
      */
     ClusterDescription getDescription();
 


### PR DESCRIPTION
Getting the description from a cluster can throw a
MongoTimeoutException or a MongoInterruptedException.
So in that case the exception should be passed to
the callback.

JAVA-4432