### PR TITLE
Fix or skip new failing unified change stream tests

### DIFF
--- a/driver-core/src/test/resources/unified-test-format/change-streams/change-streams.json
+++ b/driver-core/src/test/resources/unified-test-format/change-streams/change-streams.json
@@ -143,6 +143,7 @@
       "expectEvents": [
         {
           "client": "client0",
+          "ignoreExtraEvents": true,
           "events": [
             {
               "commandStartedEvent": {
@@ -189,6 +190,7 @@
       "expectEvents": [
         {
           "client": "client0",
+          "ignoreExtraEvents": true,
           "events": [
             {
               "commandStartedEvent": {
@@ -230,6 +232,7 @@
       "expectEvents": [
         {
           "client": "client0",
+          "ignoreExtraEvents": true,
           "events": [
             {
               "commandStartedEvent": {
@@ -288,6 +291,7 @@
       "expectEvents": [
         {
           "client": "client0",
+          "ignoreExtraEvents": true,
           "events": [
             {
               "commandStartedEvent": {
@@ -378,6 +382,7 @@
       "expectEvents": [
         {
           "client": "client0",
+          "ignoreExtraEvents": true,
           "events": [
             {
               "commandStartedEvent": {

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ChangeStreamsTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ChangeStreamsTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.disableSleep;
@@ -34,9 +35,8 @@ import static org.junit.Assume.assumeFalse;
 
 public final class ChangeStreamsTest extends UnifiedReactiveStreamsTest {
 
-    @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
     private static final List<String> ERROR_REQUIRED_FROM_CHANGE_STREAM_INITIALIZATION_TESTS =
-            Arrays.asList(
+            Collections.singletonList(
                     "Test with document comment - pre 4.4"
             );
 

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ChangeStreamsTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ChangeStreamsTest.java
@@ -19,18 +19,59 @@ package com.mongodb.reactivestreams.client.unified;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.junit.After;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+
+import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.disableSleep;
+import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.enableSleepAfterCursorOpen;
+import static org.junit.Assume.assumeFalse;
 
 public final class ChangeStreamsTest extends UnifiedReactiveStreamsTest {
+
+    @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
+    private static final List<String> ERROR_REQUIRED_FROM_CHANGE_STREAM_INITIALIZATION_TESTS =
+            Arrays.asList(
+                    "Test with document comment - pre 4.4"
+            );
+
+    private static final List<String> EVENT_SENSITIVE_TESTS =
+            Arrays.asList(
+                    "Test that comment is set on getMore",
+                    "Test that comment is not set on getMore - pre 4.4"
+            );
+
+    private static final List<String> CURSOR_OPEN_TIMING_SENSITIVE_TESTS =
+            Arrays.asList(
+                    "Test with document comment",
+                    "Test with document comment - pre 4.4",
+                    "Test with string comment",
+                    "Test that comment is set on getMore"
+            );
+
     public ChangeStreamsTest(@SuppressWarnings("unused") final String fileDescription,
                              @SuppressWarnings("unused") final String testDescription,
                              final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
                              final BsonArray initialData, final BsonDocument definition) {
         super(schemaVersion, runOnRequirements, entities, initialData, definition);
+
+        assumeFalse(ERROR_REQUIRED_FROM_CHANGE_STREAM_INITIALIZATION_TESTS.contains(testDescription));
+        assumeFalse(EVENT_SENSITIVE_TESTS.contains(testDescription));
+
+        if (CURSOR_OPEN_TIMING_SENSITIVE_TESTS.contains(testDescription)) {
+            enableSleepAfterCursorOpen(256);
+        }
+    }
+
+    @After
+    public void cleanUp() {
+        super.cleanUp();
+        disableSleep();
     }
 
     @Parameterized.Parameters(name = "{0}: {1}")

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/EventMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/EventMatcher.java
@@ -32,6 +32,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 final class EventMatcher {
     private final ValueMatcher valueMatcher;
@@ -42,11 +43,17 @@ final class EventMatcher {
         this.context = context;
     }
 
-    public void assertCommandEventsEquality(final String client, final BsonArray expectedEventDocuments, final List<CommandEvent> events) {
+    public void assertCommandEventsEquality(final String client, final boolean ignoreExtraEvents, final BsonArray expectedEventDocuments,
+                                            final List<CommandEvent> events) {
         context.push(ContextElement.ofCommandEvents(client, expectedEventDocuments, events));
-        assertEquals(context.getMessage("Number of events must be the same"), expectedEventDocuments.size(), events.size());
+        if (ignoreExtraEvents) {
+            assertTrue(context.getMessage("Number of events must be greater than or equal to the expected number of events"),
+                    events.size() >= expectedEventDocuments.size());
+        } else {
+            assertEquals(context.getMessage("Number of events must be the same"), expectedEventDocuments.size(), events.size());
+        }
 
-        for (int i = 0; i < events.size(); i++) {
+        for (int i = 0; i < expectedEventDocuments.size(); i++) {
             CommandEvent actual = events.get(i);
             BsonDocument expectedEventDocument = expectedEventDocuments.get(i).asDocument();
             String eventType = expectedEventDocument.getFirstKey();
@@ -106,11 +113,17 @@ final class EventMatcher {
         context.pop();
     }
 
-    public void assertConnectionPoolEventsEquality(final String client, final BsonArray expectedEventDocuments, final List<Object> events) {
+    public void assertConnectionPoolEventsEquality(final String client, final boolean ignoreExtraEvents, final BsonArray expectedEventDocuments,
+                                                   final List<Object> events) {
         context.push(ContextElement.ofConnectionPoolEvents(client, expectedEventDocuments, events));
-        assertEquals(context.getMessage("Number of events must be the same"), expectedEventDocuments.size(), events.size());
+        if (ignoreExtraEvents) {
+            assertTrue(context.getMessage("Number of events must be greater than or equal to the expected number of events"),
+                    events.size() >= expectedEventDocuments.size());
+        } else {
+            assertEquals(context.getMessage("Number of events must be the same"), expectedEventDocuments.size(), events.size());
+        }
 
-        for (int i = 0; i < events.size(); i++) {
+        for (int i = 0; i < expectedEventDocuments.size(); i++) {
             Object actual = events.get(i);
             BsonDocument expectedEventDocument = expectedEventDocuments.get(i).asDocument();
             String eventType = expectedEventDocument.getFirstKey();

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -188,17 +188,20 @@ public abstract class UnifiedTest {
         }
     }
 
-    private void compareEvents(final BsonDocument operation) {
-        for (BsonValue cur : operation.getArray("expectEvents")) {
+    private void compareEvents(final BsonDocument definition) {
+        for (BsonValue cur : definition.getArray("expectEvents")) {
             BsonDocument curClientEvents = cur.asDocument();
             String client = curClientEvents.getString("client").getValue();
+            boolean ignoreExtraEvents = curClientEvents.getBoolean("ignoreExtraEvents", BsonBoolean.FALSE).getValue();
             String eventType = curClientEvents.getString("eventType", new BsonString("command")).getValue();
             if (eventType.equals("command")) {
                 TestCommandListener listener = entities.getClientCommandListener(client);
-                eventMatcher.assertCommandEventsEquality(client, curClientEvents.getArray("events"), listener.getEvents());
+                eventMatcher.assertCommandEventsEquality(client, ignoreExtraEvents, curClientEvents.getArray("events"),
+                        listener.getEvents());
             } else if (eventType.equals("cmap")) {
                 TestConnectionPoolListener listener = entities.getConnectionPoolListener(client);
-                eventMatcher.assertConnectionPoolEventsEquality(client, curClientEvents.getArray("events"), listener.getEvents());
+                eventMatcher.assertConnectionPoolEventsEquality(client, ignoreExtraEvents, curClientEvents.getArray("events"),
+                        listener.getEvents());
             } else {
                 throw new UnsupportedOperationException("Unexpected event type: " + eventType);
             }


### PR DESCRIPTION
* Add support for ignoreExtraEvents in unified test runner. (note: this is a new option and not yet out of spec review, but looks like this is what it's going to look like)
* Update change stream tests to specify ignoreExtraEvents
* Update reactive change stream test runner to skip tests where extra getMore events occur between required events
* Update reactive change stream test runner to skip tests that require change stream initialization to report an error
* Enable artificial delay for change stream tests that expect an event when change stream is initialized

JAVA-4369