### PR TITLE
ByteBuffer is not released when compression is enabled, causing pool leakage

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -587,7 +587,6 @@ public class InternalStreamConnection implements InternalConnection {
         writeAsync(byteBuffers, errorHandlingCallback(callback, LOGGER));
     }
 
-    @SuppressWarnings("try")
     private void writeAsync(final List<ByteBuf> byteBuffers, final SingleResultCallback<Void> callback) {
         try {
             stream.writeAsync(byteBuffers, new AsyncCompletionHandler<Void>() {
@@ -603,14 +602,8 @@ public class InternalStreamConnection implements InternalConnection {
                 }
             });
         } catch (Throwable t) {
-            try (AutoCloseable second = () -> callback.onResult(null, t);
-                 AutoCloseable first = this::close) {
-                releaseAllBuffers(byteBuffers);
-            } catch (RuntimeException e) {
-                throw e;
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+            close();
+            callback.onResult(null, t);
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -733,6 +733,7 @@ public class InternalStreamConnection implements InternalConnection {
             ByteBuf buffer = getBuffer(compressedHeader.getUncompressedSize());
             compressor.uncompress(messageBuffer, buffer);
 
+            messageBuffer.release();
             buffer.flip();
             return new ResponseBuffers(new ReplyHeader(buffer, compressedHeader), buffer);
         } else {


### PR DESCRIPTION
Hey Mongo team.

My team experienced an increased number of failures caused by latency recently. Further investigation showed that InternalStreamConnection doesn't close buffers returned by PowerOfTwoBufferPool when compression is enabled. It leads to permits leakage. After INTEGER_MAX buffer retrievals buffer pool is fully exhausted and all following requests would be blocked indefinitely unless the thread gets interrupted. 

JAVA-4510