### PR TITLE
Add query building API for the `$fill` aggregation pipeline stage

### DIFF
--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -70,6 +70,9 @@
         <rule-config name='Instanceof'>
             <property name='doNotApplyToFilesMatching' value='.*Specification.groovy'/>
         </rule-config>
+        <rule-config name='ImplementationAsType'>
+            <property name='doNotApplyToFileNames' value='AggregatesFunctionalSpecification.groovy'/>
+        </rule-config>
     </ruleset-ref>
     <ruleset-ref path='rulesets/dry.xml'>
         <rule-config name='DuplicateListLiteral'>

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -70,9 +70,6 @@
         <rule-config name='Instanceof'>
             <property name='doNotApplyToFilesMatching' value='.*Specification.groovy'/>
         </rule-config>
-        <rule-config name='ImplementationAsType'>
-            <property name='doNotApplyToFileNames' value='AggregatesFunctionalSpecification.groovy'/>
-        </rule-config>
     </ruleset-ref>
     <ruleset-ref path='rulesets/dry.xml'>
         <rule-config name='DuplicateListLiteral'>

--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -662,7 +662,7 @@ public final class Aggregates {
     }
 
     /**
-     * Creates a {@code $fill} pipeline stage, which sets values to fields when they are {@link BsonType#NULL Null} or missing.
+     * Creates a {@code $fill} pipeline stage, which assigns values to fields when they are {@link BsonType#NULL Null} or missing.
      *
      * @param options The fill options.
      * @param output The {@link FillComputation}.
@@ -677,7 +677,7 @@ public final class Aggregates {
     }
 
     /**
-     * Creates a {@code $fill} pipeline stage, which sets values to fields when they are {@link BsonType#NULL Null} or missing.
+     * Creates a {@code $fill} pipeline stage, which assigns values to fields when they are {@link BsonType#NULL Null} or missing.
      *
      * @param options The fill options.
      * @param output The non-empty {@link FillComputation}s.

--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -668,7 +668,7 @@ public final class Aggregates {
      * @param output The {@link FillComputation}.
      * @param moreOutput More {@link FillComputation}s.
      * @return The requested pipeline stage.
-     * @mongodb.driver.dochub reference/operator/aggregation/fill/ $fill
+     * @mongodb.driver.manual reference/operator/aggregation/fill/ $fill
      * @mongodb.server.release 5.3
      * @since 4.7
      */
@@ -682,7 +682,7 @@ public final class Aggregates {
      * @param options The fill options.
      * @param output The non-empty {@link FillComputation}s.
      * @return The requested pipeline stage.
-     * @mongodb.driver.dochub reference/operator/aggregation/fill/ $fill
+     * @mongodb.driver.manual reference/operator/aggregation/fill/ $fill
      * @mongodb.server.release 5.3
      * @since 4.7
      */

--- a/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
+++ b/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
@@ -785,7 +785,7 @@ public final class WindowedComputations {
     }
 
     /**
-     * Builds a computation of the last observed non-{@code null} evaluation result of the {@code expression}.
+     * Builds a computation of the last observed non-{@link BsonType#NULL Null} evaluation result of the {@code expression}.
      *
      * @param path The output field path.
      * @param expression The expression.
@@ -802,10 +802,10 @@ public final class WindowedComputations {
     }
 
     /**
-     * Builds a computation of a value that is equal to the evaluation result of the {@code expression} when it is non-{@code null},
-     * or to the linear interpolation of surrounding evaluation results of the {@code expression} when the result is {@code null}.
+     * Builds a computation of a value that is equal to the evaluation result of the {@code expression} when it is non-{@link BsonType#NULL Null},
+     * or to the linear interpolation of surrounding evaluation results of the {@code expression} when the result is {@link BsonType#NULL Null}.
      * <p>
-     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, Iterable) Sorting} is required.</p>
      *
      * @param path The output field path.
      * @param expression The expression.

--- a/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
+++ b/driver-core/src/main/com/mongodb/client/model/WindowedComputations.java
@@ -784,6 +784,43 @@ public final class WindowedComputations {
         return simpleParameterWindowFunction(path, "$denseRank", null, null);
     }
 
+    /**
+     * Builds a computation of the last observed non-{@code null} evaluation result of the {@code expression}.
+     *
+     * @param path The output field path.
+     * @param expression The expression.
+     * @param <TExpression> The expression type.
+     * @return The constructed windowed computation.
+     * @mongodb.driver.manual reference/operator/aggregation/locf/ $locf
+     * @since 4.7
+     * @mongodb.server.release 5.2
+     */
+    public static <TExpression> WindowedComputation locf(final String path, final TExpression expression) {
+        notNull("path", path);
+        notNull("expression", expression);
+        return simpleParameterWindowFunction(path, "$locf", expression, null);
+    }
+
+    /**
+     * Builds a computation of a value that is equal to the evaluation result of the {@code expression} when it is non-{@code null},
+     * or to the linear interpolation of surrounding evaluation results of the {@code expression} when the result is {@code null}.
+     * <p>
+     * {@linkplain Aggregates#setWindowFields(Object, Bson, List) Sorting} is required.</p>
+     *
+     * @param path The output field path.
+     * @param expression The expression.
+     * @param <TExpression> The expression type.
+     * @return The constructed windowed computation.
+     * @mongodb.driver.manual reference/operator/aggregation/linearFill/ $linearFill
+     * @since 4.7
+     * @mongodb.server.release 5.3
+     */
+    public static <TExpression> WindowedComputation linearFill(final String path, final TExpression expression) {
+        notNull("path", path);
+        notNull("expression", expression);
+        return simpleParameterWindowFunction(path, "$linearFill", expression, null);
+    }
+
     private static WindowedComputation simpleParameterWindowFunction(final String path, final String functionName,
                                                                      @Nullable final Object expression,
                                                                      @Nullable final Window window) {

--- a/driver-core/src/main/com/mongodb/client/model/fill/FillComputation.java
+++ b/driver-core/src/main/com/mongodb/client/model/fill/FillComputation.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.fill;
+
+import com.mongodb.annotations.Evolving;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.WindowedComputations;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+/**
+ * The core part of the {@code $fill} pipeline stage of an aggregation pipeline.
+ * A pair of an expression/method and a path to a field to be filled with evaluation results of the expression/method.
+ *
+ * @see Aggregates#fill(FillOptions, Iterable)
+ * @see Aggregates#fill(FillOptions, FillComputation, FillComputation...)
+ * @mongodb.server.release 5.3
+ * @since 4.7
+ */
+@Evolving
+public interface FillComputation extends Bson {
+    /**
+     * Returns a {@link FillComputation} that uses the specified {@code expression}.
+     *
+     * @param field The field to fill.
+     * @param expression The expression.
+     * @param <TExpression> The {@code expression} type.
+     * @return The requested {@link FillComputation}.
+     * @mongodb.driver.manual core/document/#dot-notation Dot notation
+     */
+    static <TExpression> ValueFillComputation value(final String field, TExpression expression) {
+        return new FillConstructibleBsonElement(notNull("field", field),
+                new Document("value", (notNull("expression", expression))));
+    }
+
+    /**
+     * Returns a {@link FillComputation} that uses the {@link WindowedComputations#locf(String, Object) locf} method.
+     *
+     * @param field The field to fill.
+     * @return The requested {@link FillComputation}.
+     * @mongodb.driver.manual core/document/#dot-notation Dot notation
+     */
+    static LocfFillComputation locf(final String field) {
+        return new FillConstructibleBsonElement(notNull("field", field),
+                new Document("method", "locf"));
+    }
+
+    /**
+     * Returns a {@link FillComputation} that uses the {@link WindowedComputations#linearFill(String, Object) linear} method.
+     * <p>
+     * {@linkplain FillOptions#sortBy(Bson) Sorting} is required.</p>
+     *
+     * @param field The field to fill.
+     * @return The requested {@link FillComputation}.
+     * @mongodb.driver.manual core/document/#dot-notation Dot notation
+     */
+    static LinearFillComputation linear(final String field) {
+        return new FillConstructibleBsonElement(notNull("field", field),
+                new Document("method", "linear"));
+    }
+
+    /**
+     * Creates a {@link FillComputation} from a {@link Bson} in situations when there is no builder method
+     * that better satisfies your needs.
+     * This method cannot be used to validate the syntax.
+     * <p>
+     * <i>Example</i><br>
+     * The following code creates two functionally equivalent {@link FillComputation}s,
+     * though they may not be {@linkplain Object#equals(Object) equal}.
+     * <pre>{@code
+     *  FillComputation field1 = FillComputation.locf("fieldName");
+     *  FillComputation field2 = FillComputation.of(new Document("fieldName", new Document("method", "locf")));
+     * }</pre>
+     *
+     * @param fill A {@link Bson} representing the required {@link FillComputation}.
+     * @return The requested {@link FillComputation}.
+     */
+    static FillComputation of(final Bson fill) {
+        return new FillConstructibleBsonElement(notNull("fill", fill));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/fill/FillConstructibleBson.java
+++ b/driver-core/src/main/com/mongodb/client/model/fill/FillConstructibleBson.java
@@ -39,19 +39,21 @@ final class FillConstructibleBson extends AbstractConstructibleBson<FillConstruc
     }
 
     @Override
-    public <TExpression> FillOptions partitionBy(final TExpression partitionBy) {
+    public <TExpression> FillOptions partitionBy(final TExpression expression) {
+        notNull("expression", expression);
         return newMutated(doc -> {
             doc.remove("partitionByFields");
-            doc.append("partitionBy", notNull("partitionBy", partitionBy));
+            doc.append("partitionBy", expression);
         });
     }
 
     @Override
-    public FillOptions partitionByFields(final Iterable<String> partitionByFields) {
+    public FillOptions partitionByFields(final Iterable<String> fields) {
+        notNull("fields", fields);
         return newMutated(doc -> {
             doc.remove("partitionBy");
-            if (sizeAtLeast(partitionByFields, 1)) {
-                doc.append("partitionByFields", notNull("partitionByFields", partitionByFields));
+            if (sizeAtLeast(fields, 1)) {
+                doc.append("partitionByFields", fields);
             } else {
                 doc.remove("partitionByFields");
             }

--- a/driver-core/src/main/com/mongodb/client/model/fill/FillConstructibleBson.java
+++ b/driver-core/src/main/com/mongodb/client/model/fill/FillConstructibleBson.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.fill;
+
+import com.mongodb.internal.client.model.AbstractConstructibleBson;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.client.model.Util.sizeAtLeast;
+
+final class FillConstructibleBson extends AbstractConstructibleBson<FillConstructibleBson> implements FillOptions {
+    static final FillConstructibleBson EMPTY_IMMUTABLE = new FillConstructibleBson(AbstractConstructibleBson.EMPTY_IMMUTABLE);
+
+    FillConstructibleBson(final Bson base) {
+        super(base);
+    }
+
+    private FillConstructibleBson(final Bson base, final Document appended) {
+        super(base, appended);
+    }
+
+    @Override
+    protected FillConstructibleBson newSelf(final Bson base, final Document appended) {
+        return new FillConstructibleBson(base, appended);
+    }
+
+    @Override
+    public <TExpression> FillOptions partitionBy(final TExpression partitionBy) {
+        return newMutated(doc -> {
+            doc.remove("partitionByFields");
+            doc.append("partitionBy", notNull("partitionBy", partitionBy));
+        });
+    }
+
+    @Override
+    public FillOptions partitionByFields(final Iterable<String> partitionByFields) {
+        return newMutated(doc -> {
+            doc.remove("partitionBy");
+            if (sizeAtLeast(partitionByFields, 1)) {
+                doc.append("partitionByFields", notNull("partitionByFields", partitionByFields));
+            } else {
+                doc.remove("partitionByFields");
+            }
+        });
+    }
+
+    @Override
+    public FillOptions sortBy(final Bson sortBy) {
+        return newAppended("sortBy", notNull("sortBy", sortBy));
+    }
+
+    @Override
+    public FillOptions option(final String name, final Object value) {
+        return newAppended(notNull("name", name), notNull("value", value));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/fill/FillConstructibleBsonElement.java
+++ b/driver-core/src/main/com/mongodb/client/model/fill/FillConstructibleBsonElement.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.fill;
+
+import com.mongodb.internal.client.model.AbstractConstructibleBsonElement;
+import org.bson.conversions.Bson;
+
+final class FillConstructibleBsonElement extends AbstractConstructibleBsonElement<FillConstructibleBsonElement> implements
+        ValueFillComputation, LocfFillComputation, LinearFillComputation {
+    FillConstructibleBsonElement(final String name, final Bson value) {
+        super(name, value);
+    }
+
+    FillConstructibleBsonElement(final Bson baseElement) {
+        super(baseElement);
+    }
+
+    private FillConstructibleBsonElement(final Bson baseElement, final Bson appendedElementValue) {
+        super(baseElement, appendedElementValue);
+    }
+
+    @Override
+    protected FillConstructibleBsonElement newSelf(final Bson baseElement, final Bson appendedElementValue) {
+        return new FillConstructibleBsonElement(baseElement, appendedElementValue);
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/fill/FillOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/fill/FillOptions.java
@@ -40,34 +40,34 @@ public interface FillOptions extends Bson {
      * Creates a new {@link FillOptions} with the specified partitioning.
      * Overrides {@link #partitionByFields(Iterable)}.
      *
-     * @param partitionBy The expression specifying how to partition the data.
+     * @param expression The expression specifying how to partition the data.
      * The syntax is the same as the syntax for {@code id} in {@link Aggregates#group(Object, List)}.
-     * @param <TExpression> The type of the {@code partitionBy} expression.
+     * @param <TExpression> The type of the {@code expression} expression.
      * @return A new {@link FillOptions}.
      */
-    <TExpression> FillOptions partitionBy(TExpression partitionBy);
+    <TExpression> FillOptions partitionBy(TExpression expression);
 
     /**
      * Creates a new {@link FillOptions} with the specified partitioning.
      * Overrides {@link #partitionBy(Object)}.
      *
-     * @param partitionByFields The fields to partition by.
+     * @param fields The fields to partition by.
      * @return A new {@link FillOptions}.
      * @mongodb.driver.manual core/document/#dot-notation
      */
-    default FillOptions partitionByFields(@Nullable final String... partitionByFields) {
-        return partitionByFields(partitionByFields == null ? emptyList() : asList(partitionByFields));
+    default FillOptions partitionByFields(@Nullable final String... fields) {
+        return partitionByFields(fields == null ? emptyList() : asList(fields));
     }
 
     /**
      * Creates a new {@link FillOptions} with the specified partitioning.
      * Overrides {@link #partitionBy(Object)}.
      *
-     * @param partitionByFields The fields to partition by.
+     * @param fields The fields to partition by.
      * @return A new {@link FillOptions}.
      * @mongodb.driver.manual core/document/#dot-notation
      */
-    FillOptions partitionByFields(Iterable<String> partitionByFields);
+    FillOptions partitionByFields(Iterable<String> fields);
 
     /**
      * Creates a new {@link FillOptions} with the specified sorting.

--- a/driver-core/src/main/com/mongodb/client/model/fill/FillOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/fill/FillOptions.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.fill;
+
+import com.mongodb.annotations.Evolving;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Sorts;
+import com.mongodb.lang.Nullable;
+import org.bson.conversions.Bson;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+
+/**
+ * Represents optional fields of the {@code $fill} pipeline stage of an aggregation pipeline.
+ *
+ * @see Aggregates#fill(FillOptions, Iterable)
+ * @see Aggregates#fill(FillOptions, FillComputation, FillComputation...)
+ * @mongodb.server.release 5.3
+ * @since 4.7
+ */
+@Evolving
+public interface FillOptions extends Bson {
+    /**
+     * Creates a new {@link FillOptions} with the specified partitioning.
+     * Overrides {@link #partitionByFields(Iterable)}.
+     *
+     * @param partitionBy The expression specifying how to partition the data.
+     * The syntax is the same as the syntax for {@code id} in {@link Aggregates#group(Object, List)}.
+     * @param <TExpression> The type of the {@code partitionBy} expression.
+     * @return A new {@link FillOptions}.
+     */
+    <TExpression> FillOptions partitionBy(TExpression partitionBy);
+
+    /**
+     * Creates a new {@link FillOptions} with the specified partitioning.
+     * Overrides {@link #partitionBy(Object)}.
+     *
+     * @param partitionByFields The fields to partition by.
+     * @return A new {@link FillOptions}.
+     * @mongodb.driver.manual core/document/#dot-notation
+     */
+    default FillOptions partitionByFields(@Nullable final String... partitionByFields) {
+        return partitionByFields(partitionByFields == null ? emptyList() : asList(partitionByFields));
+    }
+
+    /**
+     * Creates a new {@link FillOptions} with the specified partitioning.
+     * Overrides {@link #partitionBy(Object)}.
+     *
+     * @param partitionByFields The fields to partition by.
+     * @return A new {@link FillOptions}.
+     * @mongodb.driver.manual core/document/#dot-notation
+     */
+    FillOptions partitionByFields(Iterable<String> partitionByFields);
+
+    /**
+     * Creates a new {@link FillOptions} with the specified sorting.
+     *
+     * @param sortBy The sort specification, which may be constructed via {@link Sorts}.
+     * @return A new {@link FillOptions}.
+     */
+    FillOptions sortBy(Bson sortBy);
+
+    /**
+     * Creates a new {@link FillOptions} with the specified option in situations when there is no builder method
+     * that better satisfies your needs.
+     * This method cannot be used to validate the syntax.
+     * <p>
+     * <i>Example</i><br>
+     * The following code creates two functionally equivalent {@link FillOptions} objects,
+     * though they may not be {@linkplain Object#equals(Object) equal}.
+     * <pre>{@code
+     *  FillOptions options1 = FillOptions.fillOptions().partitionByFields("fieldName");
+     *  FillOptions options2 = FillOptions.fillOptions().option("partitionByFields", Collections.singleton("fieldName"));
+     * }</pre>
+     *
+     * @param name The option name.
+     * @param value The option value.
+     * @return A new {@link FillOptions}.
+     */
+    FillOptions option(String name, Object value);
+
+    /**
+     * Returns {@link FillOptions} that represents server defaults.
+     *
+     * @return {@link FillOptions} that represents server defaults.
+     */
+    static FillOptions fillOptions() {
+        return FillConstructibleBson.EMPTY_IMMUTABLE;
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/fill/LinearFillComputation.java
+++ b/driver-core/src/main/com/mongodb/client/model/fill/LinearFillComputation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.fill;
+
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see FillComputation#linear(String)
+ * @mongodb.server.release 5.3
+ * @since 4.7
+ */
+@Evolving
+public interface LinearFillComputation extends FillComputation {
+}

--- a/driver-core/src/main/com/mongodb/client/model/fill/LocfFillComputation.java
+++ b/driver-core/src/main/com/mongodb/client/model/fill/LocfFillComputation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.fill;
+
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see FillComputation#locf(String)
+ * @mongodb.server.release 5.3
+ * @since 4.7
+ */
+@Evolving
+public interface LocfFillComputation extends FillComputation {
+}

--- a/driver-core/src/main/com/mongodb/client/model/fill/ValueFillComputation.java
+++ b/driver-core/src/main/com/mongodb/client/model/fill/ValueFillComputation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.fill;
+
+import com.mongodb.annotations.Evolving;
+
+/**
+ * @see FillComputation#value(String, Object)
+ * @mongodb.server.release 5.3
+ * @since 4.7
+ */
+@Evolving
+public interface ValueFillComputation extends FillComputation {
+}

--- a/driver-core/src/main/com/mongodb/client/model/fill/package-info.java
+++ b/driver-core/src/main/com/mongodb/client/model/fill/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @see com.mongodb.client.model.Aggregates#fill(com.mongodb.client.model.fill.FillOptions, java.lang.Iterable)
+ * @see com.mongodb.client.model.Aggregates#fill(
+ * com.mongodb.client.model.fill.FillOptions, com.mongodb.client.model.fill.FillComputation, com.mongodb.client.model.fill.FillComputation...)
+ * @mongodb.server.release 5.3
+ * @since 4.7
+ */
+@NonNullApi
+package com.mongodb.client.model.fill;
+
+import com.mongodb.lang.NonNullApi;

--- a/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
@@ -1147,12 +1147,12 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
                         .append('numMissing', 3)
                         .append('date', LocalDateTime.ofInstant(Instant.ofEpochSecond(3), utc))]
         getCollectionHelper().insertDocuments(original)
-        LinkedList<Bson> stages = [
+        List<Bson> stages = [
                 setWindowFields(partitionBy, sortBy, output),
                 sort(ascending('num1'))
         ]
         if (preSortBy != null) {
-            stages.addFirst(sort(preSortBy))
+            stages.add(0, sort(preSortBy))
         }
         List<Document> actual = aggregate(stages)
         List<Object> actualFieldValues = actual.stream()
@@ -1307,13 +1307,13 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
                         .append('doc', new Document('field2', 3))]
         getCollectionHelper().insertDocuments(docs)
         String resultField = 'result'
-        LinkedList<Bson> stages = [
+        List<Bson> stages = [
                 fillStage,
                 project(fields(computed(resultField, '$' + field))),
                 sort(ascending('_id'))
         ]
         if (preSortBy != null) {
-            stages.addFirst(sort(preSortBy))
+            stages.add(0, sort(preSortBy))
         }
         List<Object> actualFieldValues = aggregate(stages)
                 .stream()

--- a/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
@@ -547,6 +547,8 @@ class AggregatesSpecification extends Specification {
                         window),
                 WindowedComputations.top('newField25', ascending('sortByField'), '$field25', window),
                 WindowedComputations.topN('newField25N', ascending('sortByField'), '$field25N', 2, window),
+                WindowedComputations.locf('newField26', '$field26'),
+                WindowedComputations.linearFill('newField27', '$field27')
         )))
 
         expect:
@@ -597,7 +599,9 @@ class AggregatesSpecification extends Specification {
                             "window": { "documents": [1, 2] } },
                         "newField25N": {
                             "$topN": { "sortBy": { "sortByField": 1 }, "output": "$field25N", "n": 2 },
-                            "window": { "documents": [1, 2] } }
+                            "window": { "documents": [1, 2] } },
+                        "newField26": { "$locf": "$field26" },
+                        "newField27": { "$linearFill": "$field27" }
                     }
                 }
         }''')

--- a/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
@@ -17,6 +17,7 @@
 package com.mongodb.client.model
 
 import com.mongodb.MongoNamespace
+import com.mongodb.client.model.fill.FillComputation
 import com.mongodb.client.model.search.SearchCollector
 import com.mongodb.client.model.search.SearchOperator
 import org.bson.BsonDocument
@@ -53,6 +54,7 @@ import static com.mongodb.client.model.Aggregates.addFields
 import static com.mongodb.client.model.Aggregates.bucket
 import static com.mongodb.client.model.Aggregates.bucketAuto
 import static com.mongodb.client.model.Aggregates.count
+import static com.mongodb.client.model.Aggregates.fill
 import static com.mongodb.client.model.Aggregates.graphLookup
 import static com.mongodb.client.model.Aggregates.group
 import static com.mongodb.client.model.Aggregates.limit
@@ -84,6 +86,7 @@ import static com.mongodb.client.model.Sorts.descending
 import static com.mongodb.client.model.Windows.Bound.CURRENT
 import static com.mongodb.client.model.Windows.Bound.UNBOUNDED
 import static com.mongodb.client.model.Windows.documents
+import static com.mongodb.client.model.fill.FillOptions.fillOptions
 import static com.mongodb.client.model.search.SearchCollector.facet
 import static com.mongodb.client.model.search.SearchCount.total
 import static com.mongodb.client.model.search.SearchFacet.stringFacet
@@ -619,6 +622,26 @@ class AggregatesSpecification extends Specification {
                     "output": {
                         "newField01": { "$sum": "$field01", "window": { "documents": [1, 2] } }
                     }
+                }
+        }''')
+    }
+
+    def 'should render $fill'() {
+        when:
+        BsonDocument fillDoc = toBson(
+                fill(fillOptions().sortBy(ascending('fieldName3')),
+                        FillComputation.linear('fieldName1'),
+                        FillComputation.locf('fieldName2'))
+        )
+
+        then:
+        fillDoc == parse('''{
+                "$fill": {
+                    "output": {
+                        "fieldName1": { "method" : "linear" }
+                        "fieldName2": { "method" : "locf" }
+                    }
+                    "sortBy": { "fieldName3": 1 }
                 }
         }''')
     }

--- a/driver-core/src/test/unit/com/mongodb/client/model/TestWindowedComputations.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/TestWindowedComputations.java
@@ -41,6 +41,7 @@ import static com.mongodb.client.model.Sorts.ascending;
 import static com.mongodb.client.model.Windows.documents;
 import static com.mongodb.client.model.Windows.range;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -95,7 +96,9 @@ final class TestWindowedComputations {
                 () -> assertSimpleParameterWindowFunction("$last", WindowedComputations::last, expressions, windows, false),
                 () -> assertNoParameterNoWindowFunction("$documentNumber", WindowedComputations::documentNumber),
                 () -> assertNoParameterNoWindowFunction("$rank", WindowedComputations::rank),
-                () -> assertNoParameterNoWindowFunction("$denseRank", WindowedComputations::denseRank)
+                () -> assertNoParameterNoWindowFunction("$denseRank", WindowedComputations::denseRank),
+                () -> assertSimpleParameterNoWindowFunction("$locf", WindowedComputations::locf, expressions),
+                () -> assertSimpleParameterNoWindowFunction("$linearFill", WindowedComputations::linearFill, expressions)
         );
     }
 
@@ -343,10 +346,20 @@ final class TestWindowedComputations {
                 Collections.singletonMap(NO_EXPRESSION, BsonDocument.parse(NO_EXPRESSION)), windows, windowRequired);
     }
 
+    private static void assertSimpleParameterNoWindowFunction(
+            final String expectedFunctionName,
+            final BiFunction<String, Object, WindowedComputation> windowedComputationBuilder,
+            final Map<Object, BsonValue> expressions) {
+        assertSimpleParameterWindowFunction(
+                expectedFunctionName,
+                (fName, expr, window) -> windowedComputationBuilder.apply(fName, expr),
+                expressions, singleton(null), false);
+    }
+
     private static void assertNoParameterNoWindowFunction(final String expectedFunctionName,
                                                           final Function<String, WindowedComputation> windowedComputationBuilder) {
         assertNoParameterWindowFunction(expectedFunctionName, (fName, window) -> windowedComputationBuilder.apply(fName),
-                Collections.singleton(null), false);
+                singleton(null), false);
     }
 
     private static void assertWindowedComputation(final BsonField expected, final WindowedComputation actual,

--- a/driver-core/src/test/unit/com/mongodb/client/model/fill/FillComputationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/fill/FillComputationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.fill;
+
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class FillComputationTest {
+    @Test
+    void of() {
+        assertEquals(
+                docExamplePredefined()
+                        .toBsonDocument(),
+                FillComputation.of(docExampleCustom())
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void value() {
+        assertEquals(
+                new BsonDocument("fieldName1", new BsonDocument("value", new BsonString("$fieldName2"))),
+                FillComputation.value("fieldName1", "$fieldName2")
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void locf() {
+        assertEquals(
+                docExampleCustom()
+                        .toBsonDocument(),
+                docExamplePredefined()
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void linear() {
+        assertEquals(
+                new BsonDocument("fieldName", new BsonDocument("method", new BsonString("linear"))),
+                FillComputation.linear("fieldName")
+                        .toBsonDocument()
+        );
+    }
+
+    private static FillComputation docExamplePredefined() {
+        return FillComputation.locf("fieldName");
+    }
+
+    private static Document docExampleCustom() {
+        return new Document("fieldName", new Document("method", "locf"));
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/client/model/fill/FillOptionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/fill/FillOptionsTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.fill;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.junit.jupiter.api.Test;
+
+import static com.mongodb.client.model.Sorts.descending;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class FillOptionsTest {
+    @Test
+    void fillOptions() {
+        assertEquals(
+                new BsonDocument(),
+                FillOptions.fillOptions()
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void partitionBy() {
+        assertAll(
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("partitionBy", new BsonString("$fieldName")),
+                        FillOptions.fillOptions()
+                                .partitionBy("$fieldName")
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("partitionBy", new BsonString("$fieldName2")),
+                        FillOptions.fillOptions()
+                                .partitionByFields("fieldName1")
+                                // partitionBy overrides partitionByFields
+                                .partitionBy("$fieldName2")
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void partitionByFields() {
+        assertAll(
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("partitionByFields", new BsonArray(singletonList(new BsonString("$fieldName")))),
+                        FillOptions.fillOptions()
+                                .partitionByFields("$fieldName")
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("partitionByFields", new BsonArray(asList(new BsonString("$fieldName1"), new BsonString("$fieldName2")))),
+                        FillOptions.fillOptions()
+                                .partitionByFields("$fieldName1", "$fieldName2")
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("partitionByFields", new BsonArray(asList(new BsonString("$fieldName1"), new BsonString("$fieldName2")))),
+                        FillOptions.fillOptions()
+                                .partitionByFields(asList("$fieldName1", "$fieldName2"))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument()
+                                .append("partitionByFields", new BsonArray(singletonList(new BsonString("fieldName2")))),
+                        FillOptions.fillOptions()
+                                .partitionBy("$fieldName1")
+                                // partitionByFields overrides partitionBy
+                                .partitionByFields("fieldName2")
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        new BsonDocument(),
+                        FillOptions.fillOptions()
+                                .partitionBy("$fieldName1")
+                                // partitionByFields overrides partitionBy
+                                .partitionByFields()
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void sortBy() {
+        assertEquals(
+                new BsonDocument()
+                        .append("sortBy", descending("fieldName").toBsonDocument()),
+                FillOptions.fillOptions()
+                        .sortBy(descending("fieldName"))
+                        .toBsonDocument()
+        );
+    }
+
+    @Test
+    void option() {
+        assertAll(
+                () -> assertEquals(
+                        FillOptions.fillOptions()
+                                .partitionByFields("fieldName")
+                                .toBsonDocument(),
+                        FillOptions.fillOptions()
+                                .option("partitionByFields", new BsonArray(singletonList(new BsonString("fieldName"))))
+                                .toBsonDocument()
+                ),
+                () -> assertEquals(
+                        FillOptions.fillOptions()
+                                .option("partitionByFields", singleton("fieldName"))
+                                .toBsonDocument(),
+                        FillOptions.fillOptions()
+                                .option("partitionByFields", new BsonArray(singletonList(new BsonString("fieldName"))))
+                                .toBsonDocument()
+                )
+        );
+    }
+
+    @Test
+    void options() {
+        assertEquals(
+                new BsonDocument()
+                        .append("partitionByFields", new BsonArray(singletonList(new BsonString("fieldName1"))))
+                        .append("sortBy", descending("fieldName2").toBsonDocument()),
+                FillOptions.fillOptions()
+                        .partitionByFields("fieldName1")
+                        .sortBy(descending("fieldName2"))
+                        .toBsonDocument()
+        );
+    }
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
@@ -20,6 +20,7 @@ import scala.collection.JavaConverters._
 import com.mongodb.client.model.{ Aggregates => JAggregates }
 import org.mongodb.scala.MongoNamespace
 import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.fill.{ FillComputation, FillOptions }
 import org.mongodb.scala.model.search.{ SearchCollector, SearchOperator, SearchOptions }
 
 /**
@@ -509,6 +510,33 @@ object Aggregates {
       output: Iterable[_ <: WindowedComputation]
   ): Bson =
     JAggregates.setWindowFields(partitionBy.orNull, sortBy.orNull, output.asJava)
+
+  /**
+   * Creates a `\$fill` pipeline stage, which sets values to fields when they are BSON `Null` or missing.
+   *
+   * @param options The fill options.
+   * @param output The `FillComputation`.
+   * @param moreOutput More `FillComputation`s.
+   * @return The requested pipeline stage.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/fill/ \$fill]]
+   * @note Requires MongoDB 5.3 or greater.
+   * @since 4.7
+   */
+  def fill(options: FillOptions, output: FillComputation, moreOutput: FillComputation*): Bson =
+    JAggregates.fill(options, output, moreOutput: _*)
+
+  /**
+   * Creates a `\$fill` pipeline stage, which sets values to fields when they are BSON `Null` or missing.
+   *
+   * @param options The fill options.
+   * @param output The non-empty `FillComputation`s.
+   * @return The requested pipeline stage.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/fill/ \$fill]]
+   * @note Requires MongoDB 5.3 or greater.
+   * @since 4.7
+   */
+  def fill(options: FillOptions, output: Iterable[_ <: FillComputation]): Bson =
+    JAggregates.fill(options, output.asJava)
 
   /**
    * Creates a `\$search` pipeline stage supported by MongoDB Atlas.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
@@ -512,7 +512,7 @@ object Aggregates {
     JAggregates.setWindowFields(partitionBy.orNull, sortBy.orNull, output.asJava)
 
   /**
-   * Creates a `\$fill` pipeline stage, which sets values to fields when they are BSON `Null` or missing.
+   * Creates a `\$fill` pipeline stage, which assigns values to fields when they are BSON `Null` or missing.
    *
    * @param options The fill options.
    * @param output The `FillComputation`.
@@ -526,7 +526,7 @@ object Aggregates {
     JAggregates.fill(options, output, moreOutput: _*)
 
   /**
-   * Creates a `\$fill` pipeline stage, which sets values to fields when they are BSON `Null` or missing.
+   * Creates a `\$fill` pipeline stage, which assigns values to fields when they are BSON `Null` or missing.
    *
    * @param options The fill options.
    * @param output The non-empty `FillComputation`s.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
@@ -631,7 +631,7 @@ object WindowedComputations {
   /**
    * Builds a computation of the last observed non-`Null` evaluation result of the `expression`.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path The output field path.
    * @param expression The expression.
@@ -646,7 +646,7 @@ object WindowedComputations {
    * Builds a computation of a value that is equal to the evaluation result of the `expression` when it is non-`Null`,
    * or to the linear interpolation of surrounding evaluation results of the `expression` when the result is BSON `Null`.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path The output field path.
    * @param expression The expression.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
@@ -627,4 +627,33 @@ object WindowedComputations {
    */
   def denseRank(path: String): WindowedComputation =
     JWindowedComputations.denseRank(path)
+
+  /**
+   * Builds a computation of the last observed non-`null` evaluation result of the `expression`.
+   *
+   * [[Aggregates.setWindowFields Sorting]] is required.
+   *
+   * @param path The output field path.
+   * @param expression The expression.
+   * @tparam TExpression The expression type.
+   * @return The constructed windowed computation.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/locf \$locf]]
+   */
+  def locf[TExpression](path: String, expression: TExpression): WindowedComputation =
+    JWindowedComputations.locf(path, expression)
+
+  /**
+   * Builds a computation of a value that is equal to the evaluation result of the `expression` when it is non-`null`,
+   * or to the linear interpolation of surrounding evaluation results of the `expression` when the result is `null`.
+   *
+   * [[Aggregates.setWindowFields Sorting]] is required.
+   *
+   * @param path The output field path.
+   * @param expression The expression.
+   * @tparam TExpression The expression type.
+   * @return The constructed windowed computation.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/linearFill \$linearFill]]
+   */
+  def linearFill[TExpression](path: String, expression: TExpression): WindowedComputation =
+    JWindowedComputations.linearFill(path, expression)
 }

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
@@ -629,7 +629,7 @@ object WindowedComputations {
     JWindowedComputations.denseRank(path)
 
   /**
-   * Builds a computation of the last observed non-`null` evaluation result of the `expression`.
+   * Builds a computation of the last observed non-`Null` evaluation result of the `expression`.
    *
    * [[Aggregates.setWindowFields Sorting]] is required.
    *
@@ -643,8 +643,8 @@ object WindowedComputations {
     JWindowedComputations.locf(path, expression)
 
   /**
-   * Builds a computation of a value that is equal to the evaluation result of the `expression` when it is non-`null`,
-   * or to the linear interpolation of surrounding evaluation results of the `expression` when the result is `null`.
+   * Builds a computation of a value that is equal to the evaluation result of the `expression` when it is non-`Null`,
+   * or to the linear interpolation of surrounding evaluation results of the `expression` when the result is BSON `Null`.
    *
    * [[Aggregates.setWindowFields Sorting]] is required.
    *

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/fill/FillComputation.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/fill/FillComputation.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.fill
+
+import com.mongodb.client.model.fill.{ FillComputation => JFillComputation }
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.WindowedComputations
+
+/**
+ * The core part of the `\$fill` pipeline stage of an aggregation pipeline.
+ * A pair of an expression/method and a path to a field to be filled with evaluation results of the expression/method.
+ *
+ * @see `Aggregates.fill`
+ * @note Requires MongoDB 5.3 or greater.
+ * @since 4.7
+ */
+object FillComputation {
+
+  /**
+   * Returns a `FillComputation` that uses the specified `expression`.
+   *
+   * @param field The field to fill.
+   * @param expression The expression.
+   * @tparam TExpression The `expression` type.
+   * @return The requested `FillComputation`.
+   * @see [[https://www.mongodb.com/docs/manual/core/document/#dot-notation Dot notation]]
+   */
+  def value[TExpression](field: String, expression: TExpression): ValueFillComputation =
+    JFillComputation.value(field, expression)
+
+  /**
+   * Returns a `FillComputation` that uses the [[WindowedComputations.locf]] method.
+   *
+   * @param field The field to fill.
+   * @return The requested `FillComputation`.
+   * @see [[https://www.mongodb.com/docs/manual/core/document/#dot-notation Dot notation]]
+   */
+  def locf(field: String): LocfFillComputation = JFillComputation.locf(field)
+
+  /**
+   * Returns a `FillComputation` that uses the [[WindowedComputations.linearFill]] method.
+   *
+   * Sorting (`FillOptions.sortBy`) is required.
+   *
+   * @param field The field to fill.
+   * @return The requested `FillComputation`.
+   * @see [[https://www.mongodb.com/docs/manual/core/document/#dot-notation Dot notation]]
+   */
+  def linear(field: String): LinearFillComputation = JFillComputation.linear(field)
+
+  /**
+   * Creates a `FillComputation` from a `Bson` in situations when there is no builder method that better satisfies your needs.
+   * This method cannot be used to validate the syntax.
+   *
+   * <i>Example</i><br>
+   * The following code creates two functionally equivalent `FillComputation`s,
+   * though they may not be equal.
+   * {{{
+   *  val field1 = FillComputation.locf("fieldName")
+   *  val field2 = FillComputation.of(Document("fieldName" -> Document("method" -> "locf")))
+   * }}}
+   *
+   * @param fill A `Bson` representing the required `FillComputation`.
+   *
+   * @return The requested `FillComputation`.
+   */
+  def of(fill: Bson): FillComputation = JFillComputation.of(fill)
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/fill/FillOptions.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/fill/FillOptions.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model.fill
+
+import com.mongodb.client.model.fill.{ FillOptions => JFillOptions }
+
+/**
+ * Represents optional fields of the `\$fill` pipeline stage of an aggregation pipeline.
+ *
+ * @see `Aggregates.fill`
+ * @note Requires MongoDB 5.3 or greater.
+ * @since 4.7
+ */
+object FillOptions {
+
+  /**
+   * Returns `FillOptions` that represents server defaults.
+   *
+   * @return `FillOptions` that represents server defaults.
+   */
+  def fillOptions(): FillOptions = JFillOptions.fillOptions()
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/fill/fill.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/fill/fill.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mongodb.scala.model
+
+import com.mongodb.annotations.Evolving
+
+/**
+ * @see `Aggregates.fill`
+ * @note Requires MongoDB 5.3 or greater.
+ * @since 4.7
+ */
+package object fill {
+
+  /**
+   * Represents optional fields of the `\$fill` pipeline stage of an aggregation pipeline.
+   *
+   * @see `Aggregates.fill`
+   */
+  @Evolving
+  type FillOptions = com.mongodb.client.model.fill.FillOptions
+
+  /**
+   * The core part of the `\$fill` pipeline stage of an aggregation pipeline.
+   * A pair of an expression/method and a path to a field to be filled with evaluation results of the expression/method.
+   *
+   * @see `Aggregates.fill`
+   */
+  @Evolving
+  type FillComputation = com.mongodb.client.model.fill.FillComputation
+
+  /**
+   * @see `FillComputation.value`
+   */
+  @Evolving
+  type ValueFillComputation = com.mongodb.client.model.fill.ValueFillComputation
+
+  /**
+   * @see `FillComputation.locf`
+   */
+  @Evolving
+  type LocfFillComputation = com.mongodb.client.model.fill.LocfFillComputation
+
+  /**
+   * @see `FillComputation.linear`
+   */
+  @Evolving
+  type LinearFillComputation = com.mongodb.client.model.fill.LinearFillComputation
+}

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
@@ -28,6 +28,8 @@ import org.mongodb.scala.model.Projections._
 import org.mongodb.scala.model.Sorts._
 import org.mongodb.scala.model.Windows.Bound.{ CURRENT, UNBOUNDED }
 import org.mongodb.scala.model.Windows.{ documents, range }
+import org.mongodb.scala.model.fill.FillOptions.fillOptions
+import org.mongodb.scala.model.fill.FillComputation
 import org.mongodb.scala.model.search.SearchCount.total
 import org.mongodb.scala.model.search.SearchFacet.stringFacet
 import org.mongodb.scala.model.search.SearchHighlight.paths
@@ -525,6 +527,27 @@ class AggregatesSpec extends BaseSpec {
         "$setWindowFields": {
           "output": {
             "newField01": { "$sum": "$field01", "window": { "documents": [1, 2] } }
+          }
+        }
+      }""")
+    )
+  }
+
+  it should "render $fill" in {
+    toBson(
+      Aggregates.fill(
+        fillOptions().partitionByFields("fieldName3").sortBy(ascending("fieldName4")),
+        FillComputation.linear("fieldName1"),
+        FillComputation.locf("fieldName2")
+      )
+    ) should equal(
+      Document("""{
+        "$fill": {
+          "partitionByFields": ["fieldName3"],
+          "sortBy": { "fieldName4": 1 },
+          "output": {
+            "fieldName1": { "method": "linear" },
+            "fieldName2": { "method": "locf" }
           }
         }
       }""")

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
@@ -465,7 +465,9 @@ class AggregatesSpec extends BaseSpec {
         WindowedComputations.bottom("newField24", ascending("sortByField"), "$field24", Some(window)),
         WindowedComputations.bottomN("newField24N", ascending("sortByField"), "$field24N", 2, Some(window)),
         WindowedComputations.top("newField25", ascending("sortByField"), "$field25", Some(window)),
-        WindowedComputations.topN("newField25N", ascending("sortByField"), "$field25N", 2, Some(window))
+        WindowedComputations.topN("newField25N", ascending("sortByField"), "$field25N", 2, Some(window)),
+        WindowedComputations.locf("newField26", "$field26"),
+        WindowedComputations.linearFill("newField27", "$field27")
       )
     ) should equal(
       Document(
@@ -505,7 +507,9 @@ class AggregatesSpec extends BaseSpec {
             "newField24": { "$bottom": { "sortBy": { "sortByField": 1}, "output": "$field24"}, "window": { "documents": [1, 2] } },
             "newField24N": { "$bottomN": { "sortBy": { "sortByField": 1}, "output": "$field24N", "n": 2 }, "window": { "documents": [1, 2] } },
             "newField25": { "$top": { "sortBy": { "sortByField": 1}, "output": "$field25"}, "window": { "documents": [1, 2] } },
-            "newField25N": { "$topN": { "sortBy": { "sortByField": 1}, "output": "$field25N", "n": 2 }, "window": { "documents": [1, 2] } }
+            "newField25N": { "$topN": { "sortBy": { "sortByField": 1}, "output": "$field25N", "n": 2 }, "window": { "documents": [1, 2] } },
+            "newField26": { "$locf": "$field26" },
+            "newField27": { "$linearFill": "$field27" }
           }
         }
       }"""


### PR DESCRIPTION
The new API:

- `WindowedComputations.locf` for [`$locf`](https://www.mongodb.com/docs/v6.0/reference/operator/aggregation/locf/)
- `WindowedComputations.linearFill` for [`$linearFill`](https://www.mongodb.com/docs/v6.0/reference/operator/aggregation/linearFill/)
- `Aggregates.fill` for [`$fill`](https://www.mongodb.com/docs/v6.0/reference/operator/aggregation/fill/)

The server-side syntax document is [here](https://docs.google.com/document/d/1pwIBc5XzbZkMnZH-FAoVYf2OOUzQM2VT8wbtoC4FMTg/edit#heading=h.pkrftzkil1l1).

You may see how the API usage looks like, or play with it in

- `AggregatesFunctionalSpecification.'$setWindowFields'`
- `AggregatesFunctionalSpecification.'$fill'`

JAVA-4394