### PR TITLE
Support List<T> and Map<String, T> components in Java records

### DIFF
--- a/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
@@ -22,6 +22,7 @@ import org.bson.BsonWriter;
 import org.bson.codecs.Codec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
+import org.bson.codecs.Parameterizable;
 import org.bson.codecs.RepresentationConfigurable;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.configuration.CodecRegistry;
@@ -35,6 +36,7 @@ import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,6 +85,10 @@ final class RecordCodec<T extends Record> implements Codec<T> {
         @SuppressWarnings("deprecation")
         private static Codec<?> computeCodec(final RecordComponent component, final CodecRegistry codecRegistry) {
             var codec = codecRegistry.get(toWrapper(component.getType()));
+            if (codec instanceof Parameterizable parameterizableCodec
+                    && component.getGenericType() instanceof ParameterizedType parameterizedType) {
+                codec = parameterizableCodec.parameterize(codecRegistry, Arrays.asList(parameterizedType.getActualTypeArguments()));
+            }
             BsonType bsonRepresentationType = null;
 
             if (component.isAnnotationPresent(BsonRepresentation.class)) {

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordEmbedded.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordEmbedded.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+public record TestRecordEmbedded(String name) {
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithListOfListOfRecords.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithListOfListOfRecords.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+public record TestRecordWithListOfListOfRecords(@BsonId ObjectId id, List<List<TestRecordEmbedded>> nestedRecords) {
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithListOfRecords.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithListOfRecords.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+public record TestRecordWithListOfRecords(@BsonId ObjectId id, List<TestRecordEmbedded> nestedRecords) {
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithMapOfListOfRecords.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithMapOfListOfRecords.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+import java.util.Map;
+
+public record TestRecordWithMapOfListOfRecords(@BsonId ObjectId id, Map<String, List<TestRecordEmbedded>> nestedRecords) {
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithMapOfRecords.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithMapOfRecords.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.types.ObjectId;
+
+import java.util.Map;
+
+public record TestRecordWithMapOfRecords(@BsonId ObjectId id, Map<String, TestRecordEmbedded> nestedRecords) {
+}

--- a/bson/src/main/org/bson/codecs/AbstractIterableCodec.java
+++ b/bson/src/main/org/bson/codecs/AbstractIterableCodec.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+abstract class AbstractIterableCodec<T> implements Codec<Iterable<T>> {
+
+    abstract T readValue(BsonReader reader, DecoderContext decoderContext);
+
+    abstract void writeValue(BsonWriter writer, T cur, EncoderContext encoderContext);
+
+    @Override
+    public Iterable<T> decode(final BsonReader reader, final DecoderContext decoderContext) {
+        reader.readStartArray();
+
+        List<T> list = new ArrayList<>();
+        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+            if (reader.getCurrentBsonType() == BsonType.NULL) {
+                reader.readNull();
+                list.add(null);
+            } else {
+                list.add(readValue(reader, decoderContext));
+            }
+        }
+
+        reader.readEndArray();
+
+        return list;
+    }
+
+    @Override
+    public void encode(final BsonWriter writer, final Iterable<T> value, final EncoderContext encoderContext) {
+        writer.writeStartArray();
+        for (final T cur : value) {
+            if (cur == null) {
+                writer.writeNull();
+            } else {
+                writeValue(writer, cur, encoderContext);
+            }
+        }
+        writer.writeEndArray();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public Class<Iterable<T>> getEncoderClass() {
+        return (Class<Iterable<T>>) ((Class) Iterable.class);
+    }
+}

--- a/bson/src/main/org/bson/codecs/AbstractMapCodec.java
+++ b/bson/src/main/org/bson/codecs/AbstractMapCodec.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class AbstractMapCodec<T> implements Codec<Map<String, T>> {
+
+    abstract T readValue(BsonReader reader, DecoderContext decoderContext);
+
+    abstract void writeValue(BsonWriter writer, T value, EncoderContext encoderContext);
+
+    @Override
+    public void encode(final BsonWriter writer, final Map<String, T> map, final EncoderContext encoderContext) {
+        writer.writeStartDocument();
+        for (final Map.Entry<String, T> entry : map.entrySet()) {
+            writer.writeName(entry.getKey());
+            T value = entry.getValue();
+            if (value == null) {
+                writer.writeNull();
+            } else {
+                writeValue(writer, value, encoderContext);
+            }
+        }
+        writer.writeEndDocument();
+    }
+
+
+    @Override
+    public Map<String, T> decode(final BsonReader reader, final DecoderContext decoderContext) {
+        Map<String, T> map = new HashMap<>();
+
+        reader.readStartDocument();
+        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+            String fieldName = reader.readName();
+            if (reader.getCurrentBsonType() == BsonType.NULL) {
+                reader.readNull();
+                map.put(fieldName, null);
+            } else {
+                map.put(fieldName, readValue(reader, decoderContext));
+            }
+        }
+
+        reader.readEndDocument();
+        return map;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public Class<Map<String, T>> getEncoderClass() {
+        return (Class<Map<String, T>>) ((Class) Map.class);
+    }
+}

--- a/bson/src/main/org/bson/codecs/IterableCodec.java
+++ b/bson/src/main/org/bson/codecs/IterableCodec.java
@@ -21,12 +21,15 @@ import org.bson.BsonType;
 import org.bson.BsonWriter;
 import org.bson.Transformer;
 import org.bson.UuidRepresentation;
+import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.configuration.CodecRegistry;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.bson.assertions.Assertions.notNull;
+import static org.bson.codecs.ContainerCodecHelper.getCodec;
 import static org.bson.codecs.ContainerCodecHelper.readValue;
 
 /**
@@ -35,7 +38,7 @@ import static org.bson.codecs.ContainerCodecHelper.readValue;
  * @since 3.3
  */
 @SuppressWarnings("rawtypes")
-public class IterableCodec implements Codec<Iterable>, OverridableUuidRepresentationCodec<Iterable> {
+public class IterableCodec implements Codec<Iterable>, OverridableUuidRepresentationCodec<Iterable>, Parameterizable {
 
     private final CodecRegistry registry;
     private final BsonTypeCodecMap bsonTypeCodecMap;
@@ -63,7 +66,6 @@ public class IterableCodec implements Codec<Iterable>, OverridableUuidRepresenta
         this(registry, new BsonTypeCodecMap(notNull("bsonTypeClassMap", bsonTypeClassMap), registry), valueTransformer,
                 UuidRepresentation.UNSPECIFIED);
     }
-
     private IterableCodec(final CodecRegistry registry, final BsonTypeCodecMap bsonTypeCodecMap, final Transformer valueTransformer,
                          final UuidRepresentation uuidRepresentation) {
         this.registry = notNull("registry", registry);
@@ -77,6 +79,15 @@ public class IterableCodec implements Codec<Iterable>, OverridableUuidRepresenta
         this.uuidRepresentation = uuidRepresentation;
     }
 
+
+    @Override
+    public Codec<?> parameterize(final CodecRegistry codecRegistry, final List<Type> types) {
+        if (types.size() != 1) {
+            throw new CodecConfigurationException("Expected only one parameterized type for an Iterable, but found " + types.size());
+        }
+
+        return new ParameterizedIterableCodec<>(getCodec(codecRegistry, types.get(0)));
+    }
 
     @Override
     public Codec<Iterable> withUuidRepresentation(final UuidRepresentation uuidRepresentation) {

--- a/bson/src/main/org/bson/codecs/Parameterizable.java
+++ b/bson/src/main/org/bson/codecs/Parameterizable.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.codecs.configuration.CodecRegistry;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * An interface indicating that a Codec is for a type that can be parameterized by generic types.
+ *
+ * @since 4.8
+ */
+public interface Parameterizable {
+    /**
+     * Recursively parameterize the codec with the given registry and generic type arguments.
+     *
+     * @param codecRegistry the code registry to use to resolve codecs for the generic type arguments
+     * @param types the types that are parameterizing the containing type.
+     * @return the Codec parameterized with the given types
+     */
+    Codec<?> parameterize(CodecRegistry codecRegistry, List<Type> types);
+}

--- a/bson/src/main/org/bson/codecs/ParameterizedIterableCodec.java
+++ b/bson/src/main/org/bson/codecs/ParameterizedIterableCodec.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class ParameterizedIterableCodec<T> implements Codec<Iterable<T>> {
+    private final Codec<T> codec;
+
+    ParameterizedIterableCodec(final Codec<T> codec) {
+        this.codec = codec;
+    }
+
+    @Override
+    public Iterable<T> decode(final BsonReader reader, final DecoderContext decoderContext) {
+        reader.readStartArray();
+
+        List<T> list = new ArrayList<>();
+        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+            if (reader.getCurrentBsonType() == BsonType.NULL) {
+                list.add(null);
+            } else {
+                list.add(decoderContext.decodeWithChildContext(codec, reader));
+            }
+        }
+
+        reader.readEndArray();
+
+        return list;
+    }
+
+    @Override
+    public void encode(final BsonWriter writer, final Iterable<T> value, final EncoderContext encoderContext) {
+        writer.writeStartArray();
+        for (final T cur : value) {
+            if (cur == null) {
+                writer.writeNull();
+            } else {
+                encoderContext.encodeWithChildContext(codec, writer, cur);
+            }
+        }
+        writer.writeEndArray();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public Class<Iterable<T>> getEncoderClass() {
+        return (Class<Iterable<T>>) ((Class) Iterable.class);
+    }
+}

--- a/bson/src/main/org/bson/codecs/ParameterizedIterableCodec.java
+++ b/bson/src/main/org/bson/codecs/ParameterizedIterableCodec.java
@@ -17,13 +17,9 @@
 package org.bson.codecs;
 
 import org.bson.BsonReader;
-import org.bson.BsonType;
 import org.bson.BsonWriter;
 
-import java.util.ArrayList;
-import java.util.List;
-
-class ParameterizedIterableCodec<T> implements Codec<Iterable<T>> {
+class ParameterizedIterableCodec<T> extends AbstractIterableCodec<T> {
     private final Codec<T> codec;
 
     ParameterizedIterableCodec(final Codec<T> codec) {
@@ -31,39 +27,12 @@ class ParameterizedIterableCodec<T> implements Codec<Iterable<T>> {
     }
 
     @Override
-    public Iterable<T> decode(final BsonReader reader, final DecoderContext decoderContext) {
-        reader.readStartArray();
-
-        List<T> list = new ArrayList<>();
-        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
-            if (reader.getCurrentBsonType() == BsonType.NULL) {
-                list.add(null);
-            } else {
-                list.add(decoderContext.decodeWithChildContext(codec, reader));
-            }
-        }
-
-        reader.readEndArray();
-
-        return list;
+    T readValue(final BsonReader reader, final DecoderContext decoderContext) {
+        return decoderContext.decodeWithChildContext(codec, reader);
     }
 
     @Override
-    public void encode(final BsonWriter writer, final Iterable<T> value, final EncoderContext encoderContext) {
-        writer.writeStartArray();
-        for (final T cur : value) {
-            if (cur == null) {
-                writer.writeNull();
-            } else {
-                encoderContext.encodeWithChildContext(codec, writer, cur);
-            }
-        }
-        writer.writeEndArray();
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    @Override
-    public Class<Iterable<T>> getEncoderClass() {
-        return (Class<Iterable<T>>) ((Class) Iterable.class);
+    void writeValue(final BsonWriter writer, final T cur, final EncoderContext encoderContext) {
+        encoderContext.encodeWithChildContext(codec, writer, cur);
     }
 }

--- a/bson/src/main/org/bson/codecs/ParameterizedMapCodec.java
+++ b/bson/src/main/org/bson/codecs/ParameterizedMapCodec.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.BsonReader;
+import org.bson.BsonType;
+import org.bson.BsonWriter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A Codec for Map instances.
+ *
+ * @since 3.5
+ */
+class ParameterizedMapCodec<T> implements Codec<Map<String, T>> {
+
+    private final Codec<T> codec;
+
+    ParameterizedMapCodec(final Codec<T> codec) {
+        this.codec = codec;
+    }
+
+    @Override
+    public void encode(final BsonWriter writer, final Map<String, T> map, final EncoderContext encoderContext) {
+        writer.writeStartDocument();
+        for (final Map.Entry<String, T> entry : map.entrySet()) {
+            writer.writeName(entry.getKey());
+            T value = entry.getValue();
+            if (value == null) {
+                writer.writeNull();
+            } else {
+                encoderContext.encodeWithChildContext(codec, writer, value);
+            }
+        }
+        writer.writeEndDocument();
+    }
+
+    @Override
+    public Map<String, T> decode(final BsonReader reader, final DecoderContext decoderContext) {
+        Map<String, T> map = new HashMap<>();
+
+        reader.readStartDocument();
+        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+            String fieldName = reader.readName();
+            if (reader.getCurrentBsonType() == BsonType.NULL) {
+                reader.readNull();
+                map.put(fieldName, null);
+            } else {
+                map.put(fieldName, decoderContext.decodeWithChildContext(codec, reader));
+            }
+        }
+
+        reader.readEndDocument();
+        return map;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public Class<Map<String, T>> getEncoderClass() {
+        return (Class<Map<String, T>>) ((Class) Map.class);
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/IterableCodecSpecification.groovy
+++ b/bson/src/test/unit/org/bson/codecs/IterableCodecSpecification.groovy
@@ -16,12 +16,18 @@
 
 package org.bson.codecs
 
+import org.bson.BsonArray
+import org.bson.BsonDateTime
 import org.bson.BsonDocument
 import org.bson.BsonDocumentReader
 import org.bson.BsonDocumentWriter
+import org.bson.codecs.jsr310.Jsr310CodecProvider
 import org.bson.types.Binary
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import java.lang.reflect.ParameterizedType
+import java.time.Instant
 
 import static org.bson.BsonDocument.parse
 import static org.bson.UuidRepresentation.C_SHARP_LEGACY
@@ -36,7 +42,8 @@ import static org.bson.codecs.configuration.CodecRegistries.fromRegistries
 class IterableCodecSpecification extends Specification {
 
     static final REGISTRY = fromRegistries(fromCodecs(new UuidCodec(JAVA_LEGACY)),
-            fromProviders(new ValueCodecProvider(), new DocumentCodecProvider(), new BsonValueCodecProvider(), new IterableCodecProvider()))
+            fromProviders(new ValueCodecProvider(), new DocumentCodecProvider(), new BsonValueCodecProvider(),
+                    new IterableCodecProvider(), new MapCodecProvider()))
 
     def 'should have Iterable encoding class'() {
         given:
@@ -158,5 +165,45 @@ class IterableCodecSpecification extends Specification {
         C_SHARP_LEGACY | [new Binary((byte) 4, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as byte[])] | '{"array": [{ "$binary" : "AQIDBAUGBwgJCgsMDQ4PEA==", "$type" : "4" }]}'
         PYTHON_LEGACY  | [new Binary((byte) 4, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as byte[])] | '{"array": [{ "$binary" : "AQIDBAUGBwgJCgsMDQ4PEA==", "$type" : "4" }]}'
         UNSPECIFIED    | [new Binary((byte) 4, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as byte[])] | '{"array": [{ "$binary" : "AQIDBAUGBwgJCgsMDQ4PEA==", "$type" : "4" }]}'
+    }
+
+    def 'should parameterize'() {
+        given:
+        def codec = new IterableCodec(REGISTRY, new BsonTypeClassMap())
+        def writer = new BsonDocumentWriter(new BsonDocument())
+        def reader = new BsonDocumentReader(writer.getDocument())
+        def instants = [
+                ['firstMap': [Instant.ofEpochMilli(1), Instant.ofEpochMilli(2)]],
+                ['secondMap': [Instant.ofEpochMilli(3), Instant.ofEpochMilli(4)]]]
+        when:
+        codec = codec.parameterize(fromProviders(new Jsr310CodecProvider(), REGISTRY),
+                Arrays.asList(((ParameterizedType) Container.getMethod('getInstants').genericReturnType).actualTypeArguments))
+        writer.writeStartDocument()
+        writer.writeName('instants')
+        codec.encode(writer, instants, EncoderContext.builder().build())
+        writer.writeEndDocument()
+
+        then:
+        writer.getDocument() == new BsonDocument()
+                .append('instants', new BsonArray(List.of(
+                        new BsonDocument('firstMap', new BsonArray(List.of(new BsonDateTime(1), new BsonDateTime(2)))),
+                        new BsonDocument('secondMap', new BsonArray(List.of(new BsonDateTime(3), new BsonDateTime(4)))))))
+
+        when:
+        reader.readStartDocument()
+        reader.readName('instants')
+        def decodedInstants = codec.decode(reader, DecoderContext.builder().build())
+
+        then:
+        decodedInstants == instants
+    }
+
+    @SuppressWarnings('unused')
+    static class Container {
+        private final List<Map<String, List<Instant>>> instants = []
+
+        List<Map<String, List<Instant>>> getInstants() {
+            instants
+        }
     }
 }

--- a/bson/src/test/unit/org/bson/codecs/IterableCodecSpecification.groovy
+++ b/bson/src/test/unit/org/bson/codecs/IterableCodecSpecification.groovy
@@ -185,9 +185,11 @@ class IterableCodecSpecification extends Specification {
 
         then:
         writer.getDocument() == new BsonDocument()
-                .append('instants', new BsonArray(List.of(
-                        new BsonDocument('firstMap', new BsonArray(List.of(new BsonDateTime(1), new BsonDateTime(2)))),
-                        new BsonDocument('secondMap', new BsonArray(List.of(new BsonDateTime(3), new BsonDateTime(4)))))))
+                .append('instants', new BsonArray(
+                        [
+                                new BsonDocument('firstMap', new BsonArray([new BsonDateTime(1), new BsonDateTime(2)])),
+                                new BsonDocument('secondMap', new BsonArray([new BsonDateTime(3), new BsonDateTime(4)]))
+                        ]))
 
         when:
         reader.readStartDocument()

--- a/bson/src/test/unit/org/bson/codecs/MapCodecSpecification.groovy
+++ b/bson/src/test/unit/org/bson/codecs/MapCodecSpecification.groovy
@@ -249,8 +249,9 @@ class MapCodecSpecification extends Specification {
         then:
         writer.getDocument() == new BsonDocument()
                 .append('instants',
-                        new BsonDocument('firstMap', new BsonArray(List.of(new BsonDateTime(1), new BsonDateTime(2))))
-                        .append('secondMap', new BsonArray(List.of(new BsonDateTime(3), new BsonDateTime(4)))))
+                        new BsonDocument()
+                                .append('firstMap', new BsonArray([new BsonDateTime(1), new BsonDateTime(2)]))
+                                .append('secondMap', new BsonArray([new BsonDateTime(3), new BsonDateTime(4)])))
 
         when:
         reader.readStartDocument()


### PR DESCRIPTION
This enhances the support for any record component that is a generic List or Map where the generic type of the List or Map value is a record or POJO.  It used to incorrectly decode to org.bson.Document. Now it respects the generic type of the List or Map value when decoding.

JAVA-4667