### PR TITLE
Add missing condition for whether to sleep in server monitor

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
@@ -170,7 +170,7 @@ class DefaultServerMonitor implements ServerMonitor {
                     sdamProvider.get().update(currentServerDescription);
 
                     if (((connection == null || shouldStreamResponses(currentServerDescription))
-                            && currentServerDescription.getTopologyVersion() != null)
+                            && currentServerDescription.getTopologyVersion() != null && currentServerDescription.getType() != UNKNOWN)
                             || (connection != null && connection.hasMoreToCome())
                             || (currentServerDescription.getException() instanceof MongoSocketException
                             && previousServerDescription.getType() != UNKNOWN)) {


### PR DESCRIPTION
There is a missing check in an already-complicated conditinal statement for whether to sleep in the server monitor before executing the next check.

The condition is included in the server discovery and monitoring specification pseudo-code but missing in the driver, and there are currently no tests for it.

This commits adds the missing condition to the conditional statement.  Effectively, this will reduce the number of sockets that the monitor opens on a server that is in the process of shutting down but still accepting connections.

JAVA-4730