### PR TITLE
Replace synchronized with ReentrantLock

### DIFF
--- a/driver-core/src/main/com/mongodb/KerberosSubjectProvider.java
+++ b/driver-core/src/main/com/mongodb/KerberosSubjectProvider.java
@@ -29,7 +29,7 @@ import javax.security.auth.login.LoginException;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.internal.Locks.checkedSupplyWithLock;
+import static com.mongodb.internal.Locks.checkedWithLock;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -91,7 +91,7 @@ public class KerberosSubjectProvider implements SubjectProvider {
      */
     @NonNull
     public Subject getSubject() throws LoginException {
-        return checkedSupplyWithLock(lock, () -> {
+        return checkedWithLock(lock, () -> {
             if (subject == null || needNewSubject(subject)) {
                 subject = createNewSubject();
             }

--- a/driver-core/src/main/com/mongodb/internal/CheckedSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/CheckedSupplier.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal;
+
+/**
+ * This class is not part of the public API and may be removed or changed at any time.
+ */
+@FunctionalInterface
+public interface CheckedSupplier<T, E extends Exception> {
+
+    /**
+     * Gets a result.
+     *
+     * @return a result
+     * @throws E the checked exception to throw
+     */
+    T get() throws E;
+}

--- a/driver-core/src/main/com/mongodb/internal/Locks.java
+++ b/driver-core/src/main/com/mongodb/internal/Locks.java
@@ -25,18 +25,18 @@ import java.util.function.Supplier;
  * This class is not part of the public API and may be removed or changed at any time.
  */
 public final class Locks {
-    public static void runWithLock(final Lock lock, final Runnable action) {
-        supplyWithLock(lock, () -> {
+    public static void withLock(final Lock lock, final Runnable action) {
+        withLock(lock, () -> {
             action.run();
             return null;
         });
     }
 
-    public static <V> V supplyWithLock(final Lock lock, final Supplier<V> supplier) {
-        return checkedSupplyWithLock(lock, supplier::get);
+    public static <V> V withLock(final Lock lock, final Supplier<V> supplier) {
+        return checkedWithLock(lock, supplier::get);
     }
 
-    public static <V, E extends Exception> V checkedSupplyWithLock(final Lock lock, final CheckedSupplier<V, E> supplier) throws E {
+    public static <V, E extends Exception> V checkedWithLock(final Lock lock, final CheckedSupplier<V, E> supplier) throws E {
         try {
             lock.lockInterruptibly();
             try {

--- a/driver-core/src/main/com/mongodb/internal/Locks.java
+++ b/driver-core/src/main/com/mongodb/internal/Locks.java
@@ -26,34 +26,17 @@ import java.util.function.Supplier;
  */
 public final class Locks {
     public static void runWithLock(final Lock lock, final Runnable action) {
-        try {
-            lock.lockInterruptibly();
-            try {
-                action.run();
-            } finally {
-                lock.unlock();
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new MongoInterruptedException("Interrupted waiting for lock", e);
-        }
-    }
-
-    public static <V, E extends Exception> V checkedSupplyWithLock(final Lock lock, final CheckedSupplier<V, E> supplier) throws E {
-        try {
-            lock.lockInterruptibly();
-            try {
-                return supplier.get();
-            } finally {
-                lock.unlock();
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new MongoInterruptedException("Interrupted waiting for lock", e);
-        }
+        supplyWithLock(lock, () -> {
+            action.run();
+            return null;
+        });
     }
 
     public static <V> V supplyWithLock(final Lock lock, final Supplier<V> supplier) {
+        return checkedSupplyWithLock(lock, supplier::get);
+    }
+
+    public static <V, E extends Exception> V checkedSupplyWithLock(final Lock lock, final CheckedSupplier<V, E> supplier) throws E {
         try {
             lock.lockInterruptibly();
             try {

--- a/driver-core/src/main/com/mongodb/internal/Locks.java
+++ b/driver-core/src/main/com/mongodb/internal/Locks.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal;
+
+import com.mongodb.MongoInterruptedException;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.Supplier;
+
+/**
+ * This class is not part of the public API and may be removed or changed at any time.
+ */
+public final class Locks {
+    public static void runWithLock(final Lock lock, final Runnable action) {
+        try {
+            lock.lockInterruptibly();
+            try {
+                action.run();
+            } finally {
+                lock.unlock();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new MongoInterruptedException("Interrupted waiting for lock", e);
+        }
+    }
+
+    public static <V, E extends Exception> V checkedSupplyWithLock(final Lock lock, final CheckedSupplier<V, E> supplier) throws E {
+        try {
+            lock.lockInterruptibly();
+            try {
+                return supplier.get();
+            } finally {
+                lock.unlock();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new MongoInterruptedException("Interrupted waiting for lock", e);
+        }
+    }
+
+    public static <V> V supplyWithLock(final Lock lock, final Supplier<V> supplier) {
+        try {
+            lock.lockInterruptibly();
+            try {
+                return supplier.get();
+            } finally {
+                lock.unlock();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new MongoInterruptedException("Interrupted waiting for lock", e);
+        }
+    }
+
+    private Locks() {
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -32,6 +32,7 @@ import com.mongodb.event.ClusterClosedEvent;
 import com.mongodb.event.ClusterDescriptionChangedEvent;
 import com.mongodb.event.ClusterListener;
 import com.mongodb.event.ClusterOpeningEvent;
+import com.mongodb.internal.Locks;
 import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.selector.LatencyMinimizingServerSelector;
@@ -56,7 +57,6 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.connection.ServerDescription.MAX_DRIVER_WIRE_VERSION;
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_SERVER_VERSION;
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
-import static com.mongodb.internal.Locks.runWithLock;
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
 import static com.mongodb.internal.connection.EventHelper.wouldDescriptionsGenerateEquivalentEvents;
 import static com.mongodb.internal.event.EventListenerHelper.singleClusterListener;
@@ -272,7 +272,7 @@ abstract class BaseCluster implements Cluster {
 
     @Override
     public void withLock(final Runnable action) {
-        runWithLock(lock, action);
+        Locks.withLock(lock, action);
     }
 
     private void updatePhase() {

--- a/driver-core/src/main/com/mongodb/internal/connection/ClusterClock.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ClusterClock.java
@@ -21,8 +21,7 @@ import org.bson.BsonTimestamp;
 
 import java.util.concurrent.locks.ReentrantLock;
 
-import static com.mongodb.internal.Locks.runWithLock;
-import static com.mongodb.internal.Locks.supplyWithLock;
+import static com.mongodb.internal.Locks.withLock;
 
 public class ClusterClock {
     private static final String CLUSTER_TIME_KEY = "clusterTime";
@@ -30,19 +29,19 @@ public class ClusterClock {
     private BsonDocument clusterTime;
 
     public BsonDocument getCurrent() {
-        return supplyWithLock(lock, () -> clusterTime);
+        return withLock(lock, () -> clusterTime);
     }
 
     public BsonTimestamp getClusterTime() {
-        return supplyWithLock(lock, () -> clusterTime != null ? clusterTime.getTimestamp(CLUSTER_TIME_KEY) : null);
+        return withLock(lock, () -> clusterTime != null ? clusterTime.getTimestamp(CLUSTER_TIME_KEY) : null);
     }
 
     public void advance(final BsonDocument other) {
-        runWithLock(lock, () -> this.clusterTime = greaterOf(other));
+        withLock(lock, () -> this.clusterTime = greaterOf(other));
     }
 
     public BsonDocument greaterOf(final BsonDocument other) {
-        return supplyWithLock(lock, () -> {
+        return withLock(lock, () -> {
             if (other == null) {
                 return clusterTime;
             } else if (clusterTime == null) {

--- a/driver-core/src/main/com/mongodb/internal/connection/MongoCredentialWithCache.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/MongoCredentialWithCache.java
@@ -22,8 +22,7 @@ import com.mongodb.MongoCredential;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static com.mongodb.internal.Locks.runWithLock;
-import static com.mongodb.internal.Locks.supplyWithLock;
+import static com.mongodb.internal.Locks.withLock;
 
 public class MongoCredentialWithCache {
     private final MongoCredential credential;
@@ -69,7 +68,7 @@ public class MongoCredentialWithCache {
         private Object cacheValue;
 
         Object get(final Object key) {
-            return supplyWithLock(lock, () -> {
+            return withLock(lock, () -> {
                 if (cacheKey != null && cacheKey.equals(key)) {
                     return cacheValue;
                 }
@@ -78,7 +77,7 @@ public class MongoCredentialWithCache {
         }
 
         void set(final Object key, final Object value) {
-            runWithLock(lock, () -> {
+            withLock(lock, () -> {
                 cacheKey = key;
                 cacheValue = value;
             });

--- a/driver-core/src/main/com/mongodb/internal/connection/SaslAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SaslAuthenticator.java
@@ -42,7 +42,7 @@ import java.security.PrivilegedAction;
 
 import static com.mongodb.MongoCredential.JAVA_SUBJECT_KEY;
 import static com.mongodb.MongoCredential.JAVA_SUBJECT_PROVIDER_KEY;
-import static com.mongodb.internal.Locks.supplyWithLock;
+import static com.mongodb.internal.Locks.withLock;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.connection.CommandHelper.executeCommand;
 import static com.mongodb.internal.connection.CommandHelper.executeCommandAsync;
@@ -205,7 +205,7 @@ abstract class SaslAuthenticator extends Authenticator implements SpeculativeAut
 
     @NonNull
     private SubjectProvider getSubjectProvider() {
-        return supplyWithLock(getMongoCredentialWithCache().getLock(), () -> {
+        return withLock(getMongoCredentialWithCache().getLock(), () -> {
             SubjectProvider subjectProvider =
                     getMongoCredentialWithCache().getFromCache(SUBJECT_PROVIDER_CACHE_KEY, SubjectProvider.class);
             if (subjectProvider == null) {


### PR DESCRIPTION
In order to get the benefit for structured concurrency, the driver
must use Lock#lockInterruptibly rather than simply Lock#lock.

JAVA-4642

What use of `synchrnonized` is left out of this PR?

* Used in the bson module: I didn't include this because `MongoInterruptedException` is in driver-core, not bson, so it wasn't clear what exception should be thrown.  So deferring this for now
* Use in driver-legacy. Generally we don't make improvements in legacy
* Use in threads that the driver starts itself.  This can be done later if we ever move these to virtual threads.  But also, these threads are not accessible to applications so can't easily be interrupted.
* Use in asynchronous contexts.  Structured concurrency wouldn't be used with reactive streams, so it's not needed
* Use in tests.  Obviously these are ignorable
