### PR TITLE
Javadoc for expressions

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
@@ -21,35 +21,39 @@ import java.util.function.Function;
 import static com.mongodb.client.model.expressions.Expressions.of;
 
 /**
- * Expresses an array value. An array value is a finite, ordered collection of
- * elements of a certain type.
+ * An array {@link Expression value} in the context of the MongoDB Query
+ * Language (MQL). An array is a finite, ordered collection of elements of a
+ * certain type. It is also known as a finite mathematical sequence.
  *
- * @param <T> the type of the elements in the array
+ * @param <T> the type of the elements
  */
 public interface ArrayExpression<T extends Expression> extends Expression {
 
     /**
-     * Returns an array consisting of those elements in this array that match
-     * the given predicate condition. Evaluates each expression in this array
-     * according to the cond function. If cond evaluates to logical true, then
-     * the element is preserved; if cond evaluates to logical false, the element
-     * is omitted.
+     * An array consisting of only those elements in {@code this} array that
+     * match the provided predicate.
      *
-     * @param cond the function to apply to each element
-     * @return the new array
+     * @param predicate the predicate to apply to each element to determine if
+     *                  it should be included.
+     * @return the resulting array.
      */
-    ArrayExpression<T> filter(Function<? super T, ? extends BooleanExpression> cond);
+    ArrayExpression<T> filter(Function<? super T, ? extends BooleanExpression> predicate);
 
     /**
-     * Returns an array consisting of the results of applying the given function
-     * to the elements of this array.
+     * An array consisting of the results of applying the provided function to
+     * the elements of {@code this} array.
      *
-     * @param in the function to apply to each element
-     * @return the new array
-     * @param <R> the type contained in the resulting array
+     * @param in the function to apply to each element.
+     * @return the resulting array.
+     * @param <R> the type of the elements of the resulting array.
      */
     <R extends Expression> ArrayExpression<R> map(Function<? super T, ? extends R> in);
 
+    /**
+     * The size of {@code this} array.
+     *
+     * @return the size.
+     */
     IntegerExpression size();
 
     BooleanExpression any(Function<? super T, BooleanExpression> predicate);
@@ -113,7 +117,25 @@ public interface ArrayExpression<T extends Expression> extends Expression {
 
     ArrayExpression<T> distinct();
 
+    /**
+     * The result of passing {@code this} value to the provided function.
+     * Equivalent to {@code f.apply(this)}, and allows lambdas and static,
+     * user-defined functions to use the chaining syntax.
+     *
+     * @see Expression#passTo
+     * @param f the function to apply.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
     <R extends Expression> R passArrayTo(Function<? super ArrayExpression<T>, ? extends R> f);
 
-    <R extends Expression> R switchArrayOn(Function<Branches<ArrayExpression<T>>, ? extends BranchesTerminal<ArrayExpression<T>, ? extends R>> on);
+    /**
+     * The result of applying the provided switch mapping to {@code this} value.
+     *
+     * @see Expression#switchOn
+     * @param mapping the switch mapping.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
+    <R extends Expression> R switchArrayOn(Function<Branches<ArrayExpression<T>>, ? extends BranchesTerminal<ArrayExpression<T>, ? extends R>> mapping);
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
@@ -19,6 +19,8 @@ package com.mongodb.client.model.expressions;
 import java.util.function.Function;
 
 import static com.mongodb.client.model.expressions.Expressions.of;
+import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.PRESENT;
+import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.NON_EMPTY;
 
 /**
  * An array {@link Expression value} in the context of the MongoDB Query
@@ -85,6 +87,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      * @param i
      * @return
      */
+    @MqlUnchecked(PRESENT)
     T elementAt(IntegerExpression i);
 
     default T elementAt(final int i) {
@@ -95,6 +98,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      * user asserts that array is not empty
      * @return
      */
+    @MqlUnchecked(NON_EMPTY)
     T first();
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/expressions/BooleanExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/BooleanExpression.java
@@ -19,44 +19,41 @@ package com.mongodb.client.model.expressions;
 import java.util.function.Function;
 
 /**
- * Expresses a boolean value.
+ * A logical boolean value, either true or false.
  */
 public interface BooleanExpression extends Expression {
 
     /**
-     * Returns logical true if this expression evaluates to logical false.
-     * Returns logical false if this expression evaluates to logical true.
+     * The logical negation of {@code this} value.
      *
-     * @return True if false; false if true.
+     * @return the resulting value.
      */
     BooleanExpression not();
 
     /**
-     * Returns logical true if this or the other expression evaluates to logical
-     * true. Returns logical false if both evaluate to logical false.
+     * The logical conjunction of {@code this} and the {@code other} value.
      *
-     * @param or the other boolean expression.
-     * @return True if either true, false if both false.
+     * @param other the other boolean value.
+     * @return the resulting value.
      */
-    BooleanExpression or(BooleanExpression or);
+    BooleanExpression or(BooleanExpression other);
 
     /**
-     * Returns logical true if both this and the other expression evaluate to
-     * logical true. Returns logical false if either evaluate to logical false.
+     * The logical disjunction of {@code this} and the {@code other} value.
      *
-     * @param and the other boolean expression.
-     * @return true if both true, false if either false.
+     * @param other the other boolean value.
+     * @return the resulting value.
      */
-    BooleanExpression and(BooleanExpression and);
+    BooleanExpression and(BooleanExpression other);
+    // TODO-END check the evaluation semantics of and/or
 
     /**
-     * If this expression evaluates to logical true, returns the result of the
-     * evaluated left branch expression. If this evaluates to logical false,
-     * returns the result of the evaluated right branch expression.
+     * The {@code left} branch when {@code this} is true,
+     * and the {@code right} branch otherwise.
      *
-     * @param left the left branch expression
-     * @param right the right branch expression
-     * @return left if true, right if false.
+     * @param left the left branch.
+     * @param right the right branch.
+     * @return the resulting value.
      * @param <T> The type of the resulting expression.
      */
     <T extends Expression> T cond(T left, T right);

--- a/driver-core/src/main/com/mongodb/client/model/expressions/BooleanExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/BooleanExpression.java
@@ -19,7 +19,8 @@ package com.mongodb.client.model.expressions;
 import java.util.function.Function;
 
 /**
- * A logical boolean value, either true or false.
+ * A boolean {@linkplain Expression value} in the context of the
+ * MongoDB Query Language (MQL).
  */
 public interface BooleanExpression extends Expression {
 
@@ -45,20 +46,37 @@ public interface BooleanExpression extends Expression {
      * @return the resulting value.
      */
     BooleanExpression and(BooleanExpression other);
-    // TODO-END check the evaluation semantics of and/or
 
     /**
-     * The {@code left} branch when {@code this} is true,
-     * and the {@code right} branch otherwise.
+     * The {@code ifTrue} value when {@code this} is true,
+     * and the {@code ifFalse} value otherwise.
      *
-     * @param left the left branch.
-     * @param right the right branch.
+     * @param ifTrue the ifTrue value.
+     * @param ifFalse the ifFalse value.
      * @return the resulting value.
      * @param <T> The type of the resulting expression.
      */
-    <T extends Expression> T cond(T left, T right);
+    <T extends Expression> T cond(T ifTrue, T ifFalse);
 
+    /**
+     * The result of passing {@code this} value to the provided function.
+     * Equivalent to {@code f.apply(this)}, and allows lambdas and static,
+     * user-defined functions to use the chaining syntax.
+     *
+     * @see Expression#passTo
+     * @param f the function to apply.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
     <R extends Expression> R passBooleanTo(Function<? super BooleanExpression, ? extends R> f);
 
-    <R extends Expression> R switchBooleanOn(Function<Branches<BooleanExpression>, ? extends BranchesTerminal<BooleanExpression, ? extends R>> on);
+    /**
+     * The result of applying the provided switch mapping to {@code this} value.
+     *
+     * @see Expression#switchOn
+     * @param mapping the switch mapping.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
+    <R extends Expression> R switchBooleanOn(Function<Branches<BooleanExpression>, ? extends BranchesTerminal<BooleanExpression, ? extends R>> mapping);
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Branches.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Branches.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE_ARGUMENT;
+
 public final class Branches<T extends Expression> {
 
     Branches() {
@@ -78,7 +80,7 @@ public final class Branches<T extends Expression> {
     }
 
     @SuppressWarnings("unchecked")
-    public <R extends Expression, Q extends Expression> BranchesIntermediary<T, R> isArray(final Function<? super ArrayExpression<Q>, ? extends R> r) {
+    public <R extends Expression, Q extends Expression> BranchesIntermediary<T, R> isArray(final Function<? super ArrayExpression<@MqlUnchecked(TYPE_ARGUMENT) Q>, ? extends R> r) {
         return is(v -> mqlEx(v).isArray(), v -> r.apply((ArrayExpression<Q>) v));
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/expressions/DateExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/DateExpression.java
@@ -19,8 +19,11 @@ package com.mongodb.client.model.expressions;
 import java.util.function.Function;
 
 /**
- * An instantaneous date and time. Tracks a UTC datetime, the number of
- * milliseconds since the Unix epoch. Does not track the timezone.
+ * A UTC date-time {@linkplain Expression value} in the context
+ * of the MongoDB Query Language (MQL). Tracks the number of
+ * milliseconds since the Unix epoch, and does not track the timezone.
+ *
+ * @mongodb.driver.manual reference/operator/aggregation/dateToString/ Format Specifiers, UTC Offset, and Olson Timezone Identifier
  */
 public interface DateExpression extends Expression {
 
@@ -123,11 +126,30 @@ public interface DateExpression extends Expression {
      * provided {@code timezone}, and formatted according to the {@code format}.
      *
      * @param timezone the UTC Offset or Olson Timezone Identifier.
-     * @param format the format specifier. TODO-END what standard is this?
+     * @param format the format specifier.
      * @return the resulting value.
      */
     StringExpression asString(StringExpression timezone, StringExpression format);
 
+    /**
+     * The result of passing {@code this} value to the provided function.
+     * Equivalent to {@code f.apply(this)}, and allows lambdas and static,
+     * user-defined functions to use the chaining syntax.
+     *
+     * @see Expression#passTo
+     * @param f the function to apply.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
     <R extends Expression> R passDateTo(Function<? super DateExpression, ? extends R> f);
-    <R extends Expression> R switchDateOn(Function<Branches<DateExpression>, ? extends BranchesTerminal<DateExpression, ? extends R>> on);
+
+    /**
+     * The result of applying the provided switch mapping to {@code this} value.
+     *
+     * @see Expression#switchOn
+     * @param mapping the switch mapping.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
+    <R extends Expression> R switchDateOn(Function<Branches<DateExpression>, ? extends BranchesTerminal<DateExpression, ? extends R>> mapping);
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/DateExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/DateExpression.java
@@ -19,20 +19,113 @@ package com.mongodb.client.model.expressions;
 import java.util.function.Function;
 
 /**
- * Expresses a date value.
+ * An instantaneous date and time. Tracks a UTC datetime, the number of
+ * milliseconds since the Unix epoch. Does not track the timezone.
  */
 public interface DateExpression extends Expression {
+
+    /**
+     * The year of {@code this} date as determined by the provided
+     * {@code timezone}.
+     *
+     * @param timezone the UTC Offset or Olson Timezone Identifier.
+     * @return the resulting value.
+     */
     IntegerExpression year(StringExpression timezone);
+
+    /**
+     * The month of {@code this} date as determined by the provided
+     * {@code timezone}, as an integer between 1 and 12.
+     *
+     * @param timezone the UTC Offset or Olson Timezone Identifier.
+     * @return the resulting value.
+     */
     IntegerExpression month(StringExpression timezone);
+
+    /**
+     * The day of the month of {@code this} date as determined by the provided
+     * {@code timezone}, as an integer between 1 and 31.
+     *
+     * @param timezone the UTC Offset or Olson Timezone Identifier.
+     * @return the resulting value.
+     */
     IntegerExpression dayOfMonth(StringExpression timezone);
+
+    /**
+     * The day of the week of {@code this} date as determined by the provided
+     * {@code timezone}, as an integer between 1 (Sunday) and 7 (Saturday).
+     *
+     * @param timezone the UTC Offset or Olson Timezone Identifier.
+     * @return the resulting value.
+     */
     IntegerExpression dayOfWeek(StringExpression timezone);
+
+    /**
+     * The day of the year of {@code this} date as determined by the provided
+     * {@code timezone}, as an integer between 1 and 366.
+     *
+     * @param timezone the UTC Offset or Olson Timezone Identifier.
+     * @return the resulting value.
+     */
     IntegerExpression dayOfYear(StringExpression timezone);
+
+    /**
+     * The hour of {@code this} date as determined by the provided
+     * {@code timezone}, as an integer between 0 and 23.
+     *
+     * @param timezone the UTC Offset or Olson Timezone Identifier.
+     * @return the resulting value.
+     */
     IntegerExpression hour(StringExpression timezone);
+
+    /**
+     * The minute of {@code this} date as determined by the provided
+     * {@code timezone}, as an integer between 0 and 59.
+     *
+     * @param timezone the UTC Offset or Olson Timezone Identifier.
+     * @return the resulting value.
+     */
     IntegerExpression minute(StringExpression timezone);
+
+    /**
+     * The second of {@code this} date as determined by the provided
+     * {@code timezone}, as an integer between 0 and 59, and 60 in the case
+     * of a leap second.
+     *
+     * @param timezone the UTC Offset or Olson Timezone Identifier.
+     * @return the resulting value.
+     */
     IntegerExpression second(StringExpression timezone);
+
+    /**
+     * The week of the year of {@code this} date as determined by the provided
+     * {@code timezone}, as an integer between 0 and 53.
+     *
+     * <p>Weeks begin on Sundays, and week 1 begins with the first Sunday of the
+     * year. Days preceding the first Sunday of the year are in week 0.
+     *
+     * @param timezone the UTC Offset or Olson Timezone Identifier.
+     * @return the resulting value.
+     */
     IntegerExpression week(StringExpression timezone);
+
+    /**
+     * The millisecond part of {@code this} date as determined by the provided
+     * {@code timezone}, as an integer between 0 and 999.
+     *
+     * @param timezone the UTC Offset or Olson Timezone Identifier.
+     * @return the resulting value.
+     */
     IntegerExpression millisecond(StringExpression timezone);
 
+    /**
+     * The string representation of {@code this} date as determined by the
+     * provided {@code timezone}, and formatted according to the {@code format}.
+     *
+     * @param timezone the UTC Offset or Olson Timezone Identifier.
+     * @param format the format specifier. TODO-END what standard is this?
+     * @return the resulting value.
+     */
     StringExpression asString(StringExpression timezone, StringExpression format);
 
     <R extends Expression> R passDateTo(Function<? super DateExpression, ? extends R> f);

--- a/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
@@ -102,6 +102,25 @@ public interface DocumentExpression extends Expression {
 
     MapExpression<Expression> asMap();
 
+    /**
+     * The result of passing {@code this} value to the provided function.
+     * Equivalent to {@code f.apply(this)}, and allows lambdas and static,
+     * user-defined functions to use the chaining syntax.
+     *
+     * @see Expression#passTo
+     * @param f the function to apply.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
     <R extends Expression> R passDocumentTo(Function<? super DocumentExpression, ? extends R> f);
-    <R extends Expression> R switchDocumentOn(Function<Branches<DocumentExpression>, ? extends BranchesTerminal<DocumentExpression, ? extends R>> on);
+
+    /**
+     * The result of applying the provided switch mapping to {@code this} value.
+     *
+     * @see Expression#switchOn
+     * @param mapping the switch mapping.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
+    <R extends Expression> R switchDocumentOn(Function<Branches<DocumentExpression>, ? extends BranchesTerminal<DocumentExpression, ? extends R>> mapping);
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
@@ -23,6 +23,8 @@ import java.util.function.Function;
 
 import static com.mongodb.client.model.expressions.Expressions.of;
 import static com.mongodb.client.model.expressions.Expressions.ofMap;
+import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.PRESENT;
+import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE;
 
 /**
  * Expresses a document value. A document is an ordered set of fields, where the
@@ -34,8 +36,10 @@ public interface DocumentExpression extends Expression {
 
     DocumentExpression unsetField(String fieldName);
 
+    @MqlUnchecked(PRESENT)
     Expression getField(String fieldName);
 
+    @MqlUnchecked({PRESENT, TYPE})
     BooleanExpression getBoolean(String fieldName);
 
     BooleanExpression getBoolean(String fieldName, BooleanExpression other);

--- a/driver-core/src/main/com/mongodb/client/model/expressions/EntryExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/EntryExpression.java
@@ -18,6 +18,19 @@ package com.mongodb.client.model.expressions;
 
 import static com.mongodb.client.model.expressions.Expressions.of;
 
+/**
+ * A map entry {@linkplain Expression value} in the context
+ * of the MongoDB Query Language (MQL). An entry has a
+ * {@linkplain StringExpression string} key and some
+ * {@linkplain Expression value}. Entries are used with
+ * {@linkplain MapExpression maps}.
+ *
+ * Entries are {@linkplain Expression#isDocumentOr document-like} and
+ * {@linkplain Expression#isMapOr map-like}, unless the method returning the
+ * entry specifies otherwise.
+ *
+ * @param <T> The type of the value
+ */
 public interface EntryExpression<T extends Expression> extends Expression {
     StringExpression getKey();
 

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
@@ -20,6 +20,8 @@ import com.mongodb.annotations.Evolving;
 
 import java.util.function.Function;
 
+import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE_ARGUMENT;
+
 /**
  * A value in the context of the MongoDB Query Language (MQL).
  *
@@ -215,7 +217,7 @@ public interface Expression {
      * @return the resulting value.
      * @param <T> the type of the elements of the resulting array.
      */
-    <T extends Expression> ArrayExpression<T> isArrayOr(ArrayExpression<? extends T> other);
+    <T extends Expression> ArrayExpression<@MqlUnchecked(TYPE_ARGUMENT) T> isArrayOr(ArrayExpression<? extends T> other);
 
     /**
      * {@code this} value as a {@linkplain DocumentExpression document} if

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
@@ -21,11 +21,67 @@ import com.mongodb.annotations.Evolving;
 import java.util.function.Function;
 
 /**
- * <p>Users should treat these interfaces as sealed, and must not implement any
- * sub-interfaces.
+ * A value in the context of the MongoDB Query Language (MQL).
  *
- * TODO-END: 'cause an error', 'execution context', wrong types/unsafe operations
- * TODO-END: types and how missing/null are not part of any type.
+ * <p>The API provided by this base type and its subtypes is the Java-native
+ * variant of MQL. It is used to query the MongoDB server, to perform remote
+ * computations, to store and retrieve data, or to otherwise work with data on
+ * a MongoDB server or compatible execution context. Though the methods exposed
+ * through this API generally correspond to MQL operations, this correspondence
+ * is not exact.
+ *
+ * <p>The following is an example of usage within an aggregation pipeline. Here,
+ * the current document value is obtained and its "numberArray" field is
+ * filtered and summed, in a style similar to that of the Java Stream API:
+ *
+ * <pre>{@code
+ * import static com.mongodb.client.model.expressions.Expressions.current;
+ * MongoCollection<Document> col = ...;
+ * AggregateIterable<Document> result = col.aggregate(Arrays.asList(
+ *     addFields(new Field<>("result", current()
+ *         .<MqlNumber>getArray("numberArray")
+ *         .filter(v -> v.gt(of(0)))
+ *         .sum(v -> v)))));
+ * }</pre>
+ *
+ * <p>Values are typically initially obtained via the current document and its
+ * fields, or specified via statically-imported methods on the
+ * {@link Expressions} class.
+ *
+ * <p>As with the Java Stream API's terminal operations, corresponding Java
+ * values are not directly available, but must be obtained indirectly via
+ * {@code MongoCollection.aggregate} or {@code MongoCollection.find}.
+ * Certain methods may cause an error, which will be produced
+ * through these "terminal operations".
+ *
+ * <p>The null value is not part of, and cannot be used as if it were part
+ * of, any explicit type (except the root type {@link Expression} itself).
+ * See {@link Expressions#ofNull} for more details.
+ *
+ * <p>This API specifies no "missing" or "undefined" value. Users may use
+ * {@link MapExpression#has} to check whether a value is present.
+ *
+ * <p>This type hierarchy differs from the {@linkplain org.bson} types in that
+ * they provide computational operations, the numeric types are less granular,
+ * and it offers multiple abstractions of certain types (document, map, entry).
+ * It differs from the corresponding Java types (such as {@code int},
+ * {@link String}, {@link java.util.Map}) in that the operations
+ * available differ, and in that an implementation of this API may be used to
+ * produce MQL in the form of BSON. (This API makes no guarantee regarding the
+ * BSON output produced by its implementation, which in any case may vary due
+ * to optimization or other factors.)
+ *
+ * <p>Some methods within the API constitute an assertion by the user that the
+ * data is of a certain type. For example, {@link DocumentExpression#getArray}}
+ * requires that the underlying field is both an array, and an array of some
+ * certain type. If the field is not an array in the underlying data, behaviour
+ * is undefined by this API (though behaviours may be defined by the execution
+ * context, users are strongly discouraged from relying on behaviour that is not
+ * part of this API).
+ *
+ *
+ * <p>Users should treat these interfaces as sealed, and should not create
+ * implementations.
  *
  * @see Expressions
  */
@@ -33,7 +89,16 @@ import java.util.function.Function;
 public interface Expression {
 
     /**
+     * The method {@link Expression#eq} should be used to compare values for
+     * equality. This method checks reference equality.
+     */
+    @Override
+    boolean equals(Object other);
+
+    /**
      * Whether {@code this} value is equal to the {@code other} value.
+     *
+     * <p>The result does not correlate with {@link Expression#equals(Object)}.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -42,6 +107,8 @@ public interface Expression {
 
     /**
      * Whether {@code this} value is not equal to the {@code other} value.
+     *
+     * <p>The result does not correlate with {@link Expression#equals(Object)}.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -83,7 +150,7 @@ public interface Expression {
     BooleanExpression lte(Expression other);
 
     /**
-     * {@code this} value as a {@link BooleanExpression boolean} if
+     * {@code this} value as a {@linkplain BooleanExpression boolean} if
      * {@code this} is a boolean, or the {@code other} boolean value if
      * {@code this} is null, or is missing, or is of any other non-boolean type.
      *
@@ -93,12 +160,9 @@ public interface Expression {
     BooleanExpression isBooleanOr(BooleanExpression other);
 
     /**
-     * {@code this} value as a {@link NumberExpression number} if
+     * {@code this} value as a {@linkplain NumberExpression number} if
      * {@code this} is a number, or the {@code other} number value if
      * {@code this} is null, or is missing, or is of any other non-number type.
-     *
-     * <p>Since integers are a subset of numbers, if a value is an integer,
-     * this does not imply that it is not a number, and vice-versa.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -106,12 +170,9 @@ public interface Expression {
     NumberExpression isNumberOr(NumberExpression other);
 
     /**
-     * {@code this} value as an {@link IntegerExpression integer} if
+     * {@code this} value as an {@linkplain IntegerExpression integer} if
      * {@code this} is an integer, or the {@code other} integer value if
      * {@code this} is null, or is missing, or is of any other non-integer type.
-     *
-     * <p>Since integers are a subset of numbers, if a value is an integer,
-     * this does not imply that it is not a number, and vice-versa.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -119,9 +180,9 @@ public interface Expression {
     IntegerExpression isIntegerOr(IntegerExpression other);
 
     /**
-     * {@code this} value as a {@link BooleanExpression boolean} if
-     * {@code this} is a boolean, or the {@code other} boolean value if
-     * {@code this} is null, or is missing, or is of any other non-boolean type.
+     * {@code this} value as a {@linkplain StringExpression string} if
+     * {@code this} is a string, or the {@code other} string value if
+     * {@code this} is null, or is missing, or is of any other non-string type.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -129,28 +190,26 @@ public interface Expression {
     StringExpression isStringOr(StringExpression other);
 
     /**
-     * {@code this} value as a {@link StringExpression string} if
-     * {@code this} is a string, or the {@code other} string value if
-     * {@code this} is null, or is missing, or is of any other non-string type.
+     * {@code this} value as a {@linkplain DateExpression boolean} if
+     * {@code this} is a date, or the {@code other} date value if
+     * {@code this} is null, or is missing, or is of any other non-date type.
      *
      * @param other the other value.
      * @return the resulting value.
      */
     DateExpression isDateOr(DateExpression other);
 
-
     /**
-     * {@code this} value as a {@link ArrayExpression array} if
+     * {@code this} value as a {@linkplain ArrayExpression array} if
      * {@code this} is an array, or the {@code other} array value if
      * {@code this} is null, or is missing, or is of any other non-array type.
      *
-     * <p>Warning: this operation does not guarantee type safety. While this
-     * operation is guaranteed to produce an array, the type of the elements of
-     * that array are not guaranteed by the API. The specification of a type by
-     * the user is an unchecked assertion that all elements are of that type,
-     * and that no element is null, is missing, or is of some other type. If the
-     * user cannot make such an assertion, some appropriate super-type should be
-     * chosen, and elements should be individually type-checked.
+     * <p>Warning: The type of the elements of the resulting array are not
+     * enforced by the API. The specification of a type by the user is an
+     * unchecked assertion that all elements are of that type.
+     * If the array contains multiple types (such as both nulls and integers)
+     * then a super-type encompassing all types must be chosen, and
+     * if necessary the elements should be individually type-checked when used.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -158,46 +217,80 @@ public interface Expression {
      */
     <T extends Expression> ArrayExpression<T> isArrayOr(ArrayExpression<? extends T> other);
 
-    // TODO-END doc after Map merged, "record" and "schema objects" are decided
+    /**
+     * {@code this} value as a {@linkplain DocumentExpression document} if
+     * {@code this} is a document or document-like value (see
+     * {@link MapExpression} and {@link EntryExpression})
+     * or the {@code other} document value if {@code this} is null,
+     * or is missing, or is of any other non-document type.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
     <T extends DocumentExpression> T isDocumentOr(T other);
 
+    /**
+     * {@code this} value as a {@linkplain MapExpression map} if
+     * {@code this} is a map or map-like value (see
+     * {@link DocumentExpression} and {@link EntryExpression})
+     * or the {@code other} map value if {@code this} is null,
+     * or is missing, or is of any other non-map type.
+     *
+     * <p>Warning: The type of the values of the resulting map are not
+     * enforced by the API. The specification of a type by the user is an
+     * unchecked assertion that all map values are of that type.
+     * If the map contains multiple types (such as both nulls and integers)
+     * then a super-type encompassing all types must be chosen, and
+     * if necessary the elements should be individually type-checked when used.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     * @param <T> the type of the values of the resulting map.
+     */
     <T extends Expression> MapExpression<T> isMapOr(MapExpression<? extends T> other);
 
     /**
-     * The {@link StringExpression string} value corresponding to this value.
+     * The {@linkplain StringExpression string} representation of {@code this} value.
      *
-     * <p>This may "cause an error" if the type cannot be converted to string,
-     * as is the case with {@link ArrayExpression arrays},
-     * {@link DocumentExpression documents}, and {@link MapExpression maps}.
-     * TODO-END what about null/missing?
-     * TODO-END document vs record
-     * TODO-END "cause an error" above
-     *
+     * <p>This may cause an error to be produced if the type cannot be converted
+     * to a {@linkplain StringExpression string}, as is the case with
+     * {@linkplain ArrayExpression arrays},
+     * {@linkplain DocumentExpression documents},
+     * {@linkplain MapExpression maps},
+     * {@linkplain EntryExpression entries}, and the
+     * {@linkplain Expressions#ofNull() null value}.
      *
      * @see StringExpression#parseDate()
      * @see StringExpression#parseInteger()
-     * TODO-END all the others? implement?
      * @return the resulting value.
      */
     StringExpression asString();
 
     /**
-     * Applies the provided function to {@code this}.
+     * The result of passing {@code this} value to the provided function.
+     * Equivalent to {@code f.apply(this)}, and allows lambdas and static,
+     * user-defined functions to use the chaining syntax.
      *
-     * <p>Equivalent to {@code f.apply(this)}, and allows lambdas and static,
-     * user-defined functions to use the chaining syntax. For example:
-     * {@code myInteger.apply(isEven)} (here, {@code isEven} is a function
-     * taking an {@link IntegerExpression integer} and yielding a
-     * {@link BooleanExpression boolean}).
+     * <p>The appropriate type-based variant should be used when the type
+     * of {@code this} is known.
+     *
+     * @see BooleanExpression#passBooleanTo
+     * @see IntegerExpression#passIntegerTo
+     * @see NumberExpression#passNumberTo
+     * @see StringExpression#passStringTo
+     * @see DateExpression#passDateTo
+     * @see ArrayExpression#passArrayTo
+     * @see MapExpression#passMapTo
+     * @see DocumentExpression#passDocumentTo
      *
      * @param f the function to apply.
      * @return the resulting value.
      * @param <R> the type of the resulting value.
      */
     <R extends Expression> R passTo(Function<? super Expression, ? extends R> f);
+
     /**
-     * The value resulting from applying the provided switch mapping to
-     * {@code this} value.
+     * The result of applying the provided switch mapping to {@code this} value.
      *
      * <p>Can be used to perform pattern matching on the type of {@code this}
      * value, or to perform comparisons, or to perform any arbitrary check on
@@ -205,12 +298,29 @@ public interface Expression {
      *
      * <p>The suggested convention is to use "{@code on}" as the name of the
      * {@code mapping} parameter, for example:
-     * {@code myValue.switchOn(on -> on.isInteger(...)...)}.
+     *
+     * <pre>{@code
+     * myValue.switchOn(on -> on
+     *     .isInteger(...)
+     *     ...
+     *     .defaults(...))
+     * }</pre>
+     *
+     * <p>The appropriate type-based variant should be used when the type
+     * of {@code this} is known.
+     *
+     * @see BooleanExpression#switchBooleanOn
+     * @see IntegerExpression#switchIntegerOn
+     * @see NumberExpression#switchNumberOn
+     * @see StringExpression#switchStringOn
+     * @see DateExpression#switchDateOn
+     * @see ArrayExpression#switchArrayOn
+     * @see MapExpression#switchMapOn
+     * @see DocumentExpression#switchDocumentOn
      *
      * @param mapping the switch mapping.
      * @return the resulting value.
      * @param <R> the type of the resulting value.
      */
     <R extends Expression> R switchOn(Function<Branches<Expression>, ? extends BranchesTerminal<Expression, ? extends R>> mapping);
-
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
@@ -21,25 +21,11 @@ import com.mongodb.annotations.Evolving;
 import java.util.function.Function;
 
 /**
- * Expressions express values that may be represented in (or computations that
- * may be performed within) a MongoDB server. Each expression evaluates to some
- * value, much like any Java expression evaluates to some value. Expressions may
- * be thought of as boxed values. Evaluation of an expression will usually occur
- * on a MongoDB server.
- *
  * <p>Users should treat these interfaces as sealed, and must not implement any
- * expression interfaces.
+ * sub-interfaces.
  *
- * <p>Expressions are typed. It is possible to execute expressions against data
- * that is of the wrong type, such as by applying the "not" boolean expression
- * to a document field that is an integer, null, or missing. This API does not
- * define the output in such cases (though the output may be defined within the
- * execution context - the server - where the expression is evaluated). Users of
- * this API must mitigate any risk of applying an expression to some type where
- * resulting behaviour is not defined by this API (for example, by checking for
- * null, by ensuring that field types are correctly specified). Likewise, unless
- * otherwise specified, this API does not define the order of evaluation for all
- * arguments, and whether all arguments to some expression will be evaluated.
+ * TODO-END: 'cause an error', 'execution context', wrong types/unsafe operations
+ * TODO-END: types and how missing/null are not part of any type.
  *
  * @see Expressions
  */
@@ -47,78 +33,184 @@ import java.util.function.Function;
 public interface Expression {
 
     /**
-     * Returns logical true if the value of this expression is equal to the
-     * value of the other expression. Otherwise, false.
+     * Whether {@code this} value is equal to the {@code other} value.
      *
-     * @param eq the other expression
-     * @return true if equal, false if not equal
+     * @param other the other value.
+     * @return the resulting value.
      */
-    BooleanExpression eq(Expression eq);
+    BooleanExpression eq(Expression other);
 
     /**
-     * Returns logical true if the value of this expression is not equal to the
-     * value of the other expression. Otherwise, false.
+     * Whether {@code this} value is not equal to the {@code other} value.
      *
-     * @param ne the other expression
-     * @return true if equal, false otherwise
+     * @param other the other value.
+     * @return the resulting value.
      */
-    BooleanExpression ne(Expression ne);
+    BooleanExpression ne(Expression other);
 
     /**
-     * Returns logical true if the value of this expression is greater than the
-     * value of the other expression. Otherwise, false.
+     * Whether {@code this} value is greater than the {@code other} value.
      *
-     * @param gt the other expression
-     * @return true if greater than, false otherwise
+     * @param other the other value.
+     * @return the resulting value.
      */
-    BooleanExpression gt(Expression gt);
+    BooleanExpression gt(Expression other);
 
     /**
-     * Returns logical true if the value of this expression is greater than or
-     * equal to the value of the other expression. Otherwise, false.
+     * Whether {@code this} value is greater than or equal to the {@code other}
+     * value.
      *
-     * @param gte the other expression
-     * @return true if greater than or equal to, false otherwise
+     * @param other the other value.
+     * @return the resulting value.
      */
-    BooleanExpression gte(Expression gte);
+    BooleanExpression gte(Expression other);
 
     /**
-     * Returns logical true if the value of this expression is less than the
-     * value of the other expression. Otherwise, false.
+     * Whether {@code this} value is less than the {@code other} value.
      *
-     * @param lt the other expression
-     * @return true if less than, false otherwise
+     * @param other the other value.
+     * @return the resulting value.
      */
-    BooleanExpression lt(Expression lt);
+    BooleanExpression lt(Expression other);
 
     /**
-     * Returns logical true if the value of this expression is less than or
-     * equal to the value of the other expression. Otherwise, false.
+     * Whether {@code this} value is less than or equal to the {@code other}
+     * value.
      *
-     * @param lte the other expression
-     * @return true if less than or equal to, false otherwise
+     * @param other the other value.
+     * @return the resulting value.
      */
-    BooleanExpression lte(Expression lte);
+    BooleanExpression lte(Expression other);
 
     /**
-     * also checks for nulls
-     * @param other
-     * @return
+     * {@code this} value as a {@link BooleanExpression boolean} if
+     * {@code this} is a boolean, or the {@code other} boolean value if
+     * {@code this} is null, or is missing, or is of any other non-boolean type.
+     *
+     * @param other the other value.
+     * @return the resulting value.
      */
     BooleanExpression isBooleanOr(BooleanExpression other);
+
+    /**
+     * {@code this} value as a {@link NumberExpression number} if
+     * {@code this} is a number, or the {@code other} number value if
+     * {@code this} is null, or is missing, or is of any other non-number type.
+     *
+     * <p>Since integers are a subset of numbers, if a value is an integer,
+     * this does not imply that it is not a number, and vice-versa.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
     NumberExpression isNumberOr(NumberExpression other);
+
+    /**
+     * {@code this} value as an {@link IntegerExpression integer} if
+     * {@code this} is an integer, or the {@code other} integer value if
+     * {@code this} is null, or is missing, or is of any other non-integer type.
+     *
+     * <p>Since integers are a subset of numbers, if a value is an integer,
+     * this does not imply that it is not a number, and vice-versa.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
     IntegerExpression isIntegerOr(IntegerExpression other);
+
+    /**
+     * {@code this} value as a {@link BooleanExpression boolean} if
+     * {@code this} is a boolean, or the {@code other} boolean value if
+     * {@code this} is null, or is missing, or is of any other non-boolean type.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
     StringExpression isStringOr(StringExpression other);
+
+    /**
+     * {@code this} value as a {@link StringExpression string} if
+     * {@code this} is a string, or the {@code other} string value if
+     * {@code this} is null, or is missing, or is of any other non-string type.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
     DateExpression isDateOr(DateExpression other);
+
+
+    /**
+     * {@code this} value as a {@link ArrayExpression array} if
+     * {@code this} is an array, or the {@code other} array value if
+     * {@code this} is null, or is missing, or is of any other non-array type.
+     *
+     * <p>Warning: this operation does not guarantee type safety. While this
+     * operation is guaranteed to produce an array, the type of the elements of
+     * that array are not guaranteed by the API. The specification of a type by
+     * the user is an unchecked assertion that all elements are of that type,
+     * and that no element is null, is missing, or is of some other type. If the
+     * user cannot make such an assertion, some appropriate super-type should be
+     * chosen, and elements should be individually type-checked.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     * @param <T> the type of the elements of the resulting array.
+     */
     <T extends Expression> ArrayExpression<T> isArrayOr(ArrayExpression<? extends T> other);
+
+    // TODO-END doc after Map merged, "record" and "schema objects" are decided
     <T extends DocumentExpression> T isDocumentOr(T other);
 
     <T extends Expression> MapExpression<T> isMapOr(MapExpression<? extends T> other);
 
+    /**
+     * The {@link StringExpression string} value corresponding to this value.
+     *
+     * <p>This may "cause an error" if the type cannot be converted to string,
+     * as is the case with {@link ArrayExpression arrays},
+     * {@link DocumentExpression documents}, and {@link MapExpression maps}.
+     * TODO-END what about null/missing?
+     * TODO-END document vs record
+     * TODO-END "cause an error" above
+     *
+     *
+     * @see StringExpression#parseDate()
+     * @see StringExpression#parseInteger()
+     * TODO-END all the others? implement?
+     * @return the resulting value.
+     */
     StringExpression asString();
 
+    /**
+     * Applies the provided function to {@code this}.
+     *
+     * <p>Equivalent to {@code f.apply(this)}, and allows lambdas and static,
+     * user-defined functions to use the chaining syntax. For example:
+     * {@code myInteger.apply(isEven)} (here, {@code isEven} is a function
+     * taking an {@link IntegerExpression integer} and yielding a
+     * {@link BooleanExpression boolean}).
+     *
+     * @param f the function to apply.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
     <R extends Expression> R passTo(Function<? super Expression, ? extends R> f);
-
-    <R extends Expression> R switchOn(Function<Branches<Expression>, ? extends BranchesTerminal<Expression, ? extends R>> on);
+    /**
+     * The value resulting from applying the provided switch mapping to
+     * {@code this} value.
+     *
+     * <p>Can be used to perform pattern matching on the type of {@code this}
+     * value, or to perform comparisons, or to perform any arbitrary check on
+     * {@code this} value.
+     *
+     * <p>The suggested convention is to use "{@code on}" as the name of the
+     * {@code mapping} parameter, for example:
+     * {@code myValue.switchOn(on -> on.isInteger(...)...)}.
+     *
+     * @param mapping the switch mapping.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
+    <R extends Expression> R switchOn(Function<Branches<Expression>, ? extends BranchesTerminal<Expression, ? extends R>> mapping);
 
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/IntegerExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/IntegerExpression.java
@@ -19,9 +19,10 @@ package com.mongodb.client.model.expressions;
 import java.util.function.Function;
 
 /**
- * An integer value. Integers are a subset of {@link NumberExpression numbers},
- * and so, for example, the integer 0 and the number 0 are the same value,
- * and are equal.
+ * An integer {@linkplain Expression value} in the context of the MongoDB Query
+ * Language (MQL). Integers are a subset of {@linkplain NumberExpression numbers},
+ * and so, for example, the integer 0 and the number 0 are
+ * {@linkplain #eq(Expression) equal}.
  */
 public interface IntegerExpression extends NumberExpression {
 
@@ -62,7 +63,7 @@ public interface IntegerExpression extends NumberExpression {
     }
 
     /**
-     * The result of subtracting the {@code other} value from {@code this}.
+     * The difference of subtracting the {@code other} value from {@code this}.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -70,7 +71,7 @@ public interface IntegerExpression extends NumberExpression {
     IntegerExpression subtract(IntegerExpression other);
 
     /**
-     * The result of subtracting the {@code other} value from {@code this}.
+     * The difference of subtracting the {@code other} value from {@code this}.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -80,7 +81,8 @@ public interface IntegerExpression extends NumberExpression {
     }
 
     /**
-     * The larger value of {@code this} and the {@code other} value.
+     * The {@linkplain #gt(Expression) larger} value of {@code this}
+     * and the {@code other} value.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -88,7 +90,8 @@ public interface IntegerExpression extends NumberExpression {
     IntegerExpression max(IntegerExpression other);
 
     /**
-     * The smaller value of {@code this} and the {@code other} value.
+     * The {@linkplain #lt(Expression) smaller} value of {@code this}
+     * and the {@code other} value.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -103,14 +106,32 @@ public interface IntegerExpression extends NumberExpression {
     IntegerExpression abs();
 
     /**
-     * The {@link DateExpression date} corresponding to {@code this} value
+     * The {@linkplain DateExpression date} corresponding to {@code this} value
      * when taken to be the number of milliseconds since the Unix epoch.
      *
      * @return the resulting value.
      */
     DateExpression millisecondsToDate();
-    // TODO-END rename integer.utcMillisecondsToDate -- date.asUtcMilliseconds
 
+    /**
+     * The result of passing {@code this} value to the provided function.
+     * Equivalent to {@code f.apply(this)}, and allows lambdas and static,
+     * user-defined functions to use the chaining syntax.
+     *
+     * @see Expression#passTo
+     * @param f the function to apply.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
     <R extends Expression> R passIntegerTo(Function<? super IntegerExpression, ? extends R> f);
-    <R extends Expression> R switchIntegerOn(Function<Branches<IntegerExpression>, ? extends BranchesTerminal<IntegerExpression, ? extends R>> on);
+
+    /**
+     * The result of applying the provided switch mapping to {@code this} value.
+     *
+     * @see Expression#switchOn
+     * @param mapping the switch mapping.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
+    <R extends Expression> R switchIntegerOn(Function<Branches<IntegerExpression>, ? extends BranchesTerminal<IntegerExpression, ? extends R>> mapping);
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/IntegerExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/IntegerExpression.java
@@ -19,31 +19,97 @@ package com.mongodb.client.model.expressions;
 import java.util.function.Function;
 
 /**
- * Expresses an integer value.
+ * An integer value. Integers are a subset of {@link NumberExpression numbers},
+ * and so, for example, the integer 0 and the number 0 are the same value,
+ * and are equal.
  */
 public interface IntegerExpression extends NumberExpression {
-    IntegerExpression multiply(IntegerExpression i);
 
-    default IntegerExpression multiply(final int multiply) {
-        return this.multiply(Expressions.of(multiply));
+    /**
+     * The product of multiplying {@code this} and the {@code other} value.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    IntegerExpression multiply(IntegerExpression other);
+
+    /**
+     * The product of multiplying {@code this} and the {@code other} value.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    default IntegerExpression multiply(final int other) {
+        return this.multiply(Expressions.of(other));
     }
 
-    IntegerExpression add(IntegerExpression i);
+    /**
+     * The sum of adding {@code this} and the {@code other} value.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    IntegerExpression add(IntegerExpression other);
 
-    default IntegerExpression add(final int add) {
-        return this.add(Expressions.of(add));
+    /**
+     * The sum of adding {@code this} and the {@code other} value.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    default IntegerExpression add(final int other) {
+        return this.add(Expressions.of(other));
     }
 
-    IntegerExpression subtract(IntegerExpression i);
+    /**
+     * The result of subtracting the {@code other} value from {@code this}.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    IntegerExpression subtract(IntegerExpression other);
 
-    default IntegerExpression subtract(final int subtract) {
-        return this.subtract(Expressions.of(subtract));
+    /**
+     * The result of subtracting the {@code other} value from {@code this}.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    default IntegerExpression subtract(final int other) {
+        return this.subtract(Expressions.of(other));
     }
 
-    IntegerExpression max(IntegerExpression i);
-    IntegerExpression min(IntegerExpression i);
+    /**
+     * The larger value of {@code this} and the {@code other} value.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    IntegerExpression max(IntegerExpression other);
 
+    /**
+     * The smaller value of {@code this} and the {@code other} value.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    IntegerExpression min(IntegerExpression other);
+
+    /**
+     * The absolute value of {@code this} value.
+     *
+     * @return the resulting value.
+     */
     IntegerExpression abs();
+
+    /**
+     * The {@link DateExpression date} corresponding to {@code this} value
+     * when taken to be the number of milliseconds since the Unix epoch.
+     *
+     * @return the resulting value.
+     */
+    DateExpression millisecondsToDate();
+    // TODO-END rename integer.utcMillisecondsToDate -- date.asUtcMilliseconds
 
     <R extends Expression> R passIntegerTo(Function<? super IntegerExpression, ? extends R> f);
     <R extends Expression> R switchIntegerOn(Function<Branches<IntegerExpression>, ? extends BranchesTerminal<IntegerExpression, ? extends R>> on);

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
@@ -60,6 +60,25 @@ public interface MapExpression<T extends Expression> extends Expression {
 
     <R extends DocumentExpression> R asDocument();
 
+    /**
+     * The result of passing {@code this} value to the provided function.
+     * Equivalent to {@code f.apply(this)}, and allows lambdas and static,
+     * user-defined functions to use the chaining syntax.
+     *
+     * @see Expression#passTo
+     * @param f the function to apply.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
     <R extends Expression> R passMapTo(Function<? super MapExpression<T>, ? extends R> f);
-    <R extends Expression> R switchMapOn(Function<Branches<MapExpression<T>>, ? extends BranchesTerminal<MapExpression<T>, ? extends R>> on);
+
+    /**
+     * The result of applying the provided switch mapping to {@code this} value.
+     *
+     * @see Expression#switchOn
+     * @param mapping the switch mapping.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
+    <R extends Expression> R switchMapOn(Function<Branches<MapExpression<T>>, ? extends BranchesTerminal<MapExpression<T>, ? extends R>> mapping);
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
@@ -19,6 +19,7 @@ package com.mongodb.client.model.expressions;
 import java.util.function.Function;
 
 import static com.mongodb.client.model.expressions.Expressions.of;
+import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.PRESENT;
 
 public interface MapExpression<T extends Expression> extends Expression {
 
@@ -29,6 +30,7 @@ public interface MapExpression<T extends Expression> extends Expression {
     }
 
     // TODO-END doc "user asserts"
+    @MqlUnchecked(PRESENT)
     T get(StringExpression key);
 
     // TODO-END doc "user asserts"

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
@@ -145,13 +145,13 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public BooleanExpression or(final BooleanExpression or) {
-        return new MqlExpression<>(ast("$or", or));
+    public BooleanExpression or(final BooleanExpression other) {
+        return new MqlExpression<>(ast("$or", other));
     }
 
     @Override
-    public BooleanExpression and(final BooleanExpression and) {
-        return new MqlExpression<>(ast("$and", and));
+    public BooleanExpression and(final BooleanExpression other) {
+        return new MqlExpression<>(ast("$and", other));
     }
 
     @Override
@@ -392,33 +392,33 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public BooleanExpression eq(final Expression eq) {
-        return new MqlExpression<>(ast("$eq", eq));
+    public BooleanExpression eq(final Expression other) {
+        return new MqlExpression<>(ast("$eq", other));
     }
 
     @Override
-    public BooleanExpression ne(final Expression ne) {
-        return new MqlExpression<>(ast("$ne", ne));
+    public BooleanExpression ne(final Expression other) {
+        return new MqlExpression<>(ast("$ne", other));
     }
 
     @Override
-    public BooleanExpression gt(final Expression gt) {
-        return new MqlExpression<>(ast("$gt", gt));
+    public BooleanExpression gt(final Expression other) {
+        return new MqlExpression<>(ast("$gt", other));
     }
 
     @Override
-    public BooleanExpression gte(final Expression gte) {
-        return new MqlExpression<>(ast("$gte", gte));
+    public BooleanExpression gte(final Expression other) {
+        return new MqlExpression<>(ast("$gte", other));
     }
 
     @Override
-    public BooleanExpression lt(final Expression lt) {
-        return new MqlExpression<>(ast("$lt", lt));
+    public BooleanExpression lt(final Expression other) {
+        return new MqlExpression<>(ast("$lt", other));
     }
 
     @Override
-    public BooleanExpression lte(final Expression lte) {
-        return new MqlExpression<>(ast("$lte", lte));
+    public BooleanExpression lte(final Expression other) {
+        return new MqlExpression<>(ast("$lte", other));
     }
 
     public BooleanExpression isBoolean() {
@@ -551,11 +551,11 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public ArrayExpression<T> filter(final Function<? super T, ? extends BooleanExpression> cond) {
+    public ArrayExpression<T> filter(final Function<? super T, ? extends BooleanExpression> predicate) {
         T varThis = variable("$$this");
         return new MqlExpression<>((cr) -> astDoc("$filter", new BsonDocument()
                 .append("input", this.toBsonValue(cr))
-                .append("cond", extractBsonValue(cr, cond.apply(varThis)))));
+                .append("cond", extractBsonValue(cr, predicate.apply(varThis)))));
     }
 
     public ArrayExpression<T> sort() {
@@ -721,13 +721,13 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public NumberExpression max(final NumberExpression n) {
-        return new MqlExpression<>(ast("$max", n));
+    public NumberExpression max(final NumberExpression other) {
+        return new MqlExpression<>(ast("$max", other));
     }
 
     @Override
-    public NumberExpression min(final NumberExpression n) {
-        return new MqlExpression<>(ast("$min", n));
+    public NumberExpression min(final NumberExpression other) {
+        return new MqlExpression<>(ast("$min", other));
     }
 
     @Override
@@ -741,8 +741,8 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public IntegerExpression multiply(final IntegerExpression i) {
-        return new MqlExpression<>(ast("$multiply", i));
+    public IntegerExpression multiply(final IntegerExpression other) {
+        return new MqlExpression<>(ast("$multiply", other));
     }
 
     @Override
@@ -761,8 +761,8 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public IntegerExpression add(final IntegerExpression i) {
-        return new MqlExpression<>(ast("$add", i));
+    public IntegerExpression add(final IntegerExpression other) {
+        return new MqlExpression<>(ast("$add", other));
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
@@ -155,8 +155,8 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public <R extends Expression> R cond(final R left, final R right) {
-        return newMqlExpression(ast("$cond", left, right));
+    public <R extends Expression> R cond(final R ifTrue, final R ifFalse) {
+        return newMqlExpression(ast("$cond", ifTrue, ifFalse));
     }
 
     /** @see DocumentExpression */

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
@@ -504,7 +504,7 @@ final class MqlExpression<T extends Expression>
     }
 
     BooleanExpression isDocumentOrMap() {
-        return new MqlExpression<>(ast("$type")).eq(of("object"));
+        return new MqlExpression<>(astWrapped("$type")).eq(of("object"));
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlUnchecked.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlUnchecked.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.client.model.expressions;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Documents places where the API relies on a user asserting
+ * something that is not checked at run-time.
+ * If the assertion turns out to be false, the API behavior is unspecified.
+ *
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.TYPE_USE})
+public @interface MqlUnchecked {
+    /**
+     * @return A hint on the user assertion the API relies on.
+     */
+    Unchecked[] value();
+
+    /**
+     * @see MqlUnchecked#value()
+     */
+    enum Unchecked {
+        /**
+         * The API relies on the values it encounters being of the type
+         * implied/specified by or inferred from the user code.
+         * For example, {@link com.mongodb.client.model.expressions.DocumentExpression#getBoolean(String)}
+         * relies on the values of the document field being of the
+         * {@linkplain com.mongodb.client.model.expressions.BooleanExpression boolean} type.
+         */
+        TYPE,
+        /**
+         * The API checks the raw type, but relies on the type argument
+         * implied/specified by or inferred from the user code being correct.
+         * For example, {@link com.mongodb.client.model.expressions.Expression#isArrayOr(ArrayExpression)}
+         * checks that the value is of the
+         * {@linkplain com.mongodb.client.model.expressions.ArrayExpression array} raw type,
+         * but relies on the elements of the array being of the type derived from the user code.
+         *
+         * <p>One may think of it as a more specific version of {@link #TYPE}.</p>
+         */
+        TYPE_ARGUMENT,
+        /**
+         * The API relies on the array being non-empty.
+         * For example, {@link com.mongodb.client.model.expressions.ArrayExpression#first()}.
+         */
+        NON_EMPTY,
+        /**
+         * The API relies on the element identified by index, name, etc., being present in the
+         * {@linkplain com.mongodb.client.model.expressions.DocumentExpression document} involved.
+         * For example, {@link com.mongodb.client.model.expressions.DocumentExpression#getField(String)}.
+         */
+        PRESENT,
+    }
+}

--- a/driver-core/src/main/com/mongodb/client/model/expressions/NumberExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/NumberExpression.java
@@ -19,45 +19,127 @@ package com.mongodb.client.model.expressions;
 import java.util.function.Function;
 
 /**
- * Expresses a numeric value.
+ * A number value. {@link IntegerExpression Integers} are a subset of numbers,
+ * and so, for example, the integer 0 and the number 0 are the same value,
+ * and are equal.
  */
 public interface NumberExpression extends Expression {
 
-    NumberExpression multiply(NumberExpression n);
+    /**
+     * The product of multiplying {@code this} and the {@code other} value.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    NumberExpression multiply(NumberExpression other);
 
-    default NumberExpression multiply(final Number multiply) {
-        return this.multiply(Expressions.numberToExpression(multiply));
+    /**
+     * The product of multiplying {@code this} and the {@code other} value.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    default NumberExpression multiply(final Number other) {
+        return this.multiply(Expressions.numberToExpression(other));
     }
 
-    NumberExpression divide(NumberExpression n);
+    /**
+     * The result of dividing {@code this} value by the {@code other} value.
+     * This is not integer division: dividing {@code 1} by {@code 2} will yield
+     * {@code 0.5}.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    NumberExpression divide(NumberExpression other);
 
-    default NumberExpression divide(final Number divide) {
-        return this.divide(Expressions.numberToExpression(divide));
+    /**
+     * The result of dividing {@code this} value by the {@code other} value.
+     * This is not integer division: dividing {@code 1} by {@code 2} will yield
+     * {@code 0.5}.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    default NumberExpression divide(final Number other) {
+        return this.divide(Expressions.numberToExpression(other));
     }
 
-    NumberExpression add(NumberExpression n);
+    /**
+     * The sum of adding {@code this} and the {@code other} value.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    NumberExpression add(NumberExpression other);
 
-    default NumberExpression add(final Number add) {
-        return this.add(Expressions.numberToExpression(add));
+    /**
+     * The sum of adding {@code this} and the {@code other} value.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    default NumberExpression add(final Number other) {
+        return this.add(Expressions.numberToExpression(other));
     }
 
-    NumberExpression subtract(NumberExpression n);
+    /**
+     * The result of subtracting the {@code other} value from {@code this}.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    NumberExpression subtract(NumberExpression other);
 
-    default NumberExpression subtract(final Number subtract) {
-        return this.subtract(Expressions.numberToExpression(subtract));
+    /**
+     * The result of subtracting the {@code other} value from {@code this}.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    default NumberExpression subtract(final Number other) {
+        return this.subtract(Expressions.numberToExpression(other));
     }
 
-    NumberExpression max(NumberExpression n);
+    /**
+     * The larger value of {@code this} and the {@code other} value.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    NumberExpression max(NumberExpression other);
 
-    NumberExpression min(NumberExpression n);
+    /**
+     * The smaller value of {@code this} and the {@code other} value.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    NumberExpression min(NumberExpression other);
 
+    /**
+     * The integer result of rounding {@code this} to the nearest even value.
+     *
+     * @return the resulting value.
+     */
     IntegerExpression round();
 
+    /**
+     * The result of rounding {@code this} to the nearest even {@code place}.
+     *
+     * @param place the decimal place to round to, from -20 to 100, exclusive.
+     *              Positive values specify the place to the right of the
+     *              decimal point, while negative values, to the left.
+     * @return the resulting value.
+     */
     NumberExpression round(IntegerExpression place);
 
+    /**
+     * The absolute value of {@code this} value.
+     *
+     * @return the resulting value.
+     */
     NumberExpression abs();
-
-    DateExpression millisecondsToDate();
 
     <R extends Expression> R passNumberTo(Function<? super NumberExpression, ? extends R> f);
     <R extends Expression> R switchNumberOn(Function<Branches<NumberExpression>, ? extends BranchesTerminal<NumberExpression, ? extends R>> on);

--- a/driver-core/src/main/com/mongodb/client/model/expressions/NumberExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/NumberExpression.java
@@ -19,9 +19,10 @@ package com.mongodb.client.model.expressions;
 import java.util.function.Function;
 
 /**
- * A number value. {@link IntegerExpression Integers} are a subset of numbers,
- * and so, for example, the integer 0 and the number 0 are the same value,
- * and are equal.
+ * A number {@linkplain Expression value} in the context of the MongoDB Query
+ * Language (MQL). {@linkplain IntegerExpression Integers} are a subset of
+ * numbers, and so, for example, the integer 0 and the number 0 are
+ * {@linkplain #eq(Expression) equal}.
  */
 public interface NumberExpression extends Expression {
 
@@ -44,9 +45,9 @@ public interface NumberExpression extends Expression {
     }
 
     /**
-     * The result of dividing {@code this} value by the {@code other} value.
-     * This is not integer division: dividing {@code 1} by {@code 2} will yield
-     * {@code 0.5}.
+     * The quotient of dividing {@code this} value by the {@code other} value.
+     * This is not integer division: dividing {@code 1} by {@code 2} will
+     * always yield {@code 0.5}.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -54,9 +55,9 @@ public interface NumberExpression extends Expression {
     NumberExpression divide(NumberExpression other);
 
     /**
-     * The result of dividing {@code this} value by the {@code other} value.
-     * This is not integer division: dividing {@code 1} by {@code 2} will yield
-     * {@code 0.5}.
+     * The quotient of dividing {@code this} value by the {@code other} value.
+     * This is not integer division: dividing {@code 1} by {@code 2} will
+     * always yield {@code 0.5}.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -84,7 +85,7 @@ public interface NumberExpression extends Expression {
     }
 
     /**
-     * The result of subtracting the {@code other} value from {@code this}.
+     * The difference of subtracting the {@code other} value from {@code this}.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -92,7 +93,7 @@ public interface NumberExpression extends Expression {
     NumberExpression subtract(NumberExpression other);
 
     /**
-     * The result of subtracting the {@code other} value from {@code this}.
+     * The difference of subtracting the {@code other} value from {@code this}.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -102,7 +103,8 @@ public interface NumberExpression extends Expression {
     }
 
     /**
-     * The larger value of {@code this} and the {@code other} value.
+     * The {@linkplain #gt(Expression) larger} value of {@code this}
+     * and the {@code other} value.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -110,7 +112,8 @@ public interface NumberExpression extends Expression {
     NumberExpression max(NumberExpression other);
 
     /**
-     * The smaller value of {@code this} and the {@code other} value.
+     * The {@linkplain #lt(Expression) smaller} value of {@code this}
+     * and the {@code other} value.
      *
      * @param other the other value.
      * @return the resulting value.
@@ -125,7 +128,8 @@ public interface NumberExpression extends Expression {
     IntegerExpression round();
 
     /**
-     * The result of rounding {@code this} to the nearest even {@code place}.
+     * The result of rounding {@code this} to {@code place} decimal places
+     * using the "half to even" approach.
      *
      * @param place the decimal place to round to, from -20 to 100, exclusive.
      *              Positive values specify the place to the right of the
@@ -141,6 +145,25 @@ public interface NumberExpression extends Expression {
      */
     NumberExpression abs();
 
+    /**
+     * The result of passing {@code this} value to the provided function.
+     * Equivalent to {@code f.apply(this)}, and allows lambdas and static,
+     * user-defined functions to use the chaining syntax.
+     *
+     * @see Expression#passTo
+     * @param f the function to apply.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
     <R extends Expression> R passNumberTo(Function<? super NumberExpression, ? extends R> f);
-    <R extends Expression> R switchNumberOn(Function<Branches<NumberExpression>, ? extends BranchesTerminal<NumberExpression, ? extends R>> on);
+
+    /**
+     * The result of applying the provided switch mapping to {@code this} value.
+     *
+     * @see Expression#switchOn
+     * @param mapping the switch mapping.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
+    <R extends Expression> R switchNumberOn(Function<Branches<NumberExpression>, ? extends BranchesTerminal<NumberExpression, ? extends R>> mapping);
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/StringExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/StringExpression.java
@@ -55,6 +55,25 @@ public interface StringExpression extends Expression {
 
     DateExpression parseDate(StringExpression timezone, StringExpression format);
 
+    /**
+     * The result of passing {@code this} value to the provided function.
+     * Equivalent to {@code f.apply(this)}, and allows lambdas and static,
+     * user-defined functions to use the chaining syntax.
+     *
+     * @see Expression#passTo
+     * @param f the function to apply.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
     <R extends Expression> R passStringTo(Function<? super StringExpression, ? extends R> f);
-    <R extends Expression> R switchStringOn(Function<Branches<StringExpression>, ? extends BranchesTerminal<StringExpression, ? extends R>> on);
+
+    /**
+     * The result of applying the provided switch mapping to {@code this} value.
+     *
+     * @see Expression#switchOn
+     * @param mapping the switch mapping.
+     * @return the resulting value.
+     * @param <R> the type of the resulting value.
+     */
+    <R extends Expression> R switchStringOn(Function<Branches<StringExpression>, ? extends BranchesTerminal<StringExpression, ? extends R>> mapping);
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/package-info.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/package-info.java
@@ -18,6 +18,7 @@
  * API for MQL expressions.
  *
  * @see com.mongodb.client.model.expressions.Expression
+ * @see com.mongodb.client.model.expressions.Expressions
  */
 @NonNullApi
 package com.mongodb.client.model.expressions;

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/ControlExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/ControlExpressionsFunctionalTest.java
@@ -205,7 +205,7 @@ class ControlExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest
         assertExpression("A",
                 ofMap(Document.parse("{}")).switchOn(on -> on.isMap(v -> of("A"))),
                 "{'$switch': {'branches': [{'case': {'$eq': [{'$type': "
-                        + "{'$literal': {}}}, 'object']}, 'then': 'A'}]}}");
+                        + "[{'$literal': {}}]}, 'object']}, 'then': 'A'}]}}");
         assertExpression("A",
                 ofNull().switchOn(on -> on.isNull(v -> of("A"))),
                 "{'$switch': {'branches': [{'case': {'$eq': [null, null]}, 'then': 'A'}]}}");
@@ -268,9 +268,8 @@ class ControlExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest
                         + "{'case': {'$eq': [{'$type': [{'$literal': {}}]}, 'object']}, 'then': 'A'}]}}");
         assertExpression("A",
                 ofMap(Document.parse("{}")).switchOn(on -> on.isNull(v -> of("X")).isMap(v -> of("A"))),
-                " {'$switch': {'branches': ["
-                        + "{'case': {'$eq': [{'$literal': {}}, null]}, 'then': 'X'}, "
-                        + "{'case': {'$eq': [{'$type': {'$literal': {}}}, 'object']}, 'then': 'A'}]}}");
+                "{'$switch': {'branches': [{'case': {'$eq': [{'$literal': {}}, null]}, 'then': 'X'}, "
+                        + "{'case': {'$eq': [{'$type': [{'$literal': {}}]}, 'object']}, 'then': 'A'}]}}");
         assertExpression("A",
                 ofNull().switchOn(on -> on.isNumber(v -> of("X")).isNull(v -> of("A"))),
                 "{'$switch': {'branches': [{'case': {'$isNumber': [null]}, 'then': 'X'}, "

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/TypeExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/TypeExpressionsFunctionalTest.java
@@ -152,7 +152,7 @@ class TypeExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertExpression(
                 map,
                 ofMap(map).isMapOr(ofMap(BsonDocument.parse("{b: 2}"))),
-                "{'$cond': [{'$eq': [{'$type': {'$literal': {'a': 1}}}, 'object']}, "
+                "{'$cond': [{'$eq': [{'$type': [{'$literal': {'a': 1}}]}, 'object']}, "
                         + "{'$literal': {'a': 1}}, {'$literal': {'b': 2}}]}");
         // non-map:
         assertExpression(map, ofIntegerArray(1).isMapOr(ofMap(map)));


### PR DESCRIPTION
Partial work for JAVA-4799

Covers boolean, date, number, integer, and expression, but not others, since PRs are still in progress.

There are naming changes, to parameters especially.