### PR TITLE
Potential security vulnerability in the zstd C library.Can you help upgrade to patch versions?

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ ext {
     jnrUnixsocketVersion = '0.18'
     nettyVersion = '4.1.17.Final'
     snappyVersion = '1.1.4'
-    zstdVersion = '1.3.8-3'
+    zstdVersion = '1.4.9-1'
     mongoCryptVersion = '1.0.1'
     gitVersion = getGitVersion()
 }


### PR DESCRIPTION
Hi, @jyemin , @rozza , I'd like to report a vulnerable dependency issue in **org.mongodb:mongo-java-driver:3.12.10**.
### Issue Description
I noticed that **org.mongodb:mongo-java-driver:3.12.10** directly depends on **com.github.luben:zstd-jni:v1.3.8-3**. However, as shown in the following dependency graph, **com.github.luben:zstd-jni:v1.3.8-3** sufferes from the vulnerability which the C library **zstd(version:1.3.8)** exposed: [CVE-2021-24031](https://nvd.nist.gov/vuln/detail/CVE-2021-24031).
### Dependency Graph between Java and Shared Libraries
![image (11)](https://user-images.githubusercontent.com/103260963/163216069-ac95b602-e77d-44a2-81dc-ff1178d5eb0b.png)
### Suggested Vulnerability Patch Versions
**com.github.luben:zstd-jni:v1.4.9-1** (**>=v1.4.9-1**) has upgraded this vulnerable C library `zstd` to the patch version **1.4.9**.

Java build tools cannot report vulnerable C libraries, which may induce potential security issues to many downstream Java projects. Could you please upgrade this vulnerable dependency?

Thanks for your help~
Best regards,
Helen Parr