### PR TITLE
Add unified change stream test for comment

### DIFF
--- a/driver-core/src/test/resources/unified-test-format/change-streams/change-streams.json
+++ b/driver-core/src/test/resources/unified-test-format/change-streams/change-streams.json
@@ -1,10 +1,21 @@
 {
   "description": "change-streams",
   "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset"
+      ]
+    }
+  ],
   "createEntities": [
     {
       "client": {
-        "id": "client0"
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
       }
     },
     {
@@ -34,10 +45,7 @@
       "description": "Test array truncation",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.7",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "4.7"
         }
       ],
       "operations": [
@@ -109,6 +117,313 @@
               ]
             }
           }
+        }
+      ]
+    },
+    {
+      "description": "Test with document comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "comment": {
+              "name": "test1"
+            }
+          },
+          "saveResultAsEntity": "changeStream0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ],
+                  "comment": {
+                    "name": "test1"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test with document comment - pre 4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "comment": {
+              "name": "test1"
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ],
+                  "comment": {
+                    "name": "test1"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test with string comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "comment": "comment"
+          },
+          "saveResultAsEntity": "changeStream0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test that comment is set on getMore",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "comment": {
+              "key": "value"
+            }
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ],
+                  "comment": {
+                    "key": "value"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": 1
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "collection0",
+                  "comment": {
+                    "key": "value"
+                  }
+                },
+                "commandName": "getMore",
+                "databaseName": "database0"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Test that comment is not set on getMore - pre 4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6.0",
+          "maxServerVersion": "4.3.99",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "comment": "comment"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$changeStream": {}
+                    }
+                  ],
+                  "comment": "comment"
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": 1
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "collection0",
+                  "comment": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "getMore",
+                "databaseName": "database0"
+              }
+            }
+          ]
         }
       ]
     }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
@@ -91,7 +91,7 @@ import static java.util.stream.Collectors.toList;
 
 final class UnifiedCrudHelper {
     private final Entities entities;
-    private final AtomicInteger uniqueId = new AtomicInteger();
+    private final AtomicInteger uniqueIdGenerator = new AtomicInteger();
 
     private final Codec<ChangeStreamDocument<BsonDocument>> changeStreamDocumentCodec = ChangeStreamDocument.createCodec(
             BsonDocument.class,
@@ -1180,6 +1180,6 @@ final class UnifiedCrudHelper {
 
     @NotNull
     private String createRandomEntityId() {
-        return "random-entity-id" + uniqueId.getAndIncrement();
+        return "random-entity-id" + uniqueIdGenerator.getAndIncrement();
     }
 }


### PR DESCRIPTION
Requires support for absent saveResultAsEntity, which is optional

JAVA-4369

This test was missed in the initial PR for comment support, and requires a few changes in the runner