### PR TITLE
Add javadoc to `AbstractMapCodec`

### DIFF
--- a/bson/src/main/org/bson/codecs/AbstractMapCodec.java
+++ b/bson/src/main/org/bson/codecs/AbstractMapCodec.java
@@ -23,6 +23,12 @@ import org.bson.BsonWriter;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * A class that may simplify implementing a {@link Codec} for {@link Map}s with {@link String} key type.
+ * @param <T> The type of mapped values.
+ *
+ * @since 4.8
+ */
 public abstract class AbstractMapCodec<T> implements Codec<Map<String, T>> {
 
     abstract T readValue(BsonReader reader, DecoderContext decoderContext);


### PR DESCRIPTION
`AbstractMapCodec` was added to the public API in https://github.com/mongodb/mongo-java-driver/commit/26b15f387e14a56afb2003970e9ee22d32b01861. It is not clear to me whether it was intentional, and the class is designed to be extended by users, or accidental. Without a documentation comment, `javadoc` spits out a warning during the build process.