### PR TITLE
Do misc `$search` improvements

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -683,7 +683,7 @@ public final class Aggregates {
      *
      * @param operator A search operator.
      * @param options Optional {@code $search} pipeline stage fields.
-     * Specifying {@code null} is equivalent to either specifying {@link SearchOptions#defaultSearchOptions()}
+     * Specifying {@code null} is equivalent to either specifying {@link SearchOptions#searchOptions()}
      * or calling {@link #search(SearchOperator)}.
      * @return The {@code $search} pipeline stage.
      *
@@ -720,7 +720,7 @@ public final class Aggregates {
      *
      * @param collector A search collector.
      * @param options Optional {@code $search} pipeline stage fields.
-     * Specifying {@code null} is equivalent to either specifying {@link SearchOptions#defaultSearchOptions()}
+     * Specifying {@code null} is equivalent to either specifying {@link SearchOptions#searchOptions()}
      * or calling {@link #search(SearchCollector)}.
      * @return The {@code $search} pipeline stage.
      *
@@ -758,7 +758,7 @@ public final class Aggregates {
      *
      * @param operator A search operator.
      * @param options Optional {@code $search} pipeline stage fields.
-     * Specifying {@code null} is equivalent to either specifying {@link SearchOptions#defaultSearchOptions()}
+     * Specifying {@code null} is equivalent to either specifying {@link SearchOptions#searchOptions()}
      * or calling {@link #searchMeta(SearchOperator)}.
      * @return The {@code $searchMeta} pipeline stage.
      *
@@ -795,7 +795,7 @@ public final class Aggregates {
      *
      * @param collector A search collector.
      * @param options Optional {@code $search} pipeline stage fields.
-     * Specifying {@code null} is equivalent to either specifying {@link SearchOptions#defaultSearchOptions()}
+     * Specifying {@code null} is equivalent to either specifying {@link SearchOptions#searchOptions()}
      * or calling {@link #searchMeta(SearchCollector)}.
      * @return The {@code $searchMeta} pipeline stage.
      *

--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -683,8 +683,7 @@ public final class Aggregates {
      *
      * @param operator A search operator.
      * @param options Optional {@code $search} pipeline stage fields.
-     * Specifying {@code null} is equivalent to either specifying {@link SearchOptions#searchOptions()}
-     * or calling {@link #search(SearchOperator)}.
+     * Specifying {@link SearchOptions#searchOptions()} is equivalent to calling {@link #search(SearchOperator)}.
      * @return The {@code $search} pipeline stage.
      *
      * @mongodb.atlas.manual atlas-search/query-syntax/#-search $search
@@ -692,8 +691,8 @@ public final class Aggregates {
      * @mongodb.atlas.manual atlas-search/scoring/ Scoring
      * @since 4.7
      */
-    public static Bson search(final SearchOperator operator, @Nullable final SearchOptions options) {
-        return new SearchStage("$search", notNull("operator", operator), options);
+    public static Bson search(final SearchOperator operator, final SearchOptions options) {
+        return new SearchStage("$search", notNull("operator", operator), notNull("options", options));
     }
 
     /**
@@ -720,8 +719,7 @@ public final class Aggregates {
      *
      * @param collector A search collector.
      * @param options Optional {@code $search} pipeline stage fields.
-     * Specifying {@code null} is equivalent to either specifying {@link SearchOptions#searchOptions()}
-     * or calling {@link #search(SearchCollector)}.
+     * Specifying {@link SearchOptions#searchOptions()} is equivalent to calling {@link #search(SearchCollector)}.
      * @return The {@code $search} pipeline stage.
      *
      * @mongodb.atlas.manual atlas-search/query-syntax/#-search $search
@@ -729,8 +727,8 @@ public final class Aggregates {
      * @mongodb.atlas.manual atlas-search/scoring/ Scoring
      * @since 4.7
      */
-    public static Bson search(final SearchCollector collector, @Nullable final SearchOptions options) {
-        return new SearchStage("$search", notNull("collector", collector), options);
+    public static Bson search(final SearchCollector collector, final SearchOptions options) {
+        return new SearchStage("$search", notNull("collector", collector), notNull("options", options));
     }
 
     /**
@@ -758,16 +756,15 @@ public final class Aggregates {
      *
      * @param operator A search operator.
      * @param options Optional {@code $search} pipeline stage fields.
-     * Specifying {@code null} is equivalent to either specifying {@link SearchOptions#searchOptions()}
-     * or calling {@link #searchMeta(SearchOperator)}.
+     * Specifying {@link SearchOptions#searchOptions()} is equivalent to calling {@link #searchMeta(SearchOperator)}.
      * @return The {@code $searchMeta} pipeline stage.
      *
      * @mongodb.atlas.manual atlas-search/query-syntax/#-searchmeta $searchMeta
      * @mongodb.atlas.manual atlas-search/operators-and-collectors/#operators Search operators
      * @since 4.7
      */
-    public static Bson searchMeta(final SearchOperator operator, @Nullable final SearchOptions options) {
-        return new SearchStage("$searchMeta", notNull("operator", operator), options);
+    public static Bson searchMeta(final SearchOperator operator, final SearchOptions options) {
+        return new SearchStage("$searchMeta", notNull("operator", operator), notNull("options", options));
     }
 
     /**
@@ -795,16 +792,15 @@ public final class Aggregates {
      *
      * @param collector A search collector.
      * @param options Optional {@code $search} pipeline stage fields.
-     * Specifying {@code null} is equivalent to either specifying {@link SearchOptions#searchOptions()}
-     * or calling {@link #searchMeta(SearchCollector)}.
+     * Specifying {@link SearchOptions#searchOptions()} is equivalent to calling {@link #searchMeta(SearchCollector)}.
      * @return The {@code $searchMeta} pipeline stage.
      *
      * @mongodb.atlas.manual atlas-search/query-syntax/#-searchmeta $searchMeta
      * @mongodb.atlas.manual atlas-search/operators-and-collectors/#collectors Search collectors
      * @since 4.7
      */
-    public static Bson searchMeta(final SearchCollector collector, @Nullable final SearchOptions options) {
-        return new SearchStage("$searchMeta", notNull("collector", collector), options);
+    public static Bson searchMeta(final SearchCollector collector, final SearchOptions options) {
+        return new SearchStage("$searchMeta", notNull("collector", collector), notNull("options", options));
     }
 
     static void writeBucketOutput(final CodecRegistry codecRegistry, final BsonDocumentWriter writer,

--- a/driver-core/src/main/com/mongodb/client/model/Aggregates.java
+++ b/driver-core/src/main/com/mongodb/client/model/Aggregates.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.mongodb.assertions.Assertions.assertTrue;
+import static com.mongodb.client.model.search.SearchOptions.searchOptions;
 import static com.mongodb.internal.Iterables.concat;
 import static java.util.Arrays.asList;
 import static org.bson.assertions.Assertions.notNull;
@@ -671,7 +672,7 @@ public final class Aggregates {
      * @since 4.7
      */
     public static Bson search(final SearchOperator operator) {
-        return search(operator, null);
+        return search(operator, searchOptions());
     }
 
     /**
@@ -709,7 +710,7 @@ public final class Aggregates {
      * @since 4.7
      */
     public static Bson search(final SearchCollector collector) {
-        return search(collector, null);
+        return search(collector, searchOptions());
     }
 
     /**
@@ -745,7 +746,7 @@ public final class Aggregates {
      * @since 4.7
      */
     public static Bson searchMeta(final SearchOperator operator) {
-        return searchMeta(operator, null);
+        return searchMeta(operator, searchOptions());
     }
 
     /**
@@ -781,7 +782,7 @@ public final class Aggregates {
      * @since 4.7
      */
     public static Bson searchMeta(final SearchCollector collector) {
-        return searchMeta(collector, null);
+        return searchMeta(collector, searchOptions());
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/search/SearchOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/search/SearchOptions.java
@@ -75,8 +75,8 @@ public interface SearchOptions extends Bson {
      * The following code creates two functionally equivalent {@link SearchOptions} objects,
      * though they may not be {@linkplain Object#equals(Object) equal}.
      * <pre>{@code
-     *  SearchOptions options1 = SearchOptions.defaultSearchOptions().index("indexName");
-     *  SearchOptions options2 = SearchOptions.defaultSearchOptions().option("index", "indexName");
+     *  SearchOptions options1 = SearchOptions.searchOptions().index("indexName");
+     *  SearchOptions options2 = SearchOptions.searchOptions().option("index", "indexName");
      * }</pre>
      *
      * @param name The option name.
@@ -90,7 +90,7 @@ public interface SearchOptions extends Bson {
      *
      * @return {@link SearchOptions} that represents server defaults.
      */
-    static SearchOptions defaultSearchOptions() {
+    static SearchOptions searchOptions() {
         return SearchConstructibleBson.EMPTY_IMMUTABLE;
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/search/AggregatesSearchIntegrationTest.java
@@ -71,7 +71,7 @@ import static com.mongodb.client.model.search.SearchOperator.exists;
 import static com.mongodb.client.model.search.SearchOperator.near;
 import static com.mongodb.client.model.search.SearchOperator.numberRange;
 import static com.mongodb.client.model.search.SearchOperator.text;
-import static com.mongodb.client.model.search.SearchOptions.defaultSearchOptions;
+import static com.mongodb.client.model.search.SearchOptions.searchOptions;
 import static com.mongodb.client.model.search.SearchPath.fieldPath;
 import static com.mongodb.client.model.search.SearchPath.wildcardPath;
 import static com.mongodb.client.model.search.SearchScore.boost;
@@ -294,7 +294,7 @@ final class AggregatesSearchIntegrationTest {
                         stageCreator(
                                 // `multi` is used here only to verify that it is tolerated
                                 exists(fieldPath("title").multi("keyword")),
-                                defaultSearchOptions()
+                                searchOptions()
                                         .option("index", "default")
                                         .count(lowerBound().threshold(2_000))
                         ),
@@ -314,7 +314,7 @@ final class AggregatesSearchIntegrationTest {
                         "`highlight` option",
                         stageCreator(
                                 text(singleton(fieldPath("plot")), asList("factory", "century")),
-                                defaultSearchOptions()
+                                searchOptions()
                                         .highlight(paths(
                                                 fieldPath("title").multi("keyword"),
                                                 wildcardPath("pl*t"))
@@ -336,7 +336,7 @@ final class AggregatesSearchIntegrationTest {
                         "`returnStoredSource` option",
                         stageCreator(
                                 exists(fieldPath("plot")),
-                                defaultSearchOptions()
+                                searchOptions()
                                         .returnStoredSource(true)
                         ),
                         MFLIX_MOVIES_NS,
@@ -360,7 +360,7 @@ final class AggregatesSearchIntegrationTest {
                         "alternate analyzer (`multi` field path)",
                         stageCreator(
                                 text(singleton(fieldPath("title").multi("keyword")), singleton("The Cheat")),
-                                defaultSearchOptions().count(total())
+                                searchOptions().count(total())
                         ),
                         MFLIX_MOVIES_NS,
                         asList(
@@ -398,7 +398,7 @@ final class AggregatesSearchIntegrationTest {
                                                                 Instant.from(Year.of(1985)
                                                                         .atMonth(Month.JANUARY).atDay(1).atStartOfDay().atOffset(UTC)),
                                                                 Instant.now())))),
-                                defaultSearchOptions()
+                                searchOptions()
                         ),
                         MFLIX_MOVIES_NS,
                         asList(

--- a/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
@@ -89,7 +89,7 @@ import static com.mongodb.client.model.search.SearchCount.total
 import static com.mongodb.client.model.search.SearchFacet.stringFacet
 import static com.mongodb.client.model.search.SearchHighlight.paths
 import static com.mongodb.client.model.search.SearchOperator.exists
-import static com.mongodb.client.model.search.SearchOptions.defaultSearchOptions
+import static com.mongodb.client.model.search.SearchOptions.searchOptions
 import static com.mongodb.client.model.search.SearchPath.fieldPath
 import static com.mongodb.client.model.search.SearchPath.wildcardPath
 import static java.util.Arrays.asList
@@ -624,7 +624,7 @@ class AggregatesSpecification extends Specification {
         BsonDocument searchDoc = toBson(
                 search(
                         (SearchOperator) exists(fieldPath('fieldName')),
-                        defaultSearchOptions()
+                        searchOptions()
                 )
         )
 
@@ -641,7 +641,7 @@ class AggregatesSpecification extends Specification {
                         (SearchCollector) facet(
                                 exists(fieldPath('fieldName')),
                                 [stringFacet('stringFacetName', fieldPath('fieldName1'))]),
-                        defaultSearchOptions()
+                        searchOptions()
                                 .index('indexName')
                                 .count(total())
                                 .highlight(paths(
@@ -715,7 +715,7 @@ class AggregatesSpecification extends Specification {
         BsonDocument searchDoc = toBson(
                 searchMeta(
                         (SearchOperator) exists(fieldPath('fieldName')),
-                        defaultSearchOptions()
+                        searchOptions()
                 )
         )
 
@@ -732,7 +732,7 @@ class AggregatesSpecification extends Specification {
                         (SearchCollector) facet(
                                 exists(fieldPath('fieldName')),
                                 [stringFacet('stringFacetName', fieldPath('fieldName1'))]),
-                        defaultSearchOptions()
+                        searchOptions()
                                 .index('indexName')
                                 .count(total())
                                 .highlight(paths(

--- a/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOptionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/client/model/search/SearchOptionsTest.java
@@ -32,10 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 final class SearchOptionsTest {
     @Test
-    void defaultSearchOptions() {
+    void searchOptions() {
         assertEquals(
                 new BsonDocument(),
-                SearchOptions.defaultSearchOptions()
+                SearchOptions.searchOptions()
                         .toBsonDocument()
         );
     }
@@ -44,18 +44,18 @@ final class SearchOptionsTest {
     void option() {
         assertAll(
                 () -> assertEquals(
-                        SearchOptions.defaultSearchOptions()
+                        SearchOptions.searchOptions()
                                 .index("indexName")
                                 .toBsonDocument(),
-                        SearchOptions.defaultSearchOptions()
+                        SearchOptions.searchOptions()
                                 .option("index", new BsonString("indexName"))
                                 .toBsonDocument()
                 ),
                 () -> assertEquals(
-                        SearchOptions.defaultSearchOptions()
+                        SearchOptions.searchOptions()
                                 .option("index", "indexName")
                                 .toBsonDocument(),
-                        SearchOptions.defaultSearchOptions()
+                        SearchOptions.searchOptions()
                                 .option("index", new BsonString("indexName"))
                                 .toBsonDocument()
                 )
@@ -67,7 +67,7 @@ final class SearchOptionsTest {
         assertEquals(
                 new BsonDocument()
                         .append("index", new BsonString("indexName")),
-                SearchOptions.defaultSearchOptions()
+                SearchOptions.searchOptions()
                         .index("indexName")
                         .toBsonDocument()
         );
@@ -80,7 +80,7 @@ final class SearchOptionsTest {
                         new BsonDocument()
                                 .append("highlight", new BsonDocument()
                                         .append("path", wildcardPath("wildc*rd").toBsonValue())),
-                        SearchOptions.defaultSearchOptions()
+                        SearchOptions.searchOptions()
                                 .highlight(
                                         paths(wildcardPath("wildc*rd")))
                                 .toBsonDocument()
@@ -91,7 +91,7 @@ final class SearchOptionsTest {
                                         .append("path", new BsonArray(asList(
                                                 wildcardPath("wildc*rd").toBsonValue(),
                                                 fieldPath("fieldName").toBsonValue())))),
-                        SearchOptions.defaultSearchOptions()
+                        SearchOptions.searchOptions()
                                 .highlight(
                                         paths(
                                                 wildcardPath("wildc*rd"),
@@ -106,7 +106,7 @@ final class SearchOptionsTest {
         assertEquals(
                 new BsonDocument()
                         .append("count", total().toBsonDocument()),
-                SearchOptions.defaultSearchOptions()
+                SearchOptions.searchOptions()
                         .count(total())
                         .toBsonDocument()
         );
@@ -117,7 +117,7 @@ final class SearchOptionsTest {
         assertEquals(
                 new BsonDocument()
                         .append("returnStoredSource", new BsonBoolean(true)),
-                SearchOptions.defaultSearchOptions()
+                SearchOptions.searchOptions()
                         .returnStoredSource(true)
                         .toBsonDocument()
         );
@@ -133,7 +133,7 @@ final class SearchOptionsTest {
                                 .append("path", fieldPath("fieldName").toBsonValue()))
                         .append("count", total().toBsonDocument())
                         .append("returnStoredSource", new BsonBoolean(true)),
-                SearchOptions.defaultSearchOptions()
+                SearchOptions.searchOptions()
                         .index("indexName")
                         .option("name", new BsonArray(singletonList(new BsonString("value"))))
                         .highlight(
@@ -145,16 +145,16 @@ final class SearchOptionsTest {
     }
 
     @Test
-    void defaultSearchOptionsIsUnmodifiable() {
-        String expected = SearchOptions.defaultSearchOptions().toBsonDocument().toJson();
-        SearchOptions.defaultSearchOptions().option("name", "value");
-        assertEquals(expected, SearchOptions.defaultSearchOptions().toBsonDocument().toJson());
+    void searchOptionsIsUnmodifiable() {
+        String expected = SearchOptions.searchOptions().toBsonDocument().toJson();
+        SearchOptions.searchOptions().option("name", "value");
+        assertEquals(expected, SearchOptions.searchOptions().toBsonDocument().toJson());
     }
 
     @Test
-    void defaultSearchOptionsIsImmutable() {
-        String expected = SearchOptions.defaultSearchOptions().toBsonDocument().toJson();
-        SearchOptions.defaultSearchOptions().toBsonDocument().append("name", new BsonString("value"));
-        assertEquals(expected, SearchOptions.defaultSearchOptions().toBsonDocument().toJson());
+    void searchOptionsIsImmutable() {
+        String expected = SearchOptions.searchOptions().toBsonDocument().toJson();
+        SearchOptions.searchOptions().toBsonDocument().append("name", new BsonString("value"));
+        assertEquals(expected, SearchOptions.searchOptions().toBsonDocument().toJson());
     }
 }

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/Aggregates.scala
@@ -536,7 +536,7 @@ object Aggregates {
    *
    * @param operator A search operator.
    * @param options Optional `\$search` pipeline stage fields.
-   * Specifying `SearchOptions.defaultSearchOptions` is equivalent to calling `Aggregates.search(SearchOperator)`.
+   * Specifying `SearchOptions.searchOptions` is equivalent to calling `Aggregates.search(SearchOperator)`.
    * @return The `\$search` pipeline stage.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search]]
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
@@ -572,7 +572,7 @@ object Aggregates {
    *
    * @param collector A search collector.
    * @param options Optional `\$search` pipeline stage fields.
-   * Specifying `SearchOptions.defaultSearchOptions` is equivalent to calling `Aggregates.search(SearchCollector)`.
+   * Specifying `SearchOptions.searchOptions` is equivalent to calling `Aggregates.search(SearchCollector)`.
    * @return The `\$search` pipeline stage.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-search \$search]]
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]
@@ -605,7 +605,7 @@ object Aggregates {
    *
    * @param operator A search operator.
    * @param options Optional `\$search` pipeline stage fields.
-   * Specifying `SearchOptions.defaultSearchOptions` is equivalent to calling `Aggregates.searchMeta(SearchOperator)`.
+   * Specifying `SearchOptions.searchOptions` is equivalent to calling `Aggregates.searchMeta(SearchOperator)`.
    * @return The `\$searchMeta` pipeline stage.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-searchmeta \$searchMeta]]
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#operators Search operators]]
@@ -637,7 +637,7 @@ object Aggregates {
    *
    * @param collector A search collector.
    * @param options Optional `\$search` pipeline stage fields.
-   * Specifying `SearchOptions.defaultSearchOptions` is equivalent to calling `Aggregates.searchMeta(SearchCollector)`.
+   * Specifying `SearchOptions.searchOptions` is equivalent to calling `Aggregates.searchMeta(SearchCollector)`.
    * @return The `\$searchMeta` pipeline stage.
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#-searchmeta \$searchMeta]]
    * @see [[https://www.mongodb.com/docs/atlas/atlas-search/operators-and-collectors/#collectors Search collectors]]

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOptions.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/search/SearchOptions.scala
@@ -32,5 +32,5 @@ object SearchOptions {
    *
    * @return `SearchOptions` that represents server defaults.
    */
-  def defaultSearchOptions(): SearchOptions = JSearchOptions.defaultSearchOptions()
+  def searchOptions(): SearchOptions = JSearchOptions.searchOptions()
 }

--- a/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/model/AggregatesSpec.scala
@@ -33,7 +33,7 @@ import org.mongodb.scala.model.search.SearchFacet.stringFacet
 import org.mongodb.scala.model.search.SearchHighlight.paths
 import org.mongodb.scala.model.search.SearchCollector
 import org.mongodb.scala.model.search.SearchOperator.exists
-import org.mongodb.scala.model.search.SearchOptions.defaultSearchOptions
+import org.mongodb.scala.model.search.SearchOptions.searchOptions
 import org.mongodb.scala.model.search.SearchPath.{ fieldPath, wildcardPath }
 import org.mongodb.scala.{ BaseSpec, MongoClient, MongoNamespace }
 
@@ -531,7 +531,7 @@ class AggregatesSpec extends BaseSpec {
     toBson(
       Aggregates.search(
         exists(fieldPath("fieldName")),
-        defaultSearchOptions()
+        searchOptions()
       )
     ) should equal(
       Document("""{
@@ -544,7 +544,7 @@ class AggregatesSpec extends BaseSpec {
       Aggregates.search(
         SearchCollector
           .facet(exists(fieldPath("fieldName")), List(stringFacet("stringFacetName", fieldPath("fieldName1")))),
-        defaultSearchOptions()
+        searchOptions()
           .index("indexName")
           .count(total())
           .highlight(
@@ -618,7 +618,7 @@ class AggregatesSpec extends BaseSpec {
     toBson(
       Aggregates.searchMeta(
         exists(fieldPath("fieldName")),
-        defaultSearchOptions()
+        searchOptions()
       )
     ) should equal(
       Document("""{
@@ -631,7 +631,7 @@ class AggregatesSpec extends BaseSpec {
       Aggregates.searchMeta(
         SearchCollector
           .facet(exists(fieldPath("fieldName")), List(stringFacet("stringFacetName", fieldPath("fieldName1")))),
-        defaultSearchOptions()
+        searchOptions()
           .index("indexName")
           .count(total())
           .highlight(


### PR DESCRIPTION
- Rename `SearchOptions.defaultSearchOptions` to `searchOptions`
- Stop allowing `null` `SearchOptions` in `Aggregates.search`/`searchMeta`