### PR TITLE
Add query building API for MongoDB Atlas full-text search

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -495,6 +495,15 @@ functions:
           ${PREPARE_SHELL}
           JAVA_VERSION=${JAVA_VERSION} .evergreen/run-atlas-data-lake-test.sh
 
+  "run atlas search test":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          MONGODB_URI="${atlas_search_uri}" .evergreen/run-atlas-search-tests.sh
+
   "run-ocsp-test":
     - command: shell.exec
       type: test
@@ -1277,6 +1286,10 @@ tasks:
         - func: "bootstrap mongohoused"
         - func: "run atlas data lake test"
 
+    - name: "atlas-search-test"
+      commands:
+        - func: "run atlas search test"
+
     - name: "gssapi-auth-test"
       commands:
         - func: "run gssapi auth test"
@@ -1763,6 +1776,12 @@ buildvariants:
   run_on: rhel70-small
   tasks:
     - name: "atlas-test"
+
+- name: atlas-search-test
+  display_name: "Atlas Search test"
+  run_on: rhel70-small
+  tasks:
+    - name: "atlas-search-test"
 
 - name: "reactive-streams-tck-test"
   display_name: "Reactive Streams TCK tests"

--- a/.evergreen/javaConfig.bash
+++ b/.evergreen/javaConfig.bash
@@ -1,5 +1,4 @@
 # Java configurations for evergreen
-# Defaults to Java 11
 
 export JDK8="/opt/java/jdk8"
 export JDK11="/opt/java/jdk11"

--- a/.evergreen/run-atlas-search-tests.sh
+++ b/.evergreen/run-atlas-search-tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o errexit
+
+# Supported/used environment variables:
+# MONGODB_URI Set the connection to an Atlas cluster
+
+############################################
+#            Main Program                  #
+############################################
+RELATIVE_DIR_PATH="$(dirname "${BASH_SOURCE[0]:-$0}")"
+source "${RELATIVE_DIR_PATH}/javaConfig.bash"
+
+echo "Running Atlas Search tests"
+./gradlew -version
+./gradlew --stacktrace --info \
+    -Dorg.mongodb.test.atlas.search=true \
+    -Dorg.mongodb.test.uri=${MONGODB_URI} \
+    driver-core:test --tests AggregatesSearchIntegrationTest

--- a/bson/src/main/org/bson/codecs/jsr310/InstantCodec.java
+++ b/bson/src/main/org/bson/codecs/jsr310/InstantCodec.java
@@ -31,7 +31,8 @@ import static java.lang.String.format;
  * Instant Codec.
  *
  * <p>
- * Encodes and decodes {@code Instant} objects to and from {@code DateTime}. Data is stored to millisecond accuracy.
+ * Encodes and decodes {@code Instant} objects to and from {@code DateTime}.
+ * Data is extracted via {@link Instant#toEpochMilli()} and stored to millisecond accuracy.
  * </p>
  *
  * @mongodb.driver.manual reference/bson-types

--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,12 @@ configure(scalaProjects) {
 
     tasks.withType(ScalaCompile) {
         scalaCompileOptions.deprecation = false
+        if(scalaVersion.startsWith("2.11")) {
+            scalaCompileOptions.additionalParameters = [
+                    // support static methods in interfaces
+                    "-target:jvm-1.8"
+            ]
+        }
         if(scalaVersion.startsWith("2.13")) {
             scalaCompileOptions.additionalParameters = [
                     "-feature",

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -31,6 +31,7 @@
 
     <suppress checks="MethodLength" files="PojoRoundTripTest"/>
     <suppress checks="MethodLength" files="AbstractUnifiedTest"/>
+    <suppress checks="MethodLength" files="AggregatesSearchIntegrationTest"/>
     <suppress checks="MethodLength" files="ConnectionString"/>
 
     <suppress checks="JavadocPackage" files="com[\\/]mongodb[\\/][^\\/]*\.java"/>

--- a/driver-core/src/main/com/mongodb/AwsCredential.java
+++ b/driver-core/src/main/com/mongodb/AwsCredential.java
@@ -28,7 +28,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  * @see MongoCredential#AWS_CREDENTIAL_PROVIDER_KEY
  * @since 4.4
  */
-@Beta
+@Beta(Beta.Reason.CLIENT)
 public final class AwsCredential {
     private final String accessKeyId;
     private final String secretAccessKey;

--- a/driver-core/src/main/com/mongodb/MongoCredential.java
+++ b/driver-core/src/main/com/mongodb/MongoCredential.java
@@ -175,7 +175,7 @@ public final class MongoCredential {
      * @see AwsCredential
      * @since 4.4
      */
-    @Beta
+    @Beta(Beta.Reason.CLIENT)
     public static final String AWS_CREDENTIAL_PROVIDER_KEY = "AWS_CREDENTIAL_PROVIDER";
 
     /**
@@ -544,4 +544,3 @@ public final class MongoCredential {
                 + '}';
     }
 }
-

--- a/driver-core/src/main/com/mongodb/annotations/Beta.java
+++ b/driver-core/src/main/com/mongodb/annotations/Beta.java
@@ -47,6 +47,25 @@ import java.lang.annotation.Target;
         ElementType.PACKAGE,
         ElementType.TYPE })
 @Documented
-@Beta
+@Beta(Beta.Reason.CLIENT)
 public @interface Beta {
+    /**
+     * @return The reason an API element is marked with {@link Beta}.
+     */
+    Reason[] value();
+
+    /**
+     * @see Beta#value()
+     */
+    enum Reason {
+        /**
+         * The driver API is in preview.
+         */
+        CLIENT,
+        /**
+         * The driver API relies on the server API, which is in preview.
+         * We still may decide to change the driver API even if the server API stays unchanged.
+         */
+        SERVER
+    }
 }

--- a/driver-core/src/main/com/mongodb/annotations/Evolving.java
+++ b/driver-core/src/main/com/mongodb/annotations/Evolving.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ * Copyright 2010 The Guava Authors
+ * Copyright 2011 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Signifies that the annotated program element is subject to incompatible changes by means of adding abstract methods.
+ * This, in turn, means that implementing interfaces or extending classes annotated with {@link Evolving} bears the risk
+ * of doing extra work during upgrades.
+ * Using such program elements is no different from using ordinary unannotated program elements.
+ * Note that the presence of this annotation implies nothing about the quality or performance of the API in question.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+@Documented
+@Evolving
+public @interface Evolving {
+}

--- a/driver-core/src/main/com/mongodb/client/model/Filters.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filters.java
@@ -18,6 +18,9 @@ package com.mongodb.client.model;
 
 import com.mongodb.client.model.geojson.Geometry;
 import com.mongodb.client.model.geojson.Point;
+import com.mongodb.client.model.search.SearchCollector;
+import com.mongodb.client.model.search.SearchOperator;
+import com.mongodb.client.model.search.SearchOptions;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
@@ -417,6 +420,10 @@ public final class Filters {
 
     /**
      * Creates a filter that matches all documents matching the given search term.
+     * You may use {@link Projections#metaTextScore(String)} to extract the relevance score assigned to each matched document.
+     * <p>
+     * {@link Aggregates#search(SearchOperator, SearchOptions)} / {@link Aggregates#search(SearchCollector, SearchOptions)}
+     * is a more powerful full-text search alternative.</p>
      *
      * @param search the search term
      * @return the filter
@@ -429,6 +436,10 @@ public final class Filters {
 
     /**
      * Creates a filter that matches all documents matching the given the search term with the given text search options.
+     * You may use {@link Projections#metaTextScore(String)} to extract the relevance score assigned to each matched document.
+     * <p>
+     * {@link Aggregates#search(SearchOperator, SearchOptions)} / {@link Aggregates#search(SearchCollector, SearchOptions)}
+     * is a more powerful full-text search alternative.</p>
      *
      * @param search            the search term
      * @param textSearchOptions the text search options to use

--- a/driver-core/src/main/com/mongodb/client/model/MongoTimeUnit.java
+++ b/driver-core/src/main/com/mongodb/client/model/MongoTimeUnit.java
@@ -24,7 +24,7 @@ import com.mongodb.annotations.Beta;
  * @mongodb.server.release 5.0
  * @since 4.3
  */
-@Beta
+@Beta(Beta.Reason.SERVER)
 public enum MongoTimeUnit {
     /**
      * YEAR

--- a/driver-core/src/main/com/mongodb/client/model/Projections.java
+++ b/driver-core/src/main/com/mongodb/client/model/Projections.java
@@ -16,6 +16,10 @@
 
 package com.mongodb.client.model;
 
+import com.mongodb.client.model.search.SearchCollector;
+import com.mongodb.client.model.search.SearchCount;
+import com.mongodb.client.model.search.SearchOperator;
+import com.mongodb.client.model.search.SearchOptions;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
@@ -51,10 +55,26 @@ public final class Projections {
      * @param expression    the expression
      * @param <TExpression> the expression type
      * @return the projection
+     * @see #computedSearchMeta(String)
      * @see Aggregates#project(Bson)
      */
     public static <TExpression> Bson computed(final String fieldName, final TExpression expression) {
         return new SimpleExpression<TExpression>(fieldName, expression);
+    }
+
+    /**
+     * Creates a projection of a field whose value is equal to the {@code $$SEARCH_META} variable,
+     * for use with {@link Aggregates#search(SearchOperator, SearchOptions)} / {@link Aggregates#search(SearchCollector, SearchOptions)}.
+     * Calling this method is equivalent to calling {@link #computed(String, Object)} with {@code "$$SEARCH_META"} as the second argument.
+     *
+     * @param fieldName the field name
+     * @return the projection
+     * @see SearchCount
+     * @see SearchCollector
+     * @since 4.7
+     */
+    public static Bson computedSearchMeta(final String fieldName) {
+        return computed(fieldName, "$$SEARCH_META");
     }
 
     /**
@@ -138,8 +158,11 @@ public final class Projections {
      * @param fieldName the field name
      * @param metaFieldName the meta field name
      * @return the projection
-     * @mongodb.driver.manual reference/operator/projection/meta/#projection
+     * @mongodb.driver.manual reference/operator/aggregation/meta/
      * @since 4.1
+     * @see #metaTextScore(String)
+     * @see #metaSearchScore(String)
+     * @see #metaSearchHighlights(String)
      */
     public static Bson meta(final String fieldName, final String metaFieldName) {
         return new BsonDocument(fieldName, new BsonDocument("$meta", new BsonString(metaFieldName)));
@@ -147,13 +170,44 @@ public final class Projections {
 
     /**
      * Creates a projection to the given field name of the textScore, for use with text queries.
+     * Calling this method is equivalent to calling {@link #meta(String, String)} with {@code "textScore"} as the second argument.
      *
      * @param fieldName the field name
      * @return the projection
-     * @mongodb.driver.manual reference/operator/projection/meta/#projection textScore
+     * @see Filters#text(String, TextSearchOptions)
+     * @mongodb.driver.manual reference/operator/aggregation/meta/#text-score-metadata--meta---textscore- textScore
      */
     public static Bson metaTextScore(final String fieldName) {
         return meta(fieldName, "textScore");
+    }
+
+    /**
+     * Creates a projection to the given field name of the searchScore,
+     * for use with {@link Aggregates#search(SearchOperator, SearchOptions)} / {@link Aggregates#search(SearchCollector, SearchOptions)}.
+     * Calling this method is equivalent to calling {@link #meta(String, String)} with {@code "searchScore"} as the second argument.
+     *
+     * @param fieldName the field name
+     * @return the projection
+     * @mongodb.atlas.manual atlas-search/scoring/ Scoring
+     * @since 4.7
+     */
+    public static Bson metaSearchScore(final String fieldName) {
+        return meta(fieldName, "searchScore");
+    }
+
+    /**
+     * Creates a projection to the given field name of the searchHighlights,
+     * for use with {@link Aggregates#search(SearchOperator, SearchOptions)} / {@link Aggregates#search(SearchCollector, SearchOptions)}.
+     * Calling this method is equivalent to calling {@link #meta(String, String)} with {@code "searchHighlights"} as the second argument.
+     *
+     * @param fieldName the field name
+     * @return the projection
+     * @see com.mongodb.client.model.search.SearchHighlight
+     * @mongodb.atlas.manual atlas-search/highlighting/ Highlighting
+     * @since 4.7
+     */
+    public static Bson metaSearchHighlights(final String fieldName) {
+        return meta(fieldName, "searchHighlights");
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/Sorts.java
+++ b/driver-core/src/main/com/mongodb/client/model/Sorts.java
@@ -94,7 +94,8 @@ public final class Sorts {
      *
      * @param fieldName the field name
      * @return the sort specification
-     * @mongodb.driver.manual reference/operator/projection/meta/#sort textScore
+     * @see Filters#text(String, TextSearchOptions)
+     * @mongodb.driver.manual reference/operator/aggregation/meta/#text-score-metadata--meta---textscore- textScore
      */
     public static Bson metaTextScore(final String fieldName) {
         return new BsonDocument(fieldName, new BsonDocument("$meta", new BsonString("textScore")));

--- a/driver-core/src/main/com/mongodb/client/model/Window.java
+++ b/driver-core/src/main/com/mongodb/client/model/Window.java
@@ -27,6 +27,6 @@ import java.util.List;
  * @see Windows
  * @since 4.3
  */
-@Beta
+@Beta(Beta.Reason.SERVER)
 public interface Window extends Bson {
 }

--- a/driver-core/src/main/com/mongodb/client/model/WindowedComputation.java
+++ b/driver-core/src/main/com/mongodb/client/model/WindowedComputation.java
@@ -27,7 +27,7 @@ import java.util.List;
  * @see WindowedComputations
  * @since 4.3
  */
-@Beta
+@Beta(Beta.Reason.SERVER)
 public interface WindowedComputation {
     /**
      * Render into {@link BsonField}.

--- a/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
+++ b/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
@@ -57,7 +57,7 @@ import static org.bson.assertions.Assertions.notNull;
  * @since 4.3
  * @mongodb.server.release 5.0
  */
-@Beta
+@Beta(Beta.Reason.SERVER)
 public final class WindowedComputations {
     /**
      * Creates a windowed computation from a document field in situations when there is no builder method that better satisfies your needs.

--- a/driver-core/src/main/com/mongodb/client/model/Windows.java
+++ b/driver-core/src/main/com/mongodb/client/model/Windows.java
@@ -84,7 +84,7 @@ import static org.bson.assertions.Assertions.notNull;
  * @mongodb.server.release 5.0
  * @since 4.3
  */
-@Beta
+@Beta(Beta.Reason.SERVER)
 public final class Windows {
     /**
      * Creates a window from {@link Bson} in situations when there is no builder method that better satisfies your needs.
@@ -340,7 +340,7 @@ public final class Windows {
      * @mongodb.server.release 5.0
      * @since 4.3
      */
-    @Beta
+    @Beta(Beta.Reason.SERVER)
     public enum Bound {
         /**
          * The {@linkplain Window window} bound is determined by the current document and is inclusive.

--- a/driver-core/src/main/com/mongodb/client/model/search/AddSearchScoreExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/AddSearchScoreExpression.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchScoreExpression#addExpression(Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface AddSearchScoreExpression extends SearchScoreExpression {
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchOperator#autocomplete(String, FieldSearchPath)
+ * @see SearchOperator#autocomplete(Iterable, FieldSearchPath)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface AutocompleteSearchOperator extends SearchOperator {
+    @Override
+    AutocompleteSearchOperator score(SearchScore modifier);
+
+    /**
+     * Creates a new {@link AutocompleteSearchOperator} that uses fuzzy search.
+     *
+     * @param option Fuzzy search option.
+     * @return A new {@link AutocompleteSearchOperator}.
+     */
+    AutocompleteSearchOperator fuzzy(SearchFuzzy option);
+
+    /**
+     * Creates a new {@link AutocompleteSearchOperator} that does not require tokens to appear in the same order as they are specified.
+     *
+     * @return A new {@link AutocompleteSearchOperator}.
+     * @see #sequentialTokenOrder()
+     */
+    AutocompleteSearchOperator anyTokenOrder();
+
+    /**
+     * Creates a new {@link AutocompleteSearchOperator} that requires tokens to appear in the same order as they are specified.
+     *
+     * @return A new {@link AutocompleteSearchOperator}.
+     * @see #anyTokenOrder()
+     */
+    AutocompleteSearchOperator sequentialTokenOrder();
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/CompoundSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/CompoundSearchOperator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchOperator#compound()
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface CompoundSearchOperator extends CompoundSearchOperatorBase, SearchOperator {
+    @Override
+    CompoundSearchOperator score(SearchScore modifier);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/CompoundSearchOperatorBase.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/CompoundSearchOperatorBase.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * A base for a {@link CompoundSearchOperator} which allows creating instances of this operator.
+ * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+ *
+ * @see SearchOperator#compound()
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface CompoundSearchOperatorBase {
+    /**
+     * Creates a new {@link CompoundSearchOperator} by adding to it {@code clauses} that must all be satisfied.
+     * <p>
+     * This method may be called multiple times.</p>
+     *
+     * @param clauses The non-empty clauses to add.
+     * @return A new {@link CompoundSearchOperator}.
+     */
+    MustCompoundSearchOperator must(Iterable<? extends SearchOperator> clauses);
+
+    /**
+     * Creates a new {@link CompoundSearchOperator} by adding to it {@code clauses} that must all not be satisfied.
+     * <p>
+     * This method may be called multiple times.</p>
+     *
+     * @param clauses The non-empty clauses to add.
+     * @return A new {@link CompoundSearchOperator}.
+     */
+    MustNotCompoundSearchOperator mustNot(Iterable<? extends SearchOperator> clauses);
+
+    /**
+     * Creates a new {@link CompoundSearchOperator} by adding to it {@code clauses} that are preferred to be satisfied.
+     * <p>
+     * This method may be called multiple times.</p>
+     *
+     * @param clauses The non-empty clauses to add.
+     * @return A new {@link CompoundSearchOperator}.
+     */
+    ShouldCompoundSearchOperator should(Iterable<? extends SearchOperator> clauses);
+
+    /**
+     * Creates a new {@link CompoundSearchOperator} by adding to it {@code clauses} that, similarly to {@link #must(Iterable)},
+     * must all be satisfied. The difference is that this method does not affect the relevance score.
+     * <p>
+     * This method may be called multiple times.</p>
+     *
+     * @param clauses The non-empty clauses to add.
+     * @return A new {@link CompoundSearchOperator}.
+     */
+    FilterCompoundSearchOperator filter(Iterable<? extends SearchOperator> clauses);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/ConstantSearchScore.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/ConstantSearchScore.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchScore#constant(float)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface ConstantSearchScore extends SearchScore {
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/ConstantSearchScoreExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/ConstantSearchScoreExpression.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchScoreExpression#constantExpression(float)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface ConstantSearchScoreExpression extends SearchScoreExpression {
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/DateNearSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/DateNearSearchOperator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * @see SearchOperator#near(Instant, Duration, FieldSearchPath)
+ * @see SearchOperator#near(Instant, Duration, Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface DateNearSearchOperator extends SearchOperator {
+    @Override
+    DateNearSearchOperator score(SearchScore modifier);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/DateRangeConstructibleBsonElement.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/DateRangeConstructibleBsonElement.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import org.bson.conversions.Bson;
+
+import java.time.Instant;
+
+final class DateRangeConstructibleBsonElement extends RangeConstructibleBsonElement<Instant, DateRangeConstructibleBsonElement>
+        implements DateRangeSearchOperator {
+    DateRangeConstructibleBsonElement(final String name, final Bson value) {
+        super(name, value);
+    }
+
+    @Override
+    protected DateRangeConstructibleBsonElement newSelf(final String name, final Bson value) {
+        return new DateRangeConstructibleBsonElement(name, value);
+    }
+
+    @Override
+    public DateRangeSearchOperator gt(final Instant l) {
+        return internalGt(l);
+    }
+
+    @Override
+    public DateRangeSearchOperator lt(final Instant u) {
+        return internalLt(u);
+    }
+
+    @Override
+    public DateRangeSearchOperator gte(final Instant l) {
+        return internalGte(l);
+    }
+
+    @Override
+    public DateRangeSearchOperator lte(final Instant u) {
+        return internalLte(u);
+    }
+
+    @Override
+    public DateRangeSearchOperator gtLt(final Instant l, final Instant u) {
+        return internalGtLt(l, u);
+    }
+
+    @Override
+    public DateRangeSearchOperator gteLte(final Instant l, final Instant u) {
+        return internalGteLte(l, u);
+    }
+
+    @Override
+    public DateRangeSearchOperator gtLte(final Instant l, final Instant u) {
+        return internalGtLte(l, u);
+    }
+
+    @Override
+    public DateRangeSearchOperator gteLt(final Instant l, final Instant u) {
+        return internalGteLt(l, u);
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/DateRangeSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/DateRangeSearchOperator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchOperator#dateRange(FieldSearchPath)
+ * @see SearchOperator#dateRange(Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface DateRangeSearchOperator extends DateRangeSearchOperatorBase, SearchOperator {
+    @Override
+    DateRangeSearchOperator score(SearchScore modifier);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/DateRangeSearchOperatorBase.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/DateRangeSearchOperatorBase.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUNumber WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+import java.time.Instant;
+
+/**
+ * A base for a {@link DateRangeSearchOperator} which allows creating instances of this operator.
+ * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+ *
+ * @see SearchOperator#dateRange(FieldSearchPath)
+ * @see SearchOperator#dateRange(Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface DateRangeSearchOperatorBase {
+    /**
+     * Creates a new {@link DateRangeSearchOperator} that tests if values are within (l; ∞).
+     *
+     * @param l The lower bound.
+     * @return A new {@link DateRangeSearchOperator}.
+     */
+    DateRangeSearchOperator gt(Instant l);
+
+    /**
+     * Creates a new {@link DateRangeSearchOperator} that tests if values are within (-∞; u).
+     *
+     * @param u The upper bound.
+     * @return A new {@link DateRangeSearchOperator}.
+     */
+    DateRangeSearchOperator lt(Instant u);
+
+    /**
+     * Creates a new {@link DateRangeSearchOperator} that tests if values are within [l; ∞).
+     *
+     * @param l The lower bound.
+     * @return A new {@link DateRangeSearchOperator}.
+     */
+    DateRangeSearchOperator gte(Instant l);
+
+    /**
+     * Creates a new {@link DateRangeSearchOperator} that tests if values are within (-∞; u].
+     *
+     * @param u The upper bound.
+     * @return A new {@link DateRangeSearchOperator}.
+     */
+    DateRangeSearchOperator lte(Instant u);
+
+    /**
+     * Creates a new {@link DateRangeSearchOperator} that tests if values are within (l; u).
+     *
+     * @param l The lower bound.
+     * @param u The upper bound.
+     * @return A new {@link DateRangeSearchOperator}.
+     */
+    DateRangeSearchOperator gtLt(Instant l, Instant u);
+
+    /**
+     * Creates a new {@link DateRangeSearchOperator} that tests if values are within [l; u].
+     *
+     * @param l The lower bound.
+     * @param u The upper bound.
+     * @return A new {@link DateRangeSearchOperator}.
+     */
+    DateRangeSearchOperator gteLte(Instant l, Instant u);
+
+    /**
+     * Creates a new {@link DateRangeSearchOperator} that tests if values are within (l; u].
+     *
+     * @param l The lower bound.
+     * @param u The upper bound.
+     * @return A new {@link DateRangeSearchOperator}.
+     */
+    DateRangeSearchOperator gtLte(Instant l, Instant u);
+
+    /**
+     * Creates a new {@link DateRangeSearchOperator} that tests if values are within [l; u).
+     *
+     * @param l The lower bound.
+     * @param u The upper bound.
+     * @return A new {@link DateRangeSearchOperator}.
+     */
+    DateRangeSearchOperator gteLt(Instant l, Instant u);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/DateSearchFacet.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/DateSearchFacet.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchFacet#dateFacet(String, FieldSearchPath, Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta({Beta.Reason.CLIENT, Beta.Reason.SERVER})
+public interface DateSearchFacet extends SearchFacet {
+    /**
+     * Creates a new {@link DateSearchFacet} with the default bucket specified.
+     *
+     * @param name The name of the bucket for documents that do not fall within the specified boundaries.
+     * @return A new {@link DateSearchFacet}.
+     */
+    DateSearchFacet defaultBucket(String name);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/ExistsSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/ExistsSearchOperator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchOperator#exists(FieldSearchPath)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface ExistsSearchOperator extends SearchOperator {
+    @Override
+    ExistsSearchOperator score(SearchScore modifier);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/FacetSearchCollector.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/FacetSearchCollector.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchCollector#facet(SearchOperator, Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta({Beta.Reason.CLIENT, Beta.Reason.SERVER})
+public interface FacetSearchCollector extends SearchCollector {
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/FieldSearchPath.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/FieldSearchPath.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+import org.bson.conversions.Bson;
+
+import static com.mongodb.internal.client.model.Util.SEARCH_PATH_VALUE_KEY;
+
+/**
+ * @see SearchPath#fieldPath(String)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface FieldSearchPath extends SearchPath {
+    /**
+     * Creates a new {@link FieldSearchPath} with the name of the alternate analyzer specified.
+     *
+     * @param analyzerName The name of the alternate analyzer.
+     * @return A new {@link FieldSearchPath}.
+     */
+    FieldSearchPath multi(String analyzerName);
+
+    /**
+     * Returns the name of the field represented by this path.
+     * <p>
+     * This method may be useful when using the {@code of} methods, e.g., {@link SearchScore#of(Bson)}.
+     * Depending on the syntax of the document being constructed,
+     * it may be required to use the method {@link SearchPath#toBsonValue()} instead.</p>
+     *
+     * @return A {@link String} {@linkplain String#equals(Object) equal} to the one used to {@linkplain SearchPath#fieldPath(String) create}
+     * this path.
+     * @see SearchPath#toBsonValue()
+     */
+    default String toValue() {
+        return toBsonDocument().getString(SEARCH_PATH_VALUE_KEY).getValue();
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/FilterCompoundSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/FilterCompoundSearchOperator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * A representation of a {@link CompoundSearchOperator} that allows changing
+ * {@link CompoundSearchOperator#filter(Iterable) filter}-specific options, if any.
+ * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+ *
+ * @see CompoundSearchOperatorBase#filter(Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface FilterCompoundSearchOperator extends CompoundSearchOperator {
+    @Override
+    FilterCompoundSearchOperator score(SearchScore modifier);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/FunctionSearchScore.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/FunctionSearchScore.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchScore#function(SearchScoreExpression)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface FunctionSearchScore extends SearchScore {
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/GaussSearchScoreExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/GaussSearchScoreExpression.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchScoreExpression#gaussExpression(double, PathSearchScoreExpression, double)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface GaussSearchScoreExpression extends SearchScoreExpression {
+    /**
+     * Creates a new {@link GaussSearchScoreExpression} which does not decay, i.e., its output stays 1, if the value of the
+     * {@link SearchScoreExpression#gaussExpression(double, PathSearchScoreExpression, double) path} expression is within the interval
+     * [{@link SearchScoreExpression#gaussExpression(double, PathSearchScoreExpression, double) origin} - {@code offset};
+     * {@code origin} + {@code offset}].
+     *
+     * @param offset The offset from the origin where no decay happens.
+     * @return A new {@link GaussSearchScoreExpression}.
+     */
+    GaussSearchScoreExpression offset(double offset);
+
+    /**
+     * Creates a new {@link GaussSearchScoreExpression} with the factor by which the output of the Gaussian function must decay at distance
+     * {@link SearchScoreExpression#gaussExpression(double, PathSearchScoreExpression, double) scale}.
+     *
+     * @param decay The decay.
+     * @return A new {@link GaussSearchScoreExpression}.
+     */
+    GaussSearchScoreExpression decay(double decay);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/GeoNearSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/GeoNearSearchOperator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+import com.mongodb.client.model.geojson.Point;
+
+/**
+ * @see SearchOperator#near(Point, Number, FieldSearchPath)
+ * @see SearchOperator#near(Point, Number, Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface GeoNearSearchOperator extends SearchOperator {
+    @Override
+    GeoNearSearchOperator score(SearchScore modifier);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/Log1pSearchScoreExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/Log1pSearchScoreExpression.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchScoreExpression#log1pExpression(SearchScoreExpression)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface Log1pSearchScoreExpression extends SearchScoreExpression {
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/LogSearchScoreExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/LogSearchScoreExpression.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchScoreExpression#logExpression(SearchScoreExpression)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface LogSearchScoreExpression extends SearchScoreExpression {
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/LowerBoundSearchCount.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/LowerBoundSearchCount.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchCount#lowerBound()
+ * @since 4.7
+ */
+@Evolving
+@Beta({Beta.Reason.CLIENT, Beta.Reason.SERVER})
+public interface LowerBoundSearchCount extends SearchCount {
+    /**
+     * Creates a new {@link LowerBoundSearchCount} that instructs to count documents up to the {@code threshold} exactly,
+     * then to count roughly.
+     *
+     * @param threshold The number of documents to include in the exact count.
+     * @return A new {@link LowerBoundSearchCount}.
+     */
+    LowerBoundSearchCount threshold(int threshold);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/MultiplySearchScoreExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/MultiplySearchScoreExpression.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchScoreExpression#multiplyExpression(Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface MultiplySearchScoreExpression extends SearchScoreExpression {
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/MustCompoundSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/MustCompoundSearchOperator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * A representation of a {@link CompoundSearchOperator} that allows changing
+ * {@link CompoundSearchOperator#must(Iterable) must}-specific options, if any.
+ * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+ *
+ * @see CompoundSearchOperatorBase#must(Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface MustCompoundSearchOperator extends CompoundSearchOperator {
+    @Override
+    MustCompoundSearchOperator score(SearchScore modifier);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/MustNotCompoundSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/MustNotCompoundSearchOperator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * A representation of a {@link CompoundSearchOperator} that allows changing
+ * {@link CompoundSearchOperator#mustNot(Iterable) mustNot}-specific options, if any.
+ * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+ *
+ * @see CompoundSearchOperatorBase#mustNot(Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface MustNotCompoundSearchOperator extends CompoundSearchOperator {
+    @Override
+    MustNotCompoundSearchOperator score(SearchScore modifier);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/NumberNearSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/NumberNearSearchOperator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchOperator#near(Number, Number, FieldSearchPath)
+ * @see SearchOperator#near(Number, Number, Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface NumberNearSearchOperator extends SearchOperator {
+    @Override
+    NumberNearSearchOperator score(SearchScore modifier);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/NumberRangeConstructibleBsonElement.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/NumberRangeConstructibleBsonElement.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import org.bson.conversions.Bson;
+
+final class NumberRangeConstructibleBsonElement extends RangeConstructibleBsonElement<Number, NumberRangeConstructibleBsonElement>
+        implements NumberRangeSearchOperator {
+    NumberRangeConstructibleBsonElement(final String name, final Bson value) {
+        super(name, value);
+    }
+
+    @Override
+    protected NumberRangeConstructibleBsonElement newSelf(final String name, final Bson value) {
+        return new NumberRangeConstructibleBsonElement(name, value);
+    }
+
+    @Override
+    public NumberRangeSearchOperator gt(final Number l) {
+        return internalGt(l);
+    }
+
+    @Override
+    public NumberRangeSearchOperator lt(final Number u) {
+        return internalLt(u);
+    }
+
+    @Override
+    public NumberRangeSearchOperator gte(final Number l) {
+        return internalGte(l);
+    }
+
+    @Override
+    public NumberRangeSearchOperator lte(final Number u) {
+        return internalLte(u);
+    }
+
+    @Override
+    public NumberRangeSearchOperator gtLt(final Number l, final Number u) {
+        return internalGtLt(l, u);
+    }
+
+    @Override
+    public NumberRangeSearchOperator gteLte(final Number l, final Number u) {
+        return internalGteLte(l, u);
+    }
+
+    @Override
+    public NumberRangeSearchOperator gtLte(final Number l, final Number u) {
+        return internalGtLte(l, u);
+    }
+
+    @Override
+    public NumberRangeSearchOperator gteLt(final Number l, final Number u) {
+        return internalGteLt(l, u);
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/NumberRangeSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/NumberRangeSearchOperator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchOperator#numberRange(FieldSearchPath)
+ * @see SearchOperator#numberRange(Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface NumberRangeSearchOperator extends NumberRangeSearchOperatorBase, SearchOperator {
+    @Override
+    NumberRangeSearchOperator score(SearchScore modifier);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/NumberRangeSearchOperatorBase.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/NumberRangeSearchOperatorBase.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUNumber WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * A base for a {@link NumberRangeSearchOperator} which allows creating instances of this operator.
+ * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+ *
+ * @see SearchOperator#numberRange(FieldSearchPath)
+ * @see SearchOperator#numberRange(Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface NumberRangeSearchOperatorBase {
+    /**
+     * Creates a new {@link NumberRangeSearchOperator} that tests if values are within (l; ∞).
+     *
+     * @param l The lower bound.
+     * @return A new {@link NumberRangeSearchOperator}.
+     */
+    NumberRangeSearchOperator gt(Number l);
+
+    /**
+     * Creates a new {@link NumberRangeSearchOperator} that tests if values are within (-∞; u).
+     *
+     * @param u The upper bound.
+     * @return A new {@link NumberRangeSearchOperator}.
+     */
+    NumberRangeSearchOperator lt(Number u);
+
+    /**
+     * Creates a new {@link NumberRangeSearchOperator} that tests if values are within [l; ∞).
+     *
+     * @param l The lower bound.
+     * @return A new {@link NumberRangeSearchOperator}.
+     */
+    NumberRangeSearchOperator gte(Number l);
+
+    /**
+     * Creates a new {@link NumberRangeSearchOperator} that tests if values are within (-∞; u].
+     *
+     * @param u The upper bound.
+     * @return A new {@link NumberRangeSearchOperator}.
+     */
+    NumberRangeSearchOperator lte(Number u);
+
+    /**
+     * Creates a new {@link NumberRangeSearchOperator} that tests if values are within (l; u).
+     *
+     * @param l The lower bound.
+     * @param u The upper bound.
+     * @return A new {@link NumberRangeSearchOperator}.
+     */
+    NumberRangeSearchOperator gtLt(Number l, Number u);
+
+    /**
+     * Creates a new {@link NumberRangeSearchOperator} that tests if values are within [l; u].
+     *
+     * @param l The lower bound.
+     * @param u The upper bound.
+     * @return A new {@link NumberRangeSearchOperator}.
+     */
+    NumberRangeSearchOperator gteLte(Number l, Number u);
+
+    /**
+     * Creates a new {@link NumberRangeSearchOperator} that tests if values are within (l; u].
+     *
+     * @param l The lower bound.
+     * @param u The upper bound.
+     * @return A new {@link NumberRangeSearchOperator}.
+     */
+    NumberRangeSearchOperator gtLte(Number l, Number u);
+
+    /**
+     * Creates a new {@link NumberRangeSearchOperator} that tests if values are within [l; u).
+     *
+     * @param l The lower bound.
+     * @param u The upper bound.
+     * @return A new {@link NumberRangeSearchOperator}.
+     */
+    NumberRangeSearchOperator gteLt(Number l, Number u);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/NumberSearchFacet.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/NumberSearchFacet.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchFacet#numberFacet(String, FieldSearchPath, Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta({Beta.Reason.CLIENT, Beta.Reason.SERVER})
+public interface NumberSearchFacet extends SearchFacet {
+    /**
+     * Creates a new {@link NumberSearchFacet} with the default bucket specified.
+     *
+     * @param name The name of the bucket for documents that do not fall within the specified boundaries.
+     * @return A new {@link NumberSearchFacet}.
+     */
+    NumberSearchFacet defaultBucket(String name);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/PathBoostSearchScore.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/PathBoostSearchScore.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchScore#boost(FieldSearchPath)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface PathBoostSearchScore extends SearchScore {
+    /**
+     * Creates a new {@link PathBoostSearchScore} with the value to fall back to
+     * if the field specified via {@link SearchScore#boost(FieldSearchPath)} is not found in a document.
+     *
+     * @param fallback The fallback value. Unlike {@link SearchScore#constant(float)}, does not have constraints.
+     * @return A new {@link PathBoostSearchScore}.
+     */
+    PathBoostSearchScore undefined(float fallback);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/PathSearchScoreExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/PathSearchScoreExpression.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchScoreExpression#pathExpression(FieldSearchPath)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface PathSearchScoreExpression extends SearchScoreExpression {
+    /**
+     * Creates a new {@link PathSearchScoreExpression} with the value to fall back to
+     * if the field specified via {@link SearchScoreExpression#pathExpression(FieldSearchPath)} is not found in a document.
+     *
+     * @param fallback The fallback value.
+     * @return A new {@link PathSearchScoreExpression}.
+     */
+    PathSearchScoreExpression undefined(float fallback);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/RangeConstructibleBsonElement.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/RangeConstructibleBsonElement.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.internal.client.model.AbstractConstructibleBsonElement;
+import com.mongodb.lang.Nullable;
+import org.bson.conversions.Bson;
+
+import static com.mongodb.assertions.Assertions.isTrueArgument;
+import static org.bson.assertions.Assertions.notNull;
+
+abstract class RangeConstructibleBsonElement<T, S extends RangeConstructibleBsonElement<T, S>> extends AbstractConstructibleBsonElement<S> {
+    RangeConstructibleBsonElement(final String name, final Bson value) {
+        super(name, value);
+    }
+
+    public final S score(final SearchScore modifier) {
+        return newWithAppendedValue("score", notNull("modifier", modifier));
+    }
+
+    final S internalGt(final T l) {
+        return newWithMutatedValue(l, false, null, false);
+    }
+
+    final S internalLt(final T u) {
+        return newWithMutatedValue(null, false, u, false);
+    }
+
+    final S internalGte(final T l) {
+        return newWithMutatedValue(l, true, null, false);
+    }
+
+    final S internalLte(final T u) {
+        return newWithMutatedValue(null, false, u, true);
+    }
+
+    final S internalGtLt(final T l, final T u) {
+        return newWithMutatedValue(l, false, u, false);
+    }
+
+    final S internalGteLte(final T l, final T u) {
+        return newWithMutatedValue(l, true, u, true);
+    }
+
+    final S internalGtLte(final T l, final T u) {
+        return newWithMutatedValue(l, false, u, true);
+    }
+
+    final S internalGteLt(final T l, final T u) {
+        return newWithMutatedValue(l, true, u, false);
+    }
+
+    private S newWithMutatedValue(
+            @Nullable final T l, final boolean includeL,
+            @Nullable final T u, final boolean includeU) {
+        if (l == null) {
+            notNull("u", u);
+        } else if (u == null) {
+            notNull("l", l);
+        }
+        if (l instanceof Comparable && u != null && l.getClass().isAssignableFrom(u.getClass())) {
+            @SuppressWarnings("unchecked")
+            Comparable<T> comparableL = (Comparable<T>) l;
+            if (includeL && includeU) {
+                isTrueArgument("l must be smaller than or equal to u", comparableL.compareTo(u) <= 0);
+            } else {
+                isTrueArgument("l must be smaller than u", comparableL.compareTo(u) < 0);
+            }
+        }
+        return newWithMutatedValue(doc -> {
+            doc.remove("gte");
+            doc.remove("gt");
+            doc.remove("lte");
+            doc.remove("lt");
+            if (l != null) {
+                if (includeL) {
+                    doc.append("gte", l);
+                } else {
+                    doc.append("gt", l);
+                }
+            }
+            if (u != null) {
+                if (includeU) {
+                    doc.append("lte", u);
+                } else {
+                    doc.append("lt", u);
+                }
+            }
+        });
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/RelevanceSearchScoreExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/RelevanceSearchScoreExpression.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchScoreExpression#relevanceExpression()
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface RelevanceSearchScoreExpression extends SearchScoreExpression {
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchCollector.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchCollector.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import static com.mongodb.client.model.search.SearchFacet.combineToBson;
+import static org.bson.assertions.Assertions.notNull;
+
+/**
+ * The core part of the {@link Aggregates#search(SearchCollector, SearchOptions) $search} pipeline stage of an aggregation pipeline.
+ * {@link SearchCollector}s allow returning metadata together with the search results.
+ * You may use the {@code $$SEARCH_META} variable, e.g., via {@link Projections#computedSearchMeta(String)}, to extract this metadata.
+ *
+ * @mongodb.atlas.manual atlas-search/operators-and-collectors/#collectors Search collectors
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface SearchCollector extends Bson {
+    /**
+     * Returns a {@link SearchCollector} that groups results by values or ranges in the specified faceted fields and returns the count
+     * for each of those groups.
+     *
+     * @param operator The search operator to use.
+     * @param facets The non-empty facet definitions.
+     * @return The requested {@link SearchCollector}.
+     * @mongodb.atlas.manual atlas-search/facet/ facet collector
+     */
+    @Beta({Beta.Reason.CLIENT, Beta.Reason.SERVER})
+    static FacetSearchCollector facet(final SearchOperator operator, final Iterable<? extends SearchFacet> facets) {
+        notNull("operator", operator);
+        notNull("facets", facets);
+        return new SearchConstructibleBsonElement("facet", new Document("operator", operator)
+                .append("facets", combineToBson(facets)));
+    }
+
+    /**
+     * Creates a {@link SearchCollector} from a {@link Bson} in situations when there is no builder method that better satisfies your needs.
+     * This method cannot be used to validate the syntax.
+     * <p>
+     * <i>Example</i><br>
+     * The following code creates two functionally equivalent {@link SearchCollector}s,
+     * though they may not be {@linkplain Object#equals(Object) equal}.
+     * <pre>{@code
+     *  SearchCollector collector1 = SearchCollector.facet(
+     *          SearchOperator.exists(
+     *                  SearchPath.fieldPath("fieldName")),
+     *          Arrays.asList(
+     *                  SearchFacet.stringFacet(
+     *                          "stringFacetName",
+     *                          SearchPath.fieldPath("stringFieldName")),
+     *                  SearchFacet.numberFacet(
+     *                          "numberFacetName",
+     *                          SearchPath.fieldPath("numberFieldName"),
+     *                          Arrays.asList(10, 20, 30))));
+     *  SearchCollector collector2 = SearchCollector.of(new Document("facet",
+     *          new Document("operator", SearchOperator.exists(
+     *                  SearchPath.fieldPath("fieldName")))
+     *                  .append("facets", SearchFacet.combineToBson(Arrays.asList(
+     *                          SearchFacet.stringFacet(
+     *                                  "stringFacetName",
+     *                                  SearchPath.fieldPath("stringFieldName")),
+     *                          SearchFacet.numberFacet(
+     *                                  "numberFacetName",
+     *                                  SearchPath.fieldPath("numberFieldName"),
+     *                                  Arrays.asList(10, 20, 30)))))));
+     * }</pre>
+     *
+     * @param collector A {@link Bson} representing the required {@link SearchCollector}.
+     * @return The requested {@link SearchCollector}.
+     */
+    static SearchCollector of(final Bson collector) {
+        return new SearchConstructibleBson(notNull("collector", collector));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBson.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBson.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.internal.client.model.AbstractConstructibleBson;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+final class SearchConstructibleBson extends AbstractConstructibleBson<SearchConstructibleBson> implements
+        SearchOperator,
+        SearchScore,
+        RelevanceSearchScoreExpression, ConstantSearchScoreExpression, LogSearchScoreExpression, Log1pSearchScoreExpression,
+        AddSearchScoreExpression, MultiplySearchScoreExpression,
+        SearchCollector,
+        SearchOptions,
+        SearchHighlight,
+        TotalSearchCount, LowerBoundSearchCount,
+        SearchFuzzy,
+        FieldSearchPath, WildcardSearchPath,
+        SearchFacet {
+    /**
+     * An {@linkplain Immutable immutable} empty instance.
+     */
+    static final SearchConstructibleBson EMPTY = new SearchConstructibleBson(new BsonDocument());
+
+    SearchConstructibleBson(final Bson base) {
+        super(base);
+    }
+
+    private SearchConstructibleBson(final Bson base, final Document appended) {
+        super(base, appended);
+    }
+
+    @Override
+    protected SearchConstructibleBson newSelf(final Bson base, final Document appended) {
+        return new SearchConstructibleBson(base, appended);
+    }
+
+    @Override
+    public SearchOptions index(final String name) {
+        return newAppended("index", new BsonString(notNull("name", name)));
+    }
+
+    @Override
+    public SearchOptions highlight(final SearchHighlight option) {
+        return newAppended("highlight", notNull("option", option));
+    }
+
+    @Override
+    public SearchOptions count(final SearchCount option) {
+        return newAppended("count", notNull("option", option));
+    }
+
+    @Override
+    public SearchOptions returnStoredSource(final boolean returnStoredSource) {
+        return newAppended("returnStoredSource", new BsonBoolean(returnStoredSource));
+    }
+
+    @Override
+    public SearchOptions option(final String name, final Object value) {
+        return newAppended(notNull("name", name), notNull("value", value));
+    }
+
+    @Override
+    public SearchHighlight maxCharsToExamine(final int maxCharsToExamine) {
+        return newAppended("maxCharsToExamine", new BsonInt32(maxCharsToExamine));
+    }
+
+    @Override
+    public SearchHighlight maxNumPassages(final int maxNumPassages) {
+        return newAppended("maxNumPassages", new BsonInt32(maxNumPassages));
+    }
+
+    @Override
+    public LowerBoundSearchCount threshold(final int threshold) {
+        return newAppended("threshold", new BsonInt32(threshold));
+    }
+
+    @Override
+    public SearchFuzzy maxEdits(final int maxEdits) {
+        return newAppended("maxEdits", maxEdits);
+    }
+
+    @Override
+    public SearchFuzzy prefixLength(final int prefixLength) {
+        return newAppended("prefixLength", prefixLength);
+    }
+
+    @Override
+    public SearchFuzzy maxExpansions(final int maxExpansions) {
+        return newAppended("maxExpansions", maxExpansions);
+    }
+
+    @Override
+    public FieldSearchPath multi(final String analyzerName) {
+        return newAppended("multi", new BsonString(notNull("analyzerName", analyzerName)));
+    }
+
+    @Override
+    public SearchOperator score(final SearchScore modifier) {
+        return newAppended("score", notNull("modifier", modifier));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBsonElement.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBsonElement.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.internal.client.model.AbstractConstructibleBsonElement;
+import org.bson.BsonInt32;
+import org.bson.conversions.Bson;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static com.mongodb.assertions.Assertions.isTrueArgument;
+import static com.mongodb.internal.client.model.Util.sizeAtLeast;
+import static org.bson.assertions.Assertions.notNull;
+
+final class SearchConstructibleBsonElement extends AbstractConstructibleBsonElement<SearchConstructibleBsonElement> implements
+        CompoundSearchOperatorBase, CompoundSearchOperator,
+        MustCompoundSearchOperator, MustNotCompoundSearchOperator, ShouldCompoundSearchOperator, FilterCompoundSearchOperator,
+        ExistsSearchOperator, TextSearchOperator, AutocompleteSearchOperator,
+        NumberNearSearchOperator, DateNearSearchOperator, GeoNearSearchOperator,
+        ValueBoostSearchScore, PathBoostSearchScore, ConstantSearchScore, FunctionSearchScore, GaussSearchScoreExpression,
+        PathSearchScoreExpression,
+        FacetSearchCollector,
+        StringSearchFacet, NumberSearchFacet, DateSearchFacet {
+    SearchConstructibleBsonElement(final String name) {
+        super(name);
+    }
+
+    SearchConstructibleBsonElement(final String name, final Bson value) {
+        super(name, value);
+    }
+
+    @Override
+    protected SearchConstructibleBsonElement newSelf(final String name, final Bson value) {
+        return new SearchConstructibleBsonElement(name, value);
+    }
+
+    @Override
+    public StringSearchFacet numBuckets(final int max) {
+        return newWithAppendedValue("numBuckets", max);
+    }
+
+    @Override
+    public SearchConstructibleBsonElement defaultBucket(final String name) {
+        return newWithAppendedValue("default", notNull("name", name));
+    }
+
+    @Override
+    public SearchConstructibleBsonElement fuzzy(final SearchFuzzy option) {
+        return newWithMutatedValue(doc -> {
+            doc.remove("synonyms");
+            doc.append("fuzzy", notNull("option", option));
+        });
+    }
+
+    @Override
+    public TextSearchOperator synonyms(final String name) {
+        return newWithMutatedValue(doc -> {
+            doc.remove("fuzzy");
+            doc.append("synonyms", notNull("name", name));
+        });
+    }
+
+    @Override
+    public AutocompleteSearchOperator anyTokenOrder() {
+        return newWithAppendedValue("tokenOrder", "any");
+    }
+
+    @Override
+    public AutocompleteSearchOperator sequentialTokenOrder() {
+        return newWithAppendedValue("tokenOrder", "sequential");
+    }
+
+    @Override
+    public MustCompoundSearchOperator must(final Iterable<? extends SearchOperator> clauses) {
+        return newCombined("must", clauses);
+    }
+
+    @Override
+    public MustNotCompoundSearchOperator mustNot(final Iterable<? extends SearchOperator> clauses) {
+        return newCombined("mustNot", clauses);
+    }
+
+    @Override
+    public ShouldCompoundSearchOperator should(final Iterable<? extends SearchOperator> clauses) {
+        return newCombined("should", clauses);
+    }
+
+    @Override
+    public FilterCompoundSearchOperator filter(final Iterable<? extends SearchOperator> clauses) {
+        return newCombined("filter", clauses);
+    }
+
+    private SearchConstructibleBsonElement newCombined(final String ruleName, final Iterable<? extends SearchOperator> clauses) {
+        notNull("clauses", clauses);
+        isTrueArgument("clauses must not be empty", sizeAtLeast(clauses, 1));
+        return newWithMutatedValue(doc -> {
+            Iterable<?> existingClauses = doc.get(ruleName, Iterable.class);
+            final Iterable<?> newClauses;
+            if (existingClauses == null) {
+                newClauses = clauses;
+            } else {
+                newClauses = Stream.concat(
+                        StreamSupport.stream(existingClauses.spliterator(), false),
+                        StreamSupport.stream(clauses.spliterator(), false)).collect(Collectors.toList());
+            }
+            doc.append(ruleName, newClauses);
+        });
+    }
+
+    @Override
+    public ShouldCompoundSearchOperator minimumShouldMatch(final int minimumShouldMatch) {
+        return newWithAppendedValue("minimumShouldMatch", new BsonInt32(minimumShouldMatch));
+    }
+
+    @Override
+    public SearchConstructibleBsonElement score(final SearchScore modifier) {
+        return newWithAppendedValue("score", notNull("modifier", modifier));
+    }
+
+    @Override
+    public SearchConstructibleBsonElement undefined(final float fallback) {
+        return newWithAppendedValue("undefined", fallback);
+    }
+
+    @Override
+    public GaussSearchScoreExpression offset(final double offset) {
+        return newWithAppendedValue("offset", offset);
+    }
+
+    @Override
+    public GaussSearchScoreExpression decay(final double decay) {
+        isTrueArgument("decay must be greater than 0", decay > 0);
+        isTrueArgument("decay must be less than 1", decay < 1);
+        return newWithAppendedValue("decay", decay);
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchCount.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchCount.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+import com.mongodb.client.model.Projections;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.conversions.Bson;
+
+import static org.bson.assertions.Assertions.notNull;
+
+/**
+ * Counting options.
+ * You may use the {@code $$SEARCH_META} variable, e.g., via {@link Projections#computedSearchMeta(String)},
+ * to extract the results of counting.
+ *
+ * @mongodb.atlas.manual atlas-search/counting/ Counting
+ * @since 4.7
+ */
+@Evolving
+@Beta({Beta.Reason.CLIENT, Beta.Reason.SERVER})
+public interface SearchCount extends Bson {
+    /**
+     * Returns a {@link SearchCount} that instructs to count documents exactly.
+     *
+     * @return The requested {@link SearchCount}.
+     */
+    static TotalSearchCount total() {
+        return new SearchConstructibleBson(new BsonDocument("type", new BsonString("total")));
+    }
+
+    /**
+     * Returns a {@link SearchCount} that instructs to count documents exactly only up to a
+     * {@linkplain LowerBoundSearchCount#threshold(int) threshold}.
+     *
+     * @return The requested {@link SearchCount}.
+     */
+    static LowerBoundSearchCount lowerBound() {
+        return new SearchConstructibleBson(new BsonDocument("type", new BsonString("lowerBound")));
+    }
+
+    /**
+     * Creates a {@link SearchCount} from a {@link Bson} in situations when there is no builder method that better satisfies your needs.
+     * This method cannot be used to validate the syntax.
+     * <p>
+     * <i>Example</i><br>
+     * The following code creates two functionally equivalent {@link SearchCount}s,
+     * though they may not be {@linkplain Object#equals(Object) equal}.
+     * <pre>{@code
+     *  SearchCount count1 = SearchCount.lowerBound();
+     *  SearchCount count2 = SearchCount.of(new Document("type", "lowerBound"));
+     * }</pre>
+     *
+     * @param count A {@link Bson} representing the required {@link SearchCount}.
+     * @return The requested {@link SearchCount}.
+     */
+    static SearchCount of(final Bson count) {
+        return new SearchConstructibleBson(notNull("count", count));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchFacet.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchFacet.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+import org.bson.BsonDocument;
+import org.bson.BsonType;
+import org.bson.BsonValue;
+import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.mongodb.assertions.Assertions.assertTrue;
+import static com.mongodb.assertions.Assertions.isTrue;
+import static com.mongodb.assertions.Assertions.isTrueArgument;
+import static com.mongodb.internal.client.model.Util.sizeAtLeast;
+import static java.lang.String.format;
+import static org.bson.assertions.Assertions.notNull;
+
+/**
+ * A facet definition for {@link FacetSearchCollector}.
+ *
+ * @mongodb.atlas.manual atlas-search/facet/#facet-definition Facet definition
+ * @since 4.7
+ */
+@Evolving
+@Beta({Beta.Reason.CLIENT, Beta.Reason.SERVER})
+public interface SearchFacet extends Bson {
+    /**
+     * Returns a {@link SearchFacet} that allows narrowing down search results based on the most frequent
+     * BSON {@link BsonType#STRING String} values of the specified field.
+     *
+     * @param name The facet name.
+     * @param path The field to facet on.
+     * @return The requested {@link SearchFacet}.
+     * @mongodb.atlas.manual atlas-search/facet/#string-facets String facet definition
+     */
+    static StringSearchFacet stringFacet(final String name, final FieldSearchPath path) {
+        return new SearchConstructibleBsonElement(notNull("name", name),
+                new Document("type", "string")
+                        .append("path", notNull("path", path).toValue()));
+    }
+
+    /**
+     * Returns a {@link SearchFacet} that allows determining the frequency of
+     * BSON {@link BsonType#INT32 32-bit integer} / {@link BsonType#INT64 64-bit integer} / {@link BsonType#DOUBLE Double} values
+     * in the search results by breaking the results into separate ranges.
+     *
+     * @param name The facet name.
+     * @param path The path to facet on.
+     * @param boundaries Bucket boundaries in ascending order. Must contain at least two boundaries.
+     * @return The requested {@link SearchFacet}.
+     * @mongodb.atlas.manual atlas-search/facet/#numeric-facets Numeric facet definition
+     */
+    static NumberSearchFacet numberFacet(final String name, final FieldSearchPath path, final Iterable<? extends Number> boundaries) {
+        isTrueArgument("boundaries must contain at least 2 elements", sizeAtLeast(boundaries, 2));
+        return new SearchConstructibleBsonElement(notNull("name", name),
+                new Document("type", "number")
+                        .append("path", notNull("path", path).toValue())
+                        .append("boundaries", notNull("boundaries", boundaries)));
+    }
+
+    /**
+     * Returns a {@link SearchFacet} that allows determining the frequency of BSON {@link BsonType#DATE_TIME Date} values
+     * in the search results by breaking the results into separate ranges.
+     *
+     * @param name The facet name.
+     * @param path The path to facet on.
+     * @param boundaries Bucket boundaries in ascending order. Must contain at least two boundaries.
+     * @return The requested {@link SearchFacet}.
+     * @mongodb.atlas.manual atlas-search/facet/#date-facets Date facet definition
+     * @see org.bson.codecs.jsr310.InstantCodec
+     */
+    static DateSearchFacet dateFacet(final String name, final FieldSearchPath path, final Iterable<Instant> boundaries) {
+        isTrueArgument("boundaries must contain at least 2 elements", sizeAtLeast(boundaries, 2));
+        return new SearchConstructibleBsonElement(notNull("name", name),
+                new Document("type", "date")
+                        .append("path", notNull("path", path).toValue())
+                        .append("boundaries", notNull("boundaries", boundaries)));
+    }
+
+    /**
+     * Creates a {@link SearchFacet} from a {@link Bson} in situations when there is no builder method that better satisfies your needs.
+     * This method cannot be used to validate the syntax.
+     * <p>
+     * <i>Example</i><br>
+     * The following code creates two functionally equivalent {@link SearchFacet}s,
+     * though they may not be {@linkplain Object#equals(Object) equal}.
+     * <pre>{@code
+     *  SearchFacet facet1 = SearchFacet.stringFacet("facetName",
+     *          SearchPath.fieldPath("fieldName"));
+     *  SearchFacet facet2 = SearchFacet.of(new Document("facetName", new Document("type", "string")
+     *          .append("path", SearchPath.fieldPath("fieldName").toValue())));
+     * }</pre>
+     *
+     * @param facet A {@link Bson} representing the required {@link SearchFacet}.
+     * @return The requested {@link SearchFacet}.
+     */
+    static SearchFacet of(final Bson facet) {
+        return new SearchConstructibleBson(notNull("facet", facet));
+    }
+
+    /**
+     * Combines {@link SearchFacet}s into a {@link Bson}.
+     * <p>
+     * This method may be useful when using {@link SearchCollector#of(Bson)}.</p>
+     *
+     * @param facets The non-empty facet definitions to combine.
+     * @return A {@link Bson} representing combined {@code facets}.
+     */
+    static Bson combineToBson(final Iterable<? extends SearchFacet> facets) {
+        notNull("facets", facets);
+        isTrueArgument("facets must not be empty", sizeAtLeast(facets, 1));
+        return new Bson() {
+            @Override
+            public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+                Set<String> names = new HashSet<>();
+                BsonDocument result = new BsonDocument();
+                for (final SearchFacet facet : facets) {
+                    BsonDocument doc = facet.toBsonDocument(documentClass, codecRegistry);
+                    assertTrue(doc.size() == 1);
+                    Map.Entry<String, BsonValue> entry = doc.entrySet().iterator().next();
+                    String name = entry.getKey();
+                    isTrue(format("facet names must be unique. '%s' is used at least twice in %s", names, facets), names.add(name));
+                    result.append(entry.getKey(), entry.getValue());
+                }
+                return result;
+            }
+
+            @Override
+            public String toString() {
+                return facets.toString();
+            }
+        };
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchFuzzy.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchFuzzy.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+import org.bson.conversions.Bson;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+/**
+ * Fuzzy search options that may be used with some {@link SearchOperator}s.
+ *
+ * @mongodb.atlas.manual atlas-search/autocomplete/ autocomplete operator
+ * @mongodb.atlas.manual atlas-search/text/ text operator
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface SearchFuzzy extends Bson {
+    /**
+     * Creates a new {@link SearchFuzzy} with the maximum
+     * <a href="https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance">number of single-character edits</a>
+     * required to match a search term.
+     *
+     * @param maxEdits The maximum number of single-character edits required to match a search term.
+     * @return A new {@link SearchFuzzy}.
+     */
+    SearchFuzzy maxEdits(int maxEdits);
+
+    /**
+     * Creates a new {@link SearchFuzzy} with the number of characters at the beginning of a search term that must exactly match.
+     *
+     * @param prefixLength The number of characters at the beginning of a search term that must exactly match.
+     * @return A new {@link SearchFuzzy}.
+     */
+    SearchFuzzy prefixLength(int prefixLength);
+
+    /**
+     * Creates a new {@link SearchFuzzy} with the maximum number of variations to generate and consider to match a search term.
+     *
+     * @param maxExpansions The maximum number of variations to generate and consider to match a search term.
+     * @return A new {@link SearchFuzzy}.
+     */
+    SearchFuzzy maxExpansions(int maxExpansions);
+
+    /**
+     * Creates a new {@link SearchFuzzy} from a {@link Bson} in situations when there is no builder method that better satisfies your needs.
+     * This method cannot be used to validate the syntax.
+     * <p>
+     * <i>Example</i><br>
+     * The following code creates two functionally equivalent {@link SearchFuzzy} objects,
+     * though they may not be {@linkplain Object#equals(Object) equal}.
+     * <pre>{@code
+     *  SearchFuzzy fuzzy1 = SearchFuzzy.defaultSearchFuzzy().maxEdits(1);
+     *  SearchFuzzy fuzzy2 = SearchFuzzy.of(new Document("maxEdits", 1));
+     * }</pre>
+     *
+     * @param fuzzy A {@link Bson} representing the required {@link SearchFuzzy}.
+     * @return A new {@link SearchFuzzy}.
+     */
+    static SearchFuzzy of(final Bson fuzzy) {
+        return new SearchConstructibleBson(notNull("fuzzy", fuzzy));
+    }
+
+    /**
+     * Returns {@link SearchFuzzy} that represents server defaults.
+     *
+     * @return {@link SearchFuzzy} that represents server defaults.
+     */
+    static SearchFuzzy defaultSearchFuzzy() {
+        return SearchConstructibleBson.EMPTY;
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchHighlight.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchHighlight.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+import com.mongodb.client.model.Projections;
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
+
+import java.util.Iterator;
+
+import static com.mongodb.assertions.Assertions.isTrueArgument;
+import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.client.model.Util.combineToBsonValue;
+import static java.util.Collections.singleton;
+
+/**
+ * Highlighting options.
+ * You may use the {@code $meta: "searchHighlights"} expression, e.g., via {@link Projections#metaSearchHighlights(String)},
+ * to extract the results of highlighting.
+ *
+ * @mongodb.atlas.manual atlas-search/highlighting/ Highlighting
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface SearchHighlight extends Bson {
+    /**
+     * Creates a new {@link SearchHighlight} with the maximum number of characters to examine on a document
+     * when performing highlighting for a field.
+     *
+     * @param maxCharsToExamine The maximum number of characters to examine.
+     * @return A new {@link SearchHighlight}.
+     */
+    SearchHighlight maxCharsToExamine(int maxCharsToExamine);
+
+    /**
+     * Creates a new {@link SearchHighlight} with the maximum number of high-scoring passages to return per document
+     * in the {@code "highlights"} results for each field.
+     *
+     * @param maxNumPassages The maximum number of high-scoring passages.
+     * @return A new {@link SearchHighlight}.
+     */
+    SearchHighlight maxNumPassages(int maxNumPassages);
+
+    /**
+     * Returns a {@link SearchHighlight} for the given {@code path}.
+     *
+     * @param path The field to be searched.
+     * @return The requested {@link SearchHighlight}.
+     */
+    static SearchHighlight path(final SearchPath path) {
+        return paths(singleton(path));
+    }
+
+    /**
+     * Returns a {@link SearchHighlight} for the given {@code paths}.
+     *
+     * @param paths The non-empty fields to be searched.
+     * @return The requested {@link SearchHighlight}.
+     */
+    static SearchHighlight paths(final Iterable<? extends SearchPath> paths) {
+        Iterator<? extends SearchPath> pathIterator = notNull("paths", paths).iterator();
+        isTrueArgument("paths must not be empty", pathIterator.hasNext());
+        return new SearchConstructibleBson(new BsonDocument("path", combineToBsonValue(pathIterator, false)));
+    }
+
+    /**
+     * Creates a {@link SearchHighlight} from a {@link Bson} in situations when there is no builder method that better satisfies your needs.
+     * This method cannot be used to validate the syntax.
+     * <p>
+     * <i>Example</i><br>
+     * The following code creates two functionally equivalent {@link SearchHighlight}s,
+     * though they may not be {@linkplain Object#equals(Object) equal}.
+     * <pre>{@code
+     *  SearchHighlight highlight1 = SearchHighlight.paths(Arrays.asList(
+     *          SearchPath.fieldPath("fieldName"),
+     *          SearchPath.wildcardPath("wildc*rd")));
+     *  SearchHighlight highlight2 = SearchHighlight.of(new Document("path", Arrays.asList(
+     *          SearchPath.fieldPath("fieldName").toBsonValue(),
+     *          SearchPath.wildcardPath("wildc*rd").toBsonValue())));
+     * }</pre>
+     *
+     * @param highlight A {@link Bson} representing the required {@link SearchHighlight}.
+     * @return The requested {@link SearchHighlight}.
+     */
+    static SearchHighlight of(final Bson highlight) {
+        return new SearchConstructibleBson(notNull("highlight", highlight));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.geojson.Point;
+import org.bson.BsonType;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Iterator;
+
+import static com.mongodb.assertions.Assertions.isTrueArgument;
+import static com.mongodb.internal.client.model.Util.combineToBsonValue;
+import static java.util.Collections.singleton;
+import static org.bson.assertions.Assertions.notNull;
+
+/**
+ * The core part of the {@link Aggregates#search(SearchOperator, SearchOptions) $search} pipeline stage of an aggregation pipeline.
+ *
+ * @mongodb.atlas.manual atlas-search/operators-and-collectors/#operators Search operators
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface SearchOperator extends Bson {
+    /**
+     * Creates a new {@link SearchOperator} with the scoring modifier specified.
+     *
+     * @param modifier The scoring modifier.
+     * @return A new {@link SearchOperator}.
+     */
+    SearchOperator score(SearchScore modifier);
+
+    /**
+     * Returns a base for a {@link SearchOperator} that may combine multiple {@link SearchOperator}s.
+     * Combining {@link SearchOperator}s affects calculation of the relevance score.
+     *
+     * @return A base for a {@link CompoundSearchOperator}.
+     * @mongodb.atlas.manual atlas-search/compound/ compound operator
+     */
+    static CompoundSearchOperatorBase compound() {
+        return new SearchConstructibleBsonElement("compound");
+    }
+
+    /**
+     * Returns a {@link SearchOperator} that tests if the {@code path} exists in a document.
+     *
+     * @param path The path to test.
+     * @return The requested {@link SearchOperator}.
+     * @mongodb.atlas.manual atlas-search/exists/ exists operator
+     */
+    static ExistsSearchOperator exists(final FieldSearchPath path) {
+        return new SearchConstructibleBsonElement("exists", new Document("path", notNull("path", path).toValue()));
+    }
+
+    /**
+     * Returns a {@link SearchOperator} that performs a full-text search.
+     *
+     * @param query The string to search for.
+     * @param path The field to be searched.
+     * @return The requested {@link SearchOperator}.
+     * @mongodb.atlas.manual atlas-search/text/ text operator
+     */
+    static TextSearchOperator text(final String query, final SearchPath path) {
+        return text(singleton(notNull("query", query)), singleton(notNull("path", path)));
+    }
+
+    /**
+     * Returns a {@link SearchOperator} that performs a full-text search.
+     *
+     * @param queries The non-empty strings to search for.
+     * @param paths The non-empty fields to be searched.
+     * @return The requested {@link SearchOperator}.
+     * @mongodb.atlas.manual atlas-search/text/ text operator
+     */
+    static TextSearchOperator text(final Iterable<String> queries, final Iterable<? extends SearchPath> paths) {
+        Iterator<String> queryIterator = notNull("queries", queries).iterator();
+        isTrueArgument("queries must not be empty", queryIterator.hasNext());
+        String firstQuery = queryIterator.next();
+        Iterator<? extends SearchPath> pathIterator = notNull("paths", paths).iterator();
+        isTrueArgument("paths must not be empty", pathIterator.hasNext());
+        return new SearchConstructibleBsonElement("text", new Document("query", queryIterator.hasNext() ? queries : firstQuery)
+                .append("path", combineToBsonValue(pathIterator, false)));
+    }
+
+    /**
+     * Returns a {@link SearchOperator} that may be used to implement search-as-you-type functionality.
+     *
+     * @param query The string to search for.
+     * @param path The field to be searched.
+     * @return The requested {@link SearchOperator}.
+     * @mongodb.atlas.manual atlas-search/autocomplete/ autocomplete operator
+     */
+    static AutocompleteSearchOperator autocomplete(final String query, final FieldSearchPath path) {
+        return autocomplete(singleton(notNull("query", query)), path);
+    }
+
+    /**
+     * Returns a {@link SearchOperator} that may be used to implement search-as-you-type functionality.
+     *
+     * @param queries The non-empty strings to search for.
+     * @param path The field to be searched.
+     * @return The requested {@link SearchOperator}.
+     * @mongodb.atlas.manual atlas-search/autocomplete/ autocomplete operator
+     */
+    static AutocompleteSearchOperator autocomplete(final Iterable<String> queries, final FieldSearchPath path) {
+        Iterator<String> queryIterator = notNull("queries", queries).iterator();
+        isTrueArgument("queries must not be empty", queryIterator.hasNext());
+        String firstQuery = queryIterator.next();
+        return new SearchConstructibleBsonElement("autocomplete", new Document("query", queryIterator.hasNext() ? queries : firstQuery)
+                .append("path", notNull("path", path).toValue()));
+    }
+
+    /**
+     * Returns a base for a {@link SearchOperator} that tests if the
+     * BSON {@link BsonType#INT32 32-bit integer} / {@link BsonType#INT64 64-bit integer} / {@link BsonType#DOUBLE Double} values
+     * of the specified field are within an interval.
+     *
+     * @param path The field to be searched.
+     * @return A base for a {@link NumberRangeSearchOperator}.
+     * @mongodb.atlas.manual atlas-search/range/ range operator
+     */
+    static NumberRangeSearchOperatorBase numberRange(final FieldSearchPath path) {
+        return numberRange(singleton(notNull("path", path)));
+    }
+
+    /**
+     * Returns a base for a {@link SearchOperator} that tests if the
+     * BSON {@link BsonType#INT32 32-bit integer} / {@link BsonType#INT64 64-bit integer} / {@link BsonType#DOUBLE Double} values
+     * of the specified fields are within an interval.
+     *
+     * @param paths The non-empty fields to be searched.
+     * @return A base for a {@link NumberRangeSearchOperator}.
+     * @mongodb.atlas.manual atlas-search/range/ range operator
+     */
+    static NumberRangeSearchOperatorBase numberRange(final Iterable<? extends FieldSearchPath> paths) {
+        Iterator<? extends SearchPath> pathIterator = notNull("paths", paths).iterator();
+        isTrueArgument("paths must not be empty", pathIterator.hasNext());
+        return new NumberRangeConstructibleBsonElement("range", new Document("path", combineToBsonValue(pathIterator, true)));
+    }
+
+    /**
+     * Returns a base for a {@link SearchOperator} that tests if the
+     * BSON {@link BsonType#DATE_TIME Date} values of the specified field are within an interval.
+     *
+     * @param path The field to be searched.
+     * @return A base for a {@link DateRangeSearchOperator}.
+     * @mongodb.atlas.manual atlas-search/range/ range operator
+     */
+    static DateRangeSearchOperatorBase dateRange(final FieldSearchPath path) {
+        return dateRange(singleton(notNull("path", path)));
+    }
+
+    /**
+     * Returns a base for a {@link SearchOperator} that tests if the
+     * BSON {@link BsonType#DATE_TIME Date} values of the specified fields are within an interval.
+     *
+     * @param paths The non-empty fields to be searched.
+     * @return A base for a {@link DateRangeSearchOperator}.
+     * @mongodb.atlas.manual atlas-search/range/ range operator
+     */
+    static DateRangeSearchOperatorBase dateRange(final Iterable<? extends FieldSearchPath> paths) {
+        Iterator<? extends SearchPath> pathIterator = notNull("paths", paths).iterator();
+        isTrueArgument("paths must not be empty", pathIterator.hasNext());
+        return new DateRangeConstructibleBsonElement("range", new Document("path", combineToBsonValue(pathIterator, true)));
+    }
+
+    /**
+     * Returns a {@link SearchOperator} that allows finding results that are near the specified {@code origin}.
+     *
+     * @param origin The origin from which the proximity of the results is measured.
+     * The relevance score is 1 if the values of the fields are {@code origin}.
+     * @param pivot The positive distance from the {@code origin} at which the relevance score drops in half.
+     * @param path The field to be searched.
+     * @return The requested {@link SearchOperator}.
+     * @mongodb.atlas.manual atlas-search/near/ near operator
+     */
+    static NumberNearSearchOperator near(final Number origin, final Number pivot, final FieldSearchPath path) {
+        return near(origin, pivot, singleton(notNull("path", path)));
+    }
+
+    /**
+     * Returns a {@link SearchOperator} that allows finding results that are near the specified {@code origin}.
+     *
+     * @param origin The origin from which the proximity of the results is measured.
+     * The relevance score is 1 if the values of the fields are {@code origin}.
+     * @param pivot The positive distance from the {@code origin} at which the relevance score drops in half.
+     * @param paths The non-empty fields to be searched.
+     * @return The requested {@link SearchOperator}.
+     * @mongodb.atlas.manual atlas-search/near/ near operator
+     */
+    static NumberNearSearchOperator near(final Number origin, final Number pivot, final Iterable<? extends FieldSearchPath> paths) {
+        Iterator<? extends SearchPath> pathIterator = notNull("paths", paths).iterator();
+        isTrueArgument("paths must not be empty", pathIterator.hasNext());
+        return new SearchConstructibleBsonElement("near", new Document("origin", notNull("origin", origin))
+                .append("path", combineToBsonValue(pathIterator, true))
+                .append("pivot", notNull("pivot", pivot)));
+    }
+
+    /**
+     * Returns a {@link SearchOperator} that allows finding results that are near the specified {@code origin}.
+     *
+     * @param origin The origin from which the proximity of the results is measured.
+     * The relevance score is 1 if the values of the fields are {@code origin}.
+     * @param pivot The positive distance from the {@code origin} at which the relevance score drops in half.
+     * Data is extracted via {@link Duration#toMillis()}.
+     * @param path The field to be searched.
+     * @return The requested {@link SearchOperator}.
+     * @mongodb.atlas.manual atlas-search/near/ near operator
+     * @see org.bson.codecs.jsr310.InstantCodec
+     */
+    static DateNearSearchOperator near(final Instant origin, final Duration pivot, final FieldSearchPath path) {
+        return near(origin, pivot, singleton(notNull("path", path)));
+    }
+
+    /**
+     * Returns a {@link SearchOperator} that allows finding results that are near the specified {@code origin}.
+     *
+     * @param origin The origin from which the proximity of the results is measured.
+     * The relevance score is 1 if the values of the fields are {@code origin}.
+     * @param pivot The positive distance from the {@code origin} at which the relevance score drops in half.
+     * Data is extracted via {@link Duration#toMillis()}.
+     * @param paths The non-empty fields to be searched.
+     * @return The requested {@link SearchOperator}.
+     * @mongodb.atlas.manual atlas-search/near/ near operator
+     * @see org.bson.codecs.jsr310.InstantCodec
+     */
+    static DateNearSearchOperator near(final Instant origin, final Duration pivot, final Iterable<? extends FieldSearchPath> paths) {
+        Iterator<? extends SearchPath> pathIterator = notNull("paths", paths).iterator();
+        isTrueArgument("paths must not be empty", pathIterator.hasNext());
+        notNull("pivot", pivot);
+        isTrueArgument("pivot must be positive", !pivot.isZero());
+        isTrueArgument("pivot must be positive", !pivot.isNegative());
+        return new SearchConstructibleBsonElement("near", new Document("origin", notNull("origin", origin))
+                .append("path", combineToBsonValue(pathIterator, true))
+                .append("pivot", pivot.toMillis()));
+    }
+
+    /**
+     * Returns a {@link SearchOperator} that allows finding results that are near the specified {@code origin}.
+     *
+     * @param origin The origin from which the proximity of the results is measured.
+     * The relevance score is 1 if the values of the fields are {@code origin}.
+     * @param pivot The positive distance in meters from the {@code origin} at which the relevance score drops in half.
+     * @param path The field to be searched.
+     * @return The requested {@link SearchOperator}.
+     * @mongodb.atlas.manual atlas-search/near/ near operator
+     */
+    static GeoNearSearchOperator near(final Point origin, final Number pivot, final FieldSearchPath path) {
+        return near(origin, pivot, singleton(notNull("path", path)));
+    }
+
+    /**
+     * Returns a {@link SearchOperator} that allows finding results that are near the specified {@code origin}.
+     *
+     * @param origin The origin from which the proximity of the results is measured.
+     * The relevance score is 1 if the values of the fields are {@code origin}.
+     * @param pivot The positive distance in meters from the {@code origin} at which the relevance score drops in half.
+     * @param paths The non-empty fields to be searched.
+     * @return The requested {@link SearchOperator}.
+     * @mongodb.atlas.manual atlas-search/near/ near operator
+     */
+    static GeoNearSearchOperator near(final Point origin, final Number pivot, final Iterable<? extends FieldSearchPath> paths) {
+        Iterator<? extends SearchPath> pathIterator = notNull("paths", paths).iterator();
+        isTrueArgument("paths must not be empty", pathIterator.hasNext());
+        return new SearchConstructibleBsonElement("near", new Document("origin", notNull("origin", origin))
+                .append("path", combineToBsonValue(pathIterator, true))
+                .append("pivot", notNull("pivot", pivot)));
+    }
+
+    /**
+     * Creates a {@link SearchOperator} from a {@link Bson} in situations when there is no builder method that better satisfies your needs.
+     * This method cannot be used to validate the syntax.
+     * <p>
+     * <i>Example</i><br>
+     * The following code creates two functionally equivalent {@link SearchOperator}s,
+     * though they may not be {@linkplain Object#equals(Object) equal}.
+     * <pre>{@code
+     *  SearchOperator operator1 = SearchOperator.exists(
+     *          SearchPath.fieldPath("fieldName"));
+     *  SearchOperator operator2 = SearchOperator.of(new Document("exists",
+     *          new Document("path", SearchPath.fieldPath("fieldName").toValue())));
+     * }</pre>
+     *
+     * @param operator A {@link Bson} representing the required {@link SearchOperator}.
+     * @return The requested {@link SearchOperator}.
+     */
+    static SearchOperator of(final Bson operator) {
+        return new SearchConstructibleBson(notNull("operator", operator));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOptions.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+import com.mongodb.client.model.Aggregates;
+import org.bson.conversions.Bson;
+
+/**
+ * Represents optional fields of the {@code $search} pipeline stage of an aggregation pipeline.
+ *
+ * @see Aggregates#search(SearchOperator, SearchOptions)
+ * @see Aggregates#search(SearchCollector, SearchOptions)
+ * @mongodb.atlas.manual atlas-search/query-syntax/#-search $search syntax
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface SearchOptions extends Bson {
+    /**
+     * Creates a new {@link SearchOptions} with the index name specified.
+     *
+     * @param name The name of the index to use.
+     * @return A new {@link SearchOptions}.
+     */
+    SearchOptions index(String name);
+
+    /**
+     * Creates a new {@link SearchOptions} with the highlighting options specified.
+     *
+     * @param option The highlighting option.
+     * @return A new {@link SearchOptions}.
+     */
+    SearchOptions highlight(SearchHighlight option);
+
+    /**
+     * Creates a new {@link SearchOptions} with the counting options specified.
+     *
+     * @param option The counting option.
+     * @return A new {@link SearchOptions}.
+     */
+    @Beta({Beta.Reason.CLIENT, Beta.Reason.SERVER})
+    SearchOptions count(SearchCount option);
+
+    /**
+     * Creates a new {@link SearchOptions} that instruct to return only stored source fields.
+     *
+     * @param returnStoredSource The option to return only stored source fields.
+     * @return A new {@link SearchOptions}.
+     * @mongodb.atlas.manual atlas-search/return-stored-source/ Return stored source fields
+     */
+    @Beta({Beta.Reason.CLIENT, Beta.Reason.SERVER})
+    SearchOptions returnStoredSource(boolean returnStoredSource);
+
+    /**
+     * Creates a new {@link SearchOptions} with the specified option in situations when there is no builder method
+     * that better satisfies your needs.
+     * This method cannot be used to validate the syntax.
+     * <p>
+     * <i>Example</i><br>
+     * The following code creates two functionally equivalent {@link SearchOptions} objects,
+     * though they may not be {@linkplain Object#equals(Object) equal}.
+     * <pre>{@code
+     *  SearchOptions options1 = SearchOptions.defaultSearchOptions().index("indexName")
+     *  SearchOptions options2 = SearchOptions.defaultSearchOptions().option("index", "indexName")
+     * }</pre>
+     *
+     * @param name The option name.
+     * @param value The option value.
+     * @return A new {@link SearchOptions}.
+     */
+    SearchOptions option(String name, Object value);
+
+    /**
+     * Returns {@link SearchOptions} that represents server defaults.
+     *
+     * @return {@link SearchOptions} that represents server defaults.
+     */
+    static SearchOptions defaultSearchOptions() {
+        return SearchConstructibleBson.EMPTY;
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchPath.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchPath.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+import com.mongodb.internal.client.model.Util;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.conversions.Bson;
+
+import static com.mongodb.assertions.Assertions.isTrueArgument;
+import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.client.model.Util.SEARCH_PATH_VALUE_KEY;
+
+/**
+ * A specification of fields to be searched.
+ * <p>
+ * Depending on the context, one of the following methods may be used to get a representation of a {@link SearchPath}
+ * with the correct syntax: {@link #toBsonDocument()}, {@link #toBsonValue()}, {@link FieldSearchPath#toValue()}.</p>
+ *
+ * @mongodb.atlas.manual atlas-search/path-construction/ Path
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface SearchPath extends Bson {
+    /**
+     * Returns a {@link SearchPath} for the given {@code path}.
+     *
+     * @param path The name of the field. Must not contain {@linkplain #wildcardPath(String) wildcard} characters.
+     * @return The requested {@link SearchPath}.
+     * @mongodb.driver.manual core/document/#dot-notation Dot notation
+     */
+    static FieldSearchPath fieldPath(final String path) {
+        notNull("path", path);
+        isTrueArgument("path must not contain '*'", !path.contains("*"));
+        return new SearchConstructibleBson(new BsonDocument(SEARCH_PATH_VALUE_KEY, new BsonString(path)));
+    }
+
+    /**
+     * Returns a {@link SearchPath} for the given {@code wildcardPath}.
+     *
+     * @param wildcardPath The specification of the fields that contains wildcard ({@code '*'}) characters.
+     * Must not contain {@code '**'}.
+     * @return The requested {@link SearchPath}.
+     * @mongodb.driver.manual core/document/#dot-notation Dot notation
+     */
+    static WildcardSearchPath wildcardPath(final String wildcardPath) {
+        notNull("wildcardPath", wildcardPath);
+        isTrueArgument("wildcardPath must contain '*'", wildcardPath.contains("*"));
+        isTrueArgument("wildcardPath must not contain '**'", !wildcardPath.contains("**"));
+        return new SearchConstructibleBson(new BsonDocument("wildcard", new BsonString(wildcardPath)));
+    }
+
+    /**
+     * Converts this object to {@link BsonValue}.
+     * If {@link #toBsonDocument()} contains only the {@value Util#SEARCH_PATH_VALUE_KEY} key,
+     * then returns {@link BsonString} representing the value of this key,
+     * otherwise returns {@link #toBsonDocument()}.
+     * <p>
+     * This method may be useful when using the {@code of} methods, e.g., {@link SearchHighlight#of(Bson)}.
+     * Depending on the syntax of the document being constructed,
+     * it may be required to use the method {@link FieldSearchPath#toValue()} instead.</p>
+     *
+     * @return A {@link BsonValue} representing this {@link SearchPath}.
+     * @see FieldSearchPath#toValue()
+     */
+    default BsonValue toBsonValue() {
+        final BsonDocument doc = toBsonDocument();
+        if (doc.size() > 1) {
+            return doc;
+        } else {
+            final BsonString value = doc.getString(SEARCH_PATH_VALUE_KEY, null);
+            if (value != null) {
+                // paths that contain only `SEARCH_PATH_VALUE_KEY` must be represented as a `BsonString`
+                return value;
+            } else {
+                return doc;
+            }
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchScore.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchScore.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+import com.mongodb.client.model.Projections;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import static com.mongodb.assertions.Assertions.isTrueArgument;
+import static org.bson.assertions.Assertions.notNull;
+
+/**
+ * A modifier of the relevance score.
+ * You may use the {@code $meta: "searchScore"} expression, e.g., via {@link Projections#metaSearchScore(String)},
+ * to extract the relevance score assigned to each found document.
+ *
+ * @mongodb.atlas.manual atlas-search/scoring/ Scoring
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface SearchScore extends Bson {
+    /**
+     * Returns a {@link SearchScore} that instructs to multiply the score by the specified {@code value}.
+     *
+     * @param value The positive value to multiply the score by.
+     * @return The requested {@link SearchScore}.
+     * @mongodb.atlas.manual atlas-search/scoring/#boost boost score modifier
+     */
+    static ValueBoostSearchScore boost(final float value) {
+        isTrueArgument("value must be positive", value > 0);
+        return new SearchConstructibleBsonElement("boost", new BsonDocument("value", new BsonDouble(value)));
+    }
+
+    /**
+     * Returns a {@link SearchScore} that instructs to multiply the score by the value of the specified field.
+     *
+     * @param path The numeric field whose value to multiply the score by.
+     * @return The requested {@link SearchScore}.
+     * @mongodb.atlas.manual atlas-search/scoring/#boost boost score modifier
+     * @see SearchScoreExpression#pathExpression(FieldSearchPath)
+     */
+    static PathBoostSearchScore boost(final FieldSearchPath path) {
+        return new SearchConstructibleBsonElement("boost", new Document("path", notNull("value", path).toValue()));
+    }
+
+    /**
+     * Returns a {@link SearchScore} that instructs to replace the score with the specified {@code value}.
+     *
+     * @param value The positive value to replace the score with.
+     * @return The requested {@link SearchScore}.
+     * @mongodb.atlas.manual atlas-search/scoring/#constant constant score modifier
+     * @see SearchScoreExpression#constantExpression(float)
+     */
+    static ConstantSearchScore constant(final float value) {
+        isTrueArgument("value must be positive", value > 0);
+        return new SearchConstructibleBsonElement("constant", new BsonDocument("value", new BsonDouble(value)));
+    }
+
+    /**
+     * Returns a {@link SearchScore} that instructs to compute the score using the specified {@code expression}.
+     *
+     * @param expression The expression to use when calculating the score.
+     * @return The requested {@link SearchScore}.
+     * @mongodb.atlas.manual atlas-search/scoring/#function function score modifier
+     */
+    static FunctionSearchScore function(final SearchScoreExpression expression) {
+        return new SearchConstructibleBsonElement("function", notNull("expression", expression));
+    }
+
+    /**
+     * Creates a {@link SearchScore} from a {@link Bson} in situations when there is no builder method that better satisfies your needs.
+     * This method cannot be used to validate the syntax.
+     * <p>
+     * <i>Example</i><br>
+     * The following code creates two functionally equivalent {@link SearchScore}s,
+     * though they may not be {@linkplain Object#equals(Object) equal}.
+     * <pre>{@code
+     *  SearchScore score1 = SearchScore.boost(
+     *      SearchPath.fieldPath("fieldName"));
+     *  SearchScore score2 = SearchScore.of(new Document("boost",
+     *      new Document("path", SearchPath.fieldPath("fieldName").toValue())));
+     * }</pre>
+     *
+     * @param score A {@link Bson} representing the required {@link SearchScore}.
+     * @return The requested {@link SearchScore}.
+     */
+    static SearchScore of(final Bson score) {
+        return new SearchConstructibleBson(notNull("score", score));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchScoreExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchScoreExpression.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import static com.mongodb.assertions.Assertions.assertTrue;
+import static com.mongodb.assertions.Assertions.isTrueArgument;
+import static com.mongodb.internal.client.model.Util.SEARCH_PATH_VALUE_KEY;
+import static com.mongodb.internal.client.model.Util.sizeAtLeast;
+import static org.bson.assertions.Assertions.notNull;
+
+/**
+ * @see SearchScore#function(SearchScoreExpression)
+ * @mongodb.atlas.manual atlas-search/scoring/#expressions Expressions for the function score modifier
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface SearchScoreExpression extends Bson {
+    /**
+     * Returns a {@link SearchScoreExpression} that evaluates into the relevance score of a document.
+     *
+     * @return The requested {@link SearchScoreExpression}.
+     */
+    static RelevanceSearchScoreExpression relevanceExpression() {
+        return new SearchConstructibleBson(new BsonDocument("score", new BsonString("relevance")));
+    }
+
+    /**
+     * Returns a {@link SearchScoreExpression} that evaluates into the value of the specified field.
+     *
+     * @param path The numeric field whose value to use as the result of the expression.
+     * @return The requested {@link SearchScoreExpression}.
+     * @see SearchScore#boost(FieldSearchPath)
+     */
+    static PathSearchScoreExpression pathExpression(final FieldSearchPath path) {
+        return new SearchConstructibleBsonElement("path", new Document(SEARCH_PATH_VALUE_KEY, notNull("path", path).toValue()));
+    }
+
+    /**
+     * Returns a {@link SearchScoreExpression} that evaluates into the specified {@code value}.
+     *
+     * @param value The value to use as the result of the expression. Unlike {@link SearchScore#constant(float)}, does not have constraints.
+     * @return The requested {@link SearchScoreExpression}.
+     * @see SearchScore#constant(float)
+     */
+    static ConstantSearchScoreExpression constantExpression(final float value) {
+        return new SearchConstructibleBson(new BsonDocument("constant", new BsonDouble(value)));
+    }
+
+    /**
+     * Returns a {@link SearchScoreExpression} that represents a Gaussian function whose output is within the interval [0, 1].
+     * Roughly speaking, the further the value of the {@code path} expression is from the {@code origin},
+     * the smaller the output of the function.
+     * <p>
+     * The {@code scale} and {@link GaussSearchScoreExpression#decay(double) decay} are parameters of the Gaussian function,
+     * they define the rate at which the function decays.
+     * The input of the Gaussian function is the output of another function:
+     * max(0, abs({@code pathValue} - {@code origin}) - {@link GaussSearchScoreExpression#offset(double) offset}),
+     * where {@code pathValue} is the value of the {@code path} expression.</p>
+     *
+     * @param origin The point of origin, see {@link GaussSearchScoreExpression#offset(double)}.
+     * The value of the Gaussian function is 1 if the value of the {@code path} expression is {@code origin}.
+     * @param path The expression whose value is used to calculate the input of the Gaussian function.
+     * @param scale The non-zero distance from the points {@code origin} ± {@link GaussSearchScoreExpression#offset(double) offset}
+     * at which the output of the Gaussian function must decay by the factor of {@link GaussSearchScoreExpression#decay(double) decay}.
+     * @return The requested {@link SearchScoreExpression}.
+     */
+    static GaussSearchScoreExpression gaussExpression(final double origin, final PathSearchScoreExpression path, final double scale) {
+        notNull("path", path);
+        isTrueArgument("scale must not be 0", scale != 0);
+        Bson value = new Bson() {
+            @Override
+            public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+                BsonDocument pathDoc = path.toBsonDocument(documentClass, codecRegistry);
+                assertTrue(pathDoc.size() == 1);
+                return new BsonDocument("origin", new BsonDouble(origin))
+                        .append("path", pathDoc.values().iterator().next())
+                        .append("scale", new BsonDouble(scale));
+            }
+
+            @Override
+            public String toString() {
+                return "{\"origin\": " + origin
+                        + ", \"path\": " + path
+                        + ", \"scale\": " + scale
+                        + '}';
+            }
+        };
+        return new SearchConstructibleBsonElement("gauss", value);
+    }
+
+    /**
+     * Returns a {@link SearchScoreExpression} that evaluates into log10({@code expressionValue}),
+     * where {@code expressionValue} is the value of the {@code expression}.
+     *
+     * @param expression The expression whose value is the input of the log10 function.
+     * @return The requested {@link SearchScoreExpression}.
+     */
+    static LogSearchScoreExpression logExpression(final SearchScoreExpression expression) {
+        return new SearchConstructibleBson(new Document("log", notNull("expression", expression)));
+    }
+
+    /**
+     * Returns a {@link SearchScoreExpression} that evaluates into log10({@code expressionValue} + 1),
+     * where {@code expressionValue} is the value of the {@code expression}.
+     *
+     * @param expression The expression whose value is used to calculate the input of the log10 function.
+     * @return The requested {@link SearchScoreExpression}.
+     */
+    static Log1pSearchScoreExpression log1pExpression(final SearchScoreExpression expression) {
+        return new SearchConstructibleBson(new Document("log1p", notNull("expression", expression)));
+    }
+
+    /**
+     * Returns a {@link SearchScoreExpression} that evaluates into the sum of the values of the specified {@code expressions}.
+     *
+     * @param expressions The expressions whose values to add. Must contain at least two expressions.
+     * @return The requested {@link SearchScoreExpression}.
+     */
+    static AddSearchScoreExpression addExpression(final Iterable<? extends SearchScoreExpression> expressions) {
+        notNull("expressions", expressions);
+        isTrueArgument("expressions must contain at least 2 elements", sizeAtLeast(expressions, 2));
+        return new SearchConstructibleBson(new Document("add", expressions));
+    }
+
+    /**
+     * Returns a {@link SearchScoreExpression} that evaluates into the product of the values of the specified {@code expressions}.
+     *
+     * @param expressions The expressions whose values to multiply. Must contain at least two expressions.
+     * @return The requested {@link SearchScoreExpression}.
+     */
+    static MultiplySearchScoreExpression multiplyExpression(final Iterable<? extends SearchScoreExpression> expressions) {
+        notNull("expressions", expressions);
+        isTrueArgument("expressions must contain at least 2 elements", sizeAtLeast(expressions, 2));
+        return new SearchConstructibleBson(new Document("multiply", expressions));
+    }
+
+    /**
+     * Creates a {@link SearchScoreExpression} from a {@link Bson} in situations when there is no builder method
+     * that better satisfies your needs.
+     * This method cannot be used to validate the syntax.
+     * <p>
+     * <i>Example</i><br>
+     * The following code creates two functionally equivalent {@link SearchScoreExpression}s,
+     * though they may not be {@linkplain Object#equals(Object) equal}.
+     * <pre>{@code
+     *  SearchScoreExpression expression1 = SearchScoreExpression.pathExpression(
+     *          SearchPath.fieldPath("fieldName"))
+     *          .undefined(-1.5f);
+     *  SearchScoreExpression expression2 = new Document("path",
+     *          new Document("value", SearchPath.fieldPath("fieldName").toValue())
+     *                  .append("undefined", -1.5));
+     * }</pre>
+     *
+     * @param expression A {@link Bson} representing the required {@link SearchScoreExpression}.
+     * @return The requested {@link SearchScoreExpression}.
+     */
+    static SearchScoreExpression of(final Bson expression) {
+        return new SearchConstructibleBson(notNull("expression", expression));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/ShouldCompoundSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/ShouldCompoundSearchOperator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * A representation of a {@link CompoundSearchOperator} that allows changing
+ * {@link CompoundSearchOperator#should(Iterable) should}-specific options, if any.
+ * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+ *
+ * @see CompoundSearchOperatorBase#should(Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface ShouldCompoundSearchOperator extends CompoundSearchOperator {
+    @Override
+    ShouldCompoundSearchOperator score(SearchScore modifier);
+    /**
+     * Creates a new {@link ShouldCompoundSearchOperator} that requires at least the requested number of clauses of those specified via
+     * {@link CompoundSearchOperatorBase#should(Iterable)} to be satisfied.
+     *
+     * @param minimumShouldMatch The minimum number of clauses that must be satisfied.
+     * @return A new {@link ShouldCompoundSearchOperator}.
+     */
+    ShouldCompoundSearchOperator minimumShouldMatch(int minimumShouldMatch);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/StringSearchFacet.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/StringSearchFacet.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchFacet#stringFacet(String, FieldSearchPath)
+ * @since 4.7
+ */
+@Evolving
+@Beta({Beta.Reason.CLIENT, Beta.Reason.SERVER})
+public interface StringSearchFacet extends SearchFacet {
+    /**
+     * Creates a new {@link StringSearchFacet} that explicitly limits the number of facet categories.
+     *
+     * @param max The maximum number of facet categories to return in the results.
+     * @return A new {@link StringSearchFacet}.
+     */
+    StringSearchFacet numBuckets(int max);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/TextSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/TextSearchOperator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchOperator#text(String, SearchPath)
+ * @see SearchOperator#text(Iterable, Iterable)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface TextSearchOperator extends SearchOperator {
+    @Override
+    TextSearchOperator score(SearchScore modifier);
+
+    /**
+     * Creates a new {@link TextSearchOperator} that uses fuzzy search
+     * and does not use {@linkplain #synonyms(String) synonyms}.
+     *
+     * @param option Fuzzy search option.
+     * @return A new {@link TextSearchOperator}.
+     */
+    TextSearchOperator fuzzy(SearchFuzzy option);
+
+    /**
+     * Creates a new {@link TextSearchOperator} that uses synonyms
+     * and does not use {@linkplain #fuzzy(SearchFuzzy) fuzzy search}.
+     *
+     * @param name The name of the synonym mapping.
+     * @return A new {@link TextSearchOperator}.
+     *
+     * @mongodb.atlas.manual atlas-search/synonyms/ Synonym mappings
+     */
+    TextSearchOperator synonyms(String name);
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/TotalSearchCount.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/TotalSearchCount.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchCount#total()
+ * @since 4.7
+ */
+@Evolving
+@Beta({Beta.Reason.CLIENT, Beta.Reason.SERVER})
+public interface TotalSearchCount extends SearchCount {
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/ValueBoostSearchScore.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/ValueBoostSearchScore.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchScore#boost(float)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface ValueBoostSearchScore extends SearchScore {
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/WildcardSearchPath.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/WildcardSearchPath.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see SearchPath#wildcardPath(String)
+ * @since 4.7
+ */
+@Evolving
+@Beta(Beta.Reason.CLIENT)
+public interface WildcardSearchPath extends SearchPath {
+}

--- a/driver-core/src/main/com/mongodb/client/model/search/package-info.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/package-info.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Query building API for MongoDB Atlas full-text search.
+ * <p>
+ * While all the building blocks of this API, such as
+ * {@link com.mongodb.client.model.search.SearchOptions}, {@link com.mongodb.client.model.search.SearchHighlight}, etc.,
+ * are not necessary {@link com.mongodb.annotations.Immutable immutable}, they are unmodifiable due to methods like
+ * {@link com.mongodb.client.model.search.SearchHighlight#maxCharsToExamine(int)} returning new instances instead of modifying the instance
+ * on which they are called. This allows storing and using such instances as templates.</p>
+ *
+ * @see com.mongodb.client.model.Aggregates#search(SearchOperator, SearchOptions)
+ * @see com.mongodb.client.model.Aggregates#search(SearchCollector, SearchOptions)
+ * @mongodb.atlas.manual atlas-search/ Atlas Search
+ * @mongodb.atlas.manual atlas-search/query-syntax/ Atlas Search aggregation pipeline stages
+ * @since 4.7
+ */
+@NonNullApi
+@Beta(Beta.Reason.CLIENT)
+package com.mongodb.client.model.search;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.lang.NonNullApi;

--- a/driver-core/src/main/com/mongodb/internal/client/model/AbstractConstructibleBson.java
+++ b/driver-core/src/main/com/mongodb/internal/client/model/AbstractConstructibleBson.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.client.model;
+
+import com.mongodb.annotations.Immutable;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * A {@link Bson} that allows constructing new instances via {@link #newAppended(String, Object)} instead of mutating {@code this}.
+ * While instances are not {@link Immutable immutable},
+ * {@link BsonDocument#isEmpty() empty} instances are treated specially and are immutable,
+ * provided that the constructor arguments are not mutated.
+ *
+ * @param <S> A type introduced by the concrete class that extends this abstract class.
+ */
+public abstract class AbstractConstructibleBson<S extends AbstractConstructibleBson<S>> implements Bson {
+    private static final Document EMPTY_APPENDED = new Document();
+
+    private final Bson base;
+    private final Document appended;
+
+    protected AbstractConstructibleBson(final Bson base) {
+        this(base, EMPTY_APPENDED);
+    }
+
+    protected AbstractConstructibleBson(final Bson base, final Document appended) {
+        this.base = base;
+        this.appended = appended;
+    }
+
+    protected abstract S newSelf(Bson base, Document appended);
+
+    @Override
+    public final <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+        BsonDocument baseDoc = base.toBsonDocument(documentClass, codecRegistry);
+        return baseDoc.isEmpty() && appended.isEmpty()
+                // eliminate the possibility of exposing internal state when it is empty to enforce immutability of empty objects
+                ? new BsonDocument()
+                : appended.isEmpty() ? baseDoc : newMerged(baseDoc, appended.toBsonDocument(documentClass, codecRegistry));
+    }
+
+    /**
+     * {@linkplain Document#append(String, Object) Appends} the specified mapping via {@link #newMutated(Consumer)}.
+     *
+     * @return A new instance.
+     */
+    protected final S newAppended(final String name, final Object value) {
+        return newMutated(doc -> doc.append(name, value));
+    }
+
+    /**
+     * Creates a {@link Document#Document(java.util.Map) shallow copy} of {@code this} and mutates it via the specified {@code mutator}.
+     *
+     * @return A new instance.
+     */
+    protected final S newMutated(final Consumer<Document> mutator) {
+        Document newAppended = new Document(appended);
+        mutator.accept(newAppended);
+        return newSelf(base, newAppended);
+    }
+
+    public static AbstractConstructibleBson<?> of(final Bson doc) {
+        return doc instanceof AbstractConstructibleBson
+                // prevent double wrapping
+                ? (AbstractConstructibleBson<?>) doc
+                : new ConstructibleBson(doc);
+    }
+
+    @Override
+    public final boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final AbstractConstructibleBson<?> that = (AbstractConstructibleBson<?>) o;
+        return Objects.equals(base, that.base) && Objects.equals(appended, that.appended);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(base, appended);
+    }
+
+    @Override
+    public String toString() {
+        return "{base=" + base
+                + ", appended=" + appended
+                + '}';
+    }
+
+    private static BsonDocument newMerged(final BsonDocument base, final BsonDocument appended) {
+        final BsonDocument result = base.clone();
+        result.putAll(appended);
+        return result;
+    }
+
+    private static final class ConstructibleBson extends AbstractConstructibleBson<ConstructibleBson> {
+        private ConstructibleBson(final Bson base) {
+            super(base);
+        }
+
+        private ConstructibleBson(final Bson base, final Document appended) {
+            super(base, appended);
+        }
+
+        @Override
+        protected ConstructibleBson newSelf(final Bson base, final Document appended) {
+            return new ConstructibleBson(base, appended);
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/client/model/AbstractConstructibleBsonElement.java
+++ b/driver-core/src/main/com/mongodb/internal/client/model/AbstractConstructibleBsonElement.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.client.model;
+
+import com.mongodb.annotations.Immutable;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * A {@link Bson} that contains exactly one name/value pair
+ * and allows constructing new instances via {@link #newWithAppendedValue(String, Object)} instead of mutating {@code this}.
+ * The value must itself be a {@code Bson}.
+ * While instances are not {@link Immutable immutable},
+ * instances with {@link BsonDocument#isEmpty() empty} values are treated specially and are immutable,
+ * provided that the constructor arguments are not mutated.
+ *
+ * @param <S> A type introduced by the concrete class that extends this abstract class.
+ * @see AbstractConstructibleBson
+ */
+public abstract class AbstractConstructibleBsonElement<S extends AbstractConstructibleBsonElement<S>> implements Bson {
+    private static final BsonDocument EMPTY_VALUE = new BsonDocument();
+
+    private final String name;
+    private final AbstractConstructibleBson<?> value;
+
+    protected AbstractConstructibleBsonElement(final String name) {
+        this(name, EMPTY_VALUE);
+    }
+
+    protected AbstractConstructibleBsonElement(final String name, final Bson value) {
+        this.name = name;
+        this.value = AbstractConstructibleBson.of(value);
+    }
+
+    protected abstract S newSelf(String name, Bson value);
+
+    /**
+     * {@linkplain Document#append(String, Object) Appends} the specified mapping to the value via {@link #newWithMutatedValue(Consumer)}.
+     *
+     * @return A new instance.
+     */
+    protected final S newWithAppendedValue(final String name, final Object value) {
+        return newWithMutatedValue(doc -> doc.append(name, value));
+    }
+
+    /**
+     * Creates a copy of {@code this} with a value that is
+     * a {@linkplain AbstractConstructibleBson#newMutated(Consumer) shallow copy} of this value mutated via the specified {@code mutator}.
+     *
+     * @return A new instance.
+     * @see AbstractConstructibleBson#newMutated(Consumer)
+     */
+    protected final S newWithMutatedValue(final Consumer<Document> mutator) {
+        return newSelf(this.name, this.value.newMutated(mutator));
+    }
+
+    @Override
+    public final <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+        return new BsonDocument(name, value.toBsonDocument(documentClass, codecRegistry));
+    }
+
+    public static AbstractConstructibleBsonElement<?> of(final String name, final Bson value) {
+        return new ConstructibleBsonElement(name, value);
+    }
+
+    @Override
+    public final boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final AbstractConstructibleBsonElement<?> that = (AbstractConstructibleBsonElement<?>) o;
+        return name.equals(that.name) && value.equals(that.value);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return "{\""
+                + name + "\": " + value
+                + '}';
+    }
+
+    private static final class ConstructibleBsonElement extends AbstractConstructibleBsonElement<ConstructibleBsonElement> {
+        private ConstructibleBsonElement(final String name, final Bson value) {
+            super(name, value);
+        }
+
+        @Override
+        protected ConstructibleBsonElement newSelf(final String name, final Bson value) {
+            return new ConstructibleBsonElement(name, value);
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/client/model/Util.java
+++ b/driver-core/src/main/com/mongodb/internal/client/model/Util.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.client.model;
+
+import com.mongodb.Function;
+import com.mongodb.client.model.search.FieldSearchPath;
+import com.mongodb.client.model.search.SearchPath;
+import org.bson.BsonArray;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+
+import java.util.Iterator;
+
+import static com.mongodb.assertions.Assertions.fail;
+
+public final class Util {
+    public static final String SEARCH_PATH_VALUE_KEY = "value";
+
+    /**
+     * If {@code nonEmptyPaths} has exactly one element, then returns the result of {@link SearchPath#toBsonValue()},
+     * otherwise returns a {@link BsonArray} of such results.
+     *
+     * @param nonEmptyPaths One or more {@link SearchPath} to convert.
+     * @param valueOnly If {@code true}, then {@link FieldSearchPath#toValue()} is used when possible;
+     * if {@code false}, then {@link SearchPath#toBsonValue()} is used.
+     * @return A single {@link BsonValue} representing the specified paths.
+     */
+    public static BsonValue combineToBsonValue(final Iterator<? extends SearchPath> nonEmptyPaths, final boolean valueOnly) {
+        Function<SearchPath, BsonValue> toBsonValueFunc = valueOnly
+                ? path -> {
+                    if (path instanceof FieldSearchPath) {
+                        return new BsonString(((FieldSearchPath) path).toValue());
+                    } else {
+                        return path.toBsonValue();
+                    }
+                }
+                : SearchPath::toBsonValue;
+        BsonValue firstPath = toBsonValueFunc.apply(nonEmptyPaths.next());
+        if (nonEmptyPaths.hasNext()) {
+            BsonArray bsonArray = new BsonArray();
+            bsonArray.add(firstPath);
+            while (nonEmptyPaths.hasNext()) {
+                bsonArray.add(toBsonValueFunc.apply(nonEmptyPaths.next()));
+            }
+            return bsonArray;
+        } else {
+            return firstPath;
+        }
+    }
+
+    public static boolean sizeAtLeast(final Iterable<?> iterable, final int minInclusive) {
+        Iterator<?> iter = iterable.iterator();
+        int size = 0;
+        while (size < minInclusive && iter.hasNext()) {
+            iter.next();
+            size++;
+        }
+        return size >= minInclusive;
+    }
+
+    private Util() {
+        throw fail();
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -107,6 +107,7 @@ public final class ClusterFixture {
     public static final String MONGODB_MULTI_MONGOS_URI_SYSTEM_PROPERTY_NAME = "org.mongodb.test.multi.mongos.uri";
     public static final String SERVERLESS_TEST_SYSTEM_PROPERTY_NAME = "org.mongodb.test.serverless";
     public static final String DATA_LAKE_TEST_SYSTEM_PROPERTY_NAME = "org.mongodb.test.data.lake";
+    public static final String ATLAS_SEARCH_TEST_SYSTEM_PROPERTY_NAME = "org.mongodb.test.atlas.search";
     private static final String MONGODB_OCSP_SHOULD_SUCCEED = "org.mongodb.test.ocsp.tls.should.succeed";
     private static final String DEFAULT_DATABASE_NAME = "JavaDriverTest";
     private static final int COMMAND_NOT_FOUND_ERROR_CODE = 59;
@@ -518,6 +519,10 @@ public final class ClusterFixture {
 
     public static boolean isClientSideEncryptionTest() {
         return !System.getProperty("org.mongodb.test.awsAccessKeyId", "").isEmpty();
+    }
+
+    public static boolean isAtlasSearchTest() {
+        return System.getProperty(ATLAS_SEARCH_TEST_SYSTEM_PROPERTY_NAME) != null;
     }
 
     public static void enableMaxTimeFailPoint() {

--- a/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
@@ -67,7 +67,6 @@ import static com.mongodb.client.model.Aggregates.sortByCount
 import static com.mongodb.client.model.Aggregates.unionWith
 import static com.mongodb.client.model.Aggregates.unwind
 import static com.mongodb.client.model.Filters.eq
-import static com.mongodb.client.model.Filters.exists
 import static com.mongodb.client.model.Filters.expr
 import static com.mongodb.client.model.Projections.computed
 import static com.mongodb.client.model.Projections.exclude
@@ -117,7 +116,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
 
     def '$match'() {
         expect:
-        aggregate([match(exists('a1'))]) == [a, b]
+        aggregate([match(Filters.exists('a1'))]) == [a, b]
     }
 
     def '$project'() {

--- a/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
@@ -1,0 +1,636 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoNamespace;
+import com.mongodb.assertions.Assertions;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.geojson.Point;
+import com.mongodb.client.model.geojson.Position;
+import com.mongodb.client.test.CollectionHelper;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonDocument;
+import org.bson.codecs.BsonDocumentCodec;
+import org.bson.conversions.Bson;
+import org.bson.json.JsonWriterSettings;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.Month;
+import java.time.Year;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.mongodb.ClusterFixture.isAtlasSearchTest;
+import static com.mongodb.client.model.Aggregates.limit;
+import static com.mongodb.client.model.Aggregates.project;
+import static com.mongodb.client.model.Aggregates.replaceWith;
+import static com.mongodb.client.model.Projections.computedSearchMeta;
+import static com.mongodb.client.model.Projections.metaSearchHighlights;
+import static com.mongodb.client.model.Projections.metaSearchScore;
+import static com.mongodb.client.model.search.SearchFuzzy.defaultSearchFuzzy;
+import static com.mongodb.client.model.search.SearchCollector.facet;
+import static com.mongodb.client.model.search.SearchCount.lowerBound;
+import static com.mongodb.client.model.search.SearchCount.total;
+import static com.mongodb.client.model.search.SearchFacet.dateFacet;
+import static com.mongodb.client.model.search.SearchFacet.numberFacet;
+import static com.mongodb.client.model.search.SearchFacet.stringFacet;
+import static com.mongodb.client.model.search.SearchHighlight.paths;
+import static com.mongodb.client.model.search.SearchOperator.autocomplete;
+import static com.mongodb.client.model.search.SearchOperator.compound;
+import static com.mongodb.client.model.search.SearchOperator.dateRange;
+import static com.mongodb.client.model.search.SearchOperator.exists;
+import static com.mongodb.client.model.search.SearchOperator.near;
+import static com.mongodb.client.model.search.SearchOperator.numberRange;
+import static com.mongodb.client.model.search.SearchOperator.text;
+import static com.mongodb.client.model.search.SearchOptions.defaultSearchOptions;
+import static com.mongodb.client.model.search.SearchPath.fieldPath;
+import static com.mongodb.client.model.search.SearchPath.wildcardPath;
+import static com.mongodb.client.model.search.SearchScore.boost;
+import static com.mongodb.client.model.search.SearchScore.constant;
+import static com.mongodb.client.model.search.SearchScore.function;
+import static com.mongodb.client.model.search.SearchScoreExpression.addExpression;
+import static com.mongodb.client.model.search.SearchScoreExpression.constantExpression;
+import static com.mongodb.client.model.search.SearchScoreExpression.gaussExpression;
+import static com.mongodb.client.model.search.SearchScoreExpression.log1pExpression;
+import static com.mongodb.client.model.search.SearchScoreExpression.logExpression;
+import static com.mongodb.client.model.search.SearchScoreExpression.multiplyExpression;
+import static com.mongodb.client.model.search.SearchScoreExpression.pathExpression;
+import static com.mongodb.client.model.search.SearchScoreExpression.relevanceExpression;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+/**
+ * These tests require the <a href="https://www.mongodb.com/docs/atlas/sample-data/">sample data</a>
+ * and the following Atlas Search indices:
+ * <table>
+ *  <thead>
+ *      <tr>
+ *          <th>Namespace</th>
+ *          <th>Index name</th>
+ *          <th>Field mappings</th>
+ *      </tr>
+ *  </thead>
+ *  <tbody>
+ *      <tr>
+ *          <td>{@code sample_mflix.movies}</td>
+ *          <td>{@code default}</td>
+ *          <td><pre>{@code
+ *            {
+ *              "mappings": {
+ *                "dynamic": true,
+ *                "fields": {
+ *                  "fullplot": {
+ *                    "type": "stringFacet"
+ *                  },
+ *                  "released": {
+ *                    "type": "dateFacet"
+ *                  },
+ *                  "title": [
+ *                    {
+ *                      "multi": {
+ *                        "keyword": {
+ *                          "analyzer": "lucene.keyword",
+ *                          "searchAnalyzer": "lucene.keyword",
+ *                          "type": "string"
+ *                        }
+ *                      },
+ *                      "type": "string"
+ *                    },
+ *                    {
+ *                      "type": "autocomplete"
+ *                    }
+ *                  ],
+ *                  "tomatoes": {
+ *                    "fields": {
+ *                      "dvd": {
+ *                        "type": "date"
+ *                      },
+ *                      "viewer": {
+ *                        "fields": {
+ *                          "meter": {
+ *                            "type": "numberFacet"
+ *                          }
+ *                        },
+ *                        "type": "document"
+ *                      }
+ *                    },
+ *                    "type": "document"
+ *                  }
+ *                }
+ *              },
+ *              "storedSource": {
+ *                "include": [
+ *                  "plot"
+ *                ]
+ *              }
+ *            }
+ *          }</pre></td>
+ *      </tr>
+ *      <tr>
+ *          <td>{@code sample_airbnb.listingsAndReviews}</td>
+ *          <td>{@code default}</td>
+ *          <td><pre>{@code
+ *            {
+ *              "mappings": {
+ *                "dynamic": true,
+ *                "fields": {
+ *                  "address": {
+ *                    "fields": {
+ *                      "location": {
+ *                        "type": "geo"
+ *                      }
+ *                    },
+ *                    "type": "document"
+ *                  }
+ *                }
+ *              }
+ *            }
+ *          }</pre></td>
+ *      </tr>
+ *  </tbody>
+ * </table>
+ */
+final class AggregatesSearchIntegrationTest {
+    private static final MongoNamespace MFLIX_MOVIES_NS = new MongoNamespace("sample_mflix", "movies");
+    private static final MongoNamespace AIRBNB_LISTINGS_AND_REVIEWS_NS = new MongoNamespace("sample_airbnb", "listingsAndReviews");
+    private static Map<MongoNamespace, CollectionHelper<BsonDocument>> collectionHelpers;
+
+    @BeforeAll
+    static void beforeAll() {
+        collectionHelpers = new HashMap<>();
+        collectionHelpers.put(MFLIX_MOVIES_NS, new CollectionHelper<>(new BsonDocumentCodec(), MFLIX_MOVIES_NS));
+        collectionHelpers.put(AIRBNB_LISTINGS_AND_REVIEWS_NS, new CollectionHelper<>(new BsonDocumentCodec(), AIRBNB_LISTINGS_AND_REVIEWS_NS));
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        assumeTrue(isAtlasSearchTest());
+    }
+
+    /**
+     * @param stageUnderTestCreator A {@link CustomizableSearchStageCreator} that is used to create both
+     * {@code $search} and {@code $searchMeta} stages. Any combination of an {@link SearchOperator}/{@link SearchCollector} and
+     * {@link SearchOptions} that is valid for the {@code $search} stage is also valid for the {@code $searchMeta} stage.
+     * This is why we use the same creator for both.
+     * @param accessories A list of {@link Accessory} objects that specify additional pipeline stages and an asserter.
+     * <ul>
+     *  <li>The item with index 0 is used with {@code $search};</li>
+     *  <li>the idem with index 1 is used with {@code $searchMeta}.</li>
+     * </ul>
+     */
+    @ParameterizedTest(name = "{index} {0}")
+    @MethodSource("args")
+    void test(
+            @SuppressWarnings("unused") final String testDescription,
+            final CustomizableSearchStageCreator stageUnderTestCreator,
+            final MongoNamespace ns,
+            final List<Accessory> accessories) {
+        List<BiFunction<Bson, SearchOptions, Bson>> stageUnderTestCustomizers = asList(
+                (bsonOperatorOrCollector, options) -> {
+                    if (bsonOperatorOrCollector instanceof SearchOperator) {
+                        return Aggregates.search((SearchOperator) bsonOperatorOrCollector, options);
+                    } else if (bsonOperatorOrCollector instanceof SearchCollector) {
+                        return Aggregates.search((SearchCollector) bsonOperatorOrCollector, options);
+                    } else {
+                        throw Assertions.fail();
+                    }
+                },
+                (bsonOperatorOrCollector, options) -> {
+                    if (bsonOperatorOrCollector instanceof SearchOperator) {
+                        return Aggregates.searchMeta((SearchOperator) bsonOperatorOrCollector, options);
+                    } else if (bsonOperatorOrCollector instanceof SearchCollector) {
+                        return Aggregates.searchMeta((SearchCollector) bsonOperatorOrCollector, options);
+                    } else {
+                        throw Assertions.fail();
+                    }
+                }
+        );
+        Assertions.assertTrue(stageUnderTestCustomizers.size() == accessories.size());
+        for (int i = 0; i < stageUnderTestCustomizers.size(); i++) {
+            Bson stageUnderTest = stageUnderTestCreator.apply(stageUnderTestCustomizers.get(i));
+            Accessory accessory = accessories.get(i);
+            final List<Bson> pipeline = new ArrayList<>();
+            pipeline.add(stageUnderTest);
+            pipeline.addAll(accessory.postStages);
+            Supplier<String> msgSupplier = () -> "For reference, the pipeline (" + pipeline.size() + " elements) used in the test is\n[\n"
+                    + pipeline.stream()
+                    .map(stage -> stage.toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry()))
+                    .map(doc -> doc.toJson(JsonWriterSettings.builder().indent(true).build()))
+                    .collect(Collectors.joining(",\n"))
+                    + "\n]\n";
+            List<BsonDocument> results;
+            try {
+                results = collectionHelpers.get(ns).aggregate(pipeline);
+            } catch (RuntimeException e) {
+                throw new RuntimeException(msgSupplier.get(), e);
+            }
+            accessory.resultAsserter.accept(results, msgSupplier);
+        }
+    }
+
+    /**
+     * @see #test(String, CustomizableSearchStageCreator, MongoNamespace, List)
+     */
+    private static Stream<Arguments> args() {
+        return Stream.of(
+                arguments(
+                        "default options",
+                        stageCreator(
+                                exists(fieldPath("tomatoes.dvd")),
+                                null
+                        ),
+                        MFLIX_MOVIES_NS,
+                        asList(
+                                new Accessory(
+                                        asList(limit(1), project(metaSearchScore("score"))),
+                                        Asserters.score(1)
+                                ),
+                                new Accessory(
+                                        emptyList(),
+                                        // specifying a bare operator works as if `SearchCount.lowerBound` were specified
+                                        Asserters.countLowerBound(1_001)
+                                )
+                        )
+                ),
+                arguments(
+                        "`index`, `count` options",
+                        stageCreator(
+                                // `multi` is used here only to verify that it is tolerated
+                                exists(fieldPath("title").multi("keyword")),
+                                defaultSearchOptions()
+                                        .option("index", "default")
+                                        .count(lowerBound().threshold(2_000))
+                        ),
+                        MFLIX_MOVIES_NS,
+                        asList(
+                                new Accessory(
+                                        asList(limit(1), project(computedSearchMeta("meta"))),
+                                        Asserters.countLowerBound("meta", 2_000)
+                                ),
+                                new Accessory(
+                                        emptyList(),
+                                        Asserters.countLowerBound(2_000)
+                                )
+                        )
+                ),
+                arguments(
+                        "`highlight` option",
+                        stageCreator(
+                                text(asList("factory", "century"), singleton(fieldPath("plot"))),
+                                defaultSearchOptions()
+                                        .highlight(paths(asList(
+                                                fieldPath("title").multi("keyword"),
+                                                wildcardPath("pl*t")))
+                                                .maxCharsToExamine(100_000))
+                        ),
+                        MFLIX_MOVIES_NS,
+                        asList(
+                                new Accessory(
+                                        asList(limit(1), project(metaSearchHighlights("highlights"))),
+                                        Asserters.firstResult((doc, msgSupplier) -> assertEquals(1, doc.getArray("highlights").size(), msgSupplier))
+                                ),
+                                new Accessory(
+                                        emptyList(),
+                                        Asserters.nonEmpty()
+                                )
+                        )
+                ),
+                arguments(
+                        "`returnStoredSource` option",
+                        stageCreator(
+                                exists(fieldPath("plot")),
+                                defaultSearchOptions()
+                                        .returnStoredSource(true)
+                        ),
+                        MFLIX_MOVIES_NS,
+                        asList(
+                                new Accessory(
+                                        singleton(limit(1)),
+                                        Asserters.firstResult((doc, msgSupplier) -> {
+                                            // assert that the fields specified in `storedSource` and "id" were returned
+                                            assertNotNull(doc.get("_id"), msgSupplier);
+                                            assertFalse(doc.get("plot").asString().getValue().isEmpty(), msgSupplier);
+                                            assertEquals(2, doc.size(), msgSupplier);
+                                        })
+                                ),
+                                new Accessory(
+                                        emptyList(),
+                                        Asserters.nonEmpty()
+                                )
+                        )
+                ),
+                arguments(
+                        "alternate analyzer (`multi` field path)",
+                        stageCreator(
+                                text(singleton("The Cheat"), singleton(fieldPath("title").multi("keyword"))),
+                                defaultSearchOptions().count(total())
+                        ),
+                        MFLIX_MOVIES_NS,
+                        asList(
+                                new Accessory(
+                                        emptyList(),
+                                        Asserters.firstResult((doc, msgSupplier) -> assertEquals(
+                                                "The Cheat", doc.getString("title").getValue(), msgSupplier))
+                                ),
+                                new Accessory(
+                                        emptyList(),
+                                        Asserters.countTotal(1)
+                                )
+                        )
+                ),
+                arguments(
+                        "facet collector",
+                        stageCreator(
+                                facet(
+                                        exists(fieldPath("tomatoes")),
+                                        asList(
+                                                stringFacet(
+                                                        "fullplotFacet",
+                                                        fieldPath("fullplot"))
+                                                        .numBuckets(1),
+                                                numberFacet(
+                                                        "tomatoesMeterFacet",
+                                                        fieldPath("tomatoes.viewer.meter"),
+                                                        asList(10f, 20d, 90, Long.MAX_VALUE / 2, Long.MAX_VALUE))
+                                                        .defaultBucket("defaultBucket"),
+                                                dateFacet(
+                                                        "releasedFacet",
+                                                        fieldPath("released"),
+                                                        asList(
+                                                                Instant.EPOCH,
+                                                                Instant.from(Year.of(1985)
+                                                                        .atMonth(Month.JANUARY).atDay(1).atStartOfDay().atOffset(UTC)),
+                                                                Instant.now())))),
+                                defaultSearchOptions()
+                        ),
+                        MFLIX_MOVIES_NS,
+                        asList(
+                                new Accessory(
+                                        asList(limit(1), project(computedSearchMeta("meta")), replaceWith("$meta")),
+                                        Asserters.firstResult((doc, msgSupplier) -> assertEquals(5, doc.getDocument("facet")
+                                                .getDocument("tomatoesMeterFacet").getArray("buckets").size(), msgSupplier))
+                                ),
+                                new Accessory(
+                                        emptyList(),
+                                        Asserters.firstResult((doc, msgSupplier) -> assertEquals(5, doc.getDocument("facet")
+                                                .getDocument("tomatoesMeterFacet").getArray("buckets").size(), msgSupplier))
+                                )
+                        )
+                ),
+                arguments(
+                        "score modifier",
+                        stageCreator(compound()
+                                .should(asList(
+                                        exists(fieldPath("fieldName1"))
+                                                .score(boost(Float.MAX_VALUE / 2)),
+                                        exists(fieldPath("fieldName2"))
+                                                .score(boost(fieldPath("boostFieldName"))),
+                                        exists(fieldPath("fieldName3"))
+                                                .score(boost(fieldPath("boostFieldName"))
+                                                        .undefined(-1)),
+                                        exists(fieldPath("fieldName4"))
+                                                .score(constant(1.2f)),
+                                        exists(fieldPath("fieldName5"))
+                                                .score(function(relevanceExpression())),
+                                        exists(fieldPath("fieldName6"))
+                                                .score(function(pathExpression(fieldPath("expressionFieldName")))),
+                                        exists(fieldPath("fieldName7"))
+                                                .score(function(pathExpression(fieldPath("expressionFieldName"))
+                                                        .undefined(-1))),
+                                        exists(fieldPath("fieldName8"))
+                                                .score(function(constantExpression(-1.2f))),
+                                        exists(fieldPath("fieldName9"))
+                                                .score(function(
+                                                        gaussExpression(-10, pathExpression(fieldPath("gaussianFieldName")), Double.MAX_VALUE / -2))),
+                                        exists(fieldPath("fieldName10"))
+                                                .score(function(
+                                                        gaussExpression(
+                                                                -10,
+                                                                pathExpression(fieldPath("gaussianFieldName"))
+                                                                        .undefined(0),
+                                                                Double.MAX_VALUE / -2)
+                                                        .offset(Double.MAX_VALUE / -2)
+                                                        .decay(Double.MIN_VALUE))),
+                                        exists(fieldPath("fieldName11"))
+                                                .score(function(logExpression(constantExpression(3)))),
+                                        exists(fieldPath("fieldName12"))
+                                                .score(function(log1pExpression(constantExpression(-3)))),
+                                        exists(fieldPath("fieldName13"))
+                                                .score(function(addExpression(asList(
+                                                        logExpression(multiplyExpression(asList(
+                                                                constantExpression(2),
+                                                                constantExpression(3),
+                                                                relevanceExpression()))),
+                                                        gaussExpression(0, pathExpression(fieldPath("gaussianFieldName")), 1)))))
+                                )),
+                                null
+                        ),
+                        MFLIX_MOVIES_NS,
+                        asList(
+                                new Accessory(
+                                        emptyList(),
+                                        Asserters.empty()
+                                ),
+                                new Accessory(
+                                        emptyList(),
+                                        Asserters.nonEmpty()
+                                )
+                        )
+                ),
+                arguments(
+                        "all operators in a `compound` operator",
+                        stageCreator(compound()
+                                .should(asList(
+                                        exists(fieldPath("fieldName1")),
+                                        text("term1", fieldPath("fieldName2"))
+                                                .score(function(logExpression(constantExpression(3)))),
+                                        text(asList("term2", "term3"), asList(wildcardPath("wildc*rd"), fieldPath("fieldName3")))
+                                                .fuzzy(defaultSearchFuzzy()
+                                                        .maxEdits(1)
+                                                        .prefixLength(2)
+                                                        .maxExpansions(3)),
+                                        autocomplete("term4", fieldPath("title")
+                                                // `multi` is used here only to verify that it is tolerated
+                                                .multi("keyword")),
+                                        // this operator produces non-empty search results
+                                        autocomplete(asList("Traffic in", "term5"), fieldPath("title"))
+                                                .fuzzy(defaultSearchFuzzy())
+                                                .sequentialTokenOrder(),
+                                        numberRange(asList(fieldPath("fieldName4"), fieldPath("fieldName5")))
+                                                .gtLt(1, 1.5),
+                                        dateRange(fieldPath("fieldName6"))
+                                                .lte(Instant.ofEpochMilli(1)),
+                                        near(0, 1.5, asList(fieldPath("fieldName7"), fieldPath("fieldName8"))),
+                                        near(Instant.ofEpochMilli(1), Duration.ofMillis(3), fieldPath("fieldName9"))
+                                ))
+                                .minimumShouldMatch(1)
+                                .mustNot(singleton(
+                                        compound().must(singleton(exists(fieldPath("fieldName")))))),
+                                null
+                        ),
+                        MFLIX_MOVIES_NS,
+                        asList(
+                                new Accessory(
+                                        emptyList(),
+                                        Asserters.nonEmpty()
+                                ),
+                                new Accessory(
+                                        emptyList(),
+                                        Asserters.countLowerBound(0)
+                                )
+                        )
+                ),
+                arguments(
+                        "geo operators in a `compound` operator",
+                        stageCreator(compound()
+                                .should(singleton(
+                                        near(
+                                                new Point(new Position(114.15, 22.28)),
+                                                1234.5,
+                                                fieldPath("address.location"))
+                                )),
+                                null
+                        ),
+                        AIRBNB_LISTINGS_AND_REVIEWS_NS,
+                        asList(
+                                new Accessory(
+                                        emptyList(),
+                                        Asserters.nonEmpty()
+                                ),
+                                new Accessory(
+                                        emptyList(),
+                                        Asserters.countLowerBound(0)
+                                )
+                        )
+                )
+        );
+    }
+
+    private static final class Asserters {
+        static Asserter empty() {
+            return decorate((results, msgSupplier) -> assertTrue(results.isEmpty(), msgSupplier));
+        }
+
+        static Asserter nonEmpty() {
+            return decorate((results, msgSupplier) -> assertFalse(results.isEmpty(), msgSupplier));
+        }
+
+        /**
+         * Checks the value of the {@code "score"} field for each result document.
+         */
+        static Asserter score(final double expectedScore) {
+            return decorate((results, msgSupplier) -> {
+                assertFalse(results.isEmpty(), msgSupplier);
+                for (BsonDocument result : results) {
+                    assertEquals(expectedScore, result.getNumber("score").doubleValue(), 0.000_1, msgSupplier);
+                }
+            });
+        }
+
+        /**
+         * Checks the value of the {@code "customMetaField.count.lowerBound"} field.
+         */
+        static Asserter countLowerBound(final String customMetaField, final int expectedAtLeast) {
+            return firstResult((doc, msgSupplier) -> assertTrue(
+                    doc.getDocument(customMetaField).getDocument("count").getNumber("lowerBound").intValue() >= expectedAtLeast, msgSupplier));
+        }
+
+        /**
+         * Checks the value of the {@code "count.lowerBound"} field.
+         */
+        static Asserter countLowerBound(final int expectedAtLeast) {
+            return firstResult((doc, msgSupplier) -> assertTrue(
+                    doc.getDocument("count").getNumber("lowerBound").intValue() >= expectedAtLeast, msgSupplier));
+        }
+
+        /**
+         * Checks the value of the {@code "count.total"} field.
+         */
+        static Asserter countTotal(final int expected) {
+            return firstResult((doc, msgSupplier) -> assertEquals(
+                    expected, doc.getDocument("count").getNumber("total").intValue(), msgSupplier));
+        }
+
+        static Asserter firstResult(final BiConsumer<BsonDocument, Supplier<String>> asserter) {
+            return decorate((results, msgSupplier) -> {
+                assertFalse(results.isEmpty(), msgSupplier);
+                asserter.accept(results.get(0), msgSupplier);
+            });
+        }
+
+        private static Asserter decorate(final Asserter asserter) {
+            int maxRenderedResults = 20;
+            return (results, msgSupplier) -> asserter.accept(
+                    results,
+                    () -> msgSupplier.get()
+                            + "\ntop " + maxRenderedResults + " out of total " + results.size() + " results are\n["
+                            + results.stream()
+                            .map(doc -> doc.toJson(JsonWriterSettings.builder().indent(true).build()))
+                            .limit(maxRenderedResults)
+                            .collect(Collectors.joining(",\n"))
+                            + "\n]\n"
+            );
+        }
+    }
+
+    private static CustomizableSearchStageCreator stageCreator(final Bson operatorOrCollector, @Nullable final SearchOptions options) {
+        return customizer -> customizer.apply(operatorOrCollector, options);
+    }
+
+    @FunctionalInterface
+    private interface CustomizableSearchStageCreator extends Function<BiFunction<Bson, SearchOptions, Bson>, Bson> {
+    }
+
+    @FunctionalInterface
+    private interface Asserter extends BiConsumer<List<BsonDocument>, Supplier<String>> {
+    }
+
+    private static final class Accessory {
+        private final Collection<Bson> postStages;
+        private final BiConsumer<List<BsonDocument>, Supplier<String>> resultAsserter;
+
+        Accessory(
+                final Collection<Bson> postStages,
+                final BiConsumer<List<BsonDocument>, Supplier<String>> resultAsserter) {
+            this.postStages = postStages;
+            this.resultAsserter = resultAsserter;
+        }
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.client.test;
 
+import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ServerCursor;
@@ -23,7 +24,6 @@ import com.mongodb.WriteConcern;
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.IndexOptionDefaults;
 import com.mongodb.client.model.ValidationOptions;
-import com.mongodb.client.model.geojson.codecs.GeoJsonCodecProvider;
 import com.mongodb.internal.binding.AsyncReadWriteBinding;
 import com.mongodb.internal.binding.ReadBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -52,16 +52,10 @@ import org.bson.BsonInt64;
 import org.bson.BsonString;
 import org.bson.Document;
 import org.bson.codecs.BsonDocumentCodec;
-import org.bson.codecs.BsonValueCodecProvider;
 import org.bson.codecs.Codec;
 import org.bson.codecs.Decoder;
 import org.bson.codecs.DocumentCodec;
-import org.bson.codecs.DocumentCodecProvider;
-import org.bson.codecs.IterableCodecProvider;
-import org.bson.codecs.ValueCodecProvider;
-import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
-import org.bson.codecs.jsr310.Jsr310CodecProvider;
 import org.bson.conversions.Bson;
 
 import java.util.ArrayList;
@@ -75,12 +69,7 @@ import static java.util.Collections.singletonList;
 public final class CollectionHelper<T> {
 
     private Codec<T> codec;
-    private CodecRegistry registry = CodecRegistries.fromProviders(new BsonValueCodecProvider(),
-                                                                   new IterableCodecProvider(),
-                                                                   new ValueCodecProvider(),
-                                                                   new DocumentCodecProvider(),
-                                                                   new GeoJsonCodecProvider(),
-                                                                   new Jsr310CodecProvider());
+    private CodecRegistry registry = MongoClientSettings.getDefaultCodecRegistry();
     private MongoNamespace namespace;
 
     public CollectionHelper(final Codec<T> codec, final MongoNamespace namespace) {

--- a/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
@@ -17,6 +17,8 @@
 package com.mongodb.client.model
 
 import com.mongodb.MongoNamespace
+import com.mongodb.client.model.search.SearchCollector
+import com.mongodb.client.model.search.SearchOperator
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.Document
@@ -43,7 +45,6 @@ import static com.mongodb.client.model.Aggregates.addFields
 import static com.mongodb.client.model.Aggregates.bucket
 import static com.mongodb.client.model.Aggregates.bucketAuto
 import static com.mongodb.client.model.Aggregates.count
-import static com.mongodb.client.model.Aggregates.facet
 import static com.mongodb.client.model.Aggregates.graphLookup
 import static com.mongodb.client.model.Aggregates.group
 import static com.mongodb.client.model.Aggregates.limit
@@ -55,6 +56,8 @@ import static com.mongodb.client.model.Aggregates.project
 import static com.mongodb.client.model.Aggregates.replaceRoot
 import static com.mongodb.client.model.Aggregates.replaceWith
 import static com.mongodb.client.model.Aggregates.sample
+import static com.mongodb.client.model.Aggregates.search
+import static com.mongodb.client.model.Aggregates.searchMeta
 import static com.mongodb.client.model.Aggregates.set
 import static com.mongodb.client.model.Aggregates.setWindowFields
 import static com.mongodb.client.model.Aggregates.skip
@@ -73,6 +76,14 @@ import static com.mongodb.client.model.Sorts.descending
 import static com.mongodb.client.model.Windows.Bound.CURRENT
 import static com.mongodb.client.model.Windows.Bound.UNBOUNDED
 import static com.mongodb.client.model.Windows.documents
+import static com.mongodb.client.model.search.SearchCollector.facet
+import static com.mongodb.client.model.search.SearchCount.total
+import static com.mongodb.client.model.search.SearchFacet.stringFacet
+import static com.mongodb.client.model.search.SearchHighlight.paths
+import static com.mongodb.client.model.search.SearchOperator.exists
+import static com.mongodb.client.model.search.SearchOptions.defaultSearchOptions
+import static com.mongodb.client.model.search.SearchPath.fieldPath
+import static com.mongodb.client.model.search.SearchPath.wildcardPath
 import static java.util.Arrays.asList
 import static org.bson.BsonDocument.parse
 
@@ -277,7 +288,7 @@ class AggregatesSpecification extends Specification {
 
     def 'should render $facet'() {
         expect:
-        toBson(facet(
+        toBson(Aggregates.facet(
                 new Facet('Screen Sizes',
                                unwind('$attributes'),
                                match(eq('attributes.name', 'screen size')),
@@ -544,6 +555,188 @@ class AggregatesSpecification extends Specification {
         }''')
     }
 
+    def 'should render $search'() {
+        when:
+        BsonDocument searchDoc = toBson(
+                search(
+                        (SearchOperator) exists(fieldPath('fieldName')),
+                        defaultSearchOptions()
+                )
+        )
+
+        then:
+        searchDoc == parse('''{
+                "$search": {
+                    "exists": { "path": "fieldName" }
+                }
+        }''')
+
+        when:
+        searchDoc = toBson(
+                search(
+                        (SearchCollector) facet(
+                                exists(fieldPath('fieldName')),
+                                [stringFacet('stringFacetName', fieldPath('fieldName1'))]),
+                        defaultSearchOptions()
+                                .index('indexName')
+                                .count(total())
+                                .highlight(paths([
+                                        fieldPath('fieldName1'),
+                                        fieldPath('fieldName2').multi('analyzerName'),
+                                        wildcardPath('field.name*')]))
+                )
+        )
+
+        then:
+        searchDoc == parse('''{
+                "$search": {
+                    "facet": {
+                        "operator": { "exists": { "path": "fieldName" } },
+                        "facets": {
+                            "stringFacetName": { "type" : "string", "path": "fieldName1" }
+                        }
+                    },
+                    "index": "indexName",
+                    "count": { "type": "total" },
+                    "highlight": {
+                        "path": [
+                            "fieldName1",
+                            { "value": "fieldName2", "multi": "analyzerName" },
+                            { "wildcard": "field.name*" }
+                        ]
+                    }
+                }
+        }''')
+    }
+
+    def 'should render $search with no options'() {
+        when:
+        BsonDocument searchDoc = toBson(
+                search(
+                        (SearchOperator) exists(fieldPath('fieldName'))
+                )
+        )
+
+        then:
+        searchDoc == parse('''{
+                "$search": {
+                    "exists": { "path": "fieldName" }
+                }
+        }''')
+
+        when:
+        searchDoc = toBson(
+                search(
+                        (SearchCollector) facet(
+                                exists(fieldPath('fieldName')),
+                                [stringFacet('facetName', fieldPath('fieldName')).numBuckets(3)])
+                )
+        )
+
+        then:
+        searchDoc == parse('''{
+                "$search": {
+                    "facet": {
+                        "operator": { "exists": { "path": "fieldName" } },
+                        "facets": {
+                          "facetName": { "type": "string", "path": "fieldName", "numBuckets": 3 }
+                        }
+                    }
+                }
+        }''')
+    }
+
+    def 'should render $searchMeta'() {
+        when:
+        BsonDocument searchDoc = toBson(
+                searchMeta(
+                        (SearchOperator) exists(fieldPath('fieldName')),
+                        defaultSearchOptions()
+                )
+        )
+
+        then:
+        searchDoc == parse('''{
+                "$searchMeta": {
+                    "exists": { "path": "fieldName" }
+                }
+        }''')
+
+        when:
+        searchDoc = toBson(
+                searchMeta(
+                        (SearchCollector) facet(
+                                exists(fieldPath('fieldName')),
+                                [stringFacet('stringFacetName', fieldPath('fieldName1'))]),
+                        defaultSearchOptions()
+                                .index('indexName')
+                                .count(total())
+                                .highlight(paths([
+                                        fieldPath('fieldName1'),
+                                        fieldPath('fieldName2').multi('analyzerName'),
+                                        wildcardPath('field.name*')]))
+                )
+        )
+
+        then:
+        searchDoc == parse('''{
+                "$searchMeta": {
+                    "facet": {
+                        "operator": { "exists": { "path": "fieldName" } },
+                        "facets": {
+                            "stringFacetName": { "type" : "string", "path": "fieldName1" }
+                        }
+                    },
+                    "index": "indexName",
+                    "count": { "type": "total" },
+                    "highlight": {
+                        "path": [
+                            "fieldName1",
+                            { "value": "fieldName2", "multi": "analyzerName" },
+                            { "wildcard": "field.name*" }
+                        ]
+                    }
+                }
+        }''')
+    }
+
+    def 'should render $searchMeta with no options'() {
+        when:
+        BsonDocument searchDoc = toBson(
+                searchMeta(
+                        (SearchOperator) exists(fieldPath('fieldName'))
+                )
+        )
+
+        then:
+        searchDoc == parse('''{
+                "$searchMeta": {
+                    "exists": { "path": "fieldName" }
+                }
+        }''')
+
+        when:
+        searchDoc = toBson(
+                searchMeta(
+                        (SearchCollector) facet(
+                                exists(fieldPath('fieldName')),
+                                [stringFacet('facetName', fieldPath('fieldName')).numBuckets(3)])
+                )
+        )
+
+        then:
+        searchDoc == parse('''{
+                "$searchMeta": {
+                    "facet": {
+                        "operator": { "exists": { "path": "fieldName" } },
+                        "facets": {
+                          "facetName": { "type": "string", "path": "fieldName", "numBuckets": 3 }
+                        }
+                    }
+                }
+        }''')
+    }
+
     def 'should create string representation for simple stages'() {
         expect:
         match(new BsonDocument('x', new BsonInt32(1))).toString() == 'Stage{name=\'$match\', value={"x": 1}}'
@@ -801,7 +994,7 @@ class AggregatesSpecification extends Specification {
 
     def 'should test equals for FacetStage'() {
         expect:
-        facet(
+        Aggregates.facet(
                 new Facet('Screen Sizes',
                         unwind('$attributes'),
                         match(eq('attributes.name', 'screen size')),
@@ -811,7 +1004,7 @@ class AggregatesSpecification extends Specification {
                         group('$attributes.value', sum('count', 1)),
                         sort(descending('count')),
                         limit(5)))
-                .equals(facet(
+                .equals(Aggregates.facet(
                 new Facet('Screen Sizes',
                         unwind('$attributes'),
                         match(eq('attributes.name', 'screen size')),
@@ -825,7 +1018,7 @@ class AggregatesSpecification extends Specification {
 
     def 'should test hashCode for FacetStage'() {
         expect:
-        facet(
+        Aggregates.facet(
                 new Facet('Screen Sizes',
                         unwind('$attributes'),
                         match(eq('attributes.name', 'screen size')),
@@ -835,7 +1028,7 @@ class AggregatesSpecification extends Specification {
                         group('$attributes.value', sum('count', 1)),
                         sort(descending('count')),
                         limit(5))).hashCode() ==
-                facet(
+                Aggregates.facet(
                 new Facet('Screen Sizes',
                         unwind('$attributes'),
                         match(eq('attributes.name', 'screen size')),

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchCollectorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchCollectorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import org.bson.Document;
+import org.bson.codecs.configuration.CodecConfigurationException;
+import org.junit.jupiter.api.Test;
+
+import static com.mongodb.client.model.search.SearchFacet.combineToBson;
+import static com.mongodb.client.model.search.SearchFacet.numberFacet;
+import static com.mongodb.client.model.search.SearchFacet.stringFacet;
+import static com.mongodb.client.model.search.SearchOperator.exists;
+import static com.mongodb.client.model.search.SearchPath.fieldPath;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class SearchCollectorTest {
+    @Test
+    void of() {
+        assertEquals(
+                docExamplePredefined()
+                        .toBsonDocument(),
+                SearchCollector.of(docExampleCustom())
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void facet() {
+        assertAll(
+                () -> assertThrows(CodecConfigurationException.class, () ->
+                        // facet names must be unique; `BsonCodec` wraps our `IllegalStateException` into `CodecConfigurationException`
+                        SearchCollector.facet(
+                                exists(fieldPath("fieldName")),
+                                asList(
+                                        stringFacet("duplicateFacetName", fieldPath("stringFieldName")),
+                                        numberFacet("duplicateFacetName", fieldPath("numberFieldName"), asList(10, 20, 30))))
+                                // we have to render into `BsonDocument` in order to trigger the lazy check
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        docExampleCustom()
+                                .toBsonDocument(),
+                        docExamplePredefined()
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    private static SearchCollector docExamplePredefined() {
+        return SearchCollector.facet(
+                exists(
+                        fieldPath("fieldName")),
+                asList(
+                        stringFacet(
+                                "stringFacetName",
+                                fieldPath("stringFieldName")),
+                        numberFacet(
+                                "numberFacetName",
+                                fieldPath("numberFieldName"),
+                                asList(10, 20, 30))));
+    }
+
+    private static Document docExampleCustom() {
+        return new Document("facet",
+                new Document("operator", exists(
+                        fieldPath("fieldName")))
+                        .append("facets", combineToBson(asList(
+                                stringFacet(
+                                        "stringFacetName",
+                                        fieldPath("stringFieldName")),
+                                numberFacet(
+                                        "numberFacetName",
+                                        fieldPath("numberFieldName"),
+                                        asList(10, 20, 30))))));
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchCountTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchCountTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class SearchCountTest {
+    @Test
+    void of() {
+        assertEquals(
+                docExamplePredefined()
+                        .toBsonDocument(),
+                SearchCount.of(docExampleCustom())
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void total() {
+        assertAll(
+                () -> assertEquals(
+                        new BsonDocument("type", new BsonString("total")),
+                        SearchCount.total()
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void lowerBound() {
+        assertAll(
+                () -> assertEquals(
+                        docExampleCustom()
+                                .toBsonDocument(),
+                        docExamplePredefined()
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("type", new BsonString("lowerBound"))
+                                .append("threshold", new BsonInt32(123)),
+                        SearchCount.lowerBound()
+                                .threshold(123)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    private static SearchCount docExamplePredefined() {
+        return SearchCount.lowerBound();
+    }
+
+    private static Document docExampleCustom() {
+        return new Document("type", "lowerBound");
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchFacetTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchFacetTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import org.bson.BsonArray;
+import org.bson.BsonDateTime;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.mongodb.client.model.search.SearchPath.fieldPath;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class SearchFacetTest {
+    @Test
+    void of() {
+        assertEquals(
+                docExamplePredefined()
+                        .toBsonDocument(),
+                SearchFacet.of(docExampleCustom())
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void stringFacet() {
+        assertAll(
+                () -> assertEquals(
+                        docExampleCustom()
+                                .toBsonDocument(),
+                        docExamplePredefined()
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("facetName", new BsonDocument("type", new BsonString("string"))
+                                .append("path", new BsonString(fieldPath("fieldName").toValue()))
+                                .append("numBuckets", new BsonInt32(3))),
+                        SearchFacet.stringFacet("facetName",
+                                fieldPath("fieldName")
+                                        // multi must be ignored
+                                        .multi("analyzerName"))
+                                .numBuckets(3)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void numberFacet() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // boundaries must contain at least 2 elements
+                        SearchFacet.numberFacet("facetName",
+                                fieldPath("fieldName"),
+                                singleton(1))
+                ),
+                () -> assertEquals(
+                        new BsonDocument("facetName", new BsonDocument("type", new BsonString("number"))
+                                .append("path", new BsonString(fieldPath("fieldName").toValue()))
+                                .append("boundaries", new BsonArray(asList(
+                                        new BsonInt32(1),
+                                        new BsonInt32(2))))),
+                        SearchFacet.numberFacet("facetName",
+                                fieldPath("fieldName")
+                                        // multi must be ignored
+                                        .multi("analyzerName"),
+                                asList(
+                                        1,
+                                        2))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("facetName", new BsonDocument("type", new BsonString("number"))
+                                .append("path", new BsonString(fieldPath("fieldName").toValue()))
+                                .append("boundaries", new BsonArray(asList(
+                                        new BsonInt32(-1),
+                                        new BsonInt32(0),
+                                        new BsonInt32(1),
+                                        new BsonInt64(2),
+                                        new BsonDouble(3.5),
+                                        new BsonDouble(4.5),
+                                        new BsonInt32(5),
+                                        new BsonInt64(6))))
+                                .append("default", new BsonString("defaultBucketName"))),
+                        SearchFacet.numberFacet("facetName",
+                                fieldPath("fieldName"),
+                                asList(
+                                        (byte) -1,
+                                        (short) 0,
+                                        1,
+                                        2L,
+                                        3.5f,
+                                        4.5d,
+                                        new AtomicInteger(5),
+                                        new AtomicLong(6)))
+                                .defaultBucket("defaultBucketName")
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void dateFacet() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // boundaries must contain at least 2 elements
+                        SearchFacet.dateFacet("facetName",
+                                        fieldPath("fieldName"),
+                                        singleton(Instant.now()))
+                ),
+                () -> assertEquals(
+                        new BsonDocument("facetName", new BsonDocument("type", new BsonString("date"))
+                                .append("path", new BsonString(fieldPath("fieldName").toValue()))
+                                .append("boundaries", new BsonArray(asList(
+                                        new BsonDateTime(0),
+                                        new BsonDateTime(1))))),
+                        SearchFacet.dateFacet("facetName",
+                                fieldPath("fieldName")
+                                        // multi must be ignored
+                                        .multi("analyzerName"),
+                                asList(
+                                        Instant.ofEpochMilli(0),
+                                        Instant.ofEpochMilli(1)))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("facetName", new BsonDocument("type", new BsonString("date"))
+                                .append("path", new BsonString(fieldPath("fieldName").toValue()))
+                                .append("boundaries", new BsonArray(asList(
+                                        new BsonDateTime(0),
+                                        new BsonDateTime(1))))
+                                .append("default", new BsonString("defaultBucketName"))),
+                        SearchFacet.dateFacet("facetName",
+                                fieldPath("fieldName"),
+                                asList(
+                                        Instant.ofEpochMilli(0),
+                                        Instant.ofEpochMilli(1)))
+                                .defaultBucket("defaultBucketName")
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void combineToBson() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // facets must not be empty
+                        SearchFacet.combineToBson(emptyList())
+                ),
+                () -> assertThrows(IllegalStateException.class, () ->
+                        // facet names must be unique
+                        SearchFacet.combineToBson(asList(
+                                        SearchFacet.stringFacet("duplicateFacetName", fieldPath("fieldName1")),
+                                        SearchFacet.numberFacet("duplicateFacetName", fieldPath("fieldName2"), asList(1, 2))))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("facetName", new BsonDocument("type", new BsonString("string"))
+                                .append("path", fieldPath("fieldName").toBsonValue())),
+                        SearchFacet.combineToBson(singleton(SearchFacet.stringFacet("facetName",
+                                        fieldPath("fieldName"))))
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    private static SearchFacet docExamplePredefined() {
+        return SearchFacet.stringFacet("facetName",
+                fieldPath("fieldName"));
+    }
+
+    private static Document docExampleCustom() {
+        return new Document("facetName", new Document("type", "string")
+                .append("path", fieldPath("fieldName").toValue()));
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchFuzzyTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchFuzzyTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class SearchFuzzyTest {
+    @Test
+    void of() {
+        assertAll(
+                () -> assertEquals(
+                        docExamplePredefined()
+                                .toBsonDocument(),
+                        SearchCount.of(docExampleCustom())
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("maxEdits", new BsonInt32(1))
+                                .append("prefixLength", new BsonInt32(5))
+                                .append("maxExpansions", new BsonInt32(10)),
+                        SearchFuzzy.defaultSearchFuzzy()
+                                .maxEdits(1)
+                                .prefixLength(5)
+                                .maxExpansions(10)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void maxEdits() {
+        assertAll(
+                () -> assertEquals(
+                        docExampleCustom()
+                                .toBsonDocument(),
+                        docExamplePredefined()
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("maxEdits", new BsonInt32(1)),
+                        SearchFuzzy.defaultSearchFuzzy()
+                                .maxEdits(1)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void prefixLength() {
+        assertEquals(
+                new BsonDocument()
+                        .append("prefixLength", new BsonInt32(5)),
+                SearchFuzzy.defaultSearchFuzzy()
+                        .prefixLength(5)
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void maxExpansions() {
+        assertEquals(
+                new BsonDocument()
+                        .append("maxExpansions", new BsonInt32(10)),
+                SearchFuzzy.defaultSearchFuzzy()
+                        .maxExpansions(10)
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void defaultSearchFuzzy() {
+        assertEquals(
+                new BsonDocument(),
+                SearchFuzzy.defaultSearchFuzzy()
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void defaultSearchFuzzyIsUnmodifiable() {
+        String expected = SearchFuzzy.defaultSearchFuzzy().toBsonDocument().toJson();
+        SearchFuzzy.defaultSearchFuzzy().maxEdits(1);
+        assertEquals(expected, SearchFuzzy.defaultSearchFuzzy().toBsonDocument().toJson());
+    }
+
+    @Test
+    void defaultSearchFuzzyIsImmutable() {
+        String expected = SearchFuzzy.defaultSearchFuzzy().toBsonDocument().toJson();
+        SearchFuzzy.defaultSearchFuzzy().toBsonDocument().append("maxEdits", new BsonInt32(1));
+        assertEquals(expected, SearchFuzzy.defaultSearchFuzzy().toBsonDocument().toJson());
+    }
+
+    private static SearchFuzzy docExamplePredefined() {
+        return SearchFuzzy.defaultSearchFuzzy().maxEdits(1);
+    }
+
+    private static Document docExampleCustom() {
+        return new Document("maxEdits", new BsonInt32(1));
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchHighlightTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchHighlightTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+import static com.mongodb.client.model.search.SearchPath.fieldPath;
+import static com.mongodb.client.model.search.SearchPath.wildcardPath;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class SearchHighlightTest {
+    @Test
+    void of() {
+        assertEquals(
+                docExamplePredefined()
+                        .toBsonDocument(),
+                SearchCount.of(docExampleCustom())
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void path() {
+        assertEquals(
+                new BsonDocument("path",
+                        fieldPath("fieldName").toBsonValue()),
+                SearchHighlight.path(
+                        fieldPath("fieldName"))
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void paths() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // paths must not be empty
+                        SearchHighlight.paths(emptyList())
+                ),
+                () -> assertEquals(
+                        docExampleCustom()
+                                .toBsonDocument(),
+                        docExamplePredefined()
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("path", new BsonArray(asList(
+                                fieldPath("fieldName").toBsonValue(),
+                                wildcardPath("wildc*rd").toBsonValue()))),
+                        SearchHighlight.paths(asList(
+                                fieldPath("fieldName"),
+                                wildcardPath("wildc*rd")))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("path",
+                                fieldPath("fieldName").toBsonValue())
+                                .append("maxCharsToExamine", new BsonInt32(10)),
+                        SearchHighlight.paths(
+                                singleton(fieldPath("fieldName")))
+                                .maxCharsToExamine(10)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("path",
+                                fieldPath("fieldName").toBsonValue())
+                                .append("maxNumPassages", new BsonInt32(20)),
+                        SearchHighlight.paths(
+                                singleton(fieldPath("fieldName")))
+                                .maxNumPassages(20)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("path",
+                                fieldPath("fieldName").toBsonValue())
+                                .append("maxCharsToExamine", new BsonInt32(10))
+                                .append("maxNumPassages", new BsonInt32(20)),
+                        SearchHighlight.paths(
+                                singleton(fieldPath("fieldName")))
+                                .maxCharsToExamine(10)
+                                .maxNumPassages(20)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    private static SearchHighlight docExamplePredefined() {
+        return SearchHighlight.paths(asList(
+                fieldPath("fieldName"),
+                wildcardPath("wildc*rd")));
+    }
+
+    private static Document docExampleCustom() {
+        return new Document("path", asList(
+                fieldPath("fieldName").toBsonValue(),
+                wildcardPath("wildc*rd").toBsonValue()));
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
@@ -1,0 +1,632 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.model.geojson.Point;
+import com.mongodb.client.model.geojson.Position;
+import org.bson.BsonArray;
+import org.bson.BsonDateTime;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static com.mongodb.client.model.search.SearchFuzzy.defaultSearchFuzzy;
+import static com.mongodb.client.model.search.SearchPath.fieldPath;
+import static com.mongodb.client.model.search.SearchPath.wildcardPath;
+import static com.mongodb.client.model.search.SearchScore.boost;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class SearchOperatorTest {
+    @Test
+    void of() {
+        assertEquals(
+                docExamplePredefined()
+                        .toBsonDocument(),
+                SearchOperator.of(docExampleCustom())
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void compound() {
+        assertAll(
+                // combinations must not be empty
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        SearchOperator.compound().must(emptyList())
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        SearchOperator.compound().mustNot(emptyList())
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        SearchOperator.compound().should(emptyList())
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        SearchOperator.compound().filter(emptyList())
+                ),
+                () -> assertEquals(
+                        new BsonDocument("compound", new BsonDocument()
+                                .append("must", new BsonArray(singletonList(SearchOperator.exists(fieldPath("fieldName1")).toBsonDocument())))
+                                .append("mustNot", new BsonArray(singletonList(SearchOperator.exists(fieldPath("fieldName2"))
+                                        .score(boost(0.1f)).toBsonDocument())))
+                                .append("should", new BsonArray(asList(
+                                        SearchOperator.exists(fieldPath("fieldName3")).toBsonDocument(),
+                                        SearchOperator.exists(fieldPath("fieldName4")).toBsonDocument(),
+                                        SearchOperator.exists(fieldPath("fieldName5")).toBsonDocument())))
+                                .append("filter", new BsonArray(singletonList(SearchOperator.exists(fieldPath("fieldName6")).toBsonDocument())))
+                                .append("minimumShouldMatch", new BsonInt32(1))
+                        ),
+                        SearchOperator.compound()
+                                .must(singleton(SearchOperator.exists(fieldPath("fieldName1"))))
+                                .mustNot(singleton(SearchOperator.exists(fieldPath("fieldName2"))
+                                        .score(boost(0.1f))))
+                                .should(singleton(SearchOperator.exists(fieldPath("fieldName3"))))
+                                // appends to the existing operators combined with the same rule
+                                .should(asList(
+                                        SearchOperator.exists(fieldPath("fieldName4")),
+                                        SearchOperator.exists(fieldPath("fieldName5"))))
+                                .minimumShouldMatch(2)
+                                // overrides the previous value
+                                .minimumShouldMatch(1)
+                                .filter(singleton(SearchOperator.exists(fieldPath("fieldName6"))))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("compound", new BsonDocument(
+                                "filter", new BsonArray(singletonList(
+                                SearchOperator.compound().filter(singleton(
+                                        SearchOperator.exists(fieldPath("fieldName")))).toBsonDocument())))
+                        ),
+                        SearchOperator.compound().filter(singleton(
+                                // nested compound operators are allowed
+                                SearchOperator.compound().filter(singleton(
+                                        SearchOperator.exists(fieldPath("fieldName"))))))
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void exists() {
+        assertAll(
+                () -> assertEquals(
+                        docExampleCustom()
+                                .toBsonDocument(),
+                        docExamplePredefined()
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("exists", new BsonDocument("path", new BsonString(fieldPath("fieldName").toValue()))),
+                        SearchOperator.exists(
+                                fieldPath("fieldName")
+                                        // multi must be ignored
+                                        .multi("analyzerName"))
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void text() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // queries must not be empty
+                        SearchOperator.text(emptyList(), singleton(fieldPath("fieldName")))
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // paths must not be empty
+                        SearchOperator.text(singleton("term"), emptyList())
+                ),
+                () -> assertEquals(
+                        new BsonDocument("text",
+                                new BsonDocument("query", new BsonString("term"))
+                                        .append("path", fieldPath("fieldName").toBsonValue())
+                        ),
+                        SearchOperator.text(
+                                "term",
+                                fieldPath("fieldName"))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("text",
+                                new BsonDocument("query", new BsonArray(asList(
+                                        new BsonString("term1"),
+                                        new BsonString("term2"))))
+                                        .append("path", new BsonArray(asList(
+                                                fieldPath("fieldName").toBsonValue(),
+                                                wildcardPath("wildc*rd").toBsonValue())))
+                        ),
+                        SearchOperator.text(
+                                asList(
+                                        "term1",
+                                        "term2"),
+                                asList(
+                                        fieldPath("fieldName"),
+                                        wildcardPath("wildc*rd")))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("text",
+                                new BsonDocument("query", new BsonString("term"))
+                                        .append("path", fieldPath("fieldName").toBsonValue())
+                                        .append("synonyms", new BsonString("synonymMappingName"))
+                        ),
+                        SearchOperator.text(
+                                        singleton("term"),
+                                        singleton(fieldPath("fieldName")))
+                                .fuzzy(defaultSearchFuzzy())
+                                // synonyms overrides fuzzy
+                                .synonyms("synonymMappingName")
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("text",
+                                new BsonDocument("query", new BsonString("term"))
+                                        .append("path", fieldPath("fieldName").toBsonValue())
+                                        .append("fuzzy", new BsonDocument())
+                        ),
+                        SearchOperator.text(
+                                        singleton("term"),
+                                        singleton(fieldPath("fieldName")))
+                                .synonyms("synonymMappingName")
+                                // fuzzy overrides synonyms
+                                .fuzzy(defaultSearchFuzzy())
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void autocomplete() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // queries must not be empty
+                        SearchOperator.autocomplete(emptyList(), fieldPath("fieldName"))
+                ),
+                () -> assertEquals(
+                        new BsonDocument("autocomplete",
+                                new BsonDocument("query", new BsonString("term"))
+                                        .append("path", fieldPath("fieldName").toBsonValue())
+                        ),
+                        SearchOperator.autocomplete(
+                                "term",
+                                fieldPath("fieldName"))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("autocomplete",
+                                new BsonDocument("query", new BsonArray(asList(
+                                        new BsonString("term1"),
+                                        new BsonString("term2"))))
+                                        .append("path", fieldPath("fieldName").toBsonValue())
+                        ),
+                        SearchOperator.autocomplete(
+                                asList(
+                                        "term1",
+                                        "term2"),
+                                fieldPath("fieldName")
+                                        // multi must be ignored
+                                        .multi("analyzerName"))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("autocomplete",
+                                new BsonDocument("query", new BsonString("term"))
+                                        .append("path", fieldPath("fieldName").toBsonValue())
+                                        .append("fuzzy", new BsonDocument())
+                                        .append("tokenOrder", new BsonString("any"))
+                        ),
+                        SearchOperator.autocomplete(
+                                singleton("term"),
+                                fieldPath("fieldName")
+                                        // multi must be ignored
+                                        .multi("analyzerName"))
+                                .fuzzy(defaultSearchFuzzy())
+                                .sequentialTokenOrder()
+                                // anyTokenOrder overrides sequentialTokenOrder
+                                .anyTokenOrder()
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void numberRange() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // queries must not be empty
+                        SearchOperator.numberRange(emptyList())
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // l must be smaller than u in an open interval
+                        SearchOperator.numberRange(fieldPath("fieldName")).gtLt(0, 0)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // l must be smaller than u in an open interval
+                        SearchOperator.numberRange(fieldPath("fieldName")).gtLt(1, 0)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // l must be smaller than u in a half-open interval
+                        SearchOperator.numberRange(fieldPath("fieldName")).gtLte(0, 0)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // l must be smaller than u in a half-open interval
+                        SearchOperator.numberRange(fieldPath("fieldName")).gtLte(1, 0)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // l must be smaller than u in a half-open interval
+                        SearchOperator.numberRange(fieldPath("fieldName")).gteLt(0, 0)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // l must be smaller than u in a half-open interval
+                        SearchOperator.numberRange(fieldPath("fieldName")).gteLt(1, 0)
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("gt", new BsonDouble(Double.MIN_VALUE))
+                        ),
+                        SearchOperator.numberRange(
+                                singleton(fieldPath("fieldName")
+                                        // multi must be ignored
+                                        .multi("analyzeName")))
+                                .gteLte(-1, 1)
+                                // overrides
+                                .gt(Double.MIN_VALUE)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("lt", new BsonInt32(Integer.MAX_VALUE))
+                        ),
+                        SearchOperator.numberRange(
+                                fieldPath("fieldName")
+                                        // multi must be ignored
+                                        .multi("analyzeName"))
+                                .lt(Integer.MAX_VALUE)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("gte", new BsonDouble(Float.MIN_VALUE))
+                        ),
+                        SearchOperator.numberRange(
+                                fieldPath("fieldName"))
+                                .gte(Float.MIN_VALUE)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("lte", new BsonInt64(Long.MAX_VALUE))
+                        ),
+                        SearchOperator.numberRange(
+                                fieldPath("fieldName"))
+                                .lte(Long.MAX_VALUE)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("gt", new BsonInt32(-1)).append("lt", new BsonInt32(1))
+                        ),
+                        SearchOperator.numberRange(
+                                fieldPath("fieldName"))
+                                .gtLt(-1, 1)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("gte", new BsonInt32(-1)).append("lte", new BsonInt32(1))
+                        ),
+                        SearchOperator.numberRange(
+                                fieldPath("fieldName"))
+                                .gteLte(-1, 1)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("gt", new BsonInt32(-1)).append("lte", new BsonInt32(1))
+                        ),
+                        SearchOperator.numberRange(
+                                fieldPath("fieldName"))
+                                .gtLte(-1, 1)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("gte", new BsonInt32(-1)).append("lt", new BsonInt32(1))
+                        ),
+                        SearchOperator.numberRange(
+                                fieldPath("fieldName"))
+                                .gteLt(-1, 1)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void dateRange() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // queries must not be empty
+                        SearchOperator.dateRange(emptyList())
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // l must be smaller than u in an open interval
+                        SearchOperator.dateRange(fieldPath("fieldName")).gtLt(Instant.EPOCH, Instant.EPOCH)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // l must be smaller than u in an open interval
+                        SearchOperator.dateRange(fieldPath("fieldName")).gtLt(Instant.now(), Instant.EPOCH)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // l must be smaller than u in a half-open interval
+                        SearchOperator.dateRange(fieldPath("fieldName")).gtLte(Instant.EPOCH, Instant.EPOCH)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // l must be smaller than u in a half-open interval
+                        SearchOperator.dateRange(fieldPath("fieldName")).gtLte(Instant.now(), Instant.EPOCH)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // l must be smaller than u in a half-open interval
+                        SearchOperator.dateRange(fieldPath("fieldName")).gteLt(Instant.EPOCH, Instant.EPOCH)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // l must be smaller than u in a half-open interval
+                        SearchOperator.dateRange(fieldPath("fieldName")).gteLt(Instant.now(), Instant.EPOCH)
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("gt", new BsonDateTime(0))
+                        ),
+                        SearchOperator.dateRange(
+                                singleton(fieldPath("fieldName")
+                                        // multi must be ignored
+                                        .multi("analyzeName")))
+                                .gteLte(Instant.ofEpochMilli(-1), Instant.ofEpochMilli(1))
+                                // overrides
+                                .gt(Instant.EPOCH)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("lt", new BsonDateTime(0))
+                        ),
+                        SearchOperator.dateRange(
+                                fieldPath("fieldName")
+                                        // multi must be ignored
+                                        .multi("analyzeName"))
+                                .lt(Instant.EPOCH)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("gte", new BsonDateTime(0))
+                        ),
+                        SearchOperator.dateRange(
+                                fieldPath("fieldName"))
+                                .gte(Instant.EPOCH)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("lte", new BsonDateTime(0))
+                        ),
+                        SearchOperator.dateRange(
+                                fieldPath("fieldName"))
+                                .lte(Instant.EPOCH)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("gt", new BsonDateTime(-1))
+                                        .append("lt", new BsonDateTime(1))
+                        ),
+                        SearchOperator.dateRange(
+                                fieldPath("fieldName"))
+                                .gtLt(
+                                        Instant.ofEpochMilli(-1),
+                                        Instant.ofEpochMilli(1))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("gte", new BsonDateTime(-1))
+                                        .append("lte", new BsonDateTime(1))
+                        ),
+                        SearchOperator.dateRange(
+                                fieldPath("fieldName"))
+                                .gteLte(
+                                        Instant.ofEpochMilli(-1),
+                                        Instant.ofEpochMilli(1))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("gt", new BsonDateTime(-1))
+                                        .append("lte", new BsonDateTime(1))
+                        ),
+                        SearchOperator.dateRange(
+                                fieldPath("fieldName"))
+                                .gtLte(
+                                        Instant.ofEpochMilli(-1),
+                                        Instant.ofEpochMilli(1))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("range",
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("gte", new BsonDateTime(-1))
+                                        .append("lt", new BsonDateTime(1))
+                        ),
+                        SearchOperator.dateRange(
+                                fieldPath("fieldName"))
+                                .gteLt(
+                                        Instant.ofEpochMilli(-1),
+                                        Instant.ofEpochMilli(1))
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void near() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // paths must not be empty
+                        SearchOperator.near(new Point(new Position(0, 0)), 1, emptyList())
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // pivot must be positive
+                        SearchOperator.near(Instant.EPOCH, Duration.ZERO, fieldPath("fieldPath"))
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // pivot must be positive
+                        SearchOperator.near(Instant.EPOCH, Duration.ofMillis(-1), fieldPath("fieldPath"))
+                ),
+                () -> assertEquals(
+                        new BsonDocument("near",
+                                new BsonDocument("origin", new BsonInt32(0))
+                                        .append("path", new BsonString(fieldPath("fieldName1").toValue()))
+                                        .append("pivot", new BsonDouble(1.5))
+                        ),
+                        SearchOperator.near(
+                                0,
+                                1.5,
+                                fieldPath("fieldName1")
+                                        // multi must be ignored
+                                        .multi("analyzeName"))
+                                .toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry())
+                ),
+                () -> assertEquals(
+                        new BsonDocument("near",
+                                new BsonDocument("origin", new BsonDouble(1.5))
+                                        .append("path", new BsonArray(asList(
+                                                new BsonString(fieldPath("fieldName1").toValue()),
+                                                new BsonString(fieldPath("fieldName2").toValue()))))
+                                        .append("pivot", new BsonDouble(1.5))
+                        ),
+                        SearchOperator.near(
+                                1.5,
+                                1.5,
+                                asList(
+                                        fieldPath("fieldName1"),
+                                        fieldPath("fieldName2")))
+                                .toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry())
+                ),
+                () -> assertEquals(
+                        new BsonDocument("near",
+                                new BsonDocument("origin", new BsonDateTime(Instant.EPOCH.toEpochMilli()))
+                                        .append("path", new BsonString(fieldPath("fieldName1").toValue()))
+                                        .append("pivot", new BsonInt64(3))
+                        ),
+                        SearchOperator.near(
+                                Instant.EPOCH,
+                                Duration.ofMillis(3),
+                                fieldPath("fieldName1")
+                                        // multi must be ignored
+                                        .multi("analyzeName"))
+                                .toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry())
+                ),
+                () -> assertEquals(
+                        new BsonDocument("near",
+                                new BsonDocument("origin", new BsonDateTime(Instant.EPOCH.toEpochMilli()))
+                                        .append("path", new BsonArray(asList(
+                                                new BsonString(fieldPath("fieldName1").toValue()),
+                                                new BsonString(fieldPath("fieldName2").toValue()))))
+                                        .append("pivot", new BsonInt64(3))
+                        ),
+                        SearchOperator.near(
+                                Instant.EPOCH,
+                                Duration.ofMillis(3),
+                                asList(
+                                        fieldPath("fieldName1"),
+                                        fieldPath("fieldName2")))
+                                .toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry())
+                ),
+                () -> assertEquals(
+                        new BsonDocument("near",
+                                new BsonDocument("origin", new BsonDocument("type", new BsonString("Point"))
+                                        .append("coordinates", new BsonArray(asList(new BsonDouble(1), new BsonDouble(2)))))
+                                        .append("path", new BsonString(fieldPath("fieldName1").toValue()))
+                                        .append("pivot", new BsonDouble(1.5))
+                        ),
+                        SearchOperator.near(
+                                new Point(
+                                        new Position(1, 2)),
+                                1.5,
+                                fieldPath("fieldName1")
+                                    // multi must be ignored
+                                    .multi("analyzeName"))
+                                .toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry())
+                ),
+                () -> assertEquals(
+                        new BsonDocument("near",
+                                new BsonDocument("origin", new BsonDocument("type", new BsonString("Point"))
+                                        .append("coordinates", new BsonArray(asList(new BsonDouble(1), new BsonDouble(2)))))
+                                        .append("path", new BsonArray(asList(
+                                                new BsonString(fieldPath("fieldName1").toValue()),
+                                                new BsonString(fieldPath("fieldName2").toValue()))))
+                                        .append("pivot", new BsonDouble(1.5))
+                        ),
+                        SearchOperator.near(
+                                new Point(
+                                        new Position(1, 2)),
+                                1.5,
+                                asList(
+                                        fieldPath("fieldName1"),
+                                        fieldPath("fieldName2")))
+                                .toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry())
+                )
+        );
+    }
+
+    private static SearchOperator docExamplePredefined() {
+        return SearchOperator.exists(
+                fieldPath("fieldName"));
+    }
+
+    private static Document docExampleCustom() {
+        return new Document("exists",
+                new Document("path", fieldPath("fieldName").toValue()));
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOptionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOptionsTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import org.bson.BsonArray;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.junit.jupiter.api.Test;
+
+import static com.mongodb.client.model.search.SearchCount.total;
+import static com.mongodb.client.model.search.SearchHighlight.path;
+import static com.mongodb.client.model.search.SearchHighlight.paths;
+import static com.mongodb.client.model.search.SearchPath.fieldPath;
+import static com.mongodb.client.model.search.SearchPath.wildcardPath;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class SearchOptionsTest {
+    @Test
+    void defaultSearchOptions() {
+        assertEquals(
+                new BsonDocument(),
+                SearchOptions.defaultSearchOptions()
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void option() {
+        assertAll(
+                () -> assertEquals(
+                        SearchOptions.defaultSearchOptions()
+                                .index("indexName")
+                                .toBsonDocument(),
+                        SearchOptions.defaultSearchOptions()
+                                .option("index", new BsonString("indexName"))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        SearchOptions.defaultSearchOptions()
+                                .option("index", "indexName")
+                                .toBsonDocument(),
+                        SearchOptions.defaultSearchOptions()
+                                .option("index", new BsonString("indexName"))
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void index() {
+        assertEquals(
+                new BsonDocument()
+                        .append("index", new BsonString("indexName")),
+                SearchOptions.defaultSearchOptions()
+                        .index("indexName")
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void highlight() {
+        assertAll(
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("highlight", new BsonDocument()
+                                        .append("path", wildcardPath("wildc*rd").toBsonValue())),
+                        SearchOptions.defaultSearchOptions()
+                                .highlight(
+                                        path(wildcardPath("wildc*rd")))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("highlight", new BsonDocument()
+                                        .append("path", new BsonArray(asList(
+                                                wildcardPath("wildc*rd").toBsonValue(),
+                                                fieldPath("fieldName").toBsonValue())))),
+                        SearchOptions.defaultSearchOptions()
+                                .highlight(
+                                        paths(asList(
+                                                wildcardPath("wildc*rd"),
+                                                fieldPath("fieldName"))))
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void count() {
+        assertEquals(
+                new BsonDocument()
+                        .append("count", total().toBsonDocument()),
+                SearchOptions.defaultSearchOptions()
+                        .count(total())
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void returnStoredSource() {
+        assertEquals(
+                new BsonDocument()
+                        .append("returnStoredSource", new BsonBoolean(true)),
+                SearchOptions.defaultSearchOptions()
+                        .returnStoredSource(true)
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void options() {
+        assertEquals(
+                new BsonDocument()
+                        .append("index", new BsonString("indexName"))
+                        .append("name", new BsonArray(singletonList(new BsonString("value"))))
+                        .append("highlight", new BsonDocument()
+                                .append("path", fieldPath("fieldName").toBsonValue()))
+                        .append("count", total().toBsonDocument())
+                        .append("returnStoredSource", new BsonBoolean(true)),
+                SearchOptions.defaultSearchOptions()
+                        .index("indexName")
+                        .option("name", new BsonArray(singletonList(new BsonString("value"))))
+                        .highlight(
+                                path(fieldPath("fieldName")))
+                        .count(total())
+                        .returnStoredSource(true)
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void defaultSearchOptionsIsUnmodifiable() {
+        String expected = SearchOptions.defaultSearchOptions().toBsonDocument().toJson();
+        SearchOptions.defaultSearchOptions().option("name", "value");
+        assertEquals(expected, SearchOptions.defaultSearchOptions().toBsonDocument().toJson());
+    }
+
+    @Test
+    void defaultSearchOptionsIsImmutable() {
+        String expected = SearchOptions.defaultSearchOptions().toBsonDocument().toJson();
+        SearchOptions.defaultSearchOptions().toBsonDocument().append("name", new BsonString("value"));
+        assertEquals(expected, SearchOptions.defaultSearchOptions().toBsonDocument().toJson());
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchPathTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchPathTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class SearchPathTest {
+    @Test
+    void fieldPath() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // path must not contain '*'
+                        SearchPath.fieldPath("wildc*rd")
+                ),
+                () -> assertEquals(
+                        new BsonString("fieldName"),
+                        SearchPath.fieldPath("fieldName")
+                                .toBsonValue()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("value", new BsonString("fieldName"))
+                                .append("multi", new BsonString("analyzerName")),
+                        SearchPath.fieldPath("fieldName")
+                                .multi("analyzerName")
+                                .toBsonValue()
+                )
+        );
+    }
+
+    @Test
+    void wildcardPath() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // wildcardPath must contain '*'
+                        SearchPath.wildcardPath("wildcard")
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // wildcardPath must not contain '**'
+                        SearchPath.wildcardPath("wildc**rd")
+                ),
+                () -> assertEquals(
+                        new BsonDocument("wildcard", new BsonString("wildc*rd")),
+                        SearchPath.wildcardPath("wildc*rd")
+                                .toBsonValue()
+                )
+        );
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchScoreExpressionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchScoreExpressionTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+import static com.mongodb.client.model.search.SearchPath.fieldPath;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class SearchScoreExpressionTest {
+    @Test
+    void of() {
+        assertEquals(
+                docExamplePredefined()
+                        .toBsonDocument(),
+                SearchCount.of(docExampleCustom())
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void relevanceExpression() {
+        assertEquals(
+                new BsonDocument("score", new BsonString("relevance")),
+                SearchScoreExpression.relevanceExpression()
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void pathExpression() {
+        assertAll(
+                () -> assertEquals(
+                        docExampleCustom()
+                                .toBsonDocument(),
+                        docExamplePredefined()
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("path",
+                                new BsonDocument("value", new BsonString(fieldPath("fieldName").toValue()))
+                                        .append("undefined", new BsonDouble(-1.5))),
+                        SearchScoreExpression.pathExpression(
+                                fieldPath("fieldName")
+                                        // multi must be ignored
+                                        .multi("analyzerName"))
+                                .undefined(-1.5f)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void constantExpression() {
+        assertEquals(
+                new BsonDocument("constant", new BsonDouble(-1.5)),
+                SearchScoreExpression.constantExpression(-1.5f)
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void gaussExpression() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // scale must not be 0
+                        SearchScoreExpression.gaussExpression(0, SearchScoreExpression.pathExpression(fieldPath("fieldName")), 0)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // decay must be positive
+                        SearchScoreExpression.gaussExpression(0, SearchScoreExpression.pathExpression(fieldPath("fieldName")), 1)
+                                .decay(-1)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // decay must be positive
+                        SearchScoreExpression.gaussExpression(0, SearchScoreExpression.pathExpression(fieldPath("fieldName")), 1)
+                                .decay(0)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // decay must be less than 1
+                        SearchScoreExpression.gaussExpression(0, SearchScoreExpression.pathExpression(fieldPath("fieldName")), 1)
+                                .decay(1)
+                ),
+                () -> assertEquals(
+                        new BsonDocument("gauss",
+                                new BsonDocument("origin", new BsonDouble(50))
+                                        .append("path", SearchScoreExpression.pathExpression(
+                                                fieldPath("fieldName"))
+                                                .toBsonDocument().values().iterator().next())
+                                        .append("scale", new BsonDouble(1))),
+                        SearchScoreExpression.gaussExpression(
+                                50,
+                                SearchScoreExpression.pathExpression(
+                                        fieldPath("fieldName")),
+                                1)
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("gauss",
+                                new BsonDocument("origin", new BsonDouble(50))
+                                        .append("path", SearchScoreExpression.pathExpression(
+                                                fieldPath("fieldName"))
+                                                .undefined(-1.5f)
+                                                .toBsonDocument().values().iterator().next())
+                                .append("scale", new BsonDouble(1))
+                                .append("offset", new BsonDouble(0))
+                                .append("decay", new BsonDouble(0.5))
+                        ),
+                        SearchScoreExpression.gaussExpression(
+                                50,
+                                SearchScoreExpression.pathExpression(
+                                        fieldPath("fieldName"))
+                                        .undefined(-1.5f),
+                                1)
+                                .offset(0)
+                                .decay(0.5)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void logExpression() {
+        assertEquals(
+                new BsonDocument("log",
+                        SearchScoreExpression.constantExpression(3).toBsonDocument()),
+                SearchScoreExpression.logExpression(
+                        SearchScoreExpression.constantExpression(3))
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void log1pExpression() {
+        assertEquals(
+                new BsonDocument("log1p",
+                        SearchScoreExpression.constantExpression(3).toBsonDocument()),
+                SearchScoreExpression.log1pExpression(
+                        SearchScoreExpression.constantExpression(3))
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void addExpression() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // expressions must contain at least 2 elements
+                        SearchScoreExpression.addExpression(singleton(SearchScoreExpression.constantExpression(1)))
+                ),
+                () -> assertEquals(
+                        new BsonDocument("add", new BsonArray(asList(
+                                SearchScoreExpression.constantExpression(1.5f).toBsonDocument(),
+                                SearchScoreExpression.relevanceExpression().toBsonDocument()))),
+                        SearchScoreExpression.addExpression(asList(
+                                SearchScoreExpression.constantExpression(1.5f),
+                                SearchScoreExpression.relevanceExpression()))
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void multiplyExpression() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // expressions must contain at least 2 elements
+                        SearchScoreExpression.multiplyExpression(singleton(SearchScoreExpression.constantExpression(1)))
+                ),
+                () -> assertEquals(
+                        new BsonDocument("multiply", new BsonArray(asList(
+                                SearchScoreExpression.constantExpression(1.5f).toBsonDocument(),
+                                SearchScoreExpression.relevanceExpression().toBsonDocument()))),
+                        SearchScoreExpression.multiplyExpression(asList(
+                                        SearchScoreExpression.constantExpression(1.5f),
+                                        SearchScoreExpression.relevanceExpression()))
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    private static SearchScoreExpression docExamplePredefined() {
+        return SearchScoreExpression.pathExpression(
+                fieldPath("fieldName"))
+                .undefined(-1.5f);
+    }
+
+    private static Document docExampleCustom() {
+        return new Document("path",
+                new Document("value", fieldPath("fieldName").toValue())
+                        .append("undefined", -1.5));
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchScoreTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchScoreTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.search;
+
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+import static com.mongodb.client.model.search.SearchPath.fieldPath;
+import static com.mongodb.client.model.search.SearchScoreExpression.constantExpression;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class SearchScoreTest {
+    @Test
+    void of() {
+        assertEquals(
+                docExamplePredefined()
+                        .toBsonDocument(),
+                SearchCount.of(docExampleCustom())
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void valueBoost() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // value must be positive
+                        SearchScore.boost(0f)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // value must be positive
+                        SearchScore.boost(-1f)
+                ),
+                () -> assertEquals(
+                        new BsonDocument("boost",
+                                new BsonDocument("value", new BsonDouble(0.5))),
+                        SearchScore.boost(0.5f)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void pathBoost() {
+        assertAll(
+                () -> assertEquals(
+                        docExampleCustom()
+                                .toBsonDocument(),
+                        docExamplePredefined()
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("boost",
+                                new BsonDocument("path",
+                                        new BsonString(fieldPath("fieldName").toValue()))
+                                        .append("undefined", new BsonDouble(1))),
+                        SearchScore.boost(
+                                fieldPath("fieldName")
+                                        // multi must be ignored
+                                        .multi("analyzerName"))
+                                .undefined(1f)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void constant() {
+        assertAll(
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // value must be positive
+                        SearchScore.constant(0f)
+                ),
+                () -> assertThrows(IllegalArgumentException.class, () ->
+                        // value must be positive
+                        SearchScore.constant(-1f)
+                ),
+                () -> assertEquals(
+                        new BsonDocument("constant",
+                                new BsonDocument("value", new BsonDouble(0.5))),
+                        SearchScore.constant(0.5f)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void function() {
+        assertEquals(
+                new BsonDocument("function",
+                        constantExpression(1.5f).toBsonDocument()),
+                SearchScore.function(
+                        constantExpression(1.5f))
+                        .toBsonDocument()
+        );
+    }
+
+    private static SearchScore docExamplePredefined() {
+        return SearchScore.boost(
+                fieldPath("fieldName"));
+    }
+
+    private static Document docExampleCustom() {
+        return new Document("boost",
+                new Document("path", fieldPath("fieldName").toValue()));
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/client/model/AbstractConstructibleBsonElementTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/client/model/AbstractConstructibleBsonElementTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.client.model;
+
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class AbstractConstructibleBsonElementTest {
+    @Test
+    void unmodifiable() {
+        Bson value = new BsonDocument("n", new BsonString("v"));
+        AbstractConstructibleBsonElement<?> constructible = AbstractConstructibleBsonElement.of("name", value);
+        String expected = constructible.toBsonDocument().toJson();
+        constructible.newWithAppendedValue("name2", value);
+        assertEquals(expected, constructible.toBsonDocument().toJson());
+    }
+
+    @Test
+    void emptyIsImmutable() {
+        AbstractConstructibleBsonElement<?> constructible = AbstractConstructibleBsonElement.of("name", new BsonDocument());
+        String expected = constructible.toBsonDocument().toJson();
+        constructible.toBsonDocument().getDocument("name").append("n", new BsonString("v"));
+        assertEquals(expected, constructible.toBsonDocument().toJson());
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/client/model/AbstractConstructibleBsonTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/client/model/AbstractConstructibleBsonTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.client.model;
+
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class AbstractConstructibleBsonTest {
+    @Test
+    void unmodifiable() {
+        AbstractConstructibleBson<?> constructible = AbstractConstructibleBson.of(new BsonDocument("name", new BsonString("value")));
+        String expected = constructible.toBsonDocument().toJson();
+        constructible.newAppended("name2", "value2");
+        assertEquals(expected, constructible.toBsonDocument().toJson());
+    }
+
+    @Test
+    void emptyIsImmutable() {
+        AbstractConstructibleBson<?> constructible = AbstractConstructibleBson.of(new BsonDocument());
+        String expected = constructible.toBsonDocument().toJson();
+        constructible.toBsonDocument().append("name2", new BsonString("value2"));
+        assertEquals(expected, constructible.toBsonDocument().toJson());
+    }
+}

--- a/driver-scala/build.gradle
+++ b/driver-scala/build.gradle
@@ -53,7 +53,10 @@ tasks.withType(Test) {
 tasks.withType(ScalaCompile) {
     if(scalaVersion.startsWith("2.11")) {
         // Better support SAM style closures in scala 2.11
-        scalaCompileOptions.additionalParameters = ["-Xexperimental"]
+        scalaCompileOptions.additionalParameters.addAll([
+                // Better support SAM style closures in scala 2.11
+                "-Xexperimental"
+        ])
     }
 }
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
@@ -22,6 +22,7 @@ import scala.collection.JavaConverters._
 import com.mongodb.client.model.{ Aggregates => JAggregates }
 import org.mongodb.scala.MongoNamespace
 import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.search.{ SearchCollector, SearchOperator, SearchOptions }
 
 /**
  * Builders for aggregation pipeline stages.
@@ -474,11 +475,147 @@ object Aggregates {
    * @since 4.3
    * @note Requires MongoDB 5.0 or greater.
    */
-  @Beta
+  @Beta(Array(Beta.Reason.SERVER))
   def setWindowFields[TExpression >: Null](
       partitionBy: Option[TExpression],
       sortBy: Option[Bson],
       output: WindowedComputation*
   ): Bson =
     JAggregates.setWindowFields(partitionBy.orNull, sortBy.orNull, output.asJava)
+
+  /**
+   * Creates a `\$search` pipeline stage supported by MongoDB Atlas.
+   * You may use the `\$meta: "searchScore"` expression, e.g., via [[Projections.metaSearchScore]],
+   * to extract the relevance score assigned to each found document.
+   *
+   * `Filters.text(String, TextSearchOptions)` is a legacy text search alternative.
+   *
+   * @param operator A search operator.
+   * @return The `\$search` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/ Scoring]]
+   * @since 4.7
+   */
+  def search(operator: SearchOperator): Bson =
+    JAggregates.search(operator)
+
+  /**
+   * Creates a `\$search` pipeline stage supported by MongoDB Atlas.
+   * You may use the `\$meta: "searchScore"` expression, e.g., via [[Projections.metaSearchScore]],
+   * to extract the relevance score assigned to each found document.
+   *
+   * `Filters.text(String, TextSearchOptions)` is a legacy text search alternative.
+   *
+   * @param operator A search operator.
+   * @param options Optional `\$search` pipeline stage fields.
+   * Specifying `SearchOptions.defaultSearchOptions` is equivalent to calling `Aggregates.search(SearchOperator)`.
+   * @return The `\$search` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/ Scoring]]
+   * @since 4.7
+   */
+  def search(operator: SearchOperator, options: SearchOptions): Bson =
+    JAggregates.search(operator, options)
+
+  /**
+   * Creates a `\$search` pipeline stage supported by MongoDB Atlas.
+   * You may use the `\$meta: "searchScore"` expression, e.g., via [[Projections.metaSearchScore]],
+   * to extract the relevance score assigned to each found document.
+   *
+   * `Filters.text(String, TextSearchOptions)` is a legacy text search alternative.
+   *
+   * @param collector A search collector.
+   * @return The `\$search` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/ Scoring]]
+   * @since 4.7
+   */
+  def search(collector: SearchCollector): Bson =
+    JAggregates.search(collector)
+
+  /**
+   * Creates a `\$search` pipeline stage supported by MongoDB Atlas.
+   * You may use the `\$meta: "searchScore"` expression, e.g., via [[Projections.metaSearchScore]],
+   * to extract the relevance score assigned to each found document.
+   *
+   * `Filters.text(String, TextSearchOptions)` is a legacy text search alternative.
+   *
+   * @param collector A search collector.
+   * @param options Optional `\$search` pipeline stage fields.
+   * Specifying `SearchOptions.defaultSearchOptions` is equivalent to calling `Aggregates.search(SearchCollector)`.
+   * @return The `\$search` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/ Scoring]]
+   * @since 4.7
+   */
+  def search(collector: SearchCollector, options: SearchOptions): Bson =
+    JAggregates.search(collector, options)
+
+  /**
+   * Creates a `\$searchMeta` pipeline stage supported by MongoDB Atlas.
+   * Unlike `\$search`, it does not return found documents,
+   * instead it returns metadata, which in case of using the `\$search` stage
+   * may be extracted by using `$$SEARCH_META` variable, e.g., via [[Projections.computedSearchMeta]].
+   *
+   * @param operator A search operator.
+   * @return The `\$searchMeta` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-searchmeta \$searchMeta]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
+   * @since 4.7
+   */
+  def searchMeta(operator: SearchOperator): Bson =
+    JAggregates.searchMeta(operator)
+
+  /**
+   * Creates a `\$searchMeta` pipeline stage supported by MongoDB Atlas.
+   * Unlike `\$search`, it does not return found documents,
+   * instead it returns metadata, which in case of using the `\$search` stage
+   * may be extracted by using `$$SEARCH_META` variable, e.g., via [[Projections.computedSearchMeta]].
+   *
+   * @param operator A search operator.
+   * @param options Optional `\$search` pipeline stage fields.
+   * Specifying `SearchOptions.defaultSearchOptions` is equivalent to calling `Aggregates.searchMeta(SearchOperator)`.
+   * @return The `\$searchMeta` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-searchmeta \$searchMeta]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
+   * @since 4.7
+   */
+  def searchMeta(operator: SearchOperator, options: SearchOptions): Bson =
+    JAggregates.searchMeta(operator, options)
+
+  /**
+   * Creates a `\$searchMeta` pipeline stage supported by MongoDB Atlas.
+   * Unlike `\$search`, it does not return found documents,
+   * instead it returns metadata, which in case of using the `\$search` stage
+   * may be extracted by using `$$SEARCH_META` variable, e.g., via [[Projections.computedSearchMeta]].
+   *
+   * @param collector A search collector.
+   * @return The `\$searchMeta` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-searchmeta \$searchMeta]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]
+   * @since 4.7
+   */
+  def searchMeta(collector: SearchCollector): Bson =
+    JAggregates.searchMeta(collector)
+
+  /**
+   * Creates a `\$searchMeta` pipeline stage supported by MongoDB Atlas.
+   * Unlike `\$search`, it does not return found documents,
+   * instead it returns metadata, which in case of using the `\$search` stage
+   * may be extracted by using `$$SEARCH_META` variable, e.g., via [[Projections.computedSearchMeta]].
+   *
+   * @param collector A search collector.
+   * @param options Optional `\$search` pipeline stage fields.
+   * Specifying `SearchOptions.defaultSearchOptions` is equivalent to calling `Aggregates.searchMeta(SearchCollector)`.
+   * @return The `\$searchMeta` pipeline stage.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-searchmeta \$searchMeta]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]
+   * @since 4.7
+   */
+  def searchMeta(collector: SearchCollector, options: SearchOptions): Bson =
+    JAggregates.searchMeta(collector, options)
 }

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Filters.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Filters.scala
@@ -318,6 +318,10 @@ object Filters {
 
   /**
    * Creates a filter that matches all documents matching the given search term.
+   * You may use [[Projections.metaTextScore]] to extract the relevance score assigned to each matched document.
+   *
+   * `Aggregates.search(SearchOperator, SearchOptions)` / `Aggregates.search(SearchCollector, SearchOptions)`
+   * is a more powerful full-text search alternative.
    *
    * @param search the search term
    * @return the filter
@@ -327,6 +331,10 @@ object Filters {
 
   /**
    * Creates a filter that matches all documents matching the given search term using the given language.
+   * You may use [[Projections.metaTextScore]] to extract the relevance score assigned to each matched document.
+   *
+   * `Aggregates.search(SearchOperator, SearchOptions)` / `Aggregates.search(SearchCollector, SearchOptions)`
+   * is a more powerful full-text search alternative.
    *
    * @param search   the search term
    * @param textSearchOptions the text search options to use

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Projections.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Projections.scala
@@ -39,10 +39,24 @@ object Projections {
    * @param  expression   the expression
    * @tparam TExpression  the expression type
    * @return the projection
+   * @see [[Projections.computedSearchMeta]]
    * @see Aggregates#project(Bson)
    */
   def computed[TExpression](fieldName: String, expression: TExpression): Bson =
     JProjections.computed(fieldName, expression)
+
+  /**
+   * Creates a projection of a field whose value is equal to the `$$SEARCH_META` variable,
+   * for use with `Aggregates.search(SearchOperator, SearchOptions)` / `Aggregates.search(SearchCollector, SearchOptions)`.
+   * Calling this method is equivalent to calling [[Projections.computed]] with `"$$SEARCH_META"` as the second argument.
+   *
+   * @param fieldName the field name
+   * @return the projection
+   * @see [[org.mongodb.scala.model.search.SearchCount]]
+   * @see [[org.mongodb.scala.model.search.SearchCollector]]
+   */
+  def computedSearchMeta(fieldName: String): Bson =
+    JProjections.computedSearchMeta(fieldName)
 
   /**
    * Creates a projection that includes all of the given fields.
@@ -95,19 +109,47 @@ object Projections {
    * @param fieldName the field name
    * @param metaFieldName the meta field name
    * @return the projection
-   * @see [[https://www.mongodb.com/docs/manual/reference/operator/projection/meta/#projection meta]]
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/meta/ meta]]
+   * @see [[Projections.metaTextScore]]
+   * @see [[Projections.metaSearchScore]]
+   * @see [[Projections.metaSearchHighlights]]
    * @since 4.1
    */
   def meta(fieldName: String, metaFieldName: String): Bson = JProjections.meta(fieldName, metaFieldName)
 
   /**
    * Creates a projection to the given field name of the textScore, for use with text queries.
+   * Calling this method is equivalent to calling [[Projections.meta]] with `"textScore"` as the second argument.
    *
    * @param fieldName the field name
    * @return the projection
-   * @see [[https://www.mongodb.com/docs/manual/reference/operator/projection/meta/#projection textScore]]
+   * @see `Filters.text(String, TextSearchOptions)`
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/meta/#text-score-metadata--meta---textscore- textScore]]
    */
   def metaTextScore(fieldName: String): Bson = JProjections.metaTextScore(fieldName)
+
+  /**
+   * Creates a projection to the given field name of the searchScore,
+   * for use with `Aggregates.search(SearchOperator, SearchOptions)` / `Aggregates.search(SearchCollector, SearchOptions)`.
+   * Calling this method is equivalent to calling [[Projections.meta]] with `"searchScore"` as the second argument.
+   *
+   * @param fieldName the field name
+   * @return the projection
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/ Scoring]]
+   */
+  def metaSearchScore(fieldName: String): Bson = JProjections.metaSearchScore(fieldName)
+
+  /**
+   * Creates a projection to the given field name of the searchHighlights,
+   * for use with `Aggregates.search(SearchOperator, SearchOptions)` / `Aggregates.search(SearchCollector, SearchOptions)`.
+   * Calling this method is equivalent to calling [[Projections.meta]] with `"searchHighlights"` as the second argument.
+   *
+   * @param fieldName the field name
+   * @return the projection
+   * @see [[org.mongodb.scala.model.search.SearchHighlight]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/highlighting/ Highlighting]]
+   */
+  def metaSearchHighlights(fieldName: String): Bson = JProjections.metaSearchHighlights(fieldName)
 
   /**
    * Creates a projection to the given field name of a slice of the array value of that field.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Sorts.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Sorts.scala
@@ -55,7 +55,8 @@ object Sorts {
    *
    * @param fieldName the field name
    * @return the sort specification
-   * @see [[https://www.mongodb.com/docs/manual/reference/operator/projection/meta/#sort textScore]]
+   * @see Filters.text(String, TextSearchOptions)
+   * @see [[https://docs.mongodb.com/manual/reference/operator/aggregation/meta/#text-score-metadata--meta---textscore- textScore]]
    */
   def metaTextScore(fieldName: String): Bson = JSorts.metaTextScore(fieldName)
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
@@ -38,7 +38,7 @@ import com.mongodb.client.model.{ MongoTimeUnit => JMongoTimeUnit, WindowedCompu
  * @since 4.3
  * @note Requires MongoDB 5.0 or greater.
  */
-@Beta
+@Beta(Array(Beta.Reason.SERVER))
 object WindowedComputations {
 
   /**

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Windows.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Windows.scala
@@ -56,7 +56,7 @@ import org.mongodb.scala.bson.conversions.Bson
  * @since 4.3
  * @note Requires MongoDB 5.0 or greater.
  */
-@Beta
+@Beta(Array(Beta.Reason.SERVER))
 object Windows {
 
   /**
@@ -248,7 +248,7 @@ object Windows {
    * @since 4.3
    * @note Requires MongoDB 5.0 or greater.
    */
-  @Beta
+  @Beta(Array(Beta.Reason.SERVER))
   object Bound {
 
     /**

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/package.scala
@@ -873,7 +873,7 @@ package object model {
    * @since 4.3
    * @note Requires MongoDB 5.0 or greater.
    */
-  @Beta
+  @Beta(Array(Beta.Reason.SERVER))
   object MongoTimeUnit {
 
     val YEAR = JMongoTimeUnit.YEAR
@@ -902,7 +902,7 @@ package object model {
    * @see [[Windows]]
    * @since 4.3
    */
-  @Beta
+  @Beta(Array(Beta.Reason.SERVER))
   type Window = com.mongodb.client.model.Window
 
   /**
@@ -912,7 +912,7 @@ package object model {
    * @see [[WindowedComputations]]
    * @since 4.3
    */
-  @Beta
+  @Beta(Array(Beta.Reason.SERVER))
   type WindowedComputation = com.mongodb.client.model.WindowedComputation
 }
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchCollector.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchCollector.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.search
+
+import com.mongodb.annotations.Beta
+import com.mongodb.client.model.search.{ SearchCollector => JSearchCollector }
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.Projections
+
+import scala.collection.JavaConverters._
+
+/**
+ * The core part of the `\$search` pipeline stage of an aggregation pipeline.
+ * `SearchCollector`s allow returning metadata together with the matching search results.
+ * You may use the `$$SEARCH_META` variable, e.g., via [[Projections.computedSearchMeta]], to extract this metadata.
+ *
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]
+ * @since 4.7
+ */
+@Beta(Array(Beta.Reason.CLIENT))
+object SearchCollector {
+
+  /**
+   * Returns a `SearchCollector` that groups results by values or ranges in the specified faceted fields and returns the count
+   * for each of those groups.
+   *
+   * @param operator The search operator to use.
+   * @param facets The non-empty facet definitions.
+   * @return The requested `SearchCollector`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/facet/ facet collector]]
+   */
+  @Beta(Array(Beta.Reason.CLIENT, Beta.Reason.SERVER))
+  def facet(operator: SearchOperator, facets: Iterable[_ <: SearchFacet]): FacetSearchCollector =
+    JSearchCollector.facet(operator, facets.asJava)
+
+  /**
+   * Creates a `SearchCollector` from a `Bson` in situations when there is no builder method that better satisfies your needs.
+   * This method cannot be used to validate the syntax.
+   *
+   * <i>Example</i><br>
+   * The following code creates two functionally equivalent `SearchCollector`s,
+   * though they may not be equal.
+   * {{{
+   *  val collector1: SearchCollector = SearchCollector.facet(
+   *    SearchOperator.exists(
+   *      SearchPath.fieldPath("fieldName")),
+   *    Seq(
+   *      SearchFacet.stringFacet(
+   *        "stringFacetName",
+   *        SearchPath.fieldPath("stringFieldName")),
+   *      SearchFacet.numberFacet(
+   *        "numberFacetName",
+   *        SearchPath.fieldPath("numberFieldName"),
+   *        Seq(10, 20, 30))))
+   *  val collector2: SearchCollector = SearchCollector.of(Document("facet" ->
+   *    Document("operator" -> SearchOperator.exists(
+   *      SearchPath.fieldPath("fieldName")).toBsonDocument,
+   *      "facets" -> SearchFacet.combineToBson(Seq(
+   *        SearchFacet.stringFacet(
+   *          "stringFacetName",
+   *          SearchPath.fieldPath("stringFieldName")),
+   *        SearchFacet.numberFacet(
+   *          "numberFacetName",
+   *          SearchPath.fieldPath("numberFieldName"),
+   *          Seq(10, 20, 30)))).toBsonDocument)))
+   * }}}
+   *
+   * @param collector A `Bson` representing the required `SearchCollector`.
+   *
+   * @return The requested `SearchCollector`.
+   */
+  def of(collector: Bson): SearchCollector = JSearchCollector.of(collector)
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchCount.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchCount.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.search
+
+import com.mongodb.annotations.Beta
+import com.mongodb.client.model.search.{ SearchCount => JSearchCount }
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.Projections
+
+/**
+ * Counting options.
+ * You may use the `$$SEARCH_META` variable, e.g., via [[Projections.computedSearchMeta]],
+ * to extract the results of counting.
+ *
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/counting/ Counting]]
+ * @since 4.7
+ */
+@Beta(Array(Beta.Reason.CLIENT, Beta.Reason.SERVER))
+object SearchCount {
+
+  /**
+   * Returns a `SearchCount` that instructs to count documents exactly.
+   *
+   * @return The requested `SearchCount`.
+   */
+  def total(): TotalSearchCount = JSearchCount.total()
+
+  /**
+   * Returns a `SearchCount` that instructs to count documents exactly only up to
+   * `LowerBoundSearchCount.threshold`.
+   *
+   * @return The requested `SearchCount`.
+   */
+  def lowerBound(): LowerBoundSearchCount = JSearchCount.lowerBound()
+
+  /**
+   * Creates a `SearchCount` from a `Bson` in situations when there is no builder method that better satisfies your needs.
+   * This method cannot be used to validate the syntax.
+   *
+   * <i>Example</i><br>
+   * The following code creates two functionally equivalent `SearchCount`s,
+   * though they may not be equal.
+   * {{{
+   *  val count1: SearchCount = SearchCount.lowerBound()
+   *  val count2: SearchCount = SearchCount.of(Document("type" -> "lowerBound"))
+   * }}}
+   *
+   * @param count A `Bson` representing the required `SearchCount`.
+   *
+   * @return The requested `SearchCount`.
+   */
+  def of(count: Bson): SearchCount = JSearchCount.of(count)
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchFacet.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchFacet.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.search
+
+import com.mongodb.annotations.Beta
+import com.mongodb.client.model.search.{ SearchFacet => JSearchFacet }
+import org.mongodb.scala.bson.conversions.Bson
+
+import java.time.Instant
+import collection.JavaConverters._
+
+/**
+ * A facet definition for [[FacetSearchCollector]].
+ *
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/facet/#facet-definition Facet definition]]
+ * @since 4.7
+ */
+@Beta(Array(Beta.Reason.CLIENT, Beta.Reason.SERVER))
+object SearchFacet {
+
+  /**
+   * Returns a `SearchFacet` that allows narrowing down search results based on the most frequent
+   * BSON `String` values of the specified field.
+   *
+   * @param name The facet name.
+   * @param path The field to facet on.
+   * @return The requested `SearchFacet`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/facet/#string-facets String facet definition]]
+   */
+  def stringFacet(name: String, path: FieldSearchPath): StringSearchFacet = JSearchFacet.stringFacet(name, path)
+
+  /**
+   * Returns a `SearchFacet` that allows determining the frequency of
+   * BSON `32-bit integer` / `64-bit integer` / `Double` values
+   * in the search results by breaking the results into separate ranges.
+   *
+   * @param name The facet name.
+   * @param path The path to facet on.
+   * @param boundaries Bucket boundaries in ascending order. Must contain at least two boundaries.
+   * @return The requested `SearchFacet`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/facet/#numeric-facets Numeric facet definition]]
+   */
+  def numberFacet(name: String, path: FieldSearchPath, boundaries: Iterable[Number]): NumberSearchFacet =
+    JSearchFacet.numberFacet(name, path, boundaries.asJava)
+
+  /**
+   * Returns a `SearchFacet` that allows determining the frequency of BSON `Date` values
+   * in the search results by breaking the results into separate ranges.
+   *
+   * @param name The facet name.
+   * @param path The path to facet on.
+   * @param boundaries Bucket boundaries in ascending order. Must contain at least two boundaries.
+   * @return The requested `SearchFacet`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/facet/#date-facets Date facet definition]]
+   * @see `org.bson.codecs.jsr310.InstantCodec`
+   */
+  def dateFacet(name: String, path: FieldSearchPath, boundaries: Iterable[Instant]): DateSearchFacet =
+    JSearchFacet.dateFacet(name, path, boundaries.asJava)
+
+  /**
+   * Creates a `SearchFacet` from a `Bson` in situations when there is no builder method that better satisfies your needs.
+   * This method cannot be used to validate the syntax.
+   *
+   * <i>Example</i><br>
+   * The following code creates two functionally equivalent `SearchFacet`s,
+   * though they may not be equal.
+   * {{{
+   *  val facet1: SearchFacet = SearchFacet.stringFacet("facetName",
+   *    SearchPath.fieldPath("fieldName"))
+   *  val facet2: SearchFacet = SearchFacet.of(Document("facetName" -> Document("type" -> "string",
+   *    "path" -> SearchPath.fieldPath("fieldName").toValue)))
+   * }}}
+   *
+   * @param facet A `Bson` representing the required `SearchFacet`.
+   *
+   * @return The requested `SearchFacet`.
+   */
+  def of(facet: Bson): SearchFacet = JSearchFacet.of(facet)
+
+  /**
+   * Combines `SearchFacet`s into a `Bson`.
+   *
+   * This method may be useful when using [[SearchCollector.of]].
+   *
+   * @param facets The non-empty facet definitions to combine.
+   * @return A `Bson` representing combined `facets`.
+   */
+  def combineToBson(facets: Iterable[_ <: SearchFacet]): Bson =
+    JSearchFacet.combineToBson(facets.asJava)
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchFuzzy.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchFuzzy.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.search
+
+import com.mongodb.annotations.Beta
+import com.mongodb.client.model.search.{ SearchFuzzy => JSearchFuzzy }
+import org.mongodb.scala.bson.conversions.Bson
+
+/**
+ * Fuzzy search options that may be used with some `SearchOperator`s.
+ *
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/ autocomplete operator]]
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/text/ text operator]]
+ * @since 4.7
+ */
+@Beta(Array(Beta.Reason.CLIENT))
+object SearchFuzzy {
+
+  /**
+   * Creates a `SearchFuzzy` from a `Bson` in situations when there is no builder method that better satisfies your needs.
+   * This method cannot be used to validate the syntax.
+   *
+   * <i>Example</i><br>
+   * The following code creates two functionally equivalent `SearchFuzzy`s,
+   * though they may not be equal.
+   * {{{
+   *  val fuzzy1: SearchFuzzy = SearchFuzzy.defaultSearchFuzzy().maxEdits(1)
+   *  val fuzzy2: SearchFuzzy = SearchFuzzy.of(Document("maxEdits" -> 1))
+   * }}}
+   *
+   * @param fuzzy A `Bson` representing the required `SearchFuzzy`.
+   *
+   * @return The requested `SearchFuzzy`.
+   */
+  def of(fuzzy: Bson): SearchFuzzy = JSearchFuzzy.of(fuzzy)
+
+  /**
+   * Returns `SearchFuzzy` that represents server defaults.
+   *
+   * @return `SearchFuzzy` that represents server defaults.
+   */
+  def defaultSearchFuzzy(): SearchFuzzy = JSearchFuzzy.defaultSearchFuzzy()
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchHighlight.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchHighlight.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.search
+
+import com.mongodb.annotations.Beta
+import com.mongodb.client.model.search.{ SearchHighlight => JSearchHighlight }
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.Projections
+
+import collection.JavaConverters._
+
+/**
+ * Highlighting options.
+ * You may use the `\$meta: "searchHighlights"` expression, e.g., via [[Projections.metaSearchHighlights]],
+ * to extract the results of highlighting.
+ *
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/highlighting/ Highlighting]]
+ * @since 4.7
+ */
+@Beta(Array(Beta.Reason.CLIENT))
+object SearchHighlight {
+
+  /**
+   * Returns a `SearchHighlight` for the given `path`.
+   *
+   * @param path The field to be searched.
+   * @return The requested `SearchHighlight`.
+   */
+  def path(path: SearchPath): SearchHighlight = JSearchHighlight.path(path)
+
+  /**
+   * Returns a `SearchHighlight` for the given `paths`.
+   *
+   * @param paths The non-empty fields to be searched.
+   * @return The requested `SearchHighlight`.
+   */
+  def paths(paths: Iterable[_ <: SearchPath]): SearchHighlight = JSearchHighlight.paths(paths.asJava)
+
+  /**
+   * Creates a `SearchHighlight` from a `Bson` in situations when there is no builder method that better satisfies your needs.
+   * This method cannot be used to validate the syntax.
+   *
+   * <i>Example</i><br>
+   * The following code creates two functionally equivalent `SearchHighlight`s,
+   * though they may not be equal.
+   * {{{
+   *  val highlight1: SearchHighlight = SearchHighlight.paths(Seq(
+   *    SearchPath.fieldPath("fieldName"),
+   *    SearchPath.wildcardPath("wildc*rd")))
+   *  val highlight2: SearchHighlight = SearchHighlight.of(Document("path" -> Seq(
+   *    SearchPath.fieldPath("fieldName").toBsonValue,
+   *    SearchPath.wildcardPath("wildc*rd").toBsonValue)))
+   * }}}
+   *
+   * @param highlight A `Bson` representing the required `SearchHighlight`.
+   *
+   * @return The requested `SearchHighlight`.
+   */
+  def of(highlight: Bson): SearchHighlight = JSearchHighlight.of(highlight)
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.search
+
+import com.mongodb.annotations.Beta
+import com.mongodb.client.model.search.{ SearchOperator => JSearchOperator }
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.geojson.Point
+
+import java.time.{ Duration, Instant }
+import collection.JavaConverters._
+
+/**
+ * The core part of the `\$search` pipeline stage of an aggregation pipeline.
+ *
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
+ * @since 4.7
+ */
+@Beta(Array(Beta.Reason.CLIENT))
+object SearchOperator {
+
+  /**
+   * Returns a base for a `SearchOperator` that may combine multiple `SearchOperator`s.
+   * Combining `SearchOperator`s affects calculation of the relevance score.
+   *
+   * @return A base for a `CompoundSearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/compound/ compound operator]]
+   */
+  def compound(): CompoundSearchOperatorBase = JSearchOperator.compound()
+
+  /**
+   * Returns a `SearchOperator` that tests if the `path` exists in a document.
+   *
+   * @param path The path to test.
+   * @return The requested `SearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/exists/ exists operator]]
+   */
+  def exists(path: FieldSearchPath): ExistsSearchOperator = JSearchOperator.exists(path)
+
+  /**
+   * Returns a `SearchOperator` that performs a full-text search.
+   *
+   * @param query The string to search for.
+   * @param path The field to be searched.
+   * @return The requested `SearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/text/ text operator]]
+   */
+  def text(query: String, path: SearchPath): TextSearchOperator = JSearchOperator.text(query, path)
+
+  /**
+   * Returns a `SearchOperator` that performs a full-text search.
+   *
+   * @param queries The non-empty strings to search for.
+   * @param paths The non-empty fields to be searched.
+   * @return The requested `SearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/text/ text operator]]
+   */
+  def text(queries: Iterable[String], paths: Iterable[_ <: SearchPath]): TextSearchOperator =
+    JSearchOperator.text(queries.asJava, paths.asJava)
+
+  /**
+   * Returns a `SearchOperator` that may be used to implement search-as-you-type functionality.
+   *
+   * @param query The string to search for.
+   * @param path The field to be searched.
+   * @return The requested `SearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/ autocomplete operator]]
+   */
+  def autocomplete(query: String, path: FieldSearchPath): AutocompleteSearchOperator =
+    JSearchOperator.autocomplete(query, path)
+
+  /**
+   * Returns a `SearchOperator` that may be used to implement search-as-you-type functionality.
+   *
+   * @param queries The non-empty strings to search for.
+   * @param path The field to be searched.
+   * @return The requested `SearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/ autocomplete operator]]
+   */
+  def autocomplete(queries: Iterable[String], path: FieldSearchPath): AutocompleteSearchOperator =
+    JSearchOperator.autocomplete(queries.asJava, path)
+
+  /**
+   * Returns a base for a `SearchOperator` that tests if the
+   * BSON `32-bit integer` / `64-bit integer` / `Double` values
+   * of the specified field are within an interval.
+   *
+   * @param path The field to be searched.
+   * @return A base for a `NumberRangeSearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/range/ range operator]]
+   */
+  def numberRange(path: FieldSearchPath): NumberRangeSearchOperatorBase = JSearchOperator.numberRange(path)
+
+  /**
+   * Returns a base for a `SearchOperator` that tests if the
+   * BSON `32-bit integer` / `64-bit integer` / `Double` values
+   * of the specified fields are within an interval.
+   *
+   * @param paths The non-empty fields to be searched.
+   * @return A base for a `NumberRangeSearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/range/ range operator]]
+   */
+  def numberRange(paths: Iterable[_ <: FieldSearchPath]): NumberRangeSearchOperatorBase =
+    JSearchOperator.numberRange(paths.asJava)
+
+  /**
+   * Returns a base for a `SearchOperator` that tests if the
+   * BSON `Date` values of the specified field are within an interval.
+   *
+   * @param path The field to be searched.
+   * @return A base for a `DateRangeSearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/range/ range operator]]
+   */
+  def dateRange(path: FieldSearchPath): DateRangeSearchOperatorBase = JSearchOperator.dateRange(path)
+
+  /**
+   * Returns a base for a `SearchOperator` that tests if the
+   * BSON `Date` values of the specified fields are within an interval.
+   *
+   * @param paths The non-empty fields to be searched.
+   * @return A base for a `DateRangeSearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/range/ range operator]]
+   */
+  def dateRange(paths: Iterable[_ <: FieldSearchPath]): DateRangeSearchOperatorBase =
+    JSearchOperator.dateRange(paths.asJava)
+
+  /**
+   * Returns a `SearchOperator` that allows finding results that are near the specified `origin`.
+   *
+   * @param origin The origin from which the proximity of the results is measured.
+   * The relevance score is 1 if the values of the fields are `origin`.
+   * @param pivot The positive distance from the `origin` at which the relevance score drops in half.
+   * @param path The field to be searched.
+   * @return The requested `SearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/near/ near operator]]
+   */
+  def near(origin: Number, pivot: Number, path: FieldSearchPath): NumberNearSearchOperator =
+    JSearchOperator.near(origin, pivot, path)
+
+  /**
+   * Returns a `SearchOperator` that allows finding results that are near the specified `origin`.
+   *
+   * @param origin The origin from which the proximity of the results is measured.
+   * The relevance score is 1 if the values of the fields are `origin`.
+   * @param pivot The positive distance from the `origin` at which the relevance score drops in half.
+   * @param paths The non-empty fields to be searched.
+   * @return The requested `SearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/near/ near operator]]
+   */
+  def near(origin: Number, pivot: Number, paths: Iterable[_ <: FieldSearchPath]): NumberNearSearchOperator =
+    JSearchOperator.near(origin, pivot, paths.asJava)
+
+  /**
+   * Returns a `SearchOperator` that allows finding results that are near the specified `origin`.
+   *
+   * @param origin The origin from which the proximity of the results is measured.
+   * The relevance score is 1 if the values of the fields are `origin`.
+   * @param pivot The positive distance from the `origin` at which the relevance score drops in half.
+   * Data is extracted via `Duration.toMillis`.
+   * @param path The field to be searched.
+   * @return The requested `SearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/near/ near operator]]
+   * @see `org.bson.codecs.jsr310.InstantCodec`
+   */
+  def near(origin: Instant, pivot: Duration, path: FieldSearchPath): DateNearSearchOperator =
+    JSearchOperator.near(origin, pivot, path)
+
+  /**
+   * Returns a `SearchOperator` that allows finding results that are near the specified `origin`.
+   *
+   * @param origin The origin from which the proximity of the results is measured.
+   * The relevance score is 1 if the values of the fields are `origin`.
+   * @param pivot The positive distance from the `origin` at which the relevance score drops in half.
+   * Data is extracted via `Duration.toMillis`.
+   * @param paths The non-empty fields to be searched.
+   * It is converted to `long` via `Duration.toMillis`.
+   * @return The requested `SearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/near/ near operator]]
+   * @see `org.bson.codecs.jsr310.InstantCodec`
+   */
+  def near(origin: Instant, pivot: Duration, paths: Iterable[_ <: FieldSearchPath]): DateNearSearchOperator =
+    JSearchOperator.near(origin, pivot, paths.asJava)
+
+  /**
+   * Returns a `SearchOperator` that allows finding results that are near the specified `origin`.
+   *
+   * @param origin The origin from which the proximity of the results is measured.
+   * The relevance score is 1 if the values of the fields are `origin`.
+   * @param pivot The positive distance in meters from the `origin` at which the relevance score drops in half.
+   * @param path The field to be searched.
+   * @return The requested `SearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/near/ near operator]]
+   */
+  def near(origin: Point, pivot: Number, path: FieldSearchPath): GeoNearSearchOperator =
+    JSearchOperator.near(origin, pivot, path)
+
+  /**
+   * Returns a `SearchOperator` that allows finding results that are near the specified `origin`.
+   *
+   * @param origin The origin from which the proximity of the results is measured.
+   * The relevance score is 1 if the values of the fields are `origin`.
+   * @param pivot The positive distance in meters from the `origin` at which the relevance score drops in half.
+   * @param paths The non-empty fields to be searched.
+   * @return The requested `SearchOperator`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/near/ near operator]]
+   */
+  def near(origin: Point, pivot: Number, paths: Iterable[_ <: FieldSearchPath]): GeoNearSearchOperator =
+    JSearchOperator.near(origin, pivot, paths.asJava)
+
+  /**
+   * Creates a `SearchOperator` from a `Bson` in situations when there is no builder method that better satisfies your needs.
+   * This method cannot be used to validate the syntax.
+   *
+   * <i>Example</i><br>
+   * The following code creates two functionally equivalent `SearchOperator`s,
+   * though they may not be equal.
+   * {{{
+   *  val operator1: SearchOperator = SearchOperator.exists(
+   *    SearchPath.fieldPath("fieldName"))
+   *  val operator2: SearchOperator = SearchOperator.of(Document("exists" ->
+   *    Document("path" -> SearchPath.fieldPath("fieldName").toValue)))
+   * }}}
+   *
+   * @param operator A `Bson` representing the required `SearchOperator`.
+   *
+   * @return The requested `SearchOperator`.
+   */
+  def of(operator: Bson): SearchOperator = JSearchOperator.of(operator)
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOptions.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOptions.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.search
+
+import com.mongodb.annotations.Beta
+import com.mongodb.client.model.search.{ SearchOptions => JSearchOptions }
+
+/**
+ * Represents optional fields of the `\$search` pipeline stage of an aggregation pipeline.
+ *
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search syntax]]
+ * @since 4.7
+ */
+@Beta(Array(Beta.Reason.CLIENT))
+object SearchOptions {
+
+  /**
+   * Returns `SearchOptions` that represents server defaults.
+   *
+   * @return `SearchOptions` that represents server defaults.
+   */
+  def defaultSearchOptions(): SearchOptions = JSearchOptions.defaultSearchOptions()
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchPath.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchPath.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.search
+
+import com.mongodb.annotations.Beta
+import com.mongodb.client.model.search.{ SearchPath => JSearchPath }
+
+/**
+ * A specification of fields to be searched.
+ *
+ * Depending on the context, one of the following methods may be used to get a representation of a `SearchPath`
+ * with the correct syntax: `SearchPath.toBsonDocument`, `SearchPath.toBsonValue`, `FieldSearchPath.toValue`.
+ *
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/path-construction/ Path]]
+ * @since 4.7
+ */
+@Beta(Array(Beta.Reason.CLIENT))
+object SearchPath {
+
+  /**
+   * Returns a `SearchPath` for the given `path`.
+   *
+   * @param path The name of the field. Must not contain [[SearchPath.wildcardPath wildcard]] characters.
+   * @return The requested `SearchPath`.
+   * @see [[https://www.mongodb.com/docs/manual/core/document/#dot-notation Dot notation]]
+   */
+  def fieldPath(path: String): FieldSearchPath = JSearchPath.fieldPath(path)
+
+  /**
+   * Returns a `SearchPath` for the given `wildcardPath`.
+   *
+   * @param wildcardPath The specification of the fields that contains wildcard (`'*'`) characters.
+   * Must not contain `'**'`.
+   * @return The requested `SearchPath`.
+   * @see [[https://www.mongodb.com/docs/manual/core/document/#dot-notation Dot notation]]
+   */
+  def wildcardPath(wildcardPath: String): WildcardSearchPath = JSearchPath.wildcardPath(wildcardPath)
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchScore.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchScore.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.search
+
+import com.mongodb.annotations.Beta
+import com.mongodb.client.model.search.{ SearchScore => JSearchScore }
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.Projections
+
+/**
+ * A modifier of the relevance score.
+ * You may use the `\$meta: "searchScore"` expression, e.g., via [[Projections.metaSearchScore]],
+ * to extract the relevance score assigned to each found document.
+ *
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/ Scoring]]
+ * @since 4.7
+ */
+@Beta(Array(Beta.Reason.CLIENT))
+object SearchScore {
+
+  /**
+   * Returns a `SearchScore` that instructs to multiply the score by the specified `value`.
+   *
+   * @param value The positive value to multiply the score by.
+   * @return The requested `SearchScore`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/#boost boost score modifier]]
+   */
+  def boost(value: Float): ValueBoostSearchScore = JSearchScore.boost(value)
+
+  /**
+   * Returns a `SearchScore` that instructs to multiply the score by the value of the specified field.
+   *
+   * @param path The numeric field whose value to multiply the score by.
+   * @return The requested `SearchScore`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/#boost boost score modifier]]
+   * @see [[SearchScoreExpression.pathExpression]]
+   */
+  def boost(path: FieldSearchPath): PathBoostSearchScore = JSearchScore.boost(path)
+
+  /**
+   * Returns a `SearchScore` that instructs to replace the score with the specified `value`.
+   *
+   * @param value The positive value to replace the score with.
+   * @return The requested `SearchScore`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/#constant constant score modifier]]
+   * @see [[SearchScoreExpression.constantExpression]]
+   */
+  def constant(value: Float): ConstantSearchScore = JSearchScore.constant(value)
+
+  /**
+   * Returns a `SearchScore` that instructs to compute the score using the specified `expression`.
+   *
+   * @param expression The expression to use when calculating the score.
+   * @return The requested `SearchScore`.
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/#function function score modifier]]
+   */
+  def function(expression: SearchScoreExpression): FunctionSearchScore = JSearchScore.function(expression)
+
+  /**
+   * Creates a `SearchScore` from a `Bson` in situations when there is no builder method that better satisfies your needs.
+   * This method cannot be used to validate the syntax.
+   *
+   * <i>Example</i><br>
+   * The following code creates two functionally equivalent `SearchScore`s,
+   * though they may not be equal.
+   * {{{
+   *  val score1: SearchScore = SearchScore.boost(
+   *    SearchPath.fieldPath("fieldName"))
+   *  val score2: SearchScore = SearchScore.of(Document("boost" ->
+   *    Document("path" -> SearchPath.fieldPath("fieldName").toValue)))
+   * }}}
+   *
+   * @param score A `Bson` representing the required `SearchScore`.
+   *
+   * @return The requested `SearchScore`.
+   */
+  def of(score: Bson): SearchScore = JSearchScore.of(score)
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchScoreExpression.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchScoreExpression.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.search
+
+import com.mongodb.annotations.Beta
+import com.mongodb.client.model.search.{ SearchScoreExpression => JSearchScoreExpression }
+import org.mongodb.scala.bson.conversions.Bson
+
+import collection.JavaConverters._
+
+/**
+ * @see [[SearchScore.function]]
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/#expressions Expressions for the function score modifier]]
+ * @since 4.7
+ */
+@Beta(Array(Beta.Reason.CLIENT))
+object SearchScoreExpression {
+
+  /**
+   * Returns a `SearchScoreExpression` that evaluates into the relevance score of a document.
+   *
+   * @return The requested `SearchScoreExpression`.
+   */
+  def relevanceExpression(): RelevanceSearchScoreExpression = JSearchScoreExpression.relevanceExpression()
+
+  /**
+   * Returns a `SearchScoreExpression` that evaluates into the value of the specified field.
+   *
+   * @param path The numeric field whose value to use as the result of the expression.
+   * @return The requested `SearchScoreExpression`.
+   * @see `SearchScore.boost(FieldSearchPath)`
+   */
+  def pathExpression(path: FieldSearchPath): PathSearchScoreExpression = JSearchScoreExpression.pathExpression(path)
+
+  /**
+   * Returns a `SearchScoreExpression` that evaluates into the specified `value`.
+   *
+   * @param value The value to use as the result of the expression. Unlike [[SearchScore.constant]], does not have constraints.
+   * @return The requested `SearchScoreExpression`.
+   * @see [[SearchScore.constant]]
+   */
+  def constantExpression(value: Float): ConstantSearchScoreExpression = JSearchScoreExpression.constantExpression(value)
+
+  /**
+   * Returns a `SearchScoreExpression` that represents a Gaussian function whose output is within the interval [0, 1].
+   * Roughly speaking, the further the value of the `path` expression is from the `origin`,
+   * the smaller the output of the function.
+   *
+   * The `scale` and `decay` are parameters of the Gaussian function,
+   * they define the rate at which the function decays.
+   * The input of the Gaussian function is the output of another function:
+   * max(0, abs(`pathValue` - `origin`) - `offset`),
+   * where `pathValue` is the value of the `path` expression.
+   *
+   * @param origin The point of origin, see `GaussSearchScoreExpression.offset`.
+   * The value of the Gaussian function is 1 if the value of the `path` expression is `origin`.
+   * @param path The expression whose value is used to calculate the input of the Gaussian function.
+   * @param scale The non-zero distance from the points `origin` ± `offset`
+   * at which the output of the Gaussian function must decay by the factor of `decay`.
+   * @return The requested `SearchScoreExpression`.
+   */
+  def gaussExpression(origin: Double, path: PathSearchScoreExpression, scale: Double): GaussSearchScoreExpression =
+    JSearchScoreExpression.gaussExpression(origin, path, scale)
+
+  /**
+   * Returns a `SearchScoreExpression` that evaluates into log10(`expressionValue`),
+   * where `expressionValue` is the value of the `expression`.
+   *
+   * @param expression The expression whose value is the input of the log10 function.
+   * @return The requested `SearchScoreExpression`.
+   */
+  def logExpression(expression: SearchScoreExpression): LogSearchScoreExpression =
+    JSearchScoreExpression.logExpression(expression)
+
+  /**
+   * Returns a `SearchScoreExpression` that evaluates into log10(`expressionValue` + 1),
+   * where `expressionValue` is the value of the `expression`.
+   *
+   * @param expression The expression whose value is used to calculate the input of the log10 function.
+   * @return The requested `SearchScoreExpression`.
+   */
+  def log1pExpression(expression: SearchScoreExpression): Log1pSearchScoreExpression =
+    JSearchScoreExpression.log1pExpression(expression)
+
+  /**
+   * Returns a `SearchScoreExpression` that evaluates into the sum of the values of the specified `expressions`.
+   *
+   * @param expressions The expressions whose values to add. Must contain at least two expressions.
+   * @return The requested `SearchScoreExpression`.
+   */
+  def addExpression(expressions: Iterable[_ <: SearchScoreExpression]): AddSearchScoreExpression =
+    JSearchScoreExpression.addExpression(expressions.asJava)
+
+  /**
+   * Returns a `SearchScoreExpression` that evaluates into the product of the values of the specified `expressions`.
+   *
+   * @param expressions The expressions whose values to multiply. Must contain at least two expressions.
+   * @return The requested `SearchScoreExpression`.
+   */
+  def multiplyExpression(expressions: Iterable[_ <: SearchScoreExpression]): MultiplySearchScoreExpression =
+    JSearchScoreExpression.multiplyExpression(expressions.asJava)
+
+  /**
+   * Creates a `SearchScoreExpression` from a `Bson` in situations when there is no builder method
+   * that better satisfies your needs.
+   * This method cannot be used to validate the syntax.
+   *
+   * <i>Example</i><br>
+   * The following code creates two functionally equivalent `SearchScoreExpression`s,
+   * though they may not be equal.
+   * {{{
+   *  val expression1: SearchScoreExpression = SearchScoreExpression.pathExpression(
+   *    SearchPath.fieldPath("fieldName"))
+   *    .undefined(-1.5f)
+   *  val expression2: SearchScoreExpression = SearchScoreExpression.of(Document("path" ->
+   *    Document("value" -> SearchPath.fieldPath("fieldName").toValue,
+   *      "undefined" -> -1.5)))
+   * }}}
+   *
+   * @param expression A `Bson` representing the required `SearchScoreExpression`.
+   *
+   * @return The requested `SearchScoreExpression`.
+   */
+  def of(expression: Bson): SearchScoreExpression = JSearchScoreExpression.of(expression)
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/package.scala
@@ -1,0 +1,416 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model
+
+import com.mongodb.annotations.{ Beta, Evolving }
+
+/**
+ * Query building API for MongoDB Atlas full-text search.
+ *
+ * While all the building blocks of this API, such as
+ * `SearchOptions`, `SearchHighlight`, etc.,
+ * are not necessary immutable, they are unmodifiable due to methods like
+ * `SearchHighlight.maxCharsToExamine` returning new instances instead of modifying the instance
+ * on which they are called. This allows storing and using such instances as templates.
+ *
+ * @see `Aggregates.search`
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/ Atlas Search]]
+ * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/ Atlas Search aggregation pipeline stages]]
+ * @since 4.7
+ */
+package object search {
+
+  /**
+   * The core part of the `\$search` pipeline stage of an aggregation pipeline.
+   *
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type SearchOperator = com.mongodb.client.model.search.SearchOperator
+
+  /**
+   * A base for a [[CompoundSearchOperator]] which allows creating instances of this operator.
+   * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+   *
+   * @see `SearchOperator.compound()`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type CompoundSearchOperatorBase = com.mongodb.client.model.search.CompoundSearchOperatorBase
+
+  /**
+   * @see `SearchOperator.compound()`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type CompoundSearchOperator = com.mongodb.client.model.search.CompoundSearchOperator
+
+  /**
+   * A representation of a [[CompoundSearchOperator]] that allows changing
+   * `must`-specific options, if any.
+   * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+   *
+   * @see `CompoundSearchOperatorBase.must(Iterable)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type MustCompoundSearchOperator = com.mongodb.client.model.search.MustCompoundSearchOperator
+
+  /**
+   * A representation of a [[CompoundSearchOperator]] that allows changing
+   * `mustNot`-specific options, if any.
+   * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+   *
+   * @see `CompoundSearchOperatorBase.mustNot(Iterable)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type MustNotCompoundSearchOperator = com.mongodb.client.model.search.MustNotCompoundSearchOperator
+
+  /**
+   * A representation of a [[CompoundSearchOperator]] that allows changing
+   * `should`-specific options, if any.
+   * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+   *
+   * @see `CompoundSearchOperatorBase.should(Iterable)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type ShouldCompoundSearchOperator = com.mongodb.client.model.search.ShouldCompoundSearchOperator
+
+  /**
+   * A representation of a [[CompoundSearchOperator]] that allows changing
+   * `filter`-specific options, if any.
+   * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+   *
+   * @see `CompoundSearchOperatorBase.filter(Iterable)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type FilterCompoundSearchOperator = com.mongodb.client.model.search.FilterCompoundSearchOperator
+
+  /**
+   * @see `SearchOperator.exists(FieldSearchPath)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type ExistsSearchOperator = com.mongodb.client.model.search.ExistsSearchOperator
+
+  /**
+   * @see `SearchOperator.text(String, SearchPath)`
+   * @see `SearchOperator.text(Iterable, Iterable)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type TextSearchOperator = com.mongodb.client.model.search.TextSearchOperator
+
+  /**
+   * @see `SearchOperator.autocomplete(String, FieldSearchPath)`
+   * @see `SearchOperator.autocomplete(Iterable, FieldSearchPath)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type AutocompleteSearchOperator = com.mongodb.client.model.search.AutocompleteSearchOperator
+
+  /**
+   * A base for a [[NumberRangeSearchOperatorBase]] which allows creating instances of this operator.
+   * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+   *
+   * @see `SearchOperator.numberRange`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type NumberRangeSearchOperatorBase = com.mongodb.client.model.search.NumberRangeSearchOperatorBase
+
+  /**
+   * A base for a [[DateRangeSearchOperatorBase]] which allows creating instances of this operator.
+   * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
+   *
+   * @see `SearchOperator.dateRange`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type DateRangeSearchOperatorBase = com.mongodb.client.model.search.DateRangeSearchOperatorBase
+
+  /**
+   * @see `SearchOperator.numberRange`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type NumberRangeSearchOperator = com.mongodb.client.model.search.NumberRangeSearchOperator
+
+  /**
+   * @see `SearchOperator.dateRange`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type DateRangeSearchOperator = com.mongodb.client.model.search.DateRangeSearchOperator
+
+  /**
+   * @see `SearchOperator.near`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type NumberNearSearchOperator = com.mongodb.client.model.search.NumberNearSearchOperator
+
+  /**
+   * @see `SearchOperator.near`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type DateNearSearchOperator = com.mongodb.client.model.search.DateNearSearchOperator
+
+  /**
+   * @see `SearchOperator.near`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type GeoNearSearchOperator = com.mongodb.client.model.search.GeoNearSearchOperator
+
+  /**
+   * Fuzzy search options that may be used with some [[SearchOperator]]s.
+   *
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/ autocomplete operator]]
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/text/ text operator]]
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type SearchFuzzy = com.mongodb.client.model.search.SearchFuzzy
+
+  /**
+   * The core part of the `\$search` pipeline stage of an aggregation pipeline.
+   * [[SearchCollector]]s allow returning metadata together with the matching search results.
+   * You may use the `$$SEARCH_META` variable, e.g., via [[Projections.computedSearchMeta]], to extract this metadata.
+   *
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type SearchCollector = com.mongodb.client.model.search.SearchCollector
+
+  /**
+   * @see `SearchCollector.facet(SearchOperator, Iterable)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT, Beta.Reason.SERVER))
+  type FacetSearchCollector = com.mongodb.client.model.search.FacetSearchCollector
+
+  /**
+   * Represents optional fields of the `\$search` pipeline stage of an aggregation pipeline.
+   *
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search syntax]]
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type SearchOptions = com.mongodb.client.model.search.SearchOptions
+
+  /**
+   * Highlighting options.
+   * You may use the `\$meta: "searchHighlights"` expression, e.g., via [[Projections.metaSearchHighlights]],
+   * to extract the results of highlighting.
+   *
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/highlighting/ Highlighting]]
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type SearchHighlight = com.mongodb.client.model.search.SearchHighlight
+
+  /**
+   * Counting options.
+   * You may use the `$$SEARCH_META` variable, e.g., via [[Projections.computedSearchMeta]],
+   * to extract the results of counting.
+   * You may use [[Projections.computedSearchMeta]] to extract the count results.
+   *
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/counting/ Counting]]
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT, Beta.Reason.SERVER))
+  type SearchCount = com.mongodb.client.model.search.SearchCount
+
+  /**
+   * @see `SearchCount.total()`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT, Beta.Reason.SERVER))
+  type TotalSearchCount = com.mongodb.client.model.search.TotalSearchCount
+
+  /**
+   * @see `SearchCount.lowerBound()`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT, Beta.Reason.SERVER))
+  type LowerBoundSearchCount = com.mongodb.client.model.search.LowerBoundSearchCount
+
+  /**
+   * A facet definition for [[FacetSearchCollector]].
+   *
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/facet/#facet-definition Facet definition]]
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT, Beta.Reason.SERVER))
+  type SearchFacet = com.mongodb.client.model.search.SearchFacet
+
+  /**
+   * @see `SearchFacet.stringFacet(String, FieldSearchPath)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT, Beta.Reason.SERVER))
+  type StringSearchFacet = com.mongodb.client.model.search.StringSearchFacet
+
+  /**
+   * @see `SearchFacet.numberFacet(String, FieldSearchPath, Iterable)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT, Beta.Reason.SERVER))
+  type NumberSearchFacet = com.mongodb.client.model.search.NumberSearchFacet
+
+  /**
+   * @see `SearchFacet.dateFacet(String, FieldSearchPath, Iterable)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT, Beta.Reason.SERVER))
+  type DateSearchFacet = com.mongodb.client.model.search.DateSearchFacet
+
+  /**
+   * A specification of fields to be searched.
+   *
+   * Despite `SearchPath` being `Bson`,
+   * its value conforming to the correct syntax must be obtained via either `SearchPath.toBsonValue` or `FieldSearchPath.toValue`.
+   *
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/path-construction/ Path]]
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type SearchPath = com.mongodb.client.model.search.SearchPath
+
+  /**
+   * @see `SearchPath.fieldPath(String)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type FieldSearchPath = com.mongodb.client.model.search.FieldSearchPath
+
+  /**
+   * @see `SearchPath.wildcardPath(String)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type WildcardSearchPath = com.mongodb.client.model.search.WildcardSearchPath
+
+  /**
+   * A modifier of the relevance score.
+   * You may use the `\$meta: "searchScore"` expression, e.g., via [[Projections.metaSearchScore]],
+   * to extract the relevance score assigned to each found document.
+   *
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/ Scoring]]
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type SearchScore = com.mongodb.client.model.search.SearchScore
+
+  /**
+   * @see `SearchScore.boost(float)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type ValueBoostSearchScore = com.mongodb.client.model.search.ValueBoostSearchScore
+
+  /**
+   * @see `SearchScore.boost(FieldSearchPath)`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type PathBoostSearchScore = com.mongodb.client.model.search.PathBoostSearchScore
+
+  /**
+   * @see `SearchScore.constant`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type ConstantSearchScore = com.mongodb.client.model.search.ConstantSearchScore
+
+  /**
+   * @see `SearchScore.function`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type FunctionSearchScore = com.mongodb.client.model.search.FunctionSearchScore
+
+  /**
+   * @see `SearchScore.function`
+   * @see [[https://www.mongodb.com/docs/atlas/atlas-search/scoring/#expressions Expressions for the function score modifier]]
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type SearchScoreExpression = com.mongodb.client.model.search.SearchScoreExpression
+
+  /**
+   * @see `SearchScoreExpression.relevanceExpression`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type RelevanceSearchScoreExpression = com.mongodb.client.model.search.RelevanceSearchScoreExpression
+
+  /**
+   * @see `SearchScoreExpression.pathExpression`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type PathSearchScoreExpression = com.mongodb.client.model.search.PathSearchScoreExpression
+
+  /**
+   * @see `SearchScoreExpression.constantExpression`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type ConstantSearchScoreExpression = com.mongodb.client.model.search.ConstantSearchScoreExpression
+
+  /**
+   * @see `SearchScoreExpression.gaussExpression`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type GaussSearchScoreExpression = com.mongodb.client.model.search.GaussSearchScoreExpression
+
+  /**
+   * @see `SearchScoreExpression.log`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type LogSearchScoreExpression = com.mongodb.client.model.search.LogSearchScoreExpression
+
+  /**
+   * @see `SearchScoreExpression.log1p`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type Log1pSearchScoreExpression = com.mongodb.client.model.search.Log1pSearchScoreExpression
+
+  /**
+   * @see `SearchScoreExpression.addExpression`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type AddSearchScoreExpression = com.mongodb.client.model.search.AddSearchScoreExpression
+
+  /**
+   * @see `SearchScoreExpression.multiplyExpression`
+   */
+  @Evolving
+  @Beta(Array(Beta.Reason.CLIENT))
+  type MultiplySearchScoreExpression = com.mongodb.client.model.search.MultiplySearchScoreExpression
+}

--- a/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
@@ -295,12 +295,35 @@ class ApiAliasAndCompanionSpec extends BaseSpec {
     val localObjects = new Reflections(scalaPackageName, new SubTypesScanner(false))
       .getSubTypesOf(classOf[Object])
       .asScala
+      .filter(_.getPackage.getName == scalaPackageName)
       .filter(classFilter)
       .map(_.getSimpleName)
       .toSet
-    val scalaExclusions = Set("package", "FullDocument", "FullDocumentBeforeChange")
+    val scalaExclusions = Set("package")
     val local = (localPackage ++ localObjects) -- scalaExclusions
 
+    diff(local, wrapped) shouldBe empty
+  }
+
+  it should "mirror all com.mongodb.client.model.search in org.mongdb.scala.model.search" in {
+    val packageName = "com.mongodb.client.model.search"
+    val wrapped = new Reflections(packageName, new SubTypesScanner(false))
+      .getSubTypesOf(classOf[Object])
+      .asScala
+      .filter(_.getPackage.getName == packageName)
+      .filter(classFilter)
+      .map(_.getSimpleName)
+      .toSet
+    val scalaPackageName = "org.mongodb.scala.model.search"
+    val localPackage = currentMirror.staticPackage(scalaPackageName).info.decls.map(_.name.toString).toSet
+    val localObjects = new Reflections(scalaPackageName, new SubTypesScanner(false))
+      .getSubTypesOf(classOf[Object])
+      .asScala
+      .filter(_.getPackage.getName == scalaPackageName)
+      .filter(classFilter)
+      .map(_.getSimpleName)
+      .toSet
+    val local = localPackage ++ localObjects - "package"
     diff(local, wrapped) shouldBe empty
   }
 

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
@@ -29,6 +29,13 @@ import org.mongodb.scala.model.Projections._
 import org.mongodb.scala.model.Sorts._
 import org.mongodb.scala.model.Windows.Bound.{ CURRENT, UNBOUNDED }
 import org.mongodb.scala.model.Windows.{ documents, range }
+import org.mongodb.scala.model.search.SearchCount.total
+import org.mongodb.scala.model.search.SearchFacet.stringFacet
+import org.mongodb.scala.model.search.SearchHighlight.paths
+import org.mongodb.scala.model.search.SearchCollector
+import org.mongodb.scala.model.search.SearchOperator.exists
+import org.mongodb.scala.model.search.SearchOptions.defaultSearchOptions
+import org.mongodb.scala.model.search.SearchPath.{ fieldPath, wildcardPath }
 import org.mongodb.scala.{ BaseSpec, MongoClient, MongoNamespace }
 
 class AggregatesSpec extends BaseSpec {
@@ -483,6 +490,176 @@ class AggregatesSpec extends BaseSpec {
         "$setWindowFields": {
           "output": {
             "newField01": { "$sum": "$field01", "window": { "documents": [1, 2] } }
+          }
+        }
+      }""")
+    )
+  }
+
+  it should "render $search" in {
+    toBson(
+      Aggregates.search(
+        exists(fieldPath("fieldName")),
+        defaultSearchOptions()
+      )
+    ) should equal(
+      Document("""{
+        "$search": {
+          "exists": { "path": "fieldName" }
+        }
+      }""")
+    )
+    toBson(
+      Aggregates.search(
+        SearchCollector
+          .facet(exists(fieldPath("fieldName")), List(stringFacet("stringFacetName", fieldPath("fieldName1")))),
+        defaultSearchOptions()
+          .index("indexName")
+          .count(total())
+          .highlight(
+            paths(
+              List(fieldPath("fieldName1"), fieldPath("fieldName2").multi("analyzerName"), wildcardPath("field.name*"))
+            )
+          )
+      )
+    ) should equal(
+      Document("""{
+        "$search": {
+          "facet": {
+            "operator": { "exists": { "path": "fieldName" } },
+            "facets": {
+              "stringFacetName": { "type" : "string", "path": "fieldName1" }
+            }
+          },
+          "index": "indexName",
+          "count": { "type": "total" },
+          "highlight": {
+            "path": [
+              "fieldName1",
+              { "value": "fieldName2", "multi": "analyzerName" },
+              { "wildcard": "field.name*" }
+            ]
+          }
+        }
+      }""")
+    )
+  }
+
+  it should "render $search with no options" in {
+    toBson(
+      Aggregates.search(
+        exists(fieldPath("fieldName"))
+      )
+    ) should equal(
+      Document("""{
+        "$search": {
+          "exists": { "path": "fieldName" }
+        }
+      }""")
+    )
+    toBson(
+      Aggregates.search(
+        SearchCollector.facet(
+          exists(fieldPath("fieldName")),
+          List(
+            stringFacet("facetName", fieldPath("fieldName"))
+              .numBuckets(3)
+          )
+        )
+      )
+    ) should equal(
+      Document("""{
+        "$search": {
+          "facet": {
+            "operator": { "exists": { "path": "fieldName" } },
+            "facets": {
+              "facetName": { "type": "string", "path": "fieldName", "numBuckets": 3 }
+            }
+          }
+        }
+      }""")
+    )
+  }
+
+  it should "render $searchMeta" in {
+    toBson(
+      Aggregates.searchMeta(
+        exists(fieldPath("fieldName")),
+        defaultSearchOptions()
+      )
+    ) should equal(
+      Document("""{
+        "$searchMeta": {
+          "exists": { "path": "fieldName" }
+        }
+      }""")
+    )
+    toBson(
+      Aggregates.searchMeta(
+        SearchCollector
+          .facet(exists(fieldPath("fieldName")), List(stringFacet("stringFacetName", fieldPath("fieldName1")))),
+        defaultSearchOptions()
+          .index("indexName")
+          .count(total())
+          .highlight(
+            paths(
+              List(fieldPath("fieldName1"), fieldPath("fieldName2").multi("analyzerName"), wildcardPath("field.name*"))
+            )
+          )
+      )
+    ) should equal(
+      Document("""{
+        "$searchMeta": {
+          "facet": {
+            "operator": { "exists": { "path": "fieldName" } },
+            "facets": {
+              "stringFacetName": { "type" : "string", "path": "fieldName1" }
+            }
+          },
+          "index": "indexName",
+          "count": { "type": "total" },
+          "highlight": {
+            "path": [
+              "fieldName1",
+              { "value": "fieldName2", "multi": "analyzerName" },
+              { "wildcard": "field.name*" }
+            ]
+          }
+        }
+      }""")
+    )
+  }
+
+  it should "render $searchMeta with no options" in {
+    toBson(
+      Aggregates.searchMeta(
+        exists(fieldPath("fieldName"))
+      )
+    ) should equal(
+      Document("""{
+        "$searchMeta": {
+          "exists": { "path": "fieldName" }
+        }
+      }""")
+    )
+    toBson(
+      Aggregates.searchMeta(
+        SearchCollector.facet(
+          exists(fieldPath("fieldName")),
+          List(
+            stringFacet("facetName", fieldPath("fieldName"))
+              .numBuckets(3)
+          )
+        )
+      )
+    ) should equal(
+      Document("""{
+        "$searchMeta": {
+          "facet": {
+            "operator": { "exists": { "path": "fieldName" } },
+            "facets": {
+              "facetName": { "type": "string", "path": "fieldName", "numBuckets": 3 }
+            }
           }
         }
       }""")

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.search
+
+import org.bson.BsonDocument
+import org.mongodb.scala.{ BaseSpec, MongoClient }
+import org.mongodb.scala.bson.collection.immutable.Document
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.geojson.{ Point, Position }
+import org.mongodb.scala.model.search.SearchFuzzy.defaultSearchFuzzy
+import org.mongodb.scala.model.search.SearchOperator.{
+  autocomplete,
+  compound,
+  dateRange,
+  exists,
+  near,
+  numberRange,
+  text
+}
+import org.mongodb.scala.model.search.SearchPath.{ fieldPath, wildcardPath }
+import org.mongodb.scala.model.search.SearchScore.function
+import org.mongodb.scala.model.search.SearchScoreExpression.{ constantExpression, logExpression }
+
+import java.time.{ Duration, Instant }
+import scala.collection.JavaConverters._
+
+class SearchOperatorSpec extends BaseSpec {
+  it should "render all operators" in {
+    toDocument(
+      compound()
+        .should(Seq(
+          exists(fieldPath("fieldName1")),
+          text("term1", fieldPath("fieldName2"))
+            .score(function(logExpression(constantExpression(3)))),
+          text(Seq("term2", "term3"), Seq(wildcardPath("wildc*rd"), fieldPath("fieldName3")))
+            .fuzzy(defaultSearchFuzzy()
+              .maxEdits(1)
+              .prefixLength(2)
+              .maxExpansions(3)),
+          autocomplete(
+            "term4",
+            fieldPath("title")
+              // multi must be ignored
+              .multi("keyword")
+          ),
+          autocomplete(Seq("Traffic in", "term5"), fieldPath("title"))
+            .fuzzy(defaultSearchFuzzy())
+            .sequentialTokenOrder(),
+          numberRange(Seq(fieldPath("fieldName4"), fieldPath("fieldName5")))
+            .gtLt(1, 1.5),
+          dateRange(fieldPath("fieldName6"))
+            .lte(Instant.ofEpochMilli(1)),
+          near(0, 1.5, Seq(fieldPath("fieldName7"), fieldPath("fieldName8"))),
+          near(Instant.ofEpochMilli(1), Duration.ofMillis(3), fieldPath("fieldName9")),
+          near(Point(Position(114.15, 22.28)), 1234.5, fieldPath("address.location"))
+        ).asJava)
+        .minimumShouldMatch(1)
+        .mustNot(Seq(
+          compound().must(Seq(exists(fieldPath("fieldName"))).asJava)
+        ).asJava)
+    ) should equal(
+      Document("""{
+        "compound": {
+          "should": [
+            { "exists": { "path": "fieldName1" } },
+            { "text": { "query": "term1", "path": "fieldName2", "score": { "function": { "log": { "constant": 3.0 } } } } },
+            { "text": {
+              "query": [ "term2", "term3" ],
+              "path": [ { "wildcard": "wildc*rd" }, "fieldName3" ],
+              "fuzzy": { "maxEdits": 1, "prefixLength": 2, "maxExpansions": 3 } } },
+            { "autocomplete": { "query": "term4", "path": "title" } },
+            { "autocomplete": { "query": ["Traffic in", "term5"], "path": "title", "fuzzy": {}, "tokenOrder": "sequential" } },
+            { "range": { "path": [ "fieldName4", "fieldName5" ], "gt": 1, "lt": 1.5 } },
+            { "range": { "path": "fieldName6", "lte": { "$date": "1970-01-01T00:00:00.001Z" } } },
+            { "near": { "origin": 0, "pivot": 1.5, "path": [ "fieldName7", "fieldName8" ] } },
+            { "near": { "origin": { "$date": "1970-01-01T00:00:00.001Z" }, "pivot": { "$numberLong": "3" }, "path": "fieldName9" } },
+            { "near": { "origin": { type: "Point", coordinates: [ 114.15, 22.28 ] }, "pivot": 1234.5, "path": "address.location" } }
+          ],
+          "minimumShouldMatch": 1,
+          "mustNot": [
+            { "compound": { "must": [ { "exists": { "path": "fieldName" } } ] } }
+          ]
+        }
+      }""")
+    )
+  }
+
+  def toDocument(bson: Bson): Document =
+    Document(bson.toBsonDocument(classOf[BsonDocument], MongoClient.DEFAULT_CODEC_REGISTRY))
+}

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -52,6 +52,7 @@ subprojects { project ->
             links = ['https://docs.oracle.com/en/java/javase/11/docs/api/',
                      'https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/']
             tagletPath tagletsProject.sourceSets.main.output.classesDirs.head()
+            taglets 'AtlasManualTaglet'
             taglets 'ManualTaglet'
             taglets 'DochubTaglet'
             taglets 'ServerReleaseTaglet'

--- a/util/taglets/src/main/AtlasManualTaglet.java
+++ b/util/taglets/src/main/AtlasManualTaglet.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public final class AtlasManualTaglet extends DocTaglet {
+    @Override
+    public String getName() {
+        return "mongodb.atlas.manual";
+    }
+
+    @Override
+    protected String getHeader() {
+        return "MongoDB Atlas documentation";
+    }
+
+    @Override
+    protected String getBaseDocURI() {
+        return "https://www.mongodb.com/docs/atlas/";
+    }
+}


### PR DESCRIPTION
Java API: `com.mongodb.client.model.search`
Scala API: `org.mongodb.scala.model.search`

This PR supersedes the following PRs, which have been approved (it contains their code combined, and allows doing a single merge to `master`):

- https://github.com/mongodb/mongo-java-driver/pull/891
- https://github.com/mongodb/mongo-java-driver/pull/923
- https://github.com/mongodb/mongo-java-driver/pull/928

JAVA-4415 JAVA-4315 JAVA-4190