### PR TITLE
use implementation, not compile in Gradle docs

### DIFF
--- a/4.7/bson/installation-guide/index.html
+++ b/4.7/bson/installation-guide/index.html
@@ -358,7 +358,7 @@ BSON is short for Binary <a href="http://json.org/">JSON</a>, is a binary-encode
 <section class="gradle hidden">
 <pre><code>
   dependencies {
-      compile 'org.mongodb:bson:4.3.0'
+      implementation 'org.mongodb:bson:4.3.0'
   }
 
 </code></pre>

--- a/4.7/driver-reactive/getting-started/installation/index.html
+++ b/4.7/driver-reactive/getting-started/installation/index.html
@@ -350,7 +350,7 @@
 <section class="gradle hidden">
 <pre><code>
   dependencies {
-      compile 'org.mongodb:mongodb-driver-reactivestreams:4.7.0'
+      implementation 'org.mongodb:mongodb-driver-reactivestreams:4.7.0'
   }
 
 </code></pre>

--- a/4.7/driver-reactive/tutorials/client-side-encryption/index.html
+++ b/4.7/driver-reactive/tutorials/client-side-encryption/index.html
@@ -368,7 +368,7 @@ See the <a href="/mongo-java-driver/4.7/driver-reactive/getting-started/installa
 <section class="gradle hidden">
 <pre><code>
   dependencies {
-      compile 'org.mongodb:mongodb-crypt:1.2.1'
+      implementation 'org.mongodb:mongodb-crypt:1.2.1'
   }
 
 </code></pre>

--- a/4.7/driver-scala/getting-started/installation/index.html
+++ b/4.7/driver-scala/getting-started/installation/index.html
@@ -352,7 +352,7 @@
 <section class="gradle hidden">
 <pre><code>
   dependencies {
-      compile 'org.mongodb.scala:mongo-scala-driver:4.7.0_2.12'
+      implementation 'org.mongodb.scala:mongo-scala-driver:4.7.0_2.12'
   }
 
 </code></pre>
@@ -379,7 +379,7 @@
 <section class="gradle hidden">
 <pre><code>
   dependencies {
-      compile 'org.mongodb.scala:mongo-scala-driver:4.7.0_2.11'
+      implementation 'org.mongodb.scala:mongo-scala-driver:4.7.0_2.11'
   }
 
 </code></pre>

--- a/4.7/driver-scala/tutorials/client-side-encryption/index.html
+++ b/4.7/driver-scala/tutorials/client-side-encryption/index.html
@@ -368,7 +368,7 @@ See the <a href="/mongo-java-driver/4.7/driver-scala/getting-started/installatio
 <section class="gradle hidden">
 <pre><code>
   dependencies {
-      compile 'org.mongodb:mongodb-crypt:1.2.1'
+      implementation 'org.mongodb:mongodb-crypt:1.2.1'
   }
 
 </code></pre>

--- a/4.7/driver/getting-started/installation/index.html
+++ b/4.7/driver/getting-started/installation/index.html
@@ -368,7 +368,7 @@ complies with a new cross-driver CRUD specification.  It does <em>not</em> inclu
 <section class="gradle hidden">
 <pre><code>
   dependencies {
-      compile 'org.mongodb:mongodb-driver-sync:4.3.0'
+      implementation 'org.mongodb:mongodb-driver-sync:4.3.0'
   }
 
 </code></pre>
@@ -405,7 +405,7 @@ and central classes include <code>com.mongodb.DB</code>, <code>com.mongodb.DBCol
 <section class="gradle hidden">
 <pre><code>
   dependencies {
-      compile 'org.mongodb:mongodb-driver-legacy:4.3.0'
+      implementation 'org.mongodb:mongodb-driver-legacy:4.3.0'
   }
 
 </code></pre>

--- a/4.7/driver/tutorials/client-side-encryption/index.html
+++ b/4.7/driver/tutorials/client-side-encryption/index.html
@@ -365,7 +365,7 @@ See the <a href="/mongo-java-driver/4.7/driver/getting-started/installation/">in
 <section class="gradle hidden">
 <pre><code>
   dependencies {
-      compile 'org.mongodb:mongodb-crypt:1.2.1'
+      implementation 'org.mongodb:mongodb-crypt:1.2.1'
   }
 
 </code></pre>


### PR DESCRIPTION
compile was removed in Gradle 7
see: https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal