### PR TITLE
JAVA-4789: Make bson.record.codec module optional for OSGi

### DIFF
--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -87,6 +87,7 @@ afterEvaluate {
             'jnr.unixsocket.*;resolution:=optional',
             'com.mongodb.crypt.capi.*;resolution:=optional',
             'jdk.net.*;resolution:=optional', // Used by SocketStreamHelper & depends on JDK version
+            'org.bson.codecs.record.*;resolution:=optional', // Depends on JDK version
             '*' // import all that is not excluded or modified before
     ].join(',')
 }


### PR DESCRIPTION
Currently the Java Driver can't be used in OSGi containers using a Java version lower than 17, which according to the compatibility matrix should not happen, as it should be compatible from Java 8+.

The problem is that there is a dependency of bson.codecs.record, which requires Java17+ according to its MANIFEST.MF:

Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"

This change will make the Import-Package attribute for bson.codecs.record optional, meaning when trying to use it in a OSGi container it won't fail because the dependency can't be satisfied in lower versions than 17.

After building with this change applied, that line in the MANIFEST.MF file will look like this:

org.bson.codecs.record;resolution:=optional;version="[4.7,5)"

We can see above this line that the same approach is used for jdk.net.

This change will still require Java 17+ to build the driver, but allows its use in OSGi containers using lower versions.

[JAVA-4789](https://jira.mongodb.org/browse/JAVA-4789)