### PR TITLE
Support NEED_KMS_CREDENTIALS state for CSFLE

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -659,6 +659,17 @@ functions:
           set +o xtrace
           MONGODB_URI="${MONGODB_URI}" KMS_TLS_ERROR_TYPE=${KMS_TLS_ERROR_TYPE} .evergreen/run-kms-tls-tests.sh
 
+  "run-csfle-aws-from-environment-test":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          set +o xtrace
+          MONGODB_URI="${MONGODB_URI}" AWS_ACCESS_KEY_ID=${aws_access_key_id} AWS_SECRET_ACCESS_KEY=${aws_secret_access_key} \
+          .evergreen/run-csfle-aws-from-environment.sh
+
   "publish snapshot":
     - command: shell.exec
       type: test
@@ -1361,6 +1372,17 @@ tasks:
             TOPOLOGY: "server"
             AUTH: "noauth"
             SSL: "nossl"
+
+    - name: "test-csfle-aws-from-environment"
+      tags: ["csfle-aws-from-environment"]
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            TOPOLOGY: "server"
+            AUTH: "noauth"
+            SSL: "nossl"
+        - func: run-csfle-aws-from-environment-test
+
 axes:
   - id: version
     display_name: MongoDB Version
@@ -1772,3 +1794,9 @@ buildvariants:
   display_name: "CSFLE KMS TLS"
   tasks:
     - name: ".kms-tls"
+
+- matrix_name: "csfle-aws-from-environment-test"
+  matrix_spec: { os: "linux", version: [ "5.0" ], topology: ["standalone"] }
+  display_name: "CSFLE AWS From Environment"
+  tasks:
+    - name: ".csfle-aws-from-environment"

--- a/.evergreen/run-csfle-aws-from-environment.sh
+++ b/.evergreen/run-csfle-aws-from-environment.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Don't trace since the URI contains a password that shouldn't show up in the logs
+set -o errexit  # Exit the script with error if any of the commands fail
+
+# Supported/used environment variables:
+#       MONGODB_URI                 Set the suggested connection MONGODB_URI (including credentials and topology info)
+#       AWS_ACCESS_KEY_ID           The AWS access key identifier for client-side encryption
+#       AWS_SECRET_ACCESS_KEY       The AWS secret access key for client-side encryption
+
+############################################
+#            Main Program                  #
+############################################
+RELATIVE_DIR_PATH="$(dirname "${BASH_SOURCE:-$0}")"
+. "${RELATIVE_DIR_PATH}/javaConfig.bash"
+echo "Running CSFLE AWS from environment tests"
+
+./gradlew -version
+
+export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+
+./gradlew --stacktrace --info -Dorg.mongodb.test.uri=${MONGODB_URI} \
+    --no-build-cache driver-sync:cleanTest driver-sync:test --tests ClientSideEncryptionAwsCredentialFromEnvironmentTest
+first=$?
+echo $first
+
+./gradlew --stacktrace --info  -Dorg.mongodb.test.uri=${MONGODB_URI} \
+    --no-build-cache driver-reactive-streams:cleanTest driver-reactive-streams:test --tests ClientSideEncryptionAwsCredentialFromEnvironmentTest
+second=$?
+echo $second
+
+if [ $first -ne 0 ]; then
+   exit $first
+elif [ $second -ne 0 ]; then
+   exit $second
+else
+   exit 0
+fi

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
     nettyTcnativeBoringsslVersion = '2.0.46.Final'
     snappyVersion = '1.1.8.4'
     zstdVersion = '1.5.0-4'
-    mongoCryptVersion = '1.4.0-SNAPSHOT'
+    mongoCryptVersion = '1.4.0-alpha0'
     projectReactorVersion = 'Californium-SR23'
     junitBomVersion = '5.8.1'
     gitVersion = getGitVersion()
@@ -73,7 +73,6 @@ configure(coreProjects) {
         mavenLocal()
         google()
         mavenCentral()
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/"}
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
     nettyTcnativeBoringsslVersion = '2.0.46.Final'
     snappyVersion = '1.1.8.4'
     zstdVersion = '1.5.0-4'
-    mongoCryptVersion = '1.3.0'
+    mongoCryptVersion = '1.4.0-SNAPSHOT'
     projectReactorVersion = 'Californium-SR23'
     junitBomVersion = '5.8.1'
     gitVersion = getGitVersion()

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ configure(coreProjects) {
         mavenLocal()
         google()
         mavenCentral()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots/"}
     }
 }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypt.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypt.java
@@ -63,6 +63,7 @@ public class Crypt implements Closeable {
      * Create an instance to use for explicit encryption and decryption, and data key creation.
      *
      * @param mongoCrypt           the mongoCrypt wrapper
+     * @param kmsProviders         the kms providers
      * @param keyRetriever         the key retriever
      * @param keyManagementService the key management service
      */

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypt.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypt.java
@@ -29,6 +29,7 @@ import com.mongodb.crypt.capi.MongoExplicitEncryptOptions;
 import com.mongodb.crypt.capi.MongoKeyDecryptor;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
+import com.mongodb.internal.capi.MongoCryptHelper;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.MongoClient;
 import org.bson.BsonBinary;
@@ -39,6 +40,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.MonoSink;
 
 import java.io.Closeable;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.notNull;
@@ -48,6 +50,7 @@ import static java.lang.String.format;
 public class Crypt implements Closeable {
     private static final Logger LOGGER = Loggers.getLogger("client");
     private final MongoCrypt mongoCrypt;
+    private final Map<String, Map<String, Object>> kmsProviders;
     private final CollectionInfoRetriever collectionInfoRetriever;
     private final CommandMarker commandMarker;
     private final KeyRetriever keyRetriever;
@@ -63,8 +66,9 @@ public class Crypt implements Closeable {
      * @param keyRetriever         the key retriever
      * @param keyManagementService the key management service
      */
-    Crypt(final MongoCrypt mongoCrypt, final KeyRetriever keyRetriever, final KeyManagementService keyManagementService) {
-        this(mongoCrypt, null, null, keyRetriever, keyManagementService, false, null);
+    Crypt(final MongoCrypt mongoCrypt, final Map<String, Map<String, Object>> kmsProviders, final KeyRetriever keyRetriever,
+            final KeyManagementService keyManagementService) {
+        this(mongoCrypt, kmsProviders, null, null, keyRetriever, keyManagementService, false, null);
     }
 
     /**
@@ -77,6 +81,7 @@ public class Crypt implements Closeable {
      * @param commandMarker           the command marker
      */
     Crypt(final MongoCrypt mongoCrypt,
+          final Map<String, Map<String, Object>> kmsProviders,
           @Nullable final CollectionInfoRetriever collectionInfoRetriever,
           @Nullable final CommandMarker commandMarker,
           final KeyRetriever keyRetriever,
@@ -84,6 +89,7 @@ public class Crypt implements Closeable {
           final boolean bypassAutoEncryption,
           @Nullable final MongoClient internalClient) {
         this.mongoCrypt = mongoCrypt;
+        this.kmsProviders = kmsProviders;
         this.collectionInfoRetriever = collectionInfoRetriever;
         this.commandMarker = commandMarker;
         this.keyRetriever = keyRetriever;
@@ -213,6 +219,9 @@ public class Crypt implements Closeable {
             case NEED_MONGO_MARKINGS:
                 mark(cryptContext, databaseName, sink);
                 break;
+            case NEED_KMS_CREDENTIALS:
+                fetchCredentials(cryptContext, databaseName, sink);
+                break;
             case NEED_MONGO_KEYS:
                 fetchKeys(cryptContext, databaseName, sink);
                 break;
@@ -224,6 +233,16 @@ public class Crypt implements Closeable {
                 break;
             default:
                 sink.error(new MongoInternalException("Unsupported encryptor state + " + state));
+        }
+    }
+
+    private void fetchCredentials(final MongoCryptContext cryptContext, @Nullable final String databaseName,
+            final MonoSink<RawBsonDocument> sink) {
+        try {
+            cryptContext.provideKmsProviderCredentials(MongoCryptHelper.fetchCredentials(kmsProviders));
+            executeStateMachineWithSink(cryptContext, databaseName, sink);
+        } catch (Exception e) {
+            sink.error(e);
         }
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypts.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypts.java
@@ -52,6 +52,7 @@ public final class Crypts {
                 ? internalClient : MongoClients.create(keyVaultMongoClientSettings);
         return new Crypt(MongoCrypts.create(createMongoCryptOptions(options.getKmsProviders(),
                 options.getSchemaMap())),
+                options.getKmsProviders(),
                 options.isBypassAutoEncryption() ? null : new CollectionInfoRetriever(collectionInfoRetrieverClient),
                 new CommandMarker(options.isBypassAutoEncryption(), options.getExtraOptions()),
                 new KeyRetriever(keyVaultClient, new MongoNamespace(options.getKeyVaultNamespace())),
@@ -63,6 +64,7 @@ public final class Crypts {
     public static Crypt create(final MongoClient keyVaultClient, final ClientEncryptionSettings options) {
         return new Crypt(MongoCrypts.create(
                 createMongoCryptOptions(options.getKmsProviders(), null)),
+                         options.getKmsProviders(),
                          new KeyRetriever(keyVaultClient, new MongoNamespace(options.getKeyVaultNamespace())),
                          createKeyManagementService(options.getKmsProviderSslContextMap()));
     }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionAwsCredentialFromEnvironmentTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionAwsCredentialFromEnvironmentTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client;
+
+import com.mongodb.ClientEncryptionSettings;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.AbstractClientSideEncryptionAwsCredentialFromEnvironmentTest;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.vault.ClientEncryption;
+import com.mongodb.lang.NonNull;
+import com.mongodb.reactivestreams.client.syncadapter.SyncClientEncryption;
+import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
+import com.mongodb.reactivestreams.client.vault.ClientEncryptions;
+
+public class ClientSideEncryptionAwsCredentialFromEnvironmentTest extends AbstractClientSideEncryptionAwsCredentialFromEnvironmentTest {
+    @Override
+    @NonNull
+    protected ClientEncryption createClientEncryption(@NonNull final ClientEncryptionSettings settings) {
+        return new SyncClientEncryption(ClientEncryptions.create(settings));
+    }
+
+    @Override
+    @NonNull
+    protected MongoClient createMongoClient(@NonNull final MongoClientSettings settings) {
+        return new SyncMongoClient(MongoClients.create(settings));
+    }
+}

--- a/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
@@ -59,6 +59,7 @@ class Crypt implements Closeable {
      * Create an instance to use for explicit encryption and decryption, and data key creation.
      *
      * @param mongoCrypt the mongoCrypt wrapper
+     * @param kmsProviders the kms providers
      * @param keyRetriever the key retriever
      * @param keyManagementService the key management service
      */

--- a/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
@@ -28,6 +28,7 @@ import com.mongodb.crypt.capi.MongoCryptException;
 import com.mongodb.crypt.capi.MongoDataKeyOptions;
 import com.mongodb.crypt.capi.MongoExplicitEncryptOptions;
 import com.mongodb.crypt.capi.MongoKeyDecryptor;
+import com.mongodb.internal.capi.MongoCryptHelper;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonBinary;
 import org.bson.BsonDocument;
@@ -38,6 +39,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Map;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.crypt.capi.MongoCryptContext.State;
@@ -45,6 +47,7 @@ import static com.mongodb.crypt.capi.MongoCryptContext.State;
 class Crypt implements Closeable {
 
     private final MongoCrypt mongoCrypt;
+    private final Map<String, Map<String, Object>> kmsProviders;
     private final CollectionInfoRetriever collectionInfoRetriever;
     private final CommandMarker commandMarker;
     private final KeyRetriever keyRetriever;
@@ -59,23 +62,27 @@ class Crypt implements Closeable {
      * @param keyRetriever the key retriever
      * @param keyManagementService the key management service
      */
-    Crypt(final MongoCrypt mongoCrypt, final KeyRetriever keyRetriever, final KeyManagementService keyManagementService) {
-        this(mongoCrypt, null, null, keyRetriever, keyManagementService, false, null);
+    Crypt(final MongoCrypt mongoCrypt, final Map<String, Map<String, Object>> kmsProviders, final KeyRetriever keyRetriever,
+            final KeyManagementService keyManagementService) {
+        this(mongoCrypt, kmsProviders, null, null, keyRetriever, keyManagementService, false, null);
     }
 
     /**
      * Create an instance to use for auto-encryption and auto-decryption.
-     *
-     * @param mongoCrypt the mongoCrypt wrapper
-     * @param keyRetriever the key retriever
-     * @param keyManagementService the key management service
+     *  @param mongoCrypt the mongoCrypt wrapper
+     * @param kmsProviders the KMS provider credentials
      * @param collectionInfoRetriever the collection info retriever
      * @param commandMarker the command marker
+     * @param keyRetriever the key retriever
+     * @param keyManagementService the key management service
      */
-    Crypt(final MongoCrypt mongoCrypt, @Nullable final CollectionInfoRetriever collectionInfoRetriever,
-          @Nullable final CommandMarker commandMarker, final KeyRetriever keyRetriever,
-          final KeyManagementService keyManagementService, final boolean bypassAutoEncryption, @Nullable final MongoClient internalClient) {
+    Crypt(final MongoCrypt mongoCrypt, final Map<String, Map<String, Object>> kmsProviders,
+            @Nullable final CollectionInfoRetriever collectionInfoRetriever,
+            @Nullable final CommandMarker commandMarker, final KeyRetriever keyRetriever,
+            final KeyManagementService keyManagementService, final boolean bypassAutoEncryption,
+            @Nullable final MongoClient internalClient) {
         this.mongoCrypt = mongoCrypt;
+        this.kmsProviders = kmsProviders;
         this.collectionInfoRetriever = collectionInfoRetriever;
         this.commandMarker = commandMarker;
         this.keyRetriever = keyRetriever;
@@ -241,6 +248,9 @@ class Crypt implements Closeable {
                 case NEED_MONGO_MARKINGS:
                     mark(cryptContext, databaseName);
                     break;
+                case NEED_KMS_CREDENTIALS:
+                    fetchCredentials(cryptContext);
+                    break;
                 case NEED_MONGO_KEYS:
                     fetchKeys(cryptContext);
                     break;
@@ -253,6 +263,10 @@ class Crypt implements Closeable {
                     throw new MongoInternalException("Unsupported encryptor state + " + state);
             }
         }
+    }
+
+    private void fetchCredentials(final MongoCryptContext cryptContext) {
+        cryptContext.provideKmsProviderCredentials(MongoCryptHelper.fetchCredentials(kmsProviders));
     }
 
     private void collInfo(final MongoCryptContext cryptContext, final String databaseName) {

--- a/driver-sync/src/main/com/mongodb/client/internal/Crypts.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypts.java
@@ -46,6 +46,7 @@ public final class Crypts {
                 ? internalClient : MongoClients.create(keyVaultMongoClientSettings);
         return new Crypt(MongoCrypts.create(createMongoCryptOptions(options.getKmsProviders(),
                 options.getSchemaMap())),
+                options.getKmsProviders(),
                 options.isBypassAutoEncryption() ? null : new CollectionInfoRetriever(collectionInfoRetrieverClient),
                 new CommandMarker(options.isBypassAutoEncryption(), options.getExtraOptions()),
                 new KeyRetriever(keyVaultClient, new MongoNamespace(options.getKeyVaultNamespace())),
@@ -57,6 +58,7 @@ public final class Crypts {
     static Crypt create(final MongoClient keyVaultClient, final ClientEncryptionSettings options) {
         return new Crypt(MongoCrypts.create(
                 createMongoCryptOptions(options.getKmsProviders(), null)),
+                options.getKmsProviders(),
                 createKeyRetriever(keyVaultClient, options.getKeyVaultNamespace()),
                 createKeyManagementService(options.getKmsProviderSslContextMap()));
     }

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionAwsCredentialFromEnvironmentTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionAwsCredentialFromEnvironmentTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.AutoEncryptionSettings;
+import com.mongodb.ClientEncryptionSettings;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.model.vault.DataKeyOptions;
+import com.mongodb.client.vault.ClientEncryption;
+import org.bson.BsonBinary;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public abstract class AbstractClientSideEncryptionAwsCredentialFromEnvironmentTest {
+    protected abstract ClientEncryption createClientEncryption(ClientEncryptionSettings settings);
+
+    protected abstract MongoClient createMongoClient(MongoClientSettings settings);
+
+    @Test
+    public void testGetCredentialsFromEnvironment() {
+        assumeTrue(serverVersionAtLeast(4, 2));
+        assumeTrue(System.getenv().containsKey("AWS_ACCESS_KEY_ID"));
+
+        Map<String, Map<String, Object>> kmsProviders = new HashMap<String, Map<String, Object>>() {{
+            put("aws", new HashMap<>());
+        }};
+
+        try (ClientEncryption clientEncryption = createClientEncryption(ClientEncryptionSettings.builder()
+                .keyVaultNamespace("test.datakeys")
+                .kmsProviders(kmsProviders)
+                .keyVaultMongoClientSettings(Fixture.getMongoClientSettings())
+                .build())) {
+
+            // If this succeeds, then it means credentials have been fetched from the environment as expected
+            BsonBinary dataKeyId = clientEncryption.createDataKey("aws", new DataKeyOptions().masterKey(
+                    BsonDocument.parse("{"
+                            + "region: \"us-east-1\", "
+                            + "key: \"arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0\"}")));
+
+            String base64DataKeyId = Base64.getEncoder().encodeToString(dataKeyId.getData());
+
+            Map<String, BsonDocument> schemaMap = new HashMap<>();
+            schemaMap.put("test.coll", BsonDocument.parse("{"
+                    + "  properties: {"
+                    + "    encryptedField: {"
+                    + "      encrypt: {"
+                    + "        keyId: [{"
+                    + "          \"$binary\": {"
+                    + "            \"base64\": \"" + base64DataKeyId + "\","
+                    + "            \"subType\": \"04\""
+                    + "          }"
+                    + "        }],"
+                    + "        bsonType: \"string\","
+                    + "        algorithm: \"AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic\""
+                    + "      }"
+                    + "    }"
+                    + "  },"
+                    + "  \"bsonType\": \"object\""
+                    + "}"));
+            AutoEncryptionSettings autoEncryptionSettings = AutoEncryptionSettings.builder()
+                    .kmsProviders(kmsProviders)
+                    .keyVaultNamespace("test.datakeys")
+                    .schemaMap(schemaMap)
+                    .build();
+            try (MongoClient client = createMongoClient(getMongoClientSettingsBuilder()
+                    .autoEncryptionSettings(autoEncryptionSettings)
+                    .build())) {
+                // If this succeeds, then it means credentials have been fetched from the environment as expected
+                client.getDatabase("test").getCollection("coll")
+                        .insertOne(new Document("encryptedField", "encryptMe"));
+            }
+        }
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionAwsCredentialFromEnvironmentTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionAwsCredentialFromEnvironmentTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.ClientEncryptionSettings;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.vault.ClientEncryption;
+import com.mongodb.client.vault.ClientEncryptions;
+
+public class ClientSideEncryptionAwsCredentialFromEnvironmentTest extends AbstractClientSideEncryptionAwsCredentialFromEnvironmentTest {
+    @Override
+    protected ClientEncryption createClientEncryption(final ClientEncryptionSettings settings) {
+        return ClientEncryptions.create(settings);
+    }
+
+    @Override
+    protected MongoClient createMongoClient(final MongoClientSettings settings) {
+        return MongoClients.create(settings);
+    }
+}


### PR DESCRIPTION
Links useful for reviewers:

- [Summary of changes for bindings and drivers to add support for on-demand credentials in AWS](https://jira.mongodb.org/browse/MONGOCRYPT-382?focusedCommentId=4401229&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4401229).
- [New mongodb-crypt API](https://github.com/mongodb/libmongocrypt/commit/a6a17a052e86a21910d9e924923c183919797fc7).

JAVA-4503