### PR TITLE
Replace RuntimeException in catch with Exception to support Kotlin

### DIFF
--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -1308,7 +1308,7 @@ public class JsonReaderTest {
                                      final Class<? extends RuntimeException> exClass) {
         try {
             testFunc.apply(new JsonReader(json));
-        } catch (final RuntimeException e) {
+        } catch (final Exception e) {
             if (exClass == null) {
                 throw e;
             }
@@ -1317,7 +1317,7 @@ public class JsonReaderTest {
         try {
             testFunc.apply(new JsonReader(new InputStreamReader(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)),
                     StandardCharsets.UTF_8)));
-        } catch (final RuntimeException e) {
+        } catch (final Exception e) {
             if (exClass == null) {
                 throw e;
             }

--- a/driver-core/src/main/com/mongodb/connection/TlsChannelStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/TlsChannelStreamFactoryFactory.java
@@ -147,7 +147,7 @@ public class TlsChannelStreamFactoryFactory implements StreamFactoryFactory, Clo
                                         pendingRegistration.attachment);
                                 iter.remove();
                             }
-                        } catch (IOException | RuntimeException e) {
+                        } catch (Exception e) {
                             LOGGER.warn("Exception in selector loop", e);
                         }
                     }

--- a/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/ClientSessionBinding.java
@@ -149,7 +149,7 @@ public class ClientSessionBinding extends AbstractReferenceCounted implements As
     private void isConnectionSourcePinningRequired(final SingleResultCallback<Boolean> callback) {
         try {
             callback.onResult(isConnectionSourcePinningRequired(), null);
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             callback.onResult(null, e);
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
@@ -248,7 +248,7 @@ public final class RetryState {
                 if (predicate.get()) {
                     loopState.markAsLastIteration();
                 }
-            } catch (RuntimeException predicateException) {
+            } catch (Exception predicateException) {
                 predicateException.addSuppressed(localException);
                 throw predicateException;
             }

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryingSyncSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryingSyncSupplier.java
@@ -65,6 +65,9 @@ public final class RetryingSyncSupplier<R> implements Supplier<R> {
                 return syncFunction.get();
             } catch (RuntimeException attemptException) {
                 state.advanceOrThrow(attemptException, failedResultTransformer, retryPredicate);
+            } catch (Exception attemptException) {
+                // wrap potential sneaky / Kotlin exceptions
+                state.advanceOrThrow(new RuntimeException(attemptException), failedResultTransformer, retryPredicate);
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/AsynchronousClusterEventListener.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsynchronousClusterEventListener.java
@@ -169,7 +169,7 @@ final class AsynchronousClusterEventListener implements ClusterListener, ServerL
                 if (isLastEvent) {
                     break;
                 }
-            } catch (RuntimeException | InterruptedException e) {
+            } catch (Exception e) {
                 // ignore exceptions thrown from listeners, also ignore interrupts that user code may cause
             }
         }

--- a/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
@@ -219,7 +219,7 @@ public class ConcurrentPool<T> implements Pool<T> {
                 throw new MongoInternalException("The factory for the pool created a null item");
             }
             return newMember;
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             stateAndPermits.releasePermit();
             throw e;
         }
@@ -277,7 +277,7 @@ public class ConcurrentPool<T> implements Pool<T> {
     private void close(final T t) {
         try {
             itemFactory.close(t);
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             // ItemFactory.close() really should not throw
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultDnsSrvRecordMonitor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultDnsSrvRecordMonitor.java
@@ -88,7 +88,7 @@ class DefaultDnsSrvRecordMonitor implements DnsSrvRecordMonitor {
                         try {
                             dnsSrvRecordInitializer.initialize(unmodifiableSet(hosts));
                             currentHosts = hosts;
-                        } catch (RuntimeException e) {
+                        } catch (Exception e) {
                             LOGGER.warn("Exception in monitor thread during notification of DNS resolution state change", e);
                         }
                     }
@@ -97,7 +97,7 @@ class DefaultDnsSrvRecordMonitor implements DnsSrvRecordMonitor {
                         dnsSrvRecordInitializer.initialize(e);
                     }
                     LOGGER.info("Exception while resolving SRV records", e);
-                } catch (RuntimeException e) {
+                } catch (Exception e) {
                     if (currentHosts.isEmpty()) {
                         dnsSrvRecordInitializer.initialize(new MongoInternalException("Unexpected runtime exception", e));
                     }

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
@@ -230,7 +230,7 @@ class DefaultServerMonitor implements ServerMonitor {
                                     elapsedTimeNanos, currentServerDescription.getTopologyVersion() != null));
 
                     return createServerDescription(serverId.getAddress(), helloResult, averageRoundTripTime.getAverage());
-                } catch (RuntimeException e) {
+                } catch (Exception e) {
                     serverMonitorListener.serverHeartbeatFailed(
                             new ServerHeartbeatFailedEvent(connection.getDescription().getConnectionId(), System.nanoTime() - start,
                                     currentServerDescription.getTopologyVersion() != null, e));

--- a/driver-core/src/main/com/mongodb/internal/connection/GetMoreProtocol.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/GetMoreProtocol.java
@@ -109,7 +109,7 @@ class GetMoreProtocol<T> implements LegacyProtocol<QueryResult<T>> {
             }
             LOGGER.debug("Get-more completed");
             return result;
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             if (commandListener != null) {
                 sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos, e,
                         commandListener, requestContext);

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -327,7 +327,7 @@ public class InternalStreamConnection implements InternalConnection {
             commandEventSender.sendStartedEvent();
             try {
                 sendCommandMessage(message, bsonOutput, sessionContext);
-            } catch (RuntimeException e) {
+            } catch (Exception e) {
                 commandEventSender.sendFailedEvent(e);
                 throw e;
             }
@@ -426,7 +426,7 @@ public class InternalStreamConnection implements InternalConnection {
             }
 
             return commandResult;
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             if (!commandSuccessful) {
                 commandEventSender.sendFailedEvent(e);
             }

--- a/driver-core/src/main/com/mongodb/internal/connection/KillCursorProtocol.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/KillCursorProtocol.java
@@ -80,7 +80,7 @@ class KillCursorProtocol implements LegacyProtocol<Void> {
                                           System.nanoTime() - startTimeNanos, commandListener, requestContext);
             }
             return null;
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             if (commandListener != null && namespace != null) {
                 sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos, e,
                         commandListener, requestContext);

--- a/driver-core/src/main/com/mongodb/internal/connection/ProtocolHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ProtocolHelper.java
@@ -227,7 +227,7 @@ public final class ProtocolHelper {
     static void encodeMessage(final RequestMessage message, final BsonOutput bsonOutput) {
         try {
             message.encode(bsonOutput, NoOpSessionContext.INSTANCE);
-        } catch (RuntimeException | Error e) {
+        } catch (Exception | Error e) {
             bsonOutput.close();
             throw e;
         }
@@ -237,7 +237,7 @@ public final class ProtocolHelper {
         try {
             message.encode(bsonOutput, NoOpSessionContext.INSTANCE);
             return message.getEncodingMetadata();
-        } catch (RuntimeException | Error e) {
+        } catch (Exception | Error e) {
             bsonOutput.close();
             throw e;
         }

--- a/driver-core/src/main/com/mongodb/internal/connection/ProtocolHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ProtocolHelper.java
@@ -227,10 +227,7 @@ public final class ProtocolHelper {
     static void encodeMessage(final RequestMessage message, final BsonOutput bsonOutput) {
         try {
             message.encode(bsonOutput, NoOpSessionContext.INSTANCE);
-        } catch (RuntimeException e) {
-            bsonOutput.close();
-            throw e;
-        } catch (Error e) {
+        } catch (RuntimeException | Error e) {
             bsonOutput.close();
             throw e;
         }
@@ -240,10 +237,7 @@ public final class ProtocolHelper {
         try {
             message.encode(bsonOutput, NoOpSessionContext.INSTANCE);
             return message.getEncodingMetadata();
-        } catch (RuntimeException e) {
-            bsonOutput.close();
-            throw e;
-        } catch (Error e) {
+        } catch (RuntimeException | Error e) {
             bsonOutput.close();
             throw e;
         }

--- a/driver-core/src/main/com/mongodb/internal/connection/QueryProtocol.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/QueryProtocol.java
@@ -304,7 +304,7 @@ class QueryProtocol<T> implements LegacyProtocol<QueryResult<T>> {
                 responseBuffers.close();
             }
 
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             if (commandListener != null) {
                 sendCommandFailedEvent(message, FIND_COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos, e,
                         commandListener, requestContext);

--- a/driver-core/src/main/com/mongodb/internal/connection/WriteProtocol.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/WriteProtocol.java
@@ -73,7 +73,7 @@ abstract class WriteProtocol implements LegacyProtocol<WriteConcernResult> {
 
             messageId = requestMessage.getId();
             connection.sendMessage(bsonOutput.getByteBuffers(), messageId);
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             sendFailedEvent(connection, requestMessage, sentCommandStartedEvent, e, startTimeNanos);
             throw e;
         } finally {

--- a/driver-core/src/main/com/mongodb/internal/connection/ZstdCompressor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ZstdCompressor.java
@@ -48,7 +48,7 @@ class ZstdCompressor extends Compressor {
             byte[] out = new byte[(int) Zstd.compressBound(uncompressedSize)];
             int compressedSize = (int) Zstd.compress(out, singleByteArraySource, Zstd.maxCompressionLevel());
             target.writeBytes(out, 0, compressedSize);
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             throw new MongoInternalException("Unexpected RuntimeException", e);
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/ZstdCompressor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ZstdCompressor.java
@@ -49,7 +49,7 @@ class ZstdCompressor extends Compressor {
             int compressedSize = (int) Zstd.compress(out, singleByteArraySource, Zstd.maxCompressionLevel());
             target.writeBytes(out, 0, compressedSize);
         } catch (Exception e) {
-            throw new MongoInternalException("Unexpected RuntimeException", e);
+            throw new MongoInternalException("Unexpected exception", e);
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/event/ConnectionPoolListenerMulticaster.java
+++ b/driver-core/src/main/com/mongodb/internal/event/ConnectionPoolListenerMulticaster.java
@@ -92,7 +92,7 @@ final class ConnectionPoolListenerMulticaster implements ConnectionPoolListener 
         for (ConnectionPoolListener cur : connectionPoolListeners) {
             try {
                 cur.connectionPoolReady(event);
-            } catch (RuntimeException e) {
+            } catch (Exception e) {
                 if (LOGGER.isWarnEnabled()) {
                     LOGGER.warn(format("Exception thrown raising connection pool ready event to listener %s", cur), e);
                 }

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncChangeStreamBatchCursor.java
@@ -204,7 +204,7 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
                             cachePostBatchResumeToken(wrappedCursor);
                         }
                         errHandlingCallback.onResult(convertedResults, null);
-                    } catch (RuntimeException e) {
+                    } catch (Exception e) {
                         errHandlingCallback.onResult(null, e);
                     }
                 } else {

--- a/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
@@ -590,7 +590,7 @@ final class OperationHelper {
         try {
             try {
                 resource = resourceSupplier.get();
-            } catch (RuntimeException supplierException) {
+            } catch (Exception supplierException) {
                 if (wrapSupplierException) {
                     throw new ResourceSupplierInternalException(supplierException);
                 } else {

--- a/driver-core/src/main/com/mongodb/internal/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/QueryBatchCursor.java
@@ -533,7 +533,7 @@ class QueryBatchCursor<T> implements AggregateResponseBatchCursor<T> {
             } catch (MongoSocketException e) {
                 try {
                     onCorruptedConnection(connection);
-                } catch (RuntimeException suppressed) {
+                } catch (Exception suppressed) {
                     e.addSuppressed(suppressed);
                 }
                 throw e;

--- a/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
@@ -257,7 +257,7 @@ final class AggregatesSearchIntegrationTest {
             List<BsonDocument> results;
             try {
                 results = collectionHelpers.get(ns).aggregate(pipeline);
-            } catch (RuntimeException e) {
+            } catch (Exception e) {
                 throw new RuntimeException(msgSupplier.get(), e);
             }
             accessory.resultAsserter.accept(results, msgSupplier);

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
@@ -293,7 +293,7 @@ public class DefaultConnectionPoolTest {
             connections.forEach(connection -> {
                 try {
                     connection.close();
-                } catch (RuntimeException e) {
+                } catch (Exception e) {
                     // ignore
                 }
             });

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestInternalConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestInternalConnection.java
@@ -252,7 +252,7 @@ class TestInternalConnection implements InternalConnection {
         try {
             sendMessage(byteBuffers, lastRequestId);
             callback.onResult(null, null);
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             callback.onResult(null, e);
         }
     }

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionTest.java
@@ -297,7 +297,7 @@ public abstract class AbstractClientSideEncryptionTest {
                         getErrorContainsField(expectedResult), operationName), hasErrorContainsField(expectedResult));
                 assertFalse(String.format("Expected error code '%s' but none thrown for operation %s",
                         getErrorCodeNameField(expectedResult), operationName), hasErrorCodeNameField(expectedResult));
-            } catch (RuntimeException e) {
+            } catch (Exception e) {
                 boolean passedAssertion = false;
                 if (hasErrorContainsField(expectedResult)) {
                     String expectedError = getErrorContainsField(expectedResult);

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableWritesTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableWritesTest.java
@@ -144,7 +144,7 @@ public abstract class AbstractRetryableWritesTest {
             BsonDocument result = helper.getOperationResults(operation);
             assertFalse("Expected error but instead got result: " + result.toJson(), isErrorExpected);
             assertEquals(outcome.getDocument("result", new BsonDocument()), result.getDocument("result", new BsonDocument()));
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             if (!isErrorExpected) {
                 throw e;
             }
@@ -157,7 +157,7 @@ public abstract class AbstractRetryableWritesTest {
         }
     }
 
-    private void assertExceptionState(final RuntimeException e, final BsonValue expectedResult, final String operationName) {
+    private void assertExceptionState(final Exception e, final BsonValue expectedResult, final String operationName) {
         if (hasErrorLabelsContainField(expectedResult)) {
             if (e instanceof MongoException) {
                 MongoException mongoException = (MongoException) e;

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractUnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractUnifiedTest.java
@@ -686,7 +686,7 @@ public abstract class AbstractUnifiedTest {
         return indexes.stream().anyMatch(document -> document.get("name").equals(indexName));
     }
 
-    private boolean assertExceptionState(final RuntimeException e, final BsonValue expectedResult, final String operationName) {
+    private boolean assertExceptionState(final Exception e, final BsonValue expectedResult, final String operationName) {
         boolean passedAssertion = false;
         if (hasErrorLabelsContainField(expectedResult)) {
             if (e instanceof MongoException) {

--- a/driver-sync/src/test/functional/com/mongodb/client/WithTransactionProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/WithTransactionProseTest.java
@@ -115,7 +115,7 @@ public class WithTransactionProseTest extends DatabaseTestCase {
                 }
             });
             fail("Test should have thrown an exception.");
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             assertEquals(errorMessage, e.getMessage());
             assertTrue(((MongoException) e).getErrorLabels().contains(MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL));
         } finally {
@@ -146,7 +146,7 @@ public class WithTransactionProseTest extends DatabaseTestCase {
                 }
             });
             fail("Test should have thrown an exception.");
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             assertEquals(91, ((MongoException) e).getCode());
             assertTrue(((MongoException) e).getErrorLabels().contains(MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL));
         } finally {
@@ -181,7 +181,7 @@ public class WithTransactionProseTest extends DatabaseTestCase {
                 }
             });
             fail("Test should have thrown an exception.");
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             assertEquals(251, ((MongoException) e).getCode());
             assertTrue(((MongoException) e).getErrorLabels().contains(MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL));
         } finally {

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -383,7 +383,7 @@ public abstract class UnifiedTest {
                         throw e;
                     }
                     break;
-                } catch (RuntimeException e) {
+                } catch (Exception e) {
                     if (storeErrors) {
                         errorDescriptionDocuments.add(createDocumentFromException(e));
                     } else if (storeFailures) {

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestFailureValidator.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestFailureValidator.java
@@ -43,7 +43,7 @@ public class UnifiedTestFailureValidator extends UnifiedSyncTest {
     public void setUp() {
         try {
             super.setUp();
-        } catch (AssertionError | RuntimeException e) {
+        } catch (AssertionError | Exception e) {
             exception = e;
         }
     }
@@ -53,7 +53,7 @@ public class UnifiedTestFailureValidator extends UnifiedSyncTest {
         if (exception == null) {
             try {
                 super.shouldPassAllOutcomes();
-            } catch (AssertionError | RuntimeException e) {
+            } catch (AssertionError | Exception e) {
                 exception = e;
             }
         }


### PR DESCRIPTION
Kotlin does not support checked exceptions, so our handlers will use Exception. All handlers are replaced, even those obviously unaffected, for the sake of a consistent noticeable pattern.

JAVA-4575