### PR TITLE
Exclude javax.annotation.* from OSGi imports

### DIFF
--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -66,6 +66,7 @@ afterEvaluate {
     jar.manifest.attributes['Import-Package'] = [
             '!sun.misc.*',  // Used by DirectBufferDeallocator only for java 8
             '!sun.nio.ch.*',  // Used by DirectBufferDeallocator only for java 8
+            '!javax.annotation.*', // Brought in by com.google.code.findbugs:annotations
             'io.netty.*;resolution:=optional',
             'org.xerial.snappy.*;resolution:=optional',
             'com.github.luben.zstd.*;resolution:=optional',


### PR DESCRIPTION
JAVA-4505

Examined the MANIFEST.MF after publishing to Maven local and no longer see `javax.annotation`.