### PR TITLE
Accept `Iterable` instead of `List` in `Aggregates.setWindowFields`

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -648,7 +648,7 @@ public final class Aggregates {
      * @since 4.3
      */
     public static <TExpression> Bson setWindowFields(@Nullable final TExpression partitionBy, @Nullable final Bson sortBy,
-                                                     final List<WindowedComputation> output) {
+                                                     final Iterable<? extends WindowedComputation> output) {
         notNull("output", output);
         return new SetWindowFieldsStage<>(partitionBy, sortBy, output);
     }
@@ -1706,9 +1706,12 @@ public final class Aggregates {
         private final TExpression partitionBy;
         @Nullable
         private final Bson sortBy;
-        private final List<WindowedComputation> output;
+        private final Iterable<? extends WindowedComputation> output;
 
-        SetWindowFieldsStage(@Nullable final TExpression partitionBy, @Nullable final Bson sortBy, final List<WindowedComputation> output) {
+        SetWindowFieldsStage(
+                @Nullable final TExpression partitionBy,
+                @Nullable final Bson sortBy,
+                final Iterable<? extends WindowedComputation> output) {
             this.partitionBy = partitionBy;
             this.sortBy = sortBy;
             this.output = output;

--- a/driver-core/src/main/com/mongodb/client/model/Window.java
+++ b/driver-core/src/main/com/mongodb/client/model/Window.java
@@ -17,11 +17,9 @@ package com.mongodb.client.model;
 
 import org.bson.conversions.Bson;
 
-import java.util.List;
-
 /**
- * A subset of documents within a partition in the {@link Aggregates#setWindowFields(Object, Bson, List) $setWindowFields} pipeline stage
- * of an aggregation pipeline (see {@code partitionBy} in {@link Aggregates#setWindowFields(Object, Bson, List)}).
+ * A subset of documents within a partition in the {@link Aggregates#setWindowFields(Object, Bson, Iterable) $setWindowFields} pipeline stage
+ * of an aggregation pipeline (see {@code partitionBy} in {@link Aggregates#setWindowFields(Object, Bson, Iterable)}).
  *
  * @see Windows
  * @since 4.3

--- a/driver-core/src/main/com/mongodb/client/model/WindowedComputation.java
+++ b/driver-core/src/main/com/mongodb/client/model/WindowedComputation.java
@@ -17,10 +17,8 @@ package com.mongodb.client.model;
 
 import org.bson.conversions.Bson;
 
-import java.util.List;
-
 /**
- * The core part of the {@link Aggregates#setWindowFields(Object, Bson, List) $setWindowFields} pipeline stage of an aggregation pipeline.
+ * The core part of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) $setWindowFields} pipeline stage of an aggregation pipeline.
  * A triple of a window function, a {@linkplain Window window} and a path to a field to be computed by the window function over the window.
  *
  * @see WindowedComputations

--- a/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
+++ b/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
@@ -37,11 +37,11 @@ import static org.bson.assertions.Assertions.notNull;
 
 /**
  * Builders for {@linkplain WindowedComputation windowed computations} used in the
- * {@link Aggregates#setWindowFields(Object, Bson, List) $setWindowFields} pipeline stage
+ * {@link Aggregates#setWindowFields(Object, Bson, Iterable) $setWindowFields} pipeline stage
  * of an aggregation pipeline. Each windowed computation is a triple:
  * <ul>
  *     <li>A window function. Some functions require documents in a window to be sorted
- *     (see {@code sortBy} in {@link Aggregates#setWindowFields(Object, Bson, List)}).</li>
+ *     (see {@code sortBy} in {@link Aggregates#setWindowFields(Object, Bson, Iterable)}).</li>
  *     <li>An optional {@linkplain Window window}, a.k.a. frame.
  *     Specifying {@code null} window is equivalent to specifying an unbounded window,
  *     i.e., a window with both ends specified as {@link Bound#UNBOUNDED}.
@@ -248,10 +248,10 @@ public final class WindowedComputations {
     /**
      * Builds a computation of the time derivative by subtracting the evaluation result of the {@code expression} against the last document
      * and the first document in the {@code window} and dividing it by the difference in the values of the
-     * {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} field of the respective documents.
+     * {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} field of the respective documents.
      * Other documents in the {@code window} have no effect on the computation.
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @param expression The expression.
@@ -273,10 +273,10 @@ public final class WindowedComputations {
     /**
      * Builds a computation of the time derivative by subtracting the evaluation result of the {@code expression} against the last document
      * and the first document in the {@code window} and dividing it by the difference in the BSON {@link BsonType#DATE_TIME Date}
-     * values of the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} field of the respective documents.
+     * values of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} field of the respective documents.
      * Other documents in the {@code window} have no effect on the computation.
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @param expression The expression.
@@ -303,13 +303,13 @@ public final class WindowedComputations {
 
     /**
      * Builds a computation of the approximate integral of a function that maps values of
-     * the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} field to evaluation results of the {@code expression}
+     * the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} field to evaluation results of the {@code expression}
      * against the same document. The limits of integration match the {@code window} bounds.
      * The approximation is done by using the
      * <a href="https://www.khanacademy.org/math/ap-calculus-ab/ab-integration-new/ab-6-2/a/understanding-the-trapezoid-rule">
      * trapezoidal rule</a>.
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @param expression The expression.
@@ -329,11 +329,11 @@ public final class WindowedComputations {
 
     /**
      * Builds a computation of the approximate integral of a function that maps BSON {@link BsonType#DATE_TIME Date} values of
-     * the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} field to evaluation results of the {@code expression}
+     * the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} field to evaluation results of the {@code expression}
      * against the same document. The limits of integration match the {@code window} bounds.
      * The approximation is done by using the trapezoidal rule.
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @param expression The expression.
@@ -408,7 +408,7 @@ public final class WindowedComputations {
      * that includes {@code n} - 1 documents preceding the current document and the current document, with more weight on documents
      * closer to the current one.
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @param expression The expression.
@@ -431,7 +431,7 @@ public final class WindowedComputations {
      * Builds a computation of the exponential moving average of the evaluation results of the {@code expression} over the half-bounded
      * window [{@link Bound#UNBOUNDED}, {@link Bound#CURRENT}], with {@code alpha} representing the degree of weighting decrease.
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @param expression The expression.
@@ -455,7 +455,7 @@ public final class WindowedComputations {
     /**
      * Builds a computation that adds the evaluation results of the {@code expression} over the {@code window}
      * to a BSON {@link org.bson.BsonType#ARRAY Array}.
-     * Order within the array is guaranteed if {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} is specified.
+     * Order within the array is guaranteed if {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} is specified.
      *
      * @param path The output field path.
      * @param expression The expression.
@@ -492,7 +492,7 @@ public final class WindowedComputations {
     /**
      * Builds a computation of the evaluation result of the {@code expression} against the first document in the {@code window}.
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @param expression The expression.
@@ -512,7 +512,7 @@ public final class WindowedComputations {
      * of evaluation results of the {@code inExpression} against the first {@code N} documents in the {@code window},
      * where {@code N} is the positive integral value of the {@code nExpression}.
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @param inExpression The input expression.
@@ -595,7 +595,7 @@ public final class WindowedComputations {
     /**
      * Builds a computation of the evaluation result of the {@code expression} against the last document in the {@code window}.
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @param expression The expression.
@@ -615,7 +615,7 @@ public final class WindowedComputations {
      * of evaluation results of the {@code inExpression} against the last {@code N} documents in the {@code window},
      * where {@code N} is the positive integral value of the {@code nExpression}.
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @param inExpression The input expression.
@@ -698,10 +698,10 @@ public final class WindowedComputations {
     /**
      * Builds a computation of the evaluation result of the {@code expression} for the document whose position is shifted by the given
      * amount relative to the current document. If the shifted document is outside of the
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) partition} containing the current document,
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) partition} containing the current document,
      * then the {@code defaultExpression} is used instead of the {@code expression}.
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @param expression The expression.
@@ -733,9 +733,9 @@ public final class WindowedComputations {
 
     /**
      * Builds a computation of the order number of each document in its
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) partition}.
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) partition}.
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @return The constructed windowed computation.
@@ -748,13 +748,13 @@ public final class WindowedComputations {
 
     /**
      * Builds a computation of the rank of each document in its
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) partition}.
-     * Documents with the same value(s) of the {@linkplain Aggregates#setWindowFields(Object, Bson, List) sortBy} fields result in
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) partition}.
+     * Documents with the same value(s) of the {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} fields result in
      * the same ranking and result in gaps in the returned ranks.
      * For example, a partition with the sequence [1, 3, 3, 5] representing the values of the single {@code sortBy} field
      * produces the following sequence of rank values: [1, 2, 2, 4].
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @return The constructed windowed computation.
@@ -767,13 +767,13 @@ public final class WindowedComputations {
 
     /**
      * Builds a computation of the dense rank of each document in its
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) partition}.
-     * Documents with the same value(s) of the {@linkplain Aggregates#setWindowFields(Object, Bson, List) sortBy} fields result in
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) partition}.
+     * Documents with the same value(s) of the {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} fields result in
      * the same ranking but do not result in gaps in the returned ranks.
      * For example, a partition with the sequence [1, 3, 3, 5] representing the values of the single {@code sortBy} field
      * produces the following sequence of rank values: [1, 2, 2, 3].
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @return The constructed windowed computation.

--- a/driver-core/src/main/com/mongodb/client/model/Windows.java
+++ b/driver-core/src/main/com/mongodb/client/model/Windows.java
@@ -23,7 +23,6 @@ import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 import org.bson.types.Decimal128;
 
-import java.util.List;
 import java.util.Objects;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
@@ -51,7 +50,7 @@ import static org.bson.assertions.Assertions.notNull;
  *     </li>
  *     <li>range
  *         <ul>
- *             <li>{@link Aggregates#setWindowFields(Object, Bson, List) sortBy}
+ *             <li>{@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy}
  *                 <ul>
  *                     <li>must contain exactly one field;</li>
  *                     <li>must specify the ascending sort order;</li>
@@ -161,7 +160,7 @@ public final class Windows {
 
     /**
      * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-     * the value of the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} field in the current document.
+     * the value of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} field in the current document.
      *
      * @param lower A value based on which the lower bound of the window is calculated.
      * @param upper A value based on which the upper bound of the window is calculated.
@@ -174,7 +173,7 @@ public final class Windows {
 
     /**
      * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-     * the value of the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} field in the current document.
+     * the value of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} field in the current document.
      *
      * @param lower A value based on which the lower bound of the window is calculated.
      * @param upper A value based on which the upper bound of the window is calculated.
@@ -187,7 +186,7 @@ public final class Windows {
 
     /**
      * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-     * the value of the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} field in the current document.
+     * the value of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} field in the current document.
      *
      * @param lower A value based on which the lower bound of the window is calculated.
      * @param upper A value based on which the upper bound of the window is calculated.
@@ -202,7 +201,7 @@ public final class Windows {
 
     /**
      * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-     * the value of the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} field in the current document.
+     * the value of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} field in the current document.
      *
      * @param lower A value based on which the lower bound of the window is calculated.
      * @param upper A value based on which the upper bound of the window is calculated.
@@ -215,7 +214,7 @@ public final class Windows {
 
     /**
      * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-     * the value of the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} field in the current document.
+     * the value of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} field in the current document.
      *
      * @param lower A value based on which the lower bound of the window is calculated.
      * @param upper A value based on which the upper bound of the window is calculated.
@@ -228,7 +227,7 @@ public final class Windows {
 
     /**
      * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-     * the value of the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} field in the current document.
+     * the value of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} field in the current document.
      *
      * @param lower A value based on which the lower bound of the window is calculated.
      * @param upper A value based on which the upper bound of the window is calculated.
@@ -242,7 +241,7 @@ public final class Windows {
 
     /**
      * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-     * the value of the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} field in the current document.
+     * the value of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} field in the current document.
      *
      * @param lower A value based on which the lower bound of the window is calculated.
      * @param upper A value based on which the upper bound of the window is calculated.
@@ -255,7 +254,7 @@ public final class Windows {
 
     /**
      * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-     * the value of the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} field in the current document.
+     * the value of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} field in the current document.
      *
      * @param lower A value based on which the lower bound of the window is calculated.
      * @param upper A value based on which the upper bound of the window is calculated.
@@ -268,7 +267,7 @@ public final class Windows {
 
     /**
      * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-     * the value of the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy} field in the current document.
+     * the value of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy} field in the current document.
      *
      * @param lower A value based on which the lower bound of the window is calculated.
      * @param upper A value based on which the upper bound of the window is calculated.
@@ -282,7 +281,7 @@ public final class Windows {
 
     /**
      * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-     * the BSON {@link BsonType#DATE_TIME Date} value of the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy}
+     * the BSON {@link BsonType#DATE_TIME Date} value of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy}
      * field in the current document.
      *
      * @param lower A value based on which the lower bound of the window is calculated.
@@ -298,7 +297,7 @@ public final class Windows {
 
     /**
      * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-     * the BSON {@link BsonType#DATE_TIME Date} value of the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy}
+     * the BSON {@link BsonType#DATE_TIME Date} value of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy}
      * field in the current document.
      *
      * @param lower A value based on which the lower bound of the window is calculated.
@@ -314,7 +313,7 @@ public final class Windows {
 
     /**
      * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-     * the BSON {@link BsonType#DATE_TIME Date} value of the {@link Aggregates#setWindowFields(Object, Bson, List) sortBy}
+     * the BSON {@link BsonType#DATE_TIME Date} value of the {@link Aggregates#setWindowFields(Object, Bson, Iterable) sortBy}
      * field in the current document.
      *
      * @param lower A value based on which the lower bound of the window is calculated.


### PR DESCRIPTION
We have just removed the `@Beta` from this API an have not yet released it without `@Beta`, which means, that regardless of whether this change breaks binary compatibility or not (I don't know and have not tried to find this out), the change is allowed.