### PR TITLE
Update MongoQueryException to extend MongoCommandException

### DIFF
--- a/driver-core/src/main/com/mongodb/MongoCommandException.java
+++ b/driver-core/src/main/com/mongodb/MongoCommandException.java
@@ -83,9 +83,10 @@ public class MongoCommandException extends MongoServerException {
     }
 
     /**
-     * For internal use only.
+     * Gets the full server response document describing the error.
      *
      * @return the full response to the command failure.
+     * @since 4.8
      */
     public BsonDocument getResponse() {
         return response;

--- a/driver-core/src/main/com/mongodb/MongoCursorNotFoundException.java
+++ b/driver-core/src/main/com/mongodb/MongoCursorNotFoundException.java
@@ -16,6 +16,8 @@
 
 package com.mongodb;
 
+import org.bson.BsonDocument;
+
 /**
  * Subclass of {@link MongoException} representing a cursor-not-found exception.
  *
@@ -27,18 +29,31 @@ public class MongoCursorNotFoundException extends MongoQueryException {
     private static final long serialVersionUID = -4415279469780082174L;
 
     private final long cursorId;
-    private final ServerAddress serverAddress;
+
+    /**
+     * Construct an instance.
+     *
+     * @param cursorId      cursor identifier
+     * @param response      the server response document
+     * @param serverAddress the server address
+     * @since 4.8
+     */
+    public MongoCursorNotFoundException(final long cursorId, final BsonDocument response, final ServerAddress serverAddress) {
+        super(response, serverAddress);
+        this.cursorId = cursorId;
+    }
 
     /**
      * Construct a new instance.
      *
      * @param cursorId      cursor identifier
      * @param serverAddress server address
+     * @deprecated Prefer {@link #MongoCursorNotFoundException(long, BsonDocument, ServerAddress)}
      */
+    @Deprecated
     public MongoCursorNotFoundException(final long cursorId, final ServerAddress serverAddress) {
         super(serverAddress, -5, "Cursor " + cursorId + " not found on server " + serverAddress);
         this.cursorId = cursorId;
-        this.serverAddress = serverAddress;
     }
 
     /**
@@ -48,14 +63,5 @@ public class MongoCursorNotFoundException extends MongoQueryException {
      */
     public long getCursorId() {
         return cursorId;
-    }
-
-    /**
-     * The server address where the cursor is.
-     *
-     * @return the ServerAddress representing the server the cursor was on.
-     */
-    public ServerAddress getServerAddress() {
-        return serverAddress;
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/ProtocolHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ProtocolHelper.java
@@ -211,7 +211,7 @@ public final class ProtocolHelper {
         if (specialException != null) {
             return specialException;
         }
-        return new MongoQueryException(serverAddress, getErrorCode(errorDocument), getErrorMessage(errorDocument, "$err"));
+        return new MongoQueryException(errorDocument, serverAddress);
     }
 
     static MessageSettings getMessageSettings(final ConnectionDescription connectionDescription) {

--- a/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
@@ -333,7 +333,7 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
                             getCommandCreator(binding.getSessionContext()), CommandResultDocumentCodec.create(decoder, FIRST_BATCH),
                             transformer(), connection);
                 } catch (MongoCommandException e) {
-                    throw new MongoQueryException(e);
+                    throw new MongoQueryException(e.getResponse(), e.getServerAddress());
                 }
             });
         });
@@ -370,9 +370,8 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
                 if (t != null) {
                     if (t instanceof MongoCommandException) {
                         MongoCommandException commandException = (MongoCommandException) t;
-                        callback.onResult(result, new MongoQueryException(commandException.getServerAddress(),
-                                                                          commandException.getErrorCode(),
-                                commandException.getErrorMessage()));
+                        callback.onResult(result,
+                                new MongoQueryException(commandException.getResponse(), commandException.getServerAddress()));
                     } else {
                         callback.onResult(result, t);
                     }

--- a/driver-core/src/main/com/mongodb/internal/operation/QueryHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/QueryHelper.java
@@ -24,9 +24,9 @@ import com.mongodb.ServerCursor;
 final class QueryHelper {
     static MongoQueryException translateCommandException(final MongoCommandException commandException, final ServerCursor cursor) {
         if (commandException.getErrorCode() == 43) {
-            return new MongoCursorNotFoundException(cursor.getId(), cursor.getAddress());
+            return new MongoCursorNotFoundException(cursor.getId(), commandException.getResponse(), cursor.getAddress());
         } else {
-            return new MongoQueryException(commandException);
+            return new MongoQueryException(commandException.getResponse(), commandException.getServerAddress());
         }
     }
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/QueryOperationHelper.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/QueryOperationHelper.groovy
@@ -85,9 +85,9 @@ class QueryOperationHelper {
                         new BsonDocumentCodec(), new NoOpSessionContext(), getServerApi(), IgnorableRequestContext.INSTANCE)
             } catch (MongoCommandException e) {
                 if (e.getErrorCode() == 43) {
-                    throw new MongoCursorNotFoundException(serverCursor.getId(), serverCursor.getAddress())
+                    throw new MongoCursorNotFoundException(serverCursor.getId(), e.getResponse(), serverCursor.getAddress())
                 } else {
-                    throw new MongoQueryException(e)
+                    throw new MongoQueryException(e.getResponse(), e.getServerAddress());
                 }
             }
         }

--- a/driver-core/src/test/resources/unified-test-format/collection-management/modifyCollection-errorResponse.json
+++ b/driver-core/src/test/resources/unified-test-format/collection-management/modifyCollection-errorResponse.json
@@ -1,0 +1,118 @@
+{
+  "description": "modifyCollection-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "collMod-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "collMod-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 1
+        },
+        {
+          "_id": 2,
+          "x": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "modifyCollection prepareUnique violations are accessible",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.2"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "keys": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "modifyCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "index": {
+              "keyPattern": {
+                "x": 1
+              },
+              "prepareUnique": true
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 1
+            }
+          },
+          "expectError": {
+            "errorCode": 11000
+          }
+        },
+        {
+          "name": "modifyCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "index": {
+              "keyPattern": {
+                "x": 1
+              },
+              "unique": true
+            }
+          },
+          "expectError": {
+            "isClientError": false,
+            "errorCode": 359,
+            "errorResponse": {
+              "violations": [
+                {
+                  "ids": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/aggregate-merge-errorResponse.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/aggregate-merge-errorResponse.json
@@ -1,0 +1,90 @@
+{
+  "description": "aggregate-merge-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 1
+        },
+        {
+          "_id": 2,
+          "x": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "aggregate $merge DuplicateKey error is accessible",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.1",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "database0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$documents": [
+                  {
+                    "_id": 2,
+                    "x": 1
+                  }
+                ]
+              },
+              {
+                "$merge": {
+                  "into": "test",
+                  "whenMatched": "fail"
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "errorCode": 11000,
+            "errorResponse": {
+              "keyPattern": {
+                "_id": 1
+              },
+              "keyValue": {
+                "_id": 2
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-errorResponse.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/bulkWrite-errorResponse.json
@@ -1,0 +1,88 @@
+{
+  "description": "bulkWrite-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "bulkWrite operations support errorResponse assertions",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0.0",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.2.0",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 8
+              }
+            }
+          }
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "errorCode": 8,
+            "errorResponse": {
+              "code": 8
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/deleteOne-errorResponse.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/deleteOne-errorResponse.json
@@ -1,0 +1,82 @@
+{
+  "description": "deleteOne-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "delete operations support errorResponse assertions",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0.0",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.2.0",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "delete"
+                ],
+                "errorCode": 8
+              }
+            }
+          }
+        },
+        {
+          "name": "deleteOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectError": {
+            "errorCode": 8,
+            "errorResponse": {
+              "code": 8
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/findOneAndUpdate-errorResponse.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/findOneAndUpdate-errorResponse.json
@@ -1,0 +1,132 @@
+{
+  "description": "findOneAndUpdate-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": "foo"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "findOneAndUpdate DuplicateKey error is accessible",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "keys": {
+              "x": 1
+            },
+            "unique": true
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "update": {
+              "$set": {
+                "x": "foo"
+              }
+            },
+            "upsert": true
+          },
+          "expectError": {
+            "errorCode": 11000,
+            "errorResponse": {
+              "keyPattern": {
+                "x": 1
+              },
+              "keyValue": {
+                "x": "foo"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "findOneAndUpdate document validation errInfo is accessible",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "modifyCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "validator": {
+              "x": {
+                "$type": "string"
+              }
+            }
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          },
+          "expectError": {
+            "errorCode": 121,
+            "errorResponse": {
+              "errInfo": {
+                "failingDocumentId": 1,
+                "details": {
+                  "$$type": "object"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/insertOne-errorResponse.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/insertOne-errorResponse.json
@@ -1,0 +1,82 @@
+{
+  "description": "insertOne-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "insert operations support errorResponse assertions",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0.0",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.2.0",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 8
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          },
+          "expectError": {
+            "errorCode": 8,
+            "errorResponse": {
+              "code": 8
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/crud/updateOne-errorResponse.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/updateOne-errorResponse.json
@@ -1,0 +1,87 @@
+{
+  "description": "updateOne-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "update operations support errorResponse assertions",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0.0",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.2.0",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "update"
+                ],
+                "errorCode": 8
+              }
+            }
+          }
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          },
+          "expectError": {
+            "errorCode": 8,
+            "errorResponse": {
+              "code": 8
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/valid-pass/expectedError-errorResponse.json
+++ b/driver-core/src/test/resources/unified-test-format/valid-pass/expectedError-errorResponse.json
@@ -1,0 +1,70 @@
+{
+  "description": "expectedError-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Unsupported command",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "unsupportedCommand",
+            "command": {
+              "unsupportedCommand": 1
+            }
+          },
+          "expectError": {
+            "errorResponse": {
+              "errmsg": {
+                "$$type": "string"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Unsupported query operator",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "$unsupportedQueryOperator": 1
+            }
+          },
+          "expectError": {
+            "errorResponse": {
+              "errmsg": {
+                "$$type": "string"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/ChangeStreamBatchCursorHelperTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/ChangeStreamBatchCursorHelperTest.java
@@ -55,7 +55,8 @@ public class ChangeStreamBatchCursorHelperTest {
 
                 () -> assertTrue(isResumableError(new MongoNotPrimaryException(new BsonDocument(), new ServerAddress()),
                         FOUR_DOT_FOUR_WIRE_VERSION)),
-                () -> assertTrue(isResumableError(new MongoCursorNotFoundException(1L, new ServerAddress()), FOUR_DOT_FOUR_WIRE_VERSION)),
+                () -> assertTrue(isResumableError(new MongoCursorNotFoundException(1L, new BsonDocument("ok", new BsonInt32(0))
+                        .append("code", new BsonInt32(43)), new ServerAddress()), FOUR_DOT_FOUR_WIRE_VERSION)),
                 () -> assertTrue(isResumableError(new MongoSocketException("", new ServerAddress()), FOUR_DOT_FOUR_WIRE_VERSION)),
                 () -> assertTrue(isResumableError(new MongoSocketReadTimeoutException("", new ServerAddress(), new IOException()),
                         FOUR_DOT_FOUR_WIRE_VERSION)),

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -105,7 +105,7 @@ public abstract class UnifiedTest {
     private class UnifiedTestContext {
         private final AssertionContext context = new AssertionContext();
         private final ValueMatcher valueMatcher = new ValueMatcher(entities, context);
-        private final ErrorMatcher errorMatcher = new ErrorMatcher(context);
+        private final ErrorMatcher errorMatcher = new ErrorMatcher(context, valueMatcher);
         private final EventMatcher eventMatcher = new EventMatcher(valueMatcher, context);
 
         AssertionContext getAssertionContext() {
@@ -379,6 +379,8 @@ public abstract class UnifiedTest {
                     return crudHelper.executeDropCollection(operation);
                 case "createCollection":
                     return crudHelper.executeCreateCollection(operation);
+                case "modifyCollection":
+                    return crudHelper.executeModifyCollection(operation);
                 case "rename":
                     return crudHelper.executeRenameCollection(operation);
                 case "createIndex":


### PR DESCRIPTION
The MongoQueryException class currently extends MongoServerException,
the reason being that prior to MongoDB 3.2 the find helper was implemented
using the OP_QUERY wire protocol message, which is not a command.  But now
that 3.6 is the minimum required server version, the find helper is always
implemented via the find command.  So MongoQueryException can now extend
MongoCommandException and include the full command response document.

JAVA-4676