### PR TITLE
Support the existing pojo annotations on records

### DIFF
--- a/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
@@ -143,6 +143,7 @@ final class RecordCodec<T extends Record> implements Codec<T> {
         private static void validateAnnotations(final RecordComponent component, final int index) {
             validateAnnotationNotPresentOnType(component.getDeclaringRecord(), org.bson.codecs.pojo.annotations.BsonDiscriminator.class);
             validateAnnotationNotPresentOnConstructor(component.getDeclaringRecord(), org.bson.codecs.pojo.annotations.BsonCreator.class);
+            validateAnnotationNotPresentOnMethod(component.getDeclaringRecord(), org.bson.codecs.pojo.annotations.BsonCreator.class);
             validateAnnotationNotPresentOnFieldOrAccessor(component, org.bson.codecs.pojo.annotations.BsonIgnore.class);
             validateAnnotationNotPresentOnFieldOrAccessor(component, org.bson.codecs.pojo.annotations.BsonExtraElements.class);
             validateAnnotationOnlyOnField(component, index, org.bson.codecs.pojo.annotations.BsonId.class);
@@ -165,6 +166,17 @@ final class RecordCodec<T extends Record> implements Codec<T> {
                     throw new CodecConfigurationException(
                             format("Annotation '%s' not supported on record constructors, but found on constructor of '%s'",
                             annotation, clazz.getName()));
+                }
+            }
+        }
+
+        private static void validateAnnotationNotPresentOnMethod(final Class<?> clazz,
+                @SuppressWarnings("SameParameterValue") final Class<BsonCreator> annotation) {
+            for (var method : clazz.getMethods()) {
+                if (method.isAnnotationPresent(annotation)) {
+                    throw new CodecConfigurationException(
+                            format("Annotation '%s' not supported on methods, but found on method '%s' of '%s'",
+                                    annotation, method.getName(), clazz.getName()));
                 }
             }
         }

--- a/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
@@ -25,7 +25,6 @@ import org.bson.codecs.EncoderContext;
 import org.bson.codecs.RepresentationConfigurable;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.configuration.CodecRegistry;
-import org.bson.codecs.pojo.annotations.BsonCreator;
 import org.bson.codecs.record.annotations.BsonId;
 import org.bson.codecs.record.annotations.BsonProperty;
 import org.bson.codecs.record.annotations.BsonRepresentation;
@@ -159,8 +158,8 @@ final class RecordCodec<T extends Record> implements Codec<T> {
             }
         }
 
-        private static void validateAnnotationNotPresentOnConstructor(final Class<?> clazz,
-                @SuppressWarnings("SameParameterValue") final Class<BsonCreator> annotation) {
+        private static <T extends Annotation> void validateAnnotationNotPresentOnConstructor(final Class<?> clazz,
+                @SuppressWarnings("SameParameterValue") final Class<T> annotation) {
             for (var constructor : clazz.getConstructors()) {
                 if (constructor.isAnnotationPresent(annotation)) {
                     throw new CodecConfigurationException(
@@ -170,8 +169,8 @@ final class RecordCodec<T extends Record> implements Codec<T> {
             }
         }
 
-        private static void validateAnnotationNotPresentOnMethod(final Class<?> clazz,
-                @SuppressWarnings("SameParameterValue") final Class<BsonCreator> annotation) {
+        private static <T extends Annotation> void validateAnnotationNotPresentOnMethod(final Class<?> clazz,
+                @SuppressWarnings("SameParameterValue") final Class<T> annotation) {
             for (var method : clazz.getMethods()) {
                 if (method.isAnnotationPresent(annotation)) {
                     throw new CodecConfigurationException(

--- a/bson-record-codec/src/main/org/bson/codecs/record/annotations/BsonId.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/annotations/BsonId.java
@@ -26,7 +26,9 @@ import java.lang.annotation.Target;
  * An annotation that configures the record component as the _id field of the document
  *
  * @since 4.6
+ * @deprecated Prefer {@link org.bson.codecs.pojo.annotations.BsonId}
  */
+@Deprecated
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.RECORD_COMPONENT})

--- a/bson-record-codec/src/main/org/bson/codecs/record/annotations/BsonProperty.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/annotations/BsonProperty.java
@@ -26,7 +26,9 @@ import java.lang.annotation.Target;
  * An annotation that configures a record component.
  *
  * @since 4.6
+ * @deprecated Prefer {@link org.bson.codecs.pojo.annotations.BsonProperty}
  */
+@Deprecated
 @Documented
 @Target({ElementType.RECORD_COMPONENT})
 @Retention(RetentionPolicy.RUNTIME)

--- a/bson-record-codec/src/main/org/bson/codecs/record/annotations/BsonRepresentation.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/annotations/BsonRepresentation.java
@@ -28,7 +28,9 @@ import java.lang.annotation.Target;
  * An annotation that specifies what type the record component is stored as in the database.
  *
  * @since 4.6
+ * @deprecated Prefer {@link org.bson.codecs.pojo.annotations.BsonRepresentation}
  */
+@Deprecated
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.RECORD_COMPONENT})

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecProviderTest.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecProviderTest.java
@@ -16,9 +16,9 @@
 
 package org.bson.codecs.record;
 
-import org.bson.codecs.record.samples.TestRecord;
-import org.bson.conversions.Bson;
 import com.mongodb.MongoClientSettings;
+import org.bson.codecs.record.samples.TestRecordWithPojoAnnotations;
+import org.bson.conversions.Bson;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,22 +41,22 @@ public class RecordCodecProviderTest {
         var provider = new RecordCodecProvider();
 
         // when
-        var codec = provider.get(TestRecord.class, Bson.DEFAULT_CODEC_REGISTRY);
+        var codec = provider.get(TestRecordWithPojoAnnotations.class, Bson.DEFAULT_CODEC_REGISTRY);
 
         // then
         assertTrue(codec instanceof RecordCodec);
-        var recordCodec = (RecordCodec<TestRecord>) codec;
-        assertEquals(TestRecord.class, recordCodec.getEncoderClass());
+        var recordCodec = (RecordCodec<TestRecordWithPojoAnnotations>) codec;
+        assertEquals(TestRecordWithPojoAnnotations.class, recordCodec.getEncoderClass());
     }
 
     @Test
     public void shouldReturnRecordCodecForRecordUsingDefaultRegistry() {
         // when
-        var codec = MongoClientSettings.getDefaultCodecRegistry().get(TestRecord.class);
+        var codec = MongoClientSettings.getDefaultCodecRegistry().get(TestRecordWithPojoAnnotations.class);
 
         // then
         assertTrue(codec instanceof RecordCodec);
-        var recordCodec = (RecordCodec<TestRecord>) codec;
-        assertEquals(TestRecord.class, recordCodec.getEncoderClass());
+        var recordCodec = (RecordCodec<TestRecordWithPojoAnnotations>) codec;
+        assertEquals(TestRecordWithPojoAnnotations.class, recordCodec.getEncoderClass());
     }
 }

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
@@ -26,7 +26,7 @@ import org.bson.BsonString;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 import org.bson.codecs.configuration.CodecConfigurationException;
-import org.bson.codecs.record.samples.TestRecord;
+import org.bson.codecs.record.samples.TestRecordWithDeprecatedAnnotations;
 import org.bson.codecs.record.samples.TestRecordWithIllegalBsonCreatorOnConstructor;
 import org.bson.codecs.record.samples.TestRecordWithIllegalBsonCreatorOnMethod;
 import org.bson.codecs.record.samples.TestRecordWithIllegalBsonDiscriminatorOnRecord;
@@ -52,10 +52,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class RecordCodecTest {
 
     @Test
-    public void testSimpleRecord() {
-        var codec = new RecordCodec<>(TestRecord.class, Bson.DEFAULT_CODEC_REGISTRY);
+    public void testRecordWithDeprecatedAnnotations() {
+        var codec = new RecordCodec<>(TestRecordWithDeprecatedAnnotations.class, Bson.DEFAULT_CODEC_REGISTRY);
         var identifier = new ObjectId();
-        var testRecord = new TestRecord("Lucas", 14, List.of("soccer", "basketball"), identifier.toHexString());
+        var testRecord = new TestRecordWithDeprecatedAnnotations("Lucas", 14, List.of("soccer", "basketball"), identifier.toHexString());
 
         var document = new BsonDocument();
         var writer = new BsonDocumentWriter(document);
@@ -80,7 +80,7 @@ public class RecordCodecTest {
     }
 
     @Test
-    public void testSimpleRecordWithPojoAnnotations() {
+    public void testRecordWithPojoAnnotations() {
         var codec = new RecordCodec<>(TestRecordWithPojoAnnotations.class, Bson.DEFAULT_CODEC_REGISTRY);
         var identifier = new ObjectId();
         var testRecord = new TestRecordWithPojoAnnotations("Lucas", 14, List.of("soccer", "basketball"), identifier.toHexString());
@@ -108,10 +108,10 @@ public class RecordCodecTest {
     }
 
     @Test
-    public void testSimpleRecordWithNulls() {
-        var codec = new RecordCodec<>(TestRecord.class, Bson.DEFAULT_CODEC_REGISTRY);
+    public void testRecordWithNulls() {
+        var codec = new RecordCodec<>(TestRecordWithDeprecatedAnnotations.class, Bson.DEFAULT_CODEC_REGISTRY);
         var identifier = new ObjectId();
-        var testRecord = new TestRecord(null, 14, null, identifier.toHexString());
+        var testRecord = new TestRecordWithDeprecatedAnnotations(null, 14, null, identifier.toHexString());
 
         var document = new BsonDocument();
         var writer = new BsonDocumentWriter(document);
@@ -133,10 +133,10 @@ public class RecordCodecTest {
     }
 
     @Test
-    public void testSimpleRecordWithExtraData() {
-        var codec = new RecordCodec<>(TestRecord.class, Bson.DEFAULT_CODEC_REGISTRY);
+    public void testRecordWithExtraData() {
+        var codec = new RecordCodec<>(TestRecordWithDeprecatedAnnotations.class, Bson.DEFAULT_CODEC_REGISTRY);
         var identifier = new ObjectId();
-        var testRecord = new TestRecord("Felix", 13, List.of("rugby", "badminton"), identifier.toHexString());
+        var testRecord = new TestRecordWithDeprecatedAnnotations("Felix", 13, List.of("rugby", "badminton"), identifier.toHexString());
 
         var document = new BsonDocument("_id", new BsonObjectId(identifier))
                 .append("nationality", new BsonString("British"))

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
@@ -25,7 +25,19 @@ import org.bson.BsonObjectId;
 import org.bson.BsonString;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.record.samples.TestRecord;
+import org.bson.codecs.record.samples.TestRecordWithIllegalBsonCreatorOnConstructor;
+import org.bson.codecs.record.samples.TestRecordWithIllegalBsonDiscriminatorOnRecord;
+import org.bson.codecs.record.samples.TestRecordWithIllegalBsonExtraElementsOnAccessor;
+import org.bson.codecs.record.samples.TestRecordWithIllegalBsonExtraElementsOnComponent;
+import org.bson.codecs.record.samples.TestRecordWithIllegalBsonIdOnAccessor;
+import org.bson.codecs.record.samples.TestRecordWithIllegalBsonIdOnCanonicalConstructor;
+import org.bson.codecs.record.samples.TestRecordWithIllegalBsonIgnoreOnAccessor;
+import org.bson.codecs.record.samples.TestRecordWithIllegalBsonIgnoreOnComponent;
+import org.bson.codecs.record.samples.TestRecordWithIllegalBsonPropertyOnAccessor;
+import org.bson.codecs.record.samples.TestRecordWithIllegalBsonPropertyOnCanonicalConstructor;
+import org.bson.codecs.record.samples.TestRecordWithIllegalBsonRepresentationOnAccessor;
 import org.bson.codecs.record.samples.TestRecordWithPojoAnnotations;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
@@ -34,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RecordCodecTest {
 
@@ -135,5 +148,39 @@ public class RecordCodecTest {
 
         // then
         assertEquals(testRecord, decoded);
+    }
+
+    @Test
+    public void testExceptionsForAnnotationsNotOnRecordComponent() {
+        assertThrows(CodecConfigurationException.class, () ->
+                new RecordCodec<>(TestRecordWithIllegalBsonIdOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
+        assertThrows(CodecConfigurationException.class, () ->
+                new RecordCodec<>(TestRecordWithIllegalBsonIdOnCanonicalConstructor.class, Bson.DEFAULT_CODEC_REGISTRY));
+
+        assertThrows(CodecConfigurationException.class, () ->
+                new RecordCodec<>(TestRecordWithIllegalBsonPropertyOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
+        assertThrows(CodecConfigurationException.class, () ->
+                new RecordCodec<>(TestRecordWithIllegalBsonPropertyOnCanonicalConstructor.class, Bson.DEFAULT_CODEC_REGISTRY));
+
+        assertThrows(CodecConfigurationException.class, () ->
+                new RecordCodec<>(TestRecordWithIllegalBsonRepresentationOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
+    }
+
+    @Test
+    public void testExceptionsForUnsupportedAnnotations() {
+        assertThrows(CodecConfigurationException.class, () ->
+                new RecordCodec<>(TestRecordWithIllegalBsonDiscriminatorOnRecord.class, Bson.DEFAULT_CODEC_REGISTRY));
+
+        assertThrows(CodecConfigurationException.class, () ->
+                new RecordCodec<>(TestRecordWithIllegalBsonCreatorOnConstructor.class, Bson.DEFAULT_CODEC_REGISTRY));
+
+        assertThrows(CodecConfigurationException.class, () ->
+                new RecordCodec<>(TestRecordWithIllegalBsonIgnoreOnComponent.class, Bson.DEFAULT_CODEC_REGISTRY));
+        assertThrows(CodecConfigurationException.class, () ->
+                new RecordCodec<>(TestRecordWithIllegalBsonIgnoreOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
+        assertThrows(CodecConfigurationException.class, () ->
+                new RecordCodec<>(TestRecordWithIllegalBsonExtraElementsOnComponent.class, Bson.DEFAULT_CODEC_REGISTRY));
+        assertThrows(CodecConfigurationException.class, () ->
+                new RecordCodec<>(TestRecordWithIllegalBsonExtraElementsOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
     }
 }

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
@@ -28,6 +28,7 @@ import org.bson.codecs.EncoderContext;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.record.samples.TestRecord;
 import org.bson.codecs.record.samples.TestRecordWithIllegalBsonCreatorOnConstructor;
+import org.bson.codecs.record.samples.TestRecordWithIllegalBsonCreatorOnMethod;
 import org.bson.codecs.record.samples.TestRecordWithIllegalBsonDiscriminatorOnRecord;
 import org.bson.codecs.record.samples.TestRecordWithIllegalBsonExtraElementsOnAccessor;
 import org.bson.codecs.record.samples.TestRecordWithIllegalBsonExtraElementsOnComponent;
@@ -173,6 +174,8 @@ public class RecordCodecTest {
 
         assertThrows(CodecConfigurationException.class, () ->
                 new RecordCodec<>(TestRecordWithIllegalBsonCreatorOnConstructor.class, Bson.DEFAULT_CODEC_REGISTRY));
+        assertThrows(CodecConfigurationException.class, () ->
+                new RecordCodec<>(TestRecordWithIllegalBsonCreatorOnMethod.class, Bson.DEFAULT_CODEC_REGISTRY));
 
         assertThrows(CodecConfigurationException.class, () ->
                 new RecordCodec<>(TestRecordWithIllegalBsonIgnoreOnComponent.class, Bson.DEFAULT_CODEC_REGISTRY));

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecord.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecord.java
@@ -23,6 +23,7 @@ import org.bson.codecs.record.annotations.BsonRepresentation;
 
 import java.util.List;
 
+@SuppressWarnings("deprecation")
 public record TestRecord(String name,
                          @BsonProperty("a") int age,
                          List<String> hobbies,

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithDeprecatedAnnotations.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithDeprecatedAnnotations.java
@@ -24,13 +24,13 @@ import org.bson.codecs.record.annotations.BsonRepresentation;
 import java.util.List;
 
 @SuppressWarnings("deprecation")
-public record TestRecord(String name,
-                         @BsonProperty("a") int age,
-                         List<String> hobbies,
-                         @BsonRepresentation(BsonType.OBJECT_ID) @BsonId String identifier) {
+public record TestRecordWithDeprecatedAnnotations(String name,
+                                                  @BsonProperty("a") int age,
+                                                  List<String> hobbies,
+                                                  @BsonRepresentation(BsonType.OBJECT_ID) @BsonId String identifier) {
 
     // To test that the canonical constructor is always used for decoding
-    public TestRecord(final String identifier) {
+    public TestRecordWithDeprecatedAnnotations(final String identifier) {
         this("Adrian", 17, List.of("soccer", "music"), identifier);
     }
 }

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonCreatorOnConstructor.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonCreatorOnConstructor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonCreator;
+
+public record TestRecordWithIllegalBsonCreatorOnConstructor(String name) {
+    @SuppressWarnings("RedundantRecordConstructor")
+    @BsonCreator
+    public TestRecordWithIllegalBsonCreatorOnConstructor(final String name) {
+        this.name = name;
+    }
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonCreatorOnMethod.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonCreatorOnMethod.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonCreator;
+
+public record TestRecordWithIllegalBsonCreatorOnMethod(String name) {
+    @BsonCreator
+    public static TestRecordWithIllegalBsonCreatorOnMethod create(final String name) {
+        return new TestRecordWithIllegalBsonCreatorOnMethod(name);
+    }
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonDiscriminatorOnRecord.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonDiscriminatorOnRecord.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+@BsonDiscriminator
+public record TestRecordWithIllegalBsonDiscriminatorOnRecord(String name) {
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonExtraElementsOnAccessor.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonExtraElementsOnAccessor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonExtraElements;
+
+public record TestRecordWithIllegalBsonExtraElementsOnAccessor(String name) {
+    @Override
+    @BsonExtraElements
+    public String name() {
+        return name;
+    }
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonExtraElementsOnComponent.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonExtraElementsOnComponent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonExtraElements;
+
+public record TestRecordWithIllegalBsonExtraElementsOnComponent(@BsonExtraElements String name) {
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonIdOnAccessor.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonIdOnAccessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+
+public record TestRecordWithIllegalBsonIdOnAccessor(String name) {
+
+    @Override
+    @BsonId
+    public String name() {
+        return name;
+    }
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonIdOnCanonicalConstructor.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonIdOnCanonicalConstructor.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+
+public record TestRecordWithIllegalBsonIdOnCanonicalConstructor(String name) {
+    public TestRecordWithIllegalBsonIdOnCanonicalConstructor(@BsonId final String name) {
+        this.name = name;
+    }
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonIgnoreOnAccessor.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonIgnoreOnAccessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonIgnore;
+
+public record TestRecordWithIllegalBsonIgnoreOnAccessor(String name) {
+
+    @Override
+    @BsonIgnore
+    public String name() {
+        return name;
+    }
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonIgnoreOnComponent.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonIgnoreOnComponent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonIgnore;
+
+public record TestRecordWithIllegalBsonIgnoreOnComponent(@BsonIgnore String name) {
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonPropertyOnAccessor.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonPropertyOnAccessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+public record TestRecordWithIllegalBsonPropertyOnAccessor(String name) {
+
+    @Override
+    @BsonProperty("n")
+    public String name() {
+        return name;
+    }
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonPropertyOnCanonicalConstructor.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonPropertyOnCanonicalConstructor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonProperty;
+
+public record TestRecordWithIllegalBsonPropertyOnCanonicalConstructor(String name) {
+
+    public TestRecordWithIllegalBsonPropertyOnCanonicalConstructor(@BsonProperty("n") final String name) {
+        this.name = name;
+    }
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonRepresentationOnAccessor.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithIllegalBsonRepresentationOnAccessor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.BsonType;
+import org.bson.codecs.pojo.annotations.BsonRepresentation;
+
+public record TestRecordWithIllegalBsonRepresentationOnAccessor(String name) {
+
+    @Override
+    @BsonRepresentation(value = BsonType.INT32)
+    public String name() {
+        return name;
+    }
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithPojoAnnotations.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithPojoAnnotations.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.BsonType;
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.codecs.pojo.annotations.BsonProperty;
+import org.bson.codecs.pojo.annotations.BsonRepresentation;
+
+import java.util.List;
+
+public record TestRecordWithPojoAnnotations(String name,
+                                            @BsonProperty("a") int age,
+                                            List<String> hobbies,
+                                            @BsonRepresentation(BsonType.OBJECT_ID) @BsonId String identifier) {
+
+    public TestRecordWithPojoAnnotations(final String name, final int age, final List<String> hobbies, final String identifier) {
+        this.name = name;
+        this.age = age;
+        this.hobbies = hobbies;
+        this.identifier = identifier;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public int age() {
+        return age;
+    }
+
+    @Override
+    public List<String> hobbies() {
+        return hobbies;
+    }
+
+    @Override
+    public String identifier() {
+        return identifier;
+    }
+}

--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonCreator.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonCreator.java
@@ -22,9 +22,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An annotation that configures a constructor or method as the Creator for the Pojo.
+ * An annotation that configures a constructor or method as the creator for the POJO.
  *
- * <p>Note: Requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For POJOs, requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For Java records, the annotation is not supported.</p>
  *
  * @since 3.5
  * @see org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION

--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonDiscriminator.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonDiscriminator.java
@@ -26,7 +26,8 @@ import java.lang.annotation.Target;
 /**
  * An annotation that configures the discriminator key and value for a class.
  *
- * <p>Note: Requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For POJOs, requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For Java records, the annotation is not supported.</p>
  *
  * @since 3.5
  * @see org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION

--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonExtraElements.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonExtraElements.java
@@ -29,7 +29,8 @@ import java.lang.annotation.Target;
  *
  * <p>Can only be used on a single field in a POJO. Field must be a {@code Map<String, ?>} instance eg. {@code Document} or
  * {@code BsonDocument}.
- * <p>Note: Requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For POJOs, requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For Java records, the annotation is not yet supported.</p>
  *
  * @since 4.7
  * @see org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION

--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonId.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonId.java
@@ -23,9 +23,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An annotation that configures the property as the id property for a {@link  org.bson.codecs.pojo.ClassModel}.
+ * An annotation that configures the property as the id property for a {@link  org.bson.codecs.pojo.ClassModel} or a Java record.
  *
- * <p>Note: Requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For POJOs, requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For Java records, the annotation is only supported on the record component.</p>
  *
  * @since 3.5
  * @see org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION

--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonIgnore.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonIgnore.java
@@ -25,7 +25,8 @@ import java.lang.annotation.Target;
 /**
  * An annotation that configures a property to be ignored when reading and writing to BSON
  *
- * <p>Note: Requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For POJOs, requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For Java records, the annotation is not supported.</p>
  *
  * @since 3.5
  * @see org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION

--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonProperty.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonProperty.java
@@ -27,7 +27,8 @@ import java.lang.annotation.Target;
 /**
  * An annotation that configures a property.
  *
- * <p>Note: Requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For POJOs, requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For Java records, the annotation is only supported on the record component.</p>
  *
  * @since 3.5
  * @see org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION

--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonProperty.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonProperty.java
@@ -41,6 +41,7 @@ public @interface BsonProperty {
      * The name of the property.
      *
      * <p>
+     *     <strong>Note:</strong> Regarding POJOs:<br />
      *     For asymmetrical property names, the context of the {@code BsonProperty} can be important.
      *     For example, when used with {@code @BsonCreator} the value will relate to the read name.
      *     When used directly on a field it will set both the read name if unset and the write name if unset.

--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonRepresentation.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonRepresentation.java
@@ -27,7 +27,8 @@ import java.lang.annotation.Target;
 /**
  * An annotation that specifies what type the property is stored as in the database.
  *
- * <p>Note: Requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For POJOs, requires the {@link org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION}</p>
+ * <p>For Java records, the annotation is only supported on the record component.</p>
  *
  * @since 4.2
  * @see org.bson.codecs.pojo.Conventions#ANNOTATION_CONVENTION


### PR DESCRIPTION
JAVA-4622

Pros:

1. Less confusion for application writers.  There is no way to rely on the type system to prevent use of the existing annotations on records, so our options to restrict use are documentation, logging, or runtime exceptions 
2. Less namespace pollution with multiple attributes with the same name but different packages

Cons:

1. It's less clear which annotations are supported on records.  Currently only three are.  More could be, but some don't make sense for records
2. It relies on access to private fields in the record, which may be prevented in some deployments.  We could eventually fix this but not until Java 17 is our minimum

Decision:

Based on internal discussion, we've decided to deprecate the new annotations, support the existing ones when applied to the record component itself, and throw an exception if we detect any unsupported annotation or supported annotations applied to an unsupported place.


