### PR TITLE
Corrected successSubscriber to documentSubscriber for 2 awaits() in the QuickTour.

### DIFF
--- a/driver-reactive-streams/src/examples/reactivestreams/tour/QuickTour.java
+++ b/driver-reactive-streams/src/examples/reactivestreams/tour/QuickTour.java
@@ -127,12 +127,12 @@ public class QuickTour {
         // now use a range query to get a larger subset
         documentSubscriber = new PrintDocumentSubscriber();
         collection.find(gt("i", 50)).subscribe(documentSubscriber);
-        successSubscriber.await();
+        documentSubscriber.await();
 
         // range query with multiple constraints
         documentSubscriber = new PrintDocumentSubscriber();
         collection.find(and(gt("i", 50), lte("i", 100))).subscribe(documentSubscriber);
-        successSubscriber.await();
+        documentSubscriber.await();
 
         // Sorting
         documentSubscriber = new PrintDocumentSubscriber();


### PR DESCRIPTION
The QuickTour was calling await on the wrong subscriber.