### PR TITLE
DOCSP-22066: remove redirect from whats new page

### DIFF
--- a/4.5/apidocs/index.html
+++ b/4.5/apidocs/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.74">
+<meta name="date" content="2022-04-15T13:43:39.85">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>API Documentation</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/bson/codecs/index.html
+++ b/4.5/bson/codecs/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.03">
+<meta name="date" content="2022-04-15T13:43:40.07">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Codec and CodecRegistry</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/bson/documents/index.html
+++ b/4.5/bson/documents/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.03">
+<meta name="date" content="2022-04-15T13:43:40.07">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Documents</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/bson/extended-json/index.html
+++ b/4.5/bson/extended-json/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.04">
+<meta name="date" content="2022-04-15T13:43:40.09">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Extended JSON</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/bson/index.html
+++ b/4.5/bson/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.1">
+<meta name="date" content="2022-04-15T13:43:40.17">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>BSON</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/bson/installation-guide/index.html
+++ b/4.5/bson/installation-guide/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.17">
+<meta name="date" content="2022-04-15T13:43:40.27">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Installation Guide</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/bson/pojos/index.html
+++ b/4.5/bson/pojos/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.8">
+<meta name="date" content="2022-04-15T13:43:39.89">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>POJOs</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/bson/readers-and-writers/index.html
+++ b/4.5/bson/readers-and-writers/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.07">
+<meta name="date" content="2022-04-15T13:43:40.12">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Readers and Writers</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/builders/aggregation/index.html
+++ b/4.5/builders/aggregation/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.01">
+<meta name="date" content="2022-04-15T13:43:40.06">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Aggregates</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/builders/filters/index.html
+++ b/4.5/builders/filters/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.05">
+<meta name="date" content="2022-04-15T13:43:40.09">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Filters</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/builders/index.html
+++ b/4.5/builders/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.11">
+<meta name="date" content="2022-04-15T13:43:40.19">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Builders</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/builders/indexes/index.html
+++ b/4.5/builders/indexes/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26">
+<meta name="date" content="2022-04-15T13:43:40.05">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Indexes</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/builders/projections/index.html
+++ b/4.5/builders/projections/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.06">
+<meta name="date" content="2022-04-15T13:43:40.11">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Projections</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/builders/sorts/index.html
+++ b/4.5/builders/sorts/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.08">
+<meta name="date" content="2022-04-15T13:43:40.13">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Sort Criteria  </title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/builders/updates/index.html
+++ b/4.5/builders/updates/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.09">
+<meta name="date" content="2022-04-15T13:43:40.14">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Updates</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/getting-started/installation/index.html
+++ b/4.5/driver-reactive/getting-started/installation/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.16">
+<meta name="date" content="2022-04-15T13:43:40.25">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Installation</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/getting-started/quick-start-pojo/index.html
+++ b/4.5/driver-reactive/getting-started/quick-start-pojo/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.78">
+<meta name="date" content="2022-04-15T13:43:39.88">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Quick Start - POJOs</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/getting-started/quick-start-primer/index.html
+++ b/4.5/driver-reactive/getting-started/quick-start-primer/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.19">
+<meta name="date" content="2022-04-15T13:43:40.3">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Quick Start Primer</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/getting-started/quick-start/index.html
+++ b/4.5/driver-reactive/getting-started/quick-start/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.18">
+<meta name="date" content="2022-04-15T13:43:40.28">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Quick Start</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/index.html
+++ b/4.5/driver-reactive/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.2">
+<meta name="date" content="2022-04-15T13:43:40.31">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Reactive Streams</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/reference/index.html
+++ b/4.5/driver-reactive/reference/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.21">
+<meta name="date" content="2022-04-15T13:43:40.33">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Reference</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/reference/logging/index.html
+++ b/4.5/driver-reactive/reference/logging/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.14">
+<meta name="date" content="2022-04-15T13:43:40.23">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Logging</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/reference/monitoring/index.html
+++ b/4.5/driver-reactive/reference/monitoring/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.13">
+<meta name="date" content="2022-04-15T13:43:40.2">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Monitoring</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/aggregation/index.html
+++ b/4.5/driver-reactive/tutorials/aggregation/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.86">
+<meta name="date" content="2022-04-15T13:43:39.94">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Aggregation</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/authentication/index.html
+++ b/4.5/driver-reactive/tutorials/authentication/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.94">
+<meta name="date" content="2022-04-15T13:43:40">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Authentication</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/bulk-writes/index.html
+++ b/4.5/driver-reactive/tutorials/bulk-writes/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.99">
+<meta name="date" content="2022-04-15T13:43:40.04">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Bulk Writes</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/change-streams/index.html
+++ b/4.5/driver-reactive/tutorials/change-streams/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.76">
+<meta name="date" content="2022-04-15T13:43:39.86">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Change Streams</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/client-side-encryption/index.html
+++ b/4.5/driver-reactive/tutorials/client-side-encryption/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.74">
+<meta name="date" content="2022-04-15T13:43:39.85">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Client Side Encryption</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/commands/index.html
+++ b/4.5/driver-reactive/tutorials/commands/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.91">
+<meta name="date" content="2022-04-15T13:43:39.98">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Run Commands</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/compression/index.html
+++ b/4.5/driver-reactive/tutorials/compression/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.76">
+<meta name="date" content="2022-04-15T13:43:39.87">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Compression</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/connect-to-mongodb/index.html
+++ b/4.5/driver-reactive/tutorials/connect-to-mongodb/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.96">
+<meta name="date" content="2022-04-15T13:43:40.02">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Connect to MongoDB</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/databases-collections/index.html
+++ b/4.5/driver-reactive/tutorials/databases-collections/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.9">
+<meta name="date" content="2022-04-15T13:43:39.96">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Databases and Collections</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/geospatial-search/index.html
+++ b/4.5/driver-reactive/tutorials/geospatial-search/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.82">
+<meta name="date" content="2022-04-15T13:43:39.91">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Geospatial Search</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/gridfs/index.html
+++ b/4.5/driver-reactive/tutorials/gridfs/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.8">
+<meta name="date" content="2022-04-15T13:43:39.89">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>GridFS</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/index.html
+++ b/4.5/driver-reactive/tutorials/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.97">
+<meta name="date" content="2022-04-15T13:43:40.03">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Tutorials</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/indexes/index.html
+++ b/4.5/driver-reactive/tutorials/indexes/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.92">
+<meta name="date" content="2022-04-15T13:43:39.99">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Create Indexes</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/perform-read-operations/index.html
+++ b/4.5/driver-reactive/tutorials/perform-read-operations/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.83">
+<meta name="date" content="2022-04-15T13:43:39.92">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Read Operations</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/perform-write-operations/index.html
+++ b/4.5/driver-reactive/tutorials/perform-write-operations/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.85">
+<meta name="date" content="2022-04-15T13:43:39.93">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Write Operations</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/ssl/index.html
+++ b/4.5/driver-reactive/tutorials/ssl/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.95">
+<meta name="date" content="2022-04-15T13:43:40.01">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>TLS/SSL</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-reactive/tutorials/text-search/index.html
+++ b/4.5/driver-reactive/tutorials/text-search/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.88">
+<meta name="date" content="2022-04-15T13:43:39.95">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Text Search</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/bson/index.html
+++ b/4.5/driver-scala/bson/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.1">
+<meta name="date" content="2022-04-15T13:43:40.17">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>BSON</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/bson/macros/index.html
+++ b/4.5/driver-scala/bson/macros/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.8">
+<meta name="date" content="2022-04-15T13:43:39.89">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Macros</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/bson/scala-documents/index.html
+++ b/4.5/driver-scala/bson/scala-documents/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.03">
+<meta name="date" content="2022-04-15T13:43:40.08">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Documents</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/bson/scala-extended-json/index.html
+++ b/4.5/driver-scala/bson/scala-extended-json/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.05">
+<meta name="date" content="2022-04-15T13:43:40.09">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Extended JSON</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/builders/aggregation/index.html
+++ b/4.5/driver-scala/builders/aggregation/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.02">
+<meta name="date" content="2022-04-15T13:43:40.07">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Aggregation</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/builders/filters/index.html
+++ b/4.5/driver-scala/builders/filters/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.06">
+<meta name="date" content="2022-04-15T13:43:40.1">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Filters</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/builders/index.html
+++ b/4.5/driver-scala/builders/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.12">
+<meta name="date" content="2022-04-15T13:43:40.19">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Builders</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/builders/indexes/index.html
+++ b/4.5/driver-scala/builders/indexes/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.01">
+<meta name="date" content="2022-04-15T13:43:40.05">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Indexes</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/builders/projections/index.html
+++ b/4.5/driver-scala/builders/projections/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.07">
+<meta name="date" content="2022-04-15T13:43:40.12">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Projections</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/builders/sorts/index.html
+++ b/4.5/driver-scala/builders/sorts/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.08">
+<meta name="date" content="2022-04-15T13:43:40.13">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Sort Criteria</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/builders/updates/index.html
+++ b/4.5/driver-scala/builders/updates/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.09">
+<meta name="date" content="2022-04-15T13:43:40.16">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Updates</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/getting-started/installation/index.html
+++ b/4.5/driver-scala/getting-started/installation/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.16">
+<meta name="date" content="2022-04-15T13:43:40.26">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Installation</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/getting-started/quick-start-case-class/index.html
+++ b/4.5/driver-scala/getting-started/quick-start-case-class/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.78">
+<meta name="date" content="2022-04-15T13:43:39.88">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Quick Start - Case Classes</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/getting-started/quick-start-primer/index.html
+++ b/4.5/driver-scala/getting-started/quick-start-primer/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.2">
+<meta name="date" content="2022-04-15T13:43:40.3">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Quick Start Primer</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/getting-started/quick-start/index.html
+++ b/4.5/driver-scala/getting-started/quick-start/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.18">
+<meta name="date" content="2022-04-15T13:43:40.28">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Quick Start</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/index.html
+++ b/4.5/driver-scala/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.22">
+<meta name="date" content="2022-04-15T13:43:40.36">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Scala Driver</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/reference/index.html
+++ b/4.5/driver-scala/reference/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.21">
+<meta name="date" content="2022-04-15T13:43:40.35">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Reference</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/reference/logging/index.html
+++ b/4.5/driver-scala/reference/logging/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.15">
+<meta name="date" content="2022-04-15T13:43:40.23">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Logging</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/reference/monitoring/index.html
+++ b/4.5/driver-scala/reference/monitoring/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.13">
+<meta name="date" content="2022-04-15T13:43:40.22">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Monitoring</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/reference/observables/index.html
+++ b/4.5/driver-scala/reference/observables/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.01">
+<meta name="date" content="2022-04-15T13:43:40.06">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Observables</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/aggregation/index.html
+++ b/4.5/driver-scala/tutorials/aggregation/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.87">
+<meta name="date" content="2022-04-15T13:43:39.95">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Aggregation</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/authentication/index.html
+++ b/4.5/driver-scala/tutorials/authentication/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.94">
+<meta name="date" content="2022-04-15T13:43:40">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Authentication</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/bulk-writes/index.html
+++ b/4.5/driver-scala/tutorials/bulk-writes/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.99">
+<meta name="date" content="2022-04-15T13:43:40.04">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Bulk Writes</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/change-streams/index.html
+++ b/4.5/driver-scala/tutorials/change-streams/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.76">
+<meta name="date" content="2022-04-15T13:43:39.86">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Change Streams</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/client-side-encryption/index.html
+++ b/4.5/driver-scala/tutorials/client-side-encryption/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.74">
+<meta name="date" content="2022-04-15T13:43:39.85">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Client Side Encryption</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/commands/index.html
+++ b/4.5/driver-scala/tutorials/commands/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.91">
+<meta name="date" content="2022-04-15T13:43:39.98">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Run Commands</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/compression/index.html
+++ b/4.5/driver-scala/tutorials/compression/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.77">
+<meta name="date" content="2022-04-15T13:43:39.88">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Compression</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/connect-to-mongodb/index.html
+++ b/4.5/driver-scala/tutorials/connect-to-mongodb/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.97">
+<meta name="date" content="2022-04-15T13:43:40.02">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Connect to MongoDB</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/databases-collections/index.html
+++ b/4.5/driver-scala/tutorials/databases-collections/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.9">
+<meta name="date" content="2022-04-15T13:43:39.97">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Databases and Collections</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/geospatial-search/index.html
+++ b/4.5/driver-scala/tutorials/geospatial-search/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.82">
+<meta name="date" content="2022-04-15T13:43:39.91">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Geospatial Search</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/gridfs/index.html
+++ b/4.5/driver-scala/tutorials/gridfs/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.81">
+<meta name="date" content="2022-04-15T13:43:39.9">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>GridFS</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/index.html
+++ b/4.5/driver-scala/tutorials/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.98">
+<meta name="date" content="2022-04-15T13:43:40.03">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Tutorials</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/indexes/index.html
+++ b/4.5/driver-scala/tutorials/indexes/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.92">
+<meta name="date" content="2022-04-15T13:43:39.99">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Create Indexes</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/perform-read-operations/index.html
+++ b/4.5/driver-scala/tutorials/perform-read-operations/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.84">
+<meta name="date" content="2022-04-15T13:43:39.92">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Read Operations</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/perform-write-operations/index.html
+++ b/4.5/driver-scala/tutorials/perform-write-operations/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.85">
+<meta name="date" content="2022-04-15T13:43:39.93">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Write Operations</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/ssl/index.html
+++ b/4.5/driver-scala/tutorials/ssl/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.95">
+<meta name="date" content="2022-04-15T13:43:40.01">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>TLS/SSL</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver-scala/tutorials/text-search/index.html
+++ b/4.5/driver-scala/tutorials/text-search/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.88">
+<meta name="date" content="2022-04-15T13:43:39.96">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Text Search</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/getting-started/installation/index.html
+++ b/4.5/driver/getting-started/installation/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.17">
+<meta name="date" content="2022-04-15T13:43:40.26">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Installation</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/getting-started/quick-start-pojo/index.html
+++ b/4.5/driver/getting-started/quick-start-pojo/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.79">
+<meta name="date" content="2022-04-15T13:43:39.89">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Quick Start - POJOs</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/getting-started/quick-start/index.html
+++ b/4.5/driver/getting-started/quick-start/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.19">
+<meta name="date" content="2022-04-15T13:43:40.29">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Quick Start</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/index.html
+++ b/4.5/driver/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.18">
+<meta name="date" content="2022-04-15T13:43:40.28">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Java Driver</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/reference/index.html
+++ b/4.5/driver/reference/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.22">
+<meta name="date" content="2022-04-15T13:43:40.36">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Reference</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/reference/logging/index.html
+++ b/4.5/driver/reference/logging/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.15">
+<meta name="date" content="2022-04-15T13:43:40.24">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Logging</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/reference/monitoring/index.html
+++ b/4.5/driver/reference/monitoring/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.14">
+<meta name="date" content="2022-04-15T13:43:40.22">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Monitoring</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/aggregation/index.html
+++ b/4.5/driver/tutorials/aggregation/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.88">
+<meta name="date" content="2022-04-15T13:43:39.95">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Aggregation</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/authentication/index.html
+++ b/4.5/driver/tutorials/authentication/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.95">
+<meta name="date" content="2022-04-15T13:43:40.01">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Authentication</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/bulk-writes/index.html
+++ b/4.5/driver/tutorials/bulk-writes/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26">
+<meta name="date" content="2022-04-15T13:43:40.05">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Bulk Writes</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/change-streams/index.html
+++ b/4.5/driver/tutorials/change-streams/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.76">
+<meta name="date" content="2022-04-15T13:43:39.87">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Change Streams</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/client-side-encryption/index.html
+++ b/4.5/driver/tutorials/client-side-encryption/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.74">
+<meta name="date" content="2022-04-15T13:43:39.85">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Client Side Encryption</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/commands/index.html
+++ b/4.5/driver/tutorials/commands/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.92">
+<meta name="date" content="2022-04-15T13:43:39.99">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Run Commands</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/compression/index.html
+++ b/4.5/driver/tutorials/compression/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.78">
+<meta name="date" content="2022-04-15T13:43:39.88">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Compression</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/connect-to-mongodb/index.html
+++ b/4.5/driver/tutorials/connect-to-mongodb/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.97">
+<meta name="date" content="2022-04-15T13:43:40.03">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Connect to MongoDB</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/databases-collections/index.html
+++ b/4.5/driver/tutorials/databases-collections/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.91">
+<meta name="date" content="2022-04-15T13:43:39.97">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Databases and Collections</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/geospatial-search/index.html
+++ b/4.5/driver/tutorials/geospatial-search/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.83">
+<meta name="date" content="2022-04-15T13:43:39.91">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Geospatial Search</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/gridfs/index.html
+++ b/4.5/driver/tutorials/gridfs/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.81">
+<meta name="date" content="2022-04-15T13:43:39.91">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>GridFS</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/index.html
+++ b/4.5/driver/tutorials/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.99">
+<meta name="date" content="2022-04-15T13:43:40.04">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Tutorials</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/indexes/index.html
+++ b/4.5/driver/tutorials/indexes/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.94">
+<meta name="date" content="2022-04-15T13:43:40">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Create Indexes</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/jndi/index.html
+++ b/4.5/driver/tutorials/jndi/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.12">
+<meta name="date" content="2022-04-15T13:43:40.2">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>JNDI</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/perform-read-operations/index.html
+++ b/4.5/driver/tutorials/perform-read-operations/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.85">
+<meta name="date" content="2022-04-15T13:43:39.93">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Read Operations</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/perform-write-operations/index.html
+++ b/4.5/driver/tutorials/perform-write-operations/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.86">
+<meta name="date" content="2022-04-15T13:43:39.94">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Write Operations</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/ssl/index.html
+++ b/4.5/driver/tutorials/ssl/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.96">
+<meta name="date" content="2022-04-15T13:43:40.02">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>TLS/SSL</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/driver/tutorials/text-search/index.html
+++ b/4.5/driver/tutorials/text-search/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.89">
+<meta name="date" content="2022-04-15T13:43:39.96">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Text Search</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/index.html
+++ b/4.5/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.24">
+<meta name="date" content="2022-04-15T13:43:40.38">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>MongoDB JVM Drivers</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />
@@ -320,9 +320,9 @@
 
 <p>Welcome to the MongoDB JVM driver documentation hub for the 4.4 drivers release. Please note that the primary documentation is now located <a href="https://www.mongodb.com/docs/drivers/java/sync/current/">on the MongoDB domain</a></p>
 
-<h3 id="what-s-new-in-4-4">What&rsquo;s New in 4.4</h3>
+<h3 id="what-s-new-in-4-5">What&rsquo;s New in 4.5</h3>
 
-<p>For key new features of 4.4, see <a href="/mongo-java-driver/4.5/whats-new/">What&rsquo;s New</a>.</p>
+<p>For key new features of 4.5, see <a href="/mongo-java-driver/4.5/whats-new/">What&rsquo;s New</a>.</p>
 
 <h3 id="upgrade">Upgrade</h3>
 

--- a/4.5/index.xml
+++ b/4.5/index.xml
@@ -320,7 +320,7 @@ Prerequisites  The example below requires a restaurants collection in the test d
       <pubDate>Thu, 09 Jun 2016 12:47:43 -0400</pubDate>
       
       <guid>/mongo-java-driver/4.5/whats-new/</guid>
-      <description>What&amp;rsquo;s new in 4.4  Compatibility with MongoDB 5.1 and support for Java 17 Added support for index hints in an AggregateIterable Added support for the $merge and $out aggregation stages on secondaries Use of the mergeObjects() method in the Updates builder DocumentCodec does not ignore a CodecRegistry when writing to an Iterable or a Map instance  What&amp;rsquo;s new in 4.3 This release fully supports all MongoDB releases from versions 2.</description>
+      <description>What&amp;rsquo;s new in 4.5  Refer to What&amp;rsquo;s New - Java Sync Documentation for more information.  What&amp;rsquo;s new in 4.4  Compatibility with MongoDB 5.1 and support for Java 17 Added support for index hints in an AggregateIterable Added support for the $merge and $out aggregation stages on secondaries Use of the mergeObjects() method in the Updates builder DocumentCodec does not ignore a CodecRegistry when writing to an Iterable or a Map instance  What&amp;rsquo;s new in 4.</description>
     </item>
     
     <item>
@@ -1237,7 +1237,7 @@ Previous Releases    Release Documentation     4.4.x Reference &amp;#124; API   
       
       <guid>/mongo-java-driver/4.5/</guid>
       <description>MongoDB Java Driver Documentation Welcome to the MongoDB JVM driver documentation hub for the 4.4 drivers release. Please note that the primary documentation is now located on the MongoDB domain
-What&amp;rsquo;s New in 4.4 For key new features of 4.4, see What&amp;rsquo;s New.
+What&amp;rsquo;s New in 4.5 For key new features of 4.5, see What&amp;rsquo;s New.
 Upgrade To upgrade, refer to the Upgrade Considerations documentation.
 MongoDB Driver For the synchronous MongoDB Driver, see MongoDB Driver section.
 MongoDB Reactive Streams Driver For the MongoDB Reactive Streams Driver, see MongoDB Reactive Streams Driver section.</description>

--- a/4.5/issues-help/index.html
+++ b/4.5/issues-help/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.16">
+<meta name="date" content="2022-04-15T13:43:40.25">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Issues &amp; Help</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/upgrading/index.html
+++ b/4.5/upgrading/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:26.1">
+<meta name="date" content="2022-04-15T13:43:40.16">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>Upgrade Considerations</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />

--- a/4.5/whats-new/index.html
+++ b/4.5/whats-new/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="MongoDB Java Driver documentation">
 <meta name="author" content="MongoDB Drivers Team">
 <meta name="keyword" content="MongoDB, Java, JVM, NoSQL, Document Database">
-<meta name="date" content="2022-03-25T14:39:25.86">
+<meta name="date" content="2022-04-15T13:43:39.94">
 <link rel="shortcut icon" href="/mongo-java-driver/4.5/img/favicon.png">
 
     <title>What&#39;s New</title><link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap.css" type="text/css" />
@@ -16,10 +16,6 @@
 <link rel="stylesheet" href="/mongo-java-driver/4.5/lib/bootstrap-toggle/bootstrap-toggle.min.css" type="text/css" />
 <link rel="stylesheet" href="/mongo-java-driver/4.5/css/java.css" type="text/css" />
 
-
-  <link rel="canonical" href="https://www.mongodb.com/docs/drivers/java/sync/v4.5/"/>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta http-equiv="refresh" content="0;url=https://www.mongodb.com/docs/drivers/java/sync/v4.5/" />
 
 
 
@@ -323,6 +319,12 @@
 <ul><li>What&#39;s New</li>
 </ul>
 </div>
+
+<h1 id="what-s-new-in-4-5">What&rsquo;s new in 4.5</h1>
+
+<ul>
+<li>Refer to <a href="https://www.mongodb.com/drivers/java/sync/">What&rsquo;s New - Java Sync Documentation</a> for more information.</li>
+</ul>
 
 <h1 id="what-s-new-in-4-4">What&rsquo;s new in 4.4</h1>
 
@@ -956,6 +958,7 @@ collection.bulkWrite(Arrays.asList(
 <div class="wrapper"><div class="toc">
     <span class="toc-header">On this page</span><nav id="TableOfContents">
 <ul>
+<li><a href="#what-s-new-in-4-5">What&rsquo;s new in 4.5</a></li>
 <li><a href="#what-s-new-in-4-4">What&rsquo;s new in 4.4</a></li>
 <li><a href="#what-s-new-in-4-3">What&rsquo;s new in 4.3</a></li>
 <li><a href="#what-s-new-in-4-2">What&rsquo;s new in 4.2</a></li>


### PR DESCRIPTION
Notable change:
[4.5/whats-new/index.html ](https://github.com/mongodb/mongo-java-driver/pull/920/files#diff-e4c0dd6d354f0db5c4ec44a14f4ca9aecde534a2aabd54e1ce12878d4ee88bb0)- no longer contains the redirect in the header; added entry for 4.5 (link to Java sync docs)

Remainder of changes are generation date meta data.