### PR TITLE
Update documentation URIs

### DIFF
--- a/util/taglets/src/main/DochubTaglet.java
+++ b/util/taglets/src/main/DochubTaglet.java
@@ -28,7 +28,7 @@ public class DochubTaglet extends DocTaglet {
 
     @Override
     protected String getBaseDocURI() {
-        return "http://dochub.mongodb.org/";
+        return "https://dochub.mongodb.org/";
     }
 
 }

--- a/util/taglets/src/main/ManualTaglet.java
+++ b/util/taglets/src/main/ManualTaglet.java
@@ -28,7 +28,7 @@ public class ManualTaglet extends DocTaglet {
 
     @Override
     protected String getBaseDocURI() {
-        return "http://docs.mongodb.org/manual/";
+        return "https://www.mongodb.com/docs/manual/";
     }
 
 }

--- a/util/taglets/src/main/ServerReleaseTaglet.java
+++ b/util/taglets/src/main/ServerReleaseTaglet.java
@@ -28,7 +28,7 @@ public class ServerReleaseTaglet extends DocTaglet {
 
     @Override
     protected String getBaseDocURI() {
-        return "http://docs.mongodb.org/manual/release-notes/";
+        return "https://www.mongodb.com/docs/manual/release-notes/";
     }
 
 }


### PR DESCRIPTION
- use HTTPS
- use the `www` subdomain where it exists
- do not use the `docs` subdomain