### PR TITLE
Remove useless runtime checks from the `$search` query building API

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/search/RangeConstructibleBsonElement.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/RangeConstructibleBsonElement.java
@@ -19,7 +19,6 @@ import com.mongodb.internal.client.model.AbstractConstructibleBsonElement;
 import com.mongodb.lang.Nullable;
 import org.bson.conversions.Bson;
 
-import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 
 abstract class RangeConstructibleBsonElement<T, S extends RangeConstructibleBsonElement<T, S>> extends AbstractConstructibleBsonElement<S> {
@@ -74,15 +73,6 @@ abstract class RangeConstructibleBsonElement<T, S extends RangeConstructibleBson
             notNull("u", u);
         } else if (u == null) {
             notNull("l", l);
-        }
-        if (l instanceof Comparable && u != null && l.getClass().isAssignableFrom(u.getClass())) {
-            @SuppressWarnings("unchecked")
-            Comparable<T> comparableL = (Comparable<T>) l;
-            if (includeL && includeU) {
-                isTrueArgument("l must be smaller than or equal to u", comparableL.compareTo(u) <= 0);
-            } else {
-                isTrueArgument("l must be smaller than u", comparableL.compareTo(u) < 0);
-            }
         }
         return newWithMutatedValue(doc -> {
             doc.remove("gte");

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBsonElement.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchConstructibleBsonElement.java
@@ -152,8 +152,6 @@ final class SearchConstructibleBsonElement extends AbstractConstructibleBsonElem
 
     @Override
     public GaussSearchScoreExpression decay(final double decay) {
-        isTrueArgument("decay must be greater than 0", decay > 0);
-        isTrueArgument("decay must be less than 1", decay < 1);
         return newWithAppendedValue("decay", decay);
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOperator.java
@@ -188,7 +188,7 @@ public interface SearchOperator extends Bson {
      *
      * @param origin The origin from which the proximity of the results is measured.
      * The relevance score is 1 if the values of the fields are {@code origin}.
-     * @param pivot The positive distance from the {@code origin} at which the relevance score drops in half.
+     * @param pivot The distance from the {@code origin} at which the relevance score drops in half.
      * @param path The field to be searched.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/near/ near operator
@@ -202,7 +202,7 @@ public interface SearchOperator extends Bson {
      *
      * @param origin The origin from which the proximity of the results is measured.
      * The relevance score is 1 if the values of the fields are {@code origin}.
-     * @param pivot The positive distance from the {@code origin} at which the relevance score drops in half.
+     * @param pivot The distance from the {@code origin} at which the relevance score drops in half.
      * @param paths The non-empty fields to be searched.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/near/ near operator
@@ -220,7 +220,7 @@ public interface SearchOperator extends Bson {
      *
      * @param origin The origin from which the proximity of the results is measured.
      * The relevance score is 1 if the values of the fields are {@code origin}.
-     * @param pivot The positive distance from the {@code origin} at which the relevance score drops in half.
+     * @param pivot The distance from the {@code origin} at which the relevance score drops in half.
      * Data is extracted via {@link Duration#toMillis()}.
      * @param path The field to be searched.
      * @return The requested {@link SearchOperator}.
@@ -236,7 +236,7 @@ public interface SearchOperator extends Bson {
      *
      * @param origin The origin from which the proximity of the results is measured.
      * The relevance score is 1 if the values of the fields are {@code origin}.
-     * @param pivot The positive distance from the {@code origin} at which the relevance score drops in half.
+     * @param pivot The distance from the {@code origin} at which the relevance score drops in half.
      * Data is extracted via {@link Duration#toMillis()}.
      * @param paths The non-empty fields to be searched.
      * @return The requested {@link SearchOperator}.
@@ -247,8 +247,6 @@ public interface SearchOperator extends Bson {
         Iterator<? extends SearchPath> pathIterator = notNull("paths", paths).iterator();
         isTrueArgument("paths must not be empty", pathIterator.hasNext());
         notNull("pivot", pivot);
-        isTrueArgument("pivot must be positive", !pivot.isZero());
-        isTrueArgument("pivot must be positive", !pivot.isNegative());
         return new SearchConstructibleBsonElement("near", new Document("origin", notNull("origin", origin))
                 .append("path", combineToBsonValue(pathIterator, true))
                 .append("pivot", pivot.toMillis()));
@@ -259,7 +257,7 @@ public interface SearchOperator extends Bson {
      *
      * @param origin The origin from which the proximity of the results is measured.
      * The relevance score is 1 if the values of the fields are {@code origin}.
-     * @param pivot The positive distance in meters from the {@code origin} at which the relevance score drops in half.
+     * @param pivot The distance in meters from the {@code origin} at which the relevance score drops in half.
      * @param path The field to be searched.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/near/ near operator
@@ -273,7 +271,7 @@ public interface SearchOperator extends Bson {
      *
      * @param origin The origin from which the proximity of the results is measured.
      * The relevance score is 1 if the values of the fields are {@code origin}.
-     * @param pivot The positive distance in meters from the {@code origin} at which the relevance score drops in half.
+     * @param pivot The distance in meters from the {@code origin} at which the relevance score drops in half.
      * @param paths The non-empty fields to be searched.
      * @return The requested {@link SearchOperator}.
      * @mongodb.atlas.manual atlas-search/near/ near operator

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchScore.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchScore.java
@@ -23,7 +23,6 @@ import org.bson.BsonDouble;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 
-import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 
 /**
@@ -40,12 +39,11 @@ public interface SearchScore extends Bson {
     /**
      * Returns a {@link SearchScore} that instructs to multiply the score by the specified {@code value}.
      *
-     * @param value The positive value to multiply the score by.
+     * @param value The value to multiply the score by.
      * @return The requested {@link SearchScore}.
      * @mongodb.atlas.manual atlas-search/scoring/#boost boost score modifier
      */
     static ValueBoostSearchScore boost(final float value) {
-        isTrueArgument("value must be positive", value > 0);
         return new SearchConstructibleBsonElement("boost", new BsonDocument("value", new BsonDouble(value)));
     }
 
@@ -64,13 +62,12 @@ public interface SearchScore extends Bson {
     /**
      * Returns a {@link SearchScore} that instructs to replace the score with the specified {@code value}.
      *
-     * @param value The positive value to replace the score with.
+     * @param value The value to replace the score with.
      * @return The requested {@link SearchScore}.
      * @mongodb.atlas.manual atlas-search/scoring/#constant constant score modifier
      * @see SearchScoreExpression#constantExpression(float)
      */
     static ConstantSearchScore constant(final float value) {
-        isTrueArgument("value must be positive", value > 0);
         return new SearchConstructibleBsonElement("constant", new BsonDocument("value", new BsonDouble(value)));
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchScoreExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchScoreExpression.java
@@ -83,13 +83,12 @@ public interface SearchScoreExpression extends Bson {
      * @param origin The point of origin, see {@link GaussSearchScoreExpression#offset(double)}.
      * The value of the Gaussian function is 1 if the value of the {@code path} expression is {@code origin}.
      * @param path The expression whose value is used to calculate the input of the Gaussian function.
-     * @param scale The non-zero distance from the points {@code origin} ± {@link GaussSearchScoreExpression#offset(double) offset}
+     * @param scale The distance from the points {@code origin} ± {@link GaussSearchScoreExpression#offset(double) offset}
      * at which the output of the Gaussian function must decay by the factor of {@link GaussSearchScoreExpression#decay(double) decay}.
      * @return The requested {@link SearchScoreExpression}.
      */
     static GaussSearchScoreExpression gaussExpression(final double origin, final PathSearchScoreExpression path, final double scale) {
         notNull("path", path);
-        isTrueArgument("scale must not be 0", scale != 0);
         Bson value = new Bson() {
             @Override
             public <TDocument> BsonDocument toBsonDocument(final Class<TDocument> documentClass, final CodecRegistry codecRegistry) {

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOperatorTest.java
@@ -273,30 +273,6 @@ final class SearchOperatorTest {
                         // queries must not be empty
                         SearchOperator.numberRange(emptyList())
                 ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // l must be smaller than u in an open interval
-                        SearchOperator.numberRange(fieldPath("fieldName")).gtLt(0, 0)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // l must be smaller than u in an open interval
-                        SearchOperator.numberRange(fieldPath("fieldName")).gtLt(1, 0)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // l must be smaller than u in a half-open interval
-                        SearchOperator.numberRange(fieldPath("fieldName")).gtLte(0, 0)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // l must be smaller than u in a half-open interval
-                        SearchOperator.numberRange(fieldPath("fieldName")).gtLte(1, 0)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // l must be smaller than u in a half-open interval
-                        SearchOperator.numberRange(fieldPath("fieldName")).gteLt(0, 0)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // l must be smaller than u in a half-open interval
-                        SearchOperator.numberRange(fieldPath("fieldName")).gteLt(1, 0)
-                ),
                 () -> assertEquals(
                         new BsonDocument("range",
                                 new BsonDocument("path", fieldPath("fieldName").toBsonValue())
@@ -394,30 +370,6 @@ final class SearchOperatorTest {
                 () -> assertThrows(IllegalArgumentException.class, () ->
                         // queries must not be empty
                         SearchOperator.dateRange(emptyList())
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // l must be smaller than u in an open interval
-                        SearchOperator.dateRange(fieldPath("fieldName")).gtLt(Instant.EPOCH, Instant.EPOCH)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // l must be smaller than u in an open interval
-                        SearchOperator.dateRange(fieldPath("fieldName")).gtLt(Instant.now(), Instant.EPOCH)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // l must be smaller than u in a half-open interval
-                        SearchOperator.dateRange(fieldPath("fieldName")).gtLte(Instant.EPOCH, Instant.EPOCH)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // l must be smaller than u in a half-open interval
-                        SearchOperator.dateRange(fieldPath("fieldName")).gtLte(Instant.now(), Instant.EPOCH)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // l must be smaller than u in a half-open interval
-                        SearchOperator.dateRange(fieldPath("fieldName")).gteLt(Instant.EPOCH, Instant.EPOCH)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // l must be smaller than u in a half-open interval
-                        SearchOperator.dateRange(fieldPath("fieldName")).gteLt(Instant.now(), Instant.EPOCH)
                 ),
                 () -> assertEquals(
                         new BsonDocument("range",
@@ -528,14 +480,6 @@ final class SearchOperatorTest {
                 () -> assertThrows(IllegalArgumentException.class, () ->
                         // paths must not be empty
                         SearchOperator.near(new Point(new Position(0, 0)), 1, emptyList())
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // pivot must be positive
-                        SearchOperator.near(Instant.EPOCH, Duration.ZERO, fieldPath("fieldPath"))
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // pivot must be positive
-                        SearchOperator.near(Instant.EPOCH, Duration.ofMillis(-1), fieldPath("fieldPath"))
                 ),
                 () -> assertEquals(
                         new BsonDocument("near",

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchScoreExpressionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchScoreExpressionTest.java
@@ -84,25 +84,6 @@ final class SearchScoreExpressionTest {
     @Test
     void gaussExpression() {
         assertAll(
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // scale must not be 0
-                        SearchScoreExpression.gaussExpression(0, SearchScoreExpression.pathExpression(fieldPath("fieldName")), 0)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // decay must be positive
-                        SearchScoreExpression.gaussExpression(0, SearchScoreExpression.pathExpression(fieldPath("fieldName")), 1)
-                                .decay(-1)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // decay must be positive
-                        SearchScoreExpression.gaussExpression(0, SearchScoreExpression.pathExpression(fieldPath("fieldName")), 1)
-                                .decay(0)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // decay must be less than 1
-                        SearchScoreExpression.gaussExpression(0, SearchScoreExpression.pathExpression(fieldPath("fieldName")), 1)
-                                .decay(1)
-                ),
                 () -> assertEquals(
                         new BsonDocument("gauss",
                                 new BsonDocument("origin", new BsonDouble(50))

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchScoreTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchScoreTest.java
@@ -25,7 +25,6 @@ import static com.mongodb.client.model.search.SearchPath.fieldPath;
 import static com.mongodb.client.model.search.SearchScoreExpression.constantExpression;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final class SearchScoreTest {
     @Test
@@ -40,21 +39,11 @@ final class SearchScoreTest {
 
     @Test
     void valueBoost() {
-        assertAll(
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // value must be positive
-                        SearchScore.boost(0f)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // value must be positive
-                        SearchScore.boost(-1f)
-                ),
-                () -> assertEquals(
-                        new BsonDocument("boost",
-                                new BsonDocument("value", new BsonDouble(0.5))),
-                        SearchScore.boost(0.5f)
-                                .toBsonDocument()
-                )
+        assertEquals(
+                new BsonDocument("boost",
+                        new BsonDocument("value", new BsonDouble(0.5))),
+                SearchScore.boost(0.5f)
+                        .toBsonDocument()
         );
     }
 
@@ -84,21 +73,11 @@ final class SearchScoreTest {
 
     @Test
     void constant() {
-        assertAll(
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // value must be positive
-                        SearchScore.constant(0f)
-                ),
-                () -> assertThrows(IllegalArgumentException.class, () ->
-                        // value must be positive
-                        SearchScore.constant(-1f)
-                ),
-                () -> assertEquals(
-                        new BsonDocument("constant",
-                                new BsonDocument("value", new BsonDouble(0.5))),
-                        SearchScore.constant(0.5f)
-                                .toBsonDocument()
-                )
+        assertEquals(
+                new BsonDocument("constant",
+                        new BsonDocument("value", new BsonDouble(0.5))),
+                SearchScore.constant(0.5f)
+                        .toBsonDocument()
         );
     }
 


### PR DESCRIPTION
See https://github.com/mongodb/specifications#where-possible-depend-on-server-to-return-errors for more details.