### PR TITLE
[JAVA-4816] perf: improving performance of ObjectId parseHexString()

### DIFF
--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -423,12 +423,12 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
         for (int i = 0; i < b.length; i++) {
             char c1 = s.charAt(i * 2);
             char c2 = s.charAt(i * 2 + 1);
-            b[i] = hexCharToByte(c1) * 16 + hexCharToByte(c2)
+            b[i] = (byte) ((hexCharToInt(c1) << 4) + hexCharToInt(c2));
         }
         return b;
     }
 
-    private static byte hexCharToByte(char c) {
+    private static int hexCharToInt(final char c) {
         if (c >= '0' && c <= '9') {
             return c - 48;
         } else if (c >= 'a' && c <= 'f') {

--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -420,12 +420,11 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
         }
 
         byte[] b = new byte[OBJECT_ID_LENGTH];
-        int i = 0;
-        while (i < OBJECT_ID_LENGTH) {
-            char c1 = s.charAt(i);
-            char c2 = s.charAt(i + 1);
+        for (int i = 0; i < b.length; i++) {
+            int pos = i << 1;
+            char c1 = s.charAt(pos);
+            char c2 = s.charAt(pos + 1);
             b[i] = (byte) ((hexCharToInt(c1) << 4) + hexCharToInt(c2));
-            i += 2;
         }
         return b;
     }

--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -421,9 +421,22 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
 
         byte[] b = new byte[OBJECT_ID_LENGTH];
         for (int i = 0; i < b.length; i++) {
-            b[i] = (byte) Integer.parseInt(s.substring(i * 2, i * 2 + 2), 16);
+            char c1 = s.charAt(i * 2);
+            char c2 = s.charAt(i * 2 + 1);
+            b[i] = hexCharToByte(c1) * 16 + hexCharToByte(c2)
         }
         return b;
+    }
+
+    private static byte hexCharToByte(char c) {
+        if (c >= '0' && c <= '9') {
+            return c - 48;
+        } else if (c >= 'a' && c <= 'f') {
+            return c - 87;
+        } else if (c >= 'A' && c <= 'F') {
+            return c - 55;
+        }
+        throw new IllegalArgumentException("invalid hexadecimal character: [" + c + "]");
     }
 
     private static int dateToTimestampSeconds(final Date time) {

--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -415,9 +415,8 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
     }
 
     private static byte[] parseHexString(final String s) {
-        if (!isValid(s)) {
-            throw new IllegalArgumentException("invalid hexadecimal representation of an ObjectId: [" + s + "]");
-        }
+        notNull("hexString", s);
+        isTrueArgument("hexString has 24 characters", s.length() == 24);
 
         byte[] b = new byte[OBJECT_ID_LENGTH];
         for (int i = 0; i < b.length; i++) {

--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -420,10 +420,12 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
         }
 
         byte[] b = new byte[OBJECT_ID_LENGTH];
-        for (int i = 0; i < b.length; i++) {
-            char c1 = s.charAt(i * 2);
-            char c2 = s.charAt(i * 2 + 1);
+        int i = 0;
+        while (i < OBJECT_ID_LENGTH) {
+            char c1 = s.charAt(i);
+            char c2 = s.charAt(i + 1);
             b[i] = (byte) ((hexCharToInt(c1) << 4) + hexCharToInt(c2));
+            i += 2;
         }
         return b;
     }

--- a/bson/src/test/unit/org/bson/types/ObjectIdTest.java
+++ b/bson/src/test/unit/org/bson/types/ObjectIdTest.java
@@ -27,10 +27,12 @@ import java.nio.ByteBuffer;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Random;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -142,6 +144,10 @@ public class ObjectIdTest {
     public void testHexStringConstructor() {
         ObjectId id = new ObjectId();
         assertEquals(id, new ObjectId(id.toHexString()));
+        assertEquals(id, new ObjectId(id.toHexString().toUpperCase(Locale.US)));
+        assertThrows(IllegalArgumentException.class, () -> new ObjectId((String) null));
+        assertThrows(IllegalArgumentException.class, () -> new ObjectId(id.toHexString().substring(0, 23)));
+        assertThrows(IllegalArgumentException.class, () -> new ObjectId(id.toHexString().substring(0, 23) + '%'));
     }
 
     @Test


### PR DESCRIPTION
JIRA Ticket: https://jira.mongodb.org/browse/JAVA-4816

The current implementation of `ObjectId` `parseHexString` is somewhat slow, because it makes a total of 12 calls to `Integer.parseInt`, which is not the fastest to begin with. This imposes some overhead to all `ObjectId(string)` calls, which can really add up at scale, for example when deserializing a large amount of ObjectId data via Jackson.

Replacing this implementation with a hand-rolled version which converts each part of the hex string to a byte. This in my rough testing is about 5x faster than the current implementation of `parseHexString`.

Tests (on my M1 MacBook Pro):

```
    public static void main(String[] args) {
        long startTime = System.currentTimeMillis();
        for (int i = 10000000; i < 100000000; i++) {
            new ObjectId("1234567890abcdef" + i);
        }
        long endTime = System.currentTimeMillis();

        System.out.println("Time elapsed: " + (endTime - startTime));
    }
```

On master:

```
Time elapsed: 19460
```

On branch:

```
Time elapsed: 3617
```
