### PR TITLE
Preliminary steps for using scala 3

### DIFF
--- a/bson-scala/src/main/scala-2.13+/org/mongodb/scala/bson/collection/mutable/Document.scala
+++ b/bson-scala/src/main/scala-2.13+/org/mongodb/scala/bson/collection/mutable/Document.scala
@@ -140,7 +140,7 @@ case class Document(protected[scala] val underlying: BsonDocument)
   @inline final def ++(suffix: IterableOnce[(String, BsonValue)]): Document = concat(suffix)
   // scalastyle:on method.name
   def map[B](f: ((String, BsonValue)) => (String, BsonValue)): Document = strictOptimizedMap(newSpecificBuilder, f)
-  //TODO other operations
+  // TODO other operations
 
   // scalastyle:off method.name
   /**

--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/collection/BaseDocument.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/collection/BaseDocument.scala
@@ -86,7 +86,7 @@ private[bson] trait BaseDocument[T] extends Traversable[(String, BsonValue)] wit
     case None    => default.value
   }
 
-  //scalastyle:off spaces.after.plus  method.name
+  // scalastyle:off spaces.after.plus  method.name
   /**
    * Creates a new document containing a new key/value and all the existing key/values.
    *
@@ -101,7 +101,7 @@ private[bson] trait BaseDocument[T] extends Traversable[(String, BsonValue)] wit
     elems.foreach(elem => bsonDocument.put(elem.key, elem.value))
     apply(bsonDocument)
   }
-  //scalastyle:on spaces.after.plus
+  // scalastyle:on spaces.after.plus
 
   /**
    * Removes one or more elements to this document and returns a new document.

--- a/bson-scala/src/test/scala/org/mongodb/scala/bson/BaseSpec.scala
+++ b/bson-scala/src/test/scala/org/mongodb/scala/bson/BaseSpec.scala
@@ -16,8 +16,9 @@
 package org.mongodb.scala.bson
 
 import org.junit.runner.RunWith
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-abstract class BaseSpec extends FlatSpec with Matchers {}
+abstract class BaseSpec extends AnyFlatSpec with Matchers {}

--- a/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/IterableCodecSpec.scala
+++ b/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/IterableCodecSpec.scala
@@ -57,7 +57,11 @@ class IterableCodecSpec extends BaseSpec {
 
     writer.writeStartDocument()
     writer.writeName("array")
-    codec.encode(writer, List(Map("a" -> 1, "b" -> 2, "c" -> null)), EncoderContext.builder().build()) // scalastyle:ignore
+    codec.encode(
+      writer,
+      List(Map("a" -> 1, "b" -> 2, "c" -> null)),
+      EncoderContext.builder().build()
+    ) // scalastyle:ignore
     writer.writeEndDocument()
     writer.getDocument should equal(BsonDocument("{array : [{a: 1, b: 2, c: null}]}"))
   }
@@ -98,9 +102,13 @@ class IterableCodecSpec extends BaseSpec {
   }
 
   it should "use the provided transformer" in {
-    val codec = IterableCodec(DEFAULT_CODEC_REGISTRY, BsonTypeClassMap(), new Transformer {
-      override def transform(objectToTransform: Any): AnyRef = s"$objectToTransform"
-    })
+    val codec = IterableCodec(
+      DEFAULT_CODEC_REGISTRY,
+      BsonTypeClassMap(),
+      new Transformer {
+        override def transform(objectToTransform: Any): AnyRef = s"$objectToTransform"
+      }
+    )
     val reader = new BsonDocumentReader(BsonDocument("{array : [1, 2, 3]}"))
 
     reader.readStartDocument()

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
 
         // Scala plugins
         classpath "com.adtran:scala-multiversion-plugin:2.0.4"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:3.27.1"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.3.0"
 
         // Test logging plugin
         classpath 'com.adarshr:gradle-test-logger-plugin:2.1.0'
@@ -95,7 +95,7 @@ configure(scalaProjects) {
     apply plugin: 'scala'
     apply plugin: 'idea'
     apply plugin: "com.adtran.scala-multiversion-plugin"
-    apply plugin: "com.diffplug.gradle.spotless"
+    apply plugin: "com.diffplug.spotless"
 
     group = 'org.mongodb.scala'
 
@@ -122,7 +122,7 @@ configure(scalaProjects) {
 
     spotless {
         scala {
-            scalafmt('2.0.0').configFile("$configDir/scala/scalafmt.conf")
+            scalafmt('3.0.7').configFile("$configDir/scala/scalafmt.conf")
         }
     }
     compileScala.dependsOn('spotlessApply')

--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ configure(scalaProjects) {
 
     spotless {
         scala {
-            scalafmt('3.0.7').configFile("$configDir/scala/scalafmt.conf")
+            scalafmt().configFile("$configDir/scala/scalafmt.conf")
         }
     }
     compileScala.dependsOn('spotlessApply')

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,8 @@ configure(scalaProjects) {
         testImplementation(platform("org.junit:junit-bom:$junitBomVersion"))
         testImplementation("org.junit.vintage:junit-vintage-engine")
 
-        testImplementation('org.scalatest:scalatest_%%:3.2.9')
+        testImplementation('org.scalatest:scalatest-flatspec_%%:3.2.9')
+        testImplementation('org.scalatest:scalatest-shouldmatchers_%%:3.2.9')
         testImplementation('org.scalatestplus:junit-4-13_%%:3.2.9.0')
         testImplementation('org.scalamock:scalamock_%%:4.4.0')
         testImplementation('ch.qos.logback:logback-classic:1.1.3')

--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,8 @@ configure(scalaProjects) {
         testImplementation(platform("org.junit:junit-bom:$junitBomVersion"))
         testImplementation("org.junit.vintage:junit-vintage-engine")
 
-        testImplementation('org.scalatest:scalatest_%%:3.0.8')
+        testImplementation('org.scalatest:scalatest_%%:3.1.4')
+        testImplementation('org.scalatestplus:junit-4-12_%%:3.1.2.0')
         testImplementation('org.scalamock:scalamock_%%:4.4.0')
         testImplementation('ch.qos.logback:logback-classic:1.1.3')
         testImplementation('org.reflections:reflections:0.9.10')

--- a/build.gradle
+++ b/build.gradle
@@ -106,8 +106,8 @@ configure(scalaProjects) {
         testImplementation(platform("org.junit:junit-bom:$junitBomVersion"))
         testImplementation("org.junit.vintage:junit-vintage-engine")
 
-        testImplementation('org.scalatest:scalatest_%%:3.1.4')
-        testImplementation('org.scalatestplus:junit-4-12_%%:3.1.2.0')
+        testImplementation('org.scalatest:scalatest_%%:3.2.9')
+        testImplementation('org.scalatestplus:junit-4-13_%%:3.2.9.0')
         testImplementation('org.scalamock:scalamock_%%:4.4.0')
         testImplementation('ch.qos.logback:logback-classic:1.1.3')
         testImplementation('org.reflections:reflections:0.9.10')

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ configure(scalaProjects) {
         testImplementation('org.scalatest:scalatest-flatspec_%%:3.2.9')
         testImplementation('org.scalatest:scalatest-shouldmatchers_%%:3.2.9')
         testImplementation('org.scalatestplus:junit-4-13_%%:3.2.9.0')
-        testImplementation('org.scalamock:scalamock_%%:4.4.0')
+        testImplementation('org.scalatestplus:mockito-3-12_%%:3.2.10.0')
         testImplementation('ch.qos.logback:logback-classic:1.1.3')
         testImplementation('org.reflections:reflections:0.9.10')
     }

--- a/config/scala/scalafmt.conf
+++ b/config/scala/scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.0.7"
+version = "3.4.3"
 runner.dialect = scala213
 
 preset = default

--- a/config/scala/scalafmt.conf
+++ b/config/scala/scalafmt.conf
@@ -1,10 +1,16 @@
-style = defaultWithAlign
+version = "3.0.7"
+runner.dialect = scala213
 
-align.tokens = [off]
-align = some
-danglingParentheses = true
-docstrings = JavaDoc
+preset = default
+
+danglingParentheses.preset = true
+docstrings.style = keep
+#docstrings.style = Asterisk
+#docstrings.wrap = no
 maxColumn = 120
 rewrite.rules = [SortImports]
-newlines.alwaysBeforeTopLevelStatements = false
+newlines.topLevelStatements = []
+newlines.source=keep
+newlines.implicitParamListModifierPrefer=before
+
 spaces.inImportCurlyBraces = true

--- a/driver-scala/src/it/scala/org/mongodb/scala/CrudTest.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/CrudTest.scala
@@ -17,7 +17,7 @@
 package org.mongodb.scala
 
 import com.mongodb.client.Fixture.getMongoClientSettingsBuilder
-import com.mongodb.client.{ AbstractCrudTest }
+import com.mongodb.client.AbstractCrudTest
 import com.mongodb.event.CommandListener
 import org.bson.{ BsonArray, BsonDocument }
 import org.mongodb.scala.syncadapter.SyncMongoClient

--- a/driver-scala/src/it/scala/org/mongodb/scala/RequiresMongoDBISpec.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/RequiresMongoDBISpec.scala
@@ -75,7 +75,8 @@ trait RequiresMongoDBISpec extends BaseSpec with BeforeAndAfterAll {
 
   def withDatabase(dbName: String)(testCode: MongoDatabase => Any): Unit = {
     withClient { client =>
-      val databaseName = if (dbName.startsWith(DB_PREFIX)) dbName.take(63) else s"$DB_PREFIX$dbName".take(63) // scalastyle:ignore
+      val databaseName =
+        if (dbName.startsWith(DB_PREFIX)) dbName.take(63) else s"$DB_PREFIX$dbName".take(63) // scalastyle:ignore
       val mongoDatabase = client.getDatabase(databaseName)
       try testCode(mongoDatabase) // "loan" the fixture to the test
       finally {
@@ -98,18 +99,19 @@ trait RequiresMongoDBISpec extends BaseSpec with BeforeAndAfterAll {
     }
   }
 
-  lazy val isSharded: Boolean = if (!TestMongoClientHelper.isMongoDBOnline) {
-    false
-  } else {
-    Await
-      .result(
-        mongoClient().getDatabase("admin").runCommand(Document("isMaster" -> 1)).toFuture(),
-        WAIT_DURATION
-      )
-      .getOrElse("msg", BsonString(""))
-      .asString()
-      .getValue == "isdbgrid"
-  }
+  lazy val isSharded: Boolean =
+    if (!TestMongoClientHelper.isMongoDBOnline) {
+      false
+    } else {
+      Await
+        .result(
+          mongoClient().getDatabase("admin").runCommand(Document("isMaster" -> 1)).toFuture(),
+          WAIT_DURATION
+        )
+        .getOrElse("msg", BsonString(""))
+        .asString()
+        .getValue == "isdbgrid"
+    }
 
   lazy val buildInfo: Document = {
     if (TestMongoClientHelper.isMongoDBOnline) {

--- a/driver-scala/src/it/scala/org/mongodb/scala/documentation/DocumentationExampleSpec.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/documentation/DocumentationExampleSpec.scala
@@ -213,7 +213,7 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
   }
 
   it should "be able to query array" in withCollection { collection =>
-    //Start Example 20
+    // Start Example 20
     collection
       .insertMany(
         Seq(
@@ -225,62 +225,62 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
         )
       )
       .execute()
-    //End Example 20
+    // End Example 20
 
     collection.countDocuments().execute() shouldEqual 5
 
-    //Start Example 21
+    // Start Example 21
     var findObservable = collection.find(equal("tags", Seq("red", "blank")))
-    //End Example 21
+    // End Example 21
 
     findObservable.execute().size shouldEqual 1
 
-    //Start Example 22
+    // Start Example 22
     findObservable = collection.find(all("tags", "red", "blank"))
-    //End Example 22
+    // End Example 22
 
     findObservable.execute().size shouldEqual 4
 
-    //Start Example 23
+    // Start Example 23
     findObservable = collection.find(equal("tags", "red"))
-    //End Example 23
+    // End Example 23
 
     findObservable.execute().size shouldEqual 4
 
-    //Start Example 24
+    // Start Example 24
     findObservable = collection.find(gt("dim_cm", 25))
-    //End Example 24
+    // End Example 24
 
     findObservable.execute().size shouldEqual 1
 
-    //Start Example 25
+    // Start Example 25
     findObservable = collection.find(and(gt("dim_cm", 15), lt("dim_cm", 20)))
-    //End Example 25
+    // End Example 25
 
     findObservable.execute().size shouldEqual 4
 
-    //Start Example 26
+    // Start Example 26
     findObservable = collection.find(elemMatch("dim_cm", Document("$gt" -> 22, "$lt" -> 30)))
 
-    //End Example 26
+    // End Example 26
 
     findObservable.execute().size shouldEqual 1
 
-    //Start Example 27
+    // Start Example 27
     findObservable = collection.find(gt("dim_cm.1", 25))
-    //End Example 27
+    // End Example 27
 
     findObservable.execute().size shouldEqual 1
 
-    //Start Example 28
+    // Start Example 28
     findObservable = collection.find(size("tags", 3))
-    //End Example 28
+    // End Example 28
 
     findObservable.execute().size shouldEqual 1
   }
 
   it should "query array of documents" in withCollection { collection =>
-    //Start Example 29
+    // Start Example 29
     collection
       .insertMany(
         Seq(
@@ -292,61 +292,61 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
         )
       )
       .execute()
-    //End Example 29
+    // End Example 29
 
     collection.countDocuments().execute() shouldEqual 5
 
-    //Start Example 30
+    // Start Example 30
     var findObservable = collection.find(equal("instock", Document("warehouse" -> "A", "qty" -> 5)))
-    //End Example 30
+    // End Example 30
 
     findObservable.execute().size shouldEqual 1
 
-    //Start Example 31
+    // Start Example 31
     findObservable = collection.find(equal("instock", Document("qty" -> 5, "warehouse" -> "A")))
-    //End Example 31
+    // End Example 31
 
     findObservable.execute().size shouldEqual 0
 
-    //Start Example 32
+    // Start Example 32
     findObservable = collection.find(lte("instock.0.qty", 20))
-    //End Example 32
+    // End Example 32
 
     findObservable.execute().size shouldEqual 3
 
-    //Start Example 33
+    // Start Example 33
     findObservable = collection.find(lte("instock.qty", 20))
-    //End Example 33
+    // End Example 33
 
     findObservable.execute().size shouldEqual 5
 
-    //Start Example 34
+    // Start Example 34
     findObservable = collection.find(elemMatch("instock", Document("qty" -> 5, "warehouse" -> "A")))
-    //End Example 34
+    // End Example 34
 
     findObservable.execute().size shouldEqual 1
 
-    //Start Example 35
+    // Start Example 35
     findObservable = collection.find(elemMatch("instock", Document("""{ qty: { $gt: 10, $lte: 20 } }""")))
-    //End Example 35
+    // End Example 35
 
     findObservable.execute().size shouldEqual 3
 
-    //Start Example 36
+    // Start Example 36
     findObservable = collection.find(and(gt("instock.qty", 10), lte("instock.qty", 20)))
-    //End Example 36
+    // End Example 36
 
     findObservable.execute().size shouldEqual 4
 
-    //Start Example 37
+    // Start Example 37
     findObservable = collection.find(and(equal("instock.qty", 5), equal("instock.warehouse", "A")))
-    //End Example 37
+    // End Example 37
 
     findObservable.execute().size shouldEqual 2
   }
 
   it should "query null and missing fields" in withCollection { collection =>
-    //Start Example 38
+    // Start Example 38
     collection
       .insertMany(
         Seq(
@@ -355,31 +355,31 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
         )
       )
       .execute()
-    //End Example 38
+    // End Example 38
 
     collection.countDocuments().execute() shouldEqual 2
 
-    //Start Example 39
+    // Start Example 39
     var findObservable = collection.find(equal("item", BsonNull()))
-    //End Example 39
+    // End Example 39
 
     findObservable.execute().size shouldEqual 2
 
-    //Start Example 40
+    // Start Example 40
     findObservable = collection.find(bsonType("item", BsonType.NULL))
-    //End Example 40
+    // End Example 40
 
     findObservable.execute().size shouldEqual 1
 
-    //Start Example 41
+    // Start Example 41
     findObservable = collection.find(exists("item", exists = false))
-    //End Example 41
+    // End Example 41
 
     findObservable.execute().size shouldEqual 1
   }
 
   it should "be able to project fields" in withCollection { collection =>
-    //Start Example 42
+    // Start Example 42
     collection
       .insertMany(
         Seq(
@@ -400,39 +400,39 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
         )
       )
       .execute()
-    //End Example 42
+    // End Example 42
 
     collection.countDocuments().execute() shouldEqual 5
 
-    //Start Example 43
+    // Start Example 43
     var findObservable = collection.find(equal("status", "A"))
-    //End Example 43
+    // End Example 43
 
     findObservable.execute().size shouldEqual 3
 
-    //Start Example 44
+    // Start Example 44
     findObservable = collection.find(equal("status", "A")).projection(include("item", "status"))
-    //End Example 44
+    // End Example 44
 
     findObservable.execute().foreach((doc: Document) => doc.keys should contain only ("_id", "item", "status"))
 
-    //Start Example 45
+    // Start Example 45
     findObservable = collection
       .find(equal("status", "A"))
       .projection(fields(include("item", "status"), excludeId()))
-    //End Example 45
+    // End Example 45
 
     findObservable.execute().foreach((doc: Document) => doc.keys should contain only ("item", "status"))
 
-    //Start Example 46
+    // Start Example 46
     findObservable = collection.find(equal("status", "A")).projection(exclude("item", "status"))
-    //End Example 46
+    // End Example 46
 
     findObservable.execute().foreach((doc: Document) => doc.keys should contain only ("_id", "size", "instock"))
 
-    //Start Example 47
+    // Start Example 47
     findObservable = collection.find(equal("status", "A")).projection(include("item", "status", "size.uom"))
-    //End Example 47
+    // End Example 47
 
     findObservable
       .execute()
@@ -441,9 +441,9 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
         doc.get[BsonDocument]("size").get.keys should contain only "uom"
       })
 
-    //Start Example 48
+    // Start Example 48
     findObservable = collection.find(equal("status", "A")).projection(exclude("size.uom"))
-    //End Example 48
+    // End Example 48
 
     findObservable
       .execute()
@@ -452,9 +452,9 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
         doc.get[BsonDocument]("size").get.keys should contain only ("h", "w")
       })
 
-    //Start Example 49
+    // Start Example 49
     findObservable = collection.find(equal("status", "A")).projection(include("item", "status", "instock.qty"))
-    //End Example 49
+    // End Example 49
 
     findObservable
       .execute()
@@ -467,11 +467,11 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
           .foreach((doc: BsonValue) => doc.asInstanceOf[BsonDocument].keys should contain only "qty")
       })
 
-    //Start Example 50
+    // Start Example 50
     findObservable = collection
       .find(equal("status", "A"))
       .projection(fields(include("item", "status"), slice("instock", -1)))
-    //End Example 50
+    // End Example 50
 
     findObservable
       .execute()
@@ -484,7 +484,7 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
   it should "be able to update" in withCollection { collection =>
     assume(serverVersionAtLeast(List(2, 6, 0)))
 
-    //Start Example 51
+    // Start Example 51
     collection
       .insertMany(
         Seq(
@@ -501,18 +501,18 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
         )
       )
       .execute()
-    //End Example 51
+    // End Example 51
 
     collection.countDocuments().execute() shouldEqual 10
 
-    //Start Example 52
+    // Start Example 52
     collection
       .updateOne(
         equal("item", "paper"),
         combine(set("size.uom", "cm"), set("status", "P"), currentDate("lastModified"))
       )
       .execute()
-    //End Example 52
+    // End Example 52
 
     collection
       .find(equal("item", "paper"))
@@ -523,11 +523,11 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
         doc.containsKey("lastModified") shouldBe true
       })
 
-    //Start Example 53
+    // Start Example 53
     collection
       .updateMany(lt("qty", 50), combine(set("size.uom", "in"), set("status", "P"), currentDate("lastModified")))
       .execute()
-    //End Example 53
+    // End Example 53
 
     collection
       .find(lt("qty", 50))
@@ -538,14 +538,14 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
         doc.containsKey("lastModified") shouldBe true
       })
 
-    //Start Example 54
+    // Start Example 54
     collection
       .replaceOne(
         equal("item", "paper"),
         Document("""{ item: "paper", instock: [ { warehouse: "A", qty: 60 }, { warehouse: "B", qty: 40 } ] }""")
       )
       .execute()
-    //End Example 54
+    // End Example 54
 
     collection
       .find(equal("item", "paper"))
@@ -559,7 +559,7 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
   }
 
   it should "be able to delete" in withCollection { collection =>
-    //Start Example 55
+    // Start Example 55
     collection
       .insertMany(
         Seq(
@@ -571,25 +571,25 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
         )
       )
       .execute()
-    //End Example 55
+    // End Example 55
 
     collection.countDocuments().execute() shouldEqual 5
 
-    //Start Example 57
+    // Start Example 57
     collection.deleteMany(equal("status", "A")).execute()
-    //End Example 57
+    // End Example 57
 
     collection.countDocuments().execute() shouldEqual 2
 
-    //Start Example 58
+    // Start Example 58
     collection.deleteOne(equal("status", "D")).execute()
-    //End Example 58
+    // End Example 58
 
     collection.countDocuments().execute() shouldEqual 1
 
-    //Start Example 56
+    // Start Example 56
     collection.deleteMany(Document()).execute()
-    //End Example 56
+    // End Example 56
 
     collection.countDocuments().execute() shouldEqual 0
   }

--- a/driver-scala/src/it/scala/org/mongodb/scala/documentation/DocumentationExampleSpec.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/documentation/DocumentationExampleSpec.scala
@@ -551,11 +551,10 @@ class DocumentationExampleSpec extends RequiresMongoDBISpec with FuturesSpec {
       .find(equal("item", "paper"))
       .projection(excludeId())
       .execute()
-      .foreach(
-        (doc: Document) =>
-          doc shouldEqual Document(
-            """{ item: "paper", instock: [ { warehouse: "A", qty: 60 }, { warehouse: "B", qty: 40 } ] }"""
-          )
+      .foreach((doc: Document) =>
+        doc shouldEqual Document(
+          """{ item: "paper", instock: [ { warehouse: "A", qty: 60 }, { warehouse: "B", qty: 40 } ] }"""
+        )
       )
   }
 

--- a/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncClientSession.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncClientSession.scala
@@ -17,7 +17,7 @@
 package org.mongodb.scala.syncadapter
 
 import com.mongodb.{ ClientSessionOptions, MongoInterruptedException, ServerAddress, TransactionOptions }
-import com.mongodb.client.{ TransactionBody, ClientSession => JClientSession }
+import com.mongodb.client.{ ClientSession => JClientSession, TransactionBody }
 import com.mongodb.session.ServerSession
 import org.bson.{ BsonDocument, BsonTimestamp }
 import org.mongodb.scala._

--- a/driver-scala/src/it/scala/tour/GridFSTour.scala
+++ b/driver-scala/src/it/scala/tour/GridFSTour.scala
@@ -32,7 +32,7 @@ import scala.util.Success
  */
 object GridFSTour {
 
-  //scalastyle:off
+  // scalastyle:off
   /**
    * Run this main method to see the output of this quick example.
    *
@@ -109,6 +109,6 @@ object GridFSTour {
     println("Finished")
   }
 
-  //scalastyle:on
+  // scalastyle:on
 
 }

--- a/driver-scala/src/it/scala/tour/QuickTour.scala
+++ b/driver-scala/src/it/scala/tour/QuickTour.scala
@@ -51,7 +51,7 @@ import scala.collection.immutable.IndexedSeq
  * The QuickTour code example
  */
 object QuickTour {
-  //scalastyle:off method.length
+  // scalastyle:off method.length
 
   /**
    * Run this main method to see the output of this quick example.
@@ -116,7 +116,7 @@ object QuickTour {
     // Projection
     collection.find().projection(excludeId()).first().printHeadResult()
 
-    //Aggregation
+    // Aggregation
     collection
       .aggregate(
         Seq(

--- a/driver-scala/src/it/scala/tour/QuickTourCaseClass.scala
+++ b/driver-scala/src/it/scala/tour/QuickTourCaseClass.scala
@@ -27,7 +27,7 @@ import tour.Helpers._
  * The QuickTour code example
  */
 object QuickTourCaseClass {
-  //scalastyle:off method.length
+  // scalastyle:off method.length
 
   /**
    * Run this main method to see the output of this quick example.

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoClient.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoClient.scala
@@ -19,7 +19,7 @@ package org.mongodb.scala
 import java.io.Closeable
 
 import com.mongodb.connection.ClusterDescription
-import com.mongodb.reactivestreams.client.{ MongoClients, MongoClient => JMongoClient }
+import com.mongodb.reactivestreams.client.{ MongoClient => JMongoClient, MongoClients }
 import org.bson.codecs.configuration.CodecRegistries.{ fromProviders, fromRegistries }
 import org.bson.codecs.configuration.CodecRegistry
 import org.mongodb.scala.bson.DefaultHelper.DefaultsTo

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoCollection.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoCollection.scala
@@ -472,8 +472,7 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    */
   @deprecated("Superseded by aggregate")
   def mapReduce[C](clientSession: ClientSession, mapFunction: String, reduceFunction: String)(
-      implicit
-      e: C DefaultsTo TResult,
+      implicit e: C DefaultsTo TResult,
       ct: ClassTag[C]
   ): MapReduceObservable[C] =
     MapReduceObservable(wrapped.mapReduce(clientSession, mapFunction, reduceFunction, ct))

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoDatabase.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoDatabase.scala
@@ -139,8 +139,7 @@ case class MongoDatabase(private[scala] val wrapped: JMongoDatabase) {
    * @return a Observable containing the command result
    */
   def runCommand[TResult](command: Bson, readPreference: ReadPreference)(
-      implicit
-      e: TResult DefaultsTo Document,
+      implicit e: TResult DefaultsTo Document,
       ct: ClassTag[TResult]
   ): SingleObservable[TResult] =
     wrapped.runCommand(command, readPreference, ct)
@@ -156,8 +155,7 @@ case class MongoDatabase(private[scala] val wrapped: JMongoDatabase) {
    * @note Requires MongoDB 3.6 or greater
    */
   def runCommand[TResult](clientSession: ClientSession, command: Bson)(
-      implicit
-      e: TResult DefaultsTo Document,
+      implicit e: TResult DefaultsTo Document,
       ct: ClassTag[TResult]
   ): SingleObservable[TResult] =
     wrapped.runCommand[TResult](clientSession, command, ct)
@@ -173,8 +171,7 @@ case class MongoDatabase(private[scala] val wrapped: JMongoDatabase) {
    * @note Requires MongoDB 3.6 or greater
    */
   def runCommand[TResult](clientSession: ClientSession, command: Bson, readPreference: ReadPreference)(
-      implicit
-      e: TResult DefaultsTo Document,
+      implicit e: TResult DefaultsTo Document,
       ct: ClassTag[TResult]
   ): SingleObservable[TResult] =
     wrapped.runCommand(clientSession, command, readPreference, ct)
@@ -239,8 +236,7 @@ case class MongoDatabase(private[scala] val wrapped: JMongoDatabase) {
    * @note Requires MongoDB 3.6 or greater
    */
   def listCollections[TResult](clientSession: ClientSession)(
-      implicit
-      e: TResult DefaultsTo Document,
+      implicit e: TResult DefaultsTo Document,
       ct: ClassTag[TResult]
   ): ListCollectionsObservable[TResult] =
     ListCollectionsObservable(wrapped.listCollections(clientSession, ct))

--- a/driver-scala/src/main/scala/org/mongodb/scala/Observable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/Observable.scala
@@ -411,20 +411,29 @@ trait Observable[T] extends Publisher[T] {
       }
 
       override def onError(throwable: Throwable): Unit =
-        completeWith("onError", { () =>
-          promise.failure(throwable)
-        })
+        completeWith(
+          "onError",
+          { () =>
+            promise.failure(throwable)
+          }
+        )
 
       override def onComplete(): Unit = {
-        if (!terminated) completeWith("onComplete", { () =>
-          promise.success(None)
-        }) // Completed with no values
+        if (!terminated) completeWith(
+          "onComplete",
+          { () =>
+            promise.success(None)
+          }
+        ) // Completed with no values
       }
 
       override def onNext(tResult: T): Unit = {
-        completeWith("onNext", { () =>
-          promise.success(Some(tResult))
-        })
+        completeWith(
+          "onNext",
+          { () =>
+            promise.success(Some(tResult))
+          }
+        )
       }
 
       private def completeWith(method: String, action: () => Any): Unit = {

--- a/driver-scala/src/main/scala/org/mongodb/scala/Observer.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/Observer.scala
@@ -16,7 +16,7 @@
 
 package org.mongodb.scala
 
-import org.reactivestreams.{ Subscription => JSubscription, Subscriber }
+import org.reactivestreams.{ Subscriber, Subscription => JSubscription }
 
 /**
  * A Scala based wrapper of the `Subscriber` interface which provides a mechanism for receiving push-based notifications.

--- a/driver-scala/src/main/scala/org/mongodb/scala/gridfs/GridFSBucket.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/gridfs/GridFSBucket.scala
@@ -18,7 +18,7 @@ package org.mongodb.scala.gridfs
 
 import java.nio.ByteBuffer
 
-import com.mongodb.reactivestreams.client.gridfs.{ GridFSBuckets, GridFSBucket => JGridFSBucket }
+import com.mongodb.reactivestreams.client.gridfs.{ GridFSBucket => JGridFSBucket, GridFSBuckets }
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.bson.{ BsonObjectId, BsonValue, ObjectId }
 import org.mongodb.scala.{

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
@@ -143,7 +143,7 @@ object Aggregates {
    * @see Filters
    * @see [[http://docs.mongodb.org/manual/reference/operator/aggregation/match/ \$match]]
    */
-  def `match`(filter: Bson): Bson = JAggregates.`match`(filter) //scalastyle:ignore
+  def `match`(filter: Bson): Bson = JAggregates.`match`(filter) // scalastyle:ignore
 
   /**
    * Creates a `\$match` pipeline stage for the specified filter
@@ -155,7 +155,7 @@ object Aggregates {
    * @see Filters
    * @see [[http://docs.mongodb.org/manual/reference/operator/aggregation/match/ \$match]]
    */
-  def filter(filter: Bson): Bson = `match`(filter) //scalastyle:ignore
+  def filter(filter: Bson): Bson = `match`(filter) // scalastyle:ignore
 
   /**
    * Creates a `\$facet` pipeline stage

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Filters.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Filters.scala
@@ -256,7 +256,7 @@ object Filters {
    * @return the filter
    * @see [[http://docs.mongodb.org/manual/reference/operator/query/type \$type]]
    */
-  def `type`(fieldName: String, bsonType: BsonType): Bson = JFilters.`type`(fieldName, bsonType) //scalastyle:ignore
+  def `type`(fieldName: String, bsonType: BsonType): Bson = JFilters.`type`(fieldName, bsonType) // scalastyle:ignore
 
   /**
    * Creates a filter that matches all documents where the value of the field is of the specified BSON type.

--- a/driver-scala/src/test/scala/org/mongodb/scala/AggregateObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/AggregateObservableSpec.scala
@@ -20,12 +20,13 @@ import com.mongodb.ExplainVerbosity
 
 import java.util.concurrent.TimeUnit
 import com.mongodb.reactivestreams.client.AggregatePublisher
+import org.mockito.Mockito.{ verify, verifyNoMoreInteractions }
 import org.mongodb.scala.model.Collation
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration.Duration
 
-class AggregateObservableSpec extends BaseSpec with MockFactory {
+class AggregateObservableSpec extends BaseSpec with MockitoSugar {
 
   "AggregateObservable" should "have the same methods as the wrapped AggregateObservable" in {
     val wrapped: Set[String] = classOf[AggregatePublisher[Document]].getMethods.map(_.getName).toSet
@@ -48,17 +49,6 @@ class AggregateObservableSpec extends BaseSpec with MockFactory {
     val ct = classOf[Document]
     val verbosity = ExplainVerbosity.QUERY_PLANNER
 
-    wrapper.expects(Symbol("allowDiskUse"))(true).once()
-    wrapper.expects(Symbol("maxTime"))(duration.toMillis, TimeUnit.MILLISECONDS).once()
-    wrapper.expects(Symbol("maxAwaitTime"))(duration.toMillis, TimeUnit.MILLISECONDS).once()
-    wrapper.expects(Symbol("bypassDocumentValidation"))(true).once()
-    wrapper.expects(Symbol("collation"))(collation).once()
-    wrapper.expects(Symbol("comment"))("comment").once()
-    wrapper.expects(Symbol("hint"))(hint).once()
-    wrapper.expects(Symbol("batchSize"))(batchSize).once()
-    wrapper.expects(Symbol("explain"))(ct).once()
-    wrapper.expects(Symbol("explain"))(ct, verbosity).once()
-
     observable.allowDiskUse(true)
     observable.maxTime(duration)
     observable.maxAwaitTime(duration)
@@ -70,7 +60,20 @@ class AggregateObservableSpec extends BaseSpec with MockFactory {
     observable.explain[Document]()
     observable.explain[Document](verbosity)
 
-    wrapper.expects(Symbol("toCollection"))().once()
+    verify(wrapper).allowDiskUse(true)
+    verify(wrapper).maxTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    verify(wrapper).maxAwaitTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    verify(wrapper).bypassDocumentValidation(true)
+    verify(wrapper).collation(collation)
+    verify(wrapper).comment("comment")
+    verify(wrapper).hint(hint)
+    verify(wrapper).batchSize(batchSize)
+    verify(wrapper).explain(ct)
+    verify(wrapper).explain(ct, verbosity)
+
     observable.toCollection()
+    verify(wrapper).toCollection
+
+    verifyNoMoreInteractions(wrapper)
   }
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/AggregateObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/AggregateObservableSpec.scala
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit
 import com.mongodb.reactivestreams.client.AggregatePublisher
 import org.mongodb.scala.model.Collation
 import org.scalamock.scalatest.proxy.MockFactory
-import org.scalatest.{ FlatSpec, Matchers }
 
 import scala.concurrent.duration.Duration
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
@@ -103,12 +103,12 @@ class ApiAliasAndCompanionSpec extends BaseSpec {
 
     val classFilter = (f: Class[_ <: Object]) => {
       isPublic(f.getModifiers) &&
-        !f.getName.contains("$") &&
-        !f.getSimpleName.contains("Spec") &&
-        !f.getSimpleName.contains("Test") &&
-        !f.getSimpleName.contains("Tour") &&
-        !f.getSimpleName.contains("Fixture") &&
-        !javaExclusions.contains(f.getSimpleName)
+      !f.getName.contains("$") &&
+      !f.getSimpleName.contains("Spec") &&
+      !f.getSimpleName.contains("Test") &&
+      !f.getSimpleName.contains("Tour") &&
+      !f.getSimpleName.contains("Fixture") &&
+      !javaExclusions.contains(f.getSimpleName)
     }
     val filters = FilterBuilder.parse(
       """
@@ -388,15 +388,14 @@ class ApiAliasAndCompanionSpec extends BaseSpec {
   it should "mirror com.mongodb.reactivestreams.client.gridfs in org.mongdb.scala.gridfs" in {
     val javaExclusions = Set("GridFSBuckets", "GridFSDownloadByNameOptions")
     val wrapped: Set[String] = Set("com.mongodb.reactivestreams.client.gridfs", "com.mongodb.client.gridfs.model")
-      .flatMap(
-        packageName =>
-          new Reflections(packageName, new SubTypesScanner(false))
-            .getSubTypesOf(classOf[Object])
-            .asScala
-            .filter(_.getPackage.getName == packageName)
-            .filter(classFilter)
-            .map(_.getSimpleName.replace("Publisher", "Observable"))
-            .toSet
+      .flatMap(packageName =>
+        new Reflections(packageName, new SubTypesScanner(false))
+          .getSubTypesOf(classOf[Object])
+          .asScala
+          .filter(_.getPackage.getName == packageName)
+          .filter(classFilter)
+          .map(_.getSimpleName.replace("Publisher", "Observable"))
+          .toSet
       ) -- javaExclusions + "MongoGridFSException"
 
     val scalaPackageName = "org.mongodb.scala.gridfs"

--- a/driver-scala/src/test/scala/org/mongodb/scala/BaseSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/BaseSpec.scala
@@ -15,9 +15,10 @@
  */
 package org.mongodb.scala
 
-import org.scalatest.{ FlatSpec, Matchers }
 import org.junit.runner.RunWith
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-abstract class BaseSpec extends FlatSpec with Matchers {}
+abstract class BaseSpec extends AnyFlatSpec with Matchers {}

--- a/driver-scala/src/test/scala/org/mongodb/scala/ChangeStreamObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ChangeStreamObservableSpec.scala
@@ -24,10 +24,9 @@ import org.mongodb.scala.model.Collation
 import org.mongodb.scala.model.changestream.FullDocument
 import org.reactivestreams.Publisher
 import org.scalamock.scalatest.proxy.MockFactory
-import org.scalatest.{ FlatSpec, Matchers }
 
 import scala.concurrent.duration.Duration
-import scala.util.{ Failure, Success }
+import scala.util.{ Success }
 
 class ChangeStreamObservableSpec extends BaseSpec with MockFactory {
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/ChangeStreamObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ChangeStreamObservableSpec.scala
@@ -19,16 +19,17 @@ package org.mongodb.scala
 import java.util.concurrent.TimeUnit
 
 import com.mongodb.reactivestreams.client.ChangeStreamPublisher
+import org.mockito.Mockito.{ verify, verifyNoMoreInteractions }
 import org.mongodb.scala.bson.BsonTimestamp
 import org.mongodb.scala.model.Collation
 import org.mongodb.scala.model.changestream.FullDocument
 import org.reactivestreams.Publisher
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration.Duration
-import scala.util.{ Success }
+import scala.util.Success
 
-class ChangeStreamObservableSpec extends BaseSpec with MockFactory {
+class ChangeStreamObservableSpec extends BaseSpec with MockitoSugar {
 
   "ChangeStreamObservable" should "have the same methods as the wrapped ChangeStreamObservable" in {
     val mongoPublisher: Set[String] = classOf[Publisher[Document]].getMethods.map(_.getName).toSet
@@ -54,15 +55,6 @@ class ChangeStreamObservableSpec extends BaseSpec with MockFactory {
     val collation = Collation.builder().locale("en").build()
     val batchSize = 10
 
-    wrapper.expects(Symbol("batchSize"))(batchSize).once()
-    wrapper.expects(Symbol("fullDocument"))(fullDocument).once()
-    wrapper.expects(Symbol("resumeAfter"))(resumeToken.underlying).once()
-    wrapper.expects(Symbol("startAfter"))(resumeToken.underlying).once()
-    wrapper.expects(Symbol("startAtOperationTime"))(startAtTime).once()
-    wrapper.expects(Symbol("maxAwaitTime"))(duration.toMillis, TimeUnit.MILLISECONDS).once()
-    wrapper.expects(Symbol("collation"))(collation).once()
-    wrapper.expects(Symbol("withDocumentClass"))(classOf[Int]).once()
-
     observable.batchSize(batchSize)
     observable.fullDocument(fullDocument)
     observable.resumeAfter(resumeToken)
@@ -71,6 +63,17 @@ class ChangeStreamObservableSpec extends BaseSpec with MockFactory {
     observable.maxAwaitTime(duration)
     observable.collation(collation)
     observable.withDocumentClass(classOf[Int])
+
+    verify(wrapper).batchSize(batchSize)
+    verify(wrapper).fullDocument(fullDocument)
+    verify(wrapper).resumeAfter(resumeToken.underlying)
+    verify(wrapper).startAfter(resumeToken.underlying)
+    verify(wrapper).startAtOperationTime(startAtTime)
+    verify(wrapper).maxAwaitTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    verify(wrapper).collation(collation)
+    verify(wrapper).withDocumentClass(classOf[Int])
+
+    verifyNoMoreInteractions(wrapper)
   }
 
   it should "mirror FullDocument" in {

--- a/driver-scala/src/test/scala/org/mongodb/scala/CreateIndexCommitQuorumSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/CreateIndexCommitQuorumSpec.scala
@@ -18,10 +18,6 @@ package org.mongodb.scala
 
 import java.lang.reflect.Modifier.isStatic
 
-import scala.collection.JavaConverters._
-
-import org.scalatest.{ FlatSpec, Matchers }
-
 class CreateIndexCommitQuorumSpec extends BaseSpec {
 
   "CreateIndexCommitQuorum" should "have the same methods as the wrapped CreateIndexCommitQuorum" in {

--- a/driver-scala/src/test/scala/org/mongodb/scala/DistinctObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/DistinctObservableSpec.scala
@@ -18,13 +18,14 @@ package org.mongodb.scala
 import java.util.concurrent.TimeUnit
 
 import com.mongodb.reactivestreams.client.DistinctPublisher
+import org.mockito.Mockito.{ verify, verifyNoMoreInteractions }
 import org.mongodb.scala.model.Collation
 import org.reactivestreams.Publisher
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration.Duration
 
-class DistinctObservableSpec extends BaseSpec with MockFactory {
+class DistinctObservableSpec extends BaseSpec with MockitoSugar {
 
   "DistinctObservable" should "have the same methods as the wrapped DistinctObservable" in {
     val mongoPublisher: Set[String] = classOf[Publisher[Document]].getMethods.map(_.getName).toSet
@@ -46,14 +47,15 @@ class DistinctObservableSpec extends BaseSpec with MockFactory {
     val collation = Collation.builder().locale("en").build()
     val batchSize = 10
 
-    wrapper.expects(Symbol("filter"))(filter).once()
-    wrapper.expects(Symbol("maxTime"))(duration.toMillis, TimeUnit.MILLISECONDS).once()
-    wrapper.expects(Symbol("collation"))(collation).once()
-    wrapper.expects(Symbol("batchSize"))(batchSize).once()
-
     observable.filter(filter)
     observable.maxTime(duration)
     observable.collation(collation)
     observable.batchSize(batchSize)
+
+    verify(wrapper).filter(filter)
+    verify(wrapper).maxTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    verify(wrapper).collation(collation)
+    verify(wrapper).batchSize(batchSize)
+    verifyNoMoreInteractions(wrapper)
   }
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/DistinctObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/DistinctObservableSpec.scala
@@ -21,7 +21,6 @@ import com.mongodb.reactivestreams.client.DistinctPublisher
 import org.mongodb.scala.model.Collation
 import org.reactivestreams.Publisher
 import org.scalamock.scalatest.proxy.MockFactory
-import org.scalatest.{ FlatSpec, Matchers }
 
 import scala.concurrent.duration.Duration
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/FindObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/FindObservableSpec.scala
@@ -19,14 +19,14 @@ package org.mongodb.scala
 import java.util.concurrent.TimeUnit
 import com.mongodb.{ CursorType, ExplainVerbosity }
 import com.mongodb.reactivestreams.client.FindPublisher
+import org.mockito.Mockito.{ verify, verifyNoMoreInteractions }
 import org.mongodb.scala.model.Collation
 import org.reactivestreams.Publisher
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration.Duration
-import scala.reflect.ClassTag
 
-class FindObservableSpec extends BaseSpec with MockFactory {
+class FindObservableSpec extends BaseSpec with MockitoSugar {
 
   "FindObservable" should "have the same methods as the wrapped FindPublisher" in {
     val mongoPublisher: Set[String] = classOf[Publisher[Document]].getMethods.map(_.getName).toSet
@@ -55,27 +55,8 @@ class FindObservableSpec extends BaseSpec with MockFactory {
     val ct = classOf[Document]
     val verbosity = ExplainVerbosity.QUERY_PLANNER
 
-    wrapper.expects(Symbol("first"))().once()
     observable.first()
-
-    wrapper.expects(Symbol("collation"))(collation).once()
-    wrapper.expects(Symbol("cursorType"))(CursorType.NonTailable).once()
-    wrapper.expects(Symbol("filter"))(filter).once()
-    wrapper.expects(Symbol("limit"))(1).once()
-    wrapper.expects(Symbol("hint"))(hint).once()
-    wrapper.expects(Symbol("hintString"))(hintString).once()
-    wrapper.expects(Symbol("maxAwaitTime"))(maxDuration.toMillis, TimeUnit.MILLISECONDS).once()
-    wrapper.expects(Symbol("maxTime"))(duration.toMillis, TimeUnit.MILLISECONDS).once()
-    wrapper.expects(Symbol("noCursorTimeout"))(true).once()
-    wrapper.expects(Symbol("oplogReplay"))(true).once()
-    wrapper.expects(Symbol("partial"))(true).once()
-    wrapper.expects(Symbol("projection"))(projection).once()
-    wrapper.expects(Symbol("skip"))(1).once()
-    wrapper.expects(Symbol("sort"))(sort).once()
-    wrapper.expects(Symbol("batchSize"))(batchSize).once()
-    wrapper.expects(Symbol("allowDiskUse"))(true).once()
-    wrapper.expects(Symbol("explain"))(ct).once()
-    wrapper.expects(Symbol("explain"))(ct, verbosity).once()
+    verify(wrapper).first()
 
     observable.collation(collation)
     observable.cursorType(CursorType.NonTailable)
@@ -95,5 +76,25 @@ class FindObservableSpec extends BaseSpec with MockFactory {
     observable.allowDiskUse(true)
     observable.explain[Document]()
     observable.explain[Document](verbosity)
+
+    verify(wrapper).collation(collation)
+    verify(wrapper).cursorType(CursorType.NonTailable)
+    verify(wrapper).filter(filter)
+    verify(wrapper).limit(1)
+    verify(wrapper).hint(hint)
+    verify(wrapper).hintString(hintString)
+    verify(wrapper).maxAwaitTime(maxDuration.toMillis, TimeUnit.MILLISECONDS)
+    verify(wrapper).maxTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    verify(wrapper).noCursorTimeout(true)
+    verify(wrapper).oplogReplay(true)
+    verify(wrapper).partial(true)
+    verify(wrapper).projection(projection)
+    verify(wrapper).skip(1)
+    verify(wrapper).sort(sort)
+    verify(wrapper).batchSize(batchSize)
+    verify(wrapper).allowDiskUse(true)
+    verify(wrapper).explain(ct)
+    verify(wrapper).explain(ct, verbosity)
+    verifyNoMoreInteractions(wrapper)
   }
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/ListCollectionsObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ListCollectionsObservableSpec.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit
 import com.mongodb.reactivestreams.client.ListCollectionsPublisher
 import org.reactivestreams.Publisher
 import org.scalamock.scalatest.proxy.MockFactory
-import org.scalatest.{ FlatSpec, Matchers }
 
 import scala.concurrent.duration.Duration
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/ListCollectionsObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ListCollectionsObservableSpec.scala
@@ -19,12 +19,13 @@ package org.mongodb.scala
 import java.util.concurrent.TimeUnit
 
 import com.mongodb.reactivestreams.client.ListCollectionsPublisher
+import org.mockito.Mockito.{ verify, verifyNoMoreInteractions }
 import org.reactivestreams.Publisher
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration.Duration
 
-class ListCollectionsObservableSpec extends BaseSpec with MockFactory {
+class ListCollectionsObservableSpec extends BaseSpec with MockitoSugar {
 
   "ListCollectionsObservable" should "have the same methods as the wrapped ListCollectionsObservable" in {
     val mongoPublisher: Set[String] = classOf[Publisher[Document]].getMethods.map(_.getName).toSet
@@ -45,12 +46,13 @@ class ListCollectionsObservableSpec extends BaseSpec with MockFactory {
     val duration = Duration(1, TimeUnit.SECONDS)
     val batchSize = 10
 
-    wrapper.expects(Symbol("filter"))(filter).once()
-    wrapper.expects(Symbol("maxTime"))(duration.toMillis, TimeUnit.MILLISECONDS).once()
-    wrapper.expects(Symbol("batchSize"))(batchSize).once()
-
     observable.filter(filter)
     observable.maxTime(duration)
     observable.batchSize(batchSize)
+
+    verify(wrapper).filter(filter)
+    verify(wrapper).maxTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    verify(wrapper).batchSize(batchSize)
+    verifyNoMoreInteractions(wrapper)
   }
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/ListDatabasesObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ListDatabasesObservableSpec.scala
@@ -18,12 +18,13 @@ package org.mongodb.scala
 import java.util.concurrent.TimeUnit
 
 import com.mongodb.reactivestreams.client.ListDatabasesPublisher
+import org.mockito.Mockito.{ verify, verifyNoMoreInteractions }
 import org.reactivestreams.Publisher
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration.Duration
 
-class ListDatabasesObservableSpec extends BaseSpec with MockFactory {
+class ListDatabasesObservableSpec extends BaseSpec with MockitoSugar {
 
   "ListDatabasesObservable" should "have the same methods as the wrapped ListDatabasesObservable" in {
     val mongoPublisher: Set[String] = classOf[Publisher[Document]].getMethods.map(_.getName).toSet
@@ -43,14 +44,16 @@ class ListDatabasesObservableSpec extends BaseSpec with MockFactory {
     val duration = Duration(1, TimeUnit.SECONDS)
     val batchSize = 10
 
-    wrapper.expects(Symbol("maxTime"))(duration.toMillis, TimeUnit.MILLISECONDS).once()
-    wrapper.expects(Symbol("filter"))(filter).once()
-    wrapper.expects(Symbol("nameOnly"))(true).once()
-    wrapper.expects(Symbol("batchSize"))(batchSize).once()
-
     observable.maxTime(duration)
     observable.filter(filter)
     observable.nameOnly(true)
     observable.batchSize(batchSize)
+
+    verify(wrapper).maxTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    verify(wrapper).filter(filter)
+    verify(wrapper).nameOnly(true)
+    verify(wrapper).batchSize(batchSize)
+
+    verifyNoMoreInteractions(wrapper)
   }
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/ListDatabasesObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ListDatabasesObservableSpec.scala
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit
 import com.mongodb.reactivestreams.client.ListDatabasesPublisher
 import org.reactivestreams.Publisher
 import org.scalamock.scalatest.proxy.MockFactory
-import org.scalatest.{ FlatSpec, Matchers }
 
 import scala.concurrent.duration.Duration
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/ListIndexesObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ListIndexesObservableSpec.scala
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit
 import com.mongodb.reactivestreams.client.ListIndexesPublisher
 import org.reactivestreams.Publisher
 import org.scalamock.scalatest.proxy.MockFactory
-import org.scalatest.{ FlatSpec, Matchers }
 
 import scala.concurrent.duration.Duration
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/ListIndexesObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ListIndexesObservableSpec.scala
@@ -18,12 +18,13 @@ package org.mongodb.scala
 import java.util.concurrent.TimeUnit
 
 import com.mongodb.reactivestreams.client.ListIndexesPublisher
+import org.mockito.Mockito.{ verify, verifyNoMoreInteractions }
 import org.reactivestreams.Publisher
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration.Duration
 
-class ListIndexesObservableSpec extends BaseSpec with MockFactory {
+class ListIndexesObservableSpec extends BaseSpec with MockitoSugar {
 
   "ListIndexesObservable" should "have the same methods as the wrapped ListIndexesObservable" in {
     val mongoPublisher: Set[String] = classOf[Publisher[Document]].getMethods.map(_.getName).toSet
@@ -42,10 +43,11 @@ class ListIndexesObservableSpec extends BaseSpec with MockFactory {
     val duration = Duration(1, TimeUnit.SECONDS)
     val batchSize = 10
 
-    wrapper.expects(Symbol("maxTime"))(duration.toMillis, TimeUnit.MILLISECONDS).once()
-    wrapper.expects(Symbol("batchSize"))(batchSize).once()
-
     observable.maxTime(duration)
     observable.batchSize(batchSize)
+
+    verify(wrapper).maxTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    verify(wrapper).batchSize(batchSize)
+    verifyNoMoreInteractions(wrapper)
   }
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/MapReduceObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/MapReduceObservableSpec.scala
@@ -22,7 +22,6 @@ import com.mongodb.client.model.MapReduceAction
 import com.mongodb.reactivestreams.client.MapReducePublisher
 import org.mongodb.scala.model.Collation
 import org.scalamock.scalatest.proxy.MockFactory
-import org.scalatest.{ FlatSpec, Matchers }
 
 import scala.concurrent.duration.Duration
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/MapReduceObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/MapReduceObservableSpec.scala
@@ -20,12 +20,13 @@ import java.util.concurrent.TimeUnit
 
 import com.mongodb.client.model.MapReduceAction
 import com.mongodb.reactivestreams.client.MapReducePublisher
+import org.mockito.Mockito.{ verify, verifyNoMoreInteractions }
 import org.mongodb.scala.model.Collation
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration.Duration
 
-class MapReduceObservableSpec extends BaseSpec with MockFactory {
+class MapReduceObservableSpec extends BaseSpec with MockitoSugar {
 
   "MapReduceObservable" should "have the same methods as the wrapped MapReduceObservable" in {
     val wrapped = classOf[MapReducePublisher[Document]].getMethods.map(_.getName).toSet
@@ -48,23 +49,6 @@ class MapReduceObservableSpec extends BaseSpec with MockFactory {
     val collation = Collation.builder().locale("en").build()
     val batchSize = 10
 
-    wrapper.expects(Symbol("filter"))(filter).once()
-    wrapper.expects(Symbol("scope"))(scope).once()
-    wrapper.expects(Symbol("sort"))(sort).once()
-    wrapper.expects(Symbol("limit"))(1).once()
-    wrapper.expects(Symbol("maxTime"))(duration.toMillis, TimeUnit.MILLISECONDS).once()
-    wrapper.expects(Symbol("collectionName"))("collectionName").once()
-    wrapper.expects(Symbol("databaseName"))("databaseName").once()
-    wrapper.expects(Symbol("finalizeFunction"))("final").once()
-    wrapper.expects(Symbol("action"))(MapReduceAction.REPLACE).once()
-    wrapper.expects(Symbol("jsMode"))(true).once()
-    wrapper.expects(Symbol("verbose"))(true).once()
-    wrapper.expects(Symbol("sharded"))(true).once()
-    wrapper.expects(Symbol("nonAtomic"))(true).once()
-    wrapper.expects(Symbol("bypassDocumentValidation"))(true).once()
-    wrapper.expects(Symbol("collation"))(collation).once()
-    wrapper.expects(Symbol("batchSize"))(batchSize).once()
-
     observable.filter(filter)
     observable.scope(scope)
     observable.sort(sort)
@@ -82,7 +66,25 @@ class MapReduceObservableSpec extends BaseSpec with MockFactory {
     observable.collation(collation)
     observable.batchSize(batchSize)
 
-    wrapper.expects(Symbol("toCollection"))().once()
+    verify(wrapper).filter(filter)
+    verify(wrapper).scope(scope)
+    verify(wrapper).sort(sort)
+    verify(wrapper).limit(1)
+    verify(wrapper).maxTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    verify(wrapper).collectionName("collectionName")
+    verify(wrapper).databaseName("databaseName")
+    verify(wrapper).finalizeFunction("final")
+    verify(wrapper).action(MapReduceAction.REPLACE)
+    verify(wrapper).jsMode(true)
+    verify(wrapper).verbose(true)
+    verify(wrapper).sharded(true)
+    verify(wrapper).nonAtomic(true)
+    verify(wrapper).bypassDocumentValidation(true)
+    verify(wrapper).collation(collation)
+    verify(wrapper).batchSize(batchSize)
+
     observable.toCollection()
+    verify(wrapper).toCollection
+    verifyNoMoreInteractions(wrapper)
   }
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/MongoClientSettingsSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/MongoClientSettingsSpec.scala
@@ -21,10 +21,9 @@ import org.bson.codecs.configuration.CodecRegistries._
 import org.mongodb.scala.MongoClient.DEFAULT_CODEC_REGISTRY
 import org.mongodb.scala.bson.codecs.DocumentCodecProvider
 import org.mongodb.scala.connection.ConnectionPoolSettings.Builder
-import org.scalamock.scalatest.proxy.MockFactory
 import org.mongodb.scala.connection._
 
-class MongoClientSettingsSpec extends BaseSpec with MockFactory {
+class MongoClientSettingsSpec extends BaseSpec {
 
   "MongoClientSettings" should "default with the Scala Codec Registry" in {
     MongoClientSettings.builder().build().getCodecRegistry should equal(DEFAULT_CODEC_REGISTRY)

--- a/driver-scala/src/test/scala/org/mongodb/scala/MongoClientSettingsSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/MongoClientSettingsSpec.scala
@@ -22,7 +22,6 @@ import org.mongodb.scala.MongoClient.DEFAULT_CODEC_REGISTRY
 import org.mongodb.scala.bson.codecs.DocumentCodecProvider
 import org.mongodb.scala.connection.ConnectionPoolSettings.Builder
 import org.scalamock.scalatest.proxy.MockFactory
-import org.scalatest.{ FlatSpec, Matchers }
 import org.mongodb.scala.connection._
 
 class MongoClientSettingsSpec extends BaseSpec with MockFactory {

--- a/driver-scala/src/test/scala/org/mongodb/scala/MongoClientSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/MongoClientSpec.scala
@@ -18,11 +18,12 @@ package org.mongodb.scala
 
 import com.mongodb.reactivestreams.client.{ MongoClient => JMongoClient }
 import org.bson.BsonDocument
-import org.scalamock.scalatest.proxy.MockFactory
+import org.mockito.Mockito.verify
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.collection.JavaConverters._
 
-class MongoClientSpec extends BaseSpec with MockFactory {
+class MongoClientSpec extends BaseSpec with MockitoSugar {
 
   val wrapped = mock[JMongoClient]
   val clientSession = mock[ClientSession]
@@ -44,62 +45,62 @@ class MongoClientSpec extends BaseSpec with MockFactory {
   }
 
   it should "call the underlying getDatabase" in {
-    wrapped.expects(Symbol("getDatabase"))("dbName").once()
-
     mongoClient.getDatabase("dbName")
+
+    verify(wrapped).getDatabase("dbName")
   }
 
   it should "call the underlying close" in {
-    wrapped.expects(Symbol("close"))().once()
-
     mongoClient.close()
+
+    verify(wrapped).close()
   }
 
   it should "call the underlying startSession" in {
-    val clientSessionOptions = ClientSessionOptions.builder.build()
-    wrapped.expects(Symbol("startSession"))(clientSessionOptions).once()
-
+    val clientSessionOptions = ClientSessionOptions.builder().build()
     mongoClient.startSession(clientSessionOptions)
+
+    verify(wrapped).startSession(clientSessionOptions)
   }
 
   it should "call the underlying listDatabases[T]" in {
-    wrapped.expects(Symbol("listDatabases"))(classOf[Document]).once()
-    wrapped.expects(Symbol("listDatabases"))(clientSession, classOf[Document]).once()
-    wrapped.expects(Symbol("listDatabases"))(classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("listDatabases"))(clientSession, classOf[BsonDocument]).once()
-
     mongoClient.listDatabases()
     mongoClient.listDatabases(clientSession)
     mongoClient.listDatabases[BsonDocument]()
     mongoClient.listDatabases[BsonDocument](clientSession)
+
+    verify(wrapped).listDatabases(classOf[Document])
+    verify(wrapped).listDatabases(clientSession, classOf[Document])
+    verify(wrapped).listDatabases(classOf[BsonDocument])
+    verify(wrapped).listDatabases(clientSession, classOf[BsonDocument])
   }
 
   it should "call the underlying listDatabaseNames" in {
-    wrapped.expects(Symbol("listDatabaseNames"))().once()
-    wrapped.expects(Symbol("listDatabaseNames"))(clientSession).once()
-
     mongoClient.listDatabaseNames()
     mongoClient.listDatabaseNames(clientSession)
+
+    verify(wrapped).listDatabaseNames()
+    verify(wrapped).listDatabaseNames(clientSession)
   }
 
   it should "call the underlying watch" in {
     val pipeline = List(Document("$match" -> 1))
-
-    wrapped.expects(Symbol("watch"))(classOf[Document]).once()
-    wrapped.expects(Symbol("watch"))(pipeline.asJava, classOf[Document]).once()
-    wrapped.expects(Symbol("watch"))(pipeline.asJava, classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("watch"))(clientSession, pipeline.asJava, classOf[Document]).once()
-    wrapped.expects(Symbol("watch"))(clientSession, pipeline.asJava, classOf[BsonDocument]).once()
 
     mongoClient.watch() shouldBe a[ChangeStreamObservable[_]]
     mongoClient.watch(pipeline) shouldBe a[ChangeStreamObservable[_]]
     mongoClient.watch[BsonDocument](pipeline) shouldBe a[ChangeStreamObservable[_]]
     mongoClient.watch(clientSession, pipeline) shouldBe a[ChangeStreamObservable[_]]
     mongoClient.watch[BsonDocument](clientSession, pipeline) shouldBe a[ChangeStreamObservable[_]]
+
+    verify(wrapped).watch(classOf[Document])
+    verify(wrapped).watch(pipeline.asJava, classOf[Document])
+    verify(wrapped).watch(pipeline.asJava, classOf[BsonDocument])
+    verify(wrapped).watch(clientSession, pipeline.asJava, classOf[Document])
+    verify(wrapped).watch(clientSession, pipeline.asJava, classOf[BsonDocument])
   }
 
   it should "call the underlying getClusterDescription" in {
-    wrapped.expects(Symbol("getClusterDescription"))().once()
     mongoClient.getClusterDescription
+    verify(wrapped).getClusterDescription
   }
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/MongoCollectionSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/MongoCollectionSpec.scala
@@ -22,12 +22,13 @@ import com.mongodb.reactivestreams.client.{ MongoCollection => JMongoCollection 
 import org.bson.BsonDocument
 import org.bson.codecs.BsonValueCodecProvider
 import org.bson.codecs.configuration.CodecRegistries.fromProviders
+import org.mockito.Mockito.{ times, verify }
 import org.mongodb.scala.model._
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.collection.JavaConverters._
 
-class MongoCollectionSpec extends BaseSpec with MockFactory {
+class MongoCollectionSpec extends BaseSpec with MockitoSugar {
 
   val wrapped = mock[JMongoCollection[Document]]
   val clientSession = mock[ClientSession]
@@ -48,88 +49,81 @@ class MongoCollectionSpec extends BaseSpec with MockFactory {
   }
 
   it should "return the underlying getNamespace" in {
-    wrapped.expects(Symbol("getNamespace"))().once()
-
     mongoCollection.namespace
+
+    verify(wrapped).getNamespace
   }
 
   it should "return the underlying getCodecRegistry" in {
-    wrapped.expects(Symbol("getCodecRegistry"))().once()
-
     mongoCollection.codecRegistry
+
+    verify(wrapped).getCodecRegistry
   }
 
   it should "return the underlying getReadPreference" in {
-    wrapped.expects(Symbol("getReadPreference"))().once()
-
     mongoCollection.readPreference
+
+    verify(wrapped).getReadPreference
   }
 
   it should "return the underlying getWriteConcern" in {
-    wrapped.expects(Symbol("getWriteConcern"))().once()
-
     mongoCollection.writeConcern
+
+    verify(wrapped).getWriteConcern
   }
 
   it should "return the underlying getReadConcern" in {
-    wrapped.expects(Symbol("getReadConcern"))().once()
-
     mongoCollection.readConcern
+
+    verify(wrapped).getReadConcern
   }
 
   it should "return the underlying getDocumentClass" in {
-    wrapped.expects(Symbol("getDocumentClass"))().once()
-
     mongoCollection.documentClass
+
+    verify(wrapped).getDocumentClass
   }
 
   it should "return the underlying withCodecRegistry" in {
     val codecRegistry = fromProviders(new BsonValueCodecProvider())
 
-    wrapped.expects(Symbol("withCodecRegistry"))(codecRegistry).once()
-
     mongoCollection.withCodecRegistry(codecRegistry)
+
+    verify(wrapped).withCodecRegistry(codecRegistry)
   }
 
   it should "return the underlying withReadPreference" in {
-    wrapped.expects(Symbol("withReadPreference"))(readPreference).once()
-
     mongoCollection.withReadPreference(readPreference)
+
+    verify(wrapped).withReadPreference(readPreference)
   }
 
   it should "return the underlying withWriteConcern" in {
     val writeConcern = WriteConcern.MAJORITY
-    wrapped.expects(Symbol("withWriteConcern"))(writeConcern).once()
-
     mongoCollection.withWriteConcern(writeConcern)
+
+    verify(wrapped).withWriteConcern(writeConcern)
   }
 
   it should "return the underlying withReadConcern" in {
     val readConcern = ReadConcern.MAJORITY
-    wrapped.expects(Symbol("withReadConcern"))(readConcern).once()
-
     mongoCollection.withReadConcern(readConcern)
+
+    verify(wrapped).withReadConcern(readConcern)
   }
 
   it should "return the underlying withDocumentClass" in {
-    wrapped.expects(Symbol("withDocumentClass"))(classOf[Document]).once()
-    wrapped.expects(Symbol("withDocumentClass"))(classOf[Document]).once()
-    wrapped.expects(Symbol("withDocumentClass"))(classOf[BsonDocument]).once()
-
     mongoCollection.withDocumentClass()
     mongoCollection.withDocumentClass[Document]()
     mongoCollection.withDocumentClass[BsonDocument]()
+
+    verify(wrapped, times(2)).withDocumentClass(classOf[Document])
+    verify(wrapped).withDocumentClass(classOf[BsonDocument])
+
   }
 
   it should "return the underlying countDocuments" in {
     val countOptions = CountOptions()
-
-    wrapped.expects(Symbol("countDocuments"))().once()
-    wrapped.expects(Symbol("countDocuments"))(filter).once()
-    wrapped.expects(Symbol("countDocuments"))(filter, countOptions).once()
-    wrapped.expects(Symbol("countDocuments"))(clientSession).once()
-    wrapped.expects(Symbol("countDocuments"))(clientSession, filter).once()
-    wrapped.expects(Symbol("countDocuments"))(clientSession, filter, countOptions).once()
 
     mongoCollection.countDocuments()
     mongoCollection.countDocuments(filter)
@@ -137,40 +131,38 @@ class MongoCollectionSpec extends BaseSpec with MockFactory {
     mongoCollection.countDocuments(clientSession)
     mongoCollection.countDocuments(clientSession, filter)
     mongoCollection.countDocuments(clientSession, filter, countOptions)
+
+    verify(wrapped).countDocuments()
+    verify(wrapped).countDocuments(filter)
+    verify(wrapped).countDocuments(filter, countOptions)
+    verify(wrapped).countDocuments(clientSession)
+    verify(wrapped).countDocuments(clientSession, filter)
+    verify(wrapped).countDocuments(clientSession, filter, countOptions)
   }
 
   it should "return the underlying estimatedDocumentCount" in {
     val options = EstimatedDocumentCountOptions().maxTime(1, TimeUnit.SECONDS)
 
-    wrapped.expects(Symbol("estimatedDocumentCount"))().once()
-    wrapped.expects(Symbol("estimatedDocumentCount"))(options).once()
-
     mongoCollection.estimatedDocumentCount()
     mongoCollection.estimatedDocumentCount(options)
+
+    verify(wrapped).estimatedDocumentCount()
+    verify(wrapped).estimatedDocumentCount(options)
   }
 
   it should "wrap the underlying DistinctObservable correctly" in {
-    wrapped.expects(Symbol("distinct"))("fieldName", classOf[String]).once()
-    wrapped.expects(Symbol("distinct"))("fieldName", filter, classOf[String]).once()
-    wrapped.expects(Symbol("distinct"))(clientSession, "fieldName", classOf[String]).once()
-    wrapped.expects(Symbol("distinct"))(clientSession, "fieldName", filter, classOf[String]).once()
-
     mongoCollection.distinct[String]("fieldName")
     mongoCollection.distinct[String]("fieldName", filter)
     mongoCollection.distinct[String](clientSession, "fieldName")
     mongoCollection.distinct[String](clientSession, "fieldName", filter)
+
+    verify(wrapped).distinct("fieldName", classOf[String])
+    verify(wrapped).distinct("fieldName", filter, classOf[String])
+    verify(wrapped).distinct(clientSession, "fieldName", classOf[String])
+    verify(wrapped).distinct(clientSession, "fieldName", filter, classOf[String])
   }
 
   it should "wrap the underlying FindObservable correctly" in {
-    wrapped.expects(Symbol("find"))(classOf[Document]).once()
-    wrapped.expects(Symbol("find"))(classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("find"))(filter, classOf[Document]).once()
-    wrapped.expects(Symbol("find"))(filter, classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("find"))(clientSession, classOf[Document]).once()
-    wrapped.expects(Symbol("find"))(clientSession, classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("find"))(clientSession, filter, classOf[Document]).once()
-    wrapped.expects(Symbol("find"))(clientSession, filter, classOf[BsonDocument]).once()
-
     mongoCollection.find() shouldBe a[FindObservable[_]]
     mongoCollection.find[BsonDocument]() shouldBe a[FindObservable[_]]
     mongoCollection.find(filter) shouldBe a[FindObservable[_]]
@@ -179,32 +171,41 @@ class MongoCollectionSpec extends BaseSpec with MockFactory {
     mongoCollection.find[BsonDocument](clientSession) shouldBe a[FindObservable[_]]
     mongoCollection.find(clientSession, filter) shouldBe a[FindObservable[_]]
     mongoCollection.find[BsonDocument](clientSession, filter) shouldBe a[FindObservable[_]]
+
+    verify(wrapped).find(classOf[Document])
+    verify(wrapped).find(classOf[BsonDocument])
+    verify(wrapped).find(filter, classOf[Document])
+    verify(wrapped).find(filter, classOf[BsonDocument])
+    verify(wrapped).find(clientSession, classOf[Document])
+    verify(wrapped).find(clientSession, classOf[BsonDocument])
+    verify(wrapped).find(clientSession, filter, classOf[Document])
+    verify(wrapped).find(clientSession, filter, classOf[BsonDocument])
   }
 
   it should "wrap the underlying AggregateObservable correctly" in {
     val pipeline = List(Document("$match" -> 1))
 
-    wrapped.expects(Symbol("aggregate"))(pipeline.asJava, classOf[Document]).once()
-    wrapped.expects(Symbol("aggregate"))(pipeline.asJava, classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("aggregate"))(clientSession, pipeline.asJava, classOf[Document]).once()
-    wrapped.expects(Symbol("aggregate"))(clientSession, pipeline.asJava, classOf[BsonDocument]).once()
-
     mongoCollection.aggregate(pipeline) shouldBe a[AggregateObservable[_]]
     mongoCollection.aggregate[BsonDocument](pipeline) shouldBe a[AggregateObservable[_]]
     mongoCollection.aggregate(clientSession, pipeline) shouldBe a[AggregateObservable[_]]
     mongoCollection.aggregate[BsonDocument](clientSession, pipeline) shouldBe a[AggregateObservable[_]]
+
+    verify(wrapped).aggregate(pipeline.asJava, classOf[Document])
+    verify(wrapped).aggregate(pipeline.asJava, classOf[BsonDocument])
+    verify(wrapped).aggregate(clientSession, pipeline.asJava, classOf[Document])
+    verify(wrapped).aggregate(clientSession, pipeline.asJava, classOf[BsonDocument])
   }
 
   it should "wrap the underlying MapReduceObservable correctly" in {
-    wrapped.expects(Symbol("mapReduce"))("map", "reduce", classOf[Document]).once()
-    wrapped.expects(Symbol("mapReduce"))("map", "reduce", classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("mapReduce"))(clientSession, "map", "reduce", classOf[Document]).once()
-    wrapped.expects(Symbol("mapReduce"))(clientSession, "map", "reduce", classOf[BsonDocument]).once()
-
     mongoCollection.mapReduce("map", "reduce") shouldBe a[MapReduceObservable[_]]
     mongoCollection.mapReduce[BsonDocument]("map", "reduce") shouldBe a[MapReduceObservable[_]]
     mongoCollection.mapReduce(clientSession, "map", "reduce") shouldBe a[MapReduceObservable[_]]
     mongoCollection.mapReduce[BsonDocument](clientSession, "map", "reduce") shouldBe a[MapReduceObservable[_]]
+
+    verify(wrapped).mapReduce("map", "reduce", classOf[Document])
+    verify(wrapped).mapReduce("map", "reduce", classOf[BsonDocument])
+    verify(wrapped).mapReduce(clientSession, "map", "reduce", classOf[Document])
+    verify(wrapped).mapReduce(clientSession, "map", "reduce", classOf[BsonDocument])
   }
 
   it should "wrap the underlying bulkWrite correctly" in {
@@ -215,101 +216,93 @@ class MongoCollectionSpec extends BaseSpec with MockFactory {
     )
     val bulkWriteOptions = new BulkWriteOptions().ordered(true)
 
-    wrapped.expects(Symbol("bulkWrite"))(bulkRequests.asJava).once()
-    wrapped.expects(Symbol("bulkWrite"))(bulkRequests.asJava, bulkWriteOptions).once()
-    wrapped.expects(Symbol("bulkWrite"))(clientSession, bulkRequests.asJava).once()
-    wrapped.expects(Symbol("bulkWrite"))(clientSession, bulkRequests.asJava, bulkWriteOptions).once()
-
     mongoCollection.bulkWrite(bulkRequests)
     mongoCollection.bulkWrite(bulkRequests, bulkWriteOptions)
     mongoCollection.bulkWrite(clientSession, bulkRequests)
     mongoCollection.bulkWrite(clientSession, bulkRequests, bulkWriteOptions)
+
+    verify(wrapped).bulkWrite(bulkRequests.asJava)
+    verify(wrapped).bulkWrite(bulkRequests.asJava, bulkWriteOptions)
+    verify(wrapped).bulkWrite(clientSession, bulkRequests.asJava)
+    verify(wrapped).bulkWrite(clientSession, bulkRequests.asJava, bulkWriteOptions)
   }
 
   it should "wrap the underlying insertOne correctly" in {
     val insertDoc = Document("a" -> 1)
     val insertOptions = InsertOneOptions().bypassDocumentValidation(true)
-    wrapped.expects(Symbol("insertOne"))(insertDoc).once()
-    wrapped.expects(Symbol("insertOne"))(insertDoc, insertOptions).once()
-    wrapped.expects(Symbol("insertOne"))(clientSession, insertDoc).once()
-    wrapped.expects(Symbol("insertOne"))(clientSession, insertDoc, insertOptions).once()
 
     mongoCollection.insertOne(insertDoc)
     mongoCollection.insertOne(insertDoc, insertOptions)
     mongoCollection.insertOne(clientSession, insertDoc)
     mongoCollection.insertOne(clientSession, insertDoc, insertOptions)
+
+    verify(wrapped).insertOne(insertDoc)
+    verify(wrapped).insertOne(insertDoc, insertOptions)
+    verify(wrapped).insertOne(clientSession, insertDoc)
+    verify(wrapped).insertOne(clientSession, insertDoc, insertOptions)
   }
 
   it should "wrap the underlying insertMany correctly" in {
     val insertDocs = List(Document("a" -> 1))
     val insertOptions = new InsertManyOptions().ordered(false)
 
-    wrapped.expects(Symbol("insertMany"))(insertDocs.asJava).once()
-    wrapped.expects(Symbol("insertMany"))(insertDocs.asJava, insertOptions).once()
-    wrapped.expects(Symbol("insertMany"))(clientSession, insertDocs.asJava).once()
-    wrapped.expects(Symbol("insertMany"))(clientSession, insertDocs.asJava, insertOptions).once()
-
     mongoCollection.insertMany(insertDocs)
     mongoCollection.insertMany(insertDocs, insertOptions)
     mongoCollection.insertMany(clientSession, insertDocs)
     mongoCollection.insertMany(clientSession, insertDocs, insertOptions)
+
+    verify(wrapped).insertMany(insertDocs.asJava)
+    verify(wrapped).insertMany(insertDocs.asJava, insertOptions)
+    verify(wrapped).insertMany(clientSession, insertDocs.asJava)
+    verify(wrapped).insertMany(clientSession, insertDocs.asJava, insertOptions)
   }
 
   it should "wrap the underlying deleteOne correctly" in {
     val options = new DeleteOptions().collation(collation)
-    wrapped.expects(Symbol("deleteOne"))(filter).once()
-    wrapped.expects(Symbol("deleteOne"))(filter, options).once()
-    wrapped.expects(Symbol("deleteOne"))(clientSession, filter).once()
-    wrapped.expects(Symbol("deleteOne"))(clientSession, filter, options).once()
 
     mongoCollection.deleteOne(filter)
     mongoCollection.deleteOne(filter, options)
     mongoCollection.deleteOne(clientSession, filter)
     mongoCollection.deleteOne(clientSession, filter, options)
+
+    verify(wrapped).deleteOne(filter)
+    verify(wrapped).deleteOne(filter, options)
+    verify(wrapped).deleteOne(clientSession, filter)
+    verify(wrapped).deleteOne(clientSession, filter, options)
   }
 
   it should "wrap the underlying deleteMany correctly" in {
     val options = new DeleteOptions().collation(collation)
-    wrapped.expects(Symbol("deleteMany"))(filter).once()
-    wrapped.expects(Symbol("deleteMany"))(filter, options).once()
-    wrapped.expects(Symbol("deleteMany"))(clientSession, filter).once()
-    wrapped.expects(Symbol("deleteMany"))(clientSession, filter, options).once()
-
     mongoCollection.deleteMany(filter)
     mongoCollection.deleteMany(filter, options)
     mongoCollection.deleteMany(clientSession, filter)
     mongoCollection.deleteMany(clientSession, filter, options)
+
+    verify(wrapped).deleteMany(filter)
+    verify(wrapped).deleteMany(filter, options)
+    verify(wrapped).deleteMany(clientSession, filter)
+    verify(wrapped).deleteMany(clientSession, filter, options)
   }
 
   it should "wrap the underlying replaceOne correctly" in {
     val replacement = Document("a" -> 1)
     val replaceOptions = new ReplaceOptions().upsert(true)
 
-    wrapped.expects(Symbol("replaceOne"))(filter, replacement).once()
-    wrapped.expects(Symbol("replaceOne"))(filter, replacement, replaceOptions).once()
-    wrapped.expects(Symbol("replaceOne"))(clientSession, filter, replacement).once()
-    wrapped.expects(Symbol("replaceOne"))(clientSession, filter, replacement, replaceOptions).once()
-
     mongoCollection.replaceOne(filter, replacement)
     mongoCollection.replaceOne(filter, replacement, replaceOptions)
     mongoCollection.replaceOne(clientSession, filter, replacement)
     mongoCollection.replaceOne(clientSession, filter, replacement, replaceOptions)
+
+    verify(wrapped).replaceOne(filter, replacement)
+    verify(wrapped).replaceOne(filter, replacement, replaceOptions)
+    verify(wrapped).replaceOne(clientSession, filter, replacement)
+    verify(wrapped).replaceOne(clientSession, filter, replacement, replaceOptions)
   }
 
   it should "wrap the underlying updateOne correctly" in {
     val update = Document("$set" -> Document("a" -> 2))
     val pipeline = Seq(update)
     val updateOptions = new UpdateOptions().upsert(true)
-
-    wrapped.expects(Symbol("updateOne"))(filter, update).once()
-    wrapped.expects(Symbol("updateOne"))(filter, update, updateOptions).once()
-    wrapped.expects(Symbol("updateOne"))(clientSession, filter, update).once()
-    wrapped.expects(Symbol("updateOne"))(clientSession, filter, update, updateOptions).once()
-
-    wrapped.expects(Symbol("updateOne"))(filter, pipeline.asJava).once()
-    wrapped.expects(Symbol("updateOne"))(filter, pipeline.asJava, updateOptions).once()
-    wrapped.expects(Symbol("updateOne"))(clientSession, filter, pipeline.asJava).once()
-    wrapped.expects(Symbol("updateOne"))(clientSession, filter, pipeline.asJava, updateOptions).once()
 
     mongoCollection.updateOne(filter, update)
     mongoCollection.updateOne(filter, update, updateOptions)
@@ -320,22 +313,22 @@ class MongoCollectionSpec extends BaseSpec with MockFactory {
     mongoCollection.updateOne(filter, pipeline, updateOptions)
     mongoCollection.updateOne(clientSession, filter, pipeline)
     mongoCollection.updateOne(clientSession, filter, pipeline, updateOptions)
+
+    verify(wrapped).updateOne(filter, update)
+    verify(wrapped).updateOne(filter, update, updateOptions)
+    verify(wrapped).updateOne(clientSession, filter, update)
+    verify(wrapped).updateOne(clientSession, filter, update, updateOptions)
+
+    verify(wrapped).updateOne(filter, pipeline.asJava)
+    verify(wrapped).updateOne(filter, pipeline.asJava, updateOptions)
+    verify(wrapped).updateOne(clientSession, filter, pipeline.asJava)
+    verify(wrapped).updateOne(clientSession, filter, pipeline.asJava, updateOptions)
   }
 
   it should "wrap the underlying updateMany correctly" in {
     val update = Document("$set" -> Document("a" -> 2))
     val pipeline = Seq(update)
     val updateOptions = new UpdateOptions().upsert(true)
-
-    wrapped.expects(Symbol("updateMany"))(filter, update).once()
-    wrapped.expects(Symbol("updateMany"))(filter, update, updateOptions).once()
-    wrapped.expects(Symbol("updateMany"))(clientSession, filter, update).once()
-    wrapped.expects(Symbol("updateMany"))(clientSession, filter, update, updateOptions).once()
-
-    wrapped.expects(Symbol("updateMany"))(filter, pipeline.asJava).once()
-    wrapped.expects(Symbol("updateMany"))(filter, pipeline.asJava, updateOptions).once()
-    wrapped.expects(Symbol("updateMany"))(clientSession, filter, pipeline.asJava).once()
-    wrapped.expects(Symbol("updateMany"))(clientSession, filter, pipeline.asJava, updateOptions).once()
 
     mongoCollection.updateMany(filter, update)
     mongoCollection.updateMany(filter, update, updateOptions)
@@ -346,51 +339,51 @@ class MongoCollectionSpec extends BaseSpec with MockFactory {
     mongoCollection.updateMany(filter, pipeline, updateOptions)
     mongoCollection.updateMany(clientSession, filter, pipeline)
     mongoCollection.updateMany(clientSession, filter, pipeline, updateOptions)
+
+    verify(wrapped).updateMany(filter, update)
+    verify(wrapped).updateMany(filter, update, updateOptions)
+    verify(wrapped).updateMany(clientSession, filter, update)
+    verify(wrapped).updateMany(clientSession, filter, update, updateOptions)
+
+    verify(wrapped).updateMany(filter, pipeline.asJava)
+    verify(wrapped).updateMany(filter, pipeline.asJava, updateOptions)
+    verify(wrapped).updateMany(clientSession, filter, pipeline.asJava)
+    verify(wrapped).updateMany(clientSession, filter, pipeline.asJava, updateOptions)
   }
 
   it should "wrap the underlying findOneAndDelete correctly" in {
     val options = new FindOneAndDeleteOptions().sort(Document("sort" -> 1))
 
-    wrapped.expects(Symbol("findOneAndDelete"))(filter).once()
-    wrapped.expects(Symbol("findOneAndDelete"))(filter, options).once()
-    wrapped.expects(Symbol("findOneAndDelete"))(clientSession, filter).once()
-    wrapped.expects(Symbol("findOneAndDelete"))(clientSession, filter, options).once()
-
     mongoCollection.findOneAndDelete(filter)
     mongoCollection.findOneAndDelete(filter, options)
     mongoCollection.findOneAndDelete(clientSession, filter)
     mongoCollection.findOneAndDelete(clientSession, filter, options)
+
+    verify(wrapped).findOneAndDelete(filter)
+    verify(wrapped).findOneAndDelete(filter, options)
+    verify(wrapped).findOneAndDelete(clientSession, filter)
+    verify(wrapped).findOneAndDelete(clientSession, filter, options)
   }
 
   it should "wrap the underlying findOneAndReplace correctly" in {
     val replacement = Document("a" -> 2)
     val options = new FindOneAndReplaceOptions().sort(Document("sort" -> 1))
 
-    wrapped.expects(Symbol("findOneAndReplace"))(filter, replacement).once()
-    wrapped.expects(Symbol("findOneAndReplace"))(filter, replacement, options).once()
-    wrapped.expects(Symbol("findOneAndReplace"))(clientSession, filter, replacement).once()
-    wrapped.expects(Symbol("findOneAndReplace"))(clientSession, filter, replacement, options).once()
-
     mongoCollection.findOneAndReplace(filter, replacement)
     mongoCollection.findOneAndReplace(filter, replacement, options)
     mongoCollection.findOneAndReplace(clientSession, filter, replacement)
     mongoCollection.findOneAndReplace(clientSession, filter, replacement, options)
+
+    verify(wrapped).findOneAndReplace(filter, replacement)
+    verify(wrapped).findOneAndReplace(filter, replacement, options)
+    verify(wrapped).findOneAndReplace(clientSession, filter, replacement)
+    verify(wrapped).findOneAndReplace(clientSession, filter, replacement, options)
   }
 
   it should "wrap the underlying findOneAndUpdate correctly" in {
     val update = Document("a" -> 2)
     val pipeline = Seq(update)
     val options = new FindOneAndUpdateOptions().sort(Document("sort" -> 1))
-
-    wrapped.expects(Symbol("findOneAndUpdate"))(filter, update).once()
-    wrapped.expects(Symbol("findOneAndUpdate"))(filter, update, options).once()
-    wrapped.expects(Symbol("findOneAndUpdate"))(clientSession, filter, update).once()
-    wrapped.expects(Symbol("findOneAndUpdate"))(clientSession, filter, update, options).once()
-
-    wrapped.expects(Symbol("findOneAndUpdate"))(filter, pipeline.asJava).once()
-    wrapped.expects(Symbol("findOneAndUpdate"))(filter, pipeline.asJava, options).once()
-    wrapped.expects(Symbol("findOneAndUpdate"))(clientSession, filter, pipeline.asJava).once()
-    wrapped.expects(Symbol("findOneAndUpdate"))(clientSession, filter, pipeline.asJava, options).once()
 
     mongoCollection.findOneAndUpdate(filter, update)
     mongoCollection.findOneAndUpdate(filter, update, options)
@@ -401,70 +394,71 @@ class MongoCollectionSpec extends BaseSpec with MockFactory {
     mongoCollection.findOneAndUpdate(filter, pipeline, options)
     mongoCollection.findOneAndUpdate(clientSession, filter, pipeline)
     mongoCollection.findOneAndUpdate(clientSession, filter, pipeline, options)
+
+    verify(wrapped).findOneAndUpdate(filter, update)
+    verify(wrapped).findOneAndUpdate(filter, update, options)
+    verify(wrapped).findOneAndUpdate(clientSession, filter, update)
+    verify(wrapped).findOneAndUpdate(clientSession, filter, update, options)
+
+    verify(wrapped).findOneAndUpdate(filter, pipeline.asJava)
+    verify(wrapped).findOneAndUpdate(filter, pipeline.asJava, options)
+    verify(wrapped).findOneAndUpdate(clientSession, filter, pipeline.asJava)
+    verify(wrapped).findOneAndUpdate(clientSession, filter, pipeline.asJava, options)
   }
 
   it should "wrap the underlying drop correctly" in {
-    wrapped.expects(Symbol("drop"))().once()
-    wrapped.expects(Symbol("drop"))(clientSession).once()
-
     mongoCollection.drop()
     mongoCollection.drop(clientSession)
+
+    verify(wrapped).drop()
+    verify(wrapped).drop(clientSession)
   }
 
   it should "wrap the underlying createIndex correctly" in {
     val index = Document("a" -> 1)
     val options = new IndexOptions().background(true)
 
-    wrapped.expects(Symbol("createIndex"))(index).once()
-    wrapped.expects(Symbol("createIndex"))(index, options).once()
-    wrapped.expects(Symbol("createIndex"))(clientSession, index).once()
-    wrapped.expects(Symbol("createIndex"))(clientSession, index, options).once()
-
     mongoCollection.createIndex(index)
     mongoCollection.createIndex(index, options)
     mongoCollection.createIndex(clientSession, index)
     mongoCollection.createIndex(clientSession, index, options)
+
+    verify(wrapped).createIndex(index)
+    verify(wrapped).createIndex(index, options)
+    verify(wrapped).createIndex(clientSession, index)
+    verify(wrapped).createIndex(clientSession, index, options)
   }
 
   it should "wrap the underlying createIndexes correctly" in {
     val indexes = new IndexModel(Document("a" -> 1))
     val options = new CreateIndexOptions()
 
-    // https://github.com/paulbutcher/ScalaMock/issues/93
-    wrapped.expects(Symbol("createIndexes"))(List(indexes).asJava).once()
-    wrapped.expects(Symbol("createIndexes"))(List(indexes).asJava, options).once()
-    wrapped.expects(Symbol("createIndexes"))(clientSession, List(indexes).asJava).once()
-    wrapped.expects(Symbol("createIndexes"))(clientSession, List(indexes).asJava, options).once()
-
     mongoCollection.createIndexes(List(indexes))
     mongoCollection.createIndexes(List(indexes), options)
     mongoCollection.createIndexes(clientSession, List(indexes))
     mongoCollection.createIndexes(clientSession, List(indexes), options)
+
+    verify(wrapped).createIndexes(List(indexes).asJava)
+    verify(wrapped).createIndexes(List(indexes).asJava, options)
+    verify(wrapped).createIndexes(clientSession, List(indexes).asJava)
+    verify(wrapped).createIndexes(clientSession, List(indexes).asJava, options)
   }
 
   it should "wrap the underlying listIndexes correctly" in {
-    wrapped.expects(Symbol("listIndexes"))(classOf[Document]).once()
-    wrapped.expects(Symbol("listIndexes"))(classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("listIndexes"))(clientSession, classOf[Document]).once()
-    wrapped.expects(Symbol("listIndexes"))(clientSession, classOf[BsonDocument]).once()
-
     mongoCollection.listIndexes()
     mongoCollection.listIndexes[BsonDocument]()
     mongoCollection.listIndexes(clientSession)
     mongoCollection.listIndexes[BsonDocument](clientSession)
+
+    verify(wrapped).listIndexes(classOf[Document])
+    verify(wrapped).listIndexes(classOf[BsonDocument])
+    verify(wrapped).listIndexes(clientSession, classOf[Document])
+    verify(wrapped).listIndexes(clientSession, classOf[BsonDocument])
   }
 
   it should "wrap the underlying dropIndex correctly" in {
     val indexDocument = Document("""{a: 1}""")
     val options = new DropIndexOptions()
-    wrapped.expects(Symbol("dropIndex"))("indexName").once()
-    wrapped.expects(Symbol("dropIndex"))(indexDocument).once()
-    wrapped.expects(Symbol("dropIndex"))("indexName", options).once()
-    wrapped.expects(Symbol("dropIndex"))(indexDocument, options).once()
-    wrapped.expects(Symbol("dropIndex"))(clientSession, "indexName").once()
-    wrapped.expects(Symbol("dropIndex"))(clientSession, indexDocument).once()
-    wrapped.expects(Symbol("dropIndex"))(clientSession, "indexName", options).once()
-    wrapped.expects(Symbol("dropIndex"))(clientSession, indexDocument, options).once()
 
     mongoCollection.dropIndex("indexName")
     mongoCollection.dropIndex(indexDocument)
@@ -474,48 +468,48 @@ class MongoCollectionSpec extends BaseSpec with MockFactory {
     mongoCollection.dropIndex(clientSession, indexDocument)
     mongoCollection.dropIndex(clientSession, "indexName", options)
     mongoCollection.dropIndex(clientSession, indexDocument, options)
+
+    verify(wrapped).dropIndex("indexName")
+    verify(wrapped).dropIndex(indexDocument)
+    verify(wrapped).dropIndex("indexName", options)
+    verify(wrapped).dropIndex(indexDocument, options)
+    verify(wrapped).dropIndex(clientSession, "indexName")
+    verify(wrapped).dropIndex(clientSession, indexDocument)
+    verify(wrapped).dropIndex(clientSession, "indexName", options)
+    verify(wrapped).dropIndex(clientSession, indexDocument, options)
   }
 
   it should "wrap the underlying dropIndexes correctly" in {
-
     val options = new DropIndexOptions()
-    wrapped.expects(Symbol("dropIndexes"))().once()
-    wrapped.expects(Symbol("dropIndexes"))(options).once()
-    wrapped.expects(Symbol("dropIndexes"))(clientSession).once()
-    wrapped.expects(Symbol("dropIndexes"))(clientSession, options).once()
 
     mongoCollection.dropIndexes()
     mongoCollection.dropIndexes(options)
     mongoCollection.dropIndexes(clientSession)
     mongoCollection.dropIndexes(clientSession, options)
+
+    verify(wrapped).dropIndexes()
+    verify(wrapped).dropIndexes(options)
+    verify(wrapped).dropIndexes(clientSession)
+    verify(wrapped).dropIndexes(clientSession, options)
   }
 
   it should "wrap the underlying renameCollection correctly" in {
     val newNamespace = new MongoNamespace("db", "coll")
     val options = new RenameCollectionOptions()
 
-    wrapped.expects(Symbol("renameCollection"))(newNamespace).once()
-    wrapped.expects(Symbol("renameCollection"))(newNamespace, options).once()
-    wrapped.expects(Symbol("renameCollection"))(clientSession, newNamespace).once()
-    wrapped.expects(Symbol("renameCollection"))(clientSession, newNamespace, options).once()
-
     mongoCollection.renameCollection(newNamespace)
     mongoCollection.renameCollection(newNamespace, options)
     mongoCollection.renameCollection(clientSession, newNamespace)
     mongoCollection.renameCollection(clientSession, newNamespace, options)
+
+    verify(wrapped).renameCollection(newNamespace)
+    verify(wrapped).renameCollection(newNamespace, options)
+    verify(wrapped).renameCollection(clientSession, newNamespace)
+    verify(wrapped).renameCollection(clientSession, newNamespace, options)
   }
 
   it should "wrap the underlying ChangeStreamPublisher correctly" in {
     val pipeline = List(Document("$match" -> 1))
-
-    wrapped.expects(Symbol("watch"))(classOf[Document]).once()
-    wrapped.expects(Symbol("watch"))(classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("watch"))(pipeline.asJava, classOf[Document]).once()
-    wrapped.expects(Symbol("watch"))(pipeline.asJava, classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("watch"))(clientSession, classOf[Document]).once()
-    wrapped.expects(Symbol("watch"))(clientSession, classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("watch"))(clientSession, pipeline.asJava, classOf[Document]).once()
-    wrapped.expects(Symbol("watch"))(clientSession, pipeline.asJava, classOf[BsonDocument]).once()
 
     mongoCollection.watch() shouldBe a[ChangeStreamObservable[_]]
     mongoCollection.watch[BsonDocument]() shouldBe a[ChangeStreamObservable[_]]
@@ -525,6 +519,15 @@ class MongoCollectionSpec extends BaseSpec with MockFactory {
     mongoCollection.watch[BsonDocument](clientSession) shouldBe a[ChangeStreamObservable[_]]
     mongoCollection.watch(clientSession, pipeline) shouldBe a[ChangeStreamObservable[_]]
     mongoCollection.watch[BsonDocument](clientSession, pipeline) shouldBe a[ChangeStreamObservable[_]]
+
+    verify(wrapped).watch(classOf[Document])
+    verify(wrapped).watch(classOf[BsonDocument])
+    verify(wrapped).watch(pipeline.asJava, classOf[Document])
+    verify(wrapped).watch(pipeline.asJava, classOf[BsonDocument])
+    verify(wrapped).watch(clientSession, classOf[Document])
+    verify(wrapped).watch(clientSession, classOf[BsonDocument])
+    verify(wrapped).watch(clientSession, pipeline.asJava, classOf[Document])
+    verify(wrapped).watch(clientSession, pipeline.asJava, classOf[BsonDocument])
   }
 
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/MongoCollectionSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/MongoCollectionSpec.scala
@@ -24,7 +24,6 @@ import org.bson.codecs.BsonValueCodecProvider
 import org.bson.codecs.configuration.CodecRegistries.fromProviders
 import org.mongodb.scala.model._
 import org.scalamock.scalatest.proxy.MockFactory
-import org.scalatest.{ FlatSpec, Matchers }
 
 import scala.collection.JavaConverters._
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/MongoCredentialSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/MongoCredentialSpec.scala
@@ -17,7 +17,6 @@
 package org.mongodb.scala
 
 import com.mongodb.{ MongoCredential => JMongoCredential }
-import org.scalatest.{ FlatSpec, Matchers }
 
 class MongoCredentialSpec extends BaseSpec {
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/MongoDatabaseSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/MongoDatabaseSpec.scala
@@ -22,12 +22,12 @@ import org.bson.BsonDocument
 import org.bson.codecs.BsonValueCodecProvider
 import org.bson.codecs.configuration.CodecRegistries.fromProviders
 import com.mongodb.reactivestreams.client.{ ListCollectionsPublisher, MongoDatabase => JMongoDatabase }
-
+import org.mockito.Mockito.{ verify, when }
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model._
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
-class MongoDatabaseSpec extends BaseSpec with MockFactory {
+class MongoDatabaseSpec extends BaseSpec with MockitoSugar {
 
   val wrapped = mock[JMongoDatabase]
   val clientSession = mock[ClientSession]
@@ -47,125 +47,117 @@ class MongoDatabaseSpec extends BaseSpec with MockFactory {
   }
 
   it should "return the underlying getCollection[T]" in {
-    wrapped.expects(Symbol("getCollection"))("collectionName", classOf[Document]).once()
-    wrapped.expects(Symbol("getCollection"))("collectionName", classOf[BsonDocument]).once()
-
     mongoDatabase.getCollection("collectionName")
     mongoDatabase.getCollection[BsonDocument]("collectionName")
+
+    verify(wrapped).getCollection("collectionName", classOf[Document])
+    verify(wrapped).getCollection("collectionName", classOf[BsonDocument])
   }
 
   it should "return the underlying getName" in {
-    wrapped.expects(Symbol("getName"))().once()
-
     mongoDatabase.name
+
+    verify(wrapped).getName
   }
 
   it should "return the underlying getCodecRegistry" in {
-    wrapped.expects(Symbol("getCodecRegistry"))().once()
-
     mongoDatabase.codecRegistry
+
+    verify(wrapped).getCodecRegistry
   }
 
   it should "return the underlying getReadPreference" in {
-    wrapped.expects(Symbol("getReadPreference"))().once()
-
     mongoDatabase.readPreference
+
+    verify(wrapped).getReadPreference
   }
 
   it should "return the underlying getWriteConcern" in {
-    wrapped.expects(Symbol("getWriteConcern"))().once()
-
     mongoDatabase.writeConcern
+
+    verify(wrapped).getWriteConcern
   }
 
   it should "return the underlying getReadConcern" in {
-    wrapped.expects(Symbol("getReadConcern"))().once()
-
     mongoDatabase.readConcern
+
+    verify(wrapped).getReadConcern
   }
 
   it should "return the underlying withCodecRegistry" in {
     val codecRegistry = fromProviders(new BsonValueCodecProvider())
 
-    wrapped.expects(Symbol("withCodecRegistry"))(codecRegistry).once()
-
     mongoDatabase.withCodecRegistry(codecRegistry)
+
+    verify(wrapped).withCodecRegistry(codecRegistry)
   }
 
   it should "return the underlying withReadPreference" in {
-    wrapped.expects(Symbol("withReadPreference"))(readPreference).once()
-
     mongoDatabase.withReadPreference(readPreference)
+
+    verify(wrapped).withReadPreference(readPreference)
   }
 
   it should "return the underlying withWriteConcern" in {
     val writeConcern = WriteConcern.MAJORITY
-    wrapped.expects(Symbol("withWriteConcern"))(writeConcern).once()
-
     mongoDatabase.withWriteConcern(writeConcern)
+
+    verify(wrapped).withWriteConcern(writeConcern)
   }
 
   it should "return the underlying withReadConcern" in {
     val readConcern = ReadConcern.MAJORITY
-    wrapped.expects(Symbol("withReadConcern"))(readConcern).once()
-
     mongoDatabase.withReadConcern(readConcern)
+
+    verify(wrapped).withReadConcern(readConcern)
   }
 
   it should "call the underlying runCommand[T] when writing" in {
-    wrapped.expects(Symbol("runCommand"))(command, classOf[Document]).once()
-    wrapped.expects(Symbol("runCommand"))(command, classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("runCommand"))(clientSession, command, classOf[Document]).once()
-    wrapped.expects(Symbol("runCommand"))(clientSession, command, classOf[BsonDocument]).once()
-
     mongoDatabase.runCommand(command)
     mongoDatabase.runCommand[BsonDocument](command)
     mongoDatabase.runCommand(clientSession, command)
     mongoDatabase.runCommand[BsonDocument](clientSession, command)
+
+    verify(wrapped).runCommand(command, classOf[Document])
+    verify(wrapped).runCommand(command, classOf[BsonDocument])
+    verify(wrapped).runCommand(clientSession, command, classOf[Document])
+    verify(wrapped).runCommand(clientSession, command, classOf[BsonDocument])
   }
 
   it should "call the underlying runCommand[T] when reading" in {
-    wrapped.expects(Symbol("runCommand"))(command, readPreference, classOf[Document]).once()
-    wrapped.expects(Symbol("runCommand"))(command, readPreference, classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("runCommand"))(clientSession, command, readPreference, classOf[Document]).once()
-    wrapped.expects(Symbol("runCommand"))(clientSession, command, readPreference, classOf[BsonDocument]).once()
-
     mongoDatabase.runCommand(command, readPreference)
     mongoDatabase.runCommand[BsonDocument](command, readPreference)
     mongoDatabase.runCommand(clientSession, command, readPreference)
     mongoDatabase.runCommand[BsonDocument](clientSession, command, readPreference)
+
+    verify(wrapped).runCommand(command, readPreference, classOf[Document])
+    verify(wrapped).runCommand(command, readPreference, classOf[BsonDocument])
+    verify(wrapped).runCommand(clientSession, command, readPreference, classOf[Document])
+    verify(wrapped).runCommand(clientSession, command, readPreference, classOf[BsonDocument])
   }
 
   it should "call the underlying drop()" in {
-    wrapped.expects(Symbol("drop"))().once()
-    wrapped.expects(Symbol("drop"))(clientSession).once()
-
     mongoDatabase.drop()
     mongoDatabase.drop(clientSession)
+
+    verify(wrapped).drop()
+    verify(wrapped).drop(clientSession)
   }
 
   it should "call the underlying listCollectionNames()" in {
-    wrapped.expects(Symbol("listCollectionNames"))().once()
-    wrapped.expects(Symbol("listCollectionNames"))(clientSession).once()
-
     mongoDatabase.listCollectionNames()
     mongoDatabase.listCollectionNames(clientSession)
+
+    verify(wrapped).listCollectionNames()
+    verify(wrapped).listCollectionNames(clientSession)
   }
 
   it should "call the underlying listCollections()" in {
-    wrapped.expects(Symbol("listCollections"))(*).returns(stub[ListCollectionsPublisher[Document]]).once()
-    wrapped
-      .expects(Symbol("listCollections"))(classOf[BsonDocument])
-      .returns(stub[ListCollectionsPublisher[BsonDocument]])
-      .once()
-    wrapped
-      .expects(Symbol("listCollections"))(clientSession, *)
-      .returns(stub[ListCollectionsPublisher[Document]])
-      .once()
-    wrapped
-      .expects(Symbol("listCollections"))(clientSession, classOf[BsonDocument])
-      .returns(stub[ListCollectionsPublisher[BsonDocument]])
-      .once()
+    when(wrapped.listCollections()).thenReturn(mock[ListCollectionsPublisher[org.bson.Document]])
+    when(wrapped.listCollections(classOf[BsonDocument])).thenReturn(mock[ListCollectionsPublisher[BsonDocument]])
+    when(wrapped.listCollections(clientSession)).thenReturn(mock[ListCollectionsPublisher[org.bson.Document]])
+    when(wrapped.listCollections(clientSession, classOf[BsonDocument]))
+      .thenReturn(mock[ListCollectionsPublisher[BsonDocument]])
 
     mongoDatabase.listCollections()
     mongoDatabase.listCollections[BsonDocument]()
@@ -185,58 +177,59 @@ class MongoDatabaseSpec extends BaseSpec with MockFactory {
       .indexOptionDefaults(IndexOptionDefaults().storageEngine(Document("""{storageEngine: { mmapv1: {}}}""")))
       .storageEngineOptions(Document("""{ wiredTiger: {}}"""))
 
-    wrapped.expects(Symbol("createCollection"))("collectionName").once()
-    wrapped.expects(Symbol("createCollection"))("collectionName", options).once()
-    wrapped.expects(Symbol("createCollection"))(clientSession, "collectionName").once()
-    wrapped.expects(Symbol("createCollection"))(clientSession, "collectionName", options).once()
-
     mongoDatabase.createCollection("collectionName")
     mongoDatabase.createCollection("collectionName", options)
     mongoDatabase.createCollection(clientSession, "collectionName")
     mongoDatabase.createCollection(clientSession, "collectionName", options)
+
+    verify(wrapped).createCollection("collectionName")
+    verify(wrapped).createCollection("collectionName", options)
+    verify(wrapped).createCollection(clientSession, "collectionName")
+    verify(wrapped).createCollection(clientSession, "collectionName", options)
   }
 
   it should "call the underlying createView()" in {
     val options = CreateViewOptions().collation(Collation.builder().locale("en").build())
     val pipeline = List.empty[Bson]
 
-    wrapped.expects(Symbol("createView"))("viewName", "collectionName", pipeline.asJava).once()
-    wrapped.expects(Symbol("createView"))("viewName", "collectionName", pipeline.asJava, options).once()
-    wrapped.expects(Symbol("createView"))(clientSession, "viewName", "collectionName", pipeline.asJava).once()
-    wrapped.expects(Symbol("createView"))(clientSession, "viewName", "collectionName", pipeline.asJava, options).once()
-
     mongoDatabase.createView("viewName", "collectionName", pipeline)
     mongoDatabase.createView("viewName", "collectionName", pipeline, options)
     mongoDatabase.createView(clientSession, "viewName", "collectionName", pipeline)
     mongoDatabase.createView(clientSession, "viewName", "collectionName", pipeline, options)
+
+    verify(wrapped).createView("viewName", "collectionName", pipeline.asJava)
+    verify(wrapped).createView("viewName", "collectionName", pipeline.asJava, options)
+    verify(wrapped).createView(clientSession, "viewName", "collectionName", pipeline.asJava)
+    verify(wrapped).createView(clientSession, "viewName", "collectionName", pipeline.asJava, options)
   }
 
   it should "call the underlying watch" in {
     val pipeline = List(Document("$match" -> 1))
-
-    wrapped.expects(Symbol("watch"))(classOf[Document]).once()
-    wrapped.expects(Symbol("watch"))(pipeline.asJava, classOf[Document]).once()
-    wrapped.expects(Symbol("watch"))(pipeline.asJava, classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("watch"))(clientSession, pipeline.asJava, classOf[Document]).once()
-    wrapped.expects(Symbol("watch"))(clientSession, pipeline.asJava, classOf[BsonDocument]).once()
 
     mongoDatabase.watch() shouldBe a[ChangeStreamObservable[_]]
     mongoDatabase.watch(pipeline) shouldBe a[ChangeStreamObservable[_]]
     mongoDatabase.watch[BsonDocument](pipeline) shouldBe a[ChangeStreamObservable[_]]
     mongoDatabase.watch(clientSession, pipeline) shouldBe a[ChangeStreamObservable[_]]
     mongoDatabase.watch[BsonDocument](clientSession, pipeline) shouldBe a[ChangeStreamObservable[_]]
+
+    verify(wrapped).watch(classOf[Document])
+    verify(wrapped).watch(pipeline.asJava, classOf[Document])
+    verify(wrapped).watch(pipeline.asJava, classOf[BsonDocument])
+    verify(wrapped).watch(clientSession, pipeline.asJava, classOf[Document])
+    verify(wrapped).watch(clientSession, pipeline.asJava, classOf[BsonDocument])
   }
 
   it should "call the underlying aggregate" in {
     val pipeline = List(Document("$match" -> 1))
-    wrapped.expects(Symbol("aggregate"))(pipeline.asJava, classOf[Document]).once()
-    wrapped.expects(Symbol("aggregate"))(pipeline.asJava, classOf[BsonDocument]).once()
-    wrapped.expects(Symbol("aggregate"))(clientSession, pipeline.asJava, classOf[Document]).once()
-    wrapped.expects(Symbol("aggregate"))(clientSession, pipeline.asJava, classOf[BsonDocument]).once()
 
     mongoDatabase.aggregate(pipeline) shouldBe a[AggregateObservable[_]]
     mongoDatabase.aggregate[BsonDocument](pipeline) shouldBe a[AggregateObservable[_]]
     mongoDatabase.aggregate(clientSession, pipeline) shouldBe a[AggregateObservable[_]]
     mongoDatabase.aggregate[BsonDocument](clientSession, pipeline) shouldBe a[AggregateObservable[_]]
+
+    verify(wrapped).aggregate(pipeline.asJava, classOf[Document])
+    verify(wrapped).aggregate(pipeline.asJava, classOf[BsonDocument])
+    verify(wrapped).aggregate(clientSession, pipeline.asJava, classOf[Document])
+    verify(wrapped).aggregate(clientSession, pipeline.asJava, classOf[BsonDocument])
   }
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/MongoDatabaseSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/MongoDatabaseSpec.scala
@@ -26,7 +26,6 @@ import com.mongodb.reactivestreams.client.{ ListCollectionsPublisher, MongoDatab
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model._
 import org.scalamock.scalatest.proxy.MockFactory
-import org.scalatest.{ FlatSpec, Matchers }
 
 class MongoDatabaseSpec extends BaseSpec with MockFactory {
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/MongoDriverInformationSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/MongoDriverInformationSpec.scala
@@ -18,8 +18,6 @@ package org.mongodb.scala
 
 import java.lang.reflect.Modifier.isStatic
 
-import org.scalatest.{ FlatSpec, Matchers }
-
 class MongoDriverInformationSpec extends BaseSpec {
 
   "MongoDriverInformation" should "have the same static fields as the wrapped MongoDriverInformation" in {

--- a/driver-scala/src/test/scala/org/mongodb/scala/ReadConcernLevelSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ReadConcernLevelSpec.scala
@@ -21,7 +21,6 @@ import java.lang.reflect.Modifier._
 import scala.util.{ Success, Try }
 
 import org.scalatest.prop.TableDrivenPropertyChecks._
-import org.scalatest.{ FlatSpec, Matchers }
 
 class ReadConcernLevelSpec extends BaseSpec {
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/ReadConcernSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ReadConcernSpec.scala
@@ -21,7 +21,6 @@ import java.lang.reflect.Modifier._
 import com.mongodb.{ ReadConcern => JReadConcern }
 
 import org.scalatest.prop.TableDrivenPropertyChecks._
-import org.scalatest.{ FlatSpec, Matchers }
 
 class ReadConcernSpec extends BaseSpec {
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/ReadPreferenceSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ReadPreferenceSpec.scala
@@ -22,8 +22,6 @@ import java.util.concurrent.TimeUnit.SECONDS
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.Duration
 
-import org.scalatest.{ FlatSpec, Matchers }
-
 class ReadPreferenceSpec extends BaseSpec {
 
   val duration = Duration("95 sec")

--- a/driver-scala/src/test/scala/org/mongodb/scala/connection/ConnectionSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/connection/ConnectionSpec.scala
@@ -20,11 +20,11 @@ import java.net.{ InetAddress, InetSocketAddress }
 
 import com.mongodb.{ ServerAddress => JServerAddress }
 import org.mongodb.scala.{ BaseSpec, ServerAddress }
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.collection.JavaConverters._
 
-class ConnectionSpec extends BaseSpec with MockFactory {
+class ConnectionSpec extends BaseSpec with MockitoSugar {
 
   "The connection namespace" should "have a AsynchronousSocketChannelStreamFactoryFactory companion" in {
     val asynchronousSocketChannelStreamFactoryFactory = AsynchronousSocketChannelStreamFactoryFactory()

--- a/driver-scala/src/test/scala/org/mongodb/scala/gridfs/GridFSBucketSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/gridfs/GridFSBucketSpec.scala
@@ -19,12 +19,13 @@ package org.mongodb.scala.gridfs
 import java.nio.ByteBuffer
 
 import com.mongodb.reactivestreams.client.gridfs.{ GridFSBucket => JGridFSBucket }
+import org.mockito.Mockito.{ verify, when }
 import org.mongodb.scala.bson.BsonObjectId
 import org.mongodb.scala.bson.collection.immutable.Document
 import org.mongodb.scala.{ BaseSpec, ClientSession, Observable, ReadConcern, ReadPreference, WriteConcern }
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
-class GridFSBucketSpec extends BaseSpec with MockFactory {
+class GridFSBucketSpec extends BaseSpec with MockitoSugar {
   val wrapper = mock[JGridFSBucket]
   val clientSession = mock[ClientSession]
   val gridFSBucket = new GridFSBucket(wrapper)
@@ -40,17 +41,17 @@ class GridFSBucketSpec extends BaseSpec with MockFactory {
   }
 
   it should "call the underlying methods to get bucket values" in {
-    wrapper.expects(Symbol("getBucketName"))().once()
-    wrapper.expects(Symbol("getChunkSizeBytes"))().returning(1).once()
-    wrapper.expects(Symbol("getReadConcern"))().once()
-    wrapper.expects(Symbol("getReadPreference"))().once()
-    wrapper.expects(Symbol("getWriteConcern"))().once()
-
     gridFSBucket.bucketName
     gridFSBucket.chunkSizeBytes
     gridFSBucket.readConcern
     gridFSBucket.readPreference
     gridFSBucket.writeConcern
+
+    verify(wrapper).getBucketName
+    when(wrapper.getChunkSizeBytes).thenReturn(1)
+    verify(wrapper).getReadConcern
+    verify(wrapper).getReadPreference
+    verify(wrapper).getWriteConcern
   }
 
   it should "call the underlying methods to set bucket values" in {
@@ -59,38 +60,38 @@ class GridFSBucketSpec extends BaseSpec with MockFactory {
     val readPreference = ReadPreference.secondaryPreferred()
     val writeConcern = WriteConcern.W2
 
-    wrapper.expects(Symbol("withChunkSizeBytes"))(chunkSizeInBytes).once()
-    wrapper.expects(Symbol("withReadConcern"))(readConcern).once()
-    wrapper.expects(Symbol("withReadPreference"))(readPreference).once()
-    wrapper.expects(Symbol("withWriteConcern"))(writeConcern).once()
-
     gridFSBucket.withChunkSizeBytes(chunkSizeInBytes)
     gridFSBucket.withReadConcern(readConcern)
     gridFSBucket.withReadPreference(readPreference)
     gridFSBucket.withWriteConcern(writeConcern)
+
+    verify(wrapper).withChunkSizeBytes(chunkSizeInBytes)
+    verify(wrapper).withReadConcern(readConcern)
+    verify(wrapper).withReadPreference(readPreference)
+    verify(wrapper).withWriteConcern(writeConcern)
   }
 
   it should "call the underlying delete method" in {
     val bsonValue = BsonObjectId()
     val objectId = bsonValue.getValue
 
-    wrapper.expects(Symbol("delete"))(objectId).once()
-    wrapper.expects(Symbol("delete"))(bsonValue).once()
-    wrapper.expects(Symbol("delete"))(clientSession, objectId).once()
-    wrapper.expects(Symbol("delete"))(clientSession, bsonValue).once()
-
     gridFSBucket.delete(objectId)
     gridFSBucket.delete(bsonValue)
     gridFSBucket.delete(clientSession, objectId)
     gridFSBucket.delete(clientSession, bsonValue)
+
+    verify(wrapper).delete(objectId)
+    verify(wrapper).delete(bsonValue)
+    verify(wrapper).delete(clientSession, objectId)
+    verify(wrapper).delete(clientSession, bsonValue)
   }
 
   it should "call the underlying drop method" in {
-    wrapper.expects(Symbol("drop"))().once()
-    wrapper.expects(Symbol("drop"))(clientSession).once()
-
     gridFSBucket.drop()
     gridFSBucket.drop(clientSession)
+
+    verify(wrapper).drop()
+    verify(wrapper).drop(clientSession)
   }
 
   it should "call the underlying rename method" in {
@@ -98,29 +99,29 @@ class GridFSBucketSpec extends BaseSpec with MockFactory {
     val objectId = bsonValue.getValue
     val newName = "newName"
 
-    wrapper.expects(Symbol("rename"))(objectId, newName).once()
-    wrapper.expects(Symbol("rename"))(bsonValue, newName).once()
-    wrapper.expects(Symbol("rename"))(clientSession, objectId, newName).once()
-    wrapper.expects(Symbol("rename"))(clientSession, bsonValue, newName).once()
-
     gridFSBucket.rename(objectId, newName)
     gridFSBucket.rename(bsonValue, newName)
     gridFSBucket.rename(clientSession, objectId, newName)
     gridFSBucket.rename(clientSession, bsonValue, newName)
+
+    verify(wrapper).rename(objectId, newName)
+    verify(wrapper).rename(bsonValue, newName)
+    verify(wrapper).rename(clientSession, objectId, newName)
+    verify(wrapper).rename(clientSession, bsonValue, newName)
   }
 
   it should "return the expected findObservable" in {
     val filter = Document("{a: 1}")
 
-    wrapper.expects(Symbol("find"))().once()
-    wrapper.expects(Symbol("find"))(filter).once()
-    wrapper.expects(Symbol("find"))(clientSession).once()
-    wrapper.expects(Symbol("find"))(clientSession, filter).once()
-
     gridFSBucket.find()
     gridFSBucket.find(filter)
     gridFSBucket.find(clientSession)
     gridFSBucket.find(clientSession, filter)
+
+    verify(wrapper).find()
+    verify(wrapper).find(filter)
+    verify(wrapper).find(clientSession)
+    verify(wrapper).find(clientSession, filter)
   }
 
   it should "return the expected GridFSDownloadObservable" in {
@@ -130,25 +131,25 @@ class GridFSBucketSpec extends BaseSpec with MockFactory {
     val options = new GridFSDownloadOptions()
     val clientSession = mock[ClientSession]
 
-    wrapper.expects(Symbol("downloadToPublisher"))(objectId).once()
-    wrapper.expects(Symbol("downloadToPublisher"))(bsonValue).once()
-    wrapper.expects(Symbol("downloadToPublisher"))(fileName).once()
-    wrapper.expects(Symbol("downloadToPublisher"))(fileName, options).once()
-
     gridFSBucket.downloadToObservable(objectId)
     gridFSBucket.downloadToObservable(bsonValue)
     gridFSBucket.downloadToObservable(fileName)
     gridFSBucket.downloadToObservable(fileName, options)
 
-    wrapper.expects(Symbol("downloadToPublisher"))(clientSession, objectId).once()
-    wrapper.expects(Symbol("downloadToPublisher"))(clientSession, bsonValue).once()
-    wrapper.expects(Symbol("downloadToPublisher"))(clientSession, fileName).once()
-    wrapper.expects(Symbol("downloadToPublisher"))(clientSession, fileName, options).once()
+    verify(wrapper).downloadToPublisher(objectId)
+    verify(wrapper).downloadToPublisher(bsonValue)
+    verify(wrapper).downloadToPublisher(fileName)
+    verify(wrapper).downloadToPublisher(fileName, options)
 
     gridFSBucket.downloadToObservable(clientSession, objectId)
     gridFSBucket.downloadToObservable(clientSession, bsonValue)
     gridFSBucket.downloadToObservable(clientSession, fileName)
     gridFSBucket.downloadToObservable(clientSession, fileName, options)
+
+    verify(wrapper).downloadToPublisher(clientSession, objectId)
+    verify(wrapper).downloadToPublisher(clientSession, bsonValue)
+    verify(wrapper).downloadToPublisher(clientSession, fileName)
+    verify(wrapper).downloadToPublisher(clientSession, fileName, options)
 
   }
 
@@ -159,25 +160,25 @@ class GridFSBucketSpec extends BaseSpec with MockFactory {
     val options = new GridFSUploadOptions()
     val clientSession = mock[ClientSession]
 
-    wrapper.expects(Symbol("uploadFromPublisher"))(fileName, publisher).once()
-    wrapper.expects(Symbol("uploadFromPublisher"))(fileName, publisher, options).once()
-    wrapper.expects(Symbol("uploadFromPublisher"))(bsonValue, fileName, publisher).once()
-    wrapper.expects(Symbol("uploadFromPublisher"))(bsonValue, fileName, publisher, options).once()
-
     gridFSBucket.uploadFromObservable(fileName, publisher)
     gridFSBucket.uploadFromObservable(fileName, publisher, options)
     gridFSBucket.uploadFromObservable(bsonValue, fileName, publisher)
     gridFSBucket.uploadFromObservable(bsonValue, fileName, publisher, options)
 
-    wrapper.expects(Symbol("uploadFromPublisher"))(clientSession, fileName, publisher).once()
-    wrapper.expects(Symbol("uploadFromPublisher"))(clientSession, fileName, publisher, options).once()
-    wrapper.expects(Symbol("uploadFromPublisher"))(clientSession, bsonValue, fileName, publisher).once()
-    wrapper.expects(Symbol("uploadFromPublisher"))(clientSession, bsonValue, fileName, publisher, options).once()
+    verify(wrapper).uploadFromPublisher(fileName, publisher)
+    verify(wrapper).uploadFromPublisher(fileName, publisher, options)
+    verify(wrapper).uploadFromPublisher(bsonValue, fileName, publisher)
+    verify(wrapper).uploadFromPublisher(bsonValue, fileName, publisher, options)
 
     gridFSBucket.uploadFromObservable(clientSession, fileName, publisher)
     gridFSBucket.uploadFromObservable(clientSession, fileName, publisher, options)
     gridFSBucket.uploadFromObservable(clientSession, bsonValue, fileName, publisher)
     gridFSBucket.uploadFromObservable(clientSession, bsonValue, fileName, publisher, options)
+
+    verify(wrapper).uploadFromPublisher(clientSession, fileName, publisher)
+    verify(wrapper).uploadFromPublisher(clientSession, fileName, publisher, options)
+    verify(wrapper).uploadFromPublisher(clientSession, bsonValue, fileName, publisher)
+    verify(wrapper).uploadFromPublisher(clientSession, bsonValue, fileName, publisher, options)
   }
 
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/gridfs/GridFSDownloadObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/gridfs/GridFSDownloadObservableSpec.scala
@@ -17,10 +17,11 @@
 package org.mongodb.scala.gridfs
 
 import com.mongodb.reactivestreams.client.gridfs.GridFSDownloadPublisher
+import org.mockito.Mockito.verify
 import org.mongodb.scala.BaseSpec
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
-class GridFSDownloadObservableSpec extends BaseSpec with MockFactory {
+class GridFSDownloadObservableSpec extends BaseSpec with MockitoSugar {
   val wrapper = mock[GridFSDownloadPublisher]
   val gridFSDownloadStream = GridFSDownloadObservable(wrapper)
 
@@ -37,11 +38,11 @@ class GridFSDownloadObservableSpec extends BaseSpec with MockFactory {
   it should "call the underlying methods" in {
     val bufferSizeBytes = 1024
 
-    wrapper.expects(Symbol("bufferSizeBytes"))(bufferSizeBytes).once()
-    wrapper.expects(Symbol("getGridFSFile"))().once()
-
     gridFSDownloadStream.bufferSizeBytes(bufferSizeBytes)
     gridFSDownloadStream.gridFSFile()
+
+    verify(wrapper).bufferSizeBytes(bufferSizeBytes)
+    verify(wrapper).getGridFSFile
   }
 
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/gridfs/GridFSFindObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/gridfs/GridFSFindObservableSpec.scala
@@ -45,7 +45,7 @@ class GridFSFindObservableSpec extends BaseSpec with MockitoSugar {
     val batchSize = 20
     val filter = Document("{a: 1}")
     val limit = 10
-    val maxTime = Duration(10, "second") //scalatyle:ignore
+    val maxTime = Duration(10, "second") // scalatyle:ignore
     val skip = 5
     val sort = Document("{_id: 1}")
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/gridfs/GridFSFindObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/gridfs/GridFSFindObservableSpec.scala
@@ -19,13 +19,14 @@ package org.mongodb.scala.gridfs
 import java.util.concurrent.TimeUnit
 
 import com.mongodb.reactivestreams.client.gridfs.GridFSFindPublisher
+import org.mockito.Mockito.verify
 import org.mongodb.scala.{ BaseSpec, Document }
 import org.reactivestreams.Publisher
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration.Duration
 
-class GridFSFindObservableSpec extends BaseSpec with MockFactory {
+class GridFSFindObservableSpec extends BaseSpec with MockitoSugar {
   val wrapper = mock[GridFSFindPublisher]
   val gridFSFindObservable = GridFSFindObservable(wrapper)
 
@@ -48,14 +49,6 @@ class GridFSFindObservableSpec extends BaseSpec with MockFactory {
     val skip = 5
     val sort = Document("{_id: 1}")
 
-    wrapper.expects(Symbol("batchSize"))(batchSize).once()
-    wrapper.expects(Symbol("filter"))(filter).once()
-    wrapper.expects(Symbol("limit"))(limit).once()
-    wrapper.expects(Symbol("maxTime"))(maxTime.toMillis, TimeUnit.MILLISECONDS).once()
-    wrapper.expects(Symbol("noCursorTimeout"))(true).once()
-    wrapper.expects(Symbol("skip"))(skip).once()
-    wrapper.expects(Symbol("sort"))(sort).once()
-
     gridFSFindObservable.batchSize(batchSize)
     gridFSFindObservable.filter(filter)
     gridFSFindObservable.limit(limit)
@@ -63,6 +56,14 @@ class GridFSFindObservableSpec extends BaseSpec with MockFactory {
     gridFSFindObservable.noCursorTimeout(true)
     gridFSFindObservable.skip(skip)
     gridFSFindObservable.sort(sort)
+
+    verify(wrapper).batchSize(batchSize)
+    verify(wrapper).filter(filter)
+    verify(wrapper).limit(limit)
+    verify(wrapper).maxTime(maxTime.toMillis, TimeUnit.MILLISECONDS)
+    verify(wrapper).noCursorTimeout(true)
+    verify(wrapper).skip(skip)
+    verify(wrapper).sort(sort)
   }
 
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/gridfs/GridFSUploadPublisherSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/gridfs/GridFSUploadPublisherSpec.scala
@@ -17,10 +17,11 @@
 package org.mongodb.scala.gridfs
 
 import com.mongodb.reactivestreams.client.gridfs.GridFSUploadPublisher
+import org.mockito.Mockito.verify
 import org.mongodb.scala.BaseSpec
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
-class GridFSUploadPublisherSpec extends BaseSpec with MockFactory {
+class GridFSUploadPublisherSpec extends BaseSpec with MockitoSugar {
   val wrapper = mock[GridFSUploadPublisher[Void]]
   val gridFSUploadObservable = GridFSUploadObservable(wrapper)
 
@@ -36,11 +37,11 @@ class GridFSUploadPublisherSpec extends BaseSpec with MockFactory {
 
   it should "call the underlying methods" in {
 
-    wrapper.expects(Symbol("getObjectId"))().once()
-    wrapper.expects(Symbol("getId"))().once()
-
     gridFSUploadObservable.objectId
     gridFSUploadObservable.id
+
+    verify(wrapper).getObjectId
+    verify(wrapper).getId
   }
 
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/internal/FlatMapObservableTest.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/internal/FlatMapObservableTest.scala
@@ -29,9 +29,7 @@ class FlatMapObservableTest extends BaseSpec with Futures with Eventually {
     val p = Promise[Unit]()
     val completedCounter = new AtomicInteger(0)
     Observable(1 to 100)
-      .flatMap(
-        x => createObservable(x)
-      )
+      .flatMap(x => createObservable(x))
       .subscribe(
         _ => (),
         e => p.failure(e),
@@ -47,13 +45,12 @@ class FlatMapObservableTest extends BaseSpec with Futures with Eventually {
     val p = Promise[Unit]()
     val errorCounter = new AtomicInteger(0)
     Observable(1 to 100)
-      .flatMap(
-        x =>
-          if (x > 10) {
-            throw new IllegalStateException("Fail")
-          } else {
-            createObservable(x)
-          }
+      .flatMap(x =>
+        if (x > 10) {
+          throw new IllegalStateException("Fail")
+        } else {
+          createObservable(x)
+        }
       )
       .subscribe(
         _ => (),

--- a/driver-scala/src/test/scala/org/mongodb/scala/internal/ObservableImplementationSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/internal/ObservableImplementationSpec.scala
@@ -222,21 +222,30 @@ class ObservableImplementationSpec extends BaseSpec with TableDrivenPropertyChec
     Table(
       "observable",
       TestObservable[Int](failOn = failOn),
-      AndThenObservable[Int, Int](TestObservable[Int](failOn = failOn), {
-        case Success(r)  => 1000
-        case Failure(ex) => 0
-      }),
+      AndThenObservable[Int, Int](
+        TestObservable[Int](failOn = failOn),
+        {
+          case Success(r)  => 1000
+          case Failure(ex) => 0
+        }
+      ),
       FilterObservable[Int](TestObservable[Int](failOn = failOn), (i: Int) => i % 2 != 0),
       FlatMapObservable[Int, Int](TestObservable[Int](), (i: Int) => TestObservable[Int](failOn = failOn)),
       FoldLeftObservable(TestObservable[Int](1 to 100, failOn = failOn), 0, (v: Int, i: Int) => v + i),
       MapObservable[Int, Int](TestObservable[Int](failOn = failOn), (i: Int) => i * 100),
       RecoverObservable[Int, Int](TestObservable[Int](failOn = failOn), { case e: ArithmeticException => 999 }),
-      RecoverWithObservable[Int, Int](TestObservable[Int](failOn = failOn), {
-        case e: ArithmeticException => TestObservable[Int]()
-      }),
-      RecoverWithObservable[Int, Int](TestObservable[Int](failOn = failOn), {
-        case e => TestObservable[Int](failOn = failOn)
-      }),
+      RecoverWithObservable[Int, Int](
+        TestObservable[Int](failOn = failOn),
+        {
+          case e: ArithmeticException => TestObservable[Int]()
+        }
+      ),
+      RecoverWithObservable[Int, Int](
+        TestObservable[Int](failOn = failOn),
+        {
+          case e => TestObservable[Int](failOn = failOn)
+        }
+      ),
       ZipObservable[Int, Int](TestObservable[Int](), TestObservable[Int](failOn = failOn)).map[Int](a => a._1),
       ZipObservable[Int, Int](TestObservable[Int](failOn = failOn), TestObservable[Int]()).map[Int](a => a._1)
     )
@@ -244,40 +253,59 @@ class ObservableImplementationSpec extends BaseSpec with TableDrivenPropertyChec
   private def failingFunctionsObservables =
     Table(
       "observable",
-      FilterObservable[Int](TestObservable[Int](), (i: Int) => {
-        if (i > 10) {
-          throw new RuntimeException("Error")
+      FilterObservable[Int](
+        TestObservable[Int](),
+        (i: Int) => {
+          if (i > 10) {
+            throw new RuntimeException("Error")
+          }
+          i % 2 == 0
         }
-        i % 2 == 0
-      }),
-      FlatMapObservable[Int, Int](TestObservable[Int](), (i: Int) => {
-        if (i > 10) {
-          throw new RuntimeException("Error")
+      ),
+      FlatMapObservable[Int, Int](
+        TestObservable[Int](),
+        (i: Int) => {
+          if (i > 10) {
+            throw new RuntimeException("Error")
+          }
+          TestObservable[Int](1 to 2)
         }
-        TestObservable[Int](1 to 2)
-      }),
-      FoldLeftObservable(TestObservable[Int](1 to 100), 0, (v: Int, i: Int) => {
-        if (i > 10) {
-          throw new RuntimeException("Error")
+      ),
+      FoldLeftObservable(
+        TestObservable[Int](1 to 100),
+        0,
+        (v: Int, i: Int) => {
+          if (i > 10) {
+            throw new RuntimeException("Error")
+          }
+          v + i
         }
-        v + i
-      }),
-      MapObservable[Int, Int](TestObservable[Int](), (i: Int) => {
-        if (i > 10) {
-          throw new RuntimeException("Error")
+      ),
+      MapObservable[Int, Int](
+        TestObservable[Int](),
+        (i: Int) => {
+          if (i > 10) {
+            throw new RuntimeException("Error")
+          }
+          i * 100
         }
-        i * 100
-      })
+      )
     )
 
   private def happyObservables =
     Table(
       ("observable", "observer"),
       (TestObservable[Int](), TestObserver[Int]()),
-      (AndThenObservable[Int, Int](TestObservable[Int](), {
-        case Success(r)  => 1000
-        case Failure(ex) => 0
-      }), TestObserver[Int]()),
+      (
+        AndThenObservable[Int, Int](
+          TestObservable[Int](),
+          {
+            case Success(r)  => 1000
+            case Failure(ex) => 0
+          }
+        ),
+        TestObserver[Int]()
+      ),
       (FilterObservable[Int](TestObservable[Int](), (i: Int) => i % 2 != 0), TestObserver[Int]()),
       (
         FlatMapObservable[Int, Int](TestObservable[Int](), (i: Int) => TestObservable[Int](1 to 1)),

--- a/driver-scala/src/test/scala/org/mongodb/scala/internal/ScalaObservableSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/internal/ScalaObservableSpec.scala
@@ -399,7 +399,10 @@ class ScalaObservableSpec extends BaseSpec {
       )
     }
 
-    Await.result(TestObservable[Int](Observable(List[Int]())).headOption(), Duration(10, TimeUnit.SECONDS)) should equal(
+    Await.result(
+      TestObservable[Int](Observable(List[Int]())).headOption(),
+      Duration(10, TimeUnit.SECONDS)
+    ) should equal(
       None
     )
   }
@@ -412,7 +415,9 @@ class ScalaObservableSpec extends BaseSpec {
       Await.result(TestObservable[Int](Observable[Int](1 to 10), failOn = 1).head(), Duration(10, TimeUnit.SECONDS))
     }
 
-    Option(Await.result(TestObservable[Int](Observable(List[Int]())).head(), Duration(10, TimeUnit.SECONDS))) should equal(
+    Option(
+      Await.result(TestObservable[Int](Observable(List[Int]())).head(), Duration(10, TimeUnit.SECONDS))
+    ) should equal(
       None
     )
   }

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
@@ -146,7 +146,9 @@ class AggregatesSpec extends BaseSpec {
       )
     )
 
-    toBson(graphLookup("contacts", "$friends", "friends", "name", "socialNetwork", GraphLookupOptions().maxDepth(1))) should equal(
+    toBson(
+      graphLookup("contacts", "$friends", "friends", "name", "socialNetwork", GraphLookupOptions().maxDepth(1))
+    ) should equal(
       Document(
         """{ $graphLookup: { from: "contacts", startWith: "$friends", connectFromField: "friends", connectToField: "name",
           |  as: "socialNetwork", maxDepth: 1 } }""".stripMargin

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/FiltersSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/FiltersSpec.scala
@@ -220,7 +220,9 @@ class FiltersSpec extends BaseSpec {
     toBson(model.Filters.text("mongoDB for GIANT ideas", new TextSearchOptions().caseSensitive(true))) should equal(
       Document("""{$text : {$search : "mongoDB for GIANT ideas", $caseSensitive : true} }""")
     )
-    toBson(model.Filters.text("mongoDB for GIANT ideas", new TextSearchOptions().diacriticSensitive(false))) should equal(
+    toBson(
+      model.Filters.text("mongoDB for GIANT ideas", new TextSearchOptions().diacriticSensitive(false))
+    ) should equal(
       Document("""{$text : {$search : "mongoDB for GIANT ideas", $diacriticSensitive : false} }""")
     )
     toBson(

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/ProjectionsSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/ProjectionsSpec.scala
@@ -58,7 +58,9 @@ class ProjectionsSpec extends BaseSpec {
   }
 
   it should "elemMatch" in {
-    toBson(model.Projections.elemMatch("x", Filters.and(model.Filters.eq("y", 1), model.Filters.eq("z", 2)))) should equal(
+    toBson(
+      model.Projections.elemMatch("x", Filters.and(model.Filters.eq("y", 1), model.Filters.eq("z", 2)))
+    ) should equal(
       Document("""{x : {$elemMatch : {$and: [{y : 1}, {z : 2}]}}}""")
     )
   }
@@ -77,7 +79,9 @@ class ProjectionsSpec extends BaseSpec {
   }
 
   it should "combine fields" in {
-    toBson(model.Projections.fields(model.Projections.include("x", "y"), model.Projections.exclude("_id"))) should equal(
+    toBson(
+      model.Projections.fields(model.Projections.include("x", "y"), model.Projections.exclude("_id"))
+    ) should equal(
       Document("""{x : 1, y : 1, _id : 0}""")
     )
     toBson(model.Projections.fields(model.Projections.include("x", "y"), model.Projections.exclude("x"))) should equal(

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/vault/ClientEncryptionSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/vault/ClientEncryptionSpec.scala
@@ -19,12 +19,14 @@ package org.mongodb.scala.model.vault
 import java.lang.reflect.Modifier.{ isPublic, isStatic }
 
 import com.mongodb.reactivestreams.client.vault.{ ClientEncryption => JClientEncryption }
+import org.mockito.ArgumentMatchers.{ any, same }
+import org.mockito.Mockito.verify
 import org.mongodb.scala.BaseSpec
 import org.mongodb.scala.bson.{ BsonBinary, BsonString }
 import org.mongodb.scala.vault.ClientEncryption
-import org.scalamock.scalatest.proxy.MockFactory
+import org.scalatestplus.mockito.MockitoSugar
 
-class ClientEncryptionSpec extends BaseSpec with MockFactory {
+class ClientEncryptionSpec extends BaseSpec with MockitoSugar {
 
   val wrapped = mock[JClientEncryption]
   val clientEncryption = ClientEncryption(wrapped)
@@ -47,26 +49,26 @@ class ClientEncryptionSpec extends BaseSpec with MockFactory {
     val kmsProvider = "kmsProvider"
     val options = DataKeyOptions()
 
-    wrapped.expects(Symbol("createDataKey"))(kmsProvider, *).once()
     clientEncryption.createDataKey(kmsProvider)
+    verify(wrapped).createDataKey(same(kmsProvider), any())
 
-    wrapped.expects(Symbol("createDataKey"))(kmsProvider, options).once()
     clientEncryption.createDataKey(kmsProvider, options)
+    verify(wrapped).createDataKey(kmsProvider, options)
   }
 
   it should "call encrypt" in {
     val bsonValue = BsonString("")
     val options = EncryptOptions("algorithm")
-    wrapped.expects(Symbol("encrypt"))(bsonValue, options).once()
-
     clientEncryption.encrypt(bsonValue, options)
+
+    verify(wrapped).encrypt(bsonValue, options)
   }
 
   it should "call decrypt" in {
     val bsonBinary = BsonBinary(Array[Byte](1, 2, 3))
-    wrapped.expects(Symbol("decrypt"))(bsonBinary).once()
-
     clientEncryption.decrypt(bsonBinary)
+
+    verify(wrapped).decrypt(bsonBinary)
   }
 
 }


### PR DESCRIPTION
The upgrade to scala 3 requires upgrading a few libraries to versions that have support for it. In this PR:
* scalatest is upgraded from 3.0.x to 3.2.x
* scalamock is replaced by the use of mockito directly since scalamock does yet support scala3 (see https://github.com/paulbutcher/ScalaMock/issues/429)
* scalafmt is upgraded from 2.x to 3.x trying to keep the old scalafmt configuration, and reducing the number of formatting changes.

