### PR TITLE
Improve error message for invalid field names

### DIFF
--- a/bson/src/main/org/bson/AbstractBsonWriter.java
+++ b/bson/src/main/org/bson/AbstractBsonWriter.java
@@ -530,8 +530,9 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
         if (state != State.NAME) {
             throwInvalidState("WriteName", State.NAME);
         }
-        if (!fieldNameValidatorStack.peek().validate(name)) {
-            throw new IllegalArgumentException(format("Invalid BSON field name %s", name));
+        FieldNameValidator fieldNameValidator = fieldNameValidatorStack.peek();
+        if (!fieldNameValidator.validate(name)) {
+            throw new IllegalArgumentException(fieldNameValidator.getValidationErrorMessage(name));
         }
         doWriteName(name);
         context.name = name;

--- a/bson/src/main/org/bson/FieldNameValidator.java
+++ b/bson/src/main/org/bson/FieldNameValidator.java
@@ -17,6 +17,7 @@
 package org.bson;
 
 import static java.lang.String.format;
+import static org.bson.assertions.Assertions.isTrue;
 
 /**
  * A field name validator, for use by BSON writers to validate field names as documents are encoded.
@@ -40,9 +41,7 @@ public interface FieldNameValidator {
      * @throws IllegalArgumentException if fieldName is actually valid
      */
     default String getValidationErrorMessage(final String fieldName) {
-        if (validate(fieldName)) {
-            throw new IllegalArgumentException(format("%s is valid", fieldName));
-        }
+        isTrue(fieldName + " is valid", !validate(fieldName));
         return format("Invalid BSON field name %s", fieldName);
     }
 

--- a/bson/src/main/org/bson/FieldNameValidator.java
+++ b/bson/src/main/org/bson/FieldNameValidator.java
@@ -16,6 +16,8 @@
 
 package org.bson;
 
+import static java.lang.String.format;
+
 /**
  * A field name validator, for use by BSON writers to validate field names as documents are encoded.
  *
@@ -29,6 +31,20 @@ public interface FieldNameValidator {
      * @return true if the field name is valid, false otherwise
      */
     boolean validate(String fieldName);
+
+    /**
+     * Return the validation error message for an invalid field
+     *
+     * @param fieldName the field name
+     * @return the validation error message
+     * @throws IllegalArgumentException if fieldName is actually valid
+     */
+    default String getValidationErrorMessage(final String fieldName) {
+        if (validate(fieldName)) {
+            throw new IllegalArgumentException(format("%s is valid", fieldName));
+        }
+        return format("Invalid BSON field name %s", fieldName);
+    }
 
     /**
      * Gets a new validator to use for the value of the field with the given name.

--- a/bson/src/test/unit/org/bson/BsonWriterSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BsonWriterSpecification.groovy
@@ -384,7 +384,8 @@ class BsonWriterSpecification extends Specification {
         writer.writeString('bad-child', 'string')
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == 'testFieldNameValidator error'
 
         where:
         writer << [new BsonBinaryWriter(new BasicOutputBuffer(), new TestFieldNameValidator('bad'))]
@@ -400,6 +401,11 @@ class BsonWriterSpecification extends Specification {
         @Override
         boolean validate(final String fieldName) {
             fieldName != badFieldName
+        }
+
+        @Override
+        String getValidationErrorMessage(final String fieldName) {
+            'testFieldNameValidator error'
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/internal/validator/MappedFieldNameValidator.java
+++ b/driver-core/src/main/com/mongodb/internal/validator/MappedFieldNameValidator.java
@@ -49,6 +49,11 @@ public class MappedFieldNameValidator implements FieldNameValidator {
     }
 
     @Override
+    public String getValidationErrorMessage(final String fieldName) {
+        return defaultValidator.getValidationErrorMessage(fieldName);
+    }
+
+    @Override
     public FieldNameValidator getValidatorForField(final String fieldName) {
         if (fieldNameToValidatorMap.containsKey(fieldName)) {
             return fieldNameToValidatorMap.get(fieldName);

--- a/driver-core/src/main/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidator.java
+++ b/driver-core/src/main/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidator.java
@@ -21,6 +21,7 @@ import org.bson.FieldNameValidator;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.mongodb.assertions.Assertions.assertFalse;
 import static java.lang.String.format;
 
 /**
@@ -36,18 +37,12 @@ public class ReplacingDocumentFieldNameValidator implements FieldNameValidator {
 
     @Override
     public boolean validate(final String fieldName) {
-        if (fieldName == null) {
-            throw new IllegalArgumentException("Field name can not be null");
-        }
-
         return !fieldName.startsWith("$") || EXCEPTIONS.contains(fieldName);
     }
 
     @Override
     public String getValidationErrorMessage(final String fieldName) {
-        if (validate(fieldName)) {
-            throw new IllegalArgumentException(format("%s is valid", fieldName));
-        }
+        assertFalse(validate(fieldName));
         return format("Field names in a replacement document can not start with '$' but '%s' does", fieldName);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidator.java
+++ b/driver-core/src/main/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidator.java
@@ -21,6 +21,8 @@ import org.bson.FieldNameValidator;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.lang.String.format;
+
 /**
  * A field name validator for documents that are meant for storage in MongoDB collections via replace operations. It ensures that no
  * top-level fields start with '$' (with the exception of "$db", "$ref", and "$id", so that DBRefs are not rejected).
@@ -39,6 +41,14 @@ public class ReplacingDocumentFieldNameValidator implements FieldNameValidator {
         }
 
         return !fieldName.startsWith("$") || EXCEPTIONS.contains(fieldName);
+    }
+
+    @Override
+    public String getValidationErrorMessage(final String fieldName) {
+        if (validate(fieldName)) {
+            throw new IllegalArgumentException(format("%s is valid", fieldName));
+        }
+        return format("Field names in a replacement document can not start with '$' but '%s' does", fieldName);
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/validator/UpdateFieldNameValidator.java
+++ b/driver-core/src/main/com/mongodb/internal/validator/UpdateFieldNameValidator.java
@@ -18,6 +18,7 @@ package com.mongodb.internal.validator;
 
 import org.bson.FieldNameValidator;
 
+import static com.mongodb.assertions.Assertions.assertFalse;
 import static java.lang.String.format;
 
 /**
@@ -36,9 +37,7 @@ public class UpdateFieldNameValidator implements org.bson.FieldNameValidator {
 
     @Override
     public String getValidationErrorMessage(final String fieldName) {
-        if (validate(fieldName)) {
-            throw new IllegalArgumentException(format("%s is valid", fieldName));
-        }
+        assertFalse(fieldName.startsWith("$"));
         return format("All update operators must start with '$', but '%s' does not", fieldName);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/validator/UpdateFieldNameValidator.java
+++ b/driver-core/src/main/com/mongodb/internal/validator/UpdateFieldNameValidator.java
@@ -18,6 +18,8 @@ package com.mongodb.internal.validator;
 
 import org.bson.FieldNameValidator;
 
+import static java.lang.String.format;
+
 /**
  * A field name validator for update documents.  It ensures that all top-level fields start with a '$'.
  *
@@ -30,6 +32,14 @@ public class UpdateFieldNameValidator implements org.bson.FieldNameValidator {
     public boolean validate(final String fieldName) {
         numFields++;
         return fieldName.startsWith("$");
+    }
+
+    @Override
+    public String getValidationErrorMessage(final String fieldName) {
+        if (validate(fieldName)) {
+            throw new IllegalArgumentException(format("%s is valid", fieldName));
+        }
+        return format("All update operators must start with '$', but '%s' does not", fieldName);
     }
 
     @Override

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndReplaceOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndReplaceOperationSpecification.groovy
@@ -189,7 +189,8 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         execute(operation, async)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == 'Field names in a replacement document can not start with \'$\' but \'$inc\' does'
 
         where:
         async << [true, false]

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndUpdateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndUpdateOperationSpecification.groovy
@@ -293,7 +293,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         execute(operation, async)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == 'All update operators must start with \'$\', but \'x\' does not'
 
         where:
         async << [true, false]

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
@@ -352,7 +352,43 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         execute(operation, async)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == 'All update operators must start with \'$\', but \'a\' does not'
+
+        where:
+        [async, ordered] << [[true, false], [true, false]].combinations()
+    }
+
+    def 'when replacing an invalid document, replace should throw IllegalArgumentException'() {
+        given:
+        def id = new ObjectId()
+        def operation = new MixedBulkWriteOperation(getNamespace(),
+                [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)),
+                        new BsonDocument('$set', new BsonDocument('x', new BsonInt32(1))), REPLACE)],
+                true, ACKNOWLEDGED, false)
+
+        when:
+        execute(operation, async)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.getMessage() == 'Field names in a replacement document can not start with \'$\' but \'$set\' does'
+
+        where:
+        [async, ordered] << [[true, false], [true, false]].combinations()
+    }
+
+    def 'when inserting a document with a field starting with a dollar sign, insert should not throw IllegalArgumentException'() {
+        given:
+        def operation = new MixedBulkWriteOperation(getNamespace(),
+                [new InsertRequest(new BsonDocument('$inc', new BsonDocument('x', new BsonInt32(1))))],
+                true, ACKNOWLEDGED, false)
+
+        when:
+        execute(operation, async)
+
+        then:
+        notThrown(IllegalArgumentException)
 
         where:
         [async, ordered] << [[true, false], [true, false]].combinations()

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
@@ -378,7 +378,8 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         [async, ordered] << [[true, false], [true, false]].combinations()
     }
 
-    def 'when inserting a document with a field starting with a dollar sign, insert should not throw IllegalArgumentException'() {
+    @IgnoreIf({ serverVersionLessThan(5, 0) })
+    def 'when inserting a document with a field starting with a dollar sign, insert should not throw'() {
         given:
         def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new InsertRequest(new BsonDocument('$inc', new BsonDocument('x', new BsonInt32(1))))],

--- a/driver-core/src/test/unit/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidatorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidatorTest.java
@@ -30,11 +30,6 @@ public class ReplacingDocumentFieldNameValidatorTest {
         assertTrue(fieldNameValidator.validate("ok"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNullFieldNameValidation() {
-        fieldNameValidator.validate(null);
-    }
-
     @Test
     public void testFieldNameStartsWithDollarValidation() {
         assertFalse(fieldNameValidator.validate("$1"));


### PR DESCRIPTION
For replacement documents, it's now:
  "Field names in a replacement document can not start with '$' but '%s' does"
For update documents, it's now:
  "All update operators must start with '$', but '%s' does not"

JAVA-2114