### PR TITLE
Improve logging in server monitor

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.connection;
 
+import com.mongodb.MongoInterruptedException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.MongoSocketException;
 import com.mongodb.ServerApi;
@@ -178,6 +179,10 @@ class DefaultServerMonitor implements ServerMonitor {
                     }
                     waitForNext();
                 }
+            } catch (MongoInterruptedException e) {
+                // ignore
+            } catch (RuntimeException e) {
+                LOGGER.error(format("Server monitor for %s exiting with exception", serverId), e);
             } finally {
                 if (connection != null) {
                     connection.close();


### PR DESCRIPTION
Log as error any exception except MongoInterruptedException in server monitor before exiting monitor thread

JAVA-4822