### PR TITLE
Add query building API for the `$densify` aggregation pipeline stage

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -17,6 +17,8 @@
 package com.mongodb.client.model;
 
 import com.mongodb.MongoNamespace;
+import com.mongodb.client.model.densify.DensifyOptions;
+import com.mongodb.client.model.densify.DensifyRange;
 import com.mongodb.client.model.search.SearchOperator;
 import com.mongodb.client.model.search.SearchCollector;
 import com.mongodb.client.model.search.SearchOptions;
@@ -35,6 +37,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.mongodb.assertions.Assertions.assertTrue;
+import static com.mongodb.client.model.densify.DensifyOptions.densifyOptions;
 import static com.mongodb.client.model.search.SearchOptions.searchOptions;
 import static com.mongodb.internal.Iterables.concat;
 import static java.util.Arrays.asList;
@@ -654,6 +657,60 @@ public final class Aggregates {
                                                      final Iterable<? extends WindowedComputation> output) {
         notNull("output", output);
         return new SetWindowFieldsStage<>(partitionBy, sortBy, output);
+    }
+
+    /**
+     * Creates a {@code $densify} pipeline stage, which adds documents to a sequence of documents
+     * where certain values in the {@code field} are missing.
+     *
+     * @param field The field to densify.
+     * @param range The range.
+     * @return The requested pipeline stage.
+     * @mongodb.driver.manual reference/operator/aggregation/densify/ $densify
+     * @mongodb.driver.manual core/document/#dot-notation Dot notation
+     * @mongodb.server.release 5.1
+     * @since 4.7
+     */
+    public static Bson densify(final String field, final DensifyRange range) {
+        return densify(notNull("field", field), notNull("range", range), densifyOptions());
+    }
+
+    /**
+     * Creates a {@code $densify} pipeline stage, which adds documents to a sequence of documents
+     * where certain values in the {@code field} are missing.
+     *
+     * @param field The field to densify.
+     * @param range The range.
+     * @param options The densify options.
+     * Specifying {@link DensifyOptions#densifyOptions()} is equivalent to calling {@link #densify(String, DensifyRange)}.
+     * @return The requested pipeline stage.
+     * @mongodb.driver.manual reference/operator/aggregation/densify/ $densify
+     * @mongodb.driver.manual core/document/#dot-notation Dot notation
+     * @mongodb.server.release 5.1
+     * @since 4.7
+     */
+    public static Bson densify(final String field, final DensifyRange range, final DensifyOptions options) {
+        notNull("field", field);
+        notNull("range", range);
+        notNull("options", options);
+        return new Bson() {
+            @Override
+            public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {
+                BsonDocument densifySpecificationDoc = new BsonDocument("field", new BsonString(field));
+                densifySpecificationDoc.append("range", range.toBsonDocument(documentClass, codecRegistry));
+                densifySpecificationDoc.putAll(options.toBsonDocument(documentClass, codecRegistry));
+                return new BsonDocument("$densify", densifySpecificationDoc);
+            }
+
+            @Override
+            public String toString() {
+                return "Stage{name='$densify'"
+                        + ", field=" + field
+                        + ", range=" + range
+                        + ", options=" + options
+                        + '}';
+            }
+        };
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/MongoTimeUnit.java
+++ b/driver-core/src/main/com/mongodb/client/model/MongoTimeUnit.java
@@ -15,48 +15,53 @@
  */
 package com.mongodb.client.model;
 
+import org.bson.conversions.Bson;
+import com.mongodb.client.model.densify.DensifyRange;
+
 /**
- * Units for specifying time-based bounds for {@linkplain Window windows} and output units for some time-based
- * {@linkplain WindowedComputation windowed computations}.
+ * Units for specifying time-based values.
  *
+ * @see Windows
+ * @see WindowedComputations
+ * @see DensifyRange
  * @mongodb.server.release 5.0
  * @since 4.3
  */
 public enum MongoTimeUnit {
     /**
-     * YEAR
+     * {@linkplain #value() "year"}
      */
     YEAR("year", false),
     /**
-     * QUARTER
+     * {@linkplain #value() "quarter"}
      */
     QUARTER("quarter", false),
     /**
-     * MONTH
+     * {@linkplain #value() "month"}
      */
     MONTH("month", false),
     /**
-     * WEEK
+     * {@linkplain #value() "week"}
      */
     WEEK("week", true),
     /**
-     * DAY
+     * {@linkplain #value() "day"}
      */
     DAY("day", true),
     /**
-     * HOUR
+     * {@linkplain #value() "hour"}
      */
     HOUR("hour", true),
     /**
-     * MINUTE
+     * {@linkplain #value() "minute"}
      */
     MINUTE("minute", true),
     /**
-     * SECOND
+     * {@linkplain #value() "second"}
      */
     SECOND("second", true),
     /**
-     * MILLISECOND
+     * {@linkplain #value() "millisecond"}
      */
     MILLISECOND("millisecond", true);
 
@@ -68,7 +73,13 @@ public enum MongoTimeUnit {
         this.fixed = fixed;
     }
 
-    String value() {
+    /**
+     * Returns a {@link String} representation of the unit, which may be useful when using methods like
+     * {@link Windows#of(Bson)}, {@link DensifyRange#of(Bson)}.
+     *
+     * @return A {@link String} representation of the unit.
+     */
+    public String value() {
         return value;
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/Windows.java
+++ b/driver-core/src/main/com/mongodb/client/model/Windows.java
@@ -93,7 +93,7 @@ public final class Windows {
      *  Window pastWeek1 = Windows.timeRange(-1, MongoTimeUnit.WEEK, Windows.Bound.CURRENT);
      *  Window pastWeek2 = Windows.of(
      *          new Document("range", Arrays.asList(-1, "current"))
-     *                  .append("unit", "week"));
+     *                  .append("unit", MongoTimeUnit.WEEK.value()));
      * }</pre>
      *
      * @param window A {@link Bson} representing the required window.

--- a/driver-core/src/main/com/mongodb/client/model/densify/DateDensifyRange.java
+++ b/driver-core/src/main/com/mongodb/client/model/densify/DateDensifyRange.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUNumber WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.densify;
+
+import com.mongodb.annotations.Evolving;
+import com.mongodb.client.model.MongoTimeUnit;
+
+import java.time.Instant;
+
+/**
+ * @see DensifyRange#fullRangeWithStep(long, MongoTimeUnit)
+ * @see DensifyRange#partitionRangeWithStep(long, MongoTimeUnit)
+ * @see DensifyRange#rangeWithStep(Instant, Instant, long, MongoTimeUnit)
+ * @mongodb.server.release 5.1
+ * @since 4.7
+ */
+@Evolving
+public interface DateDensifyRange extends DensifyRange {
+}

--- a/driver-core/src/main/com/mongodb/client/model/densify/DensifyConstructibleBson.java
+++ b/driver-core/src/main/com/mongodb/client/model/densify/DensifyConstructibleBson.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.densify;
+
+import com.mongodb.internal.client.model.AbstractConstructibleBson;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.client.model.Util.sizeAtLeast;
+
+final class DensifyConstructibleBson extends AbstractConstructibleBson<DensifyConstructibleBson> implements
+        NumberDensifyRange, DateDensifyRange,
+        DensifyOptions {
+    static final DensifyConstructibleBson EMPTY_IMMUTABLE = new DensifyConstructibleBson(AbstractConstructibleBson.EMPTY_IMMUTABLE);
+
+    DensifyConstructibleBson(final Bson base) {
+        super(base);
+    }
+
+    private DensifyConstructibleBson(final Bson base, final Document appended) {
+        super(base, appended);
+    }
+
+    @Override
+    protected DensifyConstructibleBson newSelf(final Bson base, final Document appended) {
+        return new DensifyConstructibleBson(base, appended);
+    }
+
+    @Override
+    public DensifyOptions partitionByFields(final Iterable<String> fields) {
+        notNull("partitionByFields", fields);
+        return newMutated(doc -> {
+            if (sizeAtLeast(fields, 1)) {
+                doc.append("partitionByFields", fields);
+            } else {
+                doc.remove("partitionByFields");
+            }
+        });
+    }
+
+    @Override
+    public DensifyOptions option(final String name, final Object value) {
+        return newAppended(notNull("name", name), notNull("value", value));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/densify/DensifyOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/densify/DensifyOptions.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.densify;
+
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Evolving;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.lang.Nullable;
+import org.bson.conversions.Bson;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+
+/**
+ * Represents optional fields of the {@code $densify} pipeline stage of an aggregation pipeline.
+ *
+ * @see Aggregates#densify(String, DensifyRange, DensifyOptions)
+ * @see Aggregates#densify(String, DensifyRange)
+ * @mongodb.server.release 5.1
+ * @since 4.7
+ */
+@Evolving
+public interface DensifyOptions extends Bson {
+    /**
+     * Creates a new {@link DensifyOptions} with the specified {@code fields} to partition by.
+     *
+     * @param fields The fields to partition by.
+     * @return A new {@link DensifyOptions}.
+     * @mongodb.driver.manual core/document/#dot-notation Dot notation
+     */
+    default DensifyOptions partitionByFields(@Nullable final String... fields) {
+        return partitionByFields(fields == null ? emptyList() : asList(fields));
+    }
+
+    /**
+     * Creates a new {@link DensifyOptions} with the specified {@code fields} to partition by.
+     *
+     * @param fields The fields to partition by.
+     * @return A new {@link DensifyOptions}.
+     * @mongodb.driver.manual core/document/#dot-notation Dot notation
+     */
+    DensifyOptions partitionByFields(Iterable<String> fields);
+
+    /**
+     * Creates a new {@link DensifyOptions} with the specified option in situations when there is no builder method
+     * that better satisfies your needs.
+     * This method cannot be used to validate the syntax.
+     * <p>
+     * <i>Example</i><br>
+     * The following code creates two functionally equivalent {@link DensifyOptions} objects,
+     * though they may not be {@linkplain Object#equals(Object) equal}.
+     * <pre>{@code
+     *  DensifyOptions options1 = DensifyOptions.densifyOptions()
+     *          .partitionByFields("fieldName");
+     *  DensifyOptions options2 = DensifyOptions.densifyOptions()
+     *          .option("partitionByFields", Collections.singleton("fieldName"));
+     * }</pre>
+     *
+     * @param name The option name.
+     * @param value The option value.
+     * @return A new {@link DensifyOptions}.
+     */
+    DensifyOptions option(String name, Object value);
+
+    /**
+     * Returns {@link DensifyOptions} that represents server defaults.
+     *
+     * @return {@link DensifyOptions} that represents server defaults.
+     */
+    static DensifyOptions densifyOptions() {
+        return DensifyConstructibleBson.EMPTY_IMMUTABLE;
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/densify/DensifyOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/densify/DensifyOptions.java
@@ -15,7 +15,6 @@
  */
 package com.mongodb.client.model.densify;
 
-import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Evolving;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.lang.Nullable;

--- a/driver-core/src/main/com/mongodb/client/model/densify/DensifyOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/densify/DensifyOptions.java
@@ -37,6 +37,7 @@ public interface DensifyOptions extends Bson {
      * Creates a new {@link DensifyOptions} with the specified {@code fields} to partition by.
      *
      * @param fields The fields to partition by.
+     * If no fields are specified, then the whole sequence is considered to be a single partition.
      * @return A new {@link DensifyOptions}.
      * @mongodb.driver.manual core/document/#dot-notation Dot notation
      */
@@ -48,6 +49,7 @@ public interface DensifyOptions extends Bson {
      * Creates a new {@link DensifyOptions} with the specified {@code fields} to partition by.
      *
      * @param fields The fields to partition by.
+     * If no fields are specified, then the whole sequence is considered to be a single partition.
      * @return A new {@link DensifyOptions}.
      * @mongodb.driver.manual core/document/#dot-notation Dot notation
      */

--- a/driver-core/src/main/com/mongodb/client/model/densify/DensifyRange.java
+++ b/driver-core/src/main/com/mongodb/client/model/densify/DensifyRange.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.densify;
+
+import com.mongodb.annotations.Evolving;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.MongoTimeUnit;
+import org.bson.BsonDocument;
+import org.bson.BsonInt64;
+import org.bson.BsonString;
+import org.bson.BsonType;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import java.time.Instant;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static java.util.Arrays.asList;
+
+/**
+ * A specification of how to compute the missing {@linkplain Aggregates#densify(String, DensifyRange, DensifyOptions) field} values
+ * for which new documents must be added. It specifies a half-closed interval of values with the lower bound being inclusive, and a step.
+ * The first potentially missing value within each interval is its lower bound, other values are computed by adding the step
+ * multiple times, until the result is out of the interval. Each time the step is added, the result is a potentially missing value for
+ * which a new document must be added if the sequence of documents that is being densified does not have a document
+ * with equal value of the field.
+ *
+ * @see Aggregates#densify(String, DensifyRange, DensifyOptions)
+ * @see Aggregates#densify(String, DensifyRange)
+ * @mongodb.server.release 5.1
+ * @since 4.7
+ */
+@Evolving
+public interface DensifyRange extends Bson {
+    /**
+     * Returns a {@link DensifyRange} that represents an interval with the smallest
+     * BSON {@link BsonType#INT32 32-bit integer} / {@link BsonType#INT64 64-bit integer} / {@link BsonType#DOUBLE Double} /
+     * {@link BsonType#DECIMAL128 Decimal128} value of the {@linkplain Aggregates#densify(String, DensifyRange, DensifyOptions) field}
+     * in the sequence of documents being its lower bound, and the largest value being the upper bound.
+     *
+     * @param step The step.
+     * @return The requested {@link DensifyRange}.
+     */
+    static NumberDensifyRange fullRangeWithStep(final Number step) {
+        return new DensifyConstructibleBson(new Document("bounds", "full")
+                .append("step", notNull("step", step)));
+    }
+
+    /**
+     * Returns a {@link DensifyRange} that represents an interval with the smallest
+     * BSON {@link BsonType#INT32 32-bit integer} / {@link BsonType#INT64 64-bit integer} / {@link BsonType#DOUBLE Double} /
+     * {@link BsonType#DECIMAL128 Decimal128} value of the {@linkplain Aggregates#densify(String, DensifyRange, DensifyOptions) field}
+     * in the {@linkplain DensifyOptions#partitionByFields(Iterable) partition} of documents being its lower bound,
+     * and the largest value being the upper bound.
+     *
+     * @param step The step.
+     * @return The requested {@link DensifyRange}.
+     */
+    static NumberDensifyRange partitionRangeWithStep(final Number step) {
+        return new DensifyConstructibleBson(new Document("bounds", "partition")
+                .append("step", notNull("step", step)));
+    }
+
+    /**
+     * Returns a {@link DensifyRange} that represents a single interval [l; u).
+     *
+     * @param l The lower bound.
+     * @param u The upper bound.
+     * @param step The step.
+     * @return The requested {@link DensifyRange}.
+     */
+    static NumberDensifyRange rangeWithStep(final Number l, final Number u, final Number step) {
+        notNull("l", l);
+        notNull("u", u);
+        notNull("step", step);
+        return new DensifyConstructibleBson(new Document("bounds", asList(l, u))
+                .append("step", notNull("step", step)));
+    }
+
+    /**
+     * Returns a {@link DensifyRange} that represents an interval with the smallest BSON {@link BsonType#DATE_TIME Date} value
+     * of the {@linkplain Aggregates#densify(String, DensifyRange, DensifyOptions) field}
+     * in the sequence of documents being its lower bound, and the largest value being the upper bound.
+     *
+     * @param step The step.
+     * @param unit The unit in which the {@code step} is specified.
+     * @return The requested {@link DensifyRange}.
+     */
+    static DateDensifyRange fullRangeWithStep(final long step, final MongoTimeUnit unit) {
+        notNull("unit", unit);
+        return new DensifyConstructibleBson(new BsonDocument("bounds", new BsonString("full"))
+                .append("step", new BsonInt64(step))
+                .append("unit", new BsonString(unit.value())));
+    }
+
+    /**
+     * Returns a {@link DensifyRange} that represents an interval with the smallest BSON {@link BsonType#DATE_TIME Date} value
+     * of the {@linkplain Aggregates#densify(String, DensifyRange, DensifyOptions) field}
+     * in the {@linkplain DensifyOptions#partitionByFields(Iterable) partition} of documents being its lower bound,
+     * and the largest value being the upper bound.
+     *
+     * @param step The step.
+     * @param unit The unit in which the {@code step} is specified.
+     * @return The requested {@link DensifyRange}.
+     */
+    static DateDensifyRange partitionRangeWithStep(final long step, final MongoTimeUnit unit) {
+        notNull("unit", unit);
+        return new DensifyConstructibleBson(new BsonDocument("bounds", new BsonString("partition"))
+                .append("step", new BsonInt64(step))
+                .append("unit", new BsonString(unit.value())));
+    }
+
+    /**
+     * Returns a {@link DensifyRange} that represents a single interval [l; u).
+     *
+     * @param l The lower bound.
+     * @param u The upper bound.
+     * @param step The step.
+     * @param unit The unit in which the {@code step} is specified.
+     * @return The requested {@link DensifyRange}.
+     */
+    static DateDensifyRange rangeWithStep(final Instant l, final Instant u, final long step, final MongoTimeUnit unit) {
+        notNull("l", l);
+        notNull("u", u);
+        notNull("unit", unit);
+        return new DensifyConstructibleBson(new Document("bounds", asList(l, u))
+                .append("step", step)
+                .append("unit", unit.value()));
+    }
+
+    /**
+     * Creates a {@link DensifyRange} from a {@link Bson} in situations when there is no builder method that better satisfies your needs.
+     * This method cannot be used to validate the syntax.
+     * <p>
+     * <i>Example</i><br>
+     * The following code creates two functionally equivalent {@link DensifyRange}s,
+     * though they may not be {@linkplain Object#equals(Object) equal}.
+     * <pre>{@code
+     *  DensifyRange range1 = DensifyRange.partitionRangeWithStep(
+     *          1, MongoTimeUnit.MINUTE);
+     *  DensifyRange range2 = DensifyRange.of(new Document("bounds", "partition")
+     *          .append("step", 1).append("unit", MongoTimeUnit.MINUTE.value()));
+     * }</pre>
+     *
+     * @param range A {@link Bson} representing the required {@link DensifyRange}.
+     * @return The requested {@link DensifyRange}.
+     */
+    static DensifyRange of(final Bson range) {
+        return new DensifyConstructibleBson(notNull("range", range));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/densify/DensifyRange.java
+++ b/driver-core/src/main/com/mongodb/client/model/densify/DensifyRange.java
@@ -75,7 +75,7 @@ public interface DensifyRange extends Bson {
     }
 
     /**
-     * Returns a {@link DensifyRange} that represents a single interval [l; u).
+     * Returns a {@link DensifyRange} that represents a single interval [l, u).
      *
      * @param l The lower bound.
      * @param u The upper bound.
@@ -124,7 +124,7 @@ public interface DensifyRange extends Bson {
     }
 
     /**
-     * Returns a {@link DensifyRange} that represents a single interval [l; u).
+     * Returns a {@link DensifyRange} that represents a single interval [l, u).
      *
      * @param l The lower bound.
      * @param u The upper bound.

--- a/driver-core/src/main/com/mongodb/client/model/densify/NumberDensifyRange.java
+++ b/driver-core/src/main/com/mongodb/client/model/densify/NumberDensifyRange.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUNumber WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.densify;
+
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see DensifyRange#fullRangeWithStep(Number)
+ * @see DensifyRange#partitionRangeWithStep(Number)
+ * @see DensifyRange#rangeWithStep(Number, Number, Number)
+ * @mongodb.server.release 5.1
+ * @since 4.7
+ */
+@Evolving
+public interface NumberDensifyRange extends DensifyRange {
+}

--- a/driver-core/src/main/com/mongodb/client/model/densify/package-info.java
+++ b/driver-core/src/main/com/mongodb/client/model/densify/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @see com.mongodb.client.model.Aggregates#densify(java.lang.String, com.mongodb.client.model.densify.DensifyRange, com.mongodb.client.model.densify.DensifyOptions)
+ * @see com.mongodb.client.model.Aggregates#densify(java.lang.String, com.mongodb.client.model.densify.DensifyRange)
+ * @mongodb.server.release 5.1
+ * @since 4.7
+ */
+@NonNullApi
+package com.mongodb.client.model.densify;
+
+import com.mongodb.lang.NonNullApi;

--- a/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
@@ -53,6 +53,7 @@ import static com.mongodb.client.model.Aggregates.addFields
 import static com.mongodb.client.model.Aggregates.bucket
 import static com.mongodb.client.model.Aggregates.bucketAuto
 import static com.mongodb.client.model.Aggregates.count
+import static com.mongodb.client.model.Aggregates.densify
 import static com.mongodb.client.model.Aggregates.graphLookup
 import static com.mongodb.client.model.Aggregates.group
 import static com.mongodb.client.model.Aggregates.limit
@@ -84,6 +85,7 @@ import static com.mongodb.client.model.Sorts.descending
 import static com.mongodb.client.model.Windows.Bound.CURRENT
 import static com.mongodb.client.model.Windows.Bound.UNBOUNDED
 import static com.mongodb.client.model.Windows.documents
+import static com.mongodb.client.model.densify.DensifyRange.fullRangeWithStep
 import static com.mongodb.client.model.search.SearchCollector.facet
 import static com.mongodb.client.model.search.SearchCount.total
 import static com.mongodb.client.model.search.SearchFacet.stringFacet
@@ -615,6 +617,23 @@ class AggregatesSpecification extends Specification {
                     "output": {
                         "newField01": { "$sum": "$field01", "window": { "documents": [1, 2] } }
                     }
+                }
+        }''')
+    }
+
+    def 'should render $densify'() {
+        when:
+        BsonDocument densifyDoc = toBson(
+                densify(
+                        'fieldName',
+                        fullRangeWithStep(1))
+        )
+
+        then:
+        densifyDoc == parse('''{
+                "$densify": {
+                    "field": "fieldName",
+                    "range": { "bounds": "full", "step": 1 }
                 }
         }''')
     }

--- a/driver-core/src/test/unit/com/mongodb/client/model/TestWindows.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/TestWindows.java
@@ -45,7 +45,7 @@ final class TestWindows {
     @Test
     void of() {
         Window expected = Windows.timeRange(-1, SECOND, CURRENT);
-        Document windowDocument = new Document("range", asList(-1L, "current")).append("unit", "second");
+        Document windowDocument = new Document("range", asList(-1L, "current")).append("unit", SECOND.value());
         Window actualFromDocument = Windows.of(windowDocument);
         Window actualFromBsonDocument = Windows.of(windowDocument.toBsonDocument());
         assertAll(

--- a/driver-core/src/test/unit/com/mongodb/client/model/densify/DensifyOptionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/densify/DensifyOptionsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.densify;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class DensifyOptionsTest {
+    @Test
+    void densifyOptions() {
+        assertEquals(
+                new BsonDocument(),
+                DensifyOptions.densifyOptions()
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void partitionByFields() {
+        assertAll(
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("partitionByFields", new BsonArray(singletonList(new BsonString("$fieldName")))),
+                        DensifyOptions.densifyOptions()
+                                .partitionByFields("$fieldName")
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("partitionByFields", new BsonArray(asList(new BsonString("$fieldName1"), new BsonString("$fieldName2")))),
+                        DensifyOptions.densifyOptions()
+                                .partitionByFields("$fieldName1", "$fieldName2")
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("partitionByFields", new BsonArray(asList(new BsonString("$fieldName1"), new BsonString("$fieldName2")))),
+                        DensifyOptions.densifyOptions()
+                                .partitionByFields(asList("$fieldName1", "$fieldName2"))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("partitionByFields", new BsonArray(singletonList(new BsonString("fieldName2")))),
+                        DensifyOptions.densifyOptions()
+                                .partitionByFields("$fieldName1")
+                                .partitionByFields(singleton("fieldName2"))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument(),
+                        DensifyOptions.densifyOptions()
+                                .partitionByFields(singleton("$fieldName1"))
+                                .partitionByFields()
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void option() {
+        assertEquals(
+                DensifyOptions.densifyOptions()
+                        .option("partitionByFields", new BsonArray(singletonList(new BsonString("fieldName"))))
+                        .toBsonDocument(),
+                DensifyOptions.densifyOptions()
+                        .option("partitionByFields", singleton("fieldName"))
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void options() {
+        assertEquals(
+                new BsonDocument()
+                        .append("partitionByFields", new BsonArray(singletonList(new BsonString("fieldName"))))
+                        .append("name", new BsonInt32(42)),
+                DensifyOptions.densifyOptions()
+                        .partitionByFields("fieldName")
+                        .option("name", 42)
+                        .toBsonDocument()
+        );
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/densify/DensifyRangeTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/densify/DensifyRangeTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.densify;
+
+import com.mongodb.client.model.MongoTimeUnit;
+import org.bson.BsonArray;
+import org.bson.BsonDateTime;
+import org.bson.BsonDecimal128;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.bson.types.Decimal128;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class DensifyRangeTest {
+    @Test
+    void of() {
+        assertEquals(
+                docExamplePredefined()
+                        .toBsonDocument(),
+                DensifyRange.of(docExampleCustom())
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void numberRangeFull() {
+        assertAll(
+                () -> assertEquals(
+                        new BsonDocument("bounds", new BsonString("full")).append("step", new BsonInt32(1)),
+                        DensifyRange.fullRangeWithStep(1)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void numberRangePartition() {
+        assertAll(
+                () -> assertEquals(
+                        new BsonDocument("bounds", new BsonString("partition")).append("step", new BsonDouble(0.5)),
+                        DensifyRange.partitionRangeWithStep(0.5)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void numberRange() {
+        assertEquals(
+                new BsonDocument("bounds", new BsonArray(asList(
+                        new BsonDecimal128(new Decimal128(new BigDecimal("-10.5"))),
+                        new BsonDecimal128(new Decimal128(new BigDecimal("-10.5"))))))
+                        .append("step", new BsonDecimal128(new Decimal128(BigDecimal.ONE))),
+                DensifyRange.rangeWithStep(
+                                new BigDecimal("-10.5"),
+                                new BigDecimal("-10.5"),
+                                BigDecimal.ONE)
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void dateRangeFull() {
+        assertAll(
+                () -> assertEquals(
+                        new BsonDocument("bounds", new BsonString("full"))
+                                .append("step", new BsonInt64(1)).append("unit", new BsonString(MongoTimeUnit.MILLISECOND.value())),
+                        DensifyRange.fullRangeWithStep(
+                                1, MongoTimeUnit.MILLISECOND)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void dateRangePartition() {
+        assertAll(
+                () -> assertEquals(
+                        docExampleCustom()
+                                .toBsonDocument(),
+                        docExamplePredefined()
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument("bounds", new BsonString("partition"))
+                                .append("step", new BsonInt64(1))
+                                .append("unit", new BsonString(MongoTimeUnit.MILLISECOND.value())),
+                        DensifyRange.partitionRangeWithStep(1, MongoTimeUnit.MILLISECOND)
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void dateRange() {
+        assertEquals(
+                new BsonDocument("bounds", new BsonArray(asList(
+                        new BsonDateTime(0),
+                        new BsonDateTime(2))))
+                        .append("step", new BsonInt64(1)).append("unit", new BsonString(MongoTimeUnit.MILLISECOND.value())),
+                DensifyRange.rangeWithStep(
+                                Instant.EPOCH,
+                                Instant.ofEpochMilli(2),
+                                1, MongoTimeUnit.MILLISECOND)
+                        .toBsonDocument()
+        );
+    }
+
+    private static DensifyRange docExamplePredefined() {
+        return DensifyRange.partitionRangeWithStep(
+                1, MongoTimeUnit.MINUTE);
+    }
+
+    private static Document docExampleCustom() {
+        return new Document("bounds", "partition")
+                .append("step", 1L).append("unit", MongoTimeUnit.MINUTE.value());
+    }
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
@@ -20,6 +20,7 @@ import scala.collection.JavaConverters._
 import com.mongodb.client.model.{ Aggregates => JAggregates }
 import org.mongodb.scala.MongoNamespace
 import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.densify.{ DensifyOptions, DensifyRange }
 import org.mongodb.scala.model.search.{ SearchCollector, SearchOperator, SearchOptions }
 
 /**
@@ -509,6 +510,38 @@ object Aggregates {
       output: Iterable[_ <: WindowedComputation]
   ): Bson =
     JAggregates.setWindowFields(partitionBy.orNull, sortBy.orNull, output.asJava)
+
+  /**
+   * Creates a `\$densify` pipeline stage, which adds documents to a sequence of documents
+   * where certain values in the `field` are missing.
+   *
+   * @param field The field to densify.
+   * @param range The range.
+   * @return The requested pipeline stage.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/densify/ \$densify]]
+   * @see [[https://www.mongodb.com/docs/manual/core/document/#dot-notation Dot notation]]
+   * @note Requires MongoDB 5.1 or greater.
+   * @since 4.7
+   */
+  def densify(field: String, range: DensifyRange): Bson =
+    JAggregates.densify(field, range)
+
+  /**
+   * Creates a `\$densify` pipeline stage, which adds documents to a sequence of documents
+   * where certain values in the `field` are missing.
+   *
+   * @param field The field to densify.
+   * @param range The range.
+   * @param options The densify options.
+   * Specifying `DensifyOptions.densifyOptions` is equivalent to calling `Aggregates.densify(String, DensifyRange)`.
+   * @return The requested pipeline stage.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/densify/ \$densify]]
+   * @see [[https://www.mongodb.com/docs/manual/core/document/#dot-notation Dot notation]]
+   * @note Requires MongoDB 5.1 or greater.
+   * @since 4.7
+   */
+  def densify(field: String, range: DensifyRange, options: DensifyOptions): Bson =
+    JAggregates.densify(field, range, options)
 
   /**
    * Creates a `\$search` pipeline stage supported by MongoDB Atlas.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/densify/DensifyOptions.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/densify/DensifyOptions.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.densify
+
+import com.mongodb.client.model.densify.{ DensifyOptions => JDensifyOptions }
+
+/**
+ * Represents optional fields of the `\$densify` pipeline stage of an aggregation pipeline.
+ *
+ * @see `Aggregates.densify`
+ * @note Requires MongoDB 5.1 or greater.
+ * @since 4.7
+ */
+object DensifyOptions {
+
+  /**
+   * Returns `DensifyOptions` that represents server defaults.
+   *
+   * @return `DensifyOptions` that represents server defaults.
+   */
+  def densifyOptions(): DensifyOptions = JDensifyOptions.densifyOptions()
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/densify/DensifyRange.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/densify/DensifyRange.scala
@@ -57,7 +57,7 @@ object DensifyRange {
     JDensifyRange.partitionRangeWithStep(step)
 
   /**
-   * Returns a `DensifyRange` that represents a single interval [l; u).
+   * Returns a `DensifyRange` that represents a single interval [l, u).
    *
    * @param l The lower bound.
    * @param u The upper bound.
@@ -90,7 +90,7 @@ object DensifyRange {
     JDensifyRange.partitionRangeWithStep(step, unit)
 
   /**
-   * Returns a `DensifyRange` that represents a single interval [l; u).
+   * Returns a `DensifyRange` that represents a single interval [l, u).
    *
    * @param l The lower bound.
    * @param u The upper bound.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/densify/DensifyRange.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/densify/DensifyRange.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.densify
+
+import com.mongodb.client.model.{ MongoTimeUnit => JMongoTimeUnit }
+import com.mongodb.client.model.densify.{ DensifyRange => JDensifyRange }
+import org.bson.conversions.Bson
+
+import java.time.Instant
+
+/**
+ * A specification of how to compute the missing field values
+ * for which new documents must be added. It specifies a half-closed interval of values with the lower bound being inclusive, and a step.
+ * The first potentially missing value within each interval is its lower bound, other values are computed by adding the step
+ * multiple times, until the result is out of the interval. Each time the step is added, the result is a potentially missing value for
+ * which a new document must be added if the sequence of documents that is being densified does not have a document
+ * with equal value of the field.
+ *
+ * @see `Aggregates.densify`
+ * @note Requires MongoDB 5.1 or greater.
+ * @since 4.7
+ */
+object DensifyRange {
+
+  /**
+   * Returns a `DensifyRange` that represents an interval with the smallest
+   * BSON `32-bit integer` / `64-bit integer` / `Double` / `Decimal128` value of the field
+   * in the sequence of documents being its lower bound, and the largest value being the upper bound.
+   *
+   * @param step The positive step.
+   * @return The requested `DensifyRange`.
+   */
+  def fullRangeWithStep(step: Number): NumberDensifyRange = JDensifyRange.fullRangeWithStep(step)
+
+  /**
+   * Returns a `DensifyRange` that represents an interval with the smallest
+   * BSON `32-bit integer` / `64-bit integer` / `Double` / `Decimal128` value of the field
+   * in the partition of documents being its lower bound, and the largest value being the upper bound.
+   *
+   * @param step The positive step.
+   * @return The requested `DensifyRange`.
+   */
+  def partitionRangeWithStep(step: Number): NumberDensifyRange =
+    JDensifyRange.partitionRangeWithStep(step)
+
+  /**
+   * Returns a `DensifyRange` that represents a single interval [l; u).
+   *
+   * @param l The lower bound.
+   * @param u The upper bound.
+   * @param step The positive step.
+   * @return The requested `DensifyRange`.
+   */
+  def rangeWithStep(l: Number, u: Number, step: Number): NumberDensifyRange =
+    JDensifyRange.rangeWithStep(l, u, step)
+
+  /**
+   * Returns a `DensifyRange` that represents an interval with the smallest BSON `Date` value of the field
+   * in the sequence of documents being its lower bound, and the largest value being the upper bound.
+   *
+   * @param step The positive step.
+   * @param unit The unit in which the `step` is specified.
+   * @return The requested `DensifyRange`.
+   */
+  def fullRangeWithStep(step: Long, unit: JMongoTimeUnit): DateDensifyRange =
+    JDensifyRange.fullRangeWithStep(step, unit)
+
+  /**
+   * Returns a `DensifyRange` that represents an interval with the smallest BSON `Date` value of the field
+   * in the partition of documents being its lower bound, and the largest value being the upper bound.
+   *
+   * @param step The positive step.
+   * @param unit The unit in which the `step` is specified.
+   * @return The requested `DensifyRange`.
+   */
+  def partitionRangeWithStep(step: Long, unit: JMongoTimeUnit): DateDensifyRange =
+    JDensifyRange.partitionRangeWithStep(step, unit)
+
+  /**
+   * Returns a `DensifyRange` that represents a single interval [l; u).
+   *
+   * @param l The lower bound.
+   * @param u The upper bound.
+   * @param step The positive step.
+   * @param unit The unit in which the `step` is specified.
+   * @return The requested `DensifyRange`.
+   */
+  def rangeWithStep(l: Instant, u: Instant, step: Long, unit: JMongoTimeUnit): DateDensifyRange =
+    JDensifyRange.rangeWithStep(l, u, step, unit)
+
+  /**
+   * Creates a `DensifyRange` from a `Bson` in situations when there is no builder method that better satisfies your needs.
+   * This method cannot be used to validate the syntax.
+   *
+   * <i>Example</i><br>
+   * The following code creates two functionally equivalent `DensifyRange`s,
+   * though they may not be equal.
+   * {{{
+   *  val range1 = DensifyRange.partitionRangeWithStep(
+   *    1, MongoTimeUnit.MINUTE)
+   *  val range2 = DensifyRange.of(Document("bounds" -> "partition",
+   *    "step" -> 1, "unit" -> MongoTimeUnit.MINUTE.value()))
+   * }}}
+   *
+   * @param range A `Bson` representing the required `DensifyRange`.
+   *
+   * @return The requested `DensifyRange`.
+   */
+  def of(range: Bson): DensifyRange = JDensifyRange.of(range)
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/densify/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/densify/package.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model
+
+import com.mongodb.annotations.Evolving
+
+/**
+ * @see `Aggregates.densify`
+ * @note Requires MongoDB 5.1 or greater.
+ * @since 4.7
+ */
+package object densify {
+
+  /**
+   * A specification of how to compute the missing field values
+   * for which new documents must be added. It specifies a half-closed interval of values with the lower bound being inclusive, and a step.
+   * The first potentially missing value within each interval is its lower bound, other values are computed by adding the step
+   * multiple times, until the result is out of the interval. Each time the step is added, the result is a potentially missing value for
+   * which a new document must be added if the sequence of documents that is being densified does not have a document
+   * with equal value of the field.
+   *
+   * @see `Aggregates.densify`
+   */
+  @Evolving
+  type DensifyRange = com.mongodb.client.model.densify.DensifyRange
+
+  /**
+   * @see `DensifyRange.fullRangeWithStep`
+   * @see `DensifyRange.partitionRangeWithStep`
+   * @see `DensifyRange.rangeWithStep`
+   */
+  @Evolving
+  type NumberDensifyRange = com.mongodb.client.model.densify.NumberDensifyRange
+
+  /**
+   * @see `DensifyRange.fullRangeWithStep`
+   * @see `DensifyRange.partitionRangeWithStep`
+   * @see `DensifyRange.rangeWithStep`
+   */
+  @Evolving
+  type DateDensifyRange = com.mongodb.client.model.densify.DateDensifyRange
+
+  /**
+   * Represents optional fields of the `\$densify` pipeline stage of an aggregation pipeline.
+   *
+   * @see `Aggregates.densify`
+   */
+  @Evolving
+  type DensifyOptions = com.mongodb.client.model.densify.DensifyOptions
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/package.scala
@@ -865,9 +865,11 @@ package object model {
   }
 
   /**
-   * Units for specifying time-based bounds for [[Window windows]] and output units for some time-based
-   * [[WindowedComputation windowed computations]].
+   * Units for specifying time-based values.
    *
+   * @see [[Windows]]
+   * @see [[WindowedComputations]]
+   * @see `org.mongodb.scala.model.densify.DensifyRange`
    * @since 4.3
    * @note Requires MongoDB 5.0 or greater.
    */

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
@@ -28,6 +28,7 @@ import org.mongodb.scala.model.Projections._
 import org.mongodb.scala.model.Sorts._
 import org.mongodb.scala.model.Windows.Bound.{ CURRENT, UNBOUNDED }
 import org.mongodb.scala.model.Windows.{ documents, range }
+import org.mongodb.scala.model.densify.DensifyRange.fullRangeWithStep
 import org.mongodb.scala.model.search.SearchCount.total
 import org.mongodb.scala.model.search.SearchFacet.stringFacet
 import org.mongodb.scala.model.search.SearchHighlight.paths
@@ -522,6 +523,22 @@ class AggregatesSpec extends BaseSpec {
           "output": {
             "newField01": { "$sum": "$field01", "window": { "documents": [1, 2] } }
           }
+        }
+      }""")
+    )
+  }
+
+  it should "render $densify" in {
+    toBson(
+      densify(
+        "fieldName",
+        fullRangeWithStep(1)
+      )
+    ) should equal(
+      Document("""{
+        "$densify": {
+          "field": "fieldName",
+          "range": { "bounds": "full", "step": 1 }
         }
       }""")
     )


### PR DESCRIPTION
The new API:

- Aggregates.densify for [`$densify`](https://www.mongodb.com/docs/v6.0/reference/operator/aggregation/densify/)

The server-side syntax document is [here](https://docs.google.com/document/d/1pwIBc5XzbZkMnZH-FAoVYf2OOUzQM2VT8wbtoC4FMTg/edit#heading=h.sshyb2wdxr2w).

You may see how the API usage looks like, or play with it in

- `AggregatesFunctionalSpecification.'$densify'`

JAVA-4350