### PR TITLE
fix: abort transaction in all cases

### DIFF
--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
@@ -209,7 +209,7 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
             try {
                 startTransaction(options);
                 retVal = transactionBody.execute();
-            } catch (RuntimeException e) {
+            } catch (Throwable e) {
                 if (transactionState == TransactionState.IN) {
                     abortTransaction();
                 }


### PR DESCRIPTION
catching RuntimeException all other subclasses of Exception are not caught and don't abort the transaction