### PR TITLE
Fix `tlschannel.util.Util.getJavaMajorVersion`

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/util/Util.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/util/Util.java
@@ -52,7 +52,7 @@ public class Util {
   }
 
   @VisibleForTesting(otherwise = PRIVATE)
-  public static int getJavaMajorVersion(final String javaVersion) {
+  static int getJavaMajorVersion(final String javaVersion) {
       String version = javaVersion;
       if (version.startsWith("1.")) {
           version = version.substring(2);

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/util/Util.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/util/Util.java
@@ -19,7 +19,11 @@
 
 package com.mongodb.internal.connection.tlschannel.util;
 
+import com.mongodb.internal.VisibleForTesting;
+
 import javax.net.ssl.SSLEngineResult;
+
+import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
 
 public class Util {
 
@@ -44,18 +48,24 @@ public class Util {
   }
 
   public static int getJavaMajorVersion() {
-    String version = System.getProperty("java.version");
-    if (version.startsWith("1.")) {
-      version = version.substring(2);
-    }
-    // Allow these formats:
-    // 1.8.0_72-ea
-    // 9-ea
-    // 9
-    // 9.0.1
-    int dotPos = version.indexOf('.');
-    int dashPos = version.indexOf('-');
-    return Integer.parseInt(
-        version.substring(0, dotPos > -1 ? dotPos : dashPos > -1 ? dashPos : 1));
+      return getJavaMajorVersion(System.getProperty("java.version"));
+  }
+
+  @VisibleForTesting(otherwise = PRIVATE)
+  public static int getJavaMajorVersion(final String javaVersion) {
+      String version = javaVersion;
+      if (version.startsWith("1.")) {
+          version = version.substring(2);
+      }
+      // Allow these formats:
+      // 1.8.0_72-ea
+      // 9-ea
+      // 9
+      // 9.0.1
+      // 17
+      int dotPos = version.indexOf('.');
+      int dashPos = version.indexOf('-');
+      return Integer.parseInt(
+              version.substring(0, dotPos > -1 ? dotPos : dashPos > -1 ? dashPos : version.length()));
   }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/util/Util.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/util/Util.java
@@ -46,13 +46,16 @@ public class Util {
   public static int getJavaMajorVersion() {
     String version = System.getProperty("java.version");
     if (version.startsWith("1.")) {
-      version = version.substring(2, 3);
-    } else {
-      int dot = version.indexOf(".");
-      if (dot != -1) {
-        version = version.substring(0, dot);
-      }
+      version = version.substring(2);
     }
-    return Integer.parseInt(version);
+    // Allow these formats:
+    // 1.8.0_72-ea
+    // 9-ea
+    // 9
+    // 9.0.1
+    int dotPos = version.indexOf('.');
+    int dashPos = version.indexOf('-');
+    return Integer.parseInt(
+        version.substring(0, dotPos > -1 ? dotPos : dashPos > -1 ? dashPos : 1));
   }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/tlschannel/util/UtilTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/tlschannel/util/UtilTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.connection.tlschannel.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+final class UtilTest {
+    @Test
+    void getJavaMajorVersion() {
+        assertAll(
+                () -> assertEquals(8, Util.getJavaMajorVersion("1.8.0_72-ea")),
+                () -> assertEquals(9, Util.getJavaMajorVersion("9-ea")),
+                () -> assertEquals(9, Util.getJavaMajorVersion("9")),
+                () -> assertEquals(9, Util.getJavaMajorVersion("9.0.1")),
+                () -> assertEquals(17, Util.getJavaMajorVersion("17")),
+                () -> assertEquals(42, Util.getJavaMajorVersion("42.1.0-ea"))
+        );
+    }
+
+    private UtilTest() {
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/tlschannel/util/UtilTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/tlschannel/util/UtilTest.java
@@ -29,6 +29,7 @@ final class UtilTest {
                 () -> assertEquals(9, Util.getJavaMajorVersion("9")),
                 () -> assertEquals(9, Util.getJavaMajorVersion("9.0.1")),
                 () -> assertEquals(17, Util.getJavaMajorVersion("17")),
+                () -> assertEquals(19, Util.getJavaMajorVersion("19-ea")),
                 () -> assertEquals(42, Util.getJavaMajorVersion("42.1.0-ea"))
         );
     }


### PR DESCRIPTION
This is a manual cherry-pick and squash of the following commits:
- https://github.com/marianobarrios/tls-channel/commit/3b5f8a0bb592dd918b6641d771fc83d9a5c3d1ca
- https://github.com/marianobarrios/tls-channel/commit/f4b780e10c42c8a49e39f92d43fcb0179131124d

We don't test against JDK 18, and definitely not against early access builds. A manual test confirms that `18-ea` mentioned is the ticket is parsed successfully by the updated code.

The ticket does not specify the version the client uses. I am planning to backport the fix only to 4.6.x.

JAVA-4656