### PR TITLE
change the log message from INFO to DEBUG

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -250,8 +250,8 @@ public class InternalStreamConnection implements InternalConnection {
         initialServerDescription = initializationDescription.getServerDescription();
         opened.set(true);
         sendCompressor = findSendCompressor(description);
-        if (LOGGER.isInfoEnabled()) {
-            LOGGER.info(format("Opened connection [%s] to %s", getId(), serverId.getAddress()));
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(format("Opened connection [%s] to %s", getId(), serverId.getAddress()));
         }
     }
 


### PR DESCRIPTION
I directly open the PR based on the `JAVA-4719`. If it hasn't been worked yet, please review it.


---
Change the "Opened connection ..." log message from INFO to DEBUG.

Justification: it's the only remaining connection-related log message that is logged at INFO (e.g. the connection-closed message is logged at DEBUG).
  - Ticket: https://jira.mongodb.org/browse/JAVA-4719