### PR TITLE
Use AWS SDK v2/v1 if available for AWS credential fetching

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -372,7 +372,7 @@ functions:
             MONGODB_URI="mongodb://$USER:$PASS@localhost"
           EOF
           JAVA_VERSION=${JAVA_VERSION} PROJECT_DIRECTORY=${PROJECT_DIRECTORY} \
-          USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER=${USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER} \
+          AWS_CREDENTIAL_PROVIDER=${AWS_CREDENTIAL_PROVIDER} \
           .evergreen/run-mongodb-aws-test.sh
 
   "run aws auth test with assume role credentials":
@@ -403,7 +403,7 @@ functions:
             MONGODB_URI="mongodb://$USER:$PASS@localhost"
           EOF
           JAVA_VERSION=${JAVA_VERSION} PROJECT_DIRECTORY=${PROJECT_DIRECTORY} DRIVERS_TOOLS=${DRIVERS_TOOLS} \
-          USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER=${USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER} \
+          AWS_CREDENTIAL_PROVIDER=${AWS_CREDENTIAL_PROVIDER} \
           .evergreen/run-mongodb-aws-test.sh
 
   "run aws auth test with aws EC2 credentials":
@@ -424,7 +424,7 @@ functions:
           ${PREPARE_SHELL}
           # Write an empty prepare_mongodb_aws so no auth environment variables are set.
           echo "" > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-          JAVA_VERSION=${JAVA_VERSION} .evergreen/run-mongodb-aws-test.sh
+          JAVA_VERSION=${JAVA_VERSION} AWS_CREDENTIAL_PROVIDER=${AWS_CREDENTIAL_PROVIDER} .evergreen/run-mongodb-aws-test.sh
 
   "run aws auth test with aws credentials as environment variables":
     - command: shell.exec
@@ -453,7 +453,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          JAVA_VERSION=${JAVA_VERSION} .evergreen/run-mongodb-aws-test.sh
+          JAVA_VERSION=${JAVA_VERSION} AWS_CREDENTIAL_PROVIDER=${AWS_CREDENTIAL_PROVIDER} .evergreen/run-mongodb-aws-test.sh
 
   "run aws auth test with aws credentials and session token as environment variables":
     - command: shell.exec
@@ -483,7 +483,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          JAVA_VERSION=${JAVA_VERSION} .evergreen/run-mongodb-aws-test.sh
+          JAVA_VERSION=${JAVA_VERSION} AWS_CREDENTIAL_PROVIDER=${AWS_CREDENTIAL_PROVIDER} .evergreen/run-mongodb-aws-test.sh
 
   "run aws ECS auth test":
     - command: shell.exec
@@ -1647,11 +1647,15 @@ axes:
       - id: aws_sdk_v2
         display_name: AWS SDK V2
         variables:
-          USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER: "false"
+          AWS_CREDENTIAL_PROVIDER: "awsSdkV2"
+      - id: aws_sdk_v1
+        display_name: AWS SDK V1
+        variables:
+          AWS_CREDENTIAL_PROVIDER: "awsSdkV1"
       - id: built_in
         display_name: Built-In
         variables:
-          USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER: "true"
+          AWS_CREDENTIAL_PROVIDER: "builtIn"
 
 task_groups:
   - name: testgcpkms_task_group

--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -371,7 +371,9 @@ functions:
             PASS=$(urlencode ${iam_auth_ecs_secret_access_key})
             MONGODB_URI="mongodb://$USER:$PASS@localhost"
           EOF
-          JAVA_VERSION=${JAVA_VERSION} PROJECT_DIRECTORY=${PROJECT_DIRECTORY} .evergreen/run-mongodb-aws-test.sh
+          JAVA_VERSION=${JAVA_VERSION} PROJECT_DIRECTORY=${PROJECT_DIRECTORY} \
+          USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER=${USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER} \
+          .evergreen/run-mongodb-aws-test.sh
 
   "run aws auth test with assume role credentials":
     - command: shell.exec
@@ -400,7 +402,9 @@ functions:
             SESSION_TOKEN=$(urlencode $SESSION_TOKEN)
             MONGODB_URI="mongodb://$USER:$PASS@localhost"
           EOF
-          JAVA_VERSION=${JAVA_VERSION} PROJECT_DIRECTORY=${PROJECT_DIRECTORY} DRIVERS_TOOLS=${DRIVERS_TOOLS} .evergreen/run-mongodb-aws-test.sh
+          JAVA_VERSION=${JAVA_VERSION} PROJECT_DIRECTORY=${PROJECT_DIRECTORY} DRIVERS_TOOLS=${DRIVERS_TOOLS} \
+          USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER=${USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER} \
+          .evergreen/run-mongodb-aws-test.sh
 
   "run aws auth test with aws EC2 credentials":
     - command: shell.exec
@@ -1637,6 +1641,18 @@ axes:
         variables:
           LOGIN_CONTEXT_NAME: "com.sun.security.jgss.initiate"
 
+  - id: aws-credential-provider
+    display_name: AWS Credential Provider
+    values:
+      - id: aws_sdk_v2
+        display_name: AWS SDK V2
+        variables:
+          USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER: "false"
+      - id: built_in
+        display_name: Built-In
+        variables:
+          USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER: "true"
+
 task_groups:
   - name: testgcpkms_task_group
     setup_group_can_fail_task: true
@@ -1813,8 +1829,9 @@ buildvariants:
     - name: "plain-auth-test"
 
 - matrix_name: "aws-auth-test"
-  matrix_spec: { ssl: "nossl", jdk: ["jdk8", "jdk17"], version: ["4.4", "5.0", "6.0", "latest"], os: "ubuntu" }
-  display_name: "MONGODB-AWS Auth test ${version} ${jdk}"
+  matrix_spec: { ssl: "nossl", jdk: ["jdk8", "jdk17"], version: ["4.4", "5.0", "6.0", "latest"], os: "ubuntu",
+                 aws-credential-provider: "*" }
+  display_name: "MONGODB-AWS Auth test ${version} ${jdk} ${aws-credential-provider}"
   run_on: ubuntu1804-test
   tasks:
     - name: "aws-auth-test-with-regular-aws-credentials"

--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -1843,6 +1843,12 @@ buildvariants:
     - name: "aws-auth-test-with-aws-credentials-as-environment-variables"
     - name: "aws-auth-test-with-aws-credentials-and-session-token-as-environment-variables"
     - name: "aws-auth-test-with-aws-EC2-credentials"
+
+- matrix_name: "aws-ecs-auth-test"
+  matrix_spec: { ssl: "nossl", jdk: ["jdk8", "jdk17"], version: ["4.4", "5.0", "6.0", "latest"], os: "ubuntu" }
+  display_name: "MONGODB-AWS ECS Auth test ${version} ${jdk}"
+  run_on: ubuntu1804-test
+  tasks:
     - name: "aws-ECS-auth-test"
 
 - matrix_name: "accept-api-version-2-test"

--- a/.evergreen/run-mongodb-aws-ecs-test.sh
+++ b/.evergreen/run-mongodb-aws-ecs-test.sh
@@ -44,5 +44,30 @@ RELATIVE_DIR_PATH="$(dirname "${BASH_SOURCE:-$0}")"
 ./gradlew -version
 
 echo "Running tests..."
-./gradlew -Dorg.mongodb.test.uri=${MONGODB_URI} --stacktrace --debug --info driver-core:test --tests AwsAuthenticationSpecification
+./gradlew -Dorg.mongodb.test.uri=${MONGODB_URI} -Dorg.mongodb.test.aws.credential.provider=awsSdkV2 --stacktrace --debug --info \
+           driver-core:test --tests AwsAuthenticationSpecification
+first=$?
+echo $first
+
+./gradlew -Dorg.mongodb.test.uri=${MONGODB_URI} -Dorg.mongodb.test.aws.credential.provider=awsSdkV1 --stacktrace --debug --info \
+           driver-core:test --tests AwsAuthenticationSpecification
+second=$?
+echo $second
+
+./gradlew -Dorg.mongodb.test.uri=${MONGODB_URI} -Dorg.mongodb.test.aws.credential.provider=builtIn --stacktrace --debug --info \
+           driver-core:test --tests AwsAuthenticationSpecification
+third=$?
+echo $third
+
+if [ $first -ne 0 ]; then
+   exit $first
+elif [ $second -ne 0 ]; then
+   exit $second
+elif [ $third -ne 0 ]; then
+   exit $third
+else
+   exit 0
+fi
+
+
 cd -

--- a/.evergreen/run-mongodb-aws-test.sh
+++ b/.evergreen/run-mongodb-aws-test.sh
@@ -4,9 +4,9 @@ set -o xtrace
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Supported/used environment variables:
-#       JDK                     Set the version of java to be used.  Java versions can be set from the java toolchain /opt/java
-#                               "jdk5", "jdk6", "jdk7", "jdk8", "jdk9", "jdk11"
-
+#  JDK                               Set the version of java to be used.  Java versions can be set from the java toolchain /opt/java
+#                                    "jdk5", "jdk6", "jdk7", "jdk8", "jdk9", "jdk11"
+#  USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER  "true" or "false"
 ############################################
 #            Main Program                  #
 ############################################
@@ -37,5 +37,6 @@ echo "Running tests with Java ${JAVA_VERSION}"
 
 # As this script may be executed multiple times in a single task, with different values for MONGODB_URI, it's necessary
 # to run cleanTest to ensure that the test actually executes each run
-./gradlew -PjavaVersion=${JAVA_VERSION} -Dorg.mongodb.test.uri=${MONGODB_URI} --stacktrace --debug --info --no-build-cache \
-driver-core:cleanTest driver-core:test --tests AwsAuthenticationSpecification
+./gradlew -PjavaVersion="${JAVA_VERSION}" -Dorg.mongodb.test.uri="${MONGODB_URI}" \
+-Dorg.mongodb.test.use.built.in.aws.credential.provider="${USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER}" \
+--stacktrace --debug --info --no-build-cache driver-core:cleanTest driver-core:test --tests AwsAuthenticationSpecification

--- a/.evergreen/run-mongodb-aws-test.sh
+++ b/.evergreen/run-mongodb-aws-test.sh
@@ -6,7 +6,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 # Supported/used environment variables:
 #  JDK                               Set the version of java to be used.  Java versions can be set from the java toolchain /opt/java
 #                                    "jdk5", "jdk6", "jdk7", "jdk8", "jdk9", "jdk11"
-#  USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER  "true" or "false"
+#  AWS_CREDENTIAL_PROVIDER           "builtIn", 'awsSdkV1', 'awsSdkV2'
 ############################################
 #            Main Program                  #
 ############################################
@@ -38,5 +38,5 @@ echo "Running tests with Java ${JAVA_VERSION}"
 # As this script may be executed multiple times in a single task, with different values for MONGODB_URI, it's necessary
 # to run cleanTest to ensure that the test actually executes each run
 ./gradlew -PjavaVersion="${JAVA_VERSION}" -Dorg.mongodb.test.uri="${MONGODB_URI}" \
--Dorg.mongodb.test.use.built.in.aws.credential.provider="${USE_BUILT_IN_AWS_CREDENTIAL_PROVIDER}" \
+-Dorg.mongodb.test.aws.credential.provider="${AWS_CREDENTIAL_PROVIDER}" \
 --stacktrace --debug --info --no-build-cache driver-core:cleanTest driver-core:test --tests AwsAuthenticationSpecification

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ ext {
     snappyVersion = '1.1.8.4'
     zstdVersion = '1.5.2-3'
     awsSdkV2Version = '2.17.293'
+    awsSdkV1Version = '1.12.291'
     mongoCryptVersion = '1.6.0-alpha0'
     projectReactorVersion = '2020.0.22'
     junitBomVersion = '5.8.1'

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ ext {
     nettyVersion = '4.1.79.Final'
     snappyVersion = '1.1.8.4'
     zstdVersion = '1.5.2-3'
+    awsSdkV2Version = '2.17.293'
     mongoCryptVersion = '1.6.0-alpha0'
     projectReactorVersion = '2020.0.22'
     junitBomVersion = '5.8.1'

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     api "io.netty:netty-buffer", optional
     api "io.netty:netty-transport", optional
     api "io.netty:netty-handler", optional
+
+    implementation 'software.amazon.awssdk:auth:2.17.261', optional
+
     implementation "org.xerial.snappy:snappy-java:$snappyVersion", optional
     implementation "com.github.luben:zstd-jni:$zstdVersion", optional
     implementation "org.mongodb:mongodb-crypt:$mongoCryptVersion", optional

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -48,7 +48,10 @@ dependencies {
     api "io.netty:netty-transport", optional
     api "io.netty:netty-handler", optional
 
+    // Optionally depend on both AWS SDK v2 and v1.  The driver will use v2 is present, v1 if present, or built-in functionality if
+    // neither are present
     implementation "software.amazon.awssdk:auth:$awsSdkV2Version", optional
+    implementation "com.amazonaws:aws-java-sdk-core:$awsSdkV1Version", optional
 
     implementation "org.xerial.snappy:snappy-java:$snappyVersion", optional
     implementation "com.github.luben:zstd-jni:$zstdVersion", optional

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     api "io.netty:netty-transport", optional
     api "io.netty:netty-handler", optional
 
-    implementation 'software.amazon.awssdk:auth:2.17.261', optional
+    implementation "software.amazon.awssdk:auth:$awsSdkV2Version", optional
 
     implementation "org.xerial.snappy:snappy-java:$snappyVersion", optional
     implementation "com.github.luben:zstd-jni:$zstdVersion", optional

--- a/driver-core/src/main/com/mongodb/internal/authentication/AwsCredentialHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/authentication/AwsCredentialHelper.java
@@ -40,22 +40,50 @@ public final class AwsCredentialHelper {
             Class.forName("software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider");
             awsCredentialSupplier = new AwsSdkV2CredentialSupplier();
             LOGGER.info("Using software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider from AWS SDK v2 to retrieve AWS "
-                    + "credentials");
+                    + "credentials. This is the recommended configuration");
         } catch (ClassNotFoundException e) {
-            awsCredentialSupplier = new BuiltInAwsCredentialSupplier();
-            LOGGER.info("Using built-in driver implementation to retrieve AWS credentials. Consider adding a dependency to "
-                    + "software.amazon.awssdk:auth to get access to additional AWS authentication functionality");
+            try {
+                Class.forName("com.amazonaws.auth.DefaultAWSCredentialsProviderChain");
+                awsCredentialSupplier = new AwsSdkV1CredentialSupplier();
+                LOGGER.info("Using com.amazonaws.auth.DefaultAWSCredentialsProviderChain from AWS SDK v1 to retrieve AWS "
+                        + "credentials. Consider adding a dependency to AWS SDK v2's software.amazon.awssdk:auth artifact to get access "
+                        + "to additional AWS authentication functionality.");
+            } catch (ClassNotFoundException e1) {
+                awsCredentialSupplier = new BuiltInAwsCredentialSupplier();
+                LOGGER.info("Using built-in driver implementation to retrieve AWS credentials. Consider adding a dependency to AWS "
+                        + "SDK v2's software.amazon.awssdk:auth artifact to get access to additional AWS authentication functionality.");
+            }
         }
     }
 
     /**
      * This method is visible to allow tests to require the built-in provider rather than rely on the fixed checks for classes on the
-     * classpath.  It allows us to easily write tests of both implementations without resorting to runtime classpath shenanigans.
+     * classpath.  It allows us to easily write tests of the built-in implementation without resorting to runtime classpath shenanigans.
      */
     @VisibleForTesting(otherwise = PRIVATE)
     public static void requireBuiltInProvider() {
         LOGGER.info("Using built-in driver implementation to retrieve AWS credentials");
         awsCredentialSupplier = new BuiltInAwsCredentialSupplier();
+    }
+
+    /**
+     * This method is visible to allow tests to require the AWS SDK v1 provider rather than rely on the fixed checks for classes on the
+     * classpath.  It allows us to easily write tests of the AWS SDK v1 implementation without resorting to runtime classpath shenanigans.
+     */
+    @VisibleForTesting(otherwise = PRIVATE)
+    public static void requireAwsSdkV1Provider() {
+        LOGGER.info("Using AWS SDK v1 to retrieve AWS credentials");
+        awsCredentialSupplier = new AwsSdkV1CredentialSupplier();
+    }
+
+    /**
+     * This method is visible to allow tests to require the AWS SDK v2 provider rather than rely on the fixed checks for classes on the
+     * classpath.  It allows us to easily write tests of the AWS SDK v2 implementation without resorting to runtime classpath shenanigans.
+     */
+    @VisibleForTesting(otherwise = PRIVATE)
+    public static void requireAwsSdkV2Provider() {
+        LOGGER.info("Using AWS SDK v2 to retrieve AWS credentials");
+        awsCredentialSupplier = new AwsSdkV2CredentialSupplier();
     }
 
     public static AwsCredential obtainFromEnvironment() {

--- a/driver-core/src/main/com/mongodb/internal/authentication/AwsSdkV1CredentialSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/authentication/AwsSdkV1CredentialSupplier.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.authentication;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSSessionCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.mongodb.AwsCredential;
+
+import java.util.function.Supplier;
+
+public final class AwsSdkV1CredentialSupplier implements Supplier<AwsCredential> {
+
+    private final AWSCredentialsProvider provider = DefaultAWSCredentialsProviderChain.getInstance();
+
+    @Override
+    public AwsCredential get() {
+        AWSCredentials credentials = provider.getCredentials();
+        if (credentials instanceof AWSSessionCredentials) {
+            AWSSessionCredentials sessionCredentials = (AWSSessionCredentials) credentials;
+            return new AwsCredential(sessionCredentials.getAWSAccessKeyId(), sessionCredentials.getAWSSecretKey(),
+                    sessionCredentials.getSessionToken());
+        } else {
+            return new AwsCredential(credentials.getAWSAccessKeyId(), credentials.getAWSSecretKey(), null);
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/authentication/AwsSdkV2CredentialSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/authentication/AwsSdkV2CredentialSupplier.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.authentication;
+
+import com.mongodb.AwsCredential;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+
+import java.util.function.Supplier;
+
+public final class AwsSdkV2CredentialSupplier implements Supplier<AwsCredential> {
+
+    private final AwsCredentialsProvider provider = DefaultCredentialsProvider.create();
+
+    @Override
+    public AwsCredential get() {
+        AwsCredentials credentials = provider.resolveCredentials();
+        if (credentials instanceof AwsSessionCredentials) {
+            AwsSessionCredentials sessionCredentials = (AwsSessionCredentials) credentials;
+            return new AwsCredential(sessionCredentials.accessKeyId(), sessionCredentials.secretAccessKey(),
+                    sessionCredentials.sessionToken());
+        } else {
+            return new AwsCredential(credentials.accessKeyId(), credentials.secretAccessKey(), null);
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/authentication/BuiltInAwsCredentialSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/authentication/BuiltInAwsCredentialSupplier.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.authentication;
+
+import com.mongodb.AwsCredential;
+import org.bson.BsonDocument;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static com.mongodb.internal.authentication.HttpHelper.getHttpContents;
+
+public class BuiltInAwsCredentialSupplier implements Supplier<AwsCredential> {
+
+    @Override
+    public AwsCredential get() {
+        if (System.getenv("AWS_ACCESS_KEY_ID") != null) {
+            return obtainFromEnvironmentVariables();
+        } else {
+            return obtainFromEc2OrEcsResponse();
+        }
+    }
+
+    private static AwsCredential obtainFromEnvironmentVariables() {
+        return new AwsCredential(
+                System.getenv("AWS_ACCESS_KEY_ID"),
+                System.getenv("AWS_SECRET_ACCESS_KEY"),
+                System.getenv("AWS_SESSION_TOKEN"));
+    }
+
+    private static AwsCredential obtainFromEc2OrEcsResponse() {
+        String path = System.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI");
+        BsonDocument ec2OrEcsResponse = path == null ? BsonDocument.parse(getEc2Response()) : BsonDocument.parse(getEcsResponse(path));
+
+        return new AwsCredential(
+                ec2OrEcsResponse.getString("AccessKeyId").getValue(),
+                ec2OrEcsResponse.getString("SecretAccessKey").getValue(),
+                ec2OrEcsResponse.getString("Token").getValue());
+    }
+
+    private static String getEcsResponse(final String path) {
+        return getHttpContents("GET", "http://169.254.170.2" + path, null);
+    }
+
+    private static String getEc2Response() {
+        final String endpoint = "http://169.254.169.254";
+        final String path = "/latest/meta-data/iam/security-credentials/";
+
+        Map<String, String> header = new HashMap<>();
+        header.put("X-aws-ec2-metadata-token-ttl-seconds", "30");
+        String token = getHttpContents("PUT", endpoint + "/latest/api/token", header);
+
+        header.clear();
+        header.put("X-aws-ec2-metadata-token", token);
+        String role = getHttpContents("GET", endpoint + path, header);
+        return getHttpContents("GET", endpoint + path + role, header);
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/AwsAuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/AwsAuthenticationSpecification.groovy
@@ -33,8 +33,16 @@ import static java.util.concurrent.TimeUnit.SECONDS
 class AwsAuthenticationSpecification extends Specification {
 
     static {
-        if (Boolean.valueOf(System.getProperty('org.mongodb.test.use.built.in.aws.credential.provider', 'false'))) {
+        def providerProperty = System.getProperty('org.mongodb.test.aws.credential.provider', 'awsSdkV2')
+
+        if (providerProperty == 'builtIn') {
             AwsCredentialHelper.requireBuiltInProvider()
+        } else if (providerProperty == 'awsSdkV1') {
+            AwsCredentialHelper.requireAwsSdkV1Provider()
+        } else if (providerProperty == 'awsSdkV2') {
+            AwsCredentialHelper.requireAwsSdkV2Provider()
+        } else {
+            throw new IllegalArgumentException("Unrecognized AWS credential provider: $providerProperty")
         }
     }
 

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/AwsAuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/AwsAuthenticationSpecification.groovy
@@ -12,6 +12,7 @@ import com.mongodb.connection.ClusterId
 import com.mongodb.connection.ServerId
 import com.mongodb.connection.SocketSettings
 import com.mongodb.connection.SocketStreamFactory
+import com.mongodb.internal.authentication.AwsCredentialHelper
 import org.bson.BsonDocument
 import org.bson.BsonString
 import spock.lang.IgnoreIf
@@ -30,6 +31,12 @@ import static java.util.concurrent.TimeUnit.SECONDS
 
 @IgnoreIf({ getCredential() == null || getCredential().getAuthenticationMechanism() != MONGODB_AWS })
 class AwsAuthenticationSpecification extends Specification {
+
+    static {
+        if (Boolean.valueOf(System.getProperty('org.mongodb.test.use.built.in.aws.credential.provider', 'false'))) {
+            AwsCredentialHelper.requireBuiltInProvider()
+        }
+    }
 
     def 'should not authorize when not authenticated'() {
         given:


### PR DESCRIPTION
To fetch AWS credentials from the environment:

  * Use AWS SDK v2 if available on the classpath
  * Otherwise, use AWS SDK v2 if available on the classpath
  * Otherwise, use the existing driver implementation

JAVA-4718