### PR TITLE
Add builders for pick-accumulators / window functions

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/Accumulators.java
+++ b/driver-core/src/main/com/mongodb/client/model/Accumulators.java
@@ -497,7 +497,7 @@ public final class Accumulators {
         return new BsonField(fieldName, new Document(accumulatorName, new Document("input", inExpression).append("n", nExpression)));
     }
 
-    private static <OutExpression, NExpression> BsonField sortingPickAccumulator(
+    private static <OutExpression> BsonField sortingPickAccumulator(
             final String fieldName, final String accumulatorName, final Bson sort, final OutExpression outExpression) {
         return new BsonField(fieldName, new Document(accumulatorName, new Document("sortBy", sort).append("output", outExpression)));
     }

--- a/driver-core/src/main/com/mongodb/client/model/Accumulators.java
+++ b/driver-core/src/main/com/mongodb/client/model/Accumulators.java
@@ -20,10 +20,13 @@ import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
+import org.bson.Document;
+import org.bson.conversions.Bson;
 
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
+import static org.bson.assertions.Assertions.notNull;
 
 /**
  * Builders for accumulators used in the group pipeline stage of an aggregation pipeline.
@@ -79,6 +82,69 @@ public final class Accumulators {
     }
 
     /**
+     * Returns a combination of a computed field and an accumulator that produces a BSON {@link org.bson.BsonType#ARRAY Array}
+     * of values of the given {@code inExpression} computed for the first {@code N} elements within a presorted group,
+     * where {@code N} is the positive integral value of the {@code nExpression}.
+     *
+     * @param fieldName The field computed by the accumulator.
+     * @param inExpression The input expression.
+     * @param nExpression The expression limiting the number of produced values.
+     * @param <InExpression> The type of the input expression.
+     * @param <NExpression> The type of the limiting expression.
+     * @return The requested {@link BsonField}.
+     * @mongodb.driver.manual reference/operator/aggregation/firstN/ $firstN
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <InExpression, NExpression> BsonField firstN(
+            final String fieldName, final InExpression inExpression, final NExpression nExpression) {
+        return pickNAccumulator(notNull("fieldName", fieldName), "$firstN",
+                notNull("inExpression", inExpression), notNull("nExpression", nExpression));
+    }
+
+    /**
+     * Returns a combination of a computed field and an accumulator that produces
+     * a value of the given {@code outExpression} computed for the top element within a group
+     * sorted according to the provided {@code sortBy} specification.
+     *
+     * @param fieldName The field computed by the accumulator.
+     * @param sortBy The {@linkplain Sorts sort specification}. The syntax is identical to the one expected by {@link Aggregates#sort(Bson)}.
+     * @param outExpression The output expression.
+     * @param <OutExpression> The type of the output expression.
+     * @return The requested {@link BsonField}.
+     * @mongodb.driver.manual reference/operator/aggregation/top/ $top
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <OutExpression> BsonField top(final String fieldName, final Bson sortBy, final OutExpression outExpression) {
+        return sortingPickAccumulator(notNull("fieldName", fieldName), "$top",
+                notNull("sortBy", sortBy), notNull("outExpression", outExpression));
+    }
+
+    /**
+     * Returns a combination of a computed field and an accumulator that produces a BSON {@link org.bson.BsonType#ARRAY Array}
+     * of values of the given {@code outExpression} computed for the top {@code N} elements within a group
+     * sorted according to the provided {@code sortBy} specification,
+     * where {@code N} is the positive integral value of the {@code nExpression}.
+     *
+     * @param fieldName The field computed by the accumulator.
+     * @param sortBy The {@linkplain Sorts sort specification}. The syntax is identical to the one expected by {@link Aggregates#sort(Bson)}.
+     * @param outExpression The output expression.
+     * @param nExpression The expression limiting the number of produced values.
+     * @param <OutExpression> The type of the output expression.
+     * @param <NExpression> The type of the limiting expression.
+     * @return The requested {@link BsonField}.
+     * @mongodb.driver.manual reference/operator/aggregation/topN/ $topN
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <OutExpression, NExpression> BsonField topN(
+            final String fieldName, final Bson sortBy, final OutExpression outExpression, final NExpression nExpression) {
+        return sortingPickNAccumulator(notNull("fieldName", fieldName), "$topN",
+                notNull("sortBy", sortBy), notNull("outExpression", outExpression), notNull("nExpression", nExpression));
+    }
+
+    /**
      * Gets a field name for a $group operation representing the value of the given expression when applied to the last member of
      * the group.
      *
@@ -90,6 +156,69 @@ public final class Accumulators {
      */
     public static <TExpression> BsonField last(final String fieldName, final TExpression expression) {
         return accumulatorOperator("$last", fieldName, expression);
+    }
+
+    /**
+     * Returns a combination of a computed field and an accumulator that produces a BSON {@link org.bson.BsonType#ARRAY Array}
+     * of values of the given {@code inExpression} computed for the last {@code N} elements within a presorted group,
+     * where {@code N} is the positive integral value of the {@code nExpression}.
+     *
+     * @param fieldName The field computed by the accumulator.
+     * @param inExpression The input expression.
+     * @param nExpression The expression limiting the number of produced values.
+     * @param <InExpression> The type of the input expression.
+     * @param <NExpression> The type of the limiting expression.
+     * @return The requested {@link BsonField}.
+     * @mongodb.driver.manual reference/operator/aggregation/lastN/ $lastN
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <InExpression, NExpression> BsonField lastN(
+            final String fieldName, final InExpression inExpression, final NExpression nExpression) {
+        return pickNAccumulator(notNull("fieldName", fieldName), "$lastN",
+                notNull("inExpression", inExpression), notNull("nExpression", nExpression));
+    }
+
+    /**
+     * Returns a combination of a computed field and an accumulator that produces
+     * a value of the given {@code outExpression} computed for the bottom element within a group
+     * sorted according to the provided {@code sortBy} specification.
+     *
+     * @param fieldName The field computed by the accumulator.
+     * @param sortBy The {@linkplain Sorts sort specification}. The syntax is identical to the one expected by {@link Aggregates#sort(Bson)}.
+     * @param outExpression The output expression.
+     * @param <OutExpression> The type of the output expression.
+     * @return The requested {@link BsonField}.
+     * @mongodb.driver.manual reference/operator/aggregation/bottom/ $bottom
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <OutExpression> BsonField bottom(final String fieldName, final Bson sortBy, final OutExpression outExpression) {
+        return sortingPickAccumulator(notNull("fieldName", fieldName), "$bottom",
+                notNull("sortBy", sortBy), notNull("outExpression", outExpression));
+    }
+
+    /**
+     * Returns a combination of a computed field and an accumulator that produces a BSON {@link org.bson.BsonType#ARRAY Array}
+     * of values of the given {@code outExpression} computed for the bottom {@code N} elements within a group
+     * sorted according to the provided {@code sortBy} specification,
+     * where {@code N} is the positive integral value of the {@code nExpression}.
+     *
+     * @param fieldName The field computed by the accumulator.
+     * @param sortBy The {@linkplain Sorts sort specification}. The syntax is identical to the one expected by {@link Aggregates#sort(Bson)}.
+     * @param outExpression The output expression.
+     * @param nExpression The expression limiting the number of produced values.
+     * @param <OutExpression> The type of the output expression.
+     * @param <NExpression> The type of the limiting expression.
+     * @return The requested {@link BsonField}.
+     * @mongodb.driver.manual reference/operator/aggregation/bottomN/ $bottomN
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <OutExpression, NExpression> BsonField bottomN(
+            final String fieldName, final Bson sortBy, final OutExpression outExpression, final NExpression nExpression) {
+        return sortingPickNAccumulator(notNull("fieldName", fieldName), "$bottomN",
+                notNull("sortBy", sortBy), notNull("outExpression", outExpression), notNull("nExpression", nExpression));
     }
 
     /**
@@ -107,6 +236,27 @@ public final class Accumulators {
     }
 
     /**
+     * Returns a combination of a computed field and an accumulator that produces a BSON {@link org.bson.BsonType#ARRAY Array}
+     * of {@code N} largest values of the given {@code inExpression},
+     * where {@code N} is the positive integral value of the {@code nExpression}.
+     *
+     * @param fieldName The field computed by the accumulator.
+     * @param inExpression The input expression.
+     * @param nExpression The expression limiting the number of produced values.
+     * @param <InExpression> The type of the input expression.
+     * @param <NExpression> The type of the limiting expression.
+     * @return The requested {@link BsonField}.
+     * @mongodb.driver.manual reference/operator/aggregation/maxN/ $maxN
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <InExpression, NExpression> BsonField maxN(
+            final String fieldName, final InExpression inExpression, final NExpression nExpression) {
+        return pickNAccumulator(notNull("fieldName", fieldName), "$maxN",
+                notNull("inExpression", inExpression), notNull("nExpression", nExpression));
+    }
+
+    /**
      * Gets a field name for a $group operation representing the minimum of the values of the given expression when applied to all
      * members of the group.
      *
@@ -118,6 +268,27 @@ public final class Accumulators {
      */
     public static <TExpression> BsonField min(final String fieldName, final TExpression expression) {
         return accumulatorOperator("$min", fieldName, expression);
+    }
+
+    /**
+     * Returns a combination of a computed field and an accumulator that produces a BSON {@link org.bson.BsonType#ARRAY Array}
+     * of {@code N} smallest values of the given {@code inExpression},
+     * where {@code N} is the positive integral value of the {@code nExpression}.
+     *
+     * @param fieldName The field computed by the accumulator.
+     * @param inExpression The input expression.
+     * @param nExpression The expression limiting the number of produced values.
+     * @param <InExpression> The type of the input expression.
+     * @param <NExpression> The type of the limiting expression.
+     * @return The requested {@link BsonField}.
+     * @mongodb.driver.manual reference/operator/aggregation/minN/ $minN
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <InExpression, NExpression> BsonField minN(
+            final String fieldName, final InExpression inExpression, final NExpression nExpression) {
+        return pickNAccumulator(notNull("fieldName", fieldName), "$minN",
+                notNull("inExpression", inExpression), notNull("nExpression", nExpression));
     }
 
     /**
@@ -319,6 +490,24 @@ public final class Accumulators {
 
     private static <TExpression> BsonField accumulatorOperator(final String name, final String fieldName, final TExpression expression) {
         return new BsonField(fieldName, new SimpleExpression<TExpression>(name, expression));
+    }
+
+    private static <InExpression, NExpression> BsonField pickNAccumulator(
+            final String fieldName, final String accumulatorName, final InExpression inExpression, final NExpression nExpression) {
+        return new BsonField(fieldName, new Document(accumulatorName, new Document("input", inExpression).append("n", nExpression)));
+    }
+
+    private static <OutExpression, NExpression> BsonField sortingPickAccumulator(
+            final String fieldName, final String accumulatorName, final Bson sort, final OutExpression outExpression) {
+        return new BsonField(fieldName, new Document(accumulatorName, new Document("sortBy", sort).append("output", outExpression)));
+    }
+
+    private static <OutExpression, NExpression> BsonField sortingPickNAccumulator(
+            final String fieldName, final String accumulatorName,
+            final Bson sort, final OutExpression outExpression, final NExpression nExpression) {
+        return new BsonField(fieldName, new Document(accumulatorName, new Document("sortBy", sort)
+                .append("output", outExpression)
+                .append("n", nExpression)));
     }
 
     private Accumulators() {

--- a/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
+++ b/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
@@ -149,14 +149,14 @@ public final class WindowedComputations {
     }
 
     /**
-     * Builds a computation of the lowest of the evaluation results of the {@code expression} over the {@code window}.
+     * Builds a computation of the smallest of the evaluation results of the {@code expression} over the {@code window}.
      *
      * @param path The output field path.
      * @param expression The expression.
      * @param window The window.
      * @param <TExpression> The expression type.
      * @return The constructed windowed computation.
-     * @mongodb.driver.dochub core/window-functions-min $min
+     * @mongodb.driver.manual reference/operator/aggregation/min/ $min
      */
     public static <TExpression> WindowedComputation min(final String path, final TExpression expression, @Nullable final Window window) {
         notNull("path", path);
@@ -165,19 +165,73 @@ public final class WindowedComputations {
     }
 
     /**
-     * Builds a computation of the highest of the evaluation results of the {@code expression} over the {@code window}.
+     * Builds a computation of a BSON {@link org.bson.BsonType#ARRAY Array}
+     * of {@code N} smallest evaluation results of the {@code inExpression} over the {@code window},
+     * where {@code N} is the positive integral value of the {@code nExpression}.
+     *
+     * @param path The output field path.
+     * @param inExpression The input expression.
+     * @param nExpression The expression limiting the number of produced values.
+     * @param window The window.
+     * @param <InExpression> The type of the input expression.
+     * @param <NExpression> The type of the limiting expression.
+     * @return The constructed windowed computation.
+     * @mongodb.driver.manual reference/operator/aggregation/minN/ $minN
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <InExpression, NExpression> WindowedComputation minN(
+            final String path, final InExpression inExpression, final NExpression nExpression, @Nullable final Window window) {
+        notNull("path", path);
+        notNull("inExpression", inExpression);
+        notNull("nExpression", nExpression);
+        final Map<ParamName, Object> args = new LinkedHashMap<>(3);
+        args.put(ParamName.INPUT, inExpression);
+        args.put(ParamName.N_LOWERCASE, nExpression);
+        return compoundParameterWindowFunction(path, "$minN", args, window);
+    }
+
+    /**
+     * Builds a computation of the largest of the evaluation results of the {@code expression} over the {@code window}.
      *
      * @param path The output field path.
      * @param expression The expression.
      * @param window The window.
      * @param <TExpression> The expression type.
      * @return The constructed windowed computation.
-     * @mongodb.driver.dochub core/window-functions-max $max
+     * @mongodb.driver.manual reference/operator/aggregation/max/ $max
      */
     public static <TExpression> WindowedComputation max(final String path, final TExpression expression, @Nullable final Window window) {
         notNull("path", path);
         notNull("expression", expression);
         return simpleParameterWindowFunction(path, "$max", expression, window);
+    }
+
+    /**
+     * Builds a computation of a BSON {@link org.bson.BsonType#ARRAY Array}
+     * of {@code N} largest evaluation results of the {@code inExpression} over the {@code window},
+     * where {@code N} is the positive integral value of the {@code nExpression}.
+     *
+     * @param path The output field path.
+     * @param inExpression The input expression.
+     * @param nExpression The expression limiting the number of produced values.
+     * @param window The window.
+     * @param <InExpression> The type of the input expression.
+     * @param <NExpression> The type of the limiting expression.
+     * @return The constructed windowed computation.
+     * @mongodb.driver.manual reference/operator/aggregation/maxN/ $maxN
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <InExpression, NExpression> WindowedComputation maxN(
+            final String path, final InExpression inExpression, final NExpression nExpression, @Nullable final Window window) {
+        notNull("path", path);
+        notNull("inExpression", inExpression);
+        notNull("nExpression", nExpression);
+        final Map<ParamName, Object> args = new LinkedHashMap<>(3);
+        args.put(ParamName.INPUT, inExpression);
+        args.put(ParamName.N_LOWERCASE, nExpression);
+        return compoundParameterWindowFunction(path, "$maxN", args, window);
     }
 
     /**
@@ -371,7 +425,7 @@ public final class WindowedComputations {
         isTrueArgument("n > 0", n > 0);
         final Map<ParamName, Object> args = new LinkedHashMap<>(2);
         args.put(ParamName.INPUT, expression);
-        args.put(ParamName.N, n);
+        args.put(ParamName.N_UPPERCASE, n);
         return compoundParameterWindowFunction(path, "$expMovingAvg", args, null);
     }
 
@@ -447,12 +501,97 @@ public final class WindowedComputations {
      * @param window The window.
      * @param <TExpression> The expression type.
      * @return The constructed windowed computation.
-     * @mongodb.driver.dochub core/window-functions-first $first
+     * @mongodb.driver.manual reference/operator/aggregation/first/ $first
      */
     public static <TExpression> WindowedComputation first(final String path, final TExpression expression, @Nullable final Window window) {
         notNull("path", path);
         notNull("expression", expression);
         return simpleParameterWindowFunction(path, "$first", expression, window);
+    }
+
+    /**
+     * Builds a computation of a BSON {@link org.bson.BsonType#ARRAY Array}
+     * of evaluation results of the {@code inExpression} against the first {@code N} documents in the {@code window},
+     * where {@code N} is the positive integral value of the {@code nExpression}.
+     * <p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     *
+     * @param path The output field path.
+     * @param inExpression The input expression.
+     * @param nExpression The expression limiting the number of produced values.
+     * @param window The window.
+     * @param <InExpression> The type of the input expression.
+     * @param <NExpression> The type of the limiting expression.
+     * @return The constructed windowed computation.
+     * @mongodb.driver.manual reference/operator/aggregation/firstN/ $firstN
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <InExpression, NExpression> WindowedComputation firstN(
+            final String path, final InExpression inExpression, final NExpression nExpression, @Nullable final Window window) {
+        notNull("path", path);
+        notNull("inExpression", inExpression);
+        notNull("nExpression", nExpression);
+        final Map<ParamName, Object> args = new LinkedHashMap<>(3);
+        args.put(ParamName.INPUT, inExpression);
+        args.put(ParamName.N_LOWERCASE, nExpression);
+        return compoundParameterWindowFunction(path, "$firstN", args, window);
+    }
+
+    /**
+     * Builds a computation of the evaluation result of the {@code outExpression} against the top document in the {@code window}
+     * sorted according to the provided {@code sortBy} specification.
+     *
+     * @param path The output field path.
+     * @param sortBy The {@linkplain Sorts sortBy specification}. The syntax is identical to the one expected by {@link Aggregates#sort(Bson)}.
+     * @param outExpression The input expression.
+     * @param window The window.
+     * @param <OutExpression> The type of the output expression.
+     * @return The constructed windowed computation.
+     * @mongodb.driver.manual reference/operator/aggregation/top/ $top
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <OutExpression> WindowedComputation top(
+            final String path, final Bson sortBy, final OutExpression outExpression, @Nullable final Window window) {
+        notNull("path", path);
+        notNull("sortBy", sortBy);
+        notNull("outExpression", outExpression);
+        final Map<ParamName, Object> args = new LinkedHashMap<>(3);
+        args.put(ParamName.SORT_BY, sortBy);
+        args.put(ParamName.OUTPUT, outExpression);
+        return compoundParameterWindowFunction(path, "$top", args, window);
+    }
+
+    /**
+     * Builds a computation of a BSON {@link org.bson.BsonType#ARRAY Array}
+     * of evaluation results of the {@code outExpression} against the top {@code N} documents in the {@code window}
+     * sorted according to the provided {@code sortBy} specification,
+     * where {@code N} is the positive integral value of the {@code nExpression}.
+     *
+     * @param path The output field path.
+     * @param sortBy The {@linkplain Sorts sortBy specification}. The syntax is identical to the one expected by {@link Aggregates#sort(Bson)}.
+     * @param outExpression The input expression.
+     * @param nExpression The expression limiting the number of produced values.
+     * @param window The window.
+     * @param <OutExpression> The type of the output expression.
+     * @param <NExpression> The type of the limiting expression.
+     * @return The constructed windowed computation.
+     * @mongodb.driver.manual reference/operator/aggregation/topN/ $topN
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <OutExpression, NExpression> WindowedComputation topN(
+            final String path, final Bson sortBy, final OutExpression outExpression, final NExpression nExpression, @Nullable final Window window) {
+        notNull("path", path);
+        notNull("sortBy", sortBy);
+        notNull("outExpression", outExpression);
+        notNull("nExpression", nExpression);
+        final Map<ParamName, Object> args = new LinkedHashMap<>(3);
+        args.put(ParamName.SORT_BY, sortBy);
+        args.put(ParamName.OUTPUT, outExpression);
+        args.put(ParamName.N_LOWERCASE, nExpression);
+        return compoundParameterWindowFunction(path, "$topN", args, window);
     }
 
     /**
@@ -465,12 +604,97 @@ public final class WindowedComputations {
      * @param window The window.
      * @param <TExpression> The expression type.
      * @return The constructed windowed computation.
-     * @mongodb.driver.dochub core/window-functions-last $last
+     * @mongodb.driver.manual reference/operator/aggregation/last/ $last
      */
     public static <TExpression> WindowedComputation last(final String path, final TExpression expression, @Nullable final Window window) {
         notNull("path", path);
         notNull("expression", expression);
         return simpleParameterWindowFunction(path, "$last", expression, window);
+    }
+
+    /**
+     * Builds a computation of a BSON {@link org.bson.BsonType#ARRAY Array}
+     * of evaluation results of the {@code inExpression} against the last {@code N} documents in the {@code window},
+     * where {@code N} is the positive integral value of the {@code nExpression}.
+     * <p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     *
+     * @param path The output field path.
+     * @param inExpression The input expression.
+     * @param nExpression The expression limiting the number of produced values.
+     * @param window The window.
+     * @param <InExpression> The type of the input expression.
+     * @param <NExpression> The type of the limiting expression.
+     * @return The constructed windowed computation.
+     * @mongodb.driver.manual reference/operator/aggregation/lastN/ $lastN
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <InExpression, NExpression> WindowedComputation lastN(
+            final String path, final InExpression inExpression, final NExpression nExpression, @Nullable final Window window) {
+        notNull("path", path);
+        notNull("inExpression", inExpression);
+        notNull("nExpression", nExpression);
+        final Map<ParamName, Object> args = new LinkedHashMap<>(3);
+        args.put(ParamName.INPUT, inExpression);
+        args.put(ParamName.N_LOWERCASE, nExpression);
+        return compoundParameterWindowFunction(path, "$lastN", args, window);
+    }
+
+    /**
+     * Builds a computation of the evaluation result of the {@code outExpression} against the bottom document in the {@code window}
+     * sorted according to the provided {@code sortBy} specification.
+     *
+     * @param path The output field path.
+     * @param sortBy The {@linkplain Sorts sortBy specification}. The syntax is identical to the one expected by {@link Aggregates#sort(Bson)}.
+     * @param outExpression The input expression.
+     * @param window The window.
+     * @param <OutExpression> The type of the output expression.
+     * @return The constructed windowed computation.
+     * @mongodb.driver.manual reference/operator/aggregation/bottom/ $bottom
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <OutExpression> WindowedComputation bottom(
+            final String path, final Bson sortBy, final OutExpression outExpression, @Nullable final Window window) {
+        notNull("path", path);
+        notNull("sortBy", sortBy);
+        notNull("outExpression", outExpression);
+        final Map<ParamName, Object> args = new LinkedHashMap<>(3);
+        args.put(ParamName.SORT_BY, sortBy);
+        args.put(ParamName.OUTPUT, outExpression);
+        return compoundParameterWindowFunction(path, "$bottom", args, window);
+    }
+
+    /**
+     * Builds a computation of a BSON {@link org.bson.BsonType#ARRAY Array}
+     * of evaluation results of the {@code outExpression} against the bottom {@code N} documents in the {@code window}
+     * sorted according to the provided {@code sortBy} specification,
+     * where {@code N} is the positive integral value of the {@code nExpression}.
+     *
+     * @param path The output field path.
+     * @param sortBy The {@linkplain Sorts sortBy specification}. The syntax is identical to the one expected by {@link Aggregates#sort(Bson)}.
+     * @param outExpression The input expression.
+     * @param nExpression The expression limiting the number of produced values.
+     * @param window The window.
+     * @param <OutExpression> The type of the output expression.
+     * @param <NExpression> The type of the limiting expression.
+     * @return The constructed windowed computation.
+     * @mongodb.driver.manual reference/operator/aggregation/bottomN/ $bottomN
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <OutExpression, NExpression> WindowedComputation bottomN(
+            final String path, final Bson sortBy, final OutExpression outExpression, final NExpression nExpression, @Nullable final Window window) {
+        notNull("path", path);
+        notNull("sortBy", sortBy);
+        notNull("outExpression", outExpression);
+        notNull("nExpression", nExpression);
+        final Map<ParamName, Object> args = new LinkedHashMap<>(3);
+        args.put(ParamName.SORT_BY, sortBy);
+        args.put(ParamName.OUTPUT, outExpression);
+        args.put(ParamName.N_LOWERCASE, nExpression);
+        return compoundParameterWindowFunction(path, "$bottomN", args, window);
     }
 
     /**
@@ -752,11 +976,13 @@ public final class WindowedComputations {
     private enum ParamName {
         INPUT("input"),
         UNIT("unit"),
-        N("N"),
+        N_UPPERCASE("N"),
+        N_LOWERCASE("n"),
         ALPHA("alpha"),
         OUTPUT("output"),
         BY("by"),
-        DEFAULT("default");
+        DEFAULT("default"),
+        SORT_BY("sortBy");
 
         private final String value;
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Accumulators.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Accumulators.scala
@@ -69,6 +69,74 @@ object Accumulators {
     JAccumulators.first(fieldName, expression)
 
   /**
+   * Returns a combination of a computed field and an accumulator that produces a BSON `Array`
+   * of values of the given `inExpression` computed for the first `N` elements within a presorted group,
+   * where `N` is the positive integral value of the `nExpression`.
+   *
+   * @param fieldName The field computed by the accumulator.
+   * @param inExpression The input expression.
+   * @param nExpression The expression limiting the number of produced values.
+   * @tparam InExpression The type of the input expression.
+   * @tparam NExpression The type of the limiting expression.
+   * @return The requested [[BsonField]].
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/ \$firstN]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def firstN[InExpression, NExpression](
+      fieldName: String,
+      inExpression: InExpression,
+      nExpression: NExpression
+  ): BsonField =
+    JAccumulators.firstN(fieldName, inExpression, nExpression)
+
+  /**
+   * Returns a combination of a computed field and an accumulator that produces
+   * a value of the given `outExpression` computed for the top element within a group
+   * sorted according to the provided `sort` specification.
+   *
+   * @param fieldName The field computed by the accumulator.
+   * @param sortBy The sort specification. The syntax is identical to the one expected by [[Aggregates.sort]].
+   * @param outExpression The output expression.
+   * @tparam OutExpression The type of the output expression.
+   * @return The requested [[BsonField]].
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN/ \$topN]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def top[OutExpression](
+      fieldName: String,
+      sortBy: Bson,
+      outExpression: OutExpression
+  ): BsonField =
+    JAccumulators.top(fieldName, sortBy, outExpression)
+
+  /**
+   * Returns a combination of a computed field and an accumulator that produces a BSON `Array`
+   * of values of the given `outExpression` computed for the top `N` elements within a group
+   * sorted according to the provided `sort` specification,
+   * where `N` is the positive integral value of the `nExpression`.
+   *
+   * @param fieldName The field computed by the accumulator.
+   * @param sortBy The sort specification. The syntax is identical to the one expected by [[Aggregates.sort]].
+   * @param outExpression The output expression.
+   * @param nExpression The expression limiting the number of produced values.
+   * @tparam OutExpression The type of the output expression.
+   * @tparam NExpression The type of the limiting expression.
+   * @return The requested [[BsonField]].
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN/ \$topN]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def topN[OutExpression, NExpression](
+      fieldName: String,
+      sortBy: Bson,
+      outExpression: OutExpression,
+      nExpression: NExpression
+  ): BsonField =
+    JAccumulators.topN(fieldName, sortBy, outExpression, nExpression)
+
+  /**
    * Gets a field name for a `\$group` operation representing the value of the given expression when applied to the last member of
    * the group.
    *
@@ -80,6 +148,74 @@ object Accumulators {
    */
   def last[TExpression](fieldName: String, expression: TExpression): BsonField =
     JAccumulators.last(fieldName, expression)
+
+  /**
+   * Returns a combination of a computed field and an accumulator that produces a BSON `Array`
+   * of values of the given `inExpression` computed for the last `N` elements within a presorted group
+   * where `N` is the positive integral value of the `nExpression`.
+   *
+   * @param fieldName The field computed by the accumulator.
+   * @param inExpression The input expression.
+   * @param nExpression The expression limiting the number of produced values.
+   * @tparam InExpression The type of the input expression.
+   * @tparam NExpression The type of the limiting expression.
+   * @return The requested [[BsonField]].
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/lastN/ \$lastN]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def lastN[InExpression, NExpression](
+      fieldName: String,
+      inExpression: InExpression,
+      nExpression: NExpression
+  ): BsonField =
+    JAccumulators.lastN(fieldName, inExpression, nExpression)
+
+  /**
+   * Returns a combination of a computed field and an accumulator that produces
+   * a value of the given `outExpression` computed for the bottom element within a group
+   * sorted according to the provided `sort` specification.
+   *
+   * @param fieldName The field computed by the accumulator.
+   * @param sortBy The sort specification. The syntax is identical to the one expected by [[Aggregates.sort]].
+   * @param outExpression The output expression.
+   * @tparam OutExpression The type of the output expression.
+   * @return The requested [[BsonField]].
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottom/ \$bottom]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def bottom[OutExpression](
+      fieldName: String,
+      sortBy: Bson,
+      outExpression: OutExpression
+  ): BsonField =
+    JAccumulators.bottom(fieldName, sortBy, outExpression)
+
+  /**
+   * Returns a combination of a computed field and an accumulator that produces a BSON `Array`
+   * of values of the given `outExpression` computed for the bottom `N` elements within a group
+   * sorted according to the provided `sort` specification,
+   * where `N` is the positive integral value of the `nExpression`.
+   *
+   * @param fieldName The field computed by the accumulator.
+   * @param sortBy The sort specification. The syntax is identical to the one expected by [[Aggregates.sort]].
+   * @param outExpression The output expression.
+   * @param nExpression The expression limiting the number of produced values.
+   * @tparam OutExpression The type of the output expression.
+   * @tparam NExpression The type of the limiting expression.
+   * @return The requested [[BsonField]].
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottomN/ \$bottomN]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def bottomN[OutExpression, NExpression](
+      fieldName: String,
+      sortBy: Bson,
+      outExpression: OutExpression,
+      nExpression: NExpression
+  ): BsonField =
+    JAccumulators.bottomN(fieldName, sortBy, outExpression, nExpression)
 
   /**
    * Gets a field name for a `\$group` operation representing the maximum of the values of the given expression when applied to all
@@ -94,6 +230,28 @@ object Accumulators {
   def max[TExpression](fieldName: String, expression: TExpression): BsonField = JAccumulators.max(fieldName, expression)
 
   /**
+   * Returns a combination of a computed field and an accumulator that produces a BSON `Array`
+   * of `N` largest values of the given `inExpression`,
+   * where `N` is the positive integral value of the `nExpression`.
+   *
+   * @param fieldName The field computed by the accumulator.
+   * @param inExpression The input expression.
+   * @param nExpression The expression limiting the number of produced values.
+   * @tparam InExpression The type of the input expression.
+   * @tparam NExpression The type of the limiting expression.
+   * @return The requested [[BsonField]].
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/maxN/ \$maxN]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def maxN[InExpression, NExpression](
+      fieldName: String,
+      inExpression: InExpression,
+      nExpression: NExpression
+  ): BsonField =
+    JAccumulators.maxN(fieldName, inExpression, nExpression)
+
+  /**
    * Gets a field name for a `\$group` operation representing the minimum of the values of the given expression when applied to all
    * members of the group.
    *
@@ -104,6 +262,28 @@ object Accumulators {
    * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/ \$min]]
    */
   def min[TExpression](fieldName: String, expression: TExpression): BsonField = JAccumulators.min(fieldName, expression)
+
+  /**
+   * Returns a combination of a computed field and an accumulator that produces a BSON `Array`
+   * of `N` smallest values of the given `inExpression`,
+   * where `N` is the positive integral value of the `nExpression`.
+   *
+   * @param fieldName The field computed by the accumulator.
+   * @param inExpression The input expression.
+   * @param nExpression The expression limiting the number of produced values.
+   * @tparam InExpression The type of the input expression.
+   * @tparam NExpression The type of the limiting expression.
+   * @return The requested [[BsonField]].
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/minN/ \$minN]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def minN[InExpression, NExpression](
+      fieldName: String,
+      inExpression: InExpression,
+      nExpression: NExpression
+  ): BsonField =
+    JAccumulators.minN(fieldName, inExpression, nExpression)
 
   /**
    * Gets a field name for a `\$group` operation representing an array of all values that results from applying an expression to each

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
@@ -17,6 +17,7 @@ package org.mongodb.scala.model
 
 import com.mongodb.annotations.Beta
 import com.mongodb.client.model.{ MongoTimeUnit => JMongoTimeUnit, WindowedComputations => JWindowedComputations }
+import org.mongodb.scala.bson.conversions.Bson
 
 /**
  * Builders for [[WindowedComputation windowed computations]] used in the
@@ -119,10 +120,32 @@ object WindowedComputations {
    * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
-   * @see [[https://dochub.mongodb.org/core/window-functions-min \$min]]
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/ \$min]]
    */
   def min[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
     JWindowedComputations.min(path, expression, window.orNull)
+
+  /**
+   * Builds a computation of a BSON `Array`
+   * of `N` smallest evaluation results of the `inExpression` over the `window`,
+   * where `N` is the positive integral value of the `nExpression`.
+   *
+   * @param path The output field path.
+   * @param inExpression The input expression.
+   * @param nExpression The expression limiting the number of produced values.
+   * @tparam InExpression The type of the input expression.
+   * @tparam NExpression The type of the limiting expression.
+   * @return The constructed windowed computation.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/minN/ \$minN]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def minN[InExpression, NExpression](
+      path: String,
+      inExpression: InExpression,
+      nExpression: NExpression,
+      window: Option[_ <: Window]
+  ): WindowedComputation = JWindowedComputations.minN(path, inExpression, nExpression, window.orNull)
 
   /**
    * Builds a computation of the highest of the evaluation results of the `expression` over the `window`.
@@ -132,10 +155,32 @@ object WindowedComputations {
    * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
-   * @see [[https://dochub.mongodb.org/core/window-functions-max \$max]]
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/ \$max]]
    */
   def max[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
     JWindowedComputations.max(path, expression, window.orNull)
+
+  /**
+   * Builds a computation of a BSON `Array`
+   * of `N` largest evaluation results of the `inExpression` over the `window`,
+   * where `N` is the positive integral value of the `nExpression`.
+   *
+   * @param path The output field path.
+   * @param inExpression The input expression.
+   * @param nExpression The expression limiting the number of produced values.
+   * @tparam InExpression The type of the input expression.
+   * @tparam NExpression The type of the limiting expression.
+   * @return The constructed windowed computation.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/maxN/ \$maxN]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def maxN[InExpression, NExpression](
+      path: String,
+      inExpression: InExpression,
+      nExpression: NExpression,
+      window: Option[_ <: Window]
+  ): WindowedComputation = JWindowedComputations.maxN(path, inExpression, nExpression, window.orNull)
 
   /**
    * Builds a computation of the number of documents in the `window`.
@@ -351,10 +396,79 @@ object WindowedComputations {
    * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
-   * @see [[https://dochub.mongodb.org/core/window-functions-first \$first]]
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/first/ \$first]]
    */
   def first[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
     JWindowedComputations.first(path, expression, window.orNull)
+
+  /**
+   * Builds a computation of a BSON `Array`
+   * of evaluation results of the `inExpression` against the first `N`  documents in the `window`,
+   * where `N` is the positive integral value of the `nExpression`.
+   *
+   * [[Aggregates.setWindowFields Sorting]] is required.
+   *
+   * @param path The output field path.
+   * @param inExpression The input expression.
+   * @param nExpression The expression limiting the number of produced values.
+   * @tparam InExpression The type of the input expression.
+   * @tparam NExpression The type of the limiting expression.
+   * @return The constructed windowed computation.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/ \$firstN]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def firstN[InExpression, NExpression](
+      path: String,
+      inExpression: InExpression,
+      nExpression: NExpression,
+      window: Option[_ <: Window]
+  ): WindowedComputation = JWindowedComputations.firstN(path, inExpression, nExpression, window.orNull)
+
+  /**
+   * Builds a computation of the evaluation result of the `outExpression` against the top document in the `window`
+   * sorted according to the provided `sortBy` specification.
+   *
+   * @param path The output field path.
+   * @param sortBy The sort specification. The syntax is identical to the one expected by [[Aggregates.sort]].
+   * @param outExpression The output expression.
+   * @tparam OutExpression The type of the input expression.
+   * @return The constructed windowed computation.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/top/ \$top]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def top[OutExpression](
+      path: String,
+      sortBy: Bson,
+      outExpression: OutExpression,
+      window: Option[_ <: Window]
+  ): WindowedComputation = JWindowedComputations.top(path, sortBy, outExpression, window.orNull)
+
+  /**
+   * Builds a computation of a BSON `Array`
+   * of evaluation results of the `outExpression` against the top `N` documents in the `window`
+   * sorted according to the provided `sortBy` specification,
+   * where `N` is the positive integral value of the `nExpression`.
+   *
+   * @param path The output field path.
+   * @param sortBy The sort specification. The syntax is identical to the one expected by [[Aggregates.sort]].
+   * @param outExpression The output expression.
+   * @param nExpression The expression limiting the number of produced values.
+   * @tparam OutExpression The type of the input expression.
+   * @tparam NExpression The type of the limiting expression.
+   * @return The constructed windowed computation.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN/ \$topN]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def topN[OutExpression, NExpression](
+      path: String,
+      sortBy: Bson,
+      outExpression: OutExpression,
+      nExpression: NExpression,
+      window: Option[_ <: Window]
+  ): WindowedComputation = JWindowedComputations.topN(path, sortBy, outExpression, nExpression, window.orNull)
 
   /**
    * Builds a computation of the evaluation result of the `expression` against the last document in the `window`.
@@ -366,10 +480,79 @@ object WindowedComputations {
    * @param window     The window.
    * @tparam TExpression The expression type.
    * @return The constructed windowed computation.
-   * @see [[https://dochub.mongodb.org/core/window-functions-last \$last]]
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/last/ \$last]]
    */
   def last[TExpression](path: String, expression: TExpression, window: Option[_ <: Window]): WindowedComputation =
     JWindowedComputations.last(path, expression, window.orNull)
+
+  /**
+   * Builds a computation of a BSON `Array`
+   * of evaluation results of the `inExpression` against the last `N`  documents in the `window`,
+   * where `N` is the positive integral value of the `nExpression`.
+   *
+   * [[Aggregates.setWindowFields Sorting]] is required.
+   *
+   * @param path The output field path.
+   * @param inExpression The input expression.
+   * @param nExpression The expression limiting the number of produced values.
+   * @tparam InExpression The type of the input expression.
+   * @tparam NExpression The type of the limiting expression.
+   * @return The constructed windowed computation.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/lastN/ \$lastN]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def lastN[InExpression, NExpression](
+      path: String,
+      inExpression: InExpression,
+      nExpression: NExpression,
+      window: Option[_ <: Window]
+  ): WindowedComputation = JWindowedComputations.lastN(path, inExpression, nExpression, window.orNull)
+
+  /**
+   * Builds a computation of the evaluation result of the `outExpression` against the bottom document in the `window`
+   * sorted according to the provided `sortBy` specification.
+   *
+   * @param path The output field path.
+   * @param sortBy The sort specification. The syntax is identical to the one expected by [[Aggregates.sort]].
+   * @param outExpression The output expression.
+   * @tparam OutExpression The type of the input expression.
+   * @return The constructed windowed computation.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottom/ \$bottom]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def bottom[OutExpression](
+      path: String,
+      sortBy: Bson,
+      outExpression: OutExpression,
+      window: Option[_ <: Window]
+  ): WindowedComputation = JWindowedComputations.bottom(path, sortBy, outExpression, window.orNull)
+
+  /**
+   * Builds a computation of a BSON `Array`
+   * of evaluation results of the `outExpression` against the bottom `N` documents in the `window`
+   * sorted according to the provided `sortBy` specification,
+   * where `N` is the positive integral value of the `nExpression`.
+   *
+   * @param path The output field path.
+   * @param sortBy The sort specification. The syntax is identical to the one expected by [[Aggregates.sort]].
+   * @param outExpression The output expression.
+   * @param nExpression The expression limiting the number of produced values.
+   * @tparam OutExpression The type of the input expression.
+   * @tparam NExpression The type of the limiting expression.
+   * @return The constructed windowed computation.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottomN/ \$bottomN]]
+   * @since 4.7
+   * @note Requires MongoDB 5.2 or greater
+   */
+  def bottomN[OutExpression, NExpression](
+      path: String,
+      sortBy: Bson,
+      outExpression: OutExpression,
+      nExpression: NExpression,
+      window: Option[_ <: Window]
+  ): WindowedComputation = JWindowedComputations.bottomN(path, sortBy, outExpression, nExpression, window.orNull)
 
   /**
    * Builds a computation of the evaluation result of the `expression` for the document whose position is shifted by the given

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
@@ -17,7 +17,6 @@
 package org.mongodb.scala.model
 
 import java.lang.reflect.Modifier._
-
 import org.bson.BsonDocument
 import org.mongodb.scala.bson.BsonArray
 import org.mongodb.scala.bson.collection.immutable.Document
@@ -378,9 +377,17 @@ class AggregatesSpec extends BaseSpec {
         sum: { $sum: { $multiply: [ "$price", "$quantity" ] } },
         avg: { $avg: "$quantity" },
         min: { $min: "$quantity" },
+        minN: { $minN: { input: "$quantity", n: 2 } },
         max: { $max: "$quantity" },
+        maxN: { $maxN: { input: "$quantity", n: 2 } },
         first: { $first: "$quantity" },
+        firstN: { $firstN: { input: "$quantity", n: 2 } },
+        top: { $top: { sortBy: { quantity: 1 }, output: "$quantity" } },
+        topN: { $topN: { sortBy: { quantity: 1 }, output: "$quantity", n: 2 } },
         last: { $last: "$quantity" },
+        lastN: { $lastN: { input: "$quantity", n: 2 } },
+        bottom: { $bottom: { sortBy: { quantity: 1 }, output: ["$quantity", "$quality"] } },
+        bottomN: { $bottomN: { sortBy: { quantity: 1 }, output: ["$quantity", "$quality"], n: 2 } },
         all: { $push: "$quantity" },
         unique: { $addToSet: "$quantity" },
         stdDevPop: { $stdDevPop: "$quantity" },
@@ -394,9 +401,17 @@ class AggregatesSpec extends BaseSpec {
         sum("sum", Document("""{ $multiply: [ "$price", "$quantity" ] }""")),
         avg("avg", "$quantity"),
         min("min", "$quantity"),
+        minN("minN", "$quantity", 2),
         max("max", "$quantity"),
+        maxN("maxN", "$quantity", 2),
         first("first", "$quantity"),
+        firstN("firstN", "$quantity", 2),
+        top("top", ascending("quantity"), "$quantity"),
+        topN("topN", ascending("quantity"), "$quantity", 2),
         last("last", "$quantity"),
+        lastN("lastN", "$quantity", 2),
+        bottom("bottom", ascending("quantity"), List("$quantity", "$quality")),
+        bottomN("bottomN", ascending("quantity"), List("$quantity", "$quality"), 2),
         push("all", "$quantity"),
         addToSet("unique", "$quantity"),
         stdDevPop("stdDevPop", "$quantity"),
@@ -425,7 +440,9 @@ class AggregatesSpec extends BaseSpec {
         WindowedComputations.stdDevSamp("newField03", "$field03", Some(window)),
         WindowedComputations.stdDevPop("newField04", "$field04", Some(window)),
         WindowedComputations.min("newField05", "$field05", Some(window)),
+        WindowedComputations.minN("newField05N", "$field05N", 2, Some(window)),
         WindowedComputations.max("newField06", "$field06", Some(window)),
+        WindowedComputations.maxN("newField06N", "$field06N", 2, Some(window)),
         WindowedComputations.count("newField07", Some(window)),
         WindowedComputations.derivative("newField08", "$field08", window),
         WindowedComputations.timeDerivative("newField09", "$field09", window, DAY),
@@ -438,11 +455,17 @@ class AggregatesSpec extends BaseSpec {
         WindowedComputations.push("newField16", "$field16", Some(window)),
         WindowedComputations.addToSet("newField17", "$field17", Some(window)),
         WindowedComputations.first("newField18", "$field18", Some(window)),
+        WindowedComputations.firstN("newField18N", "$field18N", 2, Some(window)),
         WindowedComputations.last("newField19", "$field19", Some(window)),
+        WindowedComputations.lastN("newField19N", "$field19N", 2, Some(window)),
         WindowedComputations.shift("newField20", "$field20", Some("defaultConstantValue"), -3),
         WindowedComputations.documentNumber("newField21"),
         WindowedComputations.rank("newField22"),
-        WindowedComputations.denseRank("newField23")
+        WindowedComputations.denseRank("newField23"),
+        WindowedComputations.bottom("newField24", ascending("sortByField"), "$field24", Some(window)),
+        WindowedComputations.bottomN("newField24N", ascending("sortByField"), "$field24N", 2, Some(window)),
+        WindowedComputations.top("newField25", ascending("sortByField"), "$field25", Some(window)),
+        WindowedComputations.topN("newField25N", ascending("sortByField"), "$field25N", 2, Some(window))
       )
     ) should equal(
       Document(
@@ -457,7 +480,9 @@ class AggregatesSpec extends BaseSpec {
             "newField03": { "$stdDevSamp": "$field03", "window": { "documents": [1, 2] } },
             "newField04": { "$stdDevPop": "$field04", "window": { "documents": [1, 2] } },
             "newField05": { "$min": "$field05", "window": { "documents": [1, 2] } },
+            "newField05N": { "$minN": { "input": "$field05N", "n": 2 }, "window": { "documents": [1, 2] } },
             "newField06": { "$max": "$field06", "window": { "documents": [1, 2] } },
+            "newField06N": { "$maxN": { "input": "$field06N", "n": 2 }, "window": { "documents": [1, 2] } },
             "newField07": { "$count": {}, "window": { "documents": [1, 2] } },
             "newField08": { "$derivative": { "input": "$field08" }, "window": { "documents": [1, 2] } },
             "newField09": { "$derivative": { "input": "$field09", "unit": "day" }, "window": { "documents": [1, 2] } },
@@ -470,11 +495,17 @@ class AggregatesSpec extends BaseSpec {
             "newField16": { "$push": "$field16", "window": { "documents": [1, 2] } },
             "newField17": { "$addToSet": "$field17", "window": { "documents": [1, 2] } },
             "newField18": { "$first": "$field18", "window": { "documents": [1, 2] } },
+            "newField18N": { "$firstN": { "input": "$field18N", "n": 2 }, "window": { "documents": [1, 2] } },
             "newField19": { "$last": "$field19", "window": { "documents": [1, 2] } },
+            "newField19N": { "$lastN": { "input": "$field19N", "n": 2 }, "window": { "documents": [1, 2] } },
             "newField20": { "$shift": { "output": "$field20", "by": -3, "default": "defaultConstantValue" } },
             "newField21": { "$documentNumber": {} },
             "newField22": { "$rank": {} },
-            "newField23": { "$denseRank": {} }
+            "newField23": { "$denseRank": {} },
+            "newField24": { "$bottom": { "sortBy": { "sortByField": 1}, "output": "$field24"}, "window": { "documents": [1, 2] } },
+            "newField24N": { "$bottomN": { "sortBy": { "sortByField": 1}, "output": "$field24N", "n": 2 }, "window": { "documents": [1, 2] } },
+            "newField25": { "$top": { "sortBy": { "sortByField": 1}, "output": "$field25"}, "window": { "documents": [1, 2] } },
+            "newField25N": { "$topN": { "sortBy": { "sortByField": 1}, "output": "$field25N", "n": 2 }, "window": { "documents": [1, 2] } }
           }
         }
       }"""


### PR DESCRIPTION
Note that the links to server docs from API docs are not currently working. They will start working when MongoDB 6.0 become the "current" version. Depending when we anticipate 4.7 driver release and 6.0 MongoDB release, this may either be fine, or we may need to create a DOCSP request to prepare temporary https://dochub.mongodb.org/ URIs.

JAVA-4094