### PR TITLE
Tolerate `DefaultConnectionPool.invalidate` being called after or concurrently with `close`

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -1417,7 +1417,7 @@ class DefaultConnectionPool implements ConnectionPool {
         void start() {
             if (maintainer != null) {
                 assertTrue(cancellationHandle == null);
-                cancellationHandle = doIgnoringRejectedExecution(() -> maintainer.scheduleAtFixedRate(
+                cancellationHandle = ignoreRejectedExectution(() -> maintainer.scheduleAtFixedRate(
                         DefaultConnectionPool.this::doMaintenance,
                         initialStart ? settings.getMaintenanceInitialDelay(MILLISECONDS) : 0,
                         settings.getMaintenanceFrequency(MILLISECONDS), MILLISECONDS));
@@ -1431,7 +1431,7 @@ class DefaultConnectionPool implements ConnectionPool {
                     cancellationHandle.cancel(false);
                     cancellationHandle = null;
                 }
-                doIgnoringRejectedExecution(() -> maintainer.execute(DefaultConnectionPool.this::doMaintenance));
+                ignoreRejectedExectution(() -> maintainer.execute(DefaultConnectionPool.this::doMaintenance));
             }
         }
 
@@ -1442,15 +1442,15 @@ class DefaultConnectionPool implements ConnectionPool {
             }
         }
 
-        private void doIgnoringRejectedExecution(final Runnable action) {
-            doIgnoringRejectedExecution(() -> {
+        private void ignoreRejectedExectution(final Runnable action) {
+            ignoreRejectedExectution(() -> {
                 action.run();
                 return null;
             });
         }
 
         @Nullable
-        private <T> T doIgnoringRejectedExecution(final Supplier<T> action) {
+        private <T> T ignoreRejectedExectution(final Supplier<T> action) {
             try {
                 return action.get();
             } catch (RejectedExecutionException ignored) {

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -69,6 +69,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1416,18 +1417,21 @@ class DefaultConnectionPool implements ConnectionPool {
         void start() {
             if (maintainer != null) {
                 assertTrue(cancellationHandle == null);
-                cancellationHandle = maintainer.scheduleAtFixedRate(DefaultConnectionPool.this::doMaintenance,
+                cancellationHandle = doIgnoringRejectedExecution(() -> maintainer.scheduleAtFixedRate(
+                        DefaultConnectionPool.this::doMaintenance,
                         initialStart ? settings.getMaintenanceInitialDelay(MILLISECONDS) : 0,
-                        settings.getMaintenanceFrequency(MILLISECONDS), MILLISECONDS);
+                        settings.getMaintenanceFrequency(MILLISECONDS), MILLISECONDS));
                 initialStart = false;
             }
         }
 
         void runOnceAndStop() {
             if (maintainer != null) {
-                assertNotNull(cancellationHandle).cancel(false);
-                cancellationHandle = null;
-                maintainer.execute(DefaultConnectionPool.this::doMaintenance);
+                if (cancellationHandle != null) {
+                    cancellationHandle.cancel(false);
+                    cancellationHandle = null;
+                }
+                doIgnoringRejectedExecution(() -> maintainer.execute(DefaultConnectionPool.this::doMaintenance));
             }
         }
 
@@ -1435,6 +1439,23 @@ class DefaultConnectionPool implements ConnectionPool {
         public void close() {
             if (maintainer != null) {
                 maintainer.shutdownNow();
+            }
+        }
+
+        private void doIgnoringRejectedExecution(final Runnable action) {
+            doIgnoringRejectedExecution(() -> {
+                action.run();
+                return null;
+            });
+        }
+
+        @Nullable
+        private <T> T doIgnoringRejectedExecution(final Supplier<T> action) {
+            try {
+                return action.get();
+            } catch (RejectedExecutionException ignored) {
+                // `close` either completed or is in progress
+                return null;
             }
         }
     }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
@@ -443,6 +443,41 @@ public class DefaultConnectionPoolTest {
         }
     }
 
+    @Test
+    public void invalidateAfterCloseMustNotThrow() {
+        provider = new DefaultConnectionPool(
+                SERVER_ID,
+                connectionFactory,
+                ConnectionPoolSettings.builder().maxSize(1).build(),
+                mockSdamProvider());
+        provider.ready();
+        provider.close();
+        provider.invalidate(null);
+    }
+
+    @Test
+    public void invalidateConcurrentWithCloseMustNotThrow() throws ExecutionException, InterruptedException {
+        Future<?> backgroundTask = null;
+        for (int i = 0; i < 10_000; i++) {
+            provider = new DefaultConnectionPool(
+                    SERVER_ID,
+                    connectionFactory,
+                    ConnectionPoolSettings.builder().maxSize(1).build(),
+                    mockSdamProvider());
+            try {
+                backgroundTask = cachedExecutor.submit(() -> {
+                    provider.ready();
+                    provider.invalidate(null);
+                });
+            } finally {
+                provider.close();
+                if (backgroundTask != null) {
+                    backgroundTask.get();
+                }
+            }
+        }
+    }
+
     private static void assertUseConcurrently(final DefaultConnectionPool pool, final int concurrentUsersCount,
                                               final boolean sync, final boolean async,
                                               final float invalidateAndReadyProb, final float invalidateProb, final float readyProb,


### PR DESCRIPTION
JAVA-4551