### PR TITLE
Use varargs instead of single-value parameters in `$search`/`$setWindowFields` query building API

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.mongodb.assertions.Assertions.assertTrue;
+import static com.mongodb.internal.Iterables.concat;
 import static java.util.Arrays.asList;
 import static org.bson.assertions.Assertions.notNull;
 
@@ -614,7 +615,8 @@ public final class Aggregates {
      *               Sorting is required by certain functions and may be required by some windows (see {@link Windows} for more details).
      *               Sorting is used only for the purpose of computing window functions and does not guarantee ordering
      *               of the output documents.
-     * @param output A nonempty array of {@linkplain WindowedComputation windowed computations}.
+     * @param output A {@linkplain WindowedComputation windowed computation}.
+     * @param moreOutput More {@linkplain WindowedComputation windowed computations}.
      * @param <TExpression> The {@code partitionBy} expression type.
      * @return The {@code $setWindowFields} pipeline stage.
      * @mongodb.driver.dochub core/window-functions-set-window-fields $setWindowFields
@@ -622,9 +624,8 @@ public final class Aggregates {
      * @since 4.3
      */
     public static <TExpression> Bson setWindowFields(@Nullable final TExpression partitionBy, @Nullable final Bson sortBy,
-                                                     final WindowedComputation... output) {
-        notNull("output", output);
-        return setWindowFields(partitionBy, sortBy, asList(output));
+            final WindowedComputation output, final WindowedComputation... moreOutput) {
+        return setWindowFields(partitionBy, sortBy, concat(notNull("output", output), moreOutput));
     }
 
     /**
@@ -640,7 +641,8 @@ public final class Aggregates {
      *               Sorting is required by certain functions and may be required by some windows (see {@link Windows} for more details).
      *               Sorting is used only for the purpose of computing window functions and does not guarantee ordering
      *               of the output documents.
-     * @param output A nonempty list of {@linkplain WindowedComputation windowed computations}.
+     * @param output A list of {@linkplain WindowedComputation windowed computations}.
+     * Specifying an empty list is not an error, but the resulting stage does not do anything useful.
      * @param <TExpression> The {@code partitionBy} expression type.
      * @return The {@code $setWindowFields} pipeline stage.
      * @mongodb.driver.dochub core/window-functions-set-window-fields $setWindowFields

--- a/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
@@ -19,7 +19,7 @@ import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Evolving;
 
 /**
- * @see SearchOperator#autocomplete(FieldSearchPath, String...)
+ * @see SearchOperator#autocomplete(FieldSearchPath, String, String...)
  * @see SearchOperator#autocomplete(FieldSearchPath, Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
@@ -19,8 +19,8 @@ import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Evolving;
 
 /**
- * @see SearchOperator#autocomplete(String, FieldSearchPath)
- * @see SearchOperator#autocomplete(Iterable, FieldSearchPath)
+ * @see SearchOperator#autocomplete(FieldSearchPath, String)
+ * @see SearchOperator#autocomplete(FieldSearchPath, Iterable)
  * @since 4.7
  */
 @Evolving

--- a/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
@@ -35,7 +35,7 @@ public interface AutocompleteSearchOperator extends SearchOperator {
      * @param options The fuzzy search options.
      * @return A new {@link AutocompleteSearchOperator}.
      */
-    AutocompleteSearchOperator fuzzy(SearchFuzzy... options);
+    AutocompleteSearchOperator fuzzy(FuzzySearchOptions... options);
 
     /**
      * Creates a new {@link AutocompleteSearchOperator} that does not require tokens to appear in the same order as they are specified.

--- a/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
@@ -32,10 +32,10 @@ public interface AutocompleteSearchOperator extends SearchOperator {
     /**
      * Creates a new {@link AutocompleteSearchOperator} that uses fuzzy search.
      *
-     * @param option Fuzzy search option.
+     * @param options The fuzzy search options.
      * @return A new {@link AutocompleteSearchOperator}.
      */
-    AutocompleteSearchOperator fuzzy(SearchFuzzy option);
+    AutocompleteSearchOperator fuzzy(SearchFuzzy... options);
 
     /**
      * Creates a new {@link AutocompleteSearchOperator} that does not require tokens to appear in the same order as they are specified.

--- a/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
@@ -19,7 +19,7 @@ import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Evolving;
 
 /**
- * @see SearchOperator#autocomplete(FieldSearchPath, String)
+ * @see SearchOperator#autocomplete(FieldSearchPath, String...)
  * @see SearchOperator#autocomplete(FieldSearchPath, Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/AutocompleteSearchOperator.java
@@ -32,10 +32,18 @@ public interface AutocompleteSearchOperator extends SearchOperator {
     /**
      * Creates a new {@link AutocompleteSearchOperator} that uses fuzzy search.
      *
-     * @param options The fuzzy search options.
      * @return A new {@link AutocompleteSearchOperator}.
      */
-    AutocompleteSearchOperator fuzzy(FuzzySearchOptions... options);
+    AutocompleteSearchOperator fuzzy();
+
+    /**
+     * Creates a new {@link AutocompleteSearchOperator} that uses fuzzy search.
+     *
+     * @param options The fuzzy search options.
+     * Specifying {@link FuzzySearchOptions#fuzzySearchOptions()} is equivalent to calling {@link #fuzzy()}.
+     * @return A new {@link AutocompleteSearchOperator}.
+     */
+    AutocompleteSearchOperator fuzzy(FuzzySearchOptions options);
 
     /**
      * Creates a new {@link AutocompleteSearchOperator} that does not require tokens to appear in the same order as they are specified.

--- a/driver-core/src/main/com/mongodb/client/model/search/DateNearSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/DateNearSearchOperator.java
@@ -22,7 +22,7 @@ import java.time.Duration;
 import java.time.Instant;
 
 /**
- * @see SearchOperator#near(Instant, Duration, FieldSearchPath)
+ * @see SearchOperator#near(Instant, Duration, FieldSearchPath...)
  * @see SearchOperator#near(Instant, Duration, Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/DateNearSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/DateNearSearchOperator.java
@@ -22,7 +22,7 @@ import java.time.Duration;
 import java.time.Instant;
 
 /**
- * @see SearchOperator#near(Instant, Duration, FieldSearchPath...)
+ * @see SearchOperator#near(Instant, Duration, FieldSearchPath, FieldSearchPath...)
  * @see SearchOperator#near(Instant, Duration, Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/DateRangeSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/DateRangeSearchOperator.java
@@ -19,7 +19,7 @@ import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Evolving;
 
 /**
- * @see SearchOperator#dateRange(FieldSearchPath)
+ * @see SearchOperator#dateRange(FieldSearchPath...)
  * @see SearchOperator#dateRange(Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/DateRangeSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/DateRangeSearchOperator.java
@@ -19,7 +19,7 @@ import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Evolving;
 
 /**
- * @see SearchOperator#dateRange(FieldSearchPath...)
+ * @see SearchOperator#dateRange(FieldSearchPath, FieldSearchPath...)
  * @see SearchOperator#dateRange(Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/DateRangeSearchOperatorBase.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/DateRangeSearchOperatorBase.java
@@ -24,7 +24,7 @@ import java.time.Instant;
  * A base for a {@link DateRangeSearchOperator} which allows creating instances of this operator.
  * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
  *
- * @see SearchOperator#dateRange(FieldSearchPath...)
+ * @see SearchOperator#dateRange(FieldSearchPath, FieldSearchPath...)
  * @see SearchOperator#dateRange(Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/DateRangeSearchOperatorBase.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/DateRangeSearchOperatorBase.java
@@ -24,7 +24,7 @@ import java.time.Instant;
  * A base for a {@link DateRangeSearchOperator} which allows creating instances of this operator.
  * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
  *
- * @see SearchOperator#dateRange(FieldSearchPath)
+ * @see SearchOperator#dateRange(FieldSearchPath...)
  * @see SearchOperator#dateRange(Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/FuzzySearchOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/FuzzySearchOptions.java
@@ -30,58 +30,58 @@ import static com.mongodb.assertions.Assertions.notNull;
  */
 @Evolving
 @Beta(Beta.Reason.CLIENT)
-public interface SearchFuzzy extends Bson {
+public interface FuzzySearchOptions extends Bson {
     /**
-     * Creates a new {@link SearchFuzzy} with the maximum
+     * Creates a new {@link FuzzySearchOptions} with the maximum
      * <a href="https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance">number of single-character edits</a>
      * required to match a search term.
      *
      * @param maxEdits The maximum number of single-character edits required to match a search term.
-     * @return A new {@link SearchFuzzy}.
+     * @return A new {@link FuzzySearchOptions}.
      */
-    SearchFuzzy maxEdits(int maxEdits);
+    FuzzySearchOptions maxEdits(int maxEdits);
 
     /**
-     * Creates a new {@link SearchFuzzy} with the number of characters at the beginning of a search term that must exactly match.
+     * Creates a new {@link FuzzySearchOptions} with the number of characters at the beginning of a search term that must exactly match.
      *
      * @param prefixLength The number of characters at the beginning of a search term that must exactly match.
-     * @return A new {@link SearchFuzzy}.
+     * @return A new {@link FuzzySearchOptions}.
      */
-    SearchFuzzy prefixLength(int prefixLength);
+    FuzzySearchOptions prefixLength(int prefixLength);
 
     /**
-     * Creates a new {@link SearchFuzzy} with the maximum number of variations to generate and consider to match a search term.
+     * Creates a new {@link FuzzySearchOptions} with the maximum number of variations to generate and consider to match a search term.
      *
      * @param maxExpansions The maximum number of variations to generate and consider to match a search term.
-     * @return A new {@link SearchFuzzy}.
+     * @return A new {@link FuzzySearchOptions}.
      */
-    SearchFuzzy maxExpansions(int maxExpansions);
+    FuzzySearchOptions maxExpansions(int maxExpansions);
 
     /**
-     * Creates a new {@link SearchFuzzy} from a {@link Bson} in situations when there is no builder method that better satisfies your needs.
+     * Creates a new {@link FuzzySearchOptions} from a {@link Bson} in situations when there is no builder method that better satisfies your needs.
      * This method cannot be used to validate the syntax.
      * <p>
      * <i>Example</i><br>
-     * The following code creates two functionally equivalent {@link SearchFuzzy} objects,
+     * The following code creates two functionally equivalent {@link FuzzySearchOptions} objects,
      * though they may not be {@linkplain Object#equals(Object) equal}.
      * <pre>{@code
-     *  SearchFuzzy fuzzy1 = SearchFuzzy.defaultSearchFuzzy().maxEdits(1);
-     *  SearchFuzzy fuzzy2 = SearchFuzzy.of(new Document("maxEdits", 1));
+     *  FuzzySearchOptions fuzzy1 = FuzzySearchOptions.fuzzySearchOptions().maxEdits(1);
+     *  FuzzySearchOptions fuzzy2 = FuzzySearchOptions.of(new Document("maxEdits", 1));
      * }</pre>
      *
-     * @param fuzzy A {@link Bson} representing the required {@link SearchFuzzy}.
-     * @return A new {@link SearchFuzzy}.
+     * @param fuzzy A {@link Bson} representing the required {@link FuzzySearchOptions}.
+     * @return A new {@link FuzzySearchOptions}.
      */
-    static SearchFuzzy of(final Bson fuzzy) {
+    static FuzzySearchOptions of(final Bson fuzzy) {
         return new SearchConstructibleBson(notNull("fuzzy", fuzzy));
     }
 
     /**
-     * Returns {@link SearchFuzzy} that represents server defaults.
+     * Returns {@link FuzzySearchOptions} that represents server defaults.
      *
-     * @return {@link SearchFuzzy} that represents server defaults.
+     * @return {@link FuzzySearchOptions} that represents server defaults.
      */
-    static SearchFuzzy defaultSearchFuzzy() {
+    static FuzzySearchOptions fuzzySearchOptions() {
         return SearchConstructibleBson.EMPTY_IMMUTABLE;
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/search/FuzzySearchOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/FuzzySearchOptions.java
@@ -19,8 +19,6 @@ import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Evolving;
 import org.bson.conversions.Bson;
 
-import static com.mongodb.assertions.Assertions.notNull;
-
 /**
  * Fuzzy search options that may be used with some {@link SearchOperator}s.
  *
@@ -58,23 +56,23 @@ public interface FuzzySearchOptions extends Bson {
     FuzzySearchOptions maxExpansions(int maxExpansions);
 
     /**
-     * Creates a new {@link FuzzySearchOptions} from a {@link Bson} in situations when there is no builder method that better satisfies your needs.
+     * Creates a new {@link FuzzySearchOptions} with the specified option in situations when there is no builder method
+     * that better satisfies your needs.
      * This method cannot be used to validate the syntax.
      * <p>
      * <i>Example</i><br>
      * The following code creates two functionally equivalent {@link FuzzySearchOptions} objects,
      * though they may not be {@linkplain Object#equals(Object) equal}.
      * <pre>{@code
-     *  FuzzySearchOptions fuzzy1 = FuzzySearchOptions.fuzzySearchOptions().maxEdits(1);
-     *  FuzzySearchOptions fuzzy2 = FuzzySearchOptions.of(new Document("maxEdits", 1));
+     *  FuzzySearchOptions options1 = FuzzySearchOptions.fuzzySearchOptions().maxEdits(1)
+     *  FuzzySearchOptions options2 = FuzzySearchOptions.fuzzySearchOptions().option("maxEdits", 1)
      * }</pre>
      *
-     * @param fuzzy A {@link Bson} representing the required {@link FuzzySearchOptions}.
+     * @param name The option name.
+     * @param value The option value.
      * @return A new {@link FuzzySearchOptions}.
      */
-    static FuzzySearchOptions of(final Bson fuzzy) {
-        return new SearchConstructibleBson(notNull("fuzzy", fuzzy));
-    }
+    FuzzySearchOptions option(String name, Object value);
 
     /**
      * Returns {@link FuzzySearchOptions} that represents server defaults.

--- a/driver-core/src/main/com/mongodb/client/model/search/GeoNearSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/GeoNearSearchOperator.java
@@ -20,7 +20,7 @@ import com.mongodb.annotations.Evolving;
 import com.mongodb.client.model.geojson.Point;
 
 /**
- * @see SearchOperator#near(Point, Number, FieldSearchPath...)
+ * @see SearchOperator#near(Point, Number, FieldSearchPath, FieldSearchPath...)
  * @see SearchOperator#near(Point, Number, Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/GeoNearSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/GeoNearSearchOperator.java
@@ -20,7 +20,7 @@ import com.mongodb.annotations.Evolving;
 import com.mongodb.client.model.geojson.Point;
 
 /**
- * @see SearchOperator#near(Point, Number, FieldSearchPath)
+ * @see SearchOperator#near(Point, Number, FieldSearchPath...)
  * @see SearchOperator#near(Point, Number, Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/NumberNearSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/NumberNearSearchOperator.java
@@ -19,7 +19,7 @@ import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Evolving;
 
 /**
- * @see SearchOperator#near(Number, Number, FieldSearchPath...)
+ * @see SearchOperator#near(Number, Number, FieldSearchPath, FieldSearchPath...)
  * @see SearchOperator#near(Number, Number, Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/NumberNearSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/NumberNearSearchOperator.java
@@ -19,7 +19,7 @@ import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Evolving;
 
 /**
- * @see SearchOperator#near(Number, Number, FieldSearchPath)
+ * @see SearchOperator#near(Number, Number, FieldSearchPath...)
  * @see SearchOperator#near(Number, Number, Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/NumberRangeSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/NumberRangeSearchOperator.java
@@ -19,7 +19,7 @@ import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Evolving;
 
 /**
- * @see SearchOperator#numberRange(FieldSearchPath...)
+ * @see SearchOperator#numberRange(FieldSearchPath, FieldSearchPath...)
  * @see SearchOperator#numberRange(Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/NumberRangeSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/NumberRangeSearchOperator.java
@@ -19,7 +19,7 @@ import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Evolving;
 
 /**
- * @see SearchOperator#numberRange(FieldSearchPath)
+ * @see SearchOperator#numberRange(FieldSearchPath...)
  * @see SearchOperator#numberRange(Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/NumberRangeSearchOperatorBase.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/NumberRangeSearchOperatorBase.java
@@ -22,7 +22,7 @@ import com.mongodb.annotations.Evolving;
  * A base for a {@link NumberRangeSearchOperator} which allows creating instances of this operator.
  * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
  *
- * @see SearchOperator#numberRange(FieldSearchPath)
+ * @see SearchOperator#numberRange(FieldSearchPath...)
  * @see SearchOperator#numberRange(Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/NumberRangeSearchOperatorBase.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/NumberRangeSearchOperatorBase.java
@@ -22,7 +22,7 @@ import com.mongodb.annotations.Evolving;
  * A base for a {@link NumberRangeSearchOperator} which allows creating instances of this operator.
  * This interface is a technicality and does not represent a meaningful element of the full-text search query syntax.
  *
- * @see SearchOperator#numberRange(FieldSearchPath...)
+ * @see SearchOperator#numberRange(FieldSearchPath, FieldSearchPath...)
  * @see SearchOperator#numberRange(Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBson.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBson.java
@@ -32,7 +32,7 @@ final class SearchConstructibleBson extends AbstractConstructibleBson<SearchCons
         SearchOptions,
         SearchHighlight,
         TotalSearchCount, LowerBoundSearchCount,
-        SearchFuzzy,
+        FuzzySearchOptions,
         FieldSearchPath, WildcardSearchPath {
     /**
      * An {@linkplain Immutable immutable} {@link BsonDocument#isEmpty() empty} instance.
@@ -93,17 +93,17 @@ final class SearchConstructibleBson extends AbstractConstructibleBson<SearchCons
     }
 
     @Override
-    public SearchFuzzy maxEdits(final int maxEdits) {
+    public FuzzySearchOptions maxEdits(final int maxEdits) {
         return newAppended("maxEdits", maxEdits);
     }
 
     @Override
-    public SearchFuzzy prefixLength(final int prefixLength) {
+    public FuzzySearchOptions prefixLength(final int prefixLength) {
         return newAppended("prefixLength", prefixLength);
     }
 
     @Override
-    public SearchFuzzy maxExpansions(final int maxExpansions) {
+    public FuzzySearchOptions maxExpansions(final int maxExpansions) {
         return newAppended("maxExpansions", maxExpansions);
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBson.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBson.java
@@ -73,7 +73,7 @@ final class SearchConstructibleBson extends AbstractConstructibleBson<SearchCons
     }
 
     @Override
-    public SearchOptions option(final String name, final Object value) {
+    public SearchConstructibleBson option(final String name, final Object value) {
         return newAppended(notNull("name", name), notNull("value", value));
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBsonElement.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBsonElement.java
@@ -15,9 +15,7 @@
  */
 package com.mongodb.client.model.search;
 
-import com.mongodb.internal.client.model.AbstractConstructibleBson;
 import com.mongodb.internal.client.model.AbstractConstructibleBsonElement;
-import com.mongodb.lang.Nullable;
 import org.bson.BsonInt32;
 import org.bson.conversions.Bson;
 
@@ -27,9 +25,8 @@ import java.util.stream.StreamSupport;
 
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.internal.client.model.Util.combine;
+import static com.mongodb.client.model.search.FuzzySearchOptions.fuzzySearchOptions;
 import static com.mongodb.internal.client.model.Util.sizeAtLeast;
-import static java.util.Arrays.asList;
 
 final class SearchConstructibleBsonElement extends AbstractConstructibleBsonElement<SearchConstructibleBsonElement> implements
         CompoundSearchOperatorBase, CompoundSearchOperator,
@@ -72,16 +69,15 @@ final class SearchConstructibleBsonElement extends AbstractConstructibleBsonElem
     }
 
     @Override
-    public SearchConstructibleBsonElement fuzzy(@Nullable final FuzzySearchOptions... options) {
+    public SearchConstructibleBsonElement fuzzy() {
+        return fuzzy(fuzzySearchOptions());
+    }
+
+    @Override
+    public SearchConstructibleBsonElement fuzzy(final FuzzySearchOptions options) {
         return newWithMutatedValue(doc -> {
             doc.remove("synonyms");
-            Bson fuzzy;
-            if (options == null || options.length == 0) {
-                fuzzy = AbstractConstructibleBson.EMPTY_IMMUTABLE;
-            } else {
-                fuzzy = combine(asList(options));
-            }
-            doc.append("fuzzy", fuzzy);
+            doc.append("fuzzy", notNull("options", options));
         });
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBsonElement.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBsonElement.java
@@ -72,7 +72,7 @@ final class SearchConstructibleBsonElement extends AbstractConstructibleBsonElem
     }
 
     @Override
-    public SearchConstructibleBsonElement fuzzy(@Nullable final SearchFuzzy... options) {
+    public SearchConstructibleBsonElement fuzzy(@Nullable final FuzzySearchOptions... options) {
         return newWithMutatedValue(doc -> {
             doc.remove("synonyms");
             Bson fuzzy;

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBsonElement.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBsonElement.java
@@ -15,7 +15,9 @@
  */
 package com.mongodb.client.model.search;
 
+import com.mongodb.internal.client.model.AbstractConstructibleBson;
 import com.mongodb.internal.client.model.AbstractConstructibleBsonElement;
+import com.mongodb.lang.Nullable;
 import org.bson.BsonInt32;
 import org.bson.conversions.Bson;
 
@@ -25,7 +27,9 @@ import java.util.stream.StreamSupport;
 
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.client.model.Util.combine;
 import static com.mongodb.internal.client.model.Util.sizeAtLeast;
+import static java.util.Arrays.asList;
 
 final class SearchConstructibleBsonElement extends AbstractConstructibleBsonElement<SearchConstructibleBsonElement> implements
         CompoundSearchOperatorBase, CompoundSearchOperator,
@@ -68,10 +72,16 @@ final class SearchConstructibleBsonElement extends AbstractConstructibleBsonElem
     }
 
     @Override
-    public SearchConstructibleBsonElement fuzzy(final SearchFuzzy option) {
+    public SearchConstructibleBsonElement fuzzy(@Nullable final SearchFuzzy... options) {
         return newWithMutatedValue(doc -> {
             doc.remove("synonyms");
-            doc.append("fuzzy", notNull("option", option));
+            Bson fuzzy;
+            if (options == null || options.length == 0) {
+                fuzzy = AbstractConstructibleBson.EMPTY_IMMUTABLE;
+            } else {
+                fuzzy = combine(asList(options));
+            }
+            doc.append("fuzzy", fuzzy);
         });
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchHighlight.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchHighlight.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.client.model.Util.combineToBsonValue;
-import static java.util.Collections.singleton;
+import static java.util.Arrays.asList;
 
 /**
  * Highlighting options.
@@ -58,13 +58,13 @@ public interface SearchHighlight extends Bson {
     SearchHighlight maxNumPassages(int maxNumPassages);
 
     /**
-     * Returns a {@link SearchHighlight} for the given {@code path}.
+     * Returns a {@link SearchHighlight} for the given {@code paths}.
      *
-     * @param path The field to be searched.
+     * @param paths The non-empty fields to be searched.
      * @return The requested {@link SearchHighlight}.
      */
-    static SearchHighlight path(final SearchPath path) {
-        return paths(singleton(path));
+    static SearchHighlight paths(final SearchPath... paths) {
+        return paths(asList(notNull("paths", paths)));
     }
 
     /**
@@ -87,9 +87,9 @@ public interface SearchHighlight extends Bson {
      * The following code creates two functionally equivalent {@link SearchHighlight}s,
      * though they may not be {@linkplain Object#equals(Object) equal}.
      * <pre>{@code
-     *  SearchHighlight highlight1 = SearchHighlight.paths(Arrays.asList(
+     *  SearchHighlight highlight1 = SearchHighlight.paths(
      *          SearchPath.fieldPath("fieldName"),
-     *          SearchPath.wildcardPath("wildc*rd")));
+     *          SearchPath.wildcardPath("wildc*rd"));
      *  SearchHighlight highlight2 = SearchHighlight.of(new Document("path", Arrays.asList(
      *          SearchPath.fieldPath("fieldName").toBsonValue(),
      *          SearchPath.wildcardPath("wildc*rd").toBsonValue())));

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchHighlight.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchHighlight.java
@@ -25,8 +25,8 @@ import java.util.Iterator;
 
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.Iterables.concat;
 import static com.mongodb.internal.client.model.Util.combineToBsonValue;
-import static java.util.Arrays.asList;
 
 /**
  * Highlighting options.
@@ -60,11 +60,12 @@ public interface SearchHighlight extends Bson {
     /**
      * Returns a {@link SearchHighlight} for the given {@code paths}.
      *
-     * @param paths The non-empty fields to be searched.
+     * @param path The field to be searched.
+     * @param paths More fields to be searched.
      * @return The requested {@link SearchHighlight}.
      */
-    static SearchHighlight paths(final SearchPath... paths) {
-        return paths(asList(notNull("paths", paths)));
+    static SearchHighlight paths(final SearchPath path, final SearchPath... paths) {
+        return paths(concat(notNull("path", path), paths));
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
@@ -74,24 +74,24 @@ public interface SearchOperator extends Bson {
     /**
      * Returns a {@link SearchOperator} that performs a full-text search.
      *
-     * @param query The string to search for.
      * @param path The field to be searched.
+     * @param query The string to search for.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/text/ text operator
      */
-    static TextSearchOperator text(final String query, final SearchPath path) {
-        return text(singleton(notNull("query", query)), singleton(notNull("path", path)));
+    static TextSearchOperator text(final SearchPath path, final String query) {
+        return text(singleton(notNull("path", path)), singleton(notNull("query", query)));
     }
 
     /**
      * Returns a {@link SearchOperator} that performs a full-text search.
      *
-     * @param queries The non-empty strings to search for.
      * @param paths The non-empty fields to be searched.
+     * @param queries The non-empty strings to search for.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/text/ text operator
      */
-    static TextSearchOperator text(final Iterable<String> queries, final Iterable<? extends SearchPath> paths) {
+    static TextSearchOperator text(final Iterable<? extends SearchPath> paths, final Iterable<String> queries) {
         Iterator<String> queryIterator = notNull("queries", queries).iterator();
         isTrueArgument("queries must not be empty", queryIterator.hasNext());
         String firstQuery = queryIterator.next();

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
@@ -195,7 +195,7 @@ public interface SearchOperator extends Bson {
      * @mongodb.atlas.manual atlas-search/near/ near operator
      */
     static NumberNearSearchOperator near(final Number origin, final Number pivot, final FieldSearchPath... paths) {
-        return near(origin, pivot, asList(notNull("path", paths)));
+        return near(origin, pivot, asList(notNull("paths", paths)));
     }
 
     /**
@@ -223,13 +223,13 @@ public interface SearchOperator extends Bson {
      * The relevance score is 1 if the values of the fields are {@code origin}.
      * @param pivot The positive distance from the {@code origin} at which the relevance score drops in half.
      * Data is extracted via {@link Duration#toMillis()}.
-     * @param path The field to be searched.
+     * @param paths The non-empty fields to be searched.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/near/ near operator
      * @see org.bson.codecs.jsr310.InstantCodec
      */
-    static DateNearSearchOperator near(final Instant origin, final Duration pivot, final FieldSearchPath path) {
-        return near(origin, pivot, singleton(notNull("path", path)));
+    static DateNearSearchOperator near(final Instant origin, final Duration pivot, final FieldSearchPath... paths) {
+        return near(origin, pivot, asList(notNull("paths", paths)));
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.internal.client.model.Util.combineToBsonValue;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -105,12 +106,12 @@ public interface SearchOperator extends Bson {
      * Returns a {@link SearchOperator} that may be used to implement search-as-you-type functionality.
      *
      * @param path The field to be searched.
-     * @param query The string to search for.
+     * @param queries The non-empty strings to search for.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/autocomplete/ autocomplete operator
      */
-    static AutocompleteSearchOperator autocomplete(final FieldSearchPath path, final String query) {
-        return autocomplete(path, singleton(notNull("query", query)));
+    static AutocompleteSearchOperator autocomplete(final FieldSearchPath path, final String... queries) {
+        return autocomplete(path, asList(notNull("queries", queries)));
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
@@ -261,12 +261,12 @@ public interface SearchOperator extends Bson {
      * @param origin The origin from which the proximity of the results is measured.
      * The relevance score is 1 if the values of the fields are {@code origin}.
      * @param pivot The positive distance in meters from the {@code origin} at which the relevance score drops in half.
-     * @param path The field to be searched.
+     * @param paths The non-empty fields to be searched.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/near/ near operator
      */
-    static GeoNearSearchOperator near(final Point origin, final Number pivot, final FieldSearchPath path) {
-        return near(origin, pivot, singleton(notNull("path", path)));
+    static GeoNearSearchOperator near(final Point origin, final Number pivot, final FieldSearchPath... paths) {
+        return near(origin, pivot, asList(notNull("paths", paths)));
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
@@ -28,8 +28,8 @@ import java.time.Instant;
 import java.util.Iterator;
 
 import static com.mongodb.assertions.Assertions.isTrueArgument;
+import static com.mongodb.internal.Iterables.concat;
 import static com.mongodb.internal.client.model.Util.combineToBsonValue;
-import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -106,12 +106,13 @@ public interface SearchOperator extends Bson {
      * Returns a {@link SearchOperator} that may be used to implement search-as-you-type functionality.
      *
      * @param path The field to be searched.
-     * @param queries The non-empty strings to search for.
+     * @param query The string to search for.
+     * @param queries More strings to search for.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/autocomplete/ autocomplete operator
      */
-    static AutocompleteSearchOperator autocomplete(final FieldSearchPath path, final String... queries) {
-        return autocomplete(path, asList(notNull("queries", queries)));
+    static AutocompleteSearchOperator autocomplete(final FieldSearchPath path, final String query, final String... queries) {
+        return autocomplete(path, concat(notNull("query", query), queries));
     }
 
     /**
@@ -135,12 +136,13 @@ public interface SearchOperator extends Bson {
      * BSON {@link BsonType#INT32 32-bit integer} / {@link BsonType#INT64 64-bit integer} / {@link BsonType#DOUBLE Double} values
      * of the specified fields are within an interval.
      *
-     * @param paths The non-empty fields to be searched.
+     * @param path The field to be searched.
+     * @param paths More fields to be searched.
      * @return A base for a {@link NumberRangeSearchOperator}.
      * @mongodb.atlas.manual atlas-search/range/ range operator
      */
-    static NumberRangeSearchOperatorBase numberRange(final FieldSearchPath... paths) {
-        return numberRange(asList(notNull("paths", paths)));
+    static NumberRangeSearchOperatorBase numberRange(final FieldSearchPath path, final FieldSearchPath... paths) {
+        return numberRange(concat(notNull("path", path), paths));
     }
 
     /**
@@ -162,12 +164,13 @@ public interface SearchOperator extends Bson {
      * Returns a base for a {@link SearchOperator} that tests if the
      * BSON {@link BsonType#DATE_TIME Date} values of the specified fields are within an interval.
      *
-     * @param paths The non-empty fields to be searched.
+     * @param path The field to be searched.
+     * @param paths More fields to be searched.
      * @return A base for a {@link DateRangeSearchOperator}.
      * @mongodb.atlas.manual atlas-search/range/ range operator
      */
-    static DateRangeSearchOperatorBase dateRange(final FieldSearchPath... paths) {
-        return dateRange(asList(notNull("paths", paths)));
+    static DateRangeSearchOperatorBase dateRange(final FieldSearchPath path, final FieldSearchPath... paths) {
+        return dateRange(concat(notNull("path", path), paths));
     }
 
     /**
@@ -190,12 +193,13 @@ public interface SearchOperator extends Bson {
      * @param origin The origin from which the proximity of the results is measured.
      * The relevance score is 1 if the values of the fields are {@code origin}.
      * @param pivot The positive distance from the {@code origin} at which the relevance score drops in half.
-     * @param paths The non-empty fields to be searched.
+     * @param path The field to be searched.
+     * @param paths More fields to be searched.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/near/ near operator
      */
-    static NumberNearSearchOperator near(final Number origin, final Number pivot, final FieldSearchPath... paths) {
-        return near(origin, pivot, asList(notNull("paths", paths)));
+    static NumberNearSearchOperator near(final Number origin, final Number pivot, final FieldSearchPath path, final FieldSearchPath... paths) {
+        return near(origin, pivot, concat(notNull("path", path), paths));
     }
 
     /**
@@ -223,13 +227,14 @@ public interface SearchOperator extends Bson {
      * The relevance score is 1 if the values of the fields are {@code origin}.
      * @param pivot The positive distance from the {@code origin} at which the relevance score drops in half.
      * Data is extracted via {@link Duration#toMillis()}.
-     * @param paths The non-empty fields to be searched.
+     * @param path The field to be searched.
+     * @param paths More fields to be searched.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/near/ near operator
      * @see org.bson.codecs.jsr310.InstantCodec
      */
-    static DateNearSearchOperator near(final Instant origin, final Duration pivot, final FieldSearchPath... paths) {
-        return near(origin, pivot, asList(notNull("paths", paths)));
+    static DateNearSearchOperator near(final Instant origin, final Duration pivot, final FieldSearchPath path, final FieldSearchPath... paths) {
+        return near(origin, pivot, concat(notNull("path", path), paths));
     }
 
     /**
@@ -261,12 +266,13 @@ public interface SearchOperator extends Bson {
      * @param origin The origin from which the proximity of the results is measured.
      * The relevance score is 1 if the values of the fields are {@code origin}.
      * @param pivot The positive distance in meters from the {@code origin} at which the relevance score drops in half.
-     * @param paths The non-empty fields to be searched.
+     * @param path The field to be searched.
+     * @param paths More fields to be searched.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/near/ near operator
      */
-    static GeoNearSearchOperator near(final Point origin, final Number pivot, final FieldSearchPath... paths) {
-        return near(origin, pivot, asList(notNull("paths", paths)));
+    static GeoNearSearchOperator near(final Point origin, final Number pivot, final FieldSearchPath path, final FieldSearchPath... paths) {
+        return near(origin, pivot, concat(notNull("path", path), paths));
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
@@ -133,14 +133,14 @@ public interface SearchOperator extends Bson {
     /**
      * Returns a base for a {@link SearchOperator} that tests if the
      * BSON {@link BsonType#INT32 32-bit integer} / {@link BsonType#INT64 64-bit integer} / {@link BsonType#DOUBLE Double} values
-     * of the specified field are within an interval.
+     * of the specified fields are within an interval.
      *
-     * @param path The field to be searched.
+     * @param paths The non-empty fields to be searched.
      * @return A base for a {@link NumberRangeSearchOperator}.
      * @mongodb.atlas.manual atlas-search/range/ range operator
      */
-    static NumberRangeSearchOperatorBase numberRange(final FieldSearchPath path) {
-        return numberRange(singleton(notNull("path", path)));
+    static NumberRangeSearchOperatorBase numberRange(final FieldSearchPath... paths) {
+        return numberRange(asList(notNull("paths", paths)));
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
@@ -160,14 +160,14 @@ public interface SearchOperator extends Bson {
 
     /**
      * Returns a base for a {@link SearchOperator} that tests if the
-     * BSON {@link BsonType#DATE_TIME Date} values of the specified field are within an interval.
+     * BSON {@link BsonType#DATE_TIME Date} values of the specified fields are within an interval.
      *
-     * @param path The field to be searched.
+     * @param paths The non-empty fields to be searched.
      * @return A base for a {@link DateRangeSearchOperator}.
      * @mongodb.atlas.manual atlas-search/range/ range operator
      */
-    static DateRangeSearchOperatorBase dateRange(final FieldSearchPath path) {
-        return dateRange(singleton(notNull("path", path)));
+    static DateRangeSearchOperatorBase dateRange(final FieldSearchPath... paths) {
+        return dateRange(asList(notNull("paths", paths)));
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
@@ -190,12 +190,12 @@ public interface SearchOperator extends Bson {
      * @param origin The origin from which the proximity of the results is measured.
      * The relevance score is 1 if the values of the fields are {@code origin}.
      * @param pivot The positive distance from the {@code origin} at which the relevance score drops in half.
-     * @param path The field to be searched.
+     * @param paths The non-empty fields to be searched.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/near/ near operator
      */
-    static NumberNearSearchOperator near(final Number origin, final Number pivot, final FieldSearchPath path) {
-        return near(origin, pivot, singleton(notNull("path", path)));
+    static NumberNearSearchOperator near(final Number origin, final Number pivot, final FieldSearchPath... paths) {
+        return near(origin, pivot, asList(notNull("path", paths)));
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
@@ -104,24 +104,24 @@ public interface SearchOperator extends Bson {
     /**
      * Returns a {@link SearchOperator} that may be used to implement search-as-you-type functionality.
      *
-     * @param query The string to search for.
      * @param path The field to be searched.
+     * @param query The string to search for.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/autocomplete/ autocomplete operator
      */
-    static AutocompleteSearchOperator autocomplete(final String query, final FieldSearchPath path) {
-        return autocomplete(singleton(notNull("query", query)), path);
+    static AutocompleteSearchOperator autocomplete(final FieldSearchPath path, final String query) {
+        return autocomplete(path, singleton(notNull("query", query)));
     }
 
     /**
      * Returns a {@link SearchOperator} that may be used to implement search-as-you-type functionality.
      *
-     * @param queries The non-empty strings to search for.
      * @param path The field to be searched.
+     * @param queries The non-empty strings to search for.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/autocomplete/ autocomplete operator
      */
-    static AutocompleteSearchOperator autocomplete(final Iterable<String> queries, final FieldSearchPath path) {
+    static AutocompleteSearchOperator autocomplete(final FieldSearchPath path, final Iterable<String> queries) {
         Iterator<String> queryIterator = notNull("queries", queries).iterator();
         isTrueArgument("queries must not be empty", queryIterator.hasNext());
         String firstQuery = queryIterator.next();

--- a/driver-core/src/main/com/mongodb/client/model/search/TextSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/TextSearchOperator.java
@@ -19,7 +19,7 @@ import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Evolving;
 
 /**
- * @see SearchOperator#text(String, SearchPath)
+ * @see SearchOperator#text(SearchPath, String)
  * @see SearchOperator#text(Iterable, Iterable)
  * @since 4.7
  */

--- a/driver-core/src/main/com/mongodb/client/model/search/TextSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/TextSearchOperator.java
@@ -36,11 +36,11 @@ public interface TextSearchOperator extends SearchOperator {
      * @param options The fuzzy search options.
      * @return A new {@link TextSearchOperator}.
      */
-    TextSearchOperator fuzzy(SearchFuzzy... options);
+    TextSearchOperator fuzzy(FuzzySearchOptions... options);
 
     /**
      * Creates a new {@link TextSearchOperator} that uses synonyms
-     * and does not use {@linkplain #fuzzy(SearchFuzzy...) fuzzy search}.
+     * and does not use {@linkplain #fuzzy(FuzzySearchOptions...) fuzzy search}.
      *
      * @param name The name of the synonym mapping.
      * @return A new {@link TextSearchOperator}.

--- a/driver-core/src/main/com/mongodb/client/model/search/TextSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/TextSearchOperator.java
@@ -33,14 +33,14 @@ public interface TextSearchOperator extends SearchOperator {
      * Creates a new {@link TextSearchOperator} that uses fuzzy search
      * and does not use {@linkplain #synonyms(String) synonyms}.
      *
-     * @param option Fuzzy search option.
+     * @param options The fuzzy search options.
      * @return A new {@link TextSearchOperator}.
      */
-    TextSearchOperator fuzzy(SearchFuzzy option);
+    TextSearchOperator fuzzy(SearchFuzzy... options);
 
     /**
      * Creates a new {@link TextSearchOperator} that uses synonyms
-     * and does not use {@linkplain #fuzzy(SearchFuzzy) fuzzy search}.
+     * and does not use {@linkplain #fuzzy(SearchFuzzy...) fuzzy search}.
      *
      * @param name The name of the synonym mapping.
      * @return A new {@link TextSearchOperator}.

--- a/driver-core/src/main/com/mongodb/client/model/search/TextSearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/TextSearchOperator.java
@@ -33,14 +33,23 @@ public interface TextSearchOperator extends SearchOperator {
      * Creates a new {@link TextSearchOperator} that uses fuzzy search
      * and does not use {@linkplain #synonyms(String) synonyms}.
      *
-     * @param options The fuzzy search options.
      * @return A new {@link TextSearchOperator}.
      */
-    TextSearchOperator fuzzy(FuzzySearchOptions... options);
+    TextSearchOperator fuzzy();
+
+    /**
+     * Creates a new {@link TextSearchOperator} that uses fuzzy search
+     * and does not use {@linkplain #synonyms(String) synonyms}.
+     *
+     * @param options The fuzzy search options.
+     * Specifying {@link FuzzySearchOptions#fuzzySearchOptions()} is equivalent to calling {@link #fuzzy()}.
+     * @return A new {@link TextSearchOperator}.
+     */
+    TextSearchOperator fuzzy(FuzzySearchOptions options);
 
     /**
      * Creates a new {@link TextSearchOperator} that uses synonyms
-     * and does not use {@linkplain #fuzzy(FuzzySearchOptions...) fuzzy search}.
+     * and does not use {@linkplain #fuzzy(FuzzySearchOptions) fuzzy search}.
      *
      * @param name The name of the synonym mapping.
      * @return A new {@link TextSearchOperator}.

--- a/driver-core/src/main/com/mongodb/internal/Iterables.java
+++ b/driver-core/src/main/com/mongodb/internal/Iterables.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal;
+
+import com.mongodb.lang.Nullable;
+
+import java.util.Iterator;
+
+import static com.mongodb.assertions.Assertions.fail;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+
+public final class Iterables {
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public static <T> Iterable<T> concat(@Nullable final T first, final T... more) {
+        if (more == null) {
+            return singleton(first);
+        } else {
+            Iterable<? extends T> moreIterable = asList(more);
+            return () -> new ConcatIterator<>(first, moreIterable);
+        }
+    }
+
+    public static <T> Iterable<T> concat(@Nullable final T first, final Iterable<? extends T> more) {
+        return () -> new ConcatIterator<>(first, more);
+    }
+
+    private Iterables() {
+        throw fail();
+    }
+
+    private static class ConcatIterator<T> implements Iterator<T> {
+        private static final Object NONE = new Object();
+
+        @Nullable
+        private T first;
+        @Nullable
+        private Iterator<? extends T> moreIterator;
+        private final Iterable<? extends T> more;
+
+        ConcatIterator(@Nullable final T first, final Iterable<? extends T> more) {
+            this.first = first;
+            this.more = more;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return firstNotConsumed() || moreIterator().hasNext();
+        }
+
+        @Override
+        public T next() {
+            return firstNotConsumed() ? consumeFirst() : moreIterator().next();
+        }
+
+        private boolean firstNotConsumed() {
+            return first != NONE;
+        }
+
+        @SuppressWarnings("unchecked")
+        private T consumeFirst() {
+            T result = first;
+            first = (T) NONE;
+            return result;
+        }
+
+        private Iterator<? extends T> moreIterator() {
+            if (moreIterator == null) {
+                moreIterator = more.iterator();
+            }
+            return moreIterator;
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/Iterables.java
+++ b/driver-core/src/main/com/mongodb/internal/Iterables.java
@@ -26,7 +26,7 @@ import static java.util.Collections.singleton;
 public final class Iterables {
     @SafeVarargs
     @SuppressWarnings("varargs")
-    public static <T> Iterable<T> concat(@Nullable final T first, final T... more) {
+    public static <T> Iterable<T> concat(@Nullable final T first, @Nullable final T... more) {
         if (more == null) {
             return singleton(first);
         } else {

--- a/driver-core/src/main/com/mongodb/internal/client/model/Util.java
+++ b/driver-core/src/main/com/mongodb/internal/client/model/Util.java
@@ -19,8 +19,11 @@ import com.mongodb.Function;
 import com.mongodb.client.model.search.FieldSearchPath;
 import com.mongodb.client.model.search.SearchPath;
 import org.bson.BsonArray;
+import org.bson.BsonDocument;
 import org.bson.BsonString;
 import org.bson.BsonValue;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
 
 import java.util.Iterator;
 
@@ -59,6 +62,17 @@ public final class Util {
         } else {
             return firstPath;
         }
+    }
+
+    public static Bson combine(final Iterable<? extends Bson> objects) {
+        return new Bson() {
+            @Override
+            public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> tDocumentClass, final CodecRegistry codecRegistry) {
+                BsonDocument result = new BsonDocument();
+                objects.forEach(bson -> result.putAll(bson.toBsonDocument(tDocumentClass, codecRegistry)));
+                return result;
+            }
+        };
     }
 
     public static boolean sizeAtLeast(final Iterable<?> iterable, final int minInclusive) {

--- a/driver-core/src/main/com/mongodb/internal/client/model/Util.java
+++ b/driver-core/src/main/com/mongodb/internal/client/model/Util.java
@@ -19,11 +19,8 @@ import com.mongodb.Function;
 import com.mongodb.client.model.search.FieldSearchPath;
 import com.mongodb.client.model.search.SearchPath;
 import org.bson.BsonArray;
-import org.bson.BsonDocument;
 import org.bson.BsonString;
 import org.bson.BsonValue;
-import org.bson.codecs.configuration.CodecRegistry;
-import org.bson.conversions.Bson;
 
 import java.util.Iterator;
 
@@ -62,17 +59,6 @@ public final class Util {
         } else {
             return firstPath;
         }
-    }
-
-    public static Bson combine(final Iterable<? extends Bson> objects) {
-        return new Bson() {
-            @Override
-            public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> tDocumentClass, final CodecRegistry codecRegistry) {
-                BsonDocument result = new BsonDocument();
-                objects.forEach(bson -> result.putAll(bson.toBsonDocument(tDocumentClass, codecRegistry)));
-                return result;
-            }
-        };
     }
 
     public static boolean sizeAtLeast(final Iterable<?> iterable, final int minInclusive) {

--- a/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
@@ -1268,7 +1268,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         Document[] original = [new Document('num', 1)]
         getCollectionHelper().insertDocuments(original)
         List<Document> actual = aggregate([
-                setWindowFields(null, null),
+                setWindowFields(null, null, []),
                 project(fields(excludeId()))])
 
         expect:

--- a/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
@@ -490,7 +490,7 @@ final class AggregatesSearchIntegrationTest {
                                                 // `multi` is used here only to verify that it is tolerated
                                                 .multi("keyword"), "term4"),
                                         // this operator produces non-empty search results
-                                        autocomplete(fieldPath("title"), asList("Traffic in", "term5"))
+                                        autocomplete(fieldPath("title"), "Traffic in", "term5")
                                                 .fuzzy(defaultSearchFuzzy())
                                                 .sequentialTokenOrder(),
                                         numberRange(asList(fieldPath("fieldName4"), fieldPath("fieldName5")))

--- a/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
@@ -315,9 +315,9 @@ final class AggregatesSearchIntegrationTest {
                         stageCreator(
                                 text(asList("factory", "century"), singleton(fieldPath("plot"))),
                                 defaultSearchOptions()
-                                        .highlight(paths(asList(
+                                        .highlight(paths(
                                                 fieldPath("title").multi("keyword"),
-                                                wildcardPath("pl*t")))
+                                                wildcardPath("pl*t"))
                                                 .maxCharsToExamine(100_000))
                         ),
                         MFLIX_MOVIES_NS,

--- a/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
@@ -491,7 +491,7 @@ final class AggregatesSearchIntegrationTest {
                                                 .multi("keyword"), "term4"),
                                         // this operator produces non-empty search results
                                         autocomplete(fieldPath("title"), "Traffic in", "term5")
-                                                .fuzzy(defaultSearchFuzzy())
+                                                .fuzzy()
                                                 .sequentialTokenOrder(),
                                         numberRange(fieldPath("fieldName4"), fieldPath("fieldName5"))
                                                 .gtLt(1, 1.5),

--- a/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
@@ -497,7 +497,7 @@ final class AggregatesSearchIntegrationTest {
                                                 .gtLt(1, 1.5),
                                         dateRange(fieldPath("fieldName6"))
                                                 .lte(Instant.ofEpochMilli(1)),
-                                        near(0, 1.5, asList(fieldPath("fieldName7"), fieldPath("fieldName8"))),
+                                        near(0, 1.5, fieldPath("fieldName7"), fieldPath("fieldName8")),
                                         near(Instant.ofEpochMilli(1), Duration.ofMillis(3), fieldPath("fieldName9"))
                                 ))
                                 .minimumShouldMatch(1)

--- a/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
@@ -493,7 +493,7 @@ final class AggregatesSearchIntegrationTest {
                                         autocomplete(fieldPath("title"), "Traffic in", "term5")
                                                 .fuzzy(defaultSearchFuzzy())
                                                 .sequentialTokenOrder(),
-                                        numberRange(asList(fieldPath("fieldName4"), fieldPath("fieldName5")))
+                                        numberRange(fieldPath("fieldName4"), fieldPath("fieldName5"))
                                                 .gtLt(1, 1.5),
                                         dateRange(fieldPath("fieldName6"))
                                                 .lte(Instant.ofEpochMilli(1)),

--- a/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
@@ -313,7 +313,7 @@ final class AggregatesSearchIntegrationTest {
                 arguments(
                         "`highlight` option",
                         stageCreator(
-                                text(asList("factory", "century"), singleton(fieldPath("plot"))),
+                                text(singleton(fieldPath("plot")), asList("factory", "century")),
                                 defaultSearchOptions()
                                         .highlight(paths(
                                                 fieldPath("title").multi("keyword"),
@@ -359,7 +359,7 @@ final class AggregatesSearchIntegrationTest {
                 arguments(
                         "alternate analyzer (`multi` field path)",
                         stageCreator(
-                                text(singleton("The Cheat"), singleton(fieldPath("title").multi("keyword"))),
+                                text(singleton(fieldPath("title").multi("keyword")), singleton("The Cheat")),
                                 defaultSearchOptions().count(total())
                         ),
                         MFLIX_MOVIES_NS,
@@ -479,9 +479,9 @@ final class AggregatesSearchIntegrationTest {
                         stageCreator(compound()
                                 .should(asList(
                                         exists(fieldPath("fieldName1")),
-                                        text("term1", fieldPath("fieldName2"))
+                                        text(fieldPath("fieldName2"), "term1")
                                                 .score(function(logExpression(constantExpression(3)))),
-                                        text(asList("term2", "term3"), asList(wildcardPath("wildc*rd"), fieldPath("fieldName3")))
+                                        text(asList(wildcardPath("wildc*rd"), fieldPath("fieldName3")), asList("term2", "term3"))
                                                 .fuzzy(defaultSearchFuzzy()
                                                         .maxEdits(1)
                                                         .prefixLength(2)

--- a/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
@@ -56,7 +56,7 @@ import static com.mongodb.client.model.Aggregates.replaceWith;
 import static com.mongodb.client.model.Projections.computedSearchMeta;
 import static com.mongodb.client.model.Projections.metaSearchHighlights;
 import static com.mongodb.client.model.Projections.metaSearchScore;
-import static com.mongodb.client.model.search.SearchFuzzy.defaultSearchFuzzy;
+import static com.mongodb.client.model.search.FuzzySearchOptions.fuzzySearchOptions;
 import static com.mongodb.client.model.search.SearchCollector.facet;
 import static com.mongodb.client.model.search.SearchCount.lowerBound;
 import static com.mongodb.client.model.search.SearchCount.total;
@@ -482,7 +482,7 @@ final class AggregatesSearchIntegrationTest {
                                         text(fieldPath("fieldName2"), "term1")
                                                 .score(function(logExpression(constantExpression(3)))),
                                         text(asList(wildcardPath("wildc*rd"), fieldPath("fieldName3")), asList("term2", "term3"))
-                                                .fuzzy(defaultSearchFuzzy()
+                                                .fuzzy(fuzzySearchOptions()
                                                         .maxEdits(1)
                                                         .prefixLength(2)
                                                         .maxExpansions(3)),

--- a/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
@@ -486,11 +486,11 @@ final class AggregatesSearchIntegrationTest {
                                                         .maxEdits(1)
                                                         .prefixLength(2)
                                                         .maxExpansions(3)),
-                                        autocomplete("term4", fieldPath("title")
+                                        autocomplete(fieldPath("title")
                                                 // `multi` is used here only to verify that it is tolerated
-                                                .multi("keyword")),
+                                                .multi("keyword"), "term4"),
                                         // this operator produces non-empty search results
-                                        autocomplete(asList("Traffic in", "term5"), fieldPath("title"))
+                                        autocomplete(fieldPath("title"), asList("Traffic in", "term5"))
                                                 .fuzzy(defaultSearchFuzzy())
                                                 .sequentialTokenOrder(),
                                         numberRange(asList(fieldPath("fieldName4"), fieldPath("fieldName5")))

--- a/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
@@ -644,10 +644,10 @@ class AggregatesSpecification extends Specification {
                         defaultSearchOptions()
                                 .index('indexName')
                                 .count(total())
-                                .highlight(paths([
+                                .highlight(paths(
                                         fieldPath('fieldName1'),
                                         fieldPath('fieldName2').multi('analyzerName'),
-                                        wildcardPath('field.name*')]))
+                                        wildcardPath('field.name*')))
                 )
         )
 
@@ -735,10 +735,10 @@ class AggregatesSpecification extends Specification {
                         defaultSearchOptions()
                                 .index('indexName')
                                 .count(total())
-                                .highlight(paths([
+                                .highlight(paths(
                                         fieldPath('fieldName1'),
                                         fieldPath('fieldName2').multi('analyzerName'),
-                                        wildcardPath('field.name*')]))
+                                        wildcardPath('field.name*')))
                 )
         )
 

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/FuzzySearchOptionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/FuzzySearchOptionsTest.java
@@ -17,52 +17,28 @@ package com.mongodb.client.model.search;
 
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
-import org.bson.Document;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 final class FuzzySearchOptionsTest {
     @Test
-    void of() {
-        assertAll(
-                () -> assertEquals(
-                        docExamplePredefined()
-                                .toBsonDocument(),
-                        FuzzySearchOptions.of(docExampleCustom())
-                                .toBsonDocument()
-                ),
-                () -> assertEquals(
-                        new BsonDocument()
-                                .append("maxEdits", new BsonInt32(1))
-                                .append("prefixLength", new BsonInt32(5))
-                                .append("maxExpansions", new BsonInt32(10)),
-                        FuzzySearchOptions.fuzzySearchOptions()
-                                .maxEdits(1)
-                                .prefixLength(5)
-                                .maxExpansions(10)
-                                .toBsonDocument()
-                )
+    void fuzzySearchOptions() {
+        assertEquals(
+                new BsonDocument(),
+                FuzzySearchOptions.fuzzySearchOptions()
+                        .toBsonDocument()
         );
     }
 
     @Test
     void maxEdits() {
-        assertAll(
-                () -> assertEquals(
-                        docExampleCustom()
-                                .toBsonDocument(),
-                        docExamplePredefined()
-                                .toBsonDocument()
-                ),
-                () -> assertEquals(
-                        new BsonDocument()
-                                .append("maxEdits", new BsonInt32(1)),
-                        FuzzySearchOptions.fuzzySearchOptions()
-                                .maxEdits(1)
-                                .toBsonDocument()
-                )
+        assertEquals(
+                new BsonDocument()
+                        .append("maxEdits", new BsonInt32(1)),
+                FuzzySearchOptions.fuzzySearchOptions()
+                        .maxEdits(1)
+                        .toBsonDocument()
         );
     }
 
@@ -89,10 +65,16 @@ final class FuzzySearchOptionsTest {
     }
 
     @Test
-    void fuzzySearchOptions() {
+    void options() {
         assertEquals(
-                new BsonDocument(),
+                new BsonDocument()
+                        .append("maxEdits", new BsonInt32(1))
+                        .append("prefixLength", new BsonInt32(5))
+                        .append("maxExpansions", new BsonInt32(10)),
                 FuzzySearchOptions.fuzzySearchOptions()
+                        .maxEdits(1)
+                        .prefixLength(5)
+                        .maxExpansions(10)
                         .toBsonDocument()
         );
     }
@@ -109,13 +91,5 @@ final class FuzzySearchOptionsTest {
         String expected = FuzzySearchOptions.fuzzySearchOptions().toBsonDocument().toJson();
         FuzzySearchOptions.fuzzySearchOptions().toBsonDocument().append("maxEdits", new BsonInt32(1));
         assertEquals(expected, FuzzySearchOptions.fuzzySearchOptions().toBsonDocument().toJson());
-    }
-
-    private static FuzzySearchOptions docExamplePredefined() {
-        return FuzzySearchOptions.fuzzySearchOptions().maxEdits(1);
-    }
-
-    private static Document docExampleCustom() {
-        return new Document("maxEdits", new BsonInt32(1));
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/FuzzySearchOptionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/FuzzySearchOptionsTest.java
@@ -23,14 +23,14 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-final class SearchFuzzyTest {
+final class FuzzySearchOptionsTest {
     @Test
     void of() {
         assertAll(
                 () -> assertEquals(
                         docExamplePredefined()
                                 .toBsonDocument(),
-                        SearchFuzzy.of(docExampleCustom())
+                        FuzzySearchOptions.of(docExampleCustom())
                                 .toBsonDocument()
                 ),
                 () -> assertEquals(
@@ -38,7 +38,7 @@ final class SearchFuzzyTest {
                                 .append("maxEdits", new BsonInt32(1))
                                 .append("prefixLength", new BsonInt32(5))
                                 .append("maxExpansions", new BsonInt32(10)),
-                        SearchFuzzy.defaultSearchFuzzy()
+                        FuzzySearchOptions.fuzzySearchOptions()
                                 .maxEdits(1)
                                 .prefixLength(5)
                                 .maxExpansions(10)
@@ -59,7 +59,7 @@ final class SearchFuzzyTest {
                 () -> assertEquals(
                         new BsonDocument()
                                 .append("maxEdits", new BsonInt32(1)),
-                        SearchFuzzy.defaultSearchFuzzy()
+                        FuzzySearchOptions.fuzzySearchOptions()
                                 .maxEdits(1)
                                 .toBsonDocument()
                 )
@@ -71,7 +71,7 @@ final class SearchFuzzyTest {
         assertEquals(
                 new BsonDocument()
                         .append("prefixLength", new BsonInt32(5)),
-                SearchFuzzy.defaultSearchFuzzy()
+                FuzzySearchOptions.fuzzySearchOptions()
                         .prefixLength(5)
                         .toBsonDocument()
         );
@@ -82,37 +82,37 @@ final class SearchFuzzyTest {
         assertEquals(
                 new BsonDocument()
                         .append("maxExpansions", new BsonInt32(10)),
-                SearchFuzzy.defaultSearchFuzzy()
+                FuzzySearchOptions.fuzzySearchOptions()
                         .maxExpansions(10)
                         .toBsonDocument()
         );
     }
 
     @Test
-    void defaultSearchFuzzy() {
+    void fuzzySearchOptions() {
         assertEquals(
                 new BsonDocument(),
-                SearchFuzzy.defaultSearchFuzzy()
+                FuzzySearchOptions.fuzzySearchOptions()
                         .toBsonDocument()
         );
     }
 
     @Test
-    void defaultSearchFuzzyIsUnmodifiable() {
-        String expected = SearchFuzzy.defaultSearchFuzzy().toBsonDocument().toJson();
-        SearchFuzzy.defaultSearchFuzzy().maxEdits(1);
-        assertEquals(expected, SearchFuzzy.defaultSearchFuzzy().toBsonDocument().toJson());
+    void fuzzySearchOptionsIsUnmodifiable() {
+        String expected = FuzzySearchOptions.fuzzySearchOptions().toBsonDocument().toJson();
+        FuzzySearchOptions.fuzzySearchOptions().maxEdits(1);
+        assertEquals(expected, FuzzySearchOptions.fuzzySearchOptions().toBsonDocument().toJson());
     }
 
     @Test
-    void defaultSearchFuzzyIsImmutable() {
-        String expected = SearchFuzzy.defaultSearchFuzzy().toBsonDocument().toJson();
-        SearchFuzzy.defaultSearchFuzzy().toBsonDocument().append("maxEdits", new BsonInt32(1));
-        assertEquals(expected, SearchFuzzy.defaultSearchFuzzy().toBsonDocument().toJson());
+    void fuzzySearchOptionsIsImmutable() {
+        String expected = FuzzySearchOptions.fuzzySearchOptions().toBsonDocument().toJson();
+        FuzzySearchOptions.fuzzySearchOptions().toBsonDocument().append("maxEdits", new BsonInt32(1));
+        assertEquals(expected, FuzzySearchOptions.fuzzySearchOptions().toBsonDocument().toJson());
     }
 
-    private static SearchFuzzy docExamplePredefined() {
-        return SearchFuzzy.defaultSearchFuzzy().maxEdits(1);
+    private static FuzzySearchOptions docExamplePredefined() {
+        return FuzzySearchOptions.fuzzySearchOptions().maxEdits(1);
     }
 
     private static Document docExampleCustom() {

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchHighlightTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchHighlightTest.java
@@ -46,7 +46,7 @@ final class SearchHighlightTest {
         assertEquals(
                 new BsonDocument("path",
                         fieldPath("fieldName").toBsonValue()),
-                SearchHighlight.path(
+                SearchHighlight.paths(
                         fieldPath("fieldName"))
                         .toBsonDocument()
         );
@@ -69,9 +69,9 @@ final class SearchHighlightTest {
                         new BsonDocument("path", new BsonArray(asList(
                                 fieldPath("fieldName").toBsonValue(),
                                 wildcardPath("wildc*rd").toBsonValue()))),
-                        SearchHighlight.paths(asList(
+                        SearchHighlight.paths(
                                 fieldPath("fieldName"),
-                                wildcardPath("wildc*rd")))
+                                wildcardPath("wildc*rd"))
                                 .toBsonDocument()
                 ),
                 () -> assertEquals(
@@ -79,7 +79,7 @@ final class SearchHighlightTest {
                                 fieldPath("fieldName").toBsonValue())
                                 .append("maxCharsToExamine", new BsonInt32(10)),
                         SearchHighlight.paths(
-                                singleton(fieldPath("fieldName")))
+                                fieldPath("fieldName"))
                                 .maxCharsToExamine(10)
                                 .toBsonDocument()
                 ),
@@ -107,9 +107,9 @@ final class SearchHighlightTest {
     }
 
     private static SearchHighlight docExamplePredefined() {
-        return SearchHighlight.paths(asList(
+        return SearchHighlight.paths(
                 fieldPath("fieldName"),
-                wildcardPath("wildc*rd")));
+                wildcardPath("wildc*rd"));
     }
 
     private static Document docExampleCustom() {

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
@@ -206,7 +206,7 @@ final class SearchOperatorTest {
                                 singleton("term"))
                                 .synonyms("synonymMappingName")
                                 // fuzzy overrides synonyms
-                                .fuzzy(defaultSearchFuzzy())
+                                .fuzzy()
                                 .toBsonDocument()
                 )
         );
@@ -249,7 +249,9 @@ final class SearchOperatorTest {
                         new BsonDocument("autocomplete",
                                 new BsonDocument("path", fieldPath("fieldName").toBsonValue())
                                         .append("query", new BsonString("term"))
-                                        .append("fuzzy", new BsonDocument())
+                                        .append("fuzzy", new BsonDocument()
+                                                .append("maxExpansions", new BsonInt32(10))
+                                                .append("maxEdits", new BsonInt32(1)))
                                         .append("tokenOrder", new BsonString("any"))
                         ),
                         SearchOperator.autocomplete(
@@ -257,7 +259,10 @@ final class SearchOperatorTest {
                                         // multi must be ignored
                                         .multi("analyzerName"),
                                         singleton("term"))
-                                .fuzzy(defaultSearchFuzzy())
+                                .fuzzy(defaultSearchFuzzy()
+                                        .maxEdits(2)
+                                        .maxExpansions(10),
+                                        defaultSearchFuzzy().maxEdits(1))
                                 .sequentialTokenOrder()
                                 // anyTokenOrder overrides sequentialTokenOrder
                                 .anyTokenOrder()

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.time.Instant;
 
-import static com.mongodb.client.model.search.SearchFuzzy.defaultSearchFuzzy;
+import static com.mongodb.client.model.search.FuzzySearchOptions.fuzzySearchOptions;
 import static com.mongodb.client.model.search.SearchPath.fieldPath;
 import static com.mongodb.client.model.search.SearchPath.wildcardPath;
 import static com.mongodb.client.model.search.SearchScore.boost;
@@ -190,7 +190,7 @@ final class SearchOperatorTest {
                         SearchOperator.text(
                                 singleton(fieldPath("fieldName")),
                                 singleton("term"))
-                                .fuzzy(defaultSearchFuzzy())
+                                .fuzzy(fuzzySearchOptions())
                                 // synonyms overrides fuzzy
                                 .synonyms("synonymMappingName")
                                 .toBsonDocument()
@@ -259,10 +259,10 @@ final class SearchOperatorTest {
                                         // multi must be ignored
                                         .multi("analyzerName"),
                                         singleton("term"))
-                                .fuzzy(defaultSearchFuzzy()
+                                .fuzzy(fuzzySearchOptions()
                                         .maxEdits(2)
                                         .maxExpansions(10),
-                                        defaultSearchFuzzy().maxEdits(1))
+                                        fuzzySearchOptions().maxEdits(1))
                                 .sequentialTokenOrder()
                                 // anyTokenOrder overrides sequentialTokenOrder
                                 .anyTokenOrder()

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
@@ -260,9 +260,8 @@ final class SearchOperatorTest {
                                         .multi("analyzerName"),
                                         singleton("term"))
                                 .fuzzy(fuzzySearchOptions()
-                                        .maxEdits(2)
-                                        .maxExpansions(10),
-                                        fuzzySearchOptions().maxEdits(1))
+                                        .maxExpansions(10)
+                                        .maxEdits(1))
                                 .sequentialTokenOrder()
                                 // anyTokenOrder overrides sequentialTokenOrder
                                 .anyTokenOrder()

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
@@ -147,49 +147,49 @@ final class SearchOperatorTest {
         assertAll(
                 () -> assertThrows(IllegalArgumentException.class, () ->
                         // queries must not be empty
-                        SearchOperator.text(emptyList(), singleton(fieldPath("fieldName")))
+                        SearchOperator.text(singleton(fieldPath("fieldName")), emptyList())
                 ),
                 () -> assertThrows(IllegalArgumentException.class, () ->
                         // paths must not be empty
-                        SearchOperator.text(singleton("term"), emptyList())
+                        SearchOperator.text(emptyList(), singleton("term"))
                 ),
                 () -> assertEquals(
                         new BsonDocument("text",
-                                new BsonDocument("query", new BsonString("term"))
-                                        .append("path", fieldPath("fieldName").toBsonValue())
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("query", new BsonString("term"))
                         ),
                         SearchOperator.text(
-                                "term",
-                                fieldPath("fieldName"))
+                                fieldPath("fieldName"),
+                                "term")
                                 .toBsonDocument()
                 ),
                 () -> assertEquals(
                         new BsonDocument("text",
-                                new BsonDocument("query", new BsonArray(asList(
-                                        new BsonString("term1"),
-                                        new BsonString("term2"))))
-                                        .append("path", new BsonArray(asList(
-                                                fieldPath("fieldName").toBsonValue(),
-                                                wildcardPath("wildc*rd").toBsonValue())))
+                                new BsonDocument("path", new BsonArray(asList(
+                                        fieldPath("fieldName").toBsonValue(),
+                                        wildcardPath("wildc*rd").toBsonValue())))
+                                        .append("query", new BsonArray(asList(
+                                                new BsonString("term1"),
+                                                new BsonString("term2"))))
                         ),
                         SearchOperator.text(
-                                asList(
-                                        "term1",
-                                        "term2"),
                                 asList(
                                         fieldPath("fieldName"),
-                                        wildcardPath("wildc*rd")))
+                                        wildcardPath("wildc*rd")),
+                                asList(
+                                        "term1",
+                                        "term2"))
                                 .toBsonDocument()
                 ),
                 () -> assertEquals(
                         new BsonDocument("text",
-                                new BsonDocument("query", new BsonString("term"))
-                                        .append("path", fieldPath("fieldName").toBsonValue())
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("query", new BsonString("term"))
                                         .append("synonyms", new BsonString("synonymMappingName"))
                         ),
                         SearchOperator.text(
-                                        singleton("term"),
-                                        singleton(fieldPath("fieldName")))
+                                singleton(fieldPath("fieldName")),
+                                singleton("term"))
                                 .fuzzy(defaultSearchFuzzy())
                                 // synonyms overrides fuzzy
                                 .synonyms("synonymMappingName")
@@ -197,13 +197,13 @@ final class SearchOperatorTest {
                 ),
                 () -> assertEquals(
                         new BsonDocument("text",
-                                new BsonDocument("query", new BsonString("term"))
-                                        .append("path", fieldPath("fieldName").toBsonValue())
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("query", new BsonString("term"))
                                         .append("fuzzy", new BsonDocument())
                         ),
                         SearchOperator.text(
-                                        singleton("term"),
-                                        singleton(fieldPath("fieldName")))
+                                singleton(fieldPath("fieldName")),
+                                singleton("term"))
                                 .synonyms("synonymMappingName")
                                 // fuzzy overrides synonyms
                                 .fuzzy(defaultSearchFuzzy())

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
@@ -217,46 +217,46 @@ final class SearchOperatorTest {
         assertAll(
                 () -> assertThrows(IllegalArgumentException.class, () ->
                         // queries must not be empty
-                        SearchOperator.autocomplete(emptyList(), fieldPath("fieldName"))
+                        SearchOperator.autocomplete(fieldPath("fieldName"), emptyList())
                 ),
                 () -> assertEquals(
                         new BsonDocument("autocomplete",
-                                new BsonDocument("query", new BsonString("term"))
-                                        .append("path", fieldPath("fieldName").toBsonValue())
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("query", new BsonString("term"))
                         ),
                         SearchOperator.autocomplete(
-                                "term",
-                                fieldPath("fieldName"))
+                                fieldPath("fieldName"),
+                                "term")
                                 .toBsonDocument()
                 ),
                 () -> assertEquals(
                         new BsonDocument("autocomplete",
-                                new BsonDocument("query", new BsonArray(asList(
-                                        new BsonString("term1"),
-                                        new BsonString("term2"))))
-                                        .append("path", fieldPath("fieldName").toBsonValue())
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("query", new BsonArray(asList(
+                                                new BsonString("term1"),
+                                                new BsonString("term2"))))
                         ),
                         SearchOperator.autocomplete(
-                                asList(
-                                        "term1",
-                                        "term2"),
                                 fieldPath("fieldName")
                                         // multi must be ignored
-                                        .multi("analyzerName"))
+                                        .multi("analyzerName"),
+                                asList(
+                                        "term1",
+                                        "term2"))
                                 .toBsonDocument()
                 ),
                 () -> assertEquals(
                         new BsonDocument("autocomplete",
-                                new BsonDocument("query", new BsonString("term"))
-                                        .append("path", fieldPath("fieldName").toBsonValue())
+                                new BsonDocument("path", fieldPath("fieldName").toBsonValue())
+                                        .append("query", new BsonString("term"))
                                         .append("fuzzy", new BsonDocument())
                                         .append("tokenOrder", new BsonString("any"))
                         ),
                         SearchOperator.autocomplete(
-                                singleton("term"),
                                 fieldPath("fieldName")
                                         // multi must be ignored
-                                        .multi("analyzerName"))
+                                        .multi("analyzerName"),
+                                        singleton("term"))
                                 .fuzzy(defaultSearchFuzzy())
                                 .sequentialTokenOrder()
                                 // anyTokenOrder overrides sequentialTokenOrder

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
@@ -592,9 +592,8 @@ final class SearchOperatorTest {
                         SearchOperator.near(
                                 Instant.EPOCH,
                                 Duration.ofMillis(3),
-                                asList(
-                                        fieldPath("fieldName1"),
-                                        fieldPath("fieldName2")))
+                                fieldPath("fieldName1"),
+                                fieldPath("fieldName2"))
                                 .toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry())
                 ),
                 () -> assertEquals(

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOptionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOptionsTest.java
@@ -22,7 +22,6 @@ import org.bson.BsonString;
 import org.junit.jupiter.api.Test;
 
 import static com.mongodb.client.model.search.SearchCount.total;
-import static com.mongodb.client.model.search.SearchHighlight.path;
 import static com.mongodb.client.model.search.SearchHighlight.paths;
 import static com.mongodb.client.model.search.SearchPath.fieldPath;
 import static com.mongodb.client.model.search.SearchPath.wildcardPath;
@@ -83,7 +82,7 @@ final class SearchOptionsTest {
                                         .append("path", wildcardPath("wildc*rd").toBsonValue())),
                         SearchOptions.defaultSearchOptions()
                                 .highlight(
-                                        path(wildcardPath("wildc*rd")))
+                                        paths(wildcardPath("wildc*rd")))
                                 .toBsonDocument()
                 ),
                 () -> assertEquals(
@@ -94,9 +93,9 @@ final class SearchOptionsTest {
                                                 fieldPath("fieldName").toBsonValue())))),
                         SearchOptions.defaultSearchOptions()
                                 .highlight(
-                                        paths(asList(
+                                        paths(
                                                 wildcardPath("wildc*rd"),
-                                                fieldPath("fieldName"))))
+                                                fieldPath("fieldName")))
                                 .toBsonDocument()
                 )
         );
@@ -138,7 +137,7 @@ final class SearchOptionsTest {
                         .index("indexName")
                         .option("name", new BsonArray(singletonList(new BsonString("value"))))
                         .highlight(
-                                path(fieldPath("fieldName")))
+                                paths(fieldPath("fieldName")))
                         .count(total())
                         .returnStoredSource(true)
                         .toBsonDocument()

--- a/driver-core/src/test/unit/com/mongodb/internal/IterablesTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/IterablesTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singleton;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.util.Streams.stream;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class IterablesTest {
+    @Test
+    void concat() {
+        assertAll(
+                () -> assertIterable(singletonList(null), Iterables.concat(null)),
+                () -> assertIterable(singletonList(null), Iterables.concat(null, (Object[]) null)),
+                () -> assertIterable(singletonList(1), Iterables.concat(1)),
+                () -> assertIterable(singletonList(1), Iterables.concat(1, (Object[]) null)),
+                () -> assertIterable(asList(null, null), Iterables.concat(null, new Object[] {null})),
+                () -> assertIterable(asList(null, null), Iterables.concat(null, singleton(null))),
+                () -> assertIterable(asList(1, null), Iterables.concat(1, new Object[] {null})),
+                () -> assertIterable(asList(1, null), Iterables.concat(1, singleton(null))),
+                () -> assertIterable(asList(null, 1), Iterables.concat(null, 1)),
+                () -> assertIterable(asList(null, 1), Iterables.concat(null, singleton(1))),
+                () -> assertIterable(asList(1, 2), Iterables.concat(1, 2)),
+                () -> assertIterable(asList(1, 2), Iterables.concat(1, singleton(2))),
+                () -> assertIterable(asList(1, 2, 3), Iterables.concat(1, 2, 3)),
+                () -> assertIterable(asList(1, 2, 3), Iterables.concat(1, asList(2, 3)))
+        );
+    }
+
+    private static <T> void assertIterable(final List<? extends T> expected, final Iterable<? extends T> actual) {
+        assertEquals(expected, stream(actual).collect(toList()));
+    }
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
@@ -466,7 +466,8 @@ object Aggregates {
    *                    Sorting is required by certain functions and may be required by some windows (see [[Windows]] for more details).
    *                    Sorting is used only for the purpose of computing window functions and does not guarantee ordering
    *                    of the output documents.
-   * @param output      A nonempty list of [[WindowedComputation windowed computations]].
+   * @param output      A [[WindowedComputation windowed computation]].
+   * @param moreOutput  More [[WindowedComputation windowed computations]].
    * @tparam TExpression The `partitionBy` expression type.
    * @return The `\$setWindowFields` pipeline stage.
    * @see [[https://dochub.mongodb.org/core/window-functions-set-window-fields \$setWindowFields]]
@@ -476,7 +477,36 @@ object Aggregates {
   def setWindowFields[TExpression >: Null](
       partitionBy: Option[TExpression],
       sortBy: Option[Bson],
-      output: WindowedComputation*
+      output: WindowedComputation,
+      moreOutput: WindowedComputation*
+  ): Bson =
+    JAggregates.setWindowFields(partitionBy.orNull, sortBy.orNull, output, moreOutput: _*)
+
+  /**
+   * Creates a `\$setWindowFields` pipeline stage, which allows using window operators.
+   * This stage partitions the input documents similarly to the [[Aggregates.group \$group]] pipeline stage,
+   * optionally sorts them, computes fields in the documents by computing window functions over [[Window windows]] specified per
+   * function, and outputs the documents. The important difference from the `\$group` pipeline stage is that
+   * documents belonging to the same partition or window are not folded into a single document.
+   *
+   * @param partitionBy Optional partitioning of data specified like `id` in [[Aggregates.group]].
+   *                    If `None`, then all documents belong to the same partition.
+   * @param sortBy      Fields to sort by. The syntax is identical to `sort` in [[Aggregates.sort]] (see [[Sorts]]).
+   *                    Sorting is required by certain functions and may be required by some windows (see [[Windows]] for more details).
+   *                    Sorting is used only for the purpose of computing window functions and does not guarantee ordering
+   *                    of the output documents.
+   * @param output      A nonempty list of [[WindowedComputation windowed computations]].
+   *                    Specifying an empty list is not an error, but the resulting stage does not do anything useful.
+   * @tparam TExpression The `partitionBy` expression type.
+   * @return The `\$setWindowFields` pipeline stage.
+   * @see [[https://dochub.mongodb.org/core/window-functions-set-window-fields \$setWindowFields]]
+   * @since 4.3
+   * @note Requires MongoDB 5.0 or greater.
+   */
+  def setWindowFields[TExpression >: Null](
+      partitionBy: Option[TExpression],
+      sortBy: Option[Bson],
+      output: Iterable[_ <: WindowedComputation]
   ): Bson =
     JAggregates.setWindowFields(partitionBy.orNull, sortBy.orNull, output.asJava)
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/WindowedComputations.scala
@@ -20,10 +20,10 @@ import org.mongodb.scala.bson.conversions.Bson
 
 /**
  * Builders for [[WindowedComputation windowed computations]] used in the
- * [[Aggregates.setWindowFields \$setWindowFields]] pipeline stage
+ * `Aggregates.setWindowFields` pipeline stage
  * of an aggregation pipeline. Each windowed computation is a triple:
  *  - A window function. Some functions require documents in a window to be sorted
- *  (see `sortBy` in [[Aggregates.setWindowFields]]).
+ *  (see `sortBy` in `Aggregates.setWindowFields`).
  *  - An optional [[Window window]], a.k.a. frame.
  *  Specifying `None` window is equivalent to specifying an unbounded window,
  *  i.e., a window with both ends specified as [[Windows.Bound UNBOUNDED]].
@@ -194,10 +194,10 @@ object WindowedComputations {
   /**
    * Builds a computation of the time derivative by subtracting the evaluation result of the `expression` against the last document
    * and the first document in the `window` and dividing it by the difference in the values of the
-   * [[Aggregates.setWindowFields sortBy]] field of the respective documents.
+   * `sortBy` field of the respective documents.
    * Other documents in the `window` have no effect on the computation.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path       The output field path.
    * @param expression The expression.
@@ -212,10 +212,10 @@ object WindowedComputations {
   /**
    * Builds a computation of the time derivative by subtracting the evaluation result of the `expression` against the last document
    * and the first document in the `window` and dividing it by the difference in the BSON `Date`
-   * values of the [[Aggregates.setWindowFields sortBy]] field of the respective documents.
+   * values of the `sortBy` field of the respective documents.
    * Other documents in the `window` have no effect on the computation.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path       The output field path.
    * @param expression The expression.
@@ -237,13 +237,13 @@ object WindowedComputations {
 
   /**
    * Builds a computation of the approximate integral of a function that maps values of
-   * the [[Aggregates.setWindowFields sortBy]] field to evaluation results of the `expression`
+   * the `sortBy` field to evaluation results of the `expression`
    * against the same document. The limits of integration match the `window` bounds.
    * The approximation is done by using the
    * <a href="https://www.khanacademy.org/math/ap-calculus-ab/ab-integration-new/ab-6-2/a/understanding-the-trapezoid-rule">
    * trapezoidal rule</a>.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path       The output field path.
    * @param expression The expression.
@@ -257,11 +257,11 @@ object WindowedComputations {
 
   /**
    * Builds a computation of the approximate integral of a function that maps BSON `Date` values of
-   * the [[Aggregates.setWindowFields sortBy]] field to evaluation results of the `expression`
+   * the `sortBy` field to evaluation results of the `expression`
    * against the same document. The limits of integration match the `window` bounds.
    * The approximation is done by using the trapezoidal rule.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path       The output field path.
    * @param expression The expression.
@@ -324,7 +324,7 @@ object WindowedComputations {
    * that includes `n` - 1 documents preceding the current document and the current document, with more weight on documents
    * closer to the current one.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path       The output field path.
    * @param expression The expression.
@@ -341,7 +341,7 @@ object WindowedComputations {
    * window `[`[[Windows.Bound UNBOUNDED]], [[Windows.Bound CURRENT]]`]`,
    * with `alpha` representing the degree of weighting decrease.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path       The output field path.
    * @param expression The expression.
@@ -357,7 +357,7 @@ object WindowedComputations {
   /**
    * Builds a computation that adds the evaluation results of the `expression` over the `window`
    * to a BSON `Array`.
-   * Order within the array is guaranteed if [[Aggregates.setWindowFields sortBy]] is specified.
+   * Order within the array is guaranteed if `sortBy` is specified.
    *
    * @param path       The output field path.
    * @param expression The expression.
@@ -387,7 +387,7 @@ object WindowedComputations {
   /**
    * Builds a computation of the evaluation result of the `expression` against the first document in the `window`.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path       The output field path.
    * @param expression The expression.
@@ -404,7 +404,7 @@ object WindowedComputations {
    * of evaluation results of the `inExpression` against the first `N`  documents in the `window`,
    * where `N` is the positive integral value of the `nExpression`.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path The output field path.
    * @param inExpression The input expression.
@@ -471,7 +471,7 @@ object WindowedComputations {
   /**
    * Builds a computation of the evaluation result of the `expression` against the last document in the `window`.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path       The output field path.
    * @param expression The expression.
@@ -488,7 +488,7 @@ object WindowedComputations {
    * of evaluation results of the `inExpression` against the last `N`  documents in the `window`,
    * where `N` is the positive integral value of the `nExpression`.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path The output field path.
    * @param inExpression The input expression.
@@ -555,10 +555,10 @@ object WindowedComputations {
   /**
    * Builds a computation of the evaluation result of the `expression` for the document whose position is shifted by the given
    * amount relative to the current document. If the shifted document is outside of the
-   * [[Aggregates.setWindowFields partition]] containing the current document,
+   * partition containing the current document,
    * then the `defaultExpression` is used instead of the `expression`.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path              The output field path.
    * @param expression        The expression.
@@ -583,9 +583,9 @@ object WindowedComputations {
 
   /**
    * Builds a computation of the order number of each document in its
-   * [[Aggregates.setWindowFields partition]].
+   * partition.
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path The output field path.
    * @return The constructed windowed computation.
@@ -596,13 +596,13 @@ object WindowedComputations {
 
   /**
    * Builds a computation of the rank of each document in its
-   * [[Aggregates.setWindowFields partition]].
-   * Documents with the same value(s) of the [[Aggregates.setWindowFields sortBy]] fields result in
+   * partition.
+   * Documents with the same value(s) of the `sortBy` fields result in
    * the same ranking and result in gaps in the returned ranks.
    * For example, a partition with the sequence [1, 3, 3, 5] representing the values of the single `sortBy` field
    * produces the following sequence of rank values: [1, 2, 2, 4].
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path The output field path.
    * @return The constructed windowed computation.
@@ -613,13 +613,13 @@ object WindowedComputations {
 
   /**
    * Builds a computation of the dense rank of each document in its
-   * [[Aggregates.setWindowFields partition]].
-   * Documents with the same value(s) of the [[Aggregates.setWindowFields sortBy]] fields result in
+   * partition.
+   * Documents with the same value(s) of the `sortBy` fields result in
    * the same ranking but do not result in gaps in the returned ranks.
    * For example, a partition with the sequence [1, 3, 3, 5] representing the values of the single `sortBy` field
    * produces the following sequence of rank values: [1, 2, 2, 3].
    *
-   * [[Aggregates.setWindowFields Sorting]] is required.
+   * Sorting is required.
    *
    * @param path The output field path.
    * @return The constructed windowed computation.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Windows.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Windows.scala
@@ -33,7 +33,7 @@ import org.mongodb.scala.bson.conversions.Bson
  *      - a negative value refers to documents preceding the current one;
  *      - a positive value refers to documents following the current one;
  *  - range
- *    - [[Aggregates.setWindowFields sortBy]]
+ *    - `sortBy` (see `Aggregates.setWindowFields`)
  *      - must contain exactly one field;
  *      - must specify the ascending sort order;
  *      - the `sortBy` field must be of either a numeric BSON type
@@ -116,7 +116,7 @@ object Windows {
 
   /**
    * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-   * the value of the [[Aggregates.setWindowFields sortBy]] field in the current document.
+   * the value of the `sortBy` field in the current document.
    *
    * @param lower A value based on which the lower bound of the window is calculated.
    * @param upper A value based on which the upper bound of the window is calculated.
@@ -126,7 +126,7 @@ object Windows {
 
   /**
    * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-   * the value of the [[Aggregates.setWindowFields sortBy]] field in the current document.
+   * the value of the `sortBy` field in the current document.
    *
    * @param lower A value based on which the lower bound of the window is calculated.
    * @param upper A value based on which the upper bound of the window is calculated.
@@ -136,7 +136,7 @@ object Windows {
 
   /**
    * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-   * the value of the [[Aggregates.setWindowFields sortBy]] field in the current document.
+   * the value of the `sortBy` field in the current document.
    *
    * @param lower A value based on which the lower bound of the window is calculated.
    * @param upper A value based on which the upper bound of the window is calculated.
@@ -146,7 +146,7 @@ object Windows {
 
   /**
    * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-   * the value of the [[Aggregates.setWindowFields sortBy]] field in the current document.
+   * the value of the `sortBy` field in the current document.
    *
    * @param lower A value based on which the lower bound of the window is calculated.
    * @param upper A value based on which the upper bound of the window is calculated.
@@ -156,7 +156,7 @@ object Windows {
 
   /**
    * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-   * the value of the [[Aggregates.setWindowFields sortBy]] field in the current document.
+   * the value of the `sortBy` field in the current document.
    *
    * @param lower A value based on which the lower bound of the window is calculated.
    * @param upper A value based on which the upper bound of the window is calculated.
@@ -166,7 +166,7 @@ object Windows {
 
   /**
    * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-   * the value of the [[Aggregates.setWindowFields sortBy]] field in the current document.
+   * the value of the `sortBy` field in the current document.
    *
    * @param lower A value based on which the lower bound of the window is calculated.
    * @param upper A value based on which the upper bound of the window is calculated.
@@ -176,7 +176,7 @@ object Windows {
 
   /**
    * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-   * the value of the [[Aggregates.setWindowFields sortBy]] field in the current document.
+   * the value of the `sortBy` field in the current document.
    *
    * @param lower A value based on which the lower bound of the window is calculated.
    * @param upper A value based on which the upper bound of the window is calculated.
@@ -186,7 +186,7 @@ object Windows {
 
   /**
    * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-   * the value of the [[Aggregates.setWindowFields sortBy]] field in the current document.
+   * the value of the `sortBy` field in the current document.
    *
    * @param lower A value based on which the lower bound of the window is calculated.
    * @param upper A value based on which the upper bound of the window is calculated.
@@ -196,7 +196,7 @@ object Windows {
 
   /**
    * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-   * the value of the [[Aggregates.setWindowFields sortBy]] field in the current document.
+   * the value of the `sortBy` field in the current document.
    *
    * @param lower A value based on which the lower bound of the window is calculated.
    * @param upper A value based on which the upper bound of the window is calculated.
@@ -206,7 +206,7 @@ object Windows {
 
   /**
    * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-   * the BSON `Date` value of the [[Aggregates.setWindowFields sortBy]]
+   * the BSON `Date` value of the `sortBy`
    * field in the current document.
    *
    * @param lower A value based on which the lower bound of the window is calculated.
@@ -218,7 +218,7 @@ object Windows {
 
   /**
    * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-   * the BSON `Date` value of the [[Aggregates.setWindowFields sortBy]]
+   * the BSON `Date` value of the `sortBy`
    * field in the current document.
    *
    * @param lower A value based on which the lower bound of the window is calculated.
@@ -231,7 +231,7 @@ object Windows {
 
   /**
    * Creates a dynamically-sized range window whose bounds are determined by a range of possible values around
-   * the BSON `Date` value of the [[Aggregates.setWindowFields sortBy]]
+   * the BSON `Date` value of the `sortBy`
    * field in the current document.
    *
    * @param lower A value based on which the lower bound of the window is calculated.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/package.scala
@@ -893,8 +893,8 @@ package object model {
   }
 
   /**
-   * A subset of documents within a partition in the [[Aggregates.setWindowFields \$setWindowFields]] pipeline stage
-   * of an aggregation pipeline (see `partitionBy` in [[Aggregates.setWindowFields]]).
+   * A subset of documents within a partition in the `Aggregates.setWindowFields` pipeline stage
+   * of an aggregation pipeline (see `partitionBy` in `Aggregates.setWindowFields`).
    *
    * @see [[Windows]]
    * @since 4.3
@@ -902,7 +902,7 @@ package object model {
   type Window = com.mongodb.client.model.Window
 
   /**
-   * The core part of the [[Aggregates.setWindowFields \$setWindowFields]] pipeline stage of an aggregation pipeline.
+   * The core part of the `Aggregates.setWindowFields` pipeline stage of an aggregation pipeline.
    * A triple of a window function, a [[Window window]] and a path to a field to be computed by the window function over the window.
    *
    * @see [[WindowedComputations]]

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/FuzzySearchOptions.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/FuzzySearchOptions.scala
@@ -17,7 +17,6 @@ package org.mongodb.scala.model.search
 
 import com.mongodb.annotations.Beta
 import com.mongodb.client.model.search.{ FuzzySearchOptions => JFuzzySearchOptions }
-import org.mongodb.scala.bson.conversions.Bson
 
 /**
  * Fuzzy search options that may be used with some `SearchOperator`s.
@@ -28,24 +27,6 @@ import org.mongodb.scala.bson.conversions.Bson
  */
 @Beta(Array(Beta.Reason.CLIENT))
 object FuzzySearchOptions {
-
-  /**
-   * Creates a `FuzzySearchOptions` from a `Bson` in situations when there is no builder method that better satisfies your needs.
-   * This method cannot be used to validate the syntax.
-   *
-   * <i>Example</i><br>
-   * The following code creates two functionally equivalent `FuzzySearchOptions`s,
-   * though they may not be equal.
-   * {{{
-   *  val fuzzy1: FuzzySearchOptions = FuzzySearchOptions.fuzzySearchOptions().maxEdits(1)
-   *  val fuzzy2: FuzzySearchOptions = FuzzySearchOptions.of(Document("maxEdits" -> 1))
-   * }}}
-   *
-   * @param fuzzy A `Bson` representing the required `FuzzySearchOptions`.
-   *
-   * @return The requested `FuzzySearchOptions`.
-   */
-  def of(fuzzy: Bson): FuzzySearchOptions = JFuzzySearchOptions.of(fuzzy)
 
   /**
    * Returns `FuzzySearchOptions` that represents server defaults.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/FuzzySearchOptions.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/FuzzySearchOptions.scala
@@ -16,7 +16,7 @@
 package org.mongodb.scala.model.search
 
 import com.mongodb.annotations.Beta
-import com.mongodb.client.model.search.{ SearchFuzzy => JSearchFuzzy }
+import com.mongodb.client.model.search.{ FuzzySearchOptions => JFuzzySearchOptions }
 import org.mongodb.scala.bson.conversions.Bson
 
 /**
@@ -27,30 +27,30 @@ import org.mongodb.scala.bson.conversions.Bson
  * @since 4.7
  */
 @Beta(Array(Beta.Reason.CLIENT))
-object SearchFuzzy {
+object FuzzySearchOptions {
 
   /**
-   * Creates a `SearchFuzzy` from a `Bson` in situations when there is no builder method that better satisfies your needs.
+   * Creates a `FuzzySearchOptions` from a `Bson` in situations when there is no builder method that better satisfies your needs.
    * This method cannot be used to validate the syntax.
    *
    * <i>Example</i><br>
-   * The following code creates two functionally equivalent `SearchFuzzy`s,
+   * The following code creates two functionally equivalent `FuzzySearchOptions`s,
    * though they may not be equal.
    * {{{
-   *  val fuzzy1: SearchFuzzy = SearchFuzzy.defaultSearchFuzzy().maxEdits(1)
-   *  val fuzzy2: SearchFuzzy = SearchFuzzy.of(Document("maxEdits" -> 1))
+   *  val fuzzy1: FuzzySearchOptions = FuzzySearchOptions.fuzzySearchOptions().maxEdits(1)
+   *  val fuzzy2: FuzzySearchOptions = FuzzySearchOptions.of(Document("maxEdits" -> 1))
    * }}}
    *
-   * @param fuzzy A `Bson` representing the required `SearchFuzzy`.
+   * @param fuzzy A `Bson` representing the required `FuzzySearchOptions`.
    *
-   * @return The requested `SearchFuzzy`.
+   * @return The requested `FuzzySearchOptions`.
    */
-  def of(fuzzy: Bson): SearchFuzzy = JSearchFuzzy.of(fuzzy)
+  def of(fuzzy: Bson): FuzzySearchOptions = JFuzzySearchOptions.of(fuzzy)
 
   /**
-   * Returns `SearchFuzzy` that represents server defaults.
+   * Returns `FuzzySearchOptions` that represents server defaults.
    *
-   * @return `SearchFuzzy` that represents server defaults.
+   * @return `FuzzySearchOptions` that represents server defaults.
    */
-  def defaultSearchFuzzy(): SearchFuzzy = JSearchFuzzy.defaultSearchFuzzy()
+  def fuzzySearchOptions(): FuzzySearchOptions = JFuzzySearchOptions.fuzzySearchOptions()
 }

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchHighlight.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchHighlight.scala
@@ -34,12 +34,12 @@ import collection.JavaConverters._
 object SearchHighlight {
 
   /**
-   * Returns a `SearchHighlight` for the given `path`.
+   * Returns a `SearchHighlight` for the given `paths`.
    *
-   * @param path The field to be searched.
+   * @param paths The non-empty fields to be searched.
    * @return The requested `SearchHighlight`.
    */
-  def path(path: SearchPath): SearchHighlight = JSearchHighlight.path(path)
+  def paths(paths: SearchPath*): SearchHighlight = JSearchHighlight.paths(paths.asJava)
 
   /**
    * Returns a `SearchHighlight` for the given `paths`.
@@ -57,9 +57,9 @@ object SearchHighlight {
    * The following code creates two functionally equivalent `SearchHighlight`s,
    * though they may not be equal.
    * {{{
-   *  val highlight1: SearchHighlight = SearchHighlight.paths(Seq(
+   *  val highlight1: SearchHighlight = SearchHighlight.paths(
    *    SearchPath.fieldPath("fieldName"),
-   *    SearchPath.wildcardPath("wildc*rd")))
+   *    SearchPath.wildcardPath("wildc*rd"))
    *  val highlight2: SearchHighlight = SearchHighlight.of(Document("path" -> Seq(
    *    SearchPath.fieldPath("fieldName").toBsonValue,
    *    SearchPath.wildcardPath("wildc*rd").toBsonValue)))

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchHighlight.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchHighlight.scala
@@ -36,10 +36,11 @@ object SearchHighlight {
   /**
    * Returns a `SearchHighlight` for the given `paths`.
    *
-   * @param paths The non-empty fields to be searched.
+   * @param path The field to be searched.
+   * @param paths More fields to be searched.
    * @return The requested `SearchHighlight`.
    */
-  def paths(paths: SearchPath*): SearchHighlight = JSearchHighlight.paths(paths.asJava)
+  def paths(path: SearchPath, paths: SearchPath*): SearchHighlight = JSearchHighlight.paths(path, paths: _*)
 
   /**
    * Returns a `SearchHighlight` for the given `paths`.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
@@ -53,23 +53,23 @@ object SearchOperator {
   /**
    * Returns a `SearchOperator` that performs a full-text search.
    *
-   * @param query The string to search for.
    * @param path The field to be searched.
+   * @param query The string to search for.
    * @return The requested `SearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/text/ text operator]]
    */
-  def text(query: String, path: SearchPath): TextSearchOperator = JSearchOperator.text(query, path)
+  def text(path: SearchPath, query: String): TextSearchOperator = JSearchOperator.text(path, query)
 
   /**
    * Returns a `SearchOperator` that performs a full-text search.
    *
-   * @param queries The non-empty strings to search for.
    * @param paths The non-empty fields to be searched.
+   * @param queries The non-empty strings to search for.
    * @return The requested `SearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/text/ text operator]]
    */
-  def text(queries: Iterable[String], paths: Iterable[_ <: SearchPath]): TextSearchOperator =
-    JSearchOperator.text(queries.asJava, paths.asJava)
+  def text(paths: Iterable[_ <: SearchPath], queries: Iterable[String]): TextSearchOperator =
+    JSearchOperator.text(paths.asJava, queries.asJava)
 
   /**
    * Returns a `SearchOperator` that may be used to implement search-as-you-type functionality.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
@@ -200,12 +200,12 @@ object SearchOperator {
    * @param origin The origin from which the proximity of the results is measured.
    * The relevance score is 1 if the values of the fields are `origin`.
    * @param pivot The positive distance in meters from the `origin` at which the relevance score drops in half.
-   * @param path The field to be searched.
+   * @param paths The non-empty fields to be searched.
    * @return The requested `SearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/near/ near operator]]
    */
-  def near(origin: Point, pivot: Number, path: FieldSearchPath): GeoNearSearchOperator =
-    JSearchOperator.near(origin, pivot, path)
+  def near(origin: Point, pivot: Number, paths: FieldSearchPath*): GeoNearSearchOperator =
+    JSearchOperator.near(origin, pivot, paths.asJava)
 
   /**
    * Returns a `SearchOperator` that allows finding results that are near the specified `origin`.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
@@ -75,12 +75,13 @@ object SearchOperator {
    * Returns a `SearchOperator` that may be used to implement search-as-you-type functionality.
    *
    * @param path The field to be searched.
-   * @param queries The non-empty strings to search for.
+   * @param query The string to search for.
+   * @param queries More strings to search for.
    * @return The requested `SearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/ autocomplete operator]]
    */
-  def autocomplete(path: FieldSearchPath, queries: String*): AutocompleteSearchOperator =
-    JSearchOperator.autocomplete(path, queries.asJava)
+  def autocomplete(path: FieldSearchPath, query: String, queries: String*): AutocompleteSearchOperator =
+    JSearchOperator.autocomplete(path, query, queries: _*)
 
   /**
    * Returns a `SearchOperator` that may be used to implement search-as-you-type functionality.
@@ -98,11 +99,13 @@ object SearchOperator {
    * BSON `32-bit integer` / `64-bit integer` / `Double` values
    * of the specified fields are within an interval.
    *
-   * @param paths The non-empty fields to be searched.
+   * @param path The field to be searched.
+   * @param paths More fields to be searched.
    * @return A base for a `NumberRangeSearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/range/ range operator]]
    */
-  def numberRange(paths: FieldSearchPath*): NumberRangeSearchOperatorBase = JSearchOperator.numberRange(paths.asJava)
+  def numberRange(path: FieldSearchPath, paths: FieldSearchPath*): NumberRangeSearchOperatorBase =
+    JSearchOperator.numberRange(path, paths: _*)
 
   /**
    * Returns a base for a `SearchOperator` that tests if the
@@ -120,11 +123,13 @@ object SearchOperator {
    * Returns a base for a `SearchOperator` that tests if the
    * BSON `Date` values of the specified fields are within an interval.
    *
-   * @param paths The non-empty fields to be searched.
+   * @param path The field to be searched.
+   * @param paths More fields to be searched.
    * @return A base for a `DateRangeSearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/range/ range operator]]
    */
-  def dateRange(paths: FieldSearchPath*): DateRangeSearchOperatorBase = JSearchOperator.dateRange(paths.asJava)
+  def dateRange(path: FieldSearchPath, paths: FieldSearchPath*): DateRangeSearchOperatorBase =
+    JSearchOperator.dateRange(path, paths: _*)
 
   /**
    * Returns a base for a `SearchOperator` that tests if the
@@ -143,12 +148,13 @@ object SearchOperator {
    * @param origin The origin from which the proximity of the results is measured.
    * The relevance score is 1 if the values of the fields are `origin`.
    * @param pivot The positive distance from the `origin` at which the relevance score drops in half.
-   * @param paths The non-empty fields to be searched.
+   * @param path The field to be searched.
+   * @param paths More fields to be searched.
    * @return The requested `SearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/near/ near operator]]
    */
-  def near(origin: Number, pivot: Number, paths: FieldSearchPath*): NumberNearSearchOperator =
-    JSearchOperator.near(origin, pivot, paths.asJava)
+  def near(origin: Number, pivot: Number, path: FieldSearchPath, paths: FieldSearchPath*): NumberNearSearchOperator =
+    JSearchOperator.near(origin, pivot, path, paths: _*)
 
   /**
    * Returns a `SearchOperator` that allows finding results that are near the specified `origin`.
@@ -170,13 +176,14 @@ object SearchOperator {
    * The relevance score is 1 if the values of the fields are `origin`.
    * @param pivot The positive distance from the `origin` at which the relevance score drops in half.
    * Data is extracted via `Duration.toMillis`.
-   * @param paths The non-empty fields to be searched.
+   * @param path The field to be searched.
+   * @param paths More fields to be searched.
    * @return The requested `SearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/near/ near operator]]
    * @see `org.bson.codecs.jsr310.InstantCodec`
    */
-  def near(origin: Instant, pivot: Duration, paths: FieldSearchPath*): DateNearSearchOperator =
-    JSearchOperator.near(origin, pivot, paths.asJava)
+  def near(origin: Instant, pivot: Duration, path: FieldSearchPath, paths: FieldSearchPath*): DateNearSearchOperator =
+    JSearchOperator.near(origin, pivot, path, paths: _*)
 
   /**
    * Returns a `SearchOperator` that allows finding results that are near the specified `origin`.
@@ -200,12 +207,13 @@ object SearchOperator {
    * @param origin The origin from which the proximity of the results is measured.
    * The relevance score is 1 if the values of the fields are `origin`.
    * @param pivot The positive distance in meters from the `origin` at which the relevance score drops in half.
-   * @param paths The non-empty fields to be searched.
+   * @param path The field to be searched.
+   * @param paths More fields to be searched.
    * @return The requested `SearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/near/ near operator]]
    */
-  def near(origin: Point, pivot: Number, paths: FieldSearchPath*): GeoNearSearchOperator =
-    JSearchOperator.near(origin, pivot, paths.asJava)
+  def near(origin: Point, pivot: Number, path: FieldSearchPath, paths: FieldSearchPath*): GeoNearSearchOperator =
+    JSearchOperator.near(origin, pivot, path, paths: _*)
 
   /**
    * Returns a `SearchOperator` that allows finding results that are near the specified `origin`.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
@@ -143,12 +143,12 @@ object SearchOperator {
    * @param origin The origin from which the proximity of the results is measured.
    * The relevance score is 1 if the values of the fields are `origin`.
    * @param pivot The positive distance from the `origin` at which the relevance score drops in half.
-   * @param path The field to be searched.
+   * @param paths The non-empty fields to be searched.
    * @return The requested `SearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/near/ near operator]]
    */
-  def near(origin: Number, pivot: Number, path: FieldSearchPath): NumberNearSearchOperator =
-    JSearchOperator.near(origin, pivot, path)
+  def near(origin: Number, pivot: Number, paths: FieldSearchPath*): NumberNearSearchOperator =
+    JSearchOperator.near(origin, pivot, paths.asJava)
 
   /**
    * Returns a `SearchOperator` that allows finding results that are near the specified `origin`.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
@@ -74,24 +74,24 @@ object SearchOperator {
   /**
    * Returns a `SearchOperator` that may be used to implement search-as-you-type functionality.
    *
-   * @param query The string to search for.
    * @param path The field to be searched.
+   * @param query The string to search for.
    * @return The requested `SearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/ autocomplete operator]]
    */
-  def autocomplete(query: String, path: FieldSearchPath): AutocompleteSearchOperator =
-    JSearchOperator.autocomplete(query, path)
+  def autocomplete(path: FieldSearchPath, query: String): AutocompleteSearchOperator =
+    JSearchOperator.autocomplete(path, query)
 
   /**
    * Returns a `SearchOperator` that may be used to implement search-as-you-type functionality.
    *
-   * @param queries The non-empty strings to search for.
    * @param path The field to be searched.
+   * @param queries The non-empty strings to search for.
    * @return The requested `SearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/ autocomplete operator]]
    */
-  def autocomplete(queries: Iterable[String], path: FieldSearchPath): AutocompleteSearchOperator =
-    JSearchOperator.autocomplete(queries.asJava, path)
+  def autocomplete(path: FieldSearchPath, queries: Iterable[String]): AutocompleteSearchOperator =
+    JSearchOperator.autocomplete(path, queries.asJava)
 
   /**
    * Returns a base for a `SearchOperator` that tests if the

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
@@ -75,12 +75,12 @@ object SearchOperator {
    * Returns a `SearchOperator` that may be used to implement search-as-you-type functionality.
    *
    * @param path The field to be searched.
-   * @param query The string to search for.
+   * @param queries The non-empty strings to search for.
    * @return The requested `SearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/ autocomplete operator]]
    */
-  def autocomplete(path: FieldSearchPath, query: String): AutocompleteSearchOperator =
-    JSearchOperator.autocomplete(path, query)
+  def autocomplete(path: FieldSearchPath, queries: String*): AutocompleteSearchOperator =
+    JSearchOperator.autocomplete(path, queries.asJava)
 
   /**
    * Returns a `SearchOperator` that may be used to implement search-as-you-type functionality.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
@@ -96,13 +96,13 @@ object SearchOperator {
   /**
    * Returns a base for a `SearchOperator` that tests if the
    * BSON `32-bit integer` / `64-bit integer` / `Double` values
-   * of the specified field are within an interval.
+   * of the specified fields are within an interval.
    *
-   * @param path The field to be searched.
+   * @param paths The non-empty fields to be searched.
    * @return A base for a `NumberRangeSearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/range/ range operator]]
    */
-  def numberRange(path: FieldSearchPath): NumberRangeSearchOperatorBase = JSearchOperator.numberRange(path)
+  def numberRange(paths: FieldSearchPath*): NumberRangeSearchOperatorBase = JSearchOperator.numberRange(paths.asJava)
 
   /**
    * Returns a base for a `SearchOperator` that tests if the

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
@@ -118,13 +118,13 @@ object SearchOperator {
 
   /**
    * Returns a base for a `SearchOperator` that tests if the
-   * BSON `Date` values of the specified field are within an interval.
+   * BSON `Date` values of the specified fields are within an interval.
    *
-   * @param path The field to be searched.
+   * @param paths The non-empty fields to be searched.
    * @return A base for a `DateRangeSearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/range/ range operator]]
    */
-  def dateRange(path: FieldSearchPath): DateRangeSearchOperatorBase = JSearchOperator.dateRange(path)
+  def dateRange(paths: FieldSearchPath*): DateRangeSearchOperatorBase = JSearchOperator.dateRange(paths.asJava)
 
   /**
    * Returns a base for a `SearchOperator` that tests if the

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOperator.scala
@@ -170,13 +170,13 @@ object SearchOperator {
    * The relevance score is 1 if the values of the fields are `origin`.
    * @param pivot The positive distance from the `origin` at which the relevance score drops in half.
    * Data is extracted via `Duration.toMillis`.
-   * @param path The field to be searched.
+   * @param paths The non-empty fields to be searched.
    * @return The requested `SearchOperator`.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/near/ near operator]]
    * @see `org.bson.codecs.jsr310.InstantCodec`
    */
-  def near(origin: Instant, pivot: Duration, path: FieldSearchPath): DateNearSearchOperator =
-    JSearchOperator.near(origin, pivot, path)
+  def near(origin: Instant, pivot: Duration, paths: FieldSearchPath*): DateNearSearchOperator =
+    JSearchOperator.near(origin, pivot, paths.asJava)
 
   /**
    * Returns a `SearchOperator` that allows finding results that are near the specified `origin`.

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/package.scala
@@ -189,7 +189,7 @@ package object search {
    */
   @Evolving
   @Beta(Array(Beta.Reason.CLIENT))
-  type SearchFuzzy = com.mongodb.client.model.search.SearchFuzzy
+  type FuzzySearchOptions = com.mongodb.client.model.search.FuzzySearchOptions
 
   /**
    * The core part of the `\$search` pipeline stage of an aggregation pipeline.

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
@@ -549,7 +549,9 @@ class AggregatesSpec extends BaseSpec {
           .count(total())
           .highlight(
             paths(
-              List(fieldPath("fieldName1"), fieldPath("fieldName2").multi("analyzerName"), wildcardPath("field.name*"))
+              fieldPath("fieldName1"),
+              fieldPath("fieldName2").multi("analyzerName"),
+              wildcardPath("field.name*")
             )
           )
       )
@@ -634,7 +636,9 @@ class AggregatesSpec extends BaseSpec {
           .count(total())
           .highlight(
             paths(
-              List(fieldPath("fieldName1"), fieldPath("fieldName2").multi("analyzerName"), wildcardPath("field.name*"))
+              fieldPath("fieldName1"),
+              fieldPath("fieldName2").multi("analyzerName"),
+              wildcardPath("field.name*")
             )
           )
       )

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
@@ -63,7 +63,7 @@ class SearchOperatorSpec extends BaseSpec {
             .gtLt(1, 1.5),
           dateRange(fieldPath("fieldName6"))
             .lte(Instant.ofEpochMilli(1)),
-          near(0, 1.5, Seq(fieldPath("fieldName7"), fieldPath("fieldName8"))),
+          near(0, 1.5, fieldPath("fieldName7"), fieldPath("fieldName8")),
           near(Instant.ofEpochMilli(1), Duration.ofMillis(3), fieldPath("fieldName9")),
           near(Point(Position(114.15, 22.28)), 1234.5, fieldPath("address.location"))
         ).asJava)

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
@@ -59,7 +59,7 @@ class SearchOperatorSpec extends BaseSpec {
           autocomplete(fieldPath("title"), "Traffic in", "term5")
             .fuzzy(defaultSearchFuzzy())
             .sequentialTokenOrder(),
-          numberRange(Seq(fieldPath("fieldName4"), fieldPath("fieldName5")))
+          numberRange(fieldPath("fieldName4"), fieldPath("fieldName5"))
             .gtLt(1, 1.5),
           dateRange(fieldPath("fieldName6"))
             .lte(Instant.ofEpochMilli(1)),

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
@@ -20,7 +20,7 @@ import org.mongodb.scala.{ BaseSpec, MongoClient }
 import org.mongodb.scala.bson.collection.immutable.Document
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model.geojson.{ Point, Position }
-import org.mongodb.scala.model.search.SearchFuzzy.defaultSearchFuzzy
+import org.mongodb.scala.model.search.FuzzySearchOptions.fuzzySearchOptions
 import org.mongodb.scala.model.search.SearchOperator.{
   autocomplete,
   compound,
@@ -46,7 +46,7 @@ class SearchOperatorSpec extends BaseSpec {
           text(fieldPath("fieldName2"), "term1")
             .score(function(logExpression(constantExpression(3)))),
           text(Seq(wildcardPath("wildc*rd"), fieldPath("fieldName3")), Seq("term2", "term3"))
-            .fuzzy(defaultSearchFuzzy()
+            .fuzzy(fuzzySearchOptions()
               .maxEdits(1)
               .prefixLength(2)
               .maxExpansions(3)),

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
@@ -51,12 +51,12 @@ class SearchOperatorSpec extends BaseSpec {
               .prefixLength(2)
               .maxExpansions(3)),
           autocomplete(
-            "term4",
             fieldPath("title")
               // multi must be ignored
-              .multi("keyword")
+              .multi("keyword"),
+            "term4"
           ),
-          autocomplete(Seq("Traffic in", "term5"), fieldPath("title"))
+          autocomplete(fieldPath("title"), Seq("Traffic in", "term5"))
             .fuzzy(defaultSearchFuzzy())
             .sequentialTokenOrder(),
           numberRange(Seq(fieldPath("fieldName4"), fieldPath("fieldName5")))
@@ -81,8 +81,8 @@ class SearchOperatorSpec extends BaseSpec {
               "path": [ { "wildcard": "wildc*rd" }, "fieldName3" ],
               "query": [ "term2", "term3" ],
               "fuzzy": { "maxEdits": 1, "prefixLength": 2, "maxExpansions": 3 } } },
-            { "autocomplete": { "query": "term4", "path": "title" } },
-            { "autocomplete": { "query": ["Traffic in", "term5"], "path": "title", "fuzzy": {}, "tokenOrder": "sequential" } },
+            { "autocomplete": { "path": "title", "query": "term4" } },
+            { "autocomplete": { "path": "title", "query": ["Traffic in", "term5"], "fuzzy": {}, "tokenOrder": "sequential" } },
             { "range": { "path": [ "fieldName4", "fieldName5" ], "gt": 1, "lt": 1.5 } },
             { "range": { "path": "fieldName6", "lte": { "$date": "1970-01-01T00:00:00.001Z" } } },
             { "near": { "origin": 0, "pivot": 1.5, "path": [ "fieldName7", "fieldName8" ] } },

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
@@ -43,9 +43,9 @@ class SearchOperatorSpec extends BaseSpec {
       compound()
         .should(Seq(
           exists(fieldPath("fieldName1")),
-          text("term1", fieldPath("fieldName2"))
+          text(fieldPath("fieldName2"), "term1")
             .score(function(logExpression(constantExpression(3)))),
-          text(Seq("term2", "term3"), Seq(wildcardPath("wildc*rd"), fieldPath("fieldName3")))
+          text(Seq(wildcardPath("wildc*rd"), fieldPath("fieldName3")), Seq("term2", "term3"))
             .fuzzy(defaultSearchFuzzy()
               .maxEdits(1)
               .prefixLength(2)
@@ -76,10 +76,10 @@ class SearchOperatorSpec extends BaseSpec {
         "compound": {
           "should": [
             { "exists": { "path": "fieldName1" } },
-            { "text": { "query": "term1", "path": "fieldName2", "score": { "function": { "log": { "constant": 3.0 } } } } },
+            { "text": { "path": "fieldName2", "query": "term1", "score": { "function": { "log": { "constant": 3.0 } } } } },
             { "text": {
-              "query": [ "term2", "term3" ],
               "path": [ { "wildcard": "wildc*rd" }, "fieldName3" ],
+              "query": [ "term2", "term3" ],
               "fuzzy": { "maxEdits": 1, "prefixLength": 2, "maxExpansions": 3 } } },
             { "autocomplete": { "query": "term4", "path": "title" } },
             { "autocomplete": { "query": ["Traffic in", "term5"], "path": "title", "fuzzy": {}, "tokenOrder": "sequential" } },

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
@@ -56,7 +56,7 @@ class SearchOperatorSpec extends BaseSpec {
               .multi("keyword"),
             "term4"
           ),
-          autocomplete(fieldPath("title"), Seq("Traffic in", "term5"))
+          autocomplete(fieldPath("title"), "Traffic in", "term5")
             .fuzzy(defaultSearchFuzzy())
             .sequentialTokenOrder(),
           numberRange(Seq(fieldPath("fieldName4"), fieldPath("fieldName5")))

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/search/SearchOperatorSpec.scala
@@ -57,7 +57,7 @@ class SearchOperatorSpec extends BaseSpec {
             "term4"
           ),
           autocomplete(fieldPath("title"), "Traffic in", "term5")
-            .fuzzy(defaultSearchFuzzy())
+            .fuzzy()
             .sequentialTokenOrder(),
           numberRange(fieldPath("fieldName4"), fieldPath("fieldName5"))
             .gtLt(1, 1.5),


### PR DESCRIPTION
This PR applies the following approach:

- Instead of accepting `T` as a single-value parameter in an overloaded method, accept `T...`. This approach supports all usages supported by `T`, and more, i.e., it is more powerful.
  - When at least one value must be provided, use `T first, T... more`.
  - When omitting all values is allowed, use `T...`.

Note that overloads accepting `Iterable<? extends T>` are still present in the API.

Commits are well-organized (don't tend to override each other) and may be reviewed one by one if that's more convenient.