### PR TITLE
Use $$unsetOrMatches for upsert and multi in spec tests

### DIFF
--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-comment.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-comment.json
@@ -151,6 +151,12 @@
                       "u": {
                         "_id": 1,
                         "x": "replaced"
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -172,6 +178,12 @@
                         "$set": {
                           "x": "updated"
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -330,6 +342,12 @@
                       "u": {
                         "_id": 1,
                         "x": "replaced"
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -353,6 +371,12 @@
                         "$set": {
                           "x": "updated"
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-replaceOne-let.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-replaceOne-let.json
@@ -95,6 +95,12 @@
                       },
                       "u": {
                         "x": 3
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -183,6 +189,12 @@
                       },
                       "u": {
                         "x": 3
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/driver-core/src/test/resources/unified-test-format/crud/replaceOne-comment.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/replaceOne-comment.json
@@ -75,6 +75,12 @@
                       },
                       "u": {
                         "x": 22
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -137,6 +143,12 @@
                       },
                       "u": {
                         "x": 22
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -203,6 +215,12 @@
                       },
                       "u": {
                         "x": 22
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/driver-core/src/test/resources/unified-test-format/crud/replaceOne-let.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/replaceOne-let.json
@@ -94,6 +94,12 @@
                       },
                       "u": {
                         "x": "foo"
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -176,6 +182,12 @@
                       },
                       "u": {
                         "x": "foo"
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/driver-core/src/test/resources/unified-test-format/crud/updateMany-comment.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateMany-comment.json
@@ -80,7 +80,10 @@
                           "x": 22
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "comment": "comment"
@@ -147,7 +150,10 @@
                           "x": 22
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "comment": {
@@ -218,7 +224,10 @@
                           "x": 22
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "comment": "comment"

--- a/driver-core/src/test/resources/unified-test-format/crud/updateMany-let.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateMany-let.json
@@ -114,7 +114,10 @@
                           }
                         }
                       ],
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "let": {
@@ -207,7 +210,10 @@
                           }
                         }
                       ],
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "let": {

--- a/driver-core/src/test/resources/unified-test-format/crud/updateOne-comment.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateOne-comment.json
@@ -79,6 +79,12 @@
                         "$set": {
                           "x": 22
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -145,6 +151,12 @@
                         "$set": {
                           "x": 22
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -215,6 +227,12 @@
                         "$set": {
                           "x": 22
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/driver-core/src/test/resources/unified-test-format/crud/updateOne-let.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateOne-let.json
@@ -103,7 +103,13 @@
                             "x": "$$x"
                           }
                         }
-                      ]
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "let": {
@@ -184,7 +190,13 @@
                             "x": "$$x"
                           }
                         }
-                      ]
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "let": {


### PR DESCRIPTION
* Modifications made in a previous commit of bulkWrite-comment.json
  had to be preserved, so this is not an exact copy of the spec tests
* Modifications to require minServerVersion of 3.6 also had to be preserved,
  since Java driver still supports older server versions

JAVA-4568