### PR TITLE
RecordCodecProvider < JDK 17 canary test

### DIFF
--- a/driver-core/src/main/com/mongodb/Jep395RecordCodecProvider.java
+++ b/driver-core/src/main/com/mongodb/Jep395RecordCodecProvider.java
@@ -41,8 +41,9 @@ public class Jep395RecordCodecProvider implements CodecProvider {
         CodecProvider possibleCodecProvider;
         try {
             Class.forName("java.lang.Record"); // JEP-395 support canary test.
+            Class.forName("org.bson.codecs.record.RecordCodecProvider"); // Java 17 canary test
             possibleCodecProvider = new RecordCodecProvider();
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException | UnsupportedClassVersionError e) {
             // No JEP-395 support
             possibleCodecProvider = null;
         }


### PR DESCRIPTION
The RecordCodecProvider uses JDK 17 LTS to compile.
Users maybe using older (non LTS) JDK's where records are supported.

JAVA-4605