### PR TITLE
UUID representation configuration

### DIFF
--- a/bson/src/main/org/bson/BSONCallbackAdapter.java
+++ b/bson/src/main/org/bson/BSONCallbackAdapter.java
@@ -105,11 +105,20 @@ class BSONCallbackAdapter extends AbstractBsonWriter {
 
     @Override
     protected void doWriteBinaryData(final BsonBinary value) {
-        if (value.getType() == BsonBinarySubType.UUID_LEGACY.getValue()) {
-            UUID uuid = UuidHelper.decodeBinaryToUuid(value.getData(), value.getType(), defaultUuidRepresentation);
-            bsonCallback.gotUUID(getName(), uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+        if (defaultUuidRepresentation == UuidRepresentation.STANDARD) {
+            if (value.getType() == BsonBinarySubType.UUID_LEGACY.getValue()) {
+                bsonCallback.gotBinary(getName(), value.getType(), value.getData());
+            } else {
+                UUID uuid = UuidHelper.decodeBinaryToUuid(value.getData(), value.getType(), defaultUuidRepresentation);
+                bsonCallback.gotUUID(getName(), uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+            }
         } else {
-            bsonCallback.gotBinary(getName(), value.getType(), value.getData());
+            if (value.getType() == BsonBinarySubType.UUID_LEGACY.getValue()) {
+                UUID uuid = UuidHelper.decodeBinaryToUuid(value.getData(), value.getType(), defaultUuidRepresentation);
+                bsonCallback.gotUUID(getName(), uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+            } else {
+                bsonCallback.gotBinary(getName(), value.getType(), value.getData());
+            }
         }
     }
 

--- a/bson/src/main/org/bson/BasicBSONEncoder.java
+++ b/bson/src/main/org/bson/BasicBSONEncoder.java
@@ -364,7 +364,9 @@ public class BasicBSONEncoder implements BSONEncoder {
     protected void putUUID(final String name, final UUID uuid) {
         putName(name);
         byte[] bytes = UuidHelper.encodeUuidToBinary(uuid, defaultUuidRepresentation);
-        bsonWriter.writeBinaryData(new BsonBinary(BsonBinarySubType.UUID_LEGACY, bytes));
+        bsonWriter.writeBinaryData(new BsonBinary(
+                defaultUuidRepresentation == UuidRepresentation.STANDARD ? BsonBinarySubType.UUID_STANDARD : BsonBinarySubType.UUID_LEGACY,
+                bytes));
     }
 
     /**

--- a/bson/src/main/org/bson/BasicBSONEncoder.java
+++ b/bson/src/main/org/bson/BasicBSONEncoder.java
@@ -16,6 +16,7 @@
 
 package org.bson;
 
+import org.bson.internal.UuidHelper;
 import org.bson.io.BasicOutputBuffer;
 import org.bson.io.OutputBuffer;
 import org.bson.types.BSONTimestamp;
@@ -37,10 +38,30 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
+import static org.bson.assertions.Assertions.notNull;
+
 /**
  * This is meant to be pooled or cached. There is some per instance memory for string conversion, etc...
  */
 public class BasicBSONEncoder implements BSONEncoder {
+
+    /**
+     * Sets the default {@link UuidRepresentation} to use when encoding UUID values to BSON binary.
+     *
+     * <p>
+     * If unset, the default is {@link UuidRepresentation#JAVA_LEGACY}.
+     * </p>
+     *
+     * @param uuidRepresentation the uuid representation, which may not be null
+     * @see #putUUID(String, UUID)
+     * @see BSONCallbackAdapter#setDefaultUuidRepresentation(UuidRepresentation)
+     * @since 4.7
+     */
+    public static void setDefaultUuidRepresentation(final UuidRepresentation uuidRepresentation) {
+        defaultUuidRepresentation = notNull("uuidRepresentation", uuidRepresentation);
+    }
+
+    private static volatile UuidRepresentation defaultUuidRepresentation = UuidRepresentation.JAVA_LEGACY;
 
     private BsonBinaryWriter bsonWriter;
     private OutputBuffer outputBuffer;
@@ -342,9 +363,7 @@ public class BasicBSONEncoder implements BSONEncoder {
      */
     protected void putUUID(final String name, final UUID uuid) {
         putName(name);
-        byte[] bytes = new byte[16];
-        writeLongToArrayLittleEndian(bytes, 0, uuid.getMostSignificantBits());
-        writeLongToArrayLittleEndian(bytes, 8, uuid.getLeastSignificantBits());
+        byte[] bytes = UuidHelper.encodeUuidToBinary(uuid, defaultUuidRepresentation);
         bsonWriter.writeBinaryData(new BsonBinary(BsonBinarySubType.UUID_LEGACY, bytes));
     }
 

--- a/bson/src/main/org/bson/Document.java
+++ b/bson/src/main/org/bson/Document.java
@@ -60,7 +60,27 @@ import static org.bson.codecs.configuration.CodecRegistries.withUuidRepresentati
  * @since 3.0.0
  */
 public class Document implements Map<String, Object>, Serializable, Bson {
-    private static final Codec<Document> DEFAULT_CODEC =
+
+    /**
+     * Sets the default {@link UuidRepresentation} to use when converting to and from JSON.
+     *
+     * <p>
+     * This method is particularly useful if you want to change the process-wide default for the {@link UuidRepresentation} this is
+     * applied during any conversions. The default codec applies {@link UuidRepresentation#STANDARD}.
+     * </p>
+     *
+     * @param codec the default codec, which may not be null
+     * @see #parse(String)
+     * @see UuidRepresentation#STANDARD
+     * @see #toJson()
+     * @see #toJson(JsonWriterSettings)
+     * @since 4.7
+     */
+    public static void setDefaultCodec(final Codec<Document> codec) {
+        defaultCodec = notNull("defaultCodec", codec);
+    }
+
+    private static volatile Codec<Document> defaultCodec =
             withUuidRepresentation(fromProviders(asList(new ValueCodecProvider(), new IterableCodecProvider(),
                     new BsonValueCodecProvider(), new DocumentCodecProvider(), new MapCodecProvider())), UuidRepresentation.STANDARD)
                     .get(Document.class);
@@ -109,7 +129,7 @@ public class Document implements Map<String, Object>, Serializable, Bson {
      * @mongodb.driver.manual reference/mongodb-extended-json/ MongoDB Extended JSON
      */
     public static Document parse(final String json) {
-        return parse(json, DEFAULT_CODEC);
+        return parse(json, defaultCodec);
     }
 
     /**
@@ -427,7 +447,7 @@ public class Document implements Map<String, Object>, Serializable, Bson {
      * @throws org.bson.codecs.configuration.CodecConfigurationException if the document contains types not in the default registry
      */
     public String toJson(final JsonWriterSettings writerSettings) {
-        return toJson(writerSettings, DEFAULT_CODEC);
+        return toJson(writerSettings, defaultCodec);
     }
 
     /**

--- a/bson/src/test/unit/org/bson/BasicBSONDecoderSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BasicBSONDecoderSpecification.groovy
@@ -91,6 +91,7 @@ class BasicBSONDecoderSpecification extends Specification {
         ['k1': new MinKey()]                                     | [9, 0, 0, 0, -1, 107, 49, 0, 0]
         ['k2': new MaxKey()]                                     | [9, 0, 0, 0, 127, 107, 50, 0, 0]
         ['f': Decimal128.parse('0E-6176')]                       | [24, 0, 0, 0, 19, 102, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        ['u': new UUID(1, 2)]                                    | [29, 0, 0, 0, 5, 117, 0, 16, 0, 0, 0, 3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0]
 
         type = BsonType.findByValue(bytes[4])
     }

--- a/bson/src/test/unit/org/bson/BasicBSONEncoderSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BasicBSONEncoderSpecification.groovy
@@ -89,6 +89,7 @@ class BasicBSONEncoderSpecification extends Specification {
         ['k': new MinKey()]                                      | [8, 0, 0, 0, -1, 107, 0, 0]
         ['k': new MaxKey()]                                      | [8, 0, 0, 0, 127, 107, 0, 0]
         ['f': Decimal128.parse('0E-6176')]                       | [24, 0, 0, 0, 19, 102, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        ['u': new UUID(1, 2)]                                    | [29, 0, 0, 0, 5, 117, 0, 16, 0, 0, 0, 3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0]
 
         aClass = document.find { true }.value.getClass()
     }

--- a/driver-core/src/main/com/mongodb/BasicDBObject.java
+++ b/driver-core/src/main/com/mongodb/BasicDBObject.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
+import static org.bson.assertions.Assertions.notNull;
 import static org.bson.codecs.configuration.CodecRegistries.withUuidRepresentation;
 
 /**
@@ -60,7 +61,26 @@ import static org.bson.codecs.configuration.CodecRegistries.withUuidRepresentati
 public class BasicDBObject extends BasicBSONObject implements DBObject, Bson {
     private static final long serialVersionUID = -4415279469780082174L;
 
-    private static final Codec<BasicDBObject> DEFAULT_CODEC =
+    /**
+     * Sets the default {@link UuidRepresentation} to use when converting to and from JSON.
+     *
+     * <p>
+     * This method is particularly useful if you want to change the process-wide default for the {@link UuidRepresentation} this is
+     * applied during any conversions.  The default codec applies {@link UuidRepresentation#STANDARD}.
+     * </p>
+     *
+     * @param codec the default codec, which may not be null
+     * @see #parse(String)
+     * @see UuidRepresentation#STANDARD
+     * @see #toJson()
+     * @see #toJson(JsonWriterSettings)
+     * @since 4.7
+     */
+    public static void setDefaultCodec(final Codec<BasicDBObject> codec) {
+        defaultCodec = notNull("defaultCodec", codec);
+    }
+
+    private static volatile Codec<BasicDBObject> defaultCodec =
             withUuidRepresentation(DBObjectCodec.getDefaultRegistry(), UuidRepresentation.STANDARD)
                     .get(BasicDBObject.class);
 
@@ -78,7 +98,7 @@ public class BasicDBObject extends BasicBSONObject implements DBObject, Bson {
      * @mongodb.driver.manual reference/mongodb-extended-json/ MongoDB Extended JSON
      */
     public static BasicDBObject parse(final String json) {
-        return parse(json, DEFAULT_CODEC);
+        return parse(json, defaultCodec);
     }
 
     /**
@@ -176,7 +196,7 @@ public class BasicDBObject extends BasicBSONObject implements DBObject, Bson {
      * @throws org.bson.codecs.configuration.CodecConfigurationException if the document contains types not in the default registry
      */
     public String toJson(final JsonWriterSettings writerSettings) {
-        return toJson(writerSettings, DEFAULT_CODEC);
+        return toJson(writerSettings, defaultCodec);
     }
 
     /**
@@ -238,7 +258,7 @@ public class BasicDBObject extends BasicBSONObject implements DBObject, Bson {
      */
     private static byte[] toBson(final BasicDBObject dbObject) {
         OutputBuffer outputBuffer = new BasicOutputBuffer();
-        DEFAULT_CODEC.encode(new BsonBinaryWriter(outputBuffer), dbObject, EncoderContext.builder().build());
+        defaultCodec.encode(new BsonBinaryWriter(outputBuffer), dbObject, EncoderContext.builder().build());
         return outputBuffer.toByteArray();
     }
 


### PR DESCRIPTION
API for configuration of 

- default Codec for Document and BasicDBObject (used for JSON conversion)
- default UuidRepresentation for  BSONCallackAdapter and BasicBSONEncoder (used for UUID conversion)
