### PR TITLE
Remove `@Beta` from query builders related to `$setWindowFields`

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -17,7 +17,6 @@
 package com.mongodb.client.model;
 
 import com.mongodb.MongoNamespace;
-import com.mongodb.annotations.Beta;
 import com.mongodb.client.model.search.SearchOperator;
 import com.mongodb.client.model.search.SearchCollector;
 import com.mongodb.client.model.search.SearchOptions;
@@ -622,7 +621,6 @@ public final class Aggregates {
      * @mongodb.server.release 5.0
      * @since 4.3
      */
-    @Beta(Beta.Reason.SERVER)
     public static <TExpression> Bson setWindowFields(@Nullable final TExpression partitionBy, @Nullable final Bson sortBy,
                                                      final WindowedComputation... output) {
         notNull("output", output);
@@ -649,7 +647,6 @@ public final class Aggregates {
      * @mongodb.server.release 5.0
      * @since 4.3
      */
-    @Beta(Beta.Reason.SERVER)
     public static <TExpression> Bson setWindowFields(@Nullable final TExpression partitionBy, @Nullable final Bson sortBy,
                                                      final List<WindowedComputation> output) {
         notNull("output", output);

--- a/driver-core/src/main/com/mongodb/client/model/MongoTimeUnit.java
+++ b/driver-core/src/main/com/mongodb/client/model/MongoTimeUnit.java
@@ -15,8 +15,6 @@
  */
 package com.mongodb.client.model;
 
-import com.mongodb.annotations.Beta;
-
 /**
  * Units for specifying time-based bounds for {@linkplain Window windows} and output units for some time-based
  * {@linkplain WindowedComputation windowed computations}.
@@ -24,7 +22,6 @@ import com.mongodb.annotations.Beta;
  * @mongodb.server.release 5.0
  * @since 4.3
  */
-@Beta(Beta.Reason.SERVER)
 public enum MongoTimeUnit {
     /**
      * YEAR

--- a/driver-core/src/main/com/mongodb/client/model/Window.java
+++ b/driver-core/src/main/com/mongodb/client/model/Window.java
@@ -15,7 +15,6 @@
  */
 package com.mongodb.client.model;
 
-import com.mongodb.annotations.Beta;
 import org.bson.conversions.Bson;
 
 import java.util.List;
@@ -27,6 +26,5 @@ import java.util.List;
  * @see Windows
  * @since 4.3
  */
-@Beta(Beta.Reason.SERVER)
 public interface Window extends Bson {
 }

--- a/driver-core/src/main/com/mongodb/client/model/WindowedComputation.java
+++ b/driver-core/src/main/com/mongodb/client/model/WindowedComputation.java
@@ -15,7 +15,6 @@
  */
 package com.mongodb.client.model;
 
-import com.mongodb.annotations.Beta;
 import org.bson.conversions.Bson;
 
 import java.util.List;
@@ -27,7 +26,6 @@ import java.util.List;
  * @see WindowedComputations
  * @since 4.3
  */
-@Beta(Beta.Reason.SERVER)
 public interface WindowedComputation {
     /**
      * Render into {@link BsonField}.

--- a/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
+++ b/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
@@ -15,7 +15,6 @@
  */
 package com.mongodb.client.model;
 
-import com.mongodb.annotations.Beta;
 import com.mongodb.client.model.Windows.Bound;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
@@ -57,7 +56,6 @@ import static org.bson.assertions.Assertions.notNull;
  * @since 4.3
  * @mongodb.server.release 5.0
  */
-@Beta(Beta.Reason.SERVER)
 public final class WindowedComputations {
     /**
      * Creates a windowed computation from a document field in situations when there is no builder method that better satisfies your needs.

--- a/driver-core/src/main/com/mongodb/client/model/Windows.java
+++ b/driver-core/src/main/com/mongodb/client/model/Windows.java
@@ -15,7 +15,6 @@
  */
 package com.mongodb.client.model;
 
-import com.mongodb.annotations.Beta;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;
@@ -84,7 +83,6 @@ import static org.bson.assertions.Assertions.notNull;
  * @mongodb.server.release 5.0
  * @since 4.3
  */
-@Beta(Beta.Reason.SERVER)
 public final class Windows {
     /**
      * Creates a window from {@link Bson} in situations when there is no builder method that better satisfies your needs.
@@ -340,7 +338,6 @@ public final class Windows {
      * @mongodb.server.release 5.0
      * @since 4.3
      */
-    @Beta(Beta.Reason.SERVER)
     public enum Bound {
         /**
          * The {@linkplain Window window} bound is determined by the current document and is inclusive.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
@@ -16,8 +16,6 @@
 
 package org.mongodb.scala.model
 
-import com.mongodb.annotations.Beta
-
 import scala.collection.JavaConverters._
 import com.mongodb.client.model.{ Aggregates => JAggregates }
 import org.mongodb.scala.MongoNamespace
@@ -475,7 +473,6 @@ object Aggregates {
    * @since 4.3
    * @note Requires MongoDB 5.0 or greater.
    */
-  @Beta(Array(Beta.Reason.SERVER))
   def setWindowFields[TExpression >: Null](
       partitionBy: Option[TExpression],
       sortBy: Option[Bson],

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
@@ -15,7 +15,6 @@
  */
 package org.mongodb.scala.model
 
-import com.mongodb.annotations.Beta
 import com.mongodb.client.model.{ MongoTimeUnit => JMongoTimeUnit, WindowedComputations => JWindowedComputations }
 
 /**
@@ -38,7 +37,6 @@ import com.mongodb.client.model.{ MongoTimeUnit => JMongoTimeUnit, WindowedCompu
  * @since 4.3
  * @note Requires MongoDB 5.0 or greater.
  */
-@Beta(Array(Beta.Reason.SERVER))
 object WindowedComputations {
 
   /**

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/package.scala
@@ -16,8 +16,6 @@
 
 package org.mongodb.scala
 
-import com.mongodb.annotations.Beta
-
 import scala.collection.JavaConverters._
 import com.mongodb.client.model.{ MongoTimeUnit => JMongoTimeUnit }
 import org.mongodb.scala.bson.conversions.Bson
@@ -873,7 +871,6 @@ package object model {
    * @since 4.3
    * @note Requires MongoDB 5.0 or greater.
    */
-  @Beta(Array(Beta.Reason.SERVER))
   object MongoTimeUnit {
 
     val YEAR = JMongoTimeUnit.YEAR
@@ -902,7 +899,6 @@ package object model {
    * @see [[Windows]]
    * @since 4.3
    */
-  @Beta(Array(Beta.Reason.SERVER))
   type Window = com.mongodb.client.model.Window
 
   /**
@@ -912,7 +908,6 @@ package object model {
    * @see [[WindowedComputations]]
    * @since 4.3
    */
-  @Beta(Array(Beta.Reason.SERVER))
   type WindowedComputation = com.mongodb.client.model.WindowedComputation
 }
 


### PR DESCRIPTION
I checked that all window functions for which we have builders are in https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/, i.e., that no was removed, and that none of them is marked as "preview" when used with `$setWindowFields`.

Removing `@Beta` appears to be the only thing we need to do here.

JAVA-4559