### PR TITLE
Do not retry a read operation when in a transaction

### DIFF
--- a/driver-core/src/test/resources/unified-test-format/transactions/do-not-retry-read-in-transaction.json
+++ b/driver-core/src/test/resources/unified-test-format/transactions/do-not-retry-read-in-transaction.json
@@ -5,7 +5,6 @@
     {
       "minServerVersion": "4.0.0",
       "topologies": [
-        "single",
         "replicaset"
       ]
     },

--- a/driver-core/src/test/resources/unified-test-format/transactions/do-not-retry-read-in-transaction.json
+++ b/driver-core/src/test/resources/unified-test-format/transactions/do-not-retry-read-in-transaction.json
@@ -86,7 +86,10 @@
             "session": "session0"
           },
           "expectError": {
-            "isError": true
+            "isError": true,
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
           }
         }
       ],

--- a/driver-core/src/test/resources/unified-test-format/transactions/do-not-retry-read-in-transaction.json
+++ b/driver-core/src/test/resources/unified-test-format/transactions/do-not-retry-read-in-transaction.json
@@ -3,9 +3,15 @@
   "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.0",
+      "minServerVersion": "4.0.0",
       "topologies": [
-        "replicaset",
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.2.0",
+      "topologies": [
         "sharded",
         "load-balanced"
       ]

--- a/driver-core/src/test/resources/unified-test-format/transactions/do-not-retry-read-in-transaction.json
+++ b/driver-core/src/test/resources/unified-test-format/transactions/do-not-retry-read-in-transaction.json
@@ -1,0 +1,107 @@
+{
+  "description": "do not retry read in a transaction",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "uriOptions": {
+          "retryReads": true
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-read-in-transaction-test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "find does not retry in a transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "session": "session0"
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {},
+                  "startTransaction": true
+                },
+                "commandName": "find",
+                "databaseName": "retryable-read-in-transaction-test"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/OperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/OperationHelperSpecification.groovy
@@ -43,7 +43,7 @@ import static com.mongodb.connection.ServerType.REPLICA_SET_PRIMARY
 import static com.mongodb.connection.ServerType.STANDALONE
 import static com.mongodb.internal.operation.OperationHelper.AsyncCallableWithConnection
 import static com.mongodb.internal.operation.OperationHelper.AsyncCallableWithConnectionAndSource
-import static com.mongodb.internal.operation.OperationHelper.isRetryableRead
+import static com.mongodb.internal.operation.OperationHelper.canRetryRead
 import static com.mongodb.internal.operation.OperationHelper.isRetryableWrite
 import static com.mongodb.internal.operation.OperationHelper.validateCollation
 import static com.mongodb.internal.operation.OperationHelper.validateCollationAndWriteConcern
@@ -434,17 +434,16 @@ class OperationHelperSpecification extends Specification {
         }
 
         expect:
-        isRetryableRead(retryReads, serverDescription, connectionDescription, noTransactionSessionContext) == expected
-        !isRetryableRead(retryReads, serverDescription, connectionDescription, activeTransactionSessionContext)
-        !isRetryableRead(retryReads, serverDescription, connectionDescription, noOpSessionContext)
+        canRetryRead(serverDescription, connectionDescription, noTransactionSessionContext) == expected
+        !canRetryRead(serverDescription, connectionDescription, activeTransactionSessionContext)
+        !canRetryRead(serverDescription, connectionDescription, noOpSessionContext)
 
         where:
-        retryReads  | serverDescription             | connectionDescription                 | expected
-        false       | retryableServerDescription    | threeSixConnectionDescription         | false
-        true        | retryableServerDescription    | threeSixConnectionDescription         | true
-        true        | nonRetryableServerDescription | threeSixConnectionDescription         | false
-        true        | retryableServerDescription    | threeFourConnectionDescription        | false
-        true        | retryableServerDescription    | threeSixPrimaryConnectionDescription  | true
+        serverDescription             | connectionDescription                 | expected
+        retryableServerDescription    | threeSixConnectionDescription         | true
+        nonRetryableServerDescription | threeSixConnectionDescription         | false
+        retryableServerDescription    | threeFourConnectionDescription        | false
+        retryableServerDescription    | threeSixPrimaryConnectionDescription  | true
     }
 
 


### PR DESCRIPTION
Fixes a regression introduced in 4.4.0 in scope of JAVA-4034, and
was undetected due to the lack of a specification test for the
required behavior.

JAVA-4684