### PR TITLE
Add AsyncOperations to match SyncOperations

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+import com.mongodb.AutoEncryptionSettings;
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.client.model.BulkWriteOptions;
+import com.mongodb.client.model.Collation;
+import com.mongodb.client.model.CountOptions;
+import com.mongodb.client.model.CreateIndexOptions;
+import com.mongodb.client.model.DeleteOptions;
+import com.mongodb.client.model.DropCollectionOptions;
+import com.mongodb.client.model.DropIndexOptions;
+import com.mongodb.client.model.EstimatedDocumentCountOptions;
+import com.mongodb.client.model.FindOneAndDeleteOptions;
+import com.mongodb.client.model.FindOneAndReplaceOptions;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import com.mongodb.client.model.IndexModel;
+import com.mongodb.client.model.InsertManyOptions;
+import com.mongodb.client.model.InsertOneOptions;
+import com.mongodb.client.model.RenameCollectionOptions;
+import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.WriteModel;
+import com.mongodb.internal.async.AsyncBatchCursor;
+import com.mongodb.internal.client.model.AggregationLevel;
+import com.mongodb.internal.client.model.FindOptions;
+import org.bson.BsonValue;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.util.List;
+
+/**
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+public final class AsyncOperations<TDocument> {
+    private final Operations<TDocument> operations;
+
+    public AsyncOperations(final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
+            final CodecRegistry codecRegistry, final ReadConcern readConcern, final WriteConcern writeConcern,
+            final boolean retryWrites, final boolean retryReads) {
+        this.operations = new Operations<>(namespace, documentClass, readPreference, codecRegistry, readConcern, writeConcern,
+                retryWrites, retryReads);
+    }
+
+    public MongoNamespace getNamespace() {
+        return operations.getNamespace();
+    }
+
+    public Class<TDocument> getDocumentClass() {
+        return operations.getDocumentClass();
+    }
+
+    public ReadPreference getReadPreference() {
+        return operations.getReadPreference();
+    }
+
+    public CodecRegistry getCodecRegistry() {
+        return operations.getCodecRegistry();
+    }
+
+    public ReadConcern getReadConcern() {
+        return operations.getReadConcern();
+    }
+
+    public WriteConcern getWriteConcern() {
+        return operations.getWriteConcern();
+    }
+
+    public boolean isRetryWrites() {
+        return operations.isRetryWrites();
+    }
+
+    public boolean isRetryReads() {
+        return operations.isRetryReads();
+    }
+
+    public AsyncReadOperation<Long> countDocuments(final Bson filter, final CountOptions options) {
+        return operations.countDocuments(filter, options);
+    }
+
+    public AsyncReadOperation<Long> estimatedDocumentCount(final EstimatedDocumentCountOptions options) {
+        return operations.estimatedDocumentCount(options);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> findFirst(final Bson filter, final Class<TResult> resultClass,
+            final FindOptions options) {
+        return operations.findFirst(filter, resultClass, options);
+    }
+
+    public <TResult> AsyncExplainableReadOperation<AsyncBatchCursor<TResult>> find(final Bson filter, final Class<TResult> resultClass,
+            final FindOptions options) {
+        return operations.find(filter, resultClass, options);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> find(final MongoNamespace findNamespace, final Bson filter,
+            final Class<TResult> resultClass, final FindOptions options) {
+        return operations.find(findNamespace, filter, resultClass, options);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> distinct(final String fieldName, final Bson filter,
+            final Class<TResult> resultClass, final long maxTimeMS,
+            final Collation collation, final BsonValue comment) {
+        return operations.distinct(fieldName, filter, resultClass, maxTimeMS, collation, comment);
+    }
+
+    public <TResult> AsyncExplainableReadOperation<AsyncBatchCursor<TResult>> aggregate(final List<? extends Bson> pipeline,
+            final Class<TResult> resultClass,
+            final long maxTimeMS, final long maxAwaitTimeMS,
+            final Integer batchSize,
+            final Collation collation, final Bson hint,
+            final String hintString,
+            final BsonValue comment,
+            final Bson variables,
+            final Boolean allowDiskUse,
+            final AggregationLevel aggregationLevel) {
+        return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, batchSize, collation, hint, hintString, comment,
+                variables, allowDiskUse, aggregationLevel);
+    }
+
+    public AsyncReadOperation<Void> aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
+            final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
+            final Collation collation, final Bson hint, final String hintString, final BsonValue comment,
+            final Bson variables, final AggregationLevel aggregationLevel) {
+        return operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation, hint, hintString,
+                comment, variables, aggregationLevel);
+    }
+
+    @SuppressWarnings("deprecation")
+    public AsyncWriteOperation<MapReduceStatistics> mapReduceToCollection(final String databaseName, final String collectionName,
+            final String mapFunction, final String reduceFunction,
+            final String finalizeFunction, final Bson filter, final int limit,
+            final long maxTimeMS, final boolean jsMode, final Bson scope,
+            final Bson sort, final boolean verbose,
+            final com.mongodb.client.model.MapReduceAction action,
+            final boolean nonAtomic, final boolean sharded,
+            final Boolean bypassDocumentValidation, final Collation collation) {
+        return operations.mapReduceToCollection(databaseName, collectionName, mapFunction, reduceFunction, finalizeFunction, filter, limit,
+                maxTimeMS, jsMode, scope, sort, verbose, action, nonAtomic, sharded, bypassDocumentValidation, collation);
+    }
+
+    public <TResult> AsyncReadOperation<MapReduceAsyncBatchCursor<TResult>> mapReduce(final String mapFunction, final String reduceFunction,
+            final String finalizeFunction, final Class<TResult> resultClass,
+            final Bson filter, final int limit,
+            final long maxTimeMS, final boolean jsMode, final Bson scope,
+            final Bson sort, final boolean verbose,
+            final Collation collation) {
+        return operations.mapReduce(mapFunction, reduceFunction, finalizeFunction, resultClass, filter, limit, maxTimeMS, jsMode, scope,
+                sort, verbose, collation);
+    }
+
+    public AsyncWriteOperation<TDocument> findOneAndDelete(final Bson filter, final FindOneAndDeleteOptions options) {
+        return operations.findOneAndDelete(filter, options);
+    }
+
+    public AsyncWriteOperation<TDocument> findOneAndReplace(final Bson filter, final TDocument replacement,
+            final FindOneAndReplaceOptions options) {
+        return operations.findOneAndReplace(filter, replacement, options);
+    }
+
+    public AsyncWriteOperation<TDocument> findOneAndUpdate(final Bson filter, final Bson update, final FindOneAndUpdateOptions options) {
+        return operations.findOneAndUpdate(filter, update, options);
+    }
+
+    public AsyncWriteOperation<TDocument> findOneAndUpdate(final Bson filter, final List<? extends Bson> update,
+            final FindOneAndUpdateOptions options) {
+        return operations.findOneAndUpdate(filter, update, options);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> insertOne(final TDocument document, final InsertOneOptions options) {
+        return operations.insertOne(document, options);
+    }
+
+
+    public AsyncWriteOperation<BulkWriteResult> replaceOne(final Bson filter, final TDocument replacement, final ReplaceOptions options) {
+        return operations.replaceOne(filter, replacement, options);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> deleteOne(final Bson filter, final DeleteOptions options) {
+        return operations.deleteOne(filter, options);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> deleteMany(final Bson filter, final DeleteOptions options) {
+        return operations.deleteMany(filter, options);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> updateOne(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
+        return operations.updateOne(filter, update, updateOptions);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> updateOne(final Bson filter, final List<? extends Bson> update,
+            final UpdateOptions updateOptions) {
+        return operations.updateOne(filter, update, updateOptions);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> updateMany(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
+        return operations.updateMany(filter, update, updateOptions);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> updateMany(final Bson filter, final List<? extends Bson> update,
+            final UpdateOptions updateOptions) {
+        return operations.updateMany(filter, update, updateOptions);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> insertMany(final List<? extends TDocument> documents,
+            final InsertManyOptions options) {
+        return operations.insertMany(documents, options);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests,
+            final BulkWriteOptions options) {
+        return operations.bulkWrite(requests, options);
+    }
+
+
+    public AsyncWriteOperation<Void> dropCollection(final DropCollectionOptions dropCollectionOptions,
+            final AutoEncryptionSettings autoEncryptionSettings) {
+        return operations.dropCollection(dropCollectionOptions, autoEncryptionSettings);
+    }
+
+    public AsyncWriteOperation<Void> renameCollection(final MongoNamespace newCollectionNamespace,
+            final RenameCollectionOptions options) {
+        return operations.renameCollection(newCollectionNamespace, options);
+    }
+
+    public AsyncWriteOperation<Void> createIndexes(final List<IndexModel> indexes, final CreateIndexOptions options) {
+        return operations.createIndexes(indexes, options);
+    }
+
+    public AsyncWriteOperation<Void> dropIndex(final String indexName, final DropIndexOptions options) {
+        return operations.dropIndex(indexName, options);
+    }
+
+    public AsyncWriteOperation<Void> dropIndex(final Bson keys, final DropIndexOptions options) {
+        return operations.dropIndex(keys, options);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> listCollections(final String databaseName, final Class<TResult> resultClass,
+            final Bson filter, final boolean collectionNamesOnly,
+            final Integer batchSize, final long maxTimeMS,
+            final BsonValue comment) {
+        return operations.listCollections(databaseName, resultClass, filter, collectionNamesOnly, batchSize, maxTimeMS, comment);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> listDatabases(final Class<TResult> resultClass, final Bson filter,
+            final Boolean nameOnly, final long maxTimeMS,
+            final Boolean authorizedDatabases, final BsonValue comment) {
+        return operations.listDatabases(resultClass, filter, nameOnly, maxTimeMS, authorizedDatabases, comment);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> listIndexes(final Class<TResult> resultClass, final Integer batchSize,
+            final long maxTimeMS, final BsonValue comment) {
+        return operations.listIndexes(resultClass, batchSize, maxTimeMS, comment);
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -74,7 +74,7 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-public final class Operations<TDocument> {
+final class Operations<TDocument> {
     private final MongoNamespace namespace;
     private final Class<TDocument> documentClass;
     private final ReadPreference readPreference;
@@ -84,7 +84,7 @@ public final class Operations<TDocument> {
     private final boolean retryWrites;
     private final boolean retryReads;
 
-    public Operations(final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
+    Operations(final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
             final CodecRegistry codecRegistry, final ReadConcern readConcern, final WriteConcern writeConcern, final boolean retryWrites,
             final boolean retryReads) {
         this.namespace = namespace;
@@ -97,39 +97,39 @@ public final class Operations<TDocument> {
         this.retryReads = retryReads;
     }
 
-    public MongoNamespace getNamespace() {
+    MongoNamespace getNamespace() {
         return namespace;
     }
 
-    public Class<TDocument> getDocumentClass() {
+    Class<TDocument> getDocumentClass() {
         return documentClass;
     }
 
-    public ReadPreference getReadPreference() {
+    ReadPreference getReadPreference() {
         return readPreference;
     }
 
-    public CodecRegistry getCodecRegistry() {
+    CodecRegistry getCodecRegistry() {
         return codecRegistry;
     }
 
-    public ReadConcern getReadConcern() {
+    ReadConcern getReadConcern() {
         return readConcern;
     }
 
-    public WriteConcern getWriteConcern() {
+    WriteConcern getWriteConcern() {
         return writeConcern;
     }
 
-    public boolean isRetryWrites() {
+    boolean isRetryWrites() {
         return retryWrites;
     }
 
-    public boolean isRetryReads() {
+    boolean isRetryReads() {
         return retryReads;
     }
 
-    public CountDocumentsOperation countDocuments(final Bson filter, final CountOptions options) {
+    CountDocumentsOperation countDocuments(final Bson filter, final CountOptions options) {
         CountDocumentsOperation operation = new CountDocumentsOperation(namespace)
                 .retryReads(retryReads)
                 .filter(toBsonDocument(filter))
@@ -146,24 +146,24 @@ public final class Operations<TDocument> {
         return operation;
     }
 
-    public EstimatedDocumentCountOperation estimatedDocumentCount(final EstimatedDocumentCountOptions options) {
+    EstimatedDocumentCountOperation estimatedDocumentCount(final EstimatedDocumentCountOptions options) {
         return new EstimatedDocumentCountOperation(namespace)
                 .retryReads(retryReads)
                 .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                 .comment(options.getComment());
     }
 
-    public <TResult> FindOperation<TResult> findFirst(final Bson filter, final Class<TResult> resultClass,
+    <TResult> FindOperation<TResult> findFirst(final Bson filter, final Class<TResult> resultClass,
                                                       final FindOptions options) {
         return createFindOperation(namespace, filter, resultClass, options).batchSize(0).limit(-1);
     }
 
-    public <TResult> FindOperation<TResult> find(final Bson filter, final Class<TResult> resultClass,
+    <TResult> FindOperation<TResult> find(final Bson filter, final Class<TResult> resultClass,
                                                  final FindOptions options) {
         return createFindOperation(namespace, filter, resultClass, options);
     }
 
-    public <TResult> FindOperation<TResult> find(final MongoNamespace findNamespace, final Bson filter,
+    <TResult> FindOperation<TResult> find(final MongoNamespace findNamespace, final Bson filter,
                                                  final Class<TResult> resultClass, final FindOptions options) {
         return createFindOperation(findNamespace, filter, resultClass, options);
     }
@@ -201,7 +201,7 @@ public final class Operations<TDocument> {
         return operation;
     }
 
-    public <TResult> DistinctOperation<TResult> distinct(final String fieldName, final Bson filter,
+    <TResult> DistinctOperation<TResult> distinct(final String fieldName, final Bson filter,
                                                          final Class<TResult> resultClass, final long maxTimeMS,
                                                          final Collation collation, final BsonValue comment) {
         return new DistinctOperation<>(namespace, fieldName, codecRegistry.get(resultClass))
@@ -213,7 +213,7 @@ public final class Operations<TDocument> {
 
     }
 
-    public <TResult> AggregateOperation<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,
+    <TResult> AggregateOperation<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,
                                                     final long maxTimeMS, final long maxAwaitTimeMS, final Integer batchSize,
                                                     final Collation collation, final Bson hint, final String hintString,
                                                     final BsonValue comment,
@@ -231,7 +231,7 @@ public final class Operations<TDocument> {
                 .let(toBsonDocument(variables));
     }
 
-    public AggregateToCollectionOperation aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
+    AggregateToCollectionOperation aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
             final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
             final Collation collation, final Bson hint, final String hintString, final BsonValue comment,
             final Bson variables, final AggregationLevel aggregationLevel) {
@@ -246,7 +246,7 @@ public final class Operations<TDocument> {
     }
 
     @SuppressWarnings("deprecation")
-    public MapReduceToCollectionOperation mapReduceToCollection(final String databaseName, final String collectionName,
+    MapReduceToCollectionOperation mapReduceToCollection(final String databaseName, final String collectionName,
                                                                 final String mapFunction, final String reduceFunction,
                                                                 final String finalizeFunction, final Bson filter, final int limit,
                                                                 final long maxTimeMS, final boolean jsMode, final Bson scope,
@@ -276,7 +276,7 @@ public final class Operations<TDocument> {
         return operation;
     }
 
-    public <TResult> MapReduceWithInlineResultsOperation<TResult> mapReduce(final String mapFunction, final String reduceFunction,
+    <TResult> MapReduceWithInlineResultsOperation<TResult> mapReduce(final String mapFunction, final String reduceFunction,
                                                                             final String finalizeFunction, final Class<TResult> resultClass,
                                                                             final Bson filter, final int limit,
                                                                             final long maxTimeMS, final boolean jsMode, final Bson scope,
@@ -301,7 +301,7 @@ public final class Operations<TDocument> {
         return operation;
     }
 
-    public FindAndDeleteOperation<TDocument> findOneAndDelete(final Bson filter, final FindOneAndDeleteOptions options) {
+    FindAndDeleteOperation<TDocument> findOneAndDelete(final Bson filter, final FindOneAndDeleteOptions options) {
         return new FindAndDeleteOperation<>(namespace, writeConcern, retryWrites, getCodec())
                 .filter(toBsonDocument(filter))
                 .projection(toBsonDocument(options.getProjection()))
@@ -314,7 +314,7 @@ public final class Operations<TDocument> {
                 .let(toBsonDocument(options.getLet()));
     }
 
-    public FindAndReplaceOperation<TDocument> findOneAndReplace(final Bson filter, final TDocument replacement,
+    FindAndReplaceOperation<TDocument> findOneAndReplace(final Bson filter, final TDocument replacement,
                                                                 final FindOneAndReplaceOptions options) {
         return new FindAndReplaceOperation<>(namespace, writeConcern, retryWrites, getCodec(),
                 documentToBsonDocument(replacement))
@@ -332,7 +332,7 @@ public final class Operations<TDocument> {
                 .let(toBsonDocument(options.getLet()));
     }
 
-    public FindAndUpdateOperation<TDocument> findOneAndUpdate(final Bson filter, final Bson update, final FindOneAndUpdateOptions options) {
+    FindAndUpdateOperation<TDocument> findOneAndUpdate(final Bson filter, final Bson update, final FindOneAndUpdateOptions options) {
         return new FindAndUpdateOperation<>(namespace, writeConcern, retryWrites, getCodec(),
                 toBsonDocument(update))
                 .filter(toBsonDocument(filter))
@@ -350,7 +350,7 @@ public final class Operations<TDocument> {
                 .let(toBsonDocument(options.getLet()));
     }
 
-    public FindAndUpdateOperation<TDocument> findOneAndUpdate(final Bson filter, final List<? extends Bson> update,
+    FindAndUpdateOperation<TDocument> findOneAndUpdate(final Bson filter, final List<? extends Bson> update,
                                                        final FindOneAndUpdateOptions options) {
         return new FindAndUpdateOperation<>(namespace, writeConcern, retryWrites, getCodec(),
                 toBsonDocumentList(update))
@@ -370,53 +370,53 @@ public final class Operations<TDocument> {
     }
 
 
-    public MixedBulkWriteOperation insertOne(final TDocument document, final InsertOneOptions options) {
+    MixedBulkWriteOperation insertOne(final TDocument document, final InsertOneOptions options) {
         return bulkWrite(singletonList(new InsertOneModel<>(document)),
                 new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation()).comment(options.getComment()));
     }
 
 
-    public MixedBulkWriteOperation replaceOne(final Bson filter, final TDocument replacement, final ReplaceOptions options) {
+    MixedBulkWriteOperation replaceOne(final Bson filter, final TDocument replacement, final ReplaceOptions options) {
         return bulkWrite(singletonList(new ReplaceOneModel<>(filter, replacement, options)),
                 new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation())
                         .comment(options.getComment()).let(options.getLet()));
     }
 
-    public MixedBulkWriteOperation deleteOne(final Bson filter, final DeleteOptions options) {
+    MixedBulkWriteOperation deleteOne(final Bson filter, final DeleteOptions options) {
         return bulkWrite(singletonList(new DeleteOneModel<>(filter, options)),
                 new BulkWriteOptions().comment(options.getComment()).let(options.getLet()));
     }
 
-    public MixedBulkWriteOperation deleteMany(final Bson filter, final DeleteOptions options) {
+    MixedBulkWriteOperation deleteMany(final Bson filter, final DeleteOptions options) {
         return bulkWrite(singletonList(new DeleteManyModel<>(filter, options)),
                 new BulkWriteOptions().comment(options.getComment()).let(options.getLet()));
     }
 
-    public MixedBulkWriteOperation updateOne(final Bson filter, final Bson update, final UpdateOptions options) {
+    MixedBulkWriteOperation updateOne(final Bson filter, final Bson update, final UpdateOptions options) {
         return bulkWrite(singletonList(new UpdateOneModel<>(filter, update, options)),
                 new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation())
                         .comment(options.getComment()).let(options.getLet()));
     }
 
-    public MixedBulkWriteOperation updateOne(final Bson filter, final List<? extends Bson> update, final UpdateOptions options) {
+    MixedBulkWriteOperation updateOne(final Bson filter, final List<? extends Bson> update, final UpdateOptions options) {
         return bulkWrite(singletonList(new UpdateOneModel<>(filter, update, options)),
                 new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation())
                         .comment(options.getComment()).let(options.getLet()));
     }
 
-    public MixedBulkWriteOperation updateMany(final Bson filter, final Bson update, final UpdateOptions options) {
+    MixedBulkWriteOperation updateMany(final Bson filter, final Bson update, final UpdateOptions options) {
         return bulkWrite(singletonList(new UpdateManyModel<>(filter, update, options)),
                 new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation())
                         .comment(options.getComment()).let(options.getLet()));
     }
 
-    public MixedBulkWriteOperation updateMany(final Bson filter, final List<? extends Bson> update, final UpdateOptions options) {
+    MixedBulkWriteOperation updateMany(final Bson filter, final List<? extends Bson> update, final UpdateOptions options) {
         return bulkWrite(singletonList(new UpdateManyModel<>(filter, update, options)),
                 new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation())
                         .comment(options.getComment()).let(options.getLet()));
     }
 
-    public MixedBulkWriteOperation insertMany(final List<? extends TDocument> documents,
+    MixedBulkWriteOperation insertMany(final List<? extends TDocument> documents,
                                               final InsertManyOptions options) {
         notNull("documents", documents);
         List<InsertRequest> requests = new ArrayList<>(documents.size());
@@ -435,7 +435,7 @@ public final class Operations<TDocument> {
     }
 
     @SuppressWarnings("unchecked")
-    public MixedBulkWriteOperation bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests,
+    MixedBulkWriteOperation bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests,
                                              final BulkWriteOptions options) {
         notNull("requests", requests);
         List<WriteRequest> writeRequests = new ArrayList<>(requests.size());
@@ -505,7 +505,7 @@ public final class Operations<TDocument> {
     }
 
 
-    public DropCollectionOperation dropCollection(
+    DropCollectionOperation dropCollection(
             final DropCollectionOptions dropCollectionOptions,
             final AutoEncryptionSettings autoEncryptionSettings) {
         DropCollectionOperation operation = new DropCollectionOperation(namespace, writeConcern);
@@ -523,14 +523,14 @@ public final class Operations<TDocument> {
     }
 
 
-    public RenameCollectionOperation renameCollection(final MongoNamespace newCollectionNamespace,
+    RenameCollectionOperation renameCollection(final MongoNamespace newCollectionNamespace,
                                                       final RenameCollectionOptions renameCollectionOptions) {
         return new RenameCollectionOperation(namespace, newCollectionNamespace, writeConcern)
                 .dropTarget(renameCollectionOptions.isDropTarget());
     }
 
     @SuppressWarnings("deprecation")
-    public CreateIndexesOperation createIndexes(final List<IndexModel> indexes, final CreateIndexOptions createIndexOptions) {
+    CreateIndexesOperation createIndexes(final List<IndexModel> indexes, final CreateIndexOptions createIndexOptions) {
         notNull("indexes", indexes);
         notNull("createIndexOptions", createIndexOptions);
         List<IndexRequest> indexRequests = new ArrayList<>(indexes.size());
@@ -566,17 +566,17 @@ public final class Operations<TDocument> {
                 .commitQuorum(createIndexOptions.getCommitQuorum());
     }
 
-    public DropIndexOperation dropIndex(final String indexName, final DropIndexOptions dropIndexOptions) {
+    DropIndexOperation dropIndex(final String indexName, final DropIndexOptions dropIndexOptions) {
         return new DropIndexOperation(namespace, indexName, writeConcern)
                 .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
     }
 
-    public DropIndexOperation dropIndex(final Bson keys, final DropIndexOptions dropIndexOptions) {
+    DropIndexOperation dropIndex(final Bson keys, final DropIndexOptions dropIndexOptions) {
         return new DropIndexOperation(namespace, keys.toBsonDocument(BsonDocument.class, codecRegistry), writeConcern)
                 .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
     }
 
-    public <TResult> ListCollectionsOperation<TResult> listCollections(final String databaseName, final Class<TResult> resultClass,
+    <TResult> ListCollectionsOperation<TResult> listCollections(final String databaseName, final Class<TResult> resultClass,
                                                                 final Bson filter, final boolean collectionNamesOnly,
                                                                 final Integer batchSize, final long maxTimeMS, final BsonValue comment) {
         return new ListCollectionsOperation<>(databaseName, codecRegistry.get(resultClass))
@@ -588,7 +588,7 @@ public final class Operations<TDocument> {
                 .comment(comment);
     }
 
-    public <TResult> ListDatabasesOperation<TResult> listDatabases(final Class<TResult> resultClass, final Bson filter,
+    <TResult> ListDatabasesOperation<TResult> listDatabases(final Class<TResult> resultClass, final Bson filter,
                                                             final Boolean nameOnly, final long maxTimeMS,
                                                             final Boolean authorizedDatabasesOnly, final BsonValue comment) {
         return new ListDatabasesOperation<>(codecRegistry.get(resultClass)).maxTime(maxTimeMS, MILLISECONDS)
@@ -599,7 +599,7 @@ public final class Operations<TDocument> {
                 .comment(comment);
     }
 
-    public <TResult> ListIndexesOperation<TResult> listIndexes(final Class<TResult> resultClass, final Integer batchSize,
+    <TResult> ListIndexesOperation<TResult> listIndexes(final Class<TResult> resultClass, final Integer batchSize,
                                                                final long maxTimeMS, final BsonValue comment) {
         return new ListIndexesOperation<>(namespace, codecRegistry.get(resultClass))
                 .retryReads(retryReads)

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -49,7 +49,7 @@ import org.bson.conversions.Bson;
 import java.util.List;
 
 /**
- * This class is NOT part of the public API. It may change at any time without notification.
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public final class SyncOperations<TDocument> {
     private final Operations<TDocument> operations;

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/AggregatePublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/AggregatePublisherImpl.java
@@ -22,7 +22,7 @@ import com.mongodb.client.model.Collation;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.client.model.AggregationLevel;
 import com.mongodb.internal.client.model.FindOptions;
-import com.mongodb.internal.operation.AggregateOperation;
+import com.mongodb.internal.operation.AsyncExplainableReadOperation;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.AggregatePublisher;
@@ -185,7 +185,7 @@ final class AggregatePublisherImpl<T> extends BatchCursorPublisher<T> implements
         }
     }
 
-    private AggregateOperation<T> asAggregateOperation(final int initialBatchSize) {
+    private AsyncExplainableReadOperation<AsyncBatchCursor<T>> asAggregateOperation(final int initialBatchSize) {
         return getOperations()
                 .aggregate(pipeline, getDocumentClass(), maxTimeMS, maxAwaitTimeMS,
                            initialBatchSize, collation, hint, hintString, comment, variables, allowDiskUse, aggregationLevel);

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorPublisher.java
@@ -19,8 +19,8 @@ package com.mongodb.reactivestreams.client.internal;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
 import com.mongodb.internal.async.AsyncBatchCursor;
+import com.mongodb.internal.operation.AsyncOperations;
 import com.mongodb.internal.operation.AsyncReadOperation;
-import com.mongodb.internal.operation.Operations;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ClientSession;
 import org.bson.codecs.configuration.CodecRegistry;
@@ -63,7 +63,7 @@ abstract class BatchCursorPublisher<T> implements Publisher<T> {
         return mongoOperationPublisher;
     }
 
-    Operations<T> getOperations() {
+    AsyncOperations<T> getOperations() {
         return mongoOperationPublisher.getOperations();
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/FindPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/FindPublisherImpl.java
@@ -23,7 +23,6 @@ import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.client.model.FindOptions;
 import com.mongodb.internal.operation.AsyncExplainableReadOperation;
 import com.mongodb.internal.operation.AsyncReadOperation;
-import com.mongodb.internal.operation.FindOperation;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ClientSession;
 import com.mongodb.reactivestreams.client.FindPublisher;
@@ -220,8 +219,7 @@ final class FindPublisherImpl<T> extends BatchCursorPublisher<T> implements Find
 
     @Override
     AsyncExplainableReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
-        FindOperation<T> operation = getOperations().find(filter, getDocumentClass(), findOptions.withBatchSize(initialBatchSize));
-        return operation;
+        return getOperations().find(filter, getDocumentClass(), findOptions.withBatchSize(initialBatchSize));
     }
 
     @Override

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
@@ -58,6 +58,7 @@ import com.mongodb.client.result.InsertOneResult;
 import com.mongodb.client.result.UpdateResult;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.bulk.WriteRequest;
+import com.mongodb.internal.operation.AsyncOperations;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.internal.operation.AsyncWriteOperation;
 import com.mongodb.internal.operation.CommandReadOperation;
@@ -65,7 +66,6 @@ import com.mongodb.internal.operation.CreateCollectionOperation;
 import com.mongodb.internal.operation.CreateViewOperation;
 import com.mongodb.internal.operation.DropDatabaseOperation;
 import com.mongodb.internal.operation.IndexHelper;
-import com.mongodb.internal.operation.Operations;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ClientSession;
 import org.bson.BsonDocument;
@@ -95,7 +95,7 @@ import static org.bson.codecs.configuration.CodecRegistries.withUuidRepresentati
  */
 public final class MongoOperationPublisher<T> {
 
-    private final Operations<T> operations;
+    private final AsyncOperations<T> operations;
     private final UuidRepresentation uuidRepresentation;
     private final AutoEncryptionSettings autoEncryptionSettings;
     private final OperationExecutor executor;
@@ -116,7 +116,7 @@ public final class MongoOperationPublisher<T> {
             final boolean retryWrites, final boolean retryReads, final UuidRepresentation uuidRepresentation,
             @Nullable final AutoEncryptionSettings autoEncryptionSettings,
             final OperationExecutor executor) {
-        this.operations = new Operations<>(namespace, notNull("documentClass", documentClass),
+        this.operations = new AsyncOperations<>(namespace, notNull("documentClass", documentClass),
                                            notNull("readPreference", readPreference), notNull("codecRegistry", codecRegistry),
                                            notNull("readConcern", readConcern), notNull("writeConcern", writeConcern),
                                            retryWrites, retryReads);
@@ -157,7 +157,7 @@ public final class MongoOperationPublisher<T> {
         return operations.getDocumentClass();
     }
 
-    public Operations<T> getOperations() {
+    public AsyncOperations<T> getOperations() {
         return operations;
     }
 

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/TestHelper.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/TestHelper.java
@@ -28,7 +28,6 @@ import com.mongodb.internal.bulk.WriteRequest;
 import com.mongodb.internal.client.model.FindOptions;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.internal.operation.AsyncWriteOperation;
-import com.mongodb.internal.operation.Operations;
 import com.mongodb.lang.NonNull;
 import com.mongodb.lang.Nullable;
 import org.bson.Document;
@@ -170,8 +169,6 @@ public class TestHelper {
     private static Object checkValueTypes(final Object instance) {
         Object actual = instance instanceof Optional ? ((Optional<Object>) instance).orElse(instance) : instance;
         if (actual instanceof AsyncReadOperation || actual instanceof AsyncWriteOperation) {
-            return getClassPrivateFieldValues(actual);
-        } else if (actual instanceof Operations) {
             return getClassPrivateFieldValues(actual);
         } else if (actual.getClass().getSimpleName().equals("ChangeStreamDocumentCodec")) {
             return getClassGetterValues(actual);


### PR DESCRIPTION
JAVA-4795

One more change to clean up use of internal `operation` package

The benefit is that, like with `SyncOperation`, `AsyncOperations` doesn't expose the concrete class of any operation, and just deals with the interfaces like `AsyncReadOperation` and `AsyncWriteOperation`.

This gets us closer to a state where we can make all concrete Operation classes package private.  The main thing stopping us from doing it now is that driver-legacy was never refactored to use SyncOperations and still constructs each operation directly.