### PR TITLE
Update the requirements to build and compile the source

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Example for Maven:
 
 ## Build
 
-Java 9+ is required to build and compile the source. To build and test the driver:
+Java 17+ and git is required to build and compile the source. To build and test the driver:
 
 ```
 $ git clone https://github.com/mongodb/mongo-java-driver.git


### PR DESCRIPTION
1. Java 17+ is required rather than Java 9
   * Reference: https://github.com/mongodb/mongo-java-driver/blob/master/gradle/javaToolchain.gradle#L16
2. git is required
   * Reference: https://github.com/mongodb/mongo-java-driver/blob/master/build.gradle#L334