### PR TITLE
Add AWS Lambda example

### DIFF
--- a/driver-sync/build.gradle
+++ b/driver-sync/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     testImplementation project(':bson').sourceSets.test.output
     testImplementation project(':driver-core').sourceSets.test.output
     testRuntimeOnly project(path: ':driver-core', configuration: 'consumableTestRuntimeOnly')
+
+    testImplementation('com.amazonaws:aws-lambda-java-core:1.2.1')
 }
 
 sourceSets {

--- a/driver-sync/src/examples/documentation/ExampleAwsLambdaHandler.java
+++ b/driver-sync/src/examples/documentation/ExampleAwsLambdaHandler.java
@@ -23,10 +23,10 @@ import com.mongodb.client.MongoClients;
 import org.bson.Document;
 
 // Start AWS Lambda Example 1
-public class TestAwsLambdaHandler implements RequestHandler<String, String> {
+public class ExampleAwsLambdaHandler implements RequestHandler<String, String> {
     private final MongoClient client;
 
-    public TestAwsLambdaHandler() {
+    public ExampleAwsLambdaHandler() {
         client = MongoClients.create(System.getenv("MONGODB_URI"));
     }
 

--- a/driver-sync/src/examples/documentation/TestAwsLambdaHandler.java
+++ b/driver-sync/src/examples/documentation/TestAwsLambdaHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package documentation;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.bson.Document;
+
+// Start AWS Lambda Example 1
+public class TestAwsLambdaHandler implements RequestHandler<String, String> {
+    private final MongoClient client;
+
+    public TestAwsLambdaHandler() {
+        client = MongoClients.create(System.getenv("MONGODB_URI"));
+    }
+
+    @Override
+    public String handleRequest(final String input, final Context context) {
+        return client.getDatabase("admin").runCommand(new Document("ping", 1)).toJson();
+    }
+}
+// End AWS Lambda Example 1


### PR DESCRIPTION
JAVA-4474

Note that there is only one example rather than a separate one for MONGODB-AWS authentication.  My argument for it is that the AWS credentials should properly be obtained by the driver via either environment variables or, perhaps, EC2 or ECS endpoints, and can be used just by specifying a MONGODB_URI environment variable like:

`mongodb+srv://<host>/?authMechanism=MONGODB-AWS`