### PR TITLE
Various changes required to update unified change stream tests

### DIFF
--- a/driver-core/src/main/com/mongodb/MongoCommandException.java
+++ b/driver-core/src/main/com/mongodb/MongoCommandException.java
@@ -46,7 +46,7 @@ public class MongoCommandException extends MongoServerException {
      * @param address the address of the server that generated the response
      */
     public MongoCommandException(final BsonDocument response, final ServerAddress address) {
-        super(extractErrorCode(response),
+        super(extractErrorCode(response), extractErrorCodeName(response),
               format("Command failed with error %s: '%s' on server %s. The full response is %s", extractErrorCodeAndName(response),
                      extractErrorMessage(response), address, getResponseAsJson(response)), address);
         this.response = response;
@@ -70,7 +70,7 @@ public class MongoCommandException extends MongoServerException {
      * @mongodb.server.release 3.4
      */
     public String getErrorCodeName() {
-        return extractErrorCodeName(response);
+        return super.getErrorCodeName();
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/MongoQueryException.java
+++ b/driver-core/src/main/com/mongodb/MongoQueryException.java
@@ -16,6 +16,8 @@
 
 package com.mongodb;
 
+import com.mongodb.lang.Nullable;
+
 import static java.lang.String.format;
 
 /**
@@ -42,13 +44,32 @@ public class MongoQueryException extends MongoServerException {
     }
 
     /**
+     * Construct an instance.
+     *
+     * @param address the server address
+     * @param errorCode the error code
+     * @param errorCodeName the error code name
+     * @param errorMessage the error message
+     * @since 4.6
+     */
+    public MongoQueryException(final ServerAddress address, final int errorCode, final @Nullable String errorCodeName,
+            final String errorMessage) {
+        super(errorCode, errorCodeName,
+                format("Query failed with error code %d with name '%s' and error message '%s' on server %s", errorCode, errorCodeName,
+                        errorMessage, address),
+                address);
+        this.errorMessage = errorMessage;
+    }
+
+    /**
      * Construct an instance from a command exception.
      *
      * @param commandException the command exception
      * @since 3.7
      */
     public MongoQueryException(final MongoCommandException commandException) {
-        this(commandException.getServerAddress(), commandException.getErrorCode(), commandException.getErrorMessage());
+        this(commandException.getServerAddress(), commandException.getErrorCode(), commandException.getErrorCodeName(),
+                commandException.getErrorMessage());
         addLabels(commandException.getErrorLabels());
     }
 

--- a/driver-core/src/main/com/mongodb/MongoServerException.java
+++ b/driver-core/src/main/com/mongodb/MongoServerException.java
@@ -16,6 +16,8 @@
 
 package com.mongodb;
 
+import com.mongodb.lang.Nullable;
+
 /**
  * An exception indicating that some error has been raised by a MongoDB server in response to an operation.
  *
@@ -24,6 +26,8 @@ package com.mongodb;
  */
 public abstract class MongoServerException extends MongoException {
     private static final long serialVersionUID = -5213859742051776206L;
+    @Nullable
+    private final String errorCodeName;
     private final ServerAddress serverAddress;
 
     /**
@@ -35,6 +39,7 @@ public abstract class MongoServerException extends MongoException {
     public MongoServerException(final String message, final ServerAddress serverAddress) {
         super(message);
         this.serverAddress = serverAddress;
+        this.errorCodeName = null;
     }
 
     /**
@@ -47,6 +52,23 @@ public abstract class MongoServerException extends MongoException {
     public MongoServerException(final int code, final String message, final ServerAddress serverAddress) {
         super(code, message);
         this.serverAddress = serverAddress;
+        this.errorCodeName = null;
+    }
+
+    /**
+     * Construct a new instance.
+     *
+     * @param code the error code from the server
+     * @param errorCodeName the error code name from the server
+     * @param message the message from the server
+     * @param serverAddress the address of the server
+     * @since 4.6
+     */
+    public MongoServerException(final int code, final @Nullable String errorCodeName, final String message,
+            final ServerAddress serverAddress) {
+        super(code, message);
+        this.errorCodeName = errorCodeName;
+        this.serverAddress = serverAddress;
     }
 
     /**
@@ -56,5 +78,17 @@ public abstract class MongoServerException extends MongoException {
      */
     public ServerAddress getServerAddress() {
         return serverAddress;
+    }
+
+    /**
+     * Get the error code name, which may be null
+     *
+     * @return the error code nam
+     * @mongodb.server.release 3.4
+     * @since 4.6
+     */
+    @Nullable
+    public String getErrorCodeName() {
+        return errorCodeName;
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/changestream/ChangeStreamDocumentCodec.java
+++ b/driver-core/src/main/com/mongodb/client/model/changestream/ChangeStreamDocumentCodec.java
@@ -43,7 +43,6 @@ final class ChangeStreamDocumentCodec<TResult> implements Codec<ChangeStreamDocu
 
         ClassModelBuilder<ChangeStreamDocument> classModelBuilder = ClassModel.builder(ChangeStreamDocument.class);
         ((PropertyModelBuilder<TResult>) classModelBuilder.getProperty("fullDocument")).codec(codecRegistry.get(fullDocumentClass));
-        ((PropertyModelBuilder<OperationType>) classModelBuilder.getProperty("operationType")).codec(OPERATION_TYPE_CODEC);
         ClassModel<ChangeStreamDocument> changeStreamDocumentClassModel = classModelBuilder.build();
 
         PojoCodecProvider provider = PojoCodecProvider.builder()

--- a/driver-core/src/test/resources/unified-test-format/change-streams/change-streams.json
+++ b/driver-core/src/test/resources/unified-test-format/change-streams/change-streams.json
@@ -3,6 +3,7 @@
   "schemaVersion": "1.0",
   "runOnRequirements": [
     {
+      "minServerVersion": "3.6",
       "topologies": [
         "replicaset",
         "sharded-replicaset"
@@ -168,7 +169,6 @@
       "description": "Test with document comment - pre 4.4",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
           "maxServerVersion": "4.2.99"
         }
       ],
@@ -213,11 +213,6 @@
     },
     {
       "description": "Test with string comment",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "3.6.0"
-        }
-      ],
       "operations": [
         {
           "name": "createChangeStream",
@@ -347,7 +342,6 @@
       "description": "Test that comment is not set on getMore - pre 4.4",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
           "maxServerVersion": "4.3.99",
           "topologies": [
             "replicaset"
@@ -429,6 +423,306 @@
               }
             }
           ]
+        }
+      ]
+    },
+    {
+      "description": "to field is set in a rename change event",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0.1"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "collection1"
+          }
+        },
+        {
+          "name": "rename",
+          "object": "collection0",
+          "arguments": {
+            "to": "collection1"
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "rename",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "to": {
+              "db": "database0",
+              "coll": "collection1"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test unknown operationType MUST NOT err",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "operationType": "addedInFutureMongoDBVersion",
+                  "ns": 1
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "addedInFutureMongoDBVersion",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test newField added in response MUST NOT err",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "operationType": 1,
+                  "ns": 1,
+                  "newField": "newFieldValue"
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "newField": "newFieldValue"
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test new structure in ns document MUST NOT err",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "operationType": "insert",
+                  "ns.viewOn": "db.coll"
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "viewOn": "db.coll"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test modified structure in ns document MUST NOT err",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "operationType": "insert",
+                  "ns": {
+                    "db": "$ns.db",
+                    "coll": "$ns.coll",
+                    "viewOn": "db.coll"
+                  }
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0",
+              "viewOn": "db.coll"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test server error on projecting out _id",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 0
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectError": {
+            "errorCode": 280,
+            "errorCodeName": "ChangeStreamFatalError",
+            "errorLabelsContain": [
+              "NonResumableChangeStreamError"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test projection in change stream returns expected fields",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "optype": "$operationType",
+                  "ns": 1,
+                  "newField": "value"
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "optype": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "newField": "value"
+          }
         }
       ]
     }

--- a/driver-core/src/test/resources/unified-test-format/change-streams/change-streams.json
+++ b/driver-core/src/test/resources/unified-test-format/change-streams/change-streams.json
@@ -559,6 +559,21 @@
     },
     {
       "description": "Test new structure in ns document MUST NOT err",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "3.6",
+          "maxServerVersion": "5.0",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "createChangeStream",

--- a/driver-core/src/test/resources/unified-test-format/change-streams/change-streams.json
+++ b/driver-core/src/test/resources/unified-test-format/change-streams/change-streams.json
@@ -645,6 +645,11 @@
     },
     {
       "description": "Test server error on projecting out _id",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2"
+        }
+      ],
       "operations": [
         {
           "name": "createChangeStream",

--- a/driver-core/src/test/unit/com/mongodb/client/model/changestream/ChangeStreamDocumentCodecSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/changestream/ChangeStreamDocumentCodecSpecification.groovy
@@ -46,6 +46,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
         then:
         BsonDocument.parse(json) == writer.getDocument()
 
+        when:
         BsonReader bsonReader = new BsonDocumentReader(writer.getDocument())
         ChangeStreamDocument actual = codec.decode(bsonReader, DecoderContext.builder().build())
 
@@ -54,7 +55,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
 
         where:
         changeStreamDocument << [
-                new ChangeStreamDocument<Document>(OperationType.INSERT,
+                new ChangeStreamDocument<Document>(OperationType.INSERT.value,
                         BsonDocument.parse('{token: true}'),
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
                         null,
@@ -64,7 +65,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         ,
                         null, null, null
                 ),
-                new ChangeStreamDocument<Document>(OperationType.UPDATE,
+                new ChangeStreamDocument<Document>(OperationType.UPDATE.value,
                         BsonDocument.parse('{token: true}'),
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
                         null,
@@ -75,7 +76,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         new UpdateDescription(['phoneNumber'], BsonDocument.parse('{email: "alice@10gen.com"}'), null),
                         null, null
                 ),
-                new ChangeStreamDocument<Document>(OperationType.UPDATE,
+                new ChangeStreamDocument<Document>(OperationType.UPDATE.value,
                         BsonDocument.parse('{token: true}'),
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
                         null,
@@ -87,7 +88,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                                 singletonList(new TruncatedArray('education', 2))),
                         null, null
                 ),
-                new ChangeStreamDocument<Document>(OperationType.REPLACE,
+                new ChangeStreamDocument<Document>(OperationType.REPLACE.value,
                         BsonDocument.parse('{token: true}'),
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
                         null,
@@ -97,7 +98,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         ,
                         null, null, null
                 ),
-                new ChangeStreamDocument<Document>(OperationType.DELETE,
+                new ChangeStreamDocument<Document>(OperationType.DELETE.value,
                         BsonDocument.parse('{token: true}'),
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
                         null,
@@ -107,7 +108,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         ,
                         null, null, null
                 ),
-                new ChangeStreamDocument<Document>(OperationType.DROP,
+                new ChangeStreamDocument<Document>(OperationType.DROP.value,
                         BsonDocument.parse('{token: true}'),
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
                         null,
@@ -117,7 +118,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         ,
                         null, null, null
                 ),
-                new ChangeStreamDocument<Document>(OperationType.RENAME,
+                new ChangeStreamDocument<Document>(OperationType.RENAME.value,
                         BsonDocument.parse('{token: true}'),
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
                         BsonDocument.parse('{db: "engineering", coll: "people"}'),
@@ -127,7 +128,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         ,
                         null, null, null
                 ),
-                new ChangeStreamDocument<Document>(OperationType.DROP_DATABASE,
+                new ChangeStreamDocument<Document>(OperationType.DROP_DATABASE.value,
                         BsonDocument.parse('{token: true}'),
                         BsonDocument.parse('{db: "engineering"}'),
                         null,
@@ -137,7 +138,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         ,
                         null, null, null
                 ),
-                new ChangeStreamDocument<Document>(OperationType.INVALIDATE,
+                new ChangeStreamDocument<Document>(OperationType.INVALIDATE.value,
                         BsonDocument.parse('{token: true}'),
                         null,
                         null,
@@ -147,7 +148,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         ,
                         null, null, null
                 ),
-                new ChangeStreamDocument<Document>(OperationType.INSERT,
+                new ChangeStreamDocument<Document>(OperationType.INSERT.value,
                         BsonDocument.parse('{token: true}'),
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
                         null,

--- a/driver-core/src/test/unit/com/mongodb/client/model/changestream/ChangeStreamDocumentSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/changestream/ChangeStreamDocumentSpecification.groovy
@@ -40,11 +40,11 @@ class ChangeStreamDocumentSpecification extends Specification {
         def clusterTime = new BsonTimestamp(1234, 2)
         def operationType = OperationType.UPDATE
         def updateDesc = new UpdateDescription(['a', 'b'], BsonDocument.parse('{c: 1}'), null)
-        def txnNumber = new BsonInt64(1);
-        def lsid = BsonDocument.parse('{id: 1, uid: 1}');
+        def txnNumber = new BsonInt64(1)
+        def lsid = BsonDocument.parse('{id: 1, uid: 1}')
 
         when:
-        def changeStreamDocument = new ChangeStreamDocument<BsonDocument>(operationType, resumeToken, namespaceDocument,
+        def changeStreamDocument = new ChangeStreamDocument<BsonDocument>(operationType.value, resumeToken, namespaceDocument,
                 destinationNamespaceDocument, fullDocument, documentKey, clusterTime, updateDesc, null, null)
 
         then:
@@ -56,6 +56,7 @@ class ChangeStreamDocumentSpecification extends Specification {
         changeStreamDocument.getNamespaceDocument() == namespaceDocument
         changeStreamDocument.getDestinationNamespace() == destinationNamespace
         changeStreamDocument.getDestinationNamespaceDocument() == destinationNamespaceDocument
+        changeStreamDocument.getOperationTypeString() == operationType.value
         changeStreamDocument.getOperationType() == operationType
         changeStreamDocument.getUpdateDescription() == updateDesc
         changeStreamDocument.getDatabaseName() == namespace.getDatabaseName()
@@ -63,7 +64,28 @@ class ChangeStreamDocumentSpecification extends Specification {
         changeStreamDocument.getLsid() == null
 
         when:
-        def changeStreamDocumentWithTxnInfo = new ChangeStreamDocument<BsonDocument>(operationType, resumeToken,
+        //noinspection GrDeprecatedAPIUsage
+        changeStreamDocument = new ChangeStreamDocument<BsonDocument>(operationType, resumeToken, namespaceDocument,
+                destinationNamespaceDocument, fullDocument, documentKey, clusterTime, updateDesc, null, null)
+
+        then:
+        changeStreamDocument.getResumeToken() == resumeToken
+        changeStreamDocument.getFullDocument() == fullDocument
+        changeStreamDocument.getDocumentKey() == documentKey
+        changeStreamDocument.getClusterTime() == clusterTime
+        changeStreamDocument.getNamespace() == namespace
+        changeStreamDocument.getNamespaceDocument() == namespaceDocument
+        changeStreamDocument.getDestinationNamespace() == destinationNamespace
+        changeStreamDocument.getDestinationNamespaceDocument() == destinationNamespaceDocument
+        changeStreamDocument.getOperationTypeString() == operationType.value
+        changeStreamDocument.getOperationType() == operationType
+        changeStreamDocument.getUpdateDescription() == updateDesc
+        changeStreamDocument.getDatabaseName() == namespace.getDatabaseName()
+        changeStreamDocument.getTxnNumber() == null
+        changeStreamDocument.getLsid() == null
+
+        when:
+        def changeStreamDocumentWithTxnInfo = new ChangeStreamDocument<BsonDocument>(operationType.value, resumeToken,
                 namespaceDocument, destinationNamespaceDocument, fullDocument, documentKey, clusterTime, updateDesc,
                 txnNumber, lsid)
 
@@ -76,6 +98,7 @@ class ChangeStreamDocumentSpecification extends Specification {
         changeStreamDocumentWithTxnInfo.getNamespaceDocument() == namespaceDocument
         changeStreamDocumentWithTxnInfo.getDestinationNamespace() == destinationNamespace
         changeStreamDocumentWithTxnInfo.getDestinationNamespaceDocument() == destinationNamespaceDocument
+        changeStreamDocumentWithTxnInfo.getOperationTypeString() == operationType.value
         changeStreamDocumentWithTxnInfo.getOperationType() == operationType
         changeStreamDocumentWithTxnInfo.getUpdateDescription() == updateDesc
         changeStreamDocumentWithTxnInfo.getDatabaseName() == namespace.getDatabaseName()
@@ -91,8 +114,8 @@ class ChangeStreamDocumentSpecification extends Specification {
         def clusterTime = new BsonTimestamp(1234, 2)
         def operationType = OperationType.DROP_DATABASE
         def updateDesc = new UpdateDescription(['a', 'b'], BsonDocument.parse('{c: 1}'), emptyList())
-        def changeStreamDocumentNullNamespace = new ChangeStreamDocument<BsonDocument>(operationType, resumeToken, (BsonDocument) null,
-                (BsonDocument) null, fullDocument, documentKey, clusterTime, updateDesc, null, null)
+        def changeStreamDocumentNullNamespace = new ChangeStreamDocument<BsonDocument>(operationType.value, resumeToken,
+                (BsonDocument) null, (BsonDocument) null, fullDocument, documentKey, clusterTime, updateDesc, null, null)
 
         expect:
         changeStreamDocumentNullNamespace.getDatabaseName() == null
@@ -113,9 +136,9 @@ class ChangeStreamDocumentSpecification extends Specification {
         def operationType = OperationType.DROP_DATABASE
         def updateDesc = new UpdateDescription(['a', 'b'], BsonDocument.parse('{c: 1}'), singletonList(new TruncatedArray('d', 1)))
 
-        def changeStreamDocument = new ChangeStreamDocument<BsonDocument>(operationType, resumeToken, namespaceDocument,
+        def changeStreamDocument = new ChangeStreamDocument<BsonDocument>(operationType.value, resumeToken, namespaceDocument,
                 (BsonDocument) null, fullDocument, documentKey, clusterTime, updateDesc, null, null)
-        def changeStreamDocumentEmptyNamespace = new ChangeStreamDocument<BsonDocument>(operationType, resumeToken,
+        def changeStreamDocumentEmptyNamespace = new ChangeStreamDocument<BsonDocument>(operationType.value, resumeToken,
                 namespaceDocumentEmpty, (BsonDocument) null, fullDocument, documentKey, clusterTime, updateDesc,
         null, null)
 

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCollection.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCollection.java
@@ -260,7 +260,7 @@ class SyncMongoCollection<T> implements MongoCollection<T> {
 
     @Override
     public ChangeStreamIterable<T> watch(final List<? extends Bson> pipeline) {
-        return new SyncChangeStreamIterable<>(wrapped.watch(wrapped.getDocumentClass()));
+        return new SyncChangeStreamIterable<>(wrapped.watch(pipeline, wrapped.getDocumentClass()));
     }
 
     @Override
@@ -737,44 +737,44 @@ class SyncMongoCollection<T> implements MongoCollection<T> {
 
     @Override
     public void dropIndexes() {
-        throw new UnsupportedOperationException();
+        Mono.from(wrapped.dropIndexes()).block(TIMEOUT_DURATION);
     }
 
     @Override
     public void dropIndexes(final ClientSession clientSession) {
-        throw new UnsupportedOperationException();
+        Mono.from(wrapped.dropIndexes(unwrap(clientSession))).block(TIMEOUT_DURATION);
     }
 
     @Override
     public void dropIndexes(final DropIndexOptions dropIndexOptions) {
-        throw new UnsupportedOperationException();
+        Mono.from(wrapped.dropIndexes(dropIndexOptions)).block(TIMEOUT_DURATION);
     }
 
     @Override
     public void dropIndexes(final ClientSession clientSession, final DropIndexOptions dropIndexOptions) {
-        throw new UnsupportedOperationException();
+        Mono.from(wrapped.dropIndexes(unwrap(clientSession), dropIndexOptions)).block(TIMEOUT_DURATION);
     }
 
     @Override
     public void renameCollection(final MongoNamespace newCollectionNamespace) {
-        throw new UnsupportedOperationException();
+        Mono.from(wrapped.renameCollection(newCollectionNamespace)).block(TIMEOUT_DURATION);
     }
 
     @Override
     public void renameCollection(final MongoNamespace newCollectionNamespace, final RenameCollectionOptions renameCollectionOptions) {
-        throw new UnsupportedOperationException();
+        Mono.from(wrapped.renameCollection(newCollectionNamespace, renameCollectionOptions)).block(TIMEOUT_DURATION);
     }
 
     @Override
     public void renameCollection(final ClientSession clientSession, final MongoNamespace newCollectionNamespace) {
-        throw new UnsupportedOperationException();
+        Mono.from(wrapped.renameCollection(unwrap(clientSession), newCollectionNamespace)).block(TIMEOUT_DURATION);
     }
 
     @Override
     public void renameCollection(
             final ClientSession clientSession, final MongoNamespace newCollectionNamespace,
             final RenameCollectionOptions renameCollectionOptions) {
-        throw new UnsupportedOperationException();
+        Mono.from(wrapped.renameCollection(unwrap(clientSession), newCollectionNamespace, renameCollectionOptions)).block(TIMEOUT_DURATION);
     }
 
     private com.mongodb.reactivestreams.client.ClientSession unwrap(final ClientSession clientSession) {

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ChangeStreamsTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ChangeStreamsTest.java
@@ -46,14 +46,6 @@ public final class ChangeStreamsTest extends UnifiedReactiveStreamsTest {
                     "Test that comment is not set on getMore - pre 4.4"
             );
 
-    private static final List<String> CURSOR_OPEN_TIMING_SENSITIVE_TESTS =
-            Arrays.asList(
-                    "Test with document comment",
-                    "Test with document comment - pre 4.4",
-                    "Test with string comment",
-                    "Test that comment is set on getMore"
-            );
-
     public ChangeStreamsTest(@SuppressWarnings("unused") final String fileDescription,
                              @SuppressWarnings("unused") final String testDescription,
                              final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
@@ -63,9 +55,7 @@ public final class ChangeStreamsTest extends UnifiedReactiveStreamsTest {
         assumeFalse(ERROR_REQUIRED_FROM_CHANGE_STREAM_INITIALIZATION_TESTS.contains(testDescription));
         assumeFalse(EVENT_SENSITIVE_TESTS.contains(testDescription));
 
-        if (CURSOR_OPEN_TIMING_SENSITIVE_TESTS.contains(testDescription)) {
-            enableSleepAfterCursorOpen(256);
-        }
+        enableSleepAfterCursorOpen(256);
     }
 
     @After

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/Entities.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/Entities.java
@@ -30,7 +30,6 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.gridfs.GridFSBucket;
-import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.connection.ConnectionId;
 import com.mongodb.connection.ServerId;
@@ -102,7 +101,6 @@ public final class Entities {
     private final Map<String, GridFSBucket> buckets = new HashMap<>();
     private final Map<String, TestCommandListener> clientCommandListeners = new HashMap<>();
     private final Map<String, TestConnectionPoolListener> clientConnectionPoolListeners = new HashMap<>();
-    private final Map<String, MongoCursor<ChangeStreamDocument<BsonDocument>>> changeStreamCursors = new HashMap<>();
     private final Map<String, MongoCursor<BsonDocument>> cursors = new HashMap<>();
     private final Map<String, Long> successCounts = new HashMap<>();
     private final Map<String, Long> iterationCounts = new HashMap<>();
@@ -172,18 +170,6 @@ public final class Entities {
 
     public BsonValue getResult(final String id) {
         return getEntity(id, results, "result");
-    }
-
-    public void addChangeStreamCursor(final String id, final MongoCursor<ChangeStreamDocument<BsonDocument>> cursor) {
-        putEntity(id, cursor, changeStreamCursors);
-    }
-
-    public MongoCursor<ChangeStreamDocument<BsonDocument>> getChangeStreamCursor(final String id) {
-        return getEntity(id, changeStreamCursors, "change stream cursors");
-    }
-
-    public boolean hasCursor(final String id) {
-        return cursors.containsKey(id);
     }
 
     public void addCursor(final String id, final MongoCursor<BsonDocument> cursor) {
@@ -512,9 +498,6 @@ public final class Entities {
     }
 
     public void close() {
-        for (MongoCursor<ChangeStreamDocument<BsonDocument>> cursor : changeStreamCursors.values()) {
-             cursor.close();
-        }
         for (MongoCursor<BsonDocument> cursor : cursors.values()) {
             cursor.close();
         }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/ErrorMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/ErrorMatcher.java
@@ -21,6 +21,7 @@ import com.mongodb.MongoClientException;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoQueryException;
+import com.mongodb.MongoServerException;
 import com.mongodb.MongoSocketException;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
@@ -77,11 +78,11 @@ final class ErrorMatcher {
                     errorCode);
         }
         if (expectedError.containsKey("errorCodeName")) {
-            assertTrue(context.getMessage("Exception must be of type MongoCommandException when checking for error codes"),
-                    e instanceof MongoCommandException);
-            MongoCommandException mongoCommandException = (MongoCommandException) e;
+            assertTrue(context.getMessage("Exception must be of type MongoServerException when checking for error codes"),
+                    e instanceof MongoServerException);
+            MongoServerException mongoServerException = (MongoServerException) e;
             assertEquals(context.getMessage("Error code names must match"), expectedError.getString("errorCodeName").getValue(),
-                    mongoCommandException.getErrorCodeName());
+                    mongoServerException.getErrorCodeName());
         }
         if (expectedError.containsKey("errorLabelsOmit")) {
             assertTrue(context.getMessage("Exception must be of type MongoException when checking for error labels"),

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -84,7 +84,7 @@ public abstract class UnifiedTest {
     private final BsonDocument definition;
     private final AssertionContext context = new AssertionContext();
     private final Entities entities = new Entities();
-    private final UnifiedCrudHelper crudHelper = new UnifiedCrudHelper(entities);
+    private final UnifiedCrudHelper crudHelper;
     private final UnifiedGridFSHelper gridFSHelper = new UnifiedGridFSHelper(entities);
     private final ValueMatcher valueMatcher = new ValueMatcher(entities, context);
     private final ErrorMatcher errorMatcher = new ErrorMatcher(context);
@@ -100,6 +100,7 @@ public abstract class UnifiedTest {
         this.initialData = initialData;
         this.definition = definition;
         this.context.push(ContextElement.ofTest(definition));
+        crudHelper = new UnifiedCrudHelper(entities, definition.getString("description").getValue());
     }
 
     public Entities getEntities() {
@@ -315,6 +316,8 @@ public abstract class UnifiedTest {
                     return crudHelper.executeDropCollection(operation);
                 case "createCollection":
                     return crudHelper.executeCreateCollection(operation);
+                case "rename":
+                    return crudHelper.executeRenameCollection(operation);
                 case "createIndex":
                     return crudHelper.executeCreateIndex(operation);
                 case "startTransaction":


### PR DESCRIPTION
I'm doing all these as one PR because the unified change stream tests are what required the first two changes, but it was difficult to split up do to the overlapping commits to the unified tests.  So submitting this as together but will not squash the commits.

JAVA-4565: this one was necessary because one of the new tests ends up throwing a MongoQueryException instead of a MongoCommandException, and MongoQueryException didn't have the errorCodeName property needed to make assertion.

JAVA-4470: this one is not fully done.  It requires a bunch of things if we want to use ChangeStreamDocument for all the unified tests.  The one that's now handled properly is an operationType for which there is no associated enum value.  But for a couple of the new tests we're escaping to BsonDocument for the entire change stream document so that the assertions pass.

JAVA-4555: ChangeStreamDocument already handles the "to" field, so nothing needed to be done there.  So it's just updates to the unified tests.