### PR TITLE
Propagate the original error for write errors labeled `NoWritesPerformed`

### DIFF
--- a/driver-core/src/main/com/mongodb/MongoException.java
+++ b/driver-core/src/main/com/mongodb/MongoException.java
@@ -171,22 +171,6 @@ public class MongoException extends RuntimeException {
 
     /**
      * Gets the set of error labels associated with this exception.
-     * The following list of labels is not exhaustive, the labels may also be both added and removed in the future.
-     *
-     * <table>
-     *     <caption>Some error labels</caption>
-     *     <thead><tr><th>Error label</th><th>Description</th></tr></thead>
-     *     <tbody>
-     *         <tr>
-     *             <td>{@code RetryableWriteError}</td>
-     *             <td>Tells the driver, not the user of the driver, that the command may be retried.
-     *             It is not necessary safe for a user to retry the corresponding failed command, unless either the error
-     *             also has the {@code NoWritesPerformed} label, or the error is explicitly documented as safely retryable,
-     *             like {@link MongoConnectionPoolClearedException}.</td>
-     *         </tr>
-     *         <tr><td>{@code NoWritesPerformed}</td><td>Tells the user of the driver that the command may be safely retried.</td></tr>
-     *     </tbody>
-     * </table>
      *
      * @return the error labels, which may not be null but may be empty
      * @since 3.8

--- a/driver-core/src/main/com/mongodb/MongoException.java
+++ b/driver-core/src/main/com/mongodb/MongoException.java
@@ -171,6 +171,22 @@ public class MongoException extends RuntimeException {
 
     /**
      * Gets the set of error labels associated with this exception.
+     * The following list of labels is not exhaustive, the labels may also be both added and removed in the future.
+     *
+     * <table>
+     *     <caption>Some error labels</caption>
+     *     <thead><tr><th>Error label</th><th>Description</th></tr></thead>
+     *     <tbody>
+     *         <tr>
+     *             <td>{@code RetryableWriteError}</td>
+     *             <td>Tells the driver, not the user of the driver, that the command may be retried.
+     *             It is not necessary safe for a user to retry the corresponding failed command, unless either the error
+     *             also has the {@code NoWritesPerformed} label, or the error is explicitly documented as safely retryable,
+     *             like {@link MongoConnectionPoolClearedException}.</td>
+     *         </tr>
+     *         <tr><td>{@code NoWritesPerformed}</td><td>Tells the user of the driver that the command may be safely retried.</td></tr>
+     *     </tbody>
+     * </table>
      *
      * @return the error labels, which may not be null but may be empty
      * @since 3.8

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -165,7 +165,7 @@ final class CommandOperationHelper {
             return mostRecentAttemptException;
         } else if (mostRecentAttemptException instanceof ResourceSupplierInternalException
                 || (mostRecentAttemptException instanceof MongoException
-                    && ((MongoException)mostRecentAttemptException).hasErrorLabel(NO_WRITES_PERFORMED_ERROR_LABEL))) {
+                    && ((MongoException) mostRecentAttemptException).hasErrorLabel(NO_WRITES_PERFORMED_ERROR_LABEL))) {
             return previouslyChosenException;
         } else {
             return mostRecentAttemptException;

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -163,7 +163,9 @@ final class CommandOperationHelper {
                 return mostRecentAttemptException.getCause();
             }
             return mostRecentAttemptException;
-        } else if (mostRecentAttemptException instanceof ResourceSupplierInternalException) {
+        } else if (mostRecentAttemptException instanceof ResourceSupplierInternalException
+                || (mostRecentAttemptException instanceof MongoException
+                    && ((MongoException)mostRecentAttemptException).hasErrorLabel(NO_WRITES_PERFORMED_ERROR_LABEL))) {
             return previouslyChosenException;
         } else {
             return mostRecentAttemptException;
@@ -571,6 +573,7 @@ final class CommandOperationHelper {
     }
 
     static final String RETRYABLE_WRITE_ERROR_LABEL = "RetryableWriteError";
+    private static final String NO_WRITES_PERFORMED_ERROR_LABEL = "NoWritesPerformed";
 
     private static boolean decideRetryableAndAddRetryableWriteErrorLabel(final Throwable t, @Nullable final Integer maxWireVersion) {
         if (!(t instanceof MongoException)) {

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
@@ -846,14 +846,14 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         getCollectionHelper().insertDocuments(getTestInserts())
         def operation = new MixedBulkWriteOperation(getNamespace(),
-                [new InsertRequest(new BsonDocument('_id', new BsonInt32(7))),
-                 new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))   // duplicate key
-                ], false, ACKNOWLEDGED, true)
+                [new DeleteRequest(new BsonDocument('_id', new BsonInt32(2))), // existing key
+                 new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))  // existing (duplicate) key
+                ], true, ACKNOWLEDGED, true)
 
         def failPoint = BsonDocument.parse('''{
             "configureFailPoint": "failCommand",
             "mode": {"times": 2 },
-            "data": { "failCommands": ["insert"],
+            "data": { "failCommands": ["delete"],
                       "writeConcernError": {"code": 91, "errmsg": "Replication is being shut down"}}}''')
         configureFailPoint(failPoint)
 

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/RetryableWritesProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/RetryableWritesProseTest.java
@@ -98,6 +98,15 @@ public class RetryableWritesProseTest extends DatabaseTestCase {
                 mongoCollection -> mongoCollection.insertOne(new Document()), "insert", true);
     }
 
+    /**
+     * Prose test #3.
+     */
+    @Test
+    public void originalErrorMustBePropagatedIfNoWritesPerformed() throws InterruptedException {
+        com.mongodb.client.RetryableWritesProseTest.originalErrorMustBePropagatedIfNoWritesPerformed(
+                mongoClientSettings -> new SyncMongoClient(MongoClients.create(mongoClientSettings)));
+    }
+
     private boolean canRunTests() {
         Document storageEngine = (Document) getServerStatus().get("storageEngine");
 

--- a/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
@@ -38,7 +38,7 @@ public final class FailPoint implements AutoCloseable {
     /**
      * @param configureFailPointDoc A document representing {@code configureFailPoint} command to be issued as is via
      * {@link com.mongodb.client.MongoDatabase#runCommand(Bson)}.
-     * @param serverAddress One may use {@link Fixture#getPrimary(MongoClient)} to get the address of a primary server
+     * @param serverAddress One may use {@link Fixture#getPrimary()} to get the address of a primary server
      * if that is what is needed.
      */
     public static FailPoint enable(final BsonDocument configureFailPointDoc, final ServerAddress serverAddress) {

--- a/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
@@ -29,17 +29,17 @@ import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
 public final class FailPoint implements AutoCloseable {
     private final BsonDocument failPointDocument;
     private final MongoClient client;
-    private final boolean close;
 
-    private FailPoint(final BsonDocument failPointDocument, final MongoClient client, final boolean close) {
+    private FailPoint(final BsonDocument failPointDocument, final MongoClient client) {
         this.failPointDocument = failPointDocument.toBsonDocument();
         this.client = client;
-        this.close = close;
     }
 
     /**
      * @param configureFailPointDoc A document representing {@code configureFailPoint} command to be issued as is via
      * {@link com.mongodb.client.MongoDatabase#runCommand(Bson)}.
+     * @param serverAddress One may use {@link Fixture#getPrimary(MongoClient)} to get the address of a primary server
+     * if that is what is needed.
      */
     public static FailPoint enable(final BsonDocument configureFailPointDoc, final ServerAddress serverAddress) {
         MongoClientSettings clientSettings = getMongoClientSettingsBuilder()
@@ -48,18 +48,11 @@ public final class FailPoint implements AutoCloseable {
                         .hosts(Collections.singletonList(serverAddress)))
                 .build();
         MongoClient client = MongoClients.create(clientSettings);
-        return enable(configureFailPointDoc, client, true);
+        return enable(configureFailPointDoc, client);
     }
 
-    /**
-     * @see #enable(BsonDocument, ServerAddress)
-     */
-    public static FailPoint enable(final BsonDocument configureFailPointDoc, final MongoClient client) {
-        return enable(configureFailPointDoc, client, false);
-    }
-
-    private static FailPoint enable(final BsonDocument configureFailPointDoc, final MongoClient client, final boolean close) {
-        FailPoint result = new FailPoint(configureFailPointDoc, client, close);
+    private static FailPoint enable(final BsonDocument configureFailPointDoc, final MongoClient client) {
+        FailPoint result = new FailPoint(configureFailPointDoc, client);
         client.getDatabase("admin").runCommand(configureFailPointDoc);
         return result;
     }
@@ -71,9 +64,7 @@ public final class FailPoint implements AutoCloseable {
                     .append("configureFailPoint", failPointDocument.getString("configureFailPoint"))
                     .append("mode", new BsonString("off")));
         } finally {
-            if (close) {
-                client.close();
-            }
+            client.close();
         }
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/Fixture.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/Fixture.java
@@ -19,14 +19,10 @@ package com.mongodb.client;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.ServerAddress;
-import com.mongodb.client.internal.MongoClientImpl;
-import com.mongodb.connection.ClusterDescription;
 import com.mongodb.connection.ServerDescription;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 import static com.mongodb.ClusterFixture.getConnectionString;
 import static com.mongodb.ClusterFixture.getMultiMongosConnectionString;
@@ -112,40 +108,16 @@ public final class Fixture {
         return builder;
     }
 
-    public static ServerAddress getPrimary() throws InterruptedException {
-        return getPrimary(getMongoClient());
-    }
-
     /**
      * Beware of a potential race condition hiding here: the primary you discover may differ from the one used by the {@code client}
      * when performing some operations, as the primary may change.
      */
-    public static ServerAddress getPrimary(final MongoClient client)
-            throws InterruptedException {
-        final Supplier<ClusterDescription> clusterDescriptionSupplier;
-        if (client instanceof MongoClientImpl) {
-            clusterDescriptionSupplier = () -> ((MongoClientImpl) client).getClusterDescription();
-        } else {
-            // com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient
-            try {
-                Object wrappedReactiveClient = client.getClass().getMethod("getWrapped").invoke(client);
-                clusterDescriptionSupplier =
-                        () -> {
-                            try {
-                                return (ClusterDescription) wrappedReactiveClient.getClass().getMethod("getClusterDescription")
-                                        .invoke(wrappedReactiveClient);
-                            } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-                                throw new RuntimeException(e);
-                            }
-                        };
-            } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        List<ServerDescription> serverDescriptions = getPrimaries(clusterDescriptionSupplier.get());
+    public static ServerAddress getPrimary() throws InterruptedException {
+        MongoClient client = getMongoClient();
+        List<ServerDescription> serverDescriptions = getPrimaries(client.getClusterDescription());
         while (serverDescriptions.isEmpty()) {
             Thread.sleep(100);
-            serverDescriptions = getPrimaries(clusterDescriptionSupplier.get());
+            serverDescriptions = getPrimaries(client.getClusterDescription());
         }
         return serverDescriptions.get(0).getAddress();
     }

--- a/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
@@ -196,6 +196,7 @@ public class RetryableWritesProseTest extends DatabaseTestCase {
         originalErrorMustBePropagatedIfNoWritesPerformed(MongoClients::create);
     }
 
+    @SuppressWarnings("try")
     public static void originalErrorMustBePropagatedIfNoWritesPerformed(
             final Function<MongoClientSettings, MongoClient> clientCreator) throws InterruptedException {
         assumeTrue(serverVersionAtLeast(6, 0) && isDiscoverableReplicaSet());

--- a/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
@@ -167,7 +167,7 @@ public class RetryableWritesProseTest extends DatabaseTestCase {
                         .append("blockTimeMS", new BsonInt32(1000)));
         int timeoutSeconds = 5;
         try (MongoClient client = clientCreator.apply(clientSettings);
-                FailPoint ignored = FailPoint.enable(configureFailPoint, client)) {
+                FailPoint ignored = FailPoint.enable(configureFailPoint, Fixture.getPrimary(client))) {
             MongoCollection<Document> collection = client.getDatabase(getDefaultDatabaseName())
                     .getCollection("poolClearedExceptionMustBeRetryable");
             collection.drop();
@@ -240,7 +240,7 @@ public class RetryableWritesProseTest extends DatabaseTestCase {
                         // see `poolClearedExceptionMustBeRetryable` for the explanation
                         builder.heartbeatFrequency(50, TimeUnit.MILLISECONDS))
                 .build());
-             FailPoint ignored = FailPoint.enable(failPointDocument, client)) {
+             FailPoint ignored = FailPoint.enable(failPointDocument, Fixture.getPrimary(client))) {
             MongoCollection<Document> collection = client.getDatabase(getDefaultDatabaseName())
                     .getCollection("originalErrorMustBePropagatedIfNoWritesPerformed");
             collection.drop();


### PR DESCRIPTION
TODO for @stIncMale: what's achieved by introducing `NoWritesPerformed` given that we already have `RetryableWriteError`? 

JAVA-4701