### PR TITLE
Stop using `null` values in the Scala query building API for ``$setWindowFields`

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
+++ b/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
@@ -46,7 +46,8 @@ import static org.bson.assertions.Assertions.notNull;
  *     <li>An optional {@linkplain Window window}, a.k.a. frame.
  *     Specifying {@code null} window is equivalent to specifying an unbounded window,
  *     i.e., a window with both ends specified as {@link Bound#UNBOUNDED}.
- *     Some window functions require to specify an explicit unbounded window instead of specifying {@code null}.</li>
+ *     Some window functions, e.g., {@link #derivative(String, Object, Window)},
+ *     require an explicit unbounded window instead of {@code null}.</li>
  *     <li>A path to an output field to be computed by the window function over the window.</li>
  * </ul>
  * A windowed computation is similar to an {@linkplain Accumulators accumulator} but does not result in folding documents constituting

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
@@ -462,8 +462,8 @@ object Aggregates {
    * documents belonging to the same partition or window are not folded into a single document.
    *
    * @param partitionBy Optional partitioning of data specified like `id` in [[Aggregates.group]].
-   *                    If `null`, then all documents belong to the same partition.
-   * @param sortBy      Fields to sort by. May be `null`. The syntax is identical to `sort` in [[Aggregates.sort]] (see [[Sorts]]).
+   *                    If `None`, then all documents belong to the same partition.
+   * @param sortBy      Fields to sort by. The syntax is identical to `sort` in [[Aggregates.sort]] (see [[Sorts]]).
    *                    Sorting is required by certain functions and may be required by some windows (see [[Windows]] for more details).
    *                    Sorting is used only for the purpose of computing window functions and does not guarantee ordering
    *                    of the output documents.
@@ -475,6 +475,10 @@ object Aggregates {
    * @note Requires MongoDB 5.0 or greater.
    */
   @Beta
-  def setWindowFields[TExpression](partitionBy: TExpression, sortBy: Bson, output: WindowedComputation*): Bson =
-    JAggregates.setWindowFields(partitionBy, sortBy, output.asJava)
+  def setWindowFields[TExpression >: Null](
+      partitionBy: Option[TExpression],
+      sortBy: Option[Bson],
+      output: WindowedComputation*
+  ): Bson =
+    JAggregates.setWindowFields(partitionBy.orNull, sortBy.orNull, output.asJava)
 }

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
@@ -25,9 +25,10 @@ import com.mongodb.client.model.{ MongoTimeUnit => JMongoTimeUnit, WindowedCompu
  *  - A window function. Some functions require documents in a window to be sorted
  *  (see `sortBy` in [[Aggregates.setWindowFields]]).
  *  - An optional [[Window window]], a.k.a. frame.
- *  Specifying `null` window is equivalent to specifying an unbounded window,
+ *  Specifying `None` window is equivalent to specifying an unbounded window,
  *  i.e., a window with both ends specified as [[Windows.Bound UNBOUNDED]].
- *  Some window functions require to specify an explicit unbounded window instead of specifying `null`.
+ *  Some window functions, e.g., [[WindowedComputations.derivative]],
+ *  require an explicit unbounded window instead of `None`.
  *  - A path to an output field to be computed by the window function over the window.
  *
  * A windowed computation is similar to an [[Accumulators accumulator]] but does not result in folding documents constituting
@@ -63,89 +64,89 @@ object WindowedComputations {
    *
    * @param path       The output field path.
    * @param expression The expression.
-   * @param window     The window. May be `null`.
+   * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-sum \$sum]]
    */
-  def sum[TExpression](path: String, expression: TExpression, window: Window): WindowedComputation =
-    JWindowedComputations.sum(path, expression, window)
+  def sum[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
+    JWindowedComputations.sum(path, expression, window.orNull)
 
   /**
    * Builds a computation of the average of the evaluation results of the `expression` over the `window`.
    *
    * @param path       The output field path.
    * @param expression The expression.
-   * @param window     The window. May be `null`.
+   * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-avg \$avg]]
    */
-  def avg[TExpression](path: String, expression: TExpression, window: Window): WindowedComputation =
-    JWindowedComputations.avg(path, expression, window)
+  def avg[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
+    JWindowedComputations.avg(path, expression, window.orNull)
 
   /**
    * Builds a computation of the sample standard deviation of the evaluation results of the `expression` over the `window`.
    *
    * @param path       The output field path.
    * @param expression The expression.
-   * @param window     The window. May be `null`.
+   * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-std-dev-samp \$stdDevSamp]]
    */
-  def stdDevSamp[TExpression](path: String, expression: TExpression, window: Window): WindowedComputation =
-    JWindowedComputations.stdDevSamp(path, expression, window)
+  def stdDevSamp[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
+    JWindowedComputations.stdDevSamp(path, expression, window.orNull)
 
   /**
    * Builds a computation of the population standard deviation of the evaluation results of the `expression` over the `window`.
    *
    * @param path       The output field path.
    * @param expression The expression.
-   * @param window     The window. May be `null`.
+   * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-std-dev-pop \$stdDevPop]]
    */
-  def stdDevPop[TExpression](path: String, expression: TExpression, window: Window): WindowedComputation =
-    JWindowedComputations.stdDevPop(path, expression, window)
+  def stdDevPop[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
+    JWindowedComputations.stdDevPop(path, expression, window.orNull)
 
   /**
    * Builds a computation of the lowest of the evaluation results of the `expression` over the `window`.
    *
    * @param path       The output field path.
    * @param expression The expression.
-   * @param window     The window. May be `null`.
+   * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-min \$min]]
    */
-  def min[TExpression](path: String, expression: TExpression, window: Window): WindowedComputation =
-    JWindowedComputations.min(path, expression, window)
+  def min[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
+    JWindowedComputations.min(path, expression, window.orNull)
 
   /**
    * Builds a computation of the highest of the evaluation results of the `expression` over the `window`.
    *
    * @param path       The output field path.
    * @param expression The expression.
-   * @param window     The window. May be `null`.
+   * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-max \$max]]
    */
-  def max[TExpression](path: String, expression: TExpression, window: Window): WindowedComputation =
-    JWindowedComputations.max(path, expression, window)
+  def max[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
+    JWindowedComputations.max(path, expression, window.orNull)
 
   /**
    * Builds a computation of the number of documents in the `window`.
    *
    * @param path   The output field path.
-   * @param window The window. May be `null`.
+   * @param window The window.
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-count \$count]]
    */
-  def count(path: String, window: Window): WindowedComputation =
-    JWindowedComputations.count(path, window)
+  def count(path: String, window: Option[_ <: Window]): WindowedComputation =
+    JWindowedComputations.count(path, window.orNull)
 
   /**
    * Builds a computation of the time derivative by subtracting the evaluation result of the `expression` against the last document
@@ -243,7 +244,7 @@ object WindowedComputations {
    * @param path        The output field path.
    * @param expression1 The first expression.
    * @param expression2 The second expression.
-   * @param window      The window. May be `null`.
+   * @param window      The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-covariance-samp \$covarianceSamp]]
@@ -252,9 +253,9 @@ object WindowedComputations {
       path: String,
       expression1: TExpression,
       expression2: TExpression,
-      window: Window
+      window: Option[_ <: Window]
   ): WindowedComputation =
-    JWindowedComputations.covarianceSamp(path, expression1, expression2, window)
+    JWindowedComputations.covarianceSamp(path, expression1, expression2, window.orNull)
 
   /**
    * Builds a computation of the population covariance between the evaluation results of the two expressions over the `window`.
@@ -262,7 +263,7 @@ object WindowedComputations {
    * @param path        The output field path.
    * @param expression1 The first expression.
    * @param expression2 The second expression.
-   * @param window      The window. May be `null`.
+   * @param window      The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-covariance-pop \$covariancePop]]
@@ -271,9 +272,9 @@ object WindowedComputations {
       path: String,
       expression1: TExpression,
       expression2: TExpression,
-      window: Window
+      window: Option[_ <: Window]
   ): WindowedComputation =
-    JWindowedComputations.covariancePop(path, expression1, expression2, window)
+    JWindowedComputations.covariancePop(path, expression1, expression2, window.orNull)
 
   /**
    * Builds a computation of the exponential moving average of the evaluation results of the `expression` over a window
@@ -317,13 +318,13 @@ object WindowedComputations {
    *
    * @param path       The output field path.
    * @param expression The expression.
-   * @param window     The window. May be `null`.
+   * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-push \$push]]
    */
-  def push[TExpression](path: String, expression: TExpression, window: Window): WindowedComputation =
-    JWindowedComputations.push(path, expression, window)
+  def push[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
+    JWindowedComputations.push(path, expression, window.orNull)
 
   /**
    * Builds a computation that adds the evaluation results of the `expression` over the `window`
@@ -332,13 +333,13 @@ object WindowedComputations {
    *
    * @param path       The output field path.
    * @param expression The expression.
-   * @param window     The window. May be `null`.
+   * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-add-to-set \$addToSet]]
    */
-  def addToSet[TExpression](path: String, expression: TExpression, window: Window): WindowedComputation =
-    JWindowedComputations.addToSet(path, expression, window)
+  def addToSet[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
+    JWindowedComputations.addToSet(path, expression, window.orNull)
 
   /**
    * Builds a computation of the evaluation result of the `expression` against the first document in the `window`.
@@ -347,13 +348,13 @@ object WindowedComputations {
    *
    * @param path       The output field path.
    * @param expression The expression.
-   * @param window     The window. May be `null`.
+   * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-first \$first]]
    */
-  def first[TExpression](path: String, expression: TExpression, window: Window): WindowedComputation =
-    JWindowedComputations.first(path, expression, window)
+  def first[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
+    JWindowedComputations.first(path, expression, window.orNull)
 
   /**
    * Builds a computation of the evaluation result of the `expression` against the last document in the `window`.
@@ -362,13 +363,13 @@ object WindowedComputations {
    *
    * @param path       The output field path.
    * @param expression The expression.
-   * @param window     The window. May be `null`.
+   * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-last \$last]]
    */
-  def last[TExpression](path: String, expression: TExpression, window: Window): WindowedComputation =
-    JWindowedComputations.last(path, expression, window)
+  def last[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
+    JWindowedComputations.last(path, expression, window.orNull)
 
   /**
    * Builds a computation of the evaluation result of the `expression` for the document whose position is shifted by the given
@@ -381,7 +382,7 @@ object WindowedComputations {
    * @param path              The output field path.
    * @param expression        The expression.
    * @param defaultExpression The default expression.
-   *                          If `null`, then the default expression is evaluated to BSON `Null`.
+   *                          If `None`, then the default expression is evaluated to BSON `Null`.
    *                          Must evaluate to a constant value.
    * @param by                The shift specified similarly to [[Windows rules for window bounds]]:
    *                          - 0 means the current document;
@@ -391,13 +392,13 @@ object WindowedComputations {
    * @return The constructed windowed computation.
    * @see [[https://dochub.mongodb.org/core/window-functions-shift \$shift]]
    */
-  def shift[TExpression](
+  def shift[TExpression >: Null](
       path: String,
       expression: TExpression,
-      defaultExpression: TExpression,
+      defaultExpression: Option[TExpression],
       by: Int
   ): WindowedComputation =
-    JWindowedComputations.shift(path, expression, defaultExpression, by)
+    JWindowedComputations.shift(path, expression, defaultExpression.orNull, by)
 
   /**
    * Builds a computation of the order number of each document in its

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
@@ -402,8 +402,8 @@ class AggregatesSpec extends BaseSpec {
     val window: Window = documents(1, 2)
     toBson(
       setWindowFields(
-        "$partitionByField",
-        ascending("sortByField"),
+        Some("$partitionByField"),
+        Some(ascending("sortByField")),
         WindowedComputations.of(
           BsonField.apply(
             "newField00",
@@ -413,27 +413,26 @@ class AggregatesSpec extends BaseSpec {
             )
           )
         ),
-        WindowedComputations.sum("newField01", "$field01", range(1, CURRENT)),
-        WindowedComputations.avg("newField02", "$field02", range(UNBOUNDED, 1)),
-        WindowedComputations.stdDevSamp("newField03", "$field03", window),
-        WindowedComputations.stdDevPop("newField04", "$field04", window),
-        WindowedComputations.min("newField05", "$field05", window),
-        WindowedComputations.max("newField06", "$field06", window),
-        WindowedComputations.count("newField07", window),
+        WindowedComputations.sum("newField01", "$field01", Some(range(1, CURRENT))),
+        WindowedComputations.avg("newField02", "$field02", Some(range(UNBOUNDED, 1))),
+        WindowedComputations.stdDevSamp("newField03", "$field03", Some(window)),
+        WindowedComputations.stdDevPop("newField04", "$field04", Some(window)),
+        WindowedComputations.min("newField05", "$field05", Some(window)),
+        WindowedComputations.max("newField06", "$field06", Some(window)),
+        WindowedComputations.count("newField07", Some(window)),
         WindowedComputations.derivative("newField08", "$field08", window),
         WindowedComputations.timeDerivative("newField09", "$field09", window, DAY),
         WindowedComputations.integral("newField10", "$field10", window),
         WindowedComputations.timeIntegral("newField11", "$field11", window, DAY),
-        WindowedComputations.timeIntegral("newField11", "$field11", window, DAY),
-        WindowedComputations.covarianceSamp("newField12", "$field12_1", "$field12_2", window),
-        WindowedComputations.covariancePop("newField13", "$field13_1", "$field13_2", window),
+        WindowedComputations.covarianceSamp("newField12", "$field12_1", "$field12_2", Some(window)),
+        WindowedComputations.covariancePop("newField13", "$field13_1", "$field13_2", Some(window)),
         WindowedComputations.expMovingAvg("newField14", "$field14", 3),
         WindowedComputations.expMovingAvg("newField15", "$field15", 0.5),
-        WindowedComputations.push("newField16", "$field16", window),
-        WindowedComputations.addToSet("newField17", "$field17", window),
-        WindowedComputations.first("newField18", "$field18", window),
-        WindowedComputations.last("newField19", "$field19", window),
-        WindowedComputations.shift("newField20", "$field20", "defaultConstantValue", -3),
+        WindowedComputations.push("newField16", "$field16", Some(window)),
+        WindowedComputations.addToSet("newField17", "$field17", Some(window)),
+        WindowedComputations.first("newField18", "$field18", Some(window)),
+        WindowedComputations.last("newField19", "$field19", Some(window)),
+        WindowedComputations.shift("newField20", "$field20", Some("defaultConstantValue"), -3),
         WindowedComputations.documentNumber("newField21"),
         WindowedComputations.rank("newField22"),
         WindowedComputations.denseRank("newField23")
@@ -478,7 +477,7 @@ class AggregatesSpec extends BaseSpec {
 
   it should "render $setWindowFields with no partitionBy/sortBy" in {
     toBson(
-      setWindowFields(null, null, WindowedComputations.sum("newField01", "$field01", documents(1, 2)))
+      setWindowFields(None, None, WindowedComputations.sum("newField01", "$field01", Some(documents(1, 2))))
     ) should equal(
       Document("""{
         "$setWindowFields": {


### PR DESCRIPTION
We also need to update the examples in https://mongodb.github.io/mongo-java-driver/4.6/driver-scala/builders/aggregation/#setwindowfields such that they wrap references in `Some` where needed: https://jira.mongodb.org/browse/DOCSP-22696.

JAVA-4583