### PR TITLE
JAVA-4621: Add maintenanceInitialDelay to MongoClientOptions

### DIFF
--- a/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
@@ -250,13 +250,25 @@ public class MongoClientOptions {
      * <p>
      * Default is 0.</p>
      *
-     * @param timeUnit unit of time to convert the value into
-     * @return The maximum number of connections a pool may be establishing concurrently.
+     * @return the time period to wait in milliseconds
      * @see ConnectionPoolSettings#getMaintenanceInitialDelay
      * @since 4.7
      */
-    public long getMaintenanceInitialDelay(final TimeUnit timeUnit) {
-        return wrapped.getConnectionPoolSettings().getMaintenanceInitialDelay(timeUnit);
+    public int getMaintenanceInitialDelay() {
+        return toIntExact(wrapped.getConnectionPoolSettings().getMaintenanceInitialDelay(MILLISECONDS));
+    }
+
+    /**
+     * Returns the time period between runs of the maintenance job.
+     * <p>
+     * Default is 60,000.</p>
+     *
+     * @return the time period between runs of the maintainance job in milliseconds
+     * @see ConnectionPoolSettings#getMaintenanceFrequency
+     * @since 4.7
+     */
+    public int getMaintenanceFrequency() {
+        return toIntExact(wrapped.getConnectionPoolSettings().getMaintenanceFrequency(MILLISECONDS));
     }
 
     /**
@@ -874,6 +886,20 @@ public class MongoClientOptions {
          */
         public Builder maintenanceInitialDelay(final long maintenanceInitialDelay, final TimeUnit timeUnit) {
             wrapped.applyToConnectionPoolSettings(builder -> builder.maintenanceInitialDelay(maintenanceInitialDelay, timeUnit));
+            return this;
+        }
+
+        /**
+         * The time period between runs of the maintenance job.
+         *
+         * @param maintenanceFrequency the time period between runs of the maintenance job
+         * @param timeUnit             the TimeUnit for this time period
+         * @return {@code this}
+         * @see ConnectionPoolSettings.Builder#maintenanceFrequency
+         * @since 4.7
+         */
+        public Builder maintenanceFrequency(final long maintenanceFrequency, final TimeUnit timeUnit) {
+            wrapped.applyToConnectionPoolSettings(builder -> builder.maintenanceFrequency(maintenanceFrequency, timeUnit));
             return this;
         }
 

--- a/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
@@ -29,9 +29,6 @@ import com.mongodb.event.ServerListener;
 import com.mongodb.event.ServerMonitorListener;
 import com.mongodb.lang.Nullable;
 import com.mongodb.selector.ServerSelector;
-
-import java.util.concurrent.TimeUnit;
-
 import org.bson.UuidRepresentation;
 import org.bson.codecs.configuration.CodecRegistry;
 
@@ -248,27 +245,27 @@ public class MongoClientOptions {
     /**
      * Returns the period of time to wait before running the first maintenance job on each connection pool.
      * <p>
-     * Default is 0.</p>
+     * Default is 0 ms.</p>
      *
      * @return the time period to wait in milliseconds
      * @see ConnectionPoolSettings#getMaintenanceInitialDelay
      * @since 4.7
      */
-    public int getMaintenanceInitialDelay() {
-        return toIntExact(wrapped.getConnectionPoolSettings().getMaintenanceInitialDelay(MILLISECONDS));
+    public long getMaintenanceInitialDelay() {
+        return wrapped.getConnectionPoolSettings().getMaintenanceInitialDelay(MILLISECONDS);
     }
 
     /**
      * Returns the time period between runs of the maintenance job on each connection pool.
      * <p>
-     * Default is 60,000.</p>
+     * Default is 60,000 ms.</p>
      *
      * @return the time period between runs of the maintainance job in milliseconds
      * @see ConnectionPoolSettings#getMaintenanceFrequency
      * @since 4.7
      */
-    public int getMaintenanceFrequency() {
-        return toIntExact(wrapped.getConnectionPoolSettings().getMaintenanceFrequency(MILLISECONDS));
+    public long getMaintenanceFrequency() {
+        return wrapped.getConnectionPoolSettings().getMaintenanceFrequency(MILLISECONDS);
     }
 
     /**

--- a/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
@@ -29,6 +29,9 @@ import com.mongodb.event.ServerListener;
 import com.mongodb.event.ServerMonitorListener;
 import com.mongodb.lang.Nullable;
 import com.mongodb.selector.ServerSelector;
+
+import java.util.concurrent.TimeUnit;
+
 import org.bson.UuidRepresentation;
 import org.bson.codecs.configuration.CodecRegistry;
 
@@ -240,6 +243,20 @@ public class MongoClientOptions {
      */
     public int getMaxConnecting() {
         return wrapped.getConnectionPoolSettings().getMaxConnecting();
+    }
+
+    /**
+     * Returns the period of time to wait before running the first maintenance job on the connection pool.
+     * <p>
+     * Default is 0.</p>
+     *
+     * @param timeUnit unit of time to convert the value into
+     * @return The maximum number of connections a pool may be establishing concurrently.
+     * @see ConnectionPoolSettings#getMaintenanceInitialDelay
+     * @since 4.7
+     */
+    public long getMaintenanceInitialDelay(final TimeUnit timeUnit) {
+        return wrapped.getConnectionPoolSettings().getMaintenanceInitialDelay(timeUnit);
     }
 
     /**
@@ -843,6 +860,20 @@ public class MongoClientOptions {
          */
         public Builder maxConnecting(final int maxConnecting) {
             wrapped.applyToConnectionPoolSettings(builder -> builder.maxConnecting(maxConnecting));
+            return this;
+        }
+
+        /**
+         * The period of time to wait before running the first maintenance job on the connection pool.
+         *
+         * @param maintenanceInitialDelay the time period to wait
+         * @param timeUnit                the TimeUnit for this time period
+         * @return {@code this}.
+         * @see ConnectionPoolSettings.Builder#maintenanceInitialDelay
+         * @since 4.7
+         */
+        public Builder maintenanceInitialDelay(final long maintenanceInitialDelay, final TimeUnit timeUnit) {
+            wrapped.applyToConnectionPoolSettings(builder -> builder.maintenanceInitialDelay(maintenanceInitialDelay, timeUnit));
             return this;
         }
 

--- a/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
@@ -246,7 +246,7 @@ public class MongoClientOptions {
     }
 
     /**
-     * Returns the period of time to wait before running the first maintenance job on the connection pool.
+     * Returns the period of time to wait before running the first maintenance job on each connection pool.
      * <p>
      * Default is 0.</p>
      *
@@ -259,7 +259,7 @@ public class MongoClientOptions {
     }
 
     /**
-     * Returns the time period between runs of the maintenance job.
+     * Returns the time period between runs of the maintenance job on each connection pool.
      * <p>
      * Default is 60,000.</p>
      *
@@ -876,30 +876,28 @@ public class MongoClientOptions {
         }
 
         /**
-         * The period of time to wait before running the first maintenance job on the connection pool.
+         * The period of time to wait before running the first maintenance job on each connection pool.
          *
-         * @param maintenanceInitialDelay the time period to wait
-         * @param timeUnit                the TimeUnit for this time period
+         * @param maintenanceInitialDelay the time period to wait in milliseconds
          * @return {@code this}.
          * @see ConnectionPoolSettings.Builder#maintenanceInitialDelay
          * @since 4.7
          */
-        public Builder maintenanceInitialDelay(final long maintenanceInitialDelay, final TimeUnit timeUnit) {
-            wrapped.applyToConnectionPoolSettings(builder -> builder.maintenanceInitialDelay(maintenanceInitialDelay, timeUnit));
+        public Builder maintenanceInitialDelay(final long maintenanceInitialDelay) {
+            wrapped.applyToConnectionPoolSettings(builder -> builder.maintenanceInitialDelay(maintenanceInitialDelay, MILLISECONDS));
             return this;
         }
 
         /**
-         * The time period between runs of the maintenance job.
+         * The time period between runs of the maintenance job on each connection pool.
          *
-         * @param maintenanceFrequency the time period between runs of the maintenance job
-         * @param timeUnit             the TimeUnit for this time period
+         * @param maintenanceFrequency the time period between runs of the maintenance job in milliseconds
          * @return {@code this}
          * @see ConnectionPoolSettings.Builder#maintenanceFrequency
          * @since 4.7
          */
-        public Builder maintenanceFrequency(final long maintenanceFrequency, final TimeUnit timeUnit) {
-            wrapped.applyToConnectionPoolSettings(builder -> builder.maintenanceFrequency(maintenanceFrequency, timeUnit));
+        public Builder maintenanceFrequency(final long maintenanceFrequency) {
+            wrapped.applyToConnectionPoolSettings(builder -> builder.maintenanceFrequency(maintenanceFrequency, MILLISECONDS));
             return this;
         }
 

--- a/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
@@ -229,9 +229,11 @@ class MongoClientOptionsSpecification extends Specification {
         optionsFromSettings.getMaxConnectionLifeTime() == 400
         optionsFromSettings.getMaxConnecting() == settings.connectionPoolSettings.maxConnecting
         optionsFromSettings.getMaintenanceInitialDelay() == 100
-        optionsFromSettings.getMaintenanceInitialDelay() == settings.connectionPoolSettings.getMaintenanceInitialDelay(TimeUnit.MILLISECONDS)
+        optionsFromSettings.getMaintenanceInitialDelay() ==
+                settings.connectionPoolSettings.getMaintenanceInitialDelay(TimeUnit.MILLISECONDS)
         optionsFromSettings.getMaintenanceFrequency() == 100
-        optionsFromSettings.getMaintenanceFrequency() == settings.connectionPoolSettings.getMaintenanceFrequency(TimeUnit.MILLISECONDS)
+        optionsFromSettings.getMaintenanceFrequency() ==
+                settings.connectionPoolSettings.getMaintenanceFrequency(TimeUnit.MILLISECONDS)
         optionsFromSettings.getMinConnectionsPerHost() == 30
         optionsFromSettings.getConnectionsPerHost() == 500
         optionsFromSettings.getConnectTimeout() == 100

--- a/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
@@ -127,8 +127,8 @@ class MongoClientOptionsSpecification extends Specification {
                                         .maxConnectionIdleTime(300)
                                         .maxConnectionLifeTime(400)
                                         .maxConnecting(1)
-                                        .maintenanceInitialDelay(100, TimeUnit.MILLISECONDS)
-                                        .maintenanceFrequency(30, TimeUnit.SECONDS)
+                                        .maintenanceInitialDelay(100)
+                                        .maintenanceFrequency(100)
                                         .sslEnabled(true)
                                         .sslInvalidHostNameAllowed(true)
                                         .sslContext(SSLContext.getDefault())
@@ -166,7 +166,7 @@ class MongoClientOptionsSpecification extends Specification {
         options.getMaxConnectionLifeTime() == 400
         options.getMaxConnecting() == 1
         options.getMaintenanceInitialDelay() == 100
-        options.getMaintenanceFrequency() == 30_000
+        options.getMaintenanceFrequency() == 100
         options.getMinConnectionsPerHost() == 30
         options.getConnectionsPerHost() == 500
         options.getConnectTimeout() == 100
@@ -230,7 +230,7 @@ class MongoClientOptionsSpecification extends Specification {
         optionsFromSettings.getMaxConnecting() == settings.connectionPoolSettings.maxConnecting
         optionsFromSettings.getMaintenanceInitialDelay() == 100
         optionsFromSettings.getMaintenanceInitialDelay() == settings.connectionPoolSettings.getMaintenanceInitialDelay(TimeUnit.MILLISECONDS)
-        optionsFromSettings.getMaintenanceFrequency() == 30_000
+        optionsFromSettings.getMaintenanceFrequency() == 100
         optionsFromSettings.getMaintenanceFrequency() == settings.connectionPoolSettings.getMaintenanceFrequency(TimeUnit.MILLISECONDS)
         optionsFromSettings.getMinConnectionsPerHost() == 30
         optionsFromSettings.getConnectionsPerHost() == 500

--- a/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
@@ -28,6 +28,7 @@ import org.bson.codecs.configuration.CodecRegistry
 import spock.lang.Specification
 
 import javax.net.ssl.SSLContext
+import java.util.concurrent.TimeUnit
 
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
@@ -126,6 +127,7 @@ class MongoClientOptionsSpecification extends Specification {
                                         .maxConnectionIdleTime(300)
                                         .maxConnectionLifeTime(400)
                                         .maxConnecting(1)
+                                        .maintenanceInitialDelay(100, TimeUnit.MILLISECONDS)
                                         .sslEnabled(true)
                                         .sslInvalidHostNameAllowed(true)
                                         .sslContext(SSLContext.getDefault())
@@ -162,6 +164,7 @@ class MongoClientOptionsSpecification extends Specification {
         options.getMaxConnectionIdleTime() == 300
         options.getMaxConnectionLifeTime() == 400
         options.getMaxConnecting() == 1
+        options.getMaintenanceInitialDelay(TimeUnit.MILLISECONDS) == 100
         options.getMinConnectionsPerHost() == 30
         options.getConnectionsPerHost() == 500
         options.getConnectTimeout() == 100
@@ -223,6 +226,9 @@ class MongoClientOptionsSpecification extends Specification {
         optionsFromSettings.getMaxConnectionIdleTime() == 300
         optionsFromSettings.getMaxConnectionLifeTime() == 400
         optionsFromSettings.getMaxConnecting() == settings.connectionPoolSettings.maxConnecting
+        optionsFromSettings.getMaintenanceInitialDelay(TimeUnit.MILLISECONDS) == 100
+        optionsFromSettings.getMaintenanceInitialDelay(TimeUnit.MILLISECONDS) == settings.connectionPoolSettings
+                .getMaintenanceInitialDelay(TimeUnit.MILLISECONDS)
         optionsFromSettings.getMinConnectionsPerHost() == 30
         optionsFromSettings.getConnectionsPerHost() == 500
         optionsFromSettings.getConnectTimeout() == 100

--- a/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
@@ -128,6 +128,7 @@ class MongoClientOptionsSpecification extends Specification {
                                         .maxConnectionLifeTime(400)
                                         .maxConnecting(1)
                                         .maintenanceInitialDelay(100, TimeUnit.MILLISECONDS)
+                                        .maintenanceFrequency(30, TimeUnit.SECONDS)
                                         .sslEnabled(true)
                                         .sslInvalidHostNameAllowed(true)
                                         .sslContext(SSLContext.getDefault())
@@ -164,7 +165,8 @@ class MongoClientOptionsSpecification extends Specification {
         options.getMaxConnectionIdleTime() == 300
         options.getMaxConnectionLifeTime() == 400
         options.getMaxConnecting() == 1
-        options.getMaintenanceInitialDelay(TimeUnit.MILLISECONDS) == 100
+        options.getMaintenanceInitialDelay() == 100
+        options.getMaintenanceFrequency() == 30_000
         options.getMinConnectionsPerHost() == 30
         options.getConnectionsPerHost() == 500
         options.getConnectTimeout() == 100
@@ -226,9 +228,10 @@ class MongoClientOptionsSpecification extends Specification {
         optionsFromSettings.getMaxConnectionIdleTime() == 300
         optionsFromSettings.getMaxConnectionLifeTime() == 400
         optionsFromSettings.getMaxConnecting() == settings.connectionPoolSettings.maxConnecting
-        optionsFromSettings.getMaintenanceInitialDelay(TimeUnit.MILLISECONDS) == 100
-        optionsFromSettings.getMaintenanceInitialDelay(TimeUnit.MILLISECONDS) == settings.connectionPoolSettings
-                .getMaintenanceInitialDelay(TimeUnit.MILLISECONDS)
+        optionsFromSettings.getMaintenanceInitialDelay() == 100
+        optionsFromSettings.getMaintenanceInitialDelay() == settings.connectionPoolSettings.getMaintenanceInitialDelay(TimeUnit.MILLISECONDS)
+        optionsFromSettings.getMaintenanceFrequency() == 30_000
+        optionsFromSettings.getMaintenanceFrequency() == settings.connectionPoolSettings.getMaintenanceFrequency(TimeUnit.MILLISECONDS)
         optionsFromSettings.getMinConnectionsPerHost() == 30
         optionsFromSettings.getConnectionsPerHost() == 500
         optionsFromSettings.getConnectTimeout() == 100


### PR DESCRIPTION
JAVA-4621

Make `MongoClientOptions` aware of `maintenanceInitialDelayMs`. 

QA: Unit tests to check that the property propagates across `MongoClientOptions` and `MongoClientSettings`.