### PR TITLE
The data directory must be created before a mongod starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ $ ./gradlew check
 The test suite requires mongod to be running with [`enableTestCommands`](https://www.mongodb.com/docs/manual/reference/parameters/#param.enableTestCommands), which may be set with the `--setParameter enableTestCommands=1`
 command-line parameter:
 ```
+$ mkdir -p data/db
 $ mongod --dbpath ./data/db --logpath ./data/mongod.log --port 27017 --logappend --fork --setParameter enableTestCommands=1
 ```
 


### PR DESCRIPTION
# Motivation
I found a little problem in the build part of README.

The mongod can not start unless the data directory starts. So I think a `mkdir -p data/db` command should be added in README.

>The test suite requires mongod to be running with [`enableTestCommands`]>>(https://www.mongodb.com/docs/manual/reference/parameters/#param.enableTestCommands), which may be set with the `--setParameter enableTestCommands=1`
command-line parameter:
> ```
> $ mongod --dbpath ./data/db --logpath ./data/mongod.log --port 27017 --logappend --fork --setParameter  enableTestCommands=1
> ```