### PR TITLE
Support global configuration of UuidRepresentation for legacy encoder…

### DIFF
--- a/bson/src/main/org/bson/BSONCallbackAdapter.java
+++ b/bson/src/main/org/bson/BSONCallbackAdapter.java
@@ -86,21 +86,20 @@ class BSONCallbackAdapter extends AbstractBsonWriter {
 
     @Override
     protected void doWriteBinaryData(final BsonBinary value) {
-        UuidRepresentation defaultUuidRepresentation = getDefaultUuidRepresentation();
-        if (defaultUuidRepresentation == UuidRepresentation.STANDARD) {
-            if (value.getType() == BsonBinarySubType.UUID_LEGACY.getValue()) {
-                bsonCallback.gotBinary(getName(), value.getType(), value.getData());
-            } else {
-                UUID uuid = UuidHelper.decodeBinaryToUuid(value.getData(), value.getType(), defaultUuidRepresentation);
-                bsonCallback.gotUUID(getName(), uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
-            }
+        if (BsonBinarySubType.isUuid(value.getType())) {
+            doWriteUuid(value);
         } else {
-            if (value.getType() == BsonBinarySubType.UUID_LEGACY.getValue()) {
-                UUID uuid = UuidHelper.decodeBinaryToUuid(value.getData(), value.getType(), defaultUuidRepresentation);
-                bsonCallback.gotUUID(getName(), uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
-            } else {
-                bsonCallback.gotBinary(getName(), value.getType(), value.getData());
-            }
+            bsonCallback.gotBinary(getName(), value.getType(), value.getData());
+        }
+    }
+
+    private void doWriteUuid(final BsonBinary value) {
+        UuidRepresentation defaultUuidRepresentation = getDefaultUuidRepresentation();
+        if (value.getType() == defaultUuidRepresentation.getSubtype().getValue()) {
+            UUID uuid = UuidHelper.decodeBinaryToUuid(value.getData(), value.getType(), defaultUuidRepresentation);
+            bsonCallback.gotUUID(getName(), uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+        } else {
+            bsonCallback.gotBinary(getName(), value.getType(), value.getData());
         }
     }
 

--- a/bson/src/main/org/bson/BasicBSONDecoder.java
+++ b/bson/src/main/org/bson/BasicBSONDecoder.java
@@ -30,10 +30,11 @@ import static org.bson.assertions.Assertions.notNull;
 public class BasicBSONDecoder implements BSONDecoder {
 
     /**
-     * Sets the default {@link UuidRepresentation} to use when decoding BSON binary values.
+     * Sets the global (JVM-wide) {@link UuidRepresentation} to use when decoding BSON binary values.
      *
      * <p>
-     * If unset, the default is {@link UuidRepresentation#JAVA_LEGACY}.
+     * Defaults to {@link UuidRepresentation#JAVA_LEGACY}. If set to {@link UuidRepresentation#UNSPECIFIED}, attempting to decode any
+     * UUID will throw a {@link BSONException}.
      * </p>
      *
      * @param uuidRepresentation the uuid representation, which may not be null

--- a/bson/src/main/org/bson/BasicBSONDecoder.java
+++ b/bson/src/main/org/bson/BasicBSONDecoder.java
@@ -22,10 +22,46 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
+import static org.bson.assertions.Assertions.notNull;
+
 /**
  * Basic implementation of BSONDecoder interface that creates BasicBSONObject instances
  */
 public class BasicBSONDecoder implements BSONDecoder {
+
+    /**
+     * Sets the default {@link UuidRepresentation} to use when decoding BSON binary values.
+     *
+     * <p>
+     * If unset, the default is {@link UuidRepresentation#JAVA_LEGACY}.
+     * </p>
+     *
+     * @param uuidRepresentation the uuid representation, which may not be null
+     * @see BSONCallback#gotUUID(String, long, long)
+     * @see BasicBSONEncoder#setDefaultUuidRepresentation(UuidRepresentation)
+     * @since 4.7
+     */
+    public static void setDefaultUuidRepresentation(final UuidRepresentation uuidRepresentation) {
+        defaultUuidRepresentation = notNull("uuidRepresentation", uuidRepresentation);
+    }
+
+    /**
+     * Gets the default {@link UuidRepresentation} to use when decoding BSON binary values.
+     *
+     * <p>
+     * If unset, the default is {@link UuidRepresentation#JAVA_LEGACY}.
+     * </p>
+     *
+     * @return the uuid representation, which may not be null
+     * @see BSONCallback#gotUUID(String, long, long)
+     * @see BasicBSONEncoder#setDefaultUuidRepresentation(UuidRepresentation)
+     * @since 4.7
+     */
+    public static UuidRepresentation getDefaultUuidRepresentation() {
+        return defaultUuidRepresentation;
+    }
+
+    private static volatile UuidRepresentation defaultUuidRepresentation = UuidRepresentation.JAVA_LEGACY;
 
     @Override
     public BSONObject readObject(final byte[] bytes) {

--- a/bson/src/main/org/bson/BasicBSONDecoder.java
+++ b/bson/src/main/org/bson/BasicBSONDecoder.java
@@ -30,7 +30,14 @@ import static org.bson.assertions.Assertions.notNull;
 public class BasicBSONDecoder implements BSONDecoder {
 
     /**
-     * Sets the global (JVM-wide) {@link UuidRepresentation} to use when decoding BSON binary values.
+     * Sets the global (JVM-wide) {@link UuidRepresentation} to use when decoding BSON binary values with subtypes of either
+     * {@link BsonBinarySubType#UUID_STANDARD} or {@link BsonBinarySubType#UUID_LEGACY}.
+     *
+     * <p>
+     * If the {@link BsonBinarySubType} of the value to be decoded matches the binary subtype of the {@link UuidRepresentation},
+     * then the value will be decoded to an instance of {@link java.util.UUID}, according to the semantics of the
+     * {@link UuidRepresentation}.  Otherwise, it will be decoded to an instance of {@link org.bson.types.Binary}.
+     * </p>
      *
      * <p>
      * Defaults to {@link UuidRepresentation#JAVA_LEGACY}. If set to {@link UuidRepresentation#UNSPECIFIED}, attempting to decode any

--- a/bson/src/main/org/bson/BasicBSONEncoder.java
+++ b/bson/src/main/org/bson/BasicBSONEncoder.java
@@ -46,10 +46,11 @@ import static org.bson.assertions.Assertions.notNull;
 public class BasicBSONEncoder implements BSONEncoder {
 
     /**
-     * Sets the default {@link UuidRepresentation} to use when encoding UUID values to BSON binary.
+     * Sets the global (JVM-wide) {@link UuidRepresentation} to use when encoding UUID values to BSON binary.
      *
      * <p>
-     * If unset, the default is {@link UuidRepresentation#JAVA_LEGACY}.
+     * Defaults to {@link UuidRepresentation#JAVA_LEGACY}. If set to {@link UuidRepresentation#UNSPECIFIED}, attempting to encode any
+     * UUID will throw a {@link BSONException}.
      * </p>
      *
      * @param uuidRepresentation the uuid representation, which may not be null

--- a/bson/src/main/org/bson/BasicBSONEncoder.java
+++ b/bson/src/main/org/bson/BasicBSONEncoder.java
@@ -16,6 +16,7 @@
 
 package org.bson;
 
+import org.bson.internal.UuidHelper;
 import org.bson.io.BasicOutputBuffer;
 import org.bson.io.OutputBuffer;
 import org.bson.types.BSONTimestamp;
@@ -37,10 +38,46 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
+import static org.bson.assertions.Assertions.notNull;
+
 /**
  * This is meant to be pooled or cached. There is some per instance memory for string conversion, etc...
  */
 public class BasicBSONEncoder implements BSONEncoder {
+
+    /**
+     * Sets the default {@link UuidRepresentation} to use when encoding UUID values to BSON binary.
+     *
+     * <p>
+     * If unset, the default is {@link UuidRepresentation#JAVA_LEGACY}.
+     * </p>
+     *
+     * @param uuidRepresentation the uuid representation, which may not be null
+     * @see #putUUID(String, UUID)
+     * @see BasicBSONDecoder#setDefaultUuidRepresentation(UuidRepresentation)
+     * @since 4.7
+     */
+    public static void setDefaultUuidRepresentation(final UuidRepresentation uuidRepresentation) {
+        defaultUuidRepresentation = notNull("uuidRepresentation", uuidRepresentation);
+    }
+
+    /**
+     * Sets the default {@link UuidRepresentation} to use when encoding UUID values to BSON binary.
+     *
+     * <p>
+     * If unset, the default is {@link UuidRepresentation#JAVA_LEGACY}.
+     * </p>
+     *
+     * @return the uuid representation, which may not be null
+     * @see #putUUID(String, UUID)
+     * @see BasicBSONDecoder#setDefaultUuidRepresentation(UuidRepresentation)
+     * @since 4.7
+     */
+    public static UuidRepresentation getDefaultUuidRepresentation() {
+        return defaultUuidRepresentation;
+    }
+
+    private static volatile UuidRepresentation defaultUuidRepresentation = UuidRepresentation.JAVA_LEGACY;
 
     private BsonBinaryWriter bsonWriter;
     private OutputBuffer outputBuffer;
@@ -342,10 +379,11 @@ public class BasicBSONEncoder implements BSONEncoder {
      */
     protected void putUUID(final String name, final UUID uuid) {
         putName(name);
-        byte[] bytes = new byte[16];
-        writeLongToArrayLittleEndian(bytes, 0, uuid.getMostSignificantBits());
-        writeLongToArrayLittleEndian(bytes, 8, uuid.getLeastSignificantBits());
-        bsonWriter.writeBinaryData(new BsonBinary(BsonBinarySubType.UUID_LEGACY, bytes));
+        UuidRepresentation uuidRepresentation = defaultUuidRepresentation;
+        byte[] bytes = UuidHelper.encodeUuidToBinary(uuid, uuidRepresentation);
+        bsonWriter.writeBinaryData(new BsonBinary(
+                uuidRepresentation == UuidRepresentation.STANDARD ? BsonBinarySubType.UUID_STANDARD : BsonBinarySubType.UUID_LEGACY,
+                bytes));
     }
 
     /**

--- a/bson/src/main/org/bson/UuidRepresentation.java
+++ b/bson/src/main/org/bson/UuidRepresentation.java
@@ -69,7 +69,7 @@ public enum UuidRepresentation {
      * Gets the BSON binary subtype for the representation.
      *
      * @return the BSON binary subtype for the representation
-     * @throws BsonInvalidOperationException if this is {@link #UNSPECIFIED}
+     * @throws BSONException if this is {@link #UNSPECIFIED}
      * @since 4.7
      */
     public BsonBinarySubType getSubtype() {
@@ -81,7 +81,7 @@ public enum UuidRepresentation {
             case C_SHARP_LEGACY:
                 return UUID_LEGACY;
             default:
-                throw new BsonInvalidOperationException(format("No BsonBinarySubType for %s", this));
+                throw new BSONException(format("No BsonBinarySubType for %s", this));
         }
     }
 }

--- a/bson/src/main/org/bson/UuidRepresentation.java
+++ b/bson/src/main/org/bson/UuidRepresentation.java
@@ -16,6 +16,10 @@
 
 package org.bson;
 
+import static java.lang.String.format;
+import static org.bson.BsonBinarySubType.UUID_LEGACY;
+import static org.bson.BsonBinarySubType.UUID_STANDARD;
+
 /**
  * The representation to use when converting a UUID to a BSON binary value.
  * This class is necessary because the different drivers used to have different
@@ -59,5 +63,25 @@ public enum UuidRepresentation {
      *
      * BSON binary subtype 3
      */
-    PYTHON_LEGACY
+    PYTHON_LEGACY;
+
+    /**
+     * Gets the BSON binary subtype for the representation.
+     *
+     * @return the BSON binary subtype for the representation
+     * @throws BsonInvalidOperationException if this is {@link #UNSPECIFIED}
+     * @since 4.7
+     */
+    public BsonBinarySubType getSubtype() {
+        switch (this) {
+            case STANDARD:
+                return UUID_STANDARD;
+            case JAVA_LEGACY:
+            case PYTHON_LEGACY:
+            case C_SHARP_LEGACY:
+                return UUID_LEGACY;
+            default:
+                throw new BsonInvalidOperationException(format("No BsonBinarySubType for %s", this));
+        }
+    }
 }

--- a/bson/src/test/unit/org/bson/BasicBSONDecoderSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BasicBSONDecoderSpecification.groovy
@@ -178,10 +178,15 @@ class BasicBSONDecoderSpecification extends Specification {
         BsonSerializationException | [5, 0, 0, 0, 16, 97, 45, 1, 0, 0, 0, 0]
     }
 
+
+    def 'default value of defaultUuidRepresentation is JAVA_LEGACY'() {
+        expect:
+        getDefaultUuidRepresentation() == JAVA_LEGACY
+    }
+
     @Unroll
     def 'should decode UUID according to default uuid representation'() {
         given:
-        def defaultUuidRepresentation = getDefaultUuidRepresentation()
         def uuid = new UUID(1, 2)
         def output = new BasicOutputBuffer()
         new BsonDocumentCodec().encode(new BsonBinaryWriter(output),
@@ -189,15 +194,18 @@ class BasicBSONDecoderSpecification extends Specification {
 
         when:
         setDefaultUuidRepresentation(decodedUuidRepresentation)
-        def decodedBsonObject = bsonDecoder.readObject(output.getInternalBuffer())
-        def decodedUuid = decodedBsonObject.get('u')
 
         then:
-        defaultUuidRepresentation == JAVA_LEGACY
+        getDefaultUuidRepresentation() == decodedUuidRepresentation
+
+        when:
+        def decodedUuid = bsonDecoder.readObject(output.getInternalBuffer()).get('u')
+
+        then:
         decodedUuid == expectedUuid
 
         cleanup:
-        setDefaultUuidRepresentation(defaultUuidRepresentation)
+        setDefaultUuidRepresentation(JAVA_LEGACY)
 
         where:
         [encodedUuidRepresentation, decodedUuidRepresentation, expectedUuid] << [

--- a/bson/src/test/unit/org/bson/BasicBSONDecoderSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BasicBSONDecoderSpecification.groovy
@@ -16,6 +16,9 @@
 
 package org.bson
 
+import org.bson.codecs.BsonDocumentCodec
+import org.bson.codecs.EncoderContext
+import org.bson.io.BasicOutputBuffer
 import org.bson.types.BSONTimestamp
 import org.bson.types.Binary
 import org.bson.types.Code
@@ -29,6 +32,14 @@ import spock.lang.Subject
 import spock.lang.Unroll
 
 import java.util.regex.Pattern
+
+import static org.bson.BasicBSONDecoder.getDefaultUuidRepresentation
+import static org.bson.BasicBSONDecoder.setDefaultUuidRepresentation
+import static org.bson.BsonBinarySubType.UUID_LEGACY
+import static org.bson.BsonBinarySubType.UUID_STANDARD
+import static org.bson.UuidRepresentation.JAVA_LEGACY
+import static org.bson.UuidRepresentation.STANDARD
+import static org.bson.internal.UuidHelper.encodeUuidToBinary
 
 @SuppressWarnings(['LineLength', 'DuplicateMapLiteral', 'UnnecessaryBooleanExpression'])
 class BasicBSONDecoderSpecification extends Specification {
@@ -91,6 +102,7 @@ class BasicBSONDecoderSpecification extends Specification {
         ['k1': new MinKey()]                                     | [9, 0, 0, 0, -1, 107, 49, 0, 0]
         ['k2': new MaxKey()]                                     | [9, 0, 0, 0, 127, 107, 50, 0, 0]
         ['f': Decimal128.parse('0E-6176')]                       | [24, 0, 0, 0, 19, 102, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        ['u': new UUID(1, 2)]                                    | [29, 0, 0, 0, 5, 117, 0, 16, 0, 0, 0, 3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0]
 
         type = BsonType.findByValue(bytes[4])
     }
@@ -164,5 +176,40 @@ class BasicBSONDecoderSpecification extends Specification {
         BsonSerializationException | [12, 0, 2, 0, 16, 97, 0, 1, 0, 0, 0, 0]
         BsonSerializationException | [5, 0, 0, 0, 16, 97, 0, 1, 0, 0, 0, 0]
         BsonSerializationException | [5, 0, 0, 0, 16, 97, 45, 1, 0, 0, 0, 0]
+    }
+
+    @Unroll
+    def 'should decode UUID according to default uuid representation'() {
+        given:
+        def defaultUuidRepresentation = getDefaultUuidRepresentation()
+        def uuid = new UUID(1, 2)
+        def output = new BasicOutputBuffer()
+        new BsonDocumentCodec().encode(new BsonBinaryWriter(output),
+                new BsonDocument('u', new BsonBinary(uuid, encodedUuidRepresentation)), EncoderContext.builder().build())
+
+        when:
+        setDefaultUuidRepresentation(decodedUuidRepresentation)
+        def decodedBsonObject = bsonDecoder.readObject(output.getInternalBuffer())
+        def decodedUuid = decodedBsonObject.get('u')
+
+        then:
+        defaultUuidRepresentation == JAVA_LEGACY
+        decodedUuid == expectedUuid
+
+        cleanup:
+        setDefaultUuidRepresentation(defaultUuidRepresentation)
+
+        where:
+        [encodedUuidRepresentation, decodedUuidRepresentation, expectedUuid] << [
+                [JAVA_LEGACY, JAVA_LEGACY,
+                 new UUID(1, 2)],
+                [JAVA_LEGACY, STANDARD,
+                 new Binary(UUID_LEGACY, encodeUuidToBinary(new UUID(1, 2), JAVA_LEGACY))],
+                [STANDARD, JAVA_LEGACY,
+                 new Binary(UUID_STANDARD, encodeUuidToBinary(new UUID(1, 2), STANDARD))],
+                [STANDARD, STANDARD,
+                 new UUID(1, 2)]
+
+        ]
     }
 }


### PR DESCRIPTION
…/decoder

Both BasicBSONEncoder and BSONCallbackAdapter assume a UuidRepresentation of
JAVA_LEGACY in a way that is not configurable. Allow it to be configured process-wide
using a static method for each class to set the default.

JAVA-4587