### PR TITLE
Add Java record support to the default registry

### DIFF
--- a/bson-record-codec/build.gradle
+++ b/bson-record-codec/build.gradle
@@ -24,6 +24,7 @@ ext {
 dependencies {
     api project(path: ':bson', configuration: 'default')
     testImplementation project(':bson').sourceSets.test.output
+    testImplementation project(':driver-core')
 }
 
 afterEvaluate {

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecProviderTest.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecProviderTest.java
@@ -18,6 +18,7 @@ package org.bson.codecs.record;
 
 import org.bson.codecs.record.samples.TestRecord;
 import org.bson.conversions.Bson;
+import com.mongodb.MongoClientSettings;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,6 +42,17 @@ public class RecordCodecProviderTest {
 
         // when
         var codec = provider.get(TestRecord.class, Bson.DEFAULT_CODEC_REGISTRY);
+
+        // then
+        assertTrue(codec instanceof RecordCodec);
+        var recordCodec = (RecordCodec<TestRecord>) codec;
+        assertEquals(TestRecord.class, recordCodec.getEncoderClass());
+    }
+
+    @Test
+    public void shouldReturnRecordCodecForRecordUsingDefaultRegistry() {
+        // when
+        var codec = MongoClientSettings.getDefaultCodecRegistry().get(TestRecord.class);
 
         // then
         assertTrue(codec instanceof RecordCodec);

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -39,6 +39,7 @@ configurations {
 
 dependencies {
     api project(path: ':bson', configuration: 'default')
+    implementation project(path: ':bson-record-codec', configuration: 'default')
 
     implementation "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
     api "io.netty:netty-buffer:$nettyVersion", optional

--- a/driver-core/src/main/com/mongodb/Jep395RecordCodecProvider.java
+++ b/driver-core/src/main/com/mongodb/Jep395RecordCodecProvider.java
@@ -33,7 +33,7 @@ import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
 public class Jep395RecordCodecProvider implements CodecProvider {
 
     @Nullable
-    private static final CodecProvider recordCodecProvider;
+    private static final CodecProvider RECORD_CODEC_PROVIDER;
     static {
 
         CodecProvider possibleCodecProvider;
@@ -44,18 +44,18 @@ public class Jep395RecordCodecProvider implements CodecProvider {
             // No JEP-395 support
             possibleCodecProvider = null;
         }
-        recordCodecProvider = possibleCodecProvider;
+        RECORD_CODEC_PROVIDER = possibleCodecProvider;
     }
 
     @Override
     @Nullable
     public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
-        return recordCodecProvider != null ? recordCodecProvider.get(clazz, registry) : null;
+        return RECORD_CODEC_PROVIDER != null ? RECORD_CODEC_PROVIDER.get(clazz, registry) : null;
     }
 
     @VisibleForTesting(otherwise = PRIVATE)
     public boolean hasRecordSupport() {
-        return recordCodecProvider != null;
+        return RECORD_CODEC_PROVIDER != null;
     }
 }
 

--- a/driver-core/src/main/com/mongodb/Jep395RecordCodecProvider.java
+++ b/driver-core/src/main/com/mongodb/Jep395RecordCodecProvider.java
@@ -29,6 +29,8 @@ import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
  * A CodecProvider for Java Records.
  *
  * <p>Requires java.lang.Record support - eg Java 17 or greater.</p>
+ *
+ * @since 4.6
  */
 public class Jep395RecordCodecProvider implements CodecProvider {
 

--- a/driver-core/src/main/com/mongodb/Jep395RecordCodecProvider.java
+++ b/driver-core/src/main/com/mongodb/Jep395RecordCodecProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb;
+
+import com.mongodb.internal.VisibleForTesting;
+import com.mongodb.lang.Nullable;
+import org.bson.codecs.Codec;
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.record.RecordCodecProvider;
+
+import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
+
+
+/**
+ * A CodecProvider for Java Records.
+ *
+ * <p>Requires java.lang.Record support - eg Java 17 or greater.</p>
+ */
+public class Jep395RecordCodecProvider implements CodecProvider {
+
+    @Nullable
+    private static final CodecProvider recordCodecProvider;
+    static {
+
+        CodecProvider possibleCodecProvider;
+        try {
+            Class.forName("java.lang.Record"); // JEP-395 support canary test.
+            possibleCodecProvider = new RecordCodecProvider();
+        } catch (ClassNotFoundException e) {
+            // No JEP-395 support
+            possibleCodecProvider = null;
+        }
+        recordCodecProvider = possibleCodecProvider;
+    }
+
+    @Override
+    @Nullable
+    public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
+        return recordCodecProvider != null ? recordCodecProvider.get(clazz, registry) : null;
+    }
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    public boolean hasRecordSupport() {
+        return recordCodecProvider != null;
+    }
+}
+

--- a/driver-core/src/main/com/mongodb/MongoClientSettings.java
+++ b/driver-core/src/main/com/mongodb/MongoClientSettings.java
@@ -120,6 +120,7 @@ public final class MongoClientSettings {
      * <li>{@link org.bson.codecs.JsonObjectCodecProvider}</li>
      * <li>{@link org.bson.codecs.BsonCodecProvider}</li>
      * <li>{@link org.bson.codecs.EnumCodecProvider}</li>
+     * <li>{@link com.mongodb.Jep395RecordCodecProvider}</li>
      * </ul>
      *
      * <p>

--- a/driver-core/src/main/com/mongodb/MongoClientSettings.java
+++ b/driver-core/src/main/com/mongodb/MongoClientSettings.java
@@ -73,7 +73,8 @@ public final class MongoClientSettings {
                     new Jsr310CodecProvider(),
                     new JsonObjectCodecProvider(),
                     new BsonCodecProvider(),
-                    new EnumCodecProvider()));
+                    new EnumCodecProvider(),
+                    new Jep395RecordCodecProvider()));
 
     private final ReadPreference readPreference;
     private final WriteConcern writeConcern;

--- a/driver-core/src/test/unit/com/mongodb/Jep395RecordCodecProviderTest.java
+++ b/driver-core/src/test/unit/com/mongodb/Jep395RecordCodecProviderTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class Jep395RecordCodecProviderTest {
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_17)
+    void canSupportJavaRecordsOnJava17() {
+        assertTrue(new Jep395RecordCodecProvider().hasRecordSupport());
+    }
+
+    @Test
+    void doesNotErrorWhenCheckingNonRecords() {
+        try {
+            assertNull(new Jep395RecordCodecProvider().get(Integer.class, MongoClientSettings.getDefaultCodecRegistry()));
+        } catch (Exception e) {
+            fail("Should return null when checking for class");
+        }
+    }
+}

--- a/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
@@ -55,6 +55,7 @@ class ApiAliasAndCompanionSpec extends BaseSpec {
       "DocumentToDBRefTransformer",
       "Function",
       "FutureResultCallback",
+      "Jep395RecordCodecProvider",
       "KerberosSubjectProvider",
       "MongoClients",
       "NonNull",


### PR DESCRIPTION
Add dependency in core to bson-record-codec
Wrap the RecordCodecProvider with a canary check so support is only added if the JDK version supports it.

JAVA-3567