### PR TITLE
Add query building API for the `$searchMeta` aggregation pipeline stage

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOptions.java
@@ -21,7 +21,7 @@ import com.mongodb.client.model.Aggregates;
 import org.bson.conversions.Bson;
 
 /**
- * This interface represents optional fields of the {@code $search} pipeline stage of an aggregation pipeline.
+ * Represents optional fields of the {@code $search} pipeline stage of an aggregation pipeline.
  *
  * @see Aggregates#search(SearchOperator, SearchOptions)
  * @see Aggregates#search(SearchCollector, SearchOptions)

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
@@ -505,8 +505,7 @@ object Aggregates {
    *
    * @param operator A search operator.
    * @param options Optional `\$search` pipeline stage fields.
-   * Specifying `null` is equivalent to specifying `SearchOptions.defaultSearchOptions`
-   * or calling `Aggregates.search(SearchOperator)`.
+   * Specifying `SearchOptions.defaultSearchOptions` is equivalent to calling `Aggregates.search(SearchOperator)`.
    * @return The `\$search` pipeline stage.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search]]
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
@@ -542,8 +541,7 @@ object Aggregates {
    *
    * @param collector A search collector.
    * @param options Optional `\$search` pipeline stage fields.
-   * Specifying `null` is equivalent to specifying `SearchOptions.defaultSearchOptions`
-   * or calling `Aggregates.search(SearchCollector)`.
+   * Specifying `SearchOptions.defaultSearchOptions` is equivalent to calling `Aggregates.search(SearchCollector)`.
    * @return The `\$search` pipeline stage.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search]]
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]
@@ -576,8 +574,7 @@ object Aggregates {
    *
    * @param operator A search operator.
    * @param options Optional `\$search` pipeline stage fields.
-   * Specifying `null` is equivalent to specifying `SearchOptions.defaultSearchOptions`
-   * or calling `Aggregates.searchMeta(SearchOperator)`.
+   * Specifying `SearchOptions.defaultSearchOptions` is equivalent to calling `Aggregates.searchMeta(SearchOperator)`.
    * @return The `\$searchMeta` pipeline stage.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-searchmeta \$searchMeta]]
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
@@ -609,8 +606,7 @@ object Aggregates {
    *
    * @param collector A search collector.
    * @param options Optional `\$search` pipeline stage fields.
-   * Specifying `null` is equivalent to specifying `SearchOptions.defaultSearchOptions`
-   * or calling `Aggregates.searchMeta(SearchCollector)`.
+   * Specifying `SearchOptions.defaultSearchOptions` is equivalent to calling `Aggregates.searchMeta(SearchCollector)`.
    * @return The `\$searchMeta` pipeline stage.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-searchmeta \$searchMeta]]
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
@@ -487,8 +487,26 @@ object Aggregates {
    * `Filters.text(String, TextSearchOptions)` is a legacy text search alternative.
    *
    * @param operator A search operator.
+   * @return The `\$search` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/ Scoring]]
+   * @since 4.7
+   */
+  def search(operator: SearchOperator): Bson =
+    JAggregates.search(operator)
+
+  /**
+   * Creates a `\$search` pipeline stage supported by MongoDB Atlas.
+   * You may use the `\$meta: "searchScore"` expression, e.g., via [[Projections.metaSearchScore]],
+   * to extract the relevance score assigned to each found document.
+   *
+   * `Filters.text(String, TextSearchOptions)` is a legacy text search alternative.
+   *
+   * @param operator A search operator.
    * @param options Optional `\$search` pipeline stage fields.
-   * Specifying `null` is equivalent to specifying `SearchOptions.defaultSearchOptions`.
+   * Specifying `null` is equivalent to specifying `SearchOptions.defaultSearchOptions`
+   * or calling `Aggregates.search(SearchOperator)`.
    * @return The `\$search` pipeline stage.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search]]
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
@@ -506,8 +524,26 @@ object Aggregates {
    * `Filters.text(String, TextSearchOptions)` is a legacy text search alternative.
    *
    * @param collector A search collector.
+   * @return The `\$search` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/ Scoring]]
+   * @since 4.7
+   */
+  def search(collector: SearchCollector): Bson =
+    JAggregates.search(collector)
+
+  /**
+   * Creates a `\$search` pipeline stage supported by MongoDB Atlas.
+   * You may use the `\$meta: "searchScore"` expression, e.g., via [[Projections.metaSearchScore]],
+   * to extract the relevance score assigned to each found document.
+   *
+   * `Filters.text(String, TextSearchOptions)` is a legacy text search alternative.
+   *
+   * @param collector A search collector.
    * @param options Optional `\$search` pipeline stage fields.
-   * Specifying `null` is equivalent to specifying `SearchOptions.defaultSearchOptions`.
+   * Specifying `null` is equivalent to specifying `SearchOptions.defaultSearchOptions`
+   * or calling `Aggregates.search(SearchCollector)`.
    * @return The `\$search` pipeline stage.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search]]
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]
@@ -516,4 +552,70 @@ object Aggregates {
    */
   def search(collector: SearchCollector, options: SearchOptions): Bson =
     JAggregates.search(collector, options)
+
+  /**
+   * Creates a `\$searchMeta` pipeline stage supported by MongoDB Atlas.
+   * Unlike `\$search`, it does not return found documents,
+   * instead it returns metadata, which in case of using the `\$search` stage
+   * may be extracted by using `$$SEARCH_META` variable, e.g., via [[Projections.computedSearchMeta]].
+   *
+   * @param operator A search operator.
+   * @return The `\$searchMeta` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-searchmeta \$searchMeta]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
+   * @since 4.7
+   */
+  def searchMeta(operator: SearchOperator): Bson =
+    JAggregates.searchMeta(operator)
+
+  /**
+   * Creates a `\$searchMeta` pipeline stage supported by MongoDB Atlas.
+   * Unlike `\$search`, it does not return found documents,
+   * instead it returns metadata, which in case of using the `\$search` stage
+   * may be extracted by using `$$SEARCH_META` variable, e.g., via [[Projections.computedSearchMeta]].
+   *
+   * @param operator A search operator.
+   * @param options Optional `\$search` pipeline stage fields.
+   * Specifying `null` is equivalent to specifying `SearchOptions.defaultSearchOptions`
+   * or calling `Aggregates.searchMeta(SearchOperator)`.
+   * @return The `\$searchMeta` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-searchmeta \$searchMeta]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
+   * @since 4.7
+   */
+  def searchMeta(operator: SearchOperator, options: SearchOptions): Bson =
+    JAggregates.searchMeta(operator, options)
+
+  /**
+   * Creates a `\$searchMeta` pipeline stage supported by MongoDB Atlas.
+   * Unlike `\$search`, it does not return found documents,
+   * instead it returns metadata, which in case of using the `\$search` stage
+   * may be extracted by using `$$SEARCH_META` variable, e.g., via [[Projections.computedSearchMeta]].
+   *
+   * @param collector A search collector.
+   * @return The `\$searchMeta` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-searchmeta \$searchMeta]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]
+   * @since 4.7
+   */
+  def searchMeta(collector: SearchCollector): Bson =
+    JAggregates.searchMeta(collector)
+
+  /**
+   * Creates a `\$searchMeta` pipeline stage supported by MongoDB Atlas.
+   * Unlike `\$search`, it does not return found documents,
+   * instead it returns metadata, which in case of using the `\$search` stage
+   * may be extracted by using `$$SEARCH_META` variable, e.g., via [[Projections.computedSearchMeta]].
+   *
+   * @param collector A search collector.
+   * @param options Optional `\$search` pipeline stage fields.
+   * Specifying `null` is equivalent to specifying `SearchOptions.defaultSearchOptions`
+   * or calling `Aggregates.searchMeta(SearchCollector)`.
+   * @return The `\$searchMeta` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-searchmeta \$searchMeta]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]
+   * @since 4.7
+   */
+  def searchMeta(collector: SearchCollector, options: SearchOptions): Bson =
+    JAggregates.searchMeta(collector, options)
 }

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOptions.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOptions.scala
@@ -18,7 +18,7 @@ package org.mongodb.scala.model.search
 import com.mongodb.client.model.search.{ SearchOptions => JSearchOptions }
 
 /**
- * This interface represents optional fields of the `\$search` pipeline stage of an aggregation pipeline.
+ * Represents optional fields of the `\$search` pipeline stage of an aggregation pipeline.
  *
  * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search syntax]]
  * @since 4.7

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchPath.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchPath.scala
@@ -18,6 +18,9 @@ package org.mongodb.scala.model.search
 import com.mongodb.client.model.search.{ SearchPath => JSearchPath }
 
 /**
+ * A specification of document fields to be searched.
+ *
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/path-construction/ Path]]
  * @since 4.7
  */
 object SearchPath {

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/package.scala
@@ -20,6 +20,13 @@ import com.mongodb.annotations.{ Beta, Evolving }
 /**
  * Query building API for MongoDB Atlas full-text search.
  *
+ * While all the building blocks of this API, such as
+ * [[SearchOptions]], [[SearchHighlight]], etc.,
+ * are not necessary immutable, they are unmodifiable due to methods like
+ * `SearchHighlight.maxCharsToExamine` returning new instances instead of modifying the instance
+ * on which they are called. This allows storing and using such instances as templates.
+ *
+ * @see `Aggregates.search`
  * @see [[https://www.mongodb.com/docs/atlas/atlas-search/ Atlas Search]]
  * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/ Atlas Search aggregation pipeline stages]]
  * @since 4.7
@@ -58,7 +65,7 @@ package object search {
   type FacetSearchCollector = com.mongodb.client.model.search.FacetSearchCollector
 
   /**
-   * This interface represents optional fields of the `\$search` pipeline stage of an aggregation pipeline.
+   * Represents optional fields of the `\$search` pipeline stage of an aggregation pipeline.
    *
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search syntax]]
    */


### PR DESCRIPTION
**Superseded by https://github.com/mongodb/mongo-java-driver/pull/952.**

The main thing to know about the [`$searchMeta`](https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-searchmeta) stage is that any `$search` stage is and will be a valid `$searchMeta` stage. This is not documented, but so I was told by Evan Plotkin.

Evergreen patch: https://spruce.mongodb.com/version/6260459232f41728ef1e93c5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC.

In order to merge this PR we need to:

- merge https://github.com/mongodb/mongo-java-driver/pull/891;
- change the target branch from `JAVA-4415` to `master`;
- delete the `JAVA-4415` branch;
- merge this PR.

JAVA-4315