### PR TITLE
Fix Scala case class macro codec lookup bug

### DIFF
--- a/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
+++ b/bson-scala/src/test/scala/org/mongodb/scala/bson/codecs/MacrosSpec.scala
@@ -329,8 +329,8 @@ class MacrosSpec extends BaseSpec {
 
   it should "be able to round trip nested case classes in maps" in {
     roundTrip(
-      ContainsMapOfCaseClasses("Bob", Map("mother" -> Person("Jane", "Jones"))),
-      """{name: "Bob", friends: {mother: {firstName: "Jane", lastName: "Jones"}}}""",
+      ContainsMapOfCaseClasses("Bob", Map("name" -> Person("Jane", "Jones"))),
+      """{name: "Bob", friends: {name: {firstName: "Jane", lastName: "Jones"}}}""",
       classOf[ContainsMapOfCaseClasses],
       classOf[Person]
     )


### PR DESCRIPTION
Fixes an issue when determining the codec to use for a
case class that contains a Map type that has a value that
contains the same key name and field name.

JAVA-4611