### PR TITLE
Add OSGi package imports for AWS SDK v1 and v2

### DIFF
--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -83,6 +83,8 @@ afterEvaluate {
             '!sun.nio.ch.*',  // Used by DirectBufferDeallocator only for java 8
             '!javax.annotation.*', // Brought in by com.google.code.findbugs:annotations
             'io.netty.*;resolution:=optional',
+            'com.amazonaws.*;resolution:=optional',
+            'software.amazon.awssdk.*;resolution:=optional',
             'org.xerial.snappy.*;resolution:=optional',
             'com.github.luben.zstd.*;resolution:=optional',
             'org.slf4j.*;resolution:=optional',


### PR DESCRIPTION
JAVA-4836

One thing that's weird here is that there is no version range in the jar file:

```
Import-Package: io.netty.bootstrap;resolution:=optional;version="[4.1,
 5)",io.netty.buffer;resolution:=optional;version="[4.1,5)",io.netty.c
 hannel;resolution:=optional;version="[4.1,5)",io.netty.channel.nio;re
 solution:=optional;version="[4.1,5)",io.netty.channel.socket;resoluti
 on:=optional;version="[4.1,5)",io.netty.channel.socket.nio;resolution
 :=optional;version="[4.1,5)",io.netty.handler.ssl;resolution:=optiona
 l;version="[4.1,5)",io.netty.handler.timeout;resolution:=optional;ver
 sion="[4.1,5)",io.netty.util.concurrent;resolution:=optional;version=
 "[4.1,5)",com.amazonaws.auth;resolution:=optional,software.amazon.aws
 sdk.auth.credentials;resolution:=optional,org.xerial.snappy;resolutio
 n:=optional;version="[1.1,2)",com.github.luben.zstd;resolution:=optio
 nal;version="[1.5,2)",org.slf4j;resolution:=optional;version="[1.7,2)
 ",jnr.unixsocket;resolution:=optional;version="[0.38,1)",com.mongodb.
 crypt.capi;resolution:=optional;version="[1.6,2)",jdk.net;resolution:
 =optional,org.bson.codecs.record;resolution:=optional;version="[4.9,5
 )",javax.crypto,javax.crypto.spec,javax.management,javax.naming,javax
 .naming.directory,javax.net,javax.net.ssl,javax.security.auth,javax.s
 ecurity.auth.callback,javax.security.auth.kerberos,javax.security.aut
 h.login,javax.security.sasl,org.bson;version="[4.9,5)",org.bson.asser
 tions;version="[4.9,5)",org.bson.codecs;version="[4.9,5)",org.bson.co
 decs.configuration;version="[4.9,5)",org.bson.codecs.jsr310;version="
 [4.9,5)",org.bson.codecs.pojo;version="[4.9,5)",org.bson.codecs.pojo.
 annotations;version="[4.9,5)",org.bson.conversions;version="[4.9,5)",
 org.bson.io;version="[4.9,5)",org.bson.json;version="[4.9,5)",org.bso
 n.types;version="[4.9,5)",org.ietf.jgss
```

I don't know what control this behavior, and not clear why there is no version for `software.amazon.aws
 sdk.auth.credentials` or `software.amazon.aws.sdk.auth.credentials` or what the affect of that might be.  I will post a question about it in the ticket.