### PR TITLE
Implement map expressions

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
@@ -73,6 +73,8 @@ public interface ArrayExpression<T extends Expression> extends Expression {
 
     <R extends Expression> ArrayExpression<R> union(Function<? super T, ? extends ArrayExpression<? extends R>> mapper);
 
+    <R extends Expression> MapExpression<R> buildMap(Function<T, EntryExpression<R>> o);
+
     /**
      * user asserts that i is in bounds for the array
      *

--- a/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
@@ -73,7 +73,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
 
     <R extends Expression> ArrayExpression<R> union(Function<? super T, ? extends ArrayExpression<? extends R>> mapper);
 
-    <R extends Expression> MapExpression<R> asMap(Function<T, EntryExpression<R>> o);
+    <R extends Expression> MapExpression<R> asMap(Function<T, EntryExpression<R>> mapper);
 
     /**
      * user asserts that i is in bounds for the array

--- a/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
@@ -73,7 +73,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
 
     <R extends Expression> ArrayExpression<R> union(Function<? super T, ? extends ArrayExpression<? extends R>> mapper);
 
-    <R extends Expression> MapExpression<R> buildMap(Function<T, EntryExpression<R>> o);
+    <R extends Expression> MapExpression<R> asMap(Function<T, EntryExpression<R>> o);
 
     /**
      * user asserts that i is in bounds for the array

--- a/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
@@ -73,7 +73,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
 
     <R extends Expression> ArrayExpression<R> union(Function<? super T, ? extends ArrayExpression<? extends R>> mapper);
 
-    <R extends Expression> MapExpression<R> asMap(Function<T, EntryExpression<R>> mapper);
+    <R extends Expression> MapExpression<R> asMap(Function<? super T, ? extends EntryExpression<? extends R>> mapper);
 
     /**
      * user asserts that i is in bounds for the array

--- a/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
@@ -98,4 +98,6 @@ public interface DocumentExpression extends Expression {
     <T extends Expression> ArrayExpression<T> getArray(String fieldName, ArrayExpression<? extends T> other);
 
     DocumentExpression merge(DocumentExpression other);
+
+    MapExpression<Expression> asMap();
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
@@ -87,7 +87,7 @@ public interface DocumentExpression extends Expression {
     }
 
     <T extends Expression> MapExpression<T> getMap(String fieldName);
-    <T extends Expression> MapExpression<T> getMap(String fieldName, MapExpression<T> other);
+    <T extends Expression> MapExpression<T> getMap(String fieldName, MapExpression<? extends T> other);
 
     default <T extends Expression> MapExpression<T> getMap(final String fieldName, final Bson other) {
         return getMap(fieldName, ofMap(other));

--- a/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
@@ -21,6 +21,7 @@ import org.bson.conversions.Bson;
 import java.time.Instant;
 
 import static com.mongodb.client.model.expressions.Expressions.of;
+import static com.mongodb.client.model.expressions.Expressions.ofMap;
 
 /**
  * Expresses a document value. A document is an ordered set of fields, where the
@@ -83,6 +84,13 @@ public interface DocumentExpression extends Expression {
 
     default DocumentExpression getDocument(final String fieldName, final Bson other) {
         return getDocument(fieldName, of(other));
+    }
+
+    <T extends Expression> MapExpression<T> getMap(String fieldName);
+    <T extends Expression> MapExpression<T> getMap(String fieldName, MapExpression<T> other);
+
+    default <T extends Expression> MapExpression<T> getMap(final String fieldName, final Bson other) {
+        return getMap(fieldName, ofMap(other));
     }
 
     <T extends Expression> ArrayExpression<T> getArray(String fieldName);

--- a/driver-core/src/main/com/mongodb/client/model/expressions/EntryExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/EntryExpression.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.expressions;
+
+import static com.mongodb.client.model.expressions.Expressions.of;
+
+public interface EntryExpression<T extends Expression> extends Expression {
+    StringExpression getKey();
+
+    T getValue();
+
+    EntryExpression<T> setValue(T val);
+
+    EntryExpression<T> setKey(StringExpression key);
+    default EntryExpression<T> setKey(final String key) {
+        return setKey(of(key));
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
@@ -111,7 +111,7 @@ public interface Expression {
     <T extends Expression> ArrayExpression<T> isArrayOr(ArrayExpression<? extends T> other);
     <T extends DocumentExpression> T isDocumentOr(T other);
 
-    <T extends Expression> MapExpression<T> isMapOr(MapExpression<T> other);
+    <T extends Expression> MapExpression<T> isMapOr(MapExpression<? extends T> other);
 
     StringExpression asString();
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
@@ -111,5 +111,7 @@ public interface Expression {
     <T extends Expression> ArrayExpression<T> isArrayOr(ArrayExpression<? extends T> other);
     <T extends DocumentExpression> T isDocumentOr(T other);
 
+    <T extends Expression> MapExpression<T> isMapOr(MapExpression<T> other);
+
     StringExpression asString();
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expressions.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expressions.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.mongodb.client.model.expressions.MqlExpression.AstPlaceholder;
+import static com.mongodb.client.model.expressions.MqlExpression.extractBsonValue;
 
 /**
  * Convenience methods related to {@link Expression}.
@@ -182,6 +183,35 @@ public final class Expressions {
             }
             return new AstPlaceholder(new BsonArray(list));
         });
+    }
+
+    public static <T extends Expression> EntryExpression<T> ofEntry(final String k, final T v) {
+        Assertions.notNull("k", k);
+        Assertions.notNull("v", v);
+        return new MqlExpression<>((cr) -> {
+            BsonDocument document = new BsonDocument();
+            document.put("k", new BsonString(k));
+            document.put("v", extractBsonValue(cr, v));
+            return new AstPlaceholder(new BsonDocument("$literal",
+                    document.toBsonDocument(BsonDocument.class, cr)));
+        });
+    }
+
+    public static <T extends Expression> MapExpression<T> ofEmptyMap() {
+        return new MqlExpression<>((cr) -> new AstPlaceholder(new BsonDocument("$literal", new BsonDocument())));
+    }
+
+    /**
+     * user asserts type of values is T
+     *
+     * @param map
+     * @return
+     * @param <T>
+     */
+    public static <T extends Expression> MapExpression<T> ofMap(final Bson map) {
+        Assertions.notNull("map", map);
+        return new MqlExpression<>((cr) -> new AstPlaceholder(new BsonDocument("$literal",
+                map.toBsonDocument(BsonDocument.class, cr))));
     }
 
     public static DocumentExpression of(final Bson document) {

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expressions.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expressions.java
@@ -185,20 +185,19 @@ public final class Expressions {
         });
     }
 
-    public static <T extends Expression> EntryExpression<T> ofEntry(final String k, final T v) {
+    public static <T extends Expression> EntryExpression<T> ofEntry(final StringExpression k, final T v) {
         Assertions.notNull("k", k);
         Assertions.notNull("v", v);
         return new MqlExpression<>((cr) -> {
             BsonDocument document = new BsonDocument();
-            document.put("k", new BsonString(k));
+            document.put("k", extractBsonValue(cr, k));
             document.put("v", extractBsonValue(cr, v));
-            return new AstPlaceholder(new BsonDocument("$literal",
-                    document.toBsonDocument(BsonDocument.class, cr)));
+            return new AstPlaceholder(document);
         });
     }
 
-    public static <T extends Expression> MapExpression<T> ofEmptyMap() {
-        return new MqlExpression<>((cr) -> new AstPlaceholder(new BsonDocument("$literal", new BsonDocument())));
+    public static <T extends Expression> MapExpression<T> ofMap() {
+        return ofMap(new BsonDocument());
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
@@ -28,8 +28,8 @@ public interface MapExpression<T extends Expression> extends Expression {
 
     T get(StringExpression key, T orElse);
 
-    default T get(final String key, final T orElse) {
-        return get(of(key), orElse);
+    default T get(final String key, final T other) {
+        return get(of(key), other);
     }
 
     MapExpression<T> set(StringExpression key, T value);
@@ -44,7 +44,7 @@ public interface MapExpression<T extends Expression> extends Expression {
         return unset(of(key));
     }
 
-    MapExpression<T> merge(MapExpression<T> map);
+    MapExpression<T> merge(MapExpression<? extends T> map);
 
     ArrayExpression<EntryExpression<T>> entrySet();
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.expressions;
+
+import static com.mongodb.client.model.expressions.Expressions.of;
+
+public interface MapExpression<T extends Expression> extends Expression {
+
+    T get(StringExpression key);
+
+    default T get(final String key) {
+        return get(of(key));
+    }
+
+    T get(StringExpression key, T orElse);
+
+    default T get(final String key, final T orElse) {
+        return get(of(key), orElse);
+    }
+
+    MapExpression<T> set(StringExpression key, T value);
+
+    default MapExpression<T> set(final String key, final T value) {
+        return set(of(key), value);
+    }
+
+    MapExpression<T> unset(StringExpression key);
+
+    default MapExpression<T> unset(final String key) {
+        return unset(of(key));
+    }
+
+    MapExpression<T> mergee(MapExpression<T> map);
+
+    ArrayExpression<EntryExpression<T>> entrySet();
+}

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
@@ -20,6 +20,12 @@ import static com.mongodb.client.model.expressions.Expressions.of;
 
 public interface MapExpression<T extends Expression> extends Expression {
 
+    BooleanExpression has(StringExpression key);
+
+    default BooleanExpression has(String key) {
+        return has(of(key));
+    }
+
     // TODO-END doc "user asserts"
     T get(StringExpression key);
 

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
@@ -20,13 +20,15 @@ import static com.mongodb.client.model.expressions.Expressions.of;
 
 public interface MapExpression<T extends Expression> extends Expression {
 
+    // TODO-END doc "user asserts"
     T get(StringExpression key);
 
+    // TODO-END doc "user asserts"
     default T get(final String key) {
         return get(of(key));
     }
 
-    T get(StringExpression key, T orElse);
+    T get(StringExpression key, T other);
 
     default T get(final String key, final T other) {
         return get(of(key), other);
@@ -47,4 +49,6 @@ public interface MapExpression<T extends Expression> extends Expression {
     MapExpression<T> merge(MapExpression<? extends T> map);
 
     ArrayExpression<EntryExpression<T>> entrySet();
+
+    <R extends DocumentExpression> R asDocument();
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
@@ -44,7 +44,7 @@ public interface MapExpression<T extends Expression> extends Expression {
         return unset(of(key));
     }
 
-    MapExpression<T> mergee(MapExpression<T> map);
+    MapExpression<T> merge(MapExpression<T> map);
 
     ArrayExpression<EntryExpression<T>> entrySet();
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
@@ -777,6 +777,17 @@ final class MqlExpression<T extends Expression>
         return new MqlExpression<>(ast("$substrBytes", start, length));
     }
 
+    @Override
+    public BooleanExpression has(StringExpression key) {
+        return get(key).ne(ofRem());
+    }
+
+    static <R extends Expression> R ofRem() {
+        // $$REMOVE is intentionally not exposed to users
+        return new MqlExpression<>((cr) -> new MqlExpression.AstPlaceholder(new BsonString("$$REMOVE")))
+                .assertImplementsAllExpressions();
+    }
+
     /** @see MapExpression
      * @see EntryExpression */
 

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
@@ -778,7 +778,7 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public BooleanExpression has(StringExpression key) {
+    public BooleanExpression has(final StringExpression key) {
         return get(key).ne(ofRem());
     }
 
@@ -833,7 +833,7 @@ final class MqlExpression<T extends Expression>
     public <R extends Expression> MapExpression<R> asMap(
             final Function<? super T, ? extends EntryExpression<? extends R>> mapper) {
         @SuppressWarnings("unchecked")
-        MqlExpression<EntryExpression<? extends R>> array = (MqlExpression<EntryExpression<? extends R>>)this.map(mapper);
+        MqlExpression<EntryExpression<? extends R>> array = (MqlExpression<EntryExpression<? extends R>>) this.map(mapper);
         return newMqlExpression(array.astWrapped("$arrayToObject"));
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
@@ -795,7 +795,7 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public MapExpression<T> mergee(final MapExpression<T> map) {
+    public MapExpression<T> merge(final MapExpression<T> map) {
         return new MqlExpression<>(ast("$mergeObjects", map));
     }
 
@@ -805,7 +805,7 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public <R extends Expression> MapExpression<R> buildMap(final Function<T, EntryExpression<R>> o) {
+    public <R extends Expression> MapExpression<R> asMap(final Function<T, EntryExpression<R>> o) {
         return newMqlExpression(astWrapped("$arrayToObject"));
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
@@ -389,7 +389,6 @@ final class MqlExpression<T extends Expression>
         return this.isDocumentOrMap().cond(this.assertImplementsAllExpressions(), other);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <R extends Expression> MapExpression<R> isMapOr(final MapExpression<? extends R> other) {
         MqlExpression<?> isMap = (MqlExpression<?>) this.isDocumentOrMap();

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
@@ -238,6 +238,16 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
+    public <R extends Expression> MapExpression<R> getMap(final String field) {
+        return new MqlExpression<>(getFieldInternal(field));
+    }
+
+    @Override
+    public <R extends Expression> MapExpression<R> getMap(final String field, final MapExpression<R> other) {
+        return getMap(field).isMapOr(other);
+    }
+
+    @Override
     public DocumentExpression getDocument(final String fieldName, final DocumentExpression other) {
         return getDocument(fieldName).isDocumentOr(other);
     }
@@ -379,6 +389,15 @@ final class MqlExpression<T extends Expression>
     @Override
     public <R extends DocumentExpression> R isDocumentOr(final R other) {
         return this.isDocument().cond(this.assertImplementsAllExpressions(), other);
+    }
+
+    public BooleanExpression isMap() {
+        return new MqlExpression<>(ast("$type")).eq(of("object"));
+    }
+
+    @Override
+    public <R extends Expression> MapExpression<R> isMapOr(final MapExpression<R> other) {
+        return this.isMap().cond(this.assertImplementsAllExpressions(), other);
     }
 
     @Override

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/AbstractExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/AbstractExpressionsFunctionalTest.java
@@ -126,11 +126,5 @@ public abstract class AbstractExpressionsFunctionalTest extends OperationTest {
         }
     }
 
-
-    static <R extends Expression> R ofRem() {
-        // $$REMOVE is intentionally not exposed to users
-        return new MqlExpression<>((cr) -> new MqlExpression.AstPlaceholder(new BsonString("$$REMOVE")))
-                .assertImplementsAllExpressions();
-    }
 }
 

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/ComparisonExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/ComparisonExpressionsFunctionalTest.java
@@ -40,7 +40,7 @@ class ComparisonExpressionsFunctionalTest extends AbstractExpressionsFunctionalT
 
     // https://www.mongodb.com/docs/manual/reference/bson-type-comparison-order/#std-label-bson-types-comparison-order
     private final List<Expression> sampleValues = Arrays.asList(
-            ofRem(),
+            MqlExpression.ofRem(),
             ofNull(),
             of(0),
             of(1),

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/DocumentExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/DocumentExpressionsFunctionalTest.java
@@ -28,7 +28,9 @@ import java.util.Arrays;
 import static com.mongodb.client.model.expressions.Expressions.of;
 import static com.mongodb.client.model.expressions.Expressions.ofIntegerArray;
 import static com.mongodb.client.model.expressions.Expressions.ofMap;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("ConstantConditions")
 class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
@@ -253,5 +255,11 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
         assertExpression(
                 BsonDocument.parse("{a: 1}"),
                 ofDoc("{a: null}").merge(ofDoc("{a: 1}")));
+    }
+
+    @Test
+    public void asMapTest() {
+        DocumentExpression d = ofDoc("{a: 1}");
+        assertSame(d, d.asMap());
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/DocumentExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/DocumentExpressionsFunctionalTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 
 import static com.mongodb.client.model.expressions.Expressions.of;
 import static com.mongodb.client.model.expressions.Expressions.ofIntegerArray;
+import static com.mongodb.client.model.expressions.Expressions.ofMap;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("ConstantConditions")
@@ -120,6 +121,8 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
         // no convenience for arrays
         assertExpression(Document.parse("{b: 2}"), ofDoc("{a: {b: 2}}")
                 .getDocument("a", Document.parse("{z: 99}")));
+        assertExpression(Document.parse("{b: 2}"), ofDoc("{a: {b: 2}}")
+                .getMap("a", Document.parse("{z: 99}")));
 
         // normal
         assertExpression(true, ofDoc("{a: true}").getBoolean("a", of(false)));
@@ -131,6 +134,8 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
         assertExpression(Arrays.asList(3, 2), ofDoc("{a: [3, 2]}").getArray("a", ofIntegerArray(99, 88)));
         assertExpression(Document.parse("{b: 2}"), ofDoc("{a: {b: 2}}")
                 .getDocument("a", of(Document.parse("{z: 99}"))));
+        assertExpression(Document.parse("{b: 2}"), ofDoc("{a: {b: 2}}")
+                .getMap("a", ofMap(Document.parse("{z: 99}"))));
 
         // right branch (missing field)
         assertExpression(false, ofDoc("{}").getBoolean("a", false));
@@ -145,6 +150,8 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
         assertExpression(Arrays.asList(99, 88), ofDoc("{}").getArray("a", ofIntegerArray(99, 88)));
         assertExpression(Document.parse("{z: 99}"), ofDoc("{}")
                 .getDocument("a", Document.parse("{z: 99}")));
+        assertExpression(Document.parse("{z: 99}"), ofDoc("{}")
+                .getMap("a", Document.parse("{z: 99}")));
 
         // int vs num
         assertExpression(99, ofDoc("{a: 1.1}").getInteger("a", of(99)));

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/DocumentExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/DocumentExpressionsFunctionalTest.java
@@ -30,7 +30,6 @@ import static com.mongodb.client.model.expressions.Expressions.ofIntegerArray;
 import static com.mongodb.client.model.expressions.Expressions.ofMap;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("ConstantConditions")
 class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
@@ -27,6 +27,7 @@ import static com.mongodb.client.model.expressions.Expressions.ofArray;
 import static com.mongodb.client.model.expressions.Expressions.ofEntry;
 import static com.mongodb.client.model.expressions.Expressions.ofMap;
 import static com.mongodb.client.model.expressions.Expressions.ofStringArray;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
@@ -173,4 +174,9 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
                         + "{'$literal': {'keyA': 9, 'keyC': 3}}]}");
     }
 
+    @Test
+    public void asDocumentTest() {
+        MapExpression<IntegerExpression> d = ofMap(BsonDocument.parse("{a: 1}"));
+        assertSame(d, d.asDocument());
+    }
 }

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
@@ -89,7 +89,7 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/arrayToObject/ (48)
         assertExpression(
                 Document.parse("{'keyA': 1}"),
-                ofArray(ofEntry("keyA", of(1))).buildMap(v -> v),
+                ofArray(ofEntry("keyA", of(1))).asMap(v -> v),
                 "{'$arrayToObject': [[{'$literal': {'k': 'keyA', 'v': 1}}]]}");
     }
 
@@ -116,7 +116,7 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
                 mapA1B2
                         .entrySet()
                         .map(v -> v.setValue(v.getValue().add(1)))
-                        .buildMap(v -> v));
+                        .asMap(v -> v));
     }
 
     @Test
@@ -124,7 +124,7 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertExpression(
                 Document.parse("{'keyA': 9, 'keyB': 2, 'keyC': 3}"),
                 ofMap(Document.parse("{keyA: 1, keyB: 2}"))
-                        .mergee(ofMap(Document.parse("{keyA: 9, keyC: 3}"))),
+                        .merge(ofMap(Document.parse("{keyA: 9, keyC: 3}"))),
                 "{'$mergeObjects': [{'$literal': {'keyA': 1, 'keyB': 2}}, "
                         + "{'$literal': {'keyA': 9, 'keyC': 3}}]}");
     }

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
@@ -77,6 +77,18 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
     }
 
     @Test
+    public void hasMapTest() {
+        assertExpression(
+                true,
+                mapKey123.has(of("key")),
+                "{'$ne': [{'$getField': {'input': {'$setField': {'field': 'key', 'input': " +
+                        "{'$literal': {}}, 'value': 123}}, 'field': 'key'}}, '$$REMOVE']}");
+        assertExpression(
+                false,
+                mapKey123.has("not_key"));
+    }
+
+    @Test
     public void getSetEntryTest() {
         EntryExpression<IntegerExpression> entryA1 = ofEntry(of("keyA"), of(1));
         assertExpression(

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
@@ -81,8 +81,8 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertExpression(
                 true,
                 mapKey123.has(of("key")),
-                "{'$ne': [{'$getField': {'input': {'$setField': {'field': 'key', 'input': " +
-                        "{'$literal': {}}, 'value': 123}}, 'field': 'key'}}, '$$REMOVE']}");
+                "{'$ne': [{'$getField': {'input': {'$setField': {'field': 'key', 'input': "
+                        + "{'$literal': {}}, 'value': 123}}, 'field': 'key'}}, '$$REMOVE']}");
         assertExpression(
                 false,
                 mapKey123.has("not_key"));
@@ -122,7 +122,7 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
                 ofArray(
                         of(Document.parse("{ 'k': 'item', 'v': 'abc123' }")),
                         of(Document.parse("{ 'k': 'qty', 'v': 25 }")))
-                        .asMap(v -> ofEntry(v.getString("k"), v.getField("v")) ));
+                        .asMap(v -> ofEntry(v.getString("k"), v.getField("v"))));
         // using arrays
         assertExpression(
                 Document.parse("{ 'item' : 'abc123', 'qty' : 25 }"),

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.expressions;
+
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static com.mongodb.client.model.expressions.Expressions.of;
+import static com.mongodb.client.model.expressions.Expressions.ofArray;
+import static com.mongodb.client.model.expressions.Expressions.ofEntry;
+import static com.mongodb.client.model.expressions.Expressions.ofMap;
+
+class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
+
+    private final MapExpression<IntegerExpression> mapKey123 = Expressions.<IntegerExpression>ofEmptyMap()
+            .set("key", of(123));
+
+    private final MapExpression<IntegerExpression> mapA1B2 = ofMap(Document.parse("{keyA: 1, keyB: 2}"));
+
+    @Test
+    public void literalsTest() {
+        // map
+        assertExpression(
+                Document.parse("{key: 123}"),
+                mapKey123,
+                "{'$setField': {'field': 'key', 'input': {'$literal': {}}, 'value': 123}}");
+        assertExpression(
+                Document.parse("{keyA: 1, keyB: 2}"),
+                ofMap(Document.parse("{keyA: 1, keyB: 2}")),
+                "{'$literal': {'keyA': 1, 'keyB': 2}}");
+        // entry
+        assertExpression(
+                Document.parse("{k: 'keyA', v: 1}"),
+                ofEntry("keyA", of(1)));
+    }
+
+    @Test
+    public void getSetMapTest() {
+        // get
+        assertExpression(
+                123,
+                mapKey123.get("key"));
+        assertExpression(
+                1,
+                mapKey123.get("missing", of(1)));
+        // set (map.put)
+        assertExpression(
+                BsonDocument.parse("{key: 123, b: 1}"),
+                mapKey123.set("b", of(1)));
+        // unset (delete)
+        assertExpression(
+                BsonDocument.parse("{}"),
+                mapKey123.unset("key"));
+    }
+
+    @Test
+    public void getSetEntryTest() {
+        EntryExpression<IntegerExpression> entryA1 = ofEntry("keyA", of(1));
+        assertExpression(
+                Document.parse("{k: 'keyA', 'v': 33}"),
+                entryA1.setValue(of(33)));
+        assertExpression(
+                Document.parse("{k: 'keyB', 'v': 1}"),
+                entryA1.setKey(of("keyB")));
+        assertExpression(
+                Document.parse("{k: 'keyB', 'v': 1}"),
+                entryA1.setKey("keyB"));
+    }
+
+    @Test
+    public void buildMapTest() {
+        // https://www.mongodb.com/docs/manual/reference/operator/aggregation/arrayToObject/ (48)
+        assertExpression(
+                Document.parse("{'keyA': 1}"),
+                ofArray(ofEntry("keyA", of(1))).buildMap(v -> v),
+                "{'$arrayToObject': [[{'$literal': {'k': 'keyA', 'v': 1}}]]}");
+    }
+
+    @Test
+    public void entrySetTest() {
+        // https://www.mongodb.com/docs/manual/reference/operator/aggregation/objectToArray/ (23)
+        assertExpression(
+                Arrays.asList(Document.parse("{'k': 'k1', 'v': 1}")),
+                Expressions.<IntegerExpression>ofEmptyMap().set("k1", of(1)).entrySet(),
+                "{'$objectToArray': {'$setField': "
+                        + "{'field': 'k1', 'input': {'$literal': {}}, 'value': 1}}}");
+
+        // key/value usage
+        assertExpression(
+                "keyA|keyB|",
+                mapA1B2.entrySet().map(v -> v.getKey().concat(of("|"))).join(v -> v));
+        assertExpression(
+                23,
+                mapA1B2.entrySet().map(v -> v.getValue().add(10)).sum(v -> v));
+
+        // combined entrySet-buildMap usage
+        assertExpression(
+                Document.parse("{'keyA': 2, 'keyB': 3}"),
+                mapA1B2
+                        .entrySet()
+                        .map(v -> v.setValue(v.getValue().add(1)))
+                        .buildMap(v -> v));
+    }
+
+    @Test
+    public void mergeTest() {
+        assertExpression(
+                Document.parse("{'keyA': 9, 'keyB': 2, 'keyC': 3}"),
+                ofMap(Document.parse("{keyA: 1, keyB: 2}"))
+                        .mergee(ofMap(Document.parse("{keyA: 9, keyC: 3}"))),
+                "{'$mergeObjects': [{'$literal': {'keyA': 1, 'keyB': 2}}, "
+                        + "{'$literal': {'keyA': 9, 'keyC': 3}}]}");
+    }
+
+}

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
@@ -117,6 +117,16 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
                         .entrySet()
                         .map(v -> v.setValue(v.getValue().add(1)))
                         .asMap(v -> v));
+
+        // via getMap
+        DocumentExpression doc = of(Document.parse("{ instock: { warehouse1: 2500, warehouse2: 500 } }"));
+        assertExpression(
+                Arrays.asList(
+                        Document.parse("{'k': 'warehouse1', 'v': 2500}"),
+                        Document.parse("{'k': 'warehouse2', 'v': 500}")),
+                doc.getMap("instock").entrySet(),
+                "{'$objectToArray': {'$getField': {'input': {'$literal': "
+                        + "{'instock': {'warehouse1': 2500, 'warehouse2': 500}}}, 'field': 'instock'}}}");
     }
 
     @Test


### PR DESCRIPTION
JAVA-4817

objectToArray / arrayToObject (which correspond to Java's map.entrySet, and reduce-entries-to-map) require a Map type (as well as an Entry type)