### PR TITLE
Re-enable ClientSideEncryptionExplicitEncryptionTest for serverless

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionExplicitEncryptionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionExplicitEncryptionTest.java
@@ -43,7 +43,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.mongodb.ClusterFixture.isServerlessTest;
 import static com.mongodb.ClusterFixture.isStandalone;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.Fixture.getDefaultDatabase;
@@ -73,7 +72,6 @@ public abstract class AbstractClientSideEncryptionExplicitEncryptionTest {
     public void setUp() {
         assumeTrue(serverVersionAtLeast(6, 0));
         assumeFalse(isStandalone());
-        assumeFalse(isServerlessTest());
 
         MongoNamespace dataKeysNamespace = new MongoNamespace("keyvault.datakeys");
         BsonDocument encryptedFields = bsonDocumentFromPath("encryptedFields.json");


### PR DESCRIPTION
JAVA-4623

I tried to also re-enable the other prose tests but those still [failed](https://spruce.mongodb.com/task/mongo_java_driver_tests_serverless__os~ubuntu_jdk~jdk17_serverless_test_patch_afb5d0ae6693d1915b7afa3b84d250974fe15998_62deda02562343035a9adc1b_22_07_25_17_59_46/tests?execution=0&sortBy=STATUS&sortDir=ASC) with an error about being unable to find mongocryptd, so I limited it to just the explicit encryption tests, which do now pass.