### PR TITLE
Use Cleaner for DBCursor cleanup when runtime is Java 9+

### DIFF
--- a/driver-legacy/src/main/com/mongodb/DBCursorCleaner.java
+++ b/driver-legacy/src/main/com/mongodb/DBCursorCleaner.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+/**
+ * A cleaner for abandoned {@link DBCursor} instances.
+ *
+ * @see DBCursor
+ */
+abstract class DBCursorCleaner {
+    // Should be true on Java 9+
+    private static final boolean CLEANER_IS_AVAILABLE;
+
+    static {
+        boolean cleanerIsAvailable = false;
+        try {
+            Class.forName("java.lang.ref.Cleaner");
+            cleanerIsAvailable = true;
+        } catch (ClassNotFoundException ignored) {
+        }
+        CLEANER_IS_AVAILABLE = cleanerIsAvailable;
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * <p>
+     * The implementation of this method ensures that a {@code java.lang.ref.Cleaner}-based implementation is used when
+     * the runtime is Java 9+.  Otherwise a {@link Object#finalize}-based implementation is used.
+     * </p>
+     *
+     * @param mongoClient the client from which the {@link DBCursor} came from
+     * @param namespace the namespace of the cursor
+     * @param serverCursor the server cursor
+     * @return the cleaner
+     */
+    static DBCursorCleaner create(final MongoClient mongoClient, final MongoNamespace namespace,
+                           final ServerCursor serverCursor) {
+        if (CLEANER_IS_AVAILABLE) {
+            return new Java9DBCursorCleaner(mongoClient, namespace, serverCursor);
+        } else {
+            return new Java8DBCursorCleaner(mongoClient, namespace, serverCursor);
+        }
+    }
+
+    /**
+     * {@link DBCursor} should call this method when the cursor has been exhausted and/or explicitly closed by the
+     * application.
+     */
+    abstract void clearCursor();
+}

--- a/driver-legacy/src/main/com/mongodb/DBCursorCleaner.java
+++ b/driver-legacy/src/main/com/mongodb/DBCursorCleaner.java
@@ -48,6 +48,7 @@ abstract class DBCursorCleaner {
      * @param serverCursor the server cursor
      * @return the cleaner
      */
+    @SuppressWarnings("deprecation")
     static DBCursorCleaner create(final MongoClient mongoClient, final MongoNamespace namespace,
                            final ServerCursor serverCursor) {
         if (CLEANER_IS_AVAILABLE) {

--- a/driver-legacy/src/main/com/mongodb/Java8DBCursorCleaner.java
+++ b/driver-legacy/src/main/com/mongodb/Java8DBCursorCleaner.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+import static com.mongodb.assertions.Assertions.assertNotNull;
+
+/**
+ * A {@link Object#finalize()}-based implementation of {@link DBCursorCleaner}.
+ * {@link DBCursorCleaner#create(MongoClient, MongoNamespace, ServerCursor)} is responsible for ensuring
+ * that this class is only used if the {@code java.lang.ref.Cleaner} class is not available
+ * (i.e. the runtime is Java 8).
+ */
+final class Java8DBCursorCleaner extends DBCursorCleaner {
+    private final MongoClient mongoClient;
+    private final MongoNamespace namespace;
+    private ServerCursor serverCursor;
+
+    Java8DBCursorCleaner(final MongoClient mongoClient, final MongoNamespace namespace,
+                         final ServerCursor serverCursor) {
+        this.mongoClient = assertNotNull(mongoClient);
+        this.namespace = assertNotNull(namespace);
+        this.serverCursor = assertNotNull(serverCursor);
+    }
+
+    @Override
+    void clearCursor() {
+       serverCursor = null;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    protected void finalize() {
+        if (serverCursor != null) {
+            mongoClient.addOrphanedCursor(serverCursor, namespace);
+        }
+    }
+}

--- a/driver-legacy/src/main/com/mongodb/Java8DBCursorCleaner.java
+++ b/driver-legacy/src/main/com/mongodb/Java8DBCursorCleaner.java
@@ -24,6 +24,7 @@ import static com.mongodb.assertions.Assertions.assertNotNull;
  * that this class is only used if the {@code java.lang.ref.Cleaner} class is not available
  * (i.e. the runtime is Java 8).
  */
+@SuppressWarnings("deprecation")
 final class Java8DBCursorCleaner extends DBCursorCleaner {
     private final MongoClient mongoClient;
     private final MongoNamespace namespace;
@@ -42,7 +43,6 @@ final class Java8DBCursorCleaner extends DBCursorCleaner {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     protected void finalize() {
         if (serverCursor != null) {
             mongoClient.addOrphanedCursor(serverCursor, namespace);

--- a/driver-legacy/src/main/com/mongodb/Java8DBCursorCleaner.java
+++ b/driver-legacy/src/main/com/mongodb/Java8DBCursorCleaner.java
@@ -27,7 +27,7 @@ import static com.mongodb.assertions.Assertions.assertNotNull;
 final class Java8DBCursorCleaner extends DBCursorCleaner {
     private final MongoClient mongoClient;
     private final MongoNamespace namespace;
-    private ServerCursor serverCursor;
+    private volatile ServerCursor serverCursor;
 
     Java8DBCursorCleaner(final MongoClient mongoClient, final MongoNamespace namespace,
                          final ServerCursor serverCursor) {

--- a/driver-legacy/src/main/com/mongodb/Java9DBCursorCleaner.java
+++ b/driver-legacy/src/main/com/mongodb/Java9DBCursorCleaner.java
@@ -73,7 +73,7 @@ final class Java9DBCursorCleaner extends DBCursorCleaner {
     private static class CleanerState implements Runnable {
         private final MongoClient mongoClient;
         private final MongoNamespace namespace;
-        private ServerCursor serverCursor;
+        private volatile ServerCursor serverCursor;
 
         CleanerState(final MongoClient mongoClient, final MongoNamespace namespace, final ServerCursor serverCursor) {
             this.mongoClient = assertNotNull(mongoClient);

--- a/driver-legacy/src/main/com/mongodb/Java9DBCursorCleaner.java
+++ b/driver-legacy/src/main/com/mongodb/Java9DBCursorCleaner.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static com.mongodb.assertions.Assertions.assertNotNull;
+
+/**
+ * A {@code java.lang.ref.Cleaner}-based implementation of {@link DBCursorCleaner}.  The implementation
+ * is reflection-based so that it will compile with Java 8 even though  {@code java.lang.ref.Cleaner} was introduced in
+ * Java 9.  {@link DBCursorCleaner#create(MongoClient, MongoNamespace, ServerCursor)} is responsible for ensuring that
+ * this class is only used if the {@code java.lang.ref.Cleaner} class is available (i.e. the runtime is Java 9+).
+ */
+final class Java9DBCursorCleaner extends DBCursorCleaner {
+    // Actual type is java.lang.ref.Cleaner
+    private static final Object CLEANER;
+    // Actual method is Cleaner#register(Object, Runnable)
+    private static final Method REGISTER_METHOD;
+    // Actual method is Cleanable#clean
+    private static final Method CLEAN_METHOD;
+
+    static {
+        try {
+            Class<?> cleanerClass = Class.forName("java.lang.ref.Cleaner");
+            CLEANER = cleanerClass.getMethod("create").invoke(null);
+            REGISTER_METHOD = cleanerClass.getMethod("register", Object.class, Runnable.class);
+            CLEAN_METHOD = Class.forName("java.lang.ref.Cleaner$Cleanable").getMethod("clean");
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException | ClassNotFoundException e) {
+            throw new MongoInternalException("Unexpected exception", e);
+        }
+    }
+
+    private final CleanerState cleanerState;
+    // Actual type is java.lang.ref.Cleaner$Cleanable
+    private final Object cleanable;
+
+    Java9DBCursorCleaner(final MongoClient mongoClient, final MongoNamespace namespace,
+                         final ServerCursor serverCursor) {
+        cleanerState = new CleanerState(mongoClient, namespace, serverCursor);
+        try {
+            cleanable = REGISTER_METHOD.invoke(CLEANER, this, cleanerState);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new MongoInternalException("Unexpected exception", e);
+        }
+    }
+
+    @Override
+    void clearCursor() {
+        cleanerState.clear();
+        try {
+            CLEAN_METHOD.invoke(cleanable);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new MongoInternalException("Unexpected exception", e);
+        }
+    }
+
+    private static class CleanerState implements Runnable {
+        private final MongoClient mongoClient;
+        private final MongoNamespace namespace;
+        private ServerCursor serverCursor;
+
+        CleanerState(final MongoClient mongoClient, final MongoNamespace namespace, final ServerCursor serverCursor) {
+            this.mongoClient = assertNotNull(mongoClient);
+            this.namespace = assertNotNull(namespace);
+            this.serverCursor = assertNotNull(serverCursor);
+        }
+
+        public void run() {
+            if (serverCursor != null) {
+                mongoClient.addOrphanedCursor(serverCursor, namespace);
+            }
+        }
+
+        public void clear() {
+            serverCursor = null;
+        }
+    }
+}


### PR DESCRIPTION
JAVA-4612

I don't see a way to regression test this, given the nature of Java garbage collection.  I've proven to myself that it works in the debugger.