### PR TITLE
Enhance pre-and post-image support for change streams

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/changestream/ChangeStreamDocument.java
+++ b/driver-core/src/main/com/mongodb/client/model/changestream/ChangeStreamDocument.java
@@ -281,7 +281,7 @@ public final class ChangeStreamDocument<TDocument> {
      *
      * <p>
      * For operations of type {@link OperationType#UPDATE}, the value will contain a copy of the full version of the document from some
-     * point after the update occurred. If the document was deleted since the updated happened, the value will be null.
+     * point after the update occurred. If the document was deleted since the updated happened, the value may be null.
      * </p>
      *
      * <p>

--- a/driver-core/src/main/com/mongodb/client/model/changestream/ChangeStreamDocument.java
+++ b/driver-core/src/main/com/mongodb/client/model/changestream/ChangeStreamDocument.java
@@ -116,6 +116,7 @@ public final class ChangeStreamDocument<TDocument> {
      *
      * @since 4.6
      */
+    @Deprecated
     public ChangeStreamDocument(@BsonProperty("operationType") final String operationTypeString,
                                 @BsonProperty("resumeToken") final BsonDocument resumeToken,
                                 @Nullable @BsonProperty("ns") final BsonDocument namespaceDocument,

--- a/driver-core/src/main/com/mongodb/client/model/changestream/ChangeStreamDocumentCodec.java
+++ b/driver-core/src/main/com/mongodb/client/model/changestream/ChangeStreamDocumentCodec.java
@@ -43,6 +43,8 @@ final class ChangeStreamDocumentCodec<TResult> implements Codec<ChangeStreamDocu
 
         ClassModelBuilder<ChangeStreamDocument> classModelBuilder = ClassModel.builder(ChangeStreamDocument.class);
         ((PropertyModelBuilder<TResult>) classModelBuilder.getProperty("fullDocument")).codec(codecRegistry.get(fullDocumentClass));
+        ((PropertyModelBuilder<TResult>) classModelBuilder.getProperty("fullDocumentBeforeChange"))
+                .codec(codecRegistry.get(fullDocumentClass));
         ClassModel<ChangeStreamDocument> changeStreamDocumentClassModel = classModelBuilder.build();
 
         PojoCodecProvider provider = PojoCodecProvider.builder()

--- a/driver-core/src/main/com/mongodb/client/model/changestream/FullDocument.java
+++ b/driver-core/src/main/com/mongodb/client/model/changestream/FullDocument.java
@@ -44,7 +44,25 @@ public enum FullDocument {
      * <p>The change stream for partial updates will include both a delta describing the changes to the document as well as a copy of the
      * entire document that was changed from <em>some time</em> after the change occurred.</p>
      */
-    UPDATE_LOOKUP("updateLookup");
+    UPDATE_LOOKUP("updateLookup"),
+
+    /**
+     * Configures the change stream to return the post-image of the modified document for replace and update change events, if it
+     * is available.
+     *
+     * @since 4.7
+     * @mongodb.server.release 6.0
+     */
+    WHEN_AVAILABLE("whenAvailable"),
+
+    /**
+     * The same behavior as {@link #WHEN_AVAILABLE} except that an error is raised if the post-image is not available.
+     *
+     * @since 4.7
+     * @mongodb.server.release 6.0
+     */
+    REQUIRED("required");
+
 
     private final String value;
     FullDocument(final String caseFirst) {

--- a/driver-core/src/main/com/mongodb/client/model/changestream/FullDocumentBeforeChange.java
+++ b/driver-core/src/main/com/mongodb/client/model/changestream/FullDocumentBeforeChange.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.changestream;
+
+import static com.mongodb.assertions.Assertions.assertNotNull;
+import static java.lang.String.format;
+
+/**
+ * Change Stream fullDocumentBeforeChange configuration.
+ *
+ * <p>
+ * Determines what to return for update operations when using a Change Stream. Defaults to {@link FullDocumentBeforeChange#DEFAULT}.
+ * </p>
+ *
+ * @since 4.7
+ * @mongodb.server.release 6.0
+ */
+public enum FullDocumentBeforeChange {
+    /**
+     * The default value
+     */
+    DEFAULT("default"),
+
+    /**
+     * Configures the change stream to not include the pre-image of the modified document.
+     */
+    OFF("off"),
+
+    /**
+     * Configures the change stream to return the pre-image of the modified document for replace, update, and delete change events if it
+     * is available.
+     */
+    WHEN_AVAILABLE("whenAvailable"),
+
+    /**
+     * The same behavior as {@link #WHEN_AVAILABLE} except that an error is raised by the server if the pre-image is not available.
+     */
+    REQUIRED("required");
+
+
+    private final String value;
+
+    /**
+     * The string value.
+     *
+     * @return the string value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    FullDocumentBeforeChange(final String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the FullDocumentBeforeChange from the string value.
+     *
+     * @param value the string value.
+     * @return the full document before change
+     */
+    public static FullDocumentBeforeChange fromString(final String value) {
+        assertNotNull(value);
+        for (FullDocumentBeforeChange fullDocumentBeforeChange : FullDocumentBeforeChange.values()) {
+            if (value.equals(fullDocumentBeforeChange.value)) {
+                return fullDocumentBeforeChange;
+            }
+        }
+        throw new IllegalArgumentException(format("'%s' is not a valid FullDocumentBeforeChange", value));
+    }}

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationProseTestSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationProseTestSpecification.groovy
@@ -23,6 +23,7 @@ import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.WriteConcern
 import com.mongodb.client.model.CreateCollectionOptions
 import com.mongodb.client.model.changestream.FullDocument
+import com.mongodb.client.model.changestream.FullDocumentBeforeChange
 import com.mongodb.client.test.CollectionHelper
 import org.bson.BsonArray
 import org.bson.BsonDocument
@@ -52,7 +53,8 @@ class ChangeStreamOperationProseTestSpecification extends OperationFunctionalSpe
         given:
         def helper = getHelper()
         def pipeline = [BsonDocument.parse('{$project: {"_id": 0}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, pipeline, CODEC)
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
         def cursor = execute(operation, async)
@@ -88,7 +90,8 @@ class ChangeStreamOperationProseTestSpecification extends OperationFunctionalSpe
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
         def failPointDocument = createFailPointDocument('getMore', 10107)
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, pipeline, CODEC)
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         def cursor = execute(operation, async)
 
@@ -120,7 +123,8 @@ class ChangeStreamOperationProseTestSpecification extends OperationFunctionalSpe
     def 'should not resume for aggregation errors'() {
         given:
         def pipeline = [BsonDocument.parse('{$unsupportedStage: {_id: 0}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, pipeline, CODEC)
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
         def cursor = execute(operation, async)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
@@ -24,6 +24,7 @@ import com.mongodb.WriteConcern
 import com.mongodb.client.model.CreateCollectionOptions
 import com.mongodb.client.model.changestream.ChangeStreamDocument
 import com.mongodb.client.model.changestream.FullDocument
+import com.mongodb.client.model.changestream.FullDocumentBeforeChange
 import com.mongodb.client.model.changestream.OperationType
 import com.mongodb.client.model.changestream.UpdateDescription
 import com.mongodb.client.test.CollectionHelper
@@ -56,6 +57,7 @@ import static com.mongodb.ClusterFixture.getCluster
 import static com.mongodb.ClusterFixture.isStandalone
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.ClusterFixture.serverVersionLessThan
+import static com.mongodb.client.model.changestream.ChangeStreamDocument.createCodec
 import static com.mongodb.internal.connection.ServerHelper.waitForLastRelease
 import static com.mongodb.internal.operation.OperationUnitSpecification.getMaxWireVersionForServerVersion
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -66,7 +68,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
     def 'should have the correct defaults'() {
         when:
-        ChangeStreamOperation operation = new ChangeStreamOperation<Document>(getNamespace(), FullDocument.DEFAULT, [], new DocumentCodec())
+        ChangeStreamOperation operation = new ChangeStreamOperation<Document>(getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, [], new DocumentCodec())
 
         then:
         operation.getBatchSize() == null
@@ -79,8 +82,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
     def 'should set optional values correctly'() {
         when:
-        ChangeStreamOperation operation = new ChangeStreamOperation<Document>(getNamespace(), FullDocument.UPDATE_LOOKUP, [],
-                new DocumentCodec())
+        ChangeStreamOperation operation = new ChangeStreamOperation<Document>(getNamespace(), FullDocument.UPDATE_LOOKUP,
+                FullDocumentBeforeChange.DEFAULT, [], new DocumentCodec())
                 .batchSize(5)
                 .collation(defaultCollation)
                 .maxAwaitTime(15, MILLISECONDS)
@@ -111,8 +114,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
                 .append('cursor', new BsonDocument('id', new BsonInt64(0)).append('ns', new BsonString('db.coll'))
                 .append('firstBatch', new BsonArrayWrapper([])))
 
-        def operation = new ChangeStreamOperation<Document>(namespace, FullDocument.DEFAULT, pipeline, new DocumentCodec(),
-                changeStreamLevel)
+        def operation = new ChangeStreamOperation<Document>(namespace, FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, pipeline, new DocumentCodec(), changeStreamLevel)
                 .batchSize(5)
                 .collation(defaultCollation)
                 .maxAwaitTime(15, MILLISECONDS)
@@ -148,7 +151,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, pipeline, CODEC)
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
         def cursor = execute(operation, async)
@@ -187,8 +191,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, pipeline,
-                ChangeStreamDocument.createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, pipeline,
+                createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
 
         when:
         def cursor = execute(operation, false)
@@ -213,8 +218,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "update"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP, pipeline,
-                ChangeStreamDocument.createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+                FullDocumentBeforeChange.DEFAULT, pipeline,
+                createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
 
         when:
@@ -240,8 +246,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "replace"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP, pipeline,
-                ChangeStreamDocument.createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+                FullDocumentBeforeChange.DEFAULT, pipeline,
+                createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
 
         when:
@@ -267,8 +274,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "delete"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP, pipeline,
-                ChangeStreamDocument.createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+                FullDocumentBeforeChange.DEFAULT, pipeline,
+                createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
 
         when:
@@ -294,8 +302,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "invalidate"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP, pipeline,
-                ChangeStreamDocument.createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+                FullDocumentBeforeChange.DEFAULT, pipeline,
+                createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
 
         when:
@@ -322,8 +331,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "drop"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP, pipeline,
-                ChangeStreamDocument.createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+                FullDocumentBeforeChange.DEFAULT, pipeline,
+                createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
 
         when:
@@ -350,8 +360,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "dropDatabase"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP, pipeline,
-                ChangeStreamDocument.createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())),
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+                FullDocumentBeforeChange.DEFAULT, pipeline,
+                createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())),
                 ChangeStreamLevel.DATABASE)
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
 
@@ -379,8 +390,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "rename"}}')]
-        def operation = new ChangeStreamOperation<ChangeStreamDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP, pipeline,
-                ChangeStreamDocument.createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
+        def operation = new ChangeStreamOperation<ChangeStreamDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+                FullDocumentBeforeChange.DEFAULT, pipeline,
+                createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         def newNamespace = new MongoNamespace('JavaDriverTest', 'newCollectionName')
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
 
@@ -407,7 +419,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         given:
         def helper = getHelper()
         def pipeline = [BsonDocument.parse('{$project: {"_id": 0}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, pipeline, CODEC)
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
         def cursor = execute(operation, async)
@@ -430,7 +443,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, pipeline, CODEC)
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
         def cursor = execute(operation, async)
@@ -458,7 +472,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, pipeline, CODEC)
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
         def cursor = execute(operation, async)
@@ -498,7 +513,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, pipeline, CODEC)
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         def cursor = execute(operation, async)
 
@@ -533,7 +549,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, pipeline, CODEC)
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         def cursor = execute(operation, async)
 
@@ -569,7 +586,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, pipeline, CODEC)
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         def cursor = execute(operation, async)
 
@@ -601,7 +619,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
     def 'should support hasNext on the sync API'() {
         given:
         def helper = getHelper()
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, [], CODEC)
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange
+                .DEFAULT, [], CODEC)
 
         when:
         def cursor = execute(operation, false)
@@ -641,7 +660,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         }
 
         when: 'set resumeAfter'
-        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, [], CODEC)
+        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .resumeAfter(new BsonDocument())
                 .execute(binding)
 
@@ -650,7 +669,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         !changeStream.containsKey('startAtOperationTime')
 
         when: 'set startAfter'
-        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, [], CODEC)
+        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .startAfter(new BsonDocument())
                 .execute(binding)
 
@@ -660,7 +679,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
         when: 'set startAtOperationTime'
         def startAtTime = new BsonTimestamp(42)
-        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, [], CODEC)
+        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .startAtOperationTime(startAtTime)
                 .execute(binding)
 
@@ -698,7 +717,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         }
 
         when: 'set resumeAfter'
-        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, [], CODEC)
+        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .resumeAfter(new BsonDocument())
                 .executeAsync(binding, Stub(SingleResultCallback))
 
@@ -707,7 +726,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         !changeStream.containsKey('startAtOperationTime')
 
         when: 'set startAfter'
-        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, [], CODEC)
+        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .startAfter(new BsonDocument())
                 .executeAsync(binding, Stub(SingleResultCallback))
 
@@ -717,7 +736,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
         when: 'set startAtOperationTime'
         def startAtTime = new BsonTimestamp(42)
-        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, [], CODEC)
+        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .startAtOperationTime(startAtTime)
                 .executeAsync(binding, Stub(SingleResultCallback))
 

--- a/driver-core/src/test/resources/unified-test-format/change-streams/change-streams-pre_and_post_images.json
+++ b/driver-core/src/test/resources/unified-test-format/change-streams/change-streams-pre_and_post_images.json
@@ -1,0 +1,826 @@
+{
+  "description": "change-streams-pre_and_post_images",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.0.0",
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "ignoreCommandMonitoringEvents": [
+          "collMod",
+          "insert",
+          "update",
+          "getMore",
+          "killCursors"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "change-stream-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "change-stream-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "fullDocument:whenAvailable with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": {
+              "_id": 1,
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:whenAvailable with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": null
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:required with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": {
+              "_id": 1,
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:required with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": null
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:required with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:required with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:off with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "off"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "$$exists": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "off"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:off with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "off"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "$$exists": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "off"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/changestream/ChangeStreamDocumentCodecSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/changestream/ChangeStreamDocumentCodecSpecification.groovy
@@ -60,6 +60,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
                         null,
                         Document.parse('{_id: 1, userName: "alice123", name: "Alice"}'),
+                        null,
                         BsonDocument.parse('{userName: "alice123", _id: 1}'),
                         new BsonTimestamp(1234, 2)
                         ,
@@ -68,6 +69,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                 new ChangeStreamDocument<Document>(OperationType.UPDATE.value,
                         BsonDocument.parse('{token: true}'),
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
+                        null,
                         null,
                         null,
                         BsonDocument.parse('{_id: 1}'),
@@ -81,6 +83,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
                         null,
                         Document.parse('{_id: 1, userName: "alice123", name: "Alice"}'),
+                        Document.parse('{_id: 1, userName: "alice1234", name: "Alice"}'),
                         BsonDocument.parse('{_id: 1}'),
                         new BsonTimestamp(1234, 2)
                         ,
@@ -93,6 +96,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
                         null,
                         Document.parse('{_id: 1, userName: "alice123", name: "Alice"}'),
+                        Document.parse('{_id: 1, userName: "alice1234", name: "Alice"}'),
                         BsonDocument.parse('{_id: 1}'),
                         new BsonTimestamp(1234, 2)
                         ,
@@ -103,6 +107,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
                         null,
                         null,
+                        Document.parse('{_id: 1, userName: "alice123", name: "Alice"}'),
                         BsonDocument.parse('{_id: 1}'),
                         new BsonTimestamp(1234, 2)
                         ,
@@ -111,6 +116,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                 new ChangeStreamDocument<Document>(OperationType.DROP.value,
                         BsonDocument.parse('{token: true}'),
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
+                        null,
                         null,
                         null,
                         null,
@@ -124,6 +130,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         BsonDocument.parse('{db: "engineering", coll: "people"}'),
                         null,
                         null,
+                        null,
                         new BsonTimestamp(1234, 2)
                         ,
                         null, null, null
@@ -131,6 +138,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                 new ChangeStreamDocument<Document>(OperationType.DROP_DATABASE.value,
                         BsonDocument.parse('{token: true}'),
                         BsonDocument.parse('{db: "engineering"}'),
+                        null,
                         null,
                         null,
                         null,
@@ -144,6 +152,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         null,
                         null,
                         null,
+                        null,
                         new BsonTimestamp(1234, 2)
                         ,
                         null, null, null
@@ -153,6 +162,7 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
                         BsonDocument.parse('{db: "engineering", coll: "users"}'),
                         null,
                         Document.parse('{_id: 1, userName: "alice123", name: "Alice"}'),
+                        null,
                         BsonDocument.parse('{userName: "alice123", _id: 1}'),
                         new BsonTimestamp(1234, 2),
                         null,
@@ -232,6 +242,11 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
       _id: 1,
       name: 'Alice',
       userName: 'alice123'
+   },
+   fullDocumentBeforeChange: {
+      _id: 1,
+      name: 'Alice',
+      userName: 'alice1234'
    }
 }
 ''',
@@ -251,6 +266,11 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
       _id: 1,
       userName: 'alice123',
       name: 'Alice'
+   },
+      fullDocumentBeforeChange: {
+      _id: 1,
+      name: 'Alice',
+      userName: 'alice1234'
    }
 }
 ''',
@@ -265,6 +285,11 @@ class ChangeStreamDocumentCodecSpecification extends Specification {
    },
    documentKey: {
       _id: 1
+   },
+   fullDocumentBeforeChange: {
+      _id: 1,
+      name: 'Alice',
+      userName: 'alice123'
    }
 }
 ''',

--- a/driver-core/src/test/unit/com/mongodb/client/model/changestream/ChangeStreamDocumentSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/changestream/ChangeStreamDocumentSpecification.groovy
@@ -36,6 +36,7 @@ class ChangeStreamDocumentSpecification extends Specification {
         def destinationNamespaceDocument = BsonDocument.parse('{db: "databaseName2", coll: "collectionName2"}')
         def destinationNamespace = new MongoNamespace('databaseName2.collectionName2')
         def fullDocument = BsonDocument.parse('{key: "value for fullDocument"}')
+        def fullDocumentBeforeChange = BsonDocument.parse('{key: "value for fullDocumentBeforeChange"}')
         def documentKey = BsonDocument.parse('{_id : 1}')
         def clusterTime = new BsonTimestamp(1234, 2)
         def operationType = OperationType.UPDATE
@@ -45,11 +46,34 @@ class ChangeStreamDocumentSpecification extends Specification {
 
         when:
         def changeStreamDocument = new ChangeStreamDocument<BsonDocument>(operationType.value, resumeToken, namespaceDocument,
+                destinationNamespaceDocument, fullDocument, fullDocumentBeforeChange, documentKey, clusterTime, updateDesc, null, null)
+
+        then:
+        changeStreamDocument.getResumeToken() == resumeToken
+        changeStreamDocument.getFullDocument() == fullDocument
+        changeStreamDocument.getFullDocumentBeforeChange() == fullDocumentBeforeChange
+        changeStreamDocument.getDocumentKey() == documentKey
+        changeStreamDocument.getClusterTime() == clusterTime
+        changeStreamDocument.getNamespace() == namespace
+        changeStreamDocument.getNamespaceDocument() == namespaceDocument
+        changeStreamDocument.getDestinationNamespace() == destinationNamespace
+        changeStreamDocument.getDestinationNamespaceDocument() == destinationNamespaceDocument
+        changeStreamDocument.getOperationTypeString() == operationType.value
+        changeStreamDocument.getOperationType() == operationType
+        changeStreamDocument.getUpdateDescription() == updateDesc
+        changeStreamDocument.getDatabaseName() == namespace.getDatabaseName()
+        changeStreamDocument.getTxnNumber() == null
+        changeStreamDocument.getLsid() == null
+
+        when:
+        //noinspection GrDeprecatedAPIUsage
+        changeStreamDocument = new ChangeStreamDocument<BsonDocument>(operationType.value, resumeToken, namespaceDocument,
                 destinationNamespaceDocument, fullDocument, documentKey, clusterTime, updateDesc, null, null)
 
         then:
         changeStreamDocument.getResumeToken() == resumeToken
         changeStreamDocument.getFullDocument() == fullDocument
+        changeStreamDocument.getFullDocumentBeforeChange() == null
         changeStreamDocument.getDocumentKey() == documentKey
         changeStreamDocument.getClusterTime() == clusterTime
         changeStreamDocument.getNamespace() == namespace

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ChangeStreamPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ChangeStreamPublisher.java
@@ -20,6 +20,7 @@ package com.mongodb.reactivestreams.client;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.FullDocument;
+import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
@@ -43,6 +44,16 @@ public interface ChangeStreamPublisher<TResult> extends Publisher<ChangeStreamDo
      * @return this
      */
     ChangeStreamPublisher<TResult> fullDocument(FullDocument fullDocument);
+
+    /**
+     * Sets the fullDocumentBeforeChange value.
+     *
+     * @param fullDocumentBeforeChange the fullDocumentBeforeChange
+     * @return this
+     * @since 4.7
+     * @mongodb.server.release 6.0
+     */
+    ChangeStreamPublisher<TResult> fullDocumentBeforeChange(FullDocumentBeforeChange fullDocumentBeforeChange);
 
     /**
      * Sets the logical starting point for the new change stream.

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImpl.java
@@ -19,6 +19,7 @@ package com.mongodb.reactivestreams.client.internal;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.FullDocument;
+import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.client.model.changestream.ChangeStreamLevel;
 import com.mongodb.internal.operation.AsyncReadOperation;
@@ -50,6 +51,7 @@ final class ChangeStreamPublisherImpl<T> extends BatchCursorPublisher<ChangeStre
     private final ChangeStreamLevel changeStreamLevel;
 
     private FullDocument fullDocument = FullDocument.DEFAULT;
+    private FullDocumentBeforeChange fullDocumentBeforeChange = FullDocumentBeforeChange.DEFAULT;
     private BsonDocument resumeToken;
     private BsonDocument startAfter;
     private long maxAwaitTimeMS;
@@ -84,6 +86,12 @@ final class ChangeStreamPublisherImpl<T> extends BatchCursorPublisher<ChangeStre
     @Override
     public ChangeStreamPublisher<T> fullDocument(final FullDocument fullDocument) {
         this.fullDocument = notNull("fullDocument", fullDocument);
+        return this;
+    }
+
+    @Override
+    public ChangeStreamPublisher<T> fullDocumentBeforeChange(final FullDocumentBeforeChange fullDocumentBeforeChange) {
+        this.fullDocumentBeforeChange = notNull("fullDocumentBeforeChange", fullDocumentBeforeChange);
         return this;
     }
 
@@ -154,7 +162,7 @@ final class ChangeStreamPublisherImpl<T> extends BatchCursorPublisher<ChangeStre
     }
 
     private <S> AsyncReadOperation<AsyncBatchCursor<S>> createChangeStreamOperation(final Codec<S> codec, final int initialBatchSize) {
-        return new ChangeStreamOperation<>(getNamespace(), fullDocument,
+        return new ChangeStreamOperation<>(getNamespace(), fullDocument, fullDocumentBeforeChange,
                                            createBsonDocumentList(pipeline), codec, changeStreamLevel)
                 .batchSize(initialBatchSize)
                 .collation(collation)

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncChangeStreamIterable.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncChangeStreamIterable.java
@@ -25,6 +25,7 @@ import com.mongodb.client.MongoIterable;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.FullDocument;
+import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ChangeStreamPublisher;
 import org.bson.BsonDocument;
@@ -91,6 +92,12 @@ class SyncChangeStreamIterable<T> extends SyncMongoIterable<ChangeStreamDocument
     @Override
     public ChangeStreamIterable<T> fullDocument(final FullDocument fullDocument) {
         wrapped.fullDocument(fullDocument);
+        return this;
+    }
+
+    @Override
+    public ChangeStreamIterable<T> fullDocumentBeforeChange(final FullDocumentBeforeChange fullDocumentBeforeChange) {
+        wrapped.fullDocumentBeforeChange(fullDocumentBeforeChange);
         return this;
     }
 

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImplTest.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoException;
 import com.mongodb.ReadPreference;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.FullDocument;
+import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
 import com.mongodb.internal.client.model.changestream.ChangeStreamLevel;
 import com.mongodb.internal.operation.ChangeStreamOperation;
 import com.mongodb.reactivestreams.client.ChangeStreamPublisher;
@@ -56,7 +57,7 @@ public class ChangeStreamPublisherImplTest extends TestHelper {
                                                                                     Document.class, pipeline, ChangeStreamLevel.COLLECTION);
 
         ChangeStreamOperation<ChangeStreamDocument<Document>> expectedOperation =
-                new ChangeStreamOperation<>(NAMESPACE, FullDocument.DEFAULT, pipeline, codec)
+                new ChangeStreamOperation<>(NAMESPACE, FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, pipeline, codec)
                         .batchSize(Integer.MAX_VALUE)
                         .retryReads(true);
 
@@ -74,7 +75,8 @@ public class ChangeStreamPublisherImplTest extends TestHelper {
                 .maxAwaitTime(20, SECONDS)
                 .fullDocument(FullDocument.UPDATE_LOOKUP);
 
-        expectedOperation = new ChangeStreamOperation<>(NAMESPACE, FullDocument.UPDATE_LOOKUP, pipeline, codec).retryReads(true);
+        expectedOperation = new ChangeStreamOperation<>(NAMESPACE, FullDocument.UPDATE_LOOKUP, FullDocumentBeforeChange.DEFAULT, pipeline,
+                codec).retryReads(true);
         expectedOperation
                 .batchSize(100)
                 .collation(COLLATION)
@@ -100,7 +102,8 @@ public class ChangeStreamPublisherImplTest extends TestHelper {
                 .withDocumentClass(BsonDocument.class);
 
         ChangeStreamOperation<BsonDocument> expectedOperation =
-                new ChangeStreamOperation<>(NAMESPACE, FullDocument.DEFAULT, pipeline, getDefaultCodecRegistry().get(BsonDocument.class))
+                new ChangeStreamOperation<>(NAMESPACE, FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, pipeline,
+                        getDefaultCodecRegistry().get(BsonDocument.class))
                         .batchSize(batchSize)
                         .comment(new BsonInt32(1))
                         .retryReads(true);

--- a/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncChangeStreamIterable.scala
+++ b/driver-scala/src/it/scala/org/mongodb/scala/syncadapter/SyncChangeStreamIterable.scala
@@ -17,7 +17,7 @@
 package org.mongodb.scala.syncadapter
 
 import com.mongodb.client.model.Collation
-import com.mongodb.client.model.changestream.{ ChangeStreamDocument, FullDocument }
+import com.mongodb.client.model.changestream.{ ChangeStreamDocument, FullDocument, FullDocumentBeforeChange }
 import com.mongodb.client.{ ChangeStreamIterable, MongoChangeStreamCursor }
 import com.mongodb.{ ServerAddress, ServerCursor }
 import org.bson.{ BsonDocument, BsonTimestamp, BsonValue }
@@ -45,6 +45,11 @@ case class SyncChangeStreamIterable[T](wrapped: ChangeStreamObservable[T])
 
   override def fullDocument(fullDocument: FullDocument): ChangeStreamIterable[T] = {
     wrapped.fullDocument(fullDocument)
+    this
+  }
+
+  override def fullDocumentBeforeChange(fullDocumentBeforeChange: FullDocumentBeforeChange): ChangeStreamIterable[T] = {
+    wrapped.fullDocumentBeforeChange(fullDocumentBeforeChange)
     this
   }
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/ChangeStreamObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/ChangeStreamObservable.scala
@@ -51,11 +51,12 @@ case class ChangeStreamObservable[TResult](private val wrapped: ChangeStreamPubl
   }
 
   /**
-   * Sets the fullDocument before change value.
+   * Sets the fullDocumentBeforeChange value.
    *
-   * @param fullDocumentBeforeChange the fullDocument before change
+   * @param fullDocumentBeforeChange the fullDocumentBeforeChange
    * @return this
    * @since 4.7
+   * @note Requires MongoDB 6.0 or greater
    */
   def fullDocumentBeforeChange(fullDocumentBeforeChange: FullDocumentBeforeChange): ChangeStreamObservable[TResult] = {
     wrapped.fullDocumentBeforeChange(fullDocumentBeforeChange)

--- a/driver-scala/src/main/scala/org/mongodb/scala/ChangeStreamObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/ChangeStreamObservable.scala
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit
 import com.mongodb.reactivestreams.client.ChangeStreamPublisher
 import org.mongodb.scala.bson.{ BsonTimestamp, BsonValue }
 import org.mongodb.scala.model.Collation
-import org.mongodb.scala.model.changestream.{ ChangeStreamDocument, FullDocument }
+import org.mongodb.scala.model.changestream.{ ChangeStreamDocument, FullDocument, FullDocumentBeforeChange }
 
 import scala.concurrent.duration.Duration
 
@@ -47,6 +47,18 @@ case class ChangeStreamObservable[TResult](private val wrapped: ChangeStreamPubl
    */
   def fullDocument(fullDocument: FullDocument): ChangeStreamObservable[TResult] = {
     wrapped.fullDocument(fullDocument)
+    this
+  }
+
+  /**
+   * Sets the fullDocument before change value.
+   *
+   * @param fullDocumentBeforeChange the fullDocument before change
+   * @return this
+   * @since 4.7
+   */
+  def fullDocumentBeforeChange(fullDocumentBeforeChange: FullDocumentBeforeChange): ChangeStreamObservable[TResult] = {
+    wrapped.fullDocumentBeforeChange(fullDocumentBeforeChange)
     this
   }
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/changestream/FullDocument.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/changestream/FullDocument.scala
@@ -47,6 +47,23 @@ object FullDocument {
   val UPDATE_LOOKUP = JFullDocument.UPDATE_LOOKUP
 
   /**
+   * Configures the change stream to return the post-image of the modified document for replace and update change events, if it
+   * is available.
+   *
+   * @since 4.7
+   * @note Requires MongoDB 6.0 or greater
+   */
+  val WHEN_AVAILABLE = JFullDocument.WHEN_AVAILABLE
+
+  /**
+   * The same behavior as [[WHEN_AVAILABLE]] except that an error is raised if the post-image is not available.
+   *
+   * @since 4.7
+   * @note Requires MongoDB 6.0 or greater
+   */
+  val REQUIRED = JFullDocument.REQUIRED
+
+  /**
    * Returns the FullDocument from the string value.
    *
    * @param fullDocument the string value.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/changestream/FullDocumentBeforeChange.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/changestream/FullDocumentBeforeChange.scala
@@ -25,34 +25,29 @@ import scala.util.Try
  *
  * Determines what to return for update operations when using a Change Stream. Defaults to [[FullDocumentBeforeChange#DEFAULT]].
  *
- * @note Requires MongoDB 6.0 or greater
  * @since 4.7
+ * @note Requires MongoDB 6.0 or greater
  */
 object FullDocumentBeforeChange {
 
   /**
-   * Default
-   *
-   * Returns the servers default value in the `fullDocument` field.
+   * The default value
    */
   val DEFAULT = JFullDocumentBeforeChange.DEFAULT
 
   /**
-   * Lookup
-   *
-   * The change stream for partial updates will include both a delta describing the changes to the document as well as a copy of the
-   * entire document that was changed from *some time* after the change occurred.
+   * Configures the change stream to not include the pre-image of the modified document.
    */
   val OFF = JFullDocumentBeforeChange.OFF
 
   /**
-   * Configures the change stream to return the post-image of the modified document for replace and update change events, if it
+   * Configures the change stream to return the pre-image of the modified document for replace, update, and delete change events if it
    * is available.
    */
   val WHEN_AVAILABLE = JFullDocumentBeforeChange.WHEN_AVAILABLE
 
   /**
-   * The same behavior as WHEN_AVAILABLE except that an error is raised if the post-image is not available.
+   * The same behavior as [[WHEN_AVAILABLE]] except that an error is raised if the post-image is not available.
    */
   val REQUIRED = JFullDocumentBeforeChange.REQUIRED
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/changestream/FullDocumentBeforeChange.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/changestream/FullDocumentBeforeChange.scala
@@ -47,10 +47,10 @@ object FullDocumentBeforeChange {
   val WHEN_AVAILABLE = JFullDocumentBeforeChange.WHEN_AVAILABLE
 
   /**
-   * The same behavior as [[WHEN_AVAILABLE]] except that an error is raised if the post-image is not available.
+   * The same behavior as [[WHEN_AVAILABLE]] except that an error is raised if the pre-image is not available.
    */
   val REQUIRED = JFullDocumentBeforeChange.REQUIRED
-
+                                                                                       
   /**
    * Returns the FullDocumentBeforeChange from the string value.
    *

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/changestream/FullDocumentBeforeChange.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/changestream/FullDocumentBeforeChange.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mongodb.scala.model.changestream
+
+import com.mongodb.client.model.changestream.{ FullDocumentBeforeChange => JFullDocumentBeforeChange }
+
+import scala.util.Try
+
+/**
+ * Change Stream fullDocumentBeforeChange configuration.
+ *
+ * Determines what to return for update operations when using a Change Stream. Defaults to [[FullDocumentBeforeChange#DEFAULT]].
+ *
+ * @note Requires MongoDB 6.0 or greater
+ * @since 4.7
+ */
+object FullDocumentBeforeChange {
+
+  /**
+   * Default
+   *
+   * Returns the servers default value in the `fullDocument` field.
+   */
+  val DEFAULT = JFullDocumentBeforeChange.DEFAULT
+
+  /**
+   * Lookup
+   *
+   * The change stream for partial updates will include both a delta describing the changes to the document as well as a copy of the
+   * entire document that was changed from *some time* after the change occurred.
+   */
+  val OFF = JFullDocumentBeforeChange.OFF
+
+  /**
+   * Configures the change stream to return the post-image of the modified document for replace and update change events, if it
+   * is available.
+   */
+  val WHEN_AVAILABLE = JFullDocumentBeforeChange.WHEN_AVAILABLE
+
+  /**
+   * The same behavior as WHEN_AVAILABLE except that an error is raised if the post-image is not available.
+   */
+  val REQUIRED = JFullDocumentBeforeChange.REQUIRED
+
+  /**
+   * Returns the FullDocumentBeforeChange from the string value.
+   *
+   * @param fullDocumentBeforeChange the string value.
+   * @return the FullDocumentBeforeChange value
+   */
+  def fromString(fullDocumentBeforeChange: String): Try[JFullDocumentBeforeChange] =
+    Try(JFullDocumentBeforeChange.fromString(fullDocumentBeforeChange))
+
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/changestream/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/changestream/package.scala
@@ -33,5 +33,10 @@ package object changestream {
    */
   type FullDocument = com.mongodb.client.model.changestream.FullDocument
 
+  /**
+   * Change Stream fullDocumentBeforeChange configuration.
+   */
+  type FullDocumentBeforeChange = com.mongodb.client.model.changestream.FullDocumentBeforeChange
+
   object F
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
@@ -298,7 +298,7 @@ class ApiAliasAndCompanionSpec extends BaseSpec {
       .filter(classFilter)
       .map(_.getSimpleName)
       .toSet
-    val scalaExclusions = Set("package", "FullDocument")
+    val scalaExclusions = Set("package", "FullDocument", "FullDocumentBeforeChange")
     val local = (localPackage ++ localObjects) -- scalaExclusions
 
     diff(local, wrapped) shouldBe empty

--- a/driver-sync/src/main/com/mongodb/client/ChangeStreamIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/ChangeStreamIterable.java
@@ -19,6 +19,7 @@ package com.mongodb.client;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.FullDocument;
+import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
@@ -54,6 +55,17 @@ public interface ChangeStreamIterable<TResult> extends MongoIterable<ChangeStrea
      * @return this
      */
     ChangeStreamIterable<TResult> fullDocument(FullDocument fullDocument);
+
+
+    /**
+     * Sets the fullDocumentBeforeChange value.
+     *
+     * @param fullDocumentBeforeChange the fullDocumentBeforeChange
+     * @return this
+     * @since 4.7
+     * @mongodb.server.release 6.0
+     */
+    ChangeStreamIterable<TResult> fullDocumentBeforeChange(FullDocumentBeforeChange fullDocumentBeforeChange);
 
     /**
      * Sets the logical starting point for the new change stream.

--- a/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
@@ -27,6 +27,7 @@ import com.mongodb.client.MongoIterable;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.FullDocument;
+import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
 import com.mongodb.internal.client.model.changestream.ChangeStreamLevel;
 import com.mongodb.internal.operation.BatchCursor;
 import com.mongodb.internal.operation.ChangeStreamOperation;
@@ -61,6 +62,7 @@ public class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeS
     private final ChangeStreamLevel changeStreamLevel;
 
     private FullDocument fullDocument = FullDocument.DEFAULT;
+    private FullDocumentBeforeChange fullDocumentBeforeChange = FullDocumentBeforeChange.DEFAULT;
     private BsonDocument resumeToken;
     private BsonDocument startAfter;
     private long maxAwaitTimeMS;
@@ -91,6 +93,12 @@ public class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeS
     @Override
     public ChangeStreamIterable<TResult> fullDocument(final FullDocument fullDocument) {
         this.fullDocument = notNull("fullDocument", fullDocument);
+        return this;
+    }
+
+    @Override
+    public ChangeStreamIterable<TResult> fullDocumentBeforeChange(final FullDocumentBeforeChange fullDocumentBeforeChange) {
+        this.fullDocumentBeforeChange = notNull("fullDocumentBeforeChange", fullDocumentBeforeChange);
         return this;
     }
 
@@ -194,7 +202,7 @@ public class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeS
     }
 
     private ReadOperation<BatchCursor<RawBsonDocument>> createChangeStreamOperation() {
-        return new ChangeStreamOperation<>(namespace, fullDocument,  createBsonDocumentList(pipeline),
+        return new ChangeStreamOperation<>(namespace, fullDocument, fullDocumentBeforeChange, createBsonDocumentList(pipeline),
                 new RawBsonDocumentCodec(), changeStreamLevel)
                         .batchSize(getBatchSize())
                         .collation(collation)

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
@@ -61,6 +61,8 @@ import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import com.mongodb.client.model.changestream.FullDocument;
+import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.InsertManyResult;
 import com.mongodb.client.result.InsertOneResult;
@@ -1094,6 +1096,12 @@ final class UnifiedCrudHelper {
                 case "comment":
                     iterable.comment(cur.getValue());
                     break;
+                case "fullDocument":
+                    iterable.fullDocument(FullDocument.fromString(cur.getValue().asString().getValue()));
+                    break;
+                case "fullDocumentBeforeChange":
+                    iterable.fullDocumentBeforeChange(FullDocumentBeforeChange.fromString(cur.getValue().asString().getValue()));
+                    break;
                 default:
                     throw new UnsupportedOperationException("Unsupported argument: " + cur.getKey());
             }
@@ -1206,7 +1214,9 @@ final class UnifiedCrudHelper {
      */
     private static final List<String> BSON_DOCUMENT_CHANGE_STREAM_TESTS = asList(
                     "Test newField added in response MUST NOT err",
-                    "Test projection in change stream returns expected fields");
+                    "Test projection in change stream returns expected fields",
+                    "fullDocument:whenAvailable with changeStreamPreAndPostImages disabled",
+                    "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages disabled");
 
     @NotNull
     private MongoCursor<BsonDocument> createChangeStreamWrappingCursor(final ChangeStreamIterable<BsonDocument> iterable) {


### PR DESCRIPTION
Change stream watch helpers now accept "whenAvailable" and "required" for the fullDocument option.
Additionally, a new fullDocumentBeforeChange option is introduced, which accepts "off", "whenAvailable" and
"required". Change events may now include a "fullDocumentBeforeChange" response field.

JAVA-4468