### PR TITLE
Improve info-level logging for MongoClient construction 

### DIFF
--- a/bson/src/main/org/bson/codecs/BsonCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/BsonCodecProvider.java
@@ -35,4 +35,9 @@ public class BsonCodecProvider implements CodecProvider {
         }
         return null;
     }
+
+    @Override
+    public String toString() {
+        return "BsonCodecProvider{}";
+    }
 }

--- a/bson/src/main/org/bson/codecs/BsonValueCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/BsonValueCodecProvider.java
@@ -170,4 +170,9 @@ public class BsonValueCodecProvider implements CodecProvider {
 
         DEFAULT_BSON_TYPE_CLASS_MAP = new BsonTypeClassMap(map);
     }
+
+    @Override
+    public String toString() {
+        return "BsonValueCodecProvider{}";
+    }
 }

--- a/bson/src/main/org/bson/codecs/DocumentCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/DocumentCodecProvider.java
@@ -115,4 +115,9 @@ public class DocumentCodecProvider implements CodecProvider {
         result = 31 * result + (valueTransformer != null ? valueTransformer.hashCode() : 0);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "DocumentCodecProvider{}";
+    }
 }

--- a/bson/src/main/org/bson/codecs/EnumCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/EnumCodecProvider.java
@@ -33,4 +33,9 @@ public final class EnumCodecProvider implements CodecProvider {
         }
         return null;
     }
+
+    @Override
+    public String toString() {
+        return "EnumCodecProvider{}";
+    }
 }

--- a/bson/src/main/org/bson/codecs/IterableCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/IterableCodecProvider.java
@@ -108,4 +108,9 @@ public class IterableCodecProvider implements CodecProvider {
         result = 31 * result + (valueTransformer != null ? valueTransformer.hashCode() : 0);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "IterableCodecProvider{}";
+    }
 }

--- a/bson/src/main/org/bson/codecs/JsonObjectCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/JsonObjectCodecProvider.java
@@ -35,4 +35,9 @@ public final class JsonObjectCodecProvider implements CodecProvider {
         }
         return null;
     }
+
+    @Override
+    public String toString() {
+        return "JsonObjectCodecProvider{}";
+    }
 }

--- a/bson/src/main/org/bson/codecs/MapCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/MapCodecProvider.java
@@ -108,4 +108,9 @@ public class MapCodecProvider implements CodecProvider {
         result = 31 * result + (valueTransformer != null ? valueTransformer.hashCode() : 0);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "MapCodecProvider{}";
+    }
 }

--- a/bson/src/main/org/bson/codecs/ValueCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/ValueCodecProvider.java
@@ -117,4 +117,9 @@ public class ValueCodecProvider implements CodecProvider {
     public int hashCode() {
         return 0;
     }
+
+    @Override
+    public String toString() {
+        return "ValueCodecProvider{}";
+    }
 }

--- a/bson/src/main/org/bson/codecs/configuration/MapOfCodecsProvider.java
+++ b/bson/src/main/org/bson/codecs/configuration/MapOfCodecsProvider.java
@@ -37,4 +37,10 @@ final class MapOfCodecsProvider implements CodecProvider {
         return (Codec<T>) codecsMap.get(clazz);
     }
 
+    @Override
+    public String toString() {
+        return "MapOfCodecsProvider{"
+                + "codecsMap=" + codecsMap
+                + '}';
+    }
 }

--- a/bson/src/main/org/bson/codecs/jsr310/Jsr310CodecProvider.java
+++ b/bson/src/main/org/bson/codecs/jsr310/Jsr310CodecProvider.java
@@ -56,4 +56,9 @@ public class Jsr310CodecProvider implements CodecProvider {
     public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
         return (Codec<T>) JSR310_CODEC_MAP.get(clazz);
     }
+
+    @Override
+    public String toString() {
+        return "Jsr310CodecProvider{}";
+    }
 }

--- a/bson/src/main/org/bson/internal/OverridableUuidRepresentationCodecRegistry.java
+++ b/bson/src/main/org/bson/internal/OverridableUuidRepresentationCodecRegistry.java
@@ -95,4 +95,12 @@ public class OverridableUuidRepresentationCodecRegistry implements CycleDetectin
         result = 31 * result + uuidRepresentation.hashCode();
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "OverridableUuidRepresentationCodecRegistry{"
+                + "wrapped=" + wrapped
+                + ", uuidRepresentation=" + uuidRepresentation
+                + '}';
+    }
 }

--- a/bson/src/main/org/bson/internal/ProvidersCodecRegistry.java
+++ b/bson/src/main/org/bson/internal/ProvidersCodecRegistry.java
@@ -89,4 +89,11 @@ public final class ProvidersCodecRegistry implements CodecRegistry, CycleDetecti
     public int hashCode() {
         return codecProviders.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return "ProvidersCodecRegistry{"
+                + "codecProviders=" + codecProviders
+                + '}';
+    }
 }

--- a/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
+++ b/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
@@ -359,4 +359,9 @@ public final class AutoEncryptionSettings {
         this.extraOptions = notNull("extraOptions", builder.extraOptions);
         this.bypassAutoEncryption = builder.bypassAutoEncryption;
     }
+
+    @Override
+    public String toString() {
+        return "AutoEncryptionSettings{<hidden>}";
+    }
 }

--- a/driver-core/src/main/com/mongodb/DBObjectCodecProvider.java
+++ b/driver-core/src/main/com/mongodb/DBObjectCodecProvider.java
@@ -88,4 +88,9 @@ public class DBObjectCodecProvider implements CodecProvider {
     public int hashCode() {
         return getClass().hashCode();
     }
+
+    @Override
+    public String toString() {
+        return "DBObjectCodecProvider{}";
+    }
 }

--- a/driver-core/src/main/com/mongodb/DBRefCodecProvider.java
+++ b/driver-core/src/main/com/mongodb/DBRefCodecProvider.java
@@ -54,4 +54,9 @@ public class DBRefCodecProvider implements CodecProvider {
     public int hashCode() {
         return 0;
     }
+
+    @Override
+    public String toString() {
+        return "DBRefCodecProvider{}";
+    }
 }

--- a/driver-core/src/main/com/mongodb/MongoClientSettings.java
+++ b/driver-core/src/main/com/mongodb/MongoClientSettings.java
@@ -893,8 +893,6 @@ public final class MongoClientSettings {
                 + ", uuidRepresentation=" + uuidRepresentation
                 + ", serverApi=" + serverApi
                 + ", autoEncryptionSettings=" + autoEncryptionSettings
-                + ", heartbeatSocketTimeoutSetExplicitly=" + heartbeatSocketTimeoutSetExplicitly
-                + ", heartbeatConnectTimeoutSetExplicitly=" + heartbeatConnectTimeoutSetExplicitly
                 + ", contextProvider=" + contextProvider
                 + '}';
     }

--- a/driver-core/src/main/com/mongodb/ReadConcern.java
+++ b/driver-core/src/main/com/mongodb/ReadConcern.java
@@ -134,6 +134,14 @@ public final class ReadConcern {
         return level != null ? level.hashCode() : 0;
     }
 
+
+    @Override
+    public String toString() {
+        return "ReadConcern{"
+                + "level=" + level
+                + '}';
+    }
+
     private ReadConcern() {
         this.level = null;
     }

--- a/driver-core/src/main/com/mongodb/WriteConcern.java
+++ b/driver-core/src/main/com/mongodb/WriteConcern.java
@@ -332,7 +332,7 @@ public class WriteConcern implements Serializable {
 
     @Override
     public String toString() {
-        return "WriteConcern{w=" + w + ", wTimeout=" + wTimeoutMS + " ms, journal=" + journal;
+        return "WriteConcern{w=" + w + ", wTimeout=" + wTimeoutMS + " ms, journal=" + journal + "}";
 
     }
 

--- a/driver-core/src/main/com/mongodb/client/gridfs/codecs/GridFSFileCodecProvider.java
+++ b/driver-core/src/main/com/mongodb/client/gridfs/codecs/GridFSFileCodecProvider.java
@@ -37,4 +37,9 @@ public final class GridFSFileCodecProvider implements CodecProvider {
             return null;
         }
     }
+
+    @Override
+    public String toString() {
+        return "GridFSFileCodecProvider{}";
+    }
 }

--- a/driver-core/src/main/com/mongodb/client/model/geojson/codecs/GeoJsonCodecProvider.java
+++ b/driver-core/src/main/com/mongodb/client/model/geojson/codecs/GeoJsonCodecProvider.java
@@ -60,4 +60,9 @@ public class GeoJsonCodecProvider implements CodecProvider {
 
         return null;
     }
+
+    @Override
+    public String toString() {
+        return "GeoJsonCodecProvider{}";
+    }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
@@ -73,10 +73,6 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
         isTrue("connection mode is multiple", settings.getMode() == ClusterConnectionMode.MULTIPLE);
         clusterType = settings.getRequiredClusterType();
         replicaSetName = settings.getRequiredReplicaSetName();
-
-        if (LOGGER.isInfoEnabled()) {
-            LOGGER.info(format("Cluster created with settings %s", settings.getShortDescription()));
-        }
     }
 
     ClusterType getClusterType() {

--- a/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
@@ -51,10 +51,6 @@ public final class SingleServerCluster extends BaseCluster {
         isTrue("one server in a direct cluster", settings.getHosts().size() == 1);
         isTrue("connection mode is single", settings.getMode() == ClusterConnectionMode.SINGLE);
 
-        if (LOGGER.isInfoEnabled()) {
-            LOGGER.info(format("Cluster created with settings %s", settings.getShortDescription()));
-        }
-
         server = new AtomicReference<>();
         // synchronized in the constructor because the change listener is re-entrant to this instance.
         // In other words, we are leaking a reference to "this" from the constructor.

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoClients.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoClients.java
@@ -134,7 +134,8 @@ public final class MongoClients {
     private static MongoClient createMongoClient(final MongoClientSettings settings,
             @Nullable final MongoDriverInformation mongoDriverInformation, final StreamFactory streamFactory,
             final StreamFactory heartbeatStreamFactory, @Nullable final Closeable externalResourceCloser) {
-        return new MongoClientImpl(settings, createCluster(settings, wrapMongoDriverInformation(mongoDriverInformation),
+        MongoDriverInformation wrappedMongoDriverInformation = wrapMongoDriverInformation(mongoDriverInformation);
+        return new MongoClientImpl(settings, wrappedMongoDriverInformation, createCluster(settings, wrappedMongoDriverInformation,
                 streamFactory, heartbeatStreamFactory), externalResourceCloser);
     }
 

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoClientImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoClientImplTest.java
@@ -18,6 +18,7 @@ package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.ClientSessionOptions;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.ReadConcern;
 import com.mongodb.ServerAddress;
 import com.mongodb.TransactionOptions;
@@ -216,6 +217,7 @@ public class MongoClientImplTest extends TestHelper {
     }
 
     private MongoClientImpl createMongoClient() {
-        return new MongoClientImpl(MongoClientSettings.builder().build(), mock(Cluster.class), OPERATION_EXECUTOR);
+        return new MongoClientImpl(MongoClientSettings.builder().build(),
+                MongoDriverInformation.builder().driverName("reactive-streams").build(), mock(Cluster.class), OPERATION_EXECUTOR);
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoClientImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoClientImpl.java
@@ -36,6 +36,8 @@ import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.SocketStreamFactory;
 import com.mongodb.connection.StreamFactory;
 import com.mongodb.connection.StreamFactoryFactory;
+import com.mongodb.diagnostics.logging.Logger;
+import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.internal.client.model.changestream.ChangeStreamLevel;
 import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.DefaultClusterFactory;
@@ -52,10 +54,13 @@ import java.util.List;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.client.internal.Crypts.createCrypt;
+import static com.mongodb.internal.connection.ClientMetadataHelper.createClientMetadataDocument;
 import static com.mongodb.internal.event.EventListenerHelper.getCommandListener;
+import static java.lang.String.format;
 import static org.bson.codecs.configuration.CodecRegistries.withUuidRepresentation;
 
 public final class MongoClientImpl implements MongoClient {
+    private static final Logger LOGGER = Loggers.getLogger("client");
 
     private final MongoClientSettings settings;
     private final MongoDriverInformation mongoDriverInformation;
@@ -79,6 +84,8 @@ public final class MongoClientImpl implements MongoClient {
                 withUuidRepresentation(settings.getCodecRegistry(), settings.getUuidRepresentation()), this, operationExecutor,
                 autoEncryptionSettings == null ? null : createCrypt(this, autoEncryptionSettings), settings.getServerApi(),
                 (SynchronousContextProvider) settings.getContextProvider());
+        LOGGER.info(format("MongoClient with metadata %s created with settings %s",
+                createClientMetadataDocument(settings.getApplicationName(), mongoDriverInformation).toJson(), settings));
     }
 
     @Override


### PR DESCRIPTION
- Fix/update/add toString methods for classes referenced by MongoClientSettings
- include client metadata document as JSON
- include MongoClientSettings#toString

JAVA-4439

Sample log message with default settings:

```
10:48:53.340 [Test worker] INFO  org.mongodb.driver.client - MongoClient with metadata 
{"driver": {"name": "mongo-java-driver|sync", "version": "4.5.0"}, "os": {"type": "Darwin", "name": "Mac OS X", "architecture": "x86_64", "version": "11.6.4"}, "platform": "Java/Oracle Corporation/17+35-LTS-2724"} 
created with settings 
MongoClientSettings{readPreference=ReadPreference{name=secondary, hedgeOptions=null}, writeConcern=WriteConcern{w=majority, wTimeout=null ms, journal=null}, retryWrites=true, retryReads=true, readConcern=ReadConcern{level=MAJORITY}, credential=null, streamFactoryFactory=null, commandListeners=[], codecRegistry=ProvidersCodecRegistry{codecProviders=[ValueCodecProvider{}]}, clusterSettings={hosts=[127.0.0.1:27017], srvServiceName=mongodb, mode=SINGLE, requiredClusterType=UNKNOWN, requiredReplicaSetName='null', serverSelector='null', clusterListeners='[]', serverSelectionTimeout='30000 ms', localThreshold='30000 ms'}, socketSettings=SocketSettings{connectTimeoutMS=10000, readTimeoutMS=0, receiveBufferSize=0, sendBufferSize=0}, heartbeatSocketSettings=SocketSettings{connectTimeoutMS=10000, readTimeoutMS=10000, receiveBufferSize=0, sendBufferSize=0}, connectionPoolSettings=ConnectionPoolSettings{maxSize=100, minSize=0, maxWaitTimeMS=120000, maxConnectionLifeTimeMS=0, maxConnectionIdleTimeMS=0, maintenanceInitialDelayMS=0, maintenanceFrequencyMS=60000, connectionPoolListeners=[], maxConnecting=2}, serverSettings=ServerSettings{heartbeatFrequencyMS=10000, minHeartbeatFrequencyMS=500, serverListeners='[]', serverMonitorListeners='[]'}, sslSettings=SslSettings{enabled=false, invalidHostNameAllowed=false, context=null}, applicationName='null', compressorList=[], uuidRepresentation=UNSPECIFIED, serverApi=null, autoEncryptionSettings=null, contextProvider=null}
```