### PR TITLE
Add structured logging support for command logging

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -86,6 +86,7 @@
     <suppress checks="ParameterNumber" files="DefaultClusterableServerFactory"/>
     <suppress checks="ParameterNumber" files="Operations"/>
     <suppress checks="ParameterNumber" files="ChangeStreamDocument"/>
+    <suppress checks="ParameterNumber" files="StructuredLogger"/>
 
     <!--Legacy code that has not yet been cleaned-->
     <suppress checks="FinalClass" files="AggregationOptions"/>

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -143,6 +143,7 @@
         <exclude name="UnnecessaryObjectReferences"/>
         <exclude name="UnnecessaryBigDecimalInstantiation"/>
         <exclude name="UnnecessarySetter"/>
+        <exclude name="UnnecessaryGString"/>
     </ruleset-ref>
     <ruleset-ref path='rulesets/unused.xml'>
         <rule-config name='UnusedObject'>

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
@@ -80,7 +80,7 @@ public class DefaultClusterableServerFactory implements ClusterableServerFactory
         SameObjectProvider<SdamServerDescriptionManager> sdamProvider = SameObjectProvider.uninitialized();
         ServerMonitor serverMonitor = new DefaultServerMonitor(serverId, serverSettings, cluster.getClock(),
                 // no credentials, compressor list, or command listener for the server monitor factory
-                new InternalStreamConnectionFactory(clusterMode, heartbeatStreamFactory, null, applicationName,
+                new InternalStreamConnectionFactory(clusterMode, true, heartbeatStreamFactory, null, applicationName,
                         mongoDriverInformation, emptyList(), null, serverApi),
                 clusterMode, serverApi, sdamProvider);
         ConnectionPool connectionPool = new DefaultConnectionPool(serverId,

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -851,7 +851,7 @@ public class InternalStreamConnection implements InternalConnection {
 
     private CommandEventSender createCommandEventSender(final CommandMessage message, final ByteBufferBsonOutput bsonOutput,
             final RequestContext requestContext) {
-        if (!isMonitoringConnection && opened() && (commandListener != null || COMMAND_PROTOCOL_LOGGER.isDebugEnabled(getClusterId()))) {
+        if (!isMonitoringConnection && opened() && (commandListener != null || COMMAND_PROTOCOL_LOGGER.isDebugRequired(getClusterId()))) {
             return new LoggingCommandEventSender(SECURITY_SENSITIVE_COMMANDS, SECURITY_SENSITIVE_HELLO_COMMANDS, description,
                     commandListener, requestContext, message, bsonOutput, COMMAND_PROTOCOL_LOGGER);
         } else {

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -82,6 +82,7 @@ import static com.mongodb.internal.connection.ProtocolHelper.getOperationTime;
 import static com.mongodb.internal.connection.ProtocolHelper.getRecoveryToken;
 import static com.mongodb.internal.connection.ProtocolHelper.getSnapshotTimestamp;
 import static com.mongodb.internal.connection.ProtocolHelper.isCommandOk;
+import static com.mongodb.internal.logging.StructuredLogMessage.Level.DEBUG;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
@@ -851,7 +852,7 @@ public class InternalStreamConnection implements InternalConnection {
 
     private CommandEventSender createCommandEventSender(final CommandMessage message, final ByteBufferBsonOutput bsonOutput,
             final RequestContext requestContext) {
-        if (!isMonitoringConnection && opened() && (commandListener != null || COMMAND_PROTOCOL_LOGGER.isDebugRequired(getClusterId()))) {
+        if (!isMonitoringConnection && opened() && (commandListener != null || COMMAND_PROTOCOL_LOGGER.isRequired(DEBUG, getClusterId()))) {
             return new LoggingCommandEventSender(SECURITY_SENSITIVE_COMMANDS, SECURITY_SENSITIVE_HELLO_COMMANDS, description,
                     commandListener, requestContext, message, bsonOutput, COMMAND_PROTOCOL_LOGGER);
         } else {

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -108,6 +108,7 @@ public class InternalStreamConnection implements InternalConnection {
     private static final Logger LOGGER = Loggers.getLogger("connection");
 
     private final ClusterConnectionMode clusterConnectionMode;
+    private final boolean isMonitoringConnection;
     private final ServerId serverId;
     private final ConnectionGenerationSupplier connectionGenerationSupplier;
     private final StreamFactory streamFactory;
@@ -139,10 +140,20 @@ public class InternalStreamConnection implements InternalConnection {
     }
 
     public InternalStreamConnection(final ClusterConnectionMode clusterConnectionMode, final ServerId serverId,
+            final ConnectionGenerationSupplier connectionGenerationSupplier,
+            final StreamFactory streamFactory, final List<MongoCompressor> compressorList,
+            final CommandListener commandListener, final InternalConnectionInitializer connectionInitializer) {
+        this(clusterConnectionMode, false, serverId, connectionGenerationSupplier, streamFactory, compressorList, commandListener,
+                connectionInitializer);
+    }
+
+    public InternalStreamConnection(final ClusterConnectionMode clusterConnectionMode, final boolean isMonitoringConnection,
+                                    final ServerId serverId,
                                     final ConnectionGenerationSupplier connectionGenerationSupplier,
                                     final StreamFactory streamFactory, final List<MongoCompressor> compressorList,
                                     final CommandListener commandListener, final InternalConnectionInitializer connectionInitializer) {
         this.clusterConnectionMode = clusterConnectionMode;
+        this.isMonitoringConnection = isMonitoringConnection;
         this.serverId = notNull("serverId", serverId);
         this.connectionGenerationSupplier = notNull("connectionGeneration", connectionGenerationSupplier);
         this.streamFactory = notNull("streamFactory", streamFactory);

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionFactory.java
@@ -34,6 +34,7 @@ import static com.mongodb.internal.connection.ClientMetadataHelper.createClientM
 
 class InternalStreamConnectionFactory implements InternalConnectionFactory {
     private final ClusterConnectionMode clusterConnectionMode;
+    private final boolean isMonitoringConnection;
     private final StreamFactory streamFactory;
     private final BsonDocument clientMetadataDocument;
     private final List<MongoCompressor> compressorList;
@@ -42,12 +43,23 @@ class InternalStreamConnectionFactory implements InternalConnectionFactory {
     private final ServerApi serverApi;
     private final MongoCredentialWithCache credential;
 
-    InternalStreamConnectionFactory(final ClusterConnectionMode clusterConnectionMode, final StreamFactory streamFactory,
+    InternalStreamConnectionFactory(final ClusterConnectionMode clusterConnectionMode,
+            final StreamFactory streamFactory,
+            @Nullable final MongoCredentialWithCache credential,
+            @Nullable final String applicationName, final MongoDriverInformation mongoDriverInformation,
+            final List<MongoCompressor> compressorList,
+            @Nullable final CommandListener commandListener, @Nullable final ServerApi serverApi) {
+        this(clusterConnectionMode, false, streamFactory, credential, applicationName, mongoDriverInformation, compressorList,
+                commandListener, serverApi);
+    }
+    InternalStreamConnectionFactory(final ClusterConnectionMode clusterConnectionMode, final boolean isMonitoringConnection,
+                                    final StreamFactory streamFactory,
                                     @Nullable final MongoCredentialWithCache credential,
                                     @Nullable final String applicationName, final MongoDriverInformation mongoDriverInformation,
                                     final List<MongoCompressor> compressorList,
                                     @Nullable final CommandListener commandListener, @Nullable final ServerApi serverApi) {
         this.clusterConnectionMode = clusterConnectionMode;
+        this.isMonitoringConnection = isMonitoringConnection;
         this.streamFactory = notNull("streamFactory", streamFactory);
         this.compressorList = notNull("compressorList", compressorList);
         this.commandListener = commandListener;
@@ -59,9 +71,9 @@ class InternalStreamConnectionFactory implements InternalConnectionFactory {
     @Override
     public InternalConnection create(final ServerId serverId, final ConnectionGenerationSupplier connectionGenerationSupplier) {
         Authenticator authenticator = credential == null ? null : createAuthenticator(credential);
-        return new InternalStreamConnection(clusterConnectionMode, serverId, connectionGenerationSupplier, streamFactory, compressorList,
-                commandListener, new InternalStreamConnectionInitializer(clusterConnectionMode, authenticator, clientMetadataDocument,
-                compressorList, serverApi));
+        return new InternalStreamConnection(clusterConnectionMode, isMonitoringConnection, serverId, connectionGenerationSupplier,
+                streamFactory, compressorList, commandListener, new InternalStreamConnectionInitializer(clusterConnectionMode,
+                authenticator, clientMetadataDocument, compressorList, serverApi));
     }
 
     private Authenticator createAuthenticator(final MongoCredentialWithCache credential) {

--- a/driver-core/src/main/com/mongodb/internal/connection/LoggingCommandEventSender.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoggingCommandEventSender.java
@@ -208,7 +208,7 @@ class LoggingCommandEventSender implements CommandEventSender {
     }
 
     private boolean loggingRequired() {
-        return logger.isDebugEnabled(getClusterId());
+        return logger.isDebugRequired(getClusterId());
     }
 
 

--- a/driver-core/src/main/com/mongodb/internal/connection/LoggingCommandEventSender.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoggingCommandEventSender.java
@@ -21,6 +21,7 @@ import com.mongodb.RequestContext;
 import com.mongodb.connection.ClusterId;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.event.CommandListener;
+import com.mongodb.internal.logging.StructuredLogMessage;
 import com.mongodb.internal.logging.StructuredLogMessage.Entry;
 import com.mongodb.internal.logging.StructuredLogger;
 import com.mongodb.lang.Nullable;
@@ -42,6 +43,8 @@ import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.internal.connection.ProtocolHelper.sendCommandFailedEvent;
 import static com.mongodb.internal.connection.ProtocolHelper.sendCommandStartedEvent;
 import static com.mongodb.internal.connection.ProtocolHelper.sendCommandSucceededEvent;
+import static com.mongodb.internal.logging.StructuredLogMessage.Component.COMMAND;
+import static com.mongodb.internal.logging.StructuredLogMessage.Level.DEBUG;
 
 class LoggingCommandEventSender implements CommandEventSender {
     private static final int MAX_COMMAND_DOCUMENT_LENGTH_TO_LOG = 1000;
@@ -86,7 +89,7 @@ class LoggingCommandEventSender implements CommandEventSender {
             builder.append(" Command: %s");
             entries.add(new Entry("command", redactionRequired ? "{}" : getTruncatedJsonCommand(commandDocument)));
 
-            logger.debug("Command started", getClusterId(), builder.toString(), entries.toArray(new Entry[0]));
+            logger.log(new StructuredLogMessage(COMMAND, DEBUG, "Command started", getClusterId(), entries), builder.toString());
         }
 
         if (eventRequired()) {
@@ -120,7 +123,8 @@ class LoggingCommandEventSender implements CommandEventSender {
 
             appendCommonLogFragment(entries, builder);
 
-            logger.debug("Command failed", getClusterId(), commandEventException, builder.toString(), entries.toArray(new Entry[0]));
+            logger.log(new StructuredLogMessage(COMMAND, DEBUG, "Command failed", getClusterId(), commandEventException, entries),
+                    builder.toString());
         }
 
         if (eventRequired()) {
@@ -155,7 +159,8 @@ class LoggingCommandEventSender implements CommandEventSender {
             String replyString = redactionRequired ? "{}" : getTruncatedJsonCommand(responseDocumentForEvent);
             entries.add(new Entry("reply", replyString));
 
-            logger.debug("Command succeeded", getClusterId(), builder.toString(), entries.toArray(new Entry[0]));
+            logger.log(new StructuredLogMessage(COMMAND, DEBUG, "Command succeeded", getClusterId(), entries),
+                    builder.toString());
         }
 
         if (eventRequired()) {
@@ -166,7 +171,7 @@ class LoggingCommandEventSender implements CommandEventSender {
     }
 
     private boolean loggingRequired() {
-        return logger.isDebugRequired(getClusterId());
+        return logger.isRequired(DEBUG, getClusterId());
     }
 
 

--- a/driver-core/src/main/com/mongodb/internal/connection/LoggingCommandEventSender.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoggingCommandEventSender.java
@@ -18,9 +18,10 @@ package com.mongodb.internal.connection;
 
 import com.mongodb.MongoCommandException;
 import com.mongodb.RequestContext;
+import com.mongodb.connection.ClusterId;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.event.CommandListener;
-import com.mongodb.internal.diagnostics.logging.Logger;
+import com.mongodb.internal.logging.StructuredLogger;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
@@ -37,15 +38,15 @@ import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.internal.connection.ProtocolHelper.sendCommandFailedEvent;
 import static com.mongodb.internal.connection.ProtocolHelper.sendCommandStartedEvent;
 import static com.mongodb.internal.connection.ProtocolHelper.sendCommandSucceededEvent;
-import static java.lang.String.format;
 
 class LoggingCommandEventSender implements CommandEventSender {
     private static final int MAX_COMMAND_DOCUMENT_LENGTH_TO_LOG = 1000;
+    private static final double NANOS_PER_MILLI = 1_000_000.0d;
 
     private final ConnectionDescription description;
     @Nullable private final CommandListener commandListener;
     private final RequestContext requestContext;
-    private final Logger logger;
+    private final StructuredLogger logger;
     private final long startTimeNanos;
     private final CommandMessage message;
     private final String commandName;
@@ -55,7 +56,7 @@ class LoggingCommandEventSender implements CommandEventSender {
     LoggingCommandEventSender(final Set<String> securitySensitiveCommands, final Set<String> securitySensitiveHelloCommands,
             final ConnectionDescription description,
             @Nullable final CommandListener commandListener, final RequestContext requestContext, final CommandMessage message,
-            final ByteBufferBsonOutput bsonOutput, final Logger logger) {
+            final ByteBufferBsonOutput bsonOutput, final StructuredLogger logger) {
         this.description = description;
         this.commandListener = commandListener;
         this.requestContext = requestContext;
@@ -71,12 +72,33 @@ class LoggingCommandEventSender implements CommandEventSender {
     @Override
     public void sendStartedEvent() {
         if (loggingRequired()) {
-            String commandString = redactionRequired ? format("{\"%s\": ...", commandName) : getTruncatedJsonCommand();
-            // TODO: log RequestContext?
-            logger.debug(
-                    format("Sending command '%s' with request id %d to database %s on connection [%s] to server %s",
-                            commandString, message.getId(),
-                            message.getNamespace().getDatabaseName(), description.getConnectionId(), description.getServerAddress()));
+            String commandString = redactionRequired ? "{}" : getTruncatedJsonCommand(commandDocument);
+            if (description.getServiceId() == null) {
+                logger.debug("Command started", getClusterId(),
+                        "Command \"%s\" started on database %s using a connection with driver-generated ID %d and server-generated ID %d "
+                                + "to %s:%s. The request ID is %s. Command: %s",
+                        "commandName", commandName,
+                        "databaseName", message.getNamespace().getDatabaseName(),
+                        "driverConnectionId", description.getConnectionId().getLocalValue(),
+                        "serverConnectionId", description.getConnectionId().getServerValue(),
+                        "serverHost", description.getServerAddress().getHost(),
+                        "serverPort", description.getServerAddress().getPort(),
+                        "requestId", message.getId(),
+                        "command", commandString);
+            } else {
+                logger.debug("Command started", getClusterId(),
+                        "Command \"%s\" started on database %s using a connection with driver-generated ID %d and server-generated ID %d "
+                                + "to %s:%s with service ID %s. The request ID is %s. Command: %s",
+                        "commandName", commandName,
+                        "databaseName", message.getNamespace().getDatabaseName(),
+                        "driverConnectionId", description.getConnectionId().getLocalValue(),
+                        "serverConnectionId", description.getConnectionId().getServerValue(),
+                        "serverHost", description.getServerAddress().getHost(),
+                        "serverPort", description.getServerAddress().getPort(),
+                        "serviceId", description.getServiceId(),
+                        "requestId", message.getId(),
+                        "command", commandString);
+            }
         }
 
         if (eventRequired()) {
@@ -91,7 +113,114 @@ class LoggingCommandEventSender implements CommandEventSender {
         commandDocument = null;
     }
 
-    private String getTruncatedJsonCommand() {
+    @Override
+    public void sendFailedEvent(final Throwable t) {
+        Throwable commandEventException = t;
+        if (t instanceof MongoCommandException && redactionRequired) {
+            MongoCommandException originalCommandException = (MongoCommandException) t;
+            commandEventException = new MongoCommandException(new BsonDocument(), originalCommandException.getServerAddress());
+            commandEventException.setStackTrace(t.getStackTrace());
+        }
+        long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
+
+        if (loggingRequired()) {
+            if (description.getServiceId() == null) {
+                logger.debug("Command failed", getClusterId(), commandEventException,
+                        "Command \"%s\" failed in %.2f ms using a connection with driver-generated ID %d and server-generated ID "
+                                + "%d to %s:%s. The request ID is %d.",
+                        "commandName", commandName,
+                        "durationMS", elapsedTimeNanos / NANOS_PER_MILLI,
+                        "driverConnectionId", description.getConnectionId().getLocalValue(),
+                        "serverConnectionId", description.getConnectionId().getServerValue(),
+                        "serverHost", description.getServerAddress().getHost(),
+                        "serverPort", description.getServerAddress().getPort(),
+                        "requestId", message.getId());
+            } else {
+                logger.debug("Command failed", getClusterId(), commandEventException,
+                        "Command \"%s\" failed in %.2f ms using a connection with driver-generated ID %d and server-generated ID "
+                                + "%d to %s:%s with service ID %s. The request ID is %d.",
+                        "commandName", commandName,
+                        "durationMS", elapsedTimeNanos / NANOS_PER_MILLI,
+                        "driverConnectionId", description.getConnectionId().getLocalValue(),
+                        "serverConnectionId", description.getConnectionId().getServerValue(),
+                        "serverHost", description.getServerAddress().getHost(),
+                        "serverPort", description.getServerAddress().getPort(),
+                        "serviceId", description.getServiceId(),
+                        "requestId", message.getId());
+            }
+        }
+
+        if (eventRequired()) {
+            sendCommandFailedEvent(message, commandName, description, elapsedTimeNanos, commandEventException, commandListener,
+                    requestContext);
+        }
+    }
+
+    @Override
+    public void sendSucceededEvent(final ResponseBuffers responseBuffers) {
+        sendSucceededEvent(responseBuffers.getResponseDocument(message.getId(), new RawBsonDocumentCodec()));
+    }
+
+    @Override
+    public void sendSucceededEventForOneWayCommand() {
+        sendSucceededEvent(new BsonDocument("ok", new BsonInt32(1)));
+    }
+
+    private void sendSucceededEvent(final BsonDocument reply) {
+        long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
+
+        if (loggingRequired()) {
+            BsonDocument responseDocumentForEvent = redactionRequired ? new BsonDocument() : reply;
+            String replyString = redactionRequired ? "{}" : getTruncatedJsonCommand(responseDocumentForEvent);
+            if (description.getServiceId() == null) {
+                logger.debug("Command succeeded", getClusterId(),
+                        "Command \"%s\" succeeded in %.2f ms using a connection with driver-generated ID %d and server-generated ID %d to "
+                                + "%s:%s. The request ID is %d. Command reply: %s",
+                        "commandName", commandName,
+                        "durationMS", elapsedTimeNanos / NANOS_PER_MILLI,
+                        "driverConnectionId", description.getConnectionId().getLocalValue(),
+                        "serverConnectionId", description.getConnectionId().getServerValue(),
+                        "serverHost", description.getServerAddress().getHost(),
+                        "serverPort", description.getServerAddress().getPort(),
+                        "requestId", message.getId(),
+                        "reply", replyString);
+            } else {
+                logger.debug("Command succeeded", getClusterId(),
+                        "Command \"%s\" succeeded in %.2f ms using a connection with driver-generated ID %d and server-generated ID %d to "
+                                + " %s:%s with service ID %s. The request ID is %d. Command reply: %s",
+                        "commandName", commandName,
+                        "durationMS", elapsedTimeNanos / NANOS_PER_MILLI,
+                        "driverConnectionId", description.getConnectionId().getLocalValue(),
+                        "serverConnectionId", description.getConnectionId().getServerValue(),
+                        "serverHost", description.getServerAddress().getHost(),
+                        "serverPort", description.getServerAddress().getPort(),
+                        "serviceId", description.getServiceId(),
+                        "requestId", message.getId(),
+                        "reply", replyString);
+            }
+        }
+
+        if (eventRequired()) {
+            BsonDocument responseDocumentForEvent = redactionRequired ? new BsonDocument() : reply;
+            sendCommandSucceededEvent(message, commandName, responseDocumentForEvent, description,
+                    elapsedTimeNanos, commandListener, requestContext);
+        }
+    }
+
+    private boolean loggingRequired() {
+        return logger.isDebugEnabled(getClusterId());
+    }
+
+
+    private ClusterId getClusterId() {
+        return description.getConnectionId().getServerId().getClusterId();
+    }
+
+    private boolean eventRequired() {
+        return commandListener != null;
+    }
+
+    private static String getTruncatedJsonCommand(final BsonDocument commandDocument) {
         StringWriter writer = new StringWriter();
 
         try (BsonReader bsonReader = commandDocument.asBsonReader()) {
@@ -107,79 +236,4 @@ class LoggingCommandEventSender implements CommandEventSender {
             return writer.toString();
         }
     }
-
-    @Override
-    public void sendFailedEvent(final Throwable t) {
-        Throwable commandEventException = t;
-        if (t instanceof MongoCommandException && redactionRequired) {
-            commandEventException = new MongoCommandException(new BsonDocument(), description.getServerAddress());
-        }
-        long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
-
-        if (loggingRequired()) {
-            logger.debug(
-                    format("Execution of command with request id %d failed to complete successfully in %s ms on connection [%s] "
-                                    + "to server %s",
-                            message.getId(), getElapsedTimeFormattedInMilliseconds(elapsedTimeNanos), description.getConnectionId(),
-                            description.getServerAddress()),
-                    commandEventException);
-        }
-
-        if (eventRequired()) {
-            sendCommandFailedEvent(message, commandName, description, elapsedTimeNanos, commandEventException, commandListener,
-                    requestContext);
-        }
-    }
-
-    @Override
-    public void sendSucceededEvent(final ResponseBuffers responseBuffers) {
-        long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
-
-        if (loggingRequired()) {
-            logger.debug(
-                    format("Execution of command with request id %d completed successfully in %s ms on connection [%s] to server %s",
-                            message.getId(), getElapsedTimeFormattedInMilliseconds(elapsedTimeNanos), description.getConnectionId(),
-                            description.getServerAddress()));
-        }
-
-        if (eventRequired()) {
-            BsonDocument responseDocumentForEvent = redactionRequired
-                    ? new BsonDocument()
-                    : responseBuffers.getResponseDocument(message.getId(), new RawBsonDocumentCodec());
-            sendCommandSucceededEvent(message, commandName, responseDocumentForEvent, description,
-                    elapsedTimeNanos, commandListener, requestContext);
-        }
-    }
-
-    @Override
-    public void sendSucceededEventForOneWayCommand() {
-        long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
-
-        if (loggingRequired()) {
-            logger.debug(
-                    format("Execution of one-way command with request id %d completed successfully in %s ms on connection [%s] "
-                                    + "to server %s",
-                            message.getId(), getElapsedTimeFormattedInMilliseconds(elapsedTimeNanos), description.getConnectionId(),
-                            description.getServerAddress()));
-        }
-
-        if (eventRequired()) {
-            BsonDocument responseDocumentForEvent = new BsonDocument("ok", new BsonInt32(1));
-            sendCommandSucceededEvent(message, commandName, responseDocumentForEvent, description,
-                    elapsedTimeNanos, commandListener, requestContext);
-        }
-    }
-
-    private boolean loggingRequired() {
-        return logger.isDebugEnabled();
-    }
-
-    private boolean eventRequired() {
-        return commandListener != null;
-    }
-
-    private String getElapsedTimeFormattedInMilliseconds(final long elapsedTimeNanos) {
-        return DecimalFormatHelper.format("#0.00", elapsedTimeNanos / 1000000.0);
-    }
-
 }

--- a/driver-core/src/main/com/mongodb/internal/logging/StructuredLogMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/logging/StructuredLogMessage.java
@@ -19,7 +19,6 @@ package com.mongodb.internal.logging;
 import com.mongodb.connection.ClusterId;
 import com.mongodb.lang.Nullable;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -27,12 +26,20 @@ import java.util.List;
  */
 public final class StructuredLogMessage {
 
-    private final String loggerName;
-    private final String level;
+    private final Component component;
+    private final Level level;
     private final String messageId;
     private final ClusterId clusterId;
     private final Throwable exception;
     private final List<Entry> entries;
+
+    public enum Component {
+        COMMAND
+    }
+
+    public enum Level {
+        DEBUG
+    }
 
     public static final class Entry {
         private final String name;
@@ -52,26 +59,26 @@ public final class StructuredLogMessage {
         }
     }
 
-    public StructuredLogMessage(final String loggerName, final String level, final String messageId, final ClusterId clusterId,
-            final Entry... entries) {
-        this(loggerName, level, messageId, clusterId, null, entries);
+    public StructuredLogMessage(final Component component, final Level level, final String messageId, final ClusterId clusterId,
+            final List<Entry> entries) {
+        this(component, level, messageId, clusterId, null, entries);
     }
 
-    public StructuredLogMessage(final String loggerName, final String level, final String messageId, final ClusterId clusterId,
-                                @Nullable final Throwable exception, final Entry... entries) {
-        this.loggerName = loggerName;
+    public StructuredLogMessage(final Component component, final Level level, final String messageId, final ClusterId clusterId,
+                                @Nullable final Throwable exception, final List<Entry> entries) {
+        this.component = component;
         this.level = level;
         this.messageId = messageId;
         this.clusterId = clusterId;
         this.exception = exception;
-        this.entries = Arrays.asList(entries);
+        this.entries = entries;
     }
 
-    public String getLoggerName() {
-        return loggerName;
+    public Component getComponent() {
+        return component;
     }
 
-    public String getLevel() {
+    public Level getLevel() {
         return level;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/logging/StructuredLogMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/logging/StructuredLogMessage.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.logging;
+
+import com.mongodb.connection.ClusterId;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+public class StructuredLogMessage {
+
+    private final String loggerName;
+    private final String level;
+    private final String messageId;
+    private final ClusterId clusterId;
+    private final Throwable exception;
+    private final List<Entry> entries;
+
+    public static final class Entry {
+        private final String name;
+        private final Object value;
+
+        public Entry(final String name, final Object value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Object getValue() {
+            return value;
+        }
+    }
+
+    public StructuredLogMessage(final String loggerName, final String level, final String messageId, final ClusterId clusterId,
+            final Entry... entries) {
+        this(loggerName, level, messageId, clusterId, null, entries);
+    }
+
+    public StructuredLogMessage(final String loggerName, final String level, final String messageId, final ClusterId clusterId,
+            final Throwable exception, final Entry... entries) {
+        this.loggerName = loggerName;
+        this.level = level;
+        this.messageId = messageId;
+        this.clusterId = clusterId;
+        this.exception = exception;
+        this.entries = Arrays.asList(entries);
+    }
+
+    public String getLoggerName() {
+        return loggerName;
+    }
+
+    public String getLevel() {
+        return level;
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public ClusterId getClusterId() {
+        return clusterId;
+    }
+
+    public Throwable getException() {
+        return exception;
+    }
+
+    public List<Entry> getEntries() {
+        return entries;
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/logging/StructuredLogMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/logging/StructuredLogMessage.java
@@ -17,6 +17,7 @@
 package com.mongodb.internal.logging;
 
 import com.mongodb.connection.ClusterId;
+import com.mongodb.lang.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -57,7 +58,7 @@ public final class StructuredLogMessage {
     }
 
     public StructuredLogMessage(final String loggerName, final String level, final String messageId, final ClusterId clusterId,
-            final Throwable exception, final Entry... entries) {
+                                @Nullable final Throwable exception, final Entry... entries) {
         this.loggerName = loggerName;
         this.level = level;
         this.messageId = messageId;
@@ -82,6 +83,7 @@ public final class StructuredLogMessage {
         return clusterId;
     }
 
+    @Nullable
     public Throwable getException() {
         return exception;
     }

--- a/driver-core/src/main/com/mongodb/internal/logging/StructuredLogMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/logging/StructuredLogMessage.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
-public class StructuredLogMessage {
+public final class StructuredLogMessage {
 
     private final String loggerName;
     private final String level;

--- a/driver-core/src/main/com/mongodb/internal/logging/StructuredLogger.java
+++ b/driver-core/src/main/com/mongodb/internal/logging/StructuredLogger.java
@@ -74,40 +74,6 @@ public class StructuredLogger {
             final String k3, final Object v3,
             final String k4, final Object v4,
             final String k5, final Object v5,
-            final String k6, final Object v6) {
-        if (hasInterceptor(clusterId)) {
-            getInterceptor(clusterId).intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId,
-                    new Entry(k1, v1), new Entry(k2, v2), new Entry(k3, v3), new Entry(k4, v4), new Entry(k5, v5), new Entry(k6, v6)));
-        }
-        if (logger.isDebugEnabled()) {
-            logger.debug(format(format, v1, v2, v3, v4, v5, v6));
-        }
-    }
-
-    public void debug(final String message, final ClusterId clusterId, final String format,
-            final String k1, final Object v1,
-            final String k2, final Object v2,
-            final String k3, final Object v3,
-            final String k4, final Object v4,
-            final String k5, final Object v5,
-            final String k6, final Object v6,
-            final String k7, final Object v7) {
-        if (hasInterceptor(clusterId)) {
-            getInterceptor(clusterId).intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId,
-                    new Entry(k1, v1), new Entry(k2, v2), new Entry(k3, v3), new Entry(k4, v4), new Entry(k5, v5), new Entry(k6, v6),
-                    new Entry(k7, v7)));
-        }
-        if (logger.isDebugEnabled()) {
-            logger.debug(format(format, v1, v2, v3, v4, v5, v6, v7));
-        }
-    }
-
-    public void debug(final String message, final ClusterId clusterId, final String format,
-            final String k1, final Object v1,
-            final String k2, final Object v2,
-            final String k3, final Object v3,
-            final String k4, final Object v4,
-            final String k5, final Object v5,
             final String k6, final Object v6,
             final String k7, final Object v7,
             final String k8, final Object v8) {
@@ -138,36 +104,6 @@ public class StructuredLogger {
         }
         if (logger.isDebugEnabled()) {
             logger.debug(format(format, v1, v2, v3, v4, v5, v6, v7, v8, v9));
-        }
-    }
-
-    public void debug(final String message, final ClusterId clusterId, final String format,
-            final String k1, final Object v1,
-            final String k2, final Object v2,
-            final String k3, final Object v3,
-            final String k4, final Object v4) {
-        if (hasInterceptor(clusterId)) {
-            getInterceptor(clusterId).intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId,
-                    new Entry(k1, v1), new Entry(k2, v2), new Entry(k3, v3), new Entry(k4, v4)));
-        }
-        if (logger.isDebugEnabled()) {
-            logger.debug(format(format, v1, v2, v3, v4));
-        }
-    }
-
-    public void debug(final String message, final ClusterId clusterId, final Throwable exception, final String format,
-            final String k1, final Object v1,
-            final String k2, final Object v2,
-            final String k3, final Object v3,
-            final String k4, final Object v4,
-            final String k5, final Object v5,
-            final String k6, final Object v6) {
-        if (hasInterceptor(clusterId)) {
-            getInterceptor(clusterId).intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId, exception,
-                    new Entry(k1, v1), new Entry(k2, v2), new Entry(k3, v3), new Entry(k4, v4), new Entry(k5, v5), new Entry(k6, v6)));
-        }
-        if (logger.isDebugEnabled()) {
-            logger.debug(format(format, v1, v2, v3, v4, v5, v6), exception);
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/logging/StructuredLogger.java
+++ b/driver-core/src/main/com/mongodb/internal/logging/StructuredLogger.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.logging;
+
+import com.mongodb.connection.ClusterId;
+import com.mongodb.internal.VisibleForTesting;
+import com.mongodb.internal.diagnostics.logging.Logger;
+import com.mongodb.internal.diagnostics.logging.Loggers;
+import com.mongodb.internal.logging.StructuredLogMessage.Entry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
+import static java.lang.String.format;
+
+/**
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+public class StructuredLogger {
+
+    private final Logger logger;
+
+    private static final Map<String, StructuredLoggingInterceptor> INTERCEPTORS = new HashMap<>();
+
+    public static void addInterceptor(final String applicationName, final StructuredLoggingInterceptor interceptor) {
+        INTERCEPTORS.put(applicationName, interceptor);
+    }
+
+    public static void removeInterceptor(final String applicationName) {
+        INTERCEPTORS.remove(applicationName);
+    }
+
+    public static boolean hasInterceptor(final ClusterId clusterId) {
+        return INTERCEPTORS.containsKey(clusterId.getDescription());
+    }
+
+    public static StructuredLoggingInterceptor getInterceptor(final ClusterId clusterId) {
+        return INTERCEPTORS.get(clusterId.getDescription());
+    }
+
+    public StructuredLogger(final String suffix) {
+        this(Loggers.getLogger(suffix));
+    }
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    public StructuredLogger(final Logger logger) {
+        this.logger = logger;
+    }
+
+    public boolean isDebugEnabled(final ClusterId clusterId) {
+        return logger.isDebugEnabled() || hasInterceptor(clusterId);
+    }
+
+    public void debug(final String message, final ClusterId clusterId, final String format,
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4,
+            final String k5, final Object v5,
+            final String k6, final Object v6) {
+        if (hasInterceptor(clusterId)) {
+            getInterceptor(clusterId).intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId,
+                    new Entry(k1, v1), new Entry(k2, v2), new Entry(k3, v3), new Entry(k4, v4), new Entry(k5, v5), new Entry(k6, v6)));
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug(format(format, v1, v2, v3, v4, v5, v6));
+        }
+    }
+
+    public void debug(final String message, final ClusterId clusterId, final String format,
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4,
+            final String k5, final Object v5,
+            final String k6, final Object v6,
+            final String k7, final Object v7) {
+        if (hasInterceptor(clusterId)) {
+            getInterceptor(clusterId).intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId,
+                    new Entry(k1, v1), new Entry(k2, v2), new Entry(k3, v3), new Entry(k4, v4), new Entry(k5, v5), new Entry(k6, v6),
+                    new Entry(k7, v7)));
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug(format(format, v1, v2, v3, v4, v5, v6, v7));
+        }
+    }
+
+    public void debug(final String message, final ClusterId clusterId, final String format,
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4,
+            final String k5, final Object v5,
+            final String k6, final Object v6,
+            final String k7, final Object v7,
+            final String k8, final Object v8) {
+        if (hasInterceptor(clusterId)) {
+            getInterceptor(clusterId).intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId,
+                    new Entry(k1, v1), new Entry(k2, v2), new Entry(k3, v3), new Entry(k4, v4), new Entry(k5, v5), new Entry(k6, v6),
+                    new Entry(k7, v7), new Entry(k8, v8)));
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug(format(format, v1, v2, v3, v4, v5, v6, v7, v8));
+        }
+    }
+
+    public void debug(final String message, final ClusterId clusterId, final String format,
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4,
+            final String k5, final Object v5,
+            final String k6, final Object v6,
+            final String k7, final Object v7,
+            final String k8, final Object v8,
+            final String k9, final Object v9) {
+        if (hasInterceptor(clusterId)) {
+            getInterceptor(clusterId).intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId,
+                    new Entry(k1, v1), new Entry(k2, v2), new Entry(k3, v3), new Entry(k4, v4), new Entry(k5, v5), new Entry(k6, v6),
+                    new Entry(k7, v7), new Entry(k8, v8), new Entry(k9, v9)));
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug(format(format, v1, v2, v3, v4, v5, v6, v7, v8, v9));
+        }
+    }
+
+    public void debug(final String message, final ClusterId clusterId, final String format,
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4) {
+        if (hasInterceptor(clusterId)) {
+            getInterceptor(clusterId).intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId,
+                    new Entry(k1, v1), new Entry(k2, v2), new Entry(k3, v3), new Entry(k4, v4)));
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug(format(format, v1, v2, v3, v4));
+        }
+    }
+
+    public void debug(final String message, final ClusterId clusterId, final Throwable exception, final String format,
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4,
+            final String k5, final Object v5,
+            final String k6, final Object v6) {
+        if (hasInterceptor(clusterId)) {
+            getInterceptor(clusterId).intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId, exception,
+                    new Entry(k1, v1), new Entry(k2, v2), new Entry(k3, v3), new Entry(k4, v4), new Entry(k5, v5), new Entry(k6, v6)));
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug(format(format, v1, v2, v3, v4, v5, v6), exception);
+        }
+    }
+
+    public void debug(final String message, final ClusterId clusterId, final Throwable exception, final String format,
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4,
+            final String k5, final Object v5,
+            final String k6, final Object v6,
+            final String k7, final Object v7) {
+        if (hasInterceptor(clusterId)) {
+            getInterceptor(clusterId).intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId, exception,
+                    new Entry(k1, v1), new Entry(k2, v2), new Entry(k3, v3), new Entry(k4, v4), new Entry(k5, v5), new Entry(k6, v6),
+                    new Entry(k7, v7)));
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug(format(format, v1, v2, v3, v4, v5, v6, v7), exception);
+        }
+    }
+
+    public void debug(final String message, final ClusterId clusterId, final Throwable exception, final String format,
+            final String k1, final Object v1,
+            final String k2, final Object v2,
+            final String k3, final Object v3,
+            final String k4, final Object v4,
+            final String k5, final Object v5,
+            final String k6, final Object v6,
+            final String k7, final Object v7,
+            final String k8, final Object v8) {
+        if (hasInterceptor(clusterId)) {
+            getInterceptor(clusterId).intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId, exception,
+                    new Entry(k1, v1), new Entry(k2, v2), new Entry(k3, v3), new Entry(k4, v4), new Entry(k5, v5), new Entry(k6, v6),
+                    new Entry(k7, v7), new Entry(k8, v8)));
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug(format(format, v1, v2, v3, v4, v5, v6, v7, v8), exception);
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/logging/StructuredLogger.java
+++ b/driver-core/src/main/com/mongodb/internal/logging/StructuredLogger.java
@@ -37,19 +37,21 @@ public class StructuredLogger {
 
     private static final Map<String, StructuredLoggingInterceptor> INTERCEPTORS = new HashMap<>();
 
+    @VisibleForTesting(otherwise = PRIVATE)
     public static void addInterceptor(final String applicationName, final StructuredLoggingInterceptor interceptor) {
         INTERCEPTORS.put(applicationName, interceptor);
     }
 
+    @VisibleForTesting(otherwise = PRIVATE)
     public static void removeInterceptor(final String applicationName) {
         INTERCEPTORS.remove(applicationName);
     }
 
-    public static boolean hasInterceptor(final ClusterId clusterId) {
+    private static boolean hasInterceptor(final ClusterId clusterId) {
         return INTERCEPTORS.containsKey(clusterId.getDescription());
     }
 
-    public static StructuredLoggingInterceptor getInterceptor(final ClusterId clusterId) {
+    private static StructuredLoggingInterceptor getInterceptor(final ClusterId clusterId) {
         return INTERCEPTORS.get(clusterId.getDescription());
     }
 

--- a/driver-core/src/main/com/mongodb/internal/logging/StructuredLogger.java
+++ b/driver-core/src/main/com/mongodb/internal/logging/StructuredLogger.java
@@ -31,7 +31,7 @@ import static java.lang.String.format;
 /**
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
-public class StructuredLogger {
+public final class StructuredLogger {
 
     private final Logger logger;
 

--- a/driver-core/src/main/com/mongodb/internal/logging/StructuredLogger.java
+++ b/driver-core/src/main/com/mongodb/internal/logging/StructuredLogger.java
@@ -64,7 +64,7 @@ public class StructuredLogger {
         this.logger = logger;
     }
 
-    public boolean isDebugEnabled(final ClusterId clusterId) {
+    public boolean isDebugRequired(final ClusterId clusterId) {
         return logger.isDebugEnabled() || hasInterceptor(clusterId);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/logging/StructuredLogger.java
+++ b/driver-core/src/main/com/mongodb/internal/logging/StructuredLogger.java
@@ -69,21 +69,21 @@ public final class StructuredLogger {
         return logger.isDebugEnabled() || getInterceptor(clusterId.getDescription()) != null;
     }
 
-    public void debug(final String message, final ClusterId clusterId, final String format, final Entry... entries) {
+    public void debug(final String messageId, final ClusterId clusterId, final String format, final Entry... entries) {
         StructuredLoggingInterceptor interceptor = getInterceptor(clusterId.getDescription());
         if (interceptor != null) {
-            interceptor.intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId, entries));
+            interceptor.intercept(new StructuredLogMessage(logger.getName(), "debug", messageId, clusterId, entries));
         }
         if (logger.isDebugEnabled()) {
             logger.debug(format(format, Arrays.stream(entries).map(Entry::getValue).toArray()));
         }
     }
 
-    public void debug(final String message, final ClusterId clusterId, final Throwable exception, final String format,
+    public void debug(final String messageId, final ClusterId clusterId, final Throwable exception, final String format,
                       final Entry... entries) {
         StructuredLoggingInterceptor interceptor = getInterceptor(clusterId.getDescription());
         if (interceptor != null) {
-            interceptor.intercept(new StructuredLogMessage(logger.getName(), "debug", message, clusterId, exception,
+            interceptor.intercept(new StructuredLogMessage(logger.getName(), "debug", messageId, clusterId, exception,
                     entries));
         }
         if (logger.isDebugEnabled()) {

--- a/driver-core/src/main/com/mongodb/internal/logging/StructuredLoggingInterceptor.java
+++ b/driver-core/src/main/com/mongodb/internal/logging/StructuredLoggingInterceptor.java
@@ -16,9 +16,13 @@
 
 package com.mongodb.internal.logging;
 
+import com.mongodb.annotations.ThreadSafe;
+
 /**
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
+@FunctionalInterface
+@ThreadSafe
 public interface StructuredLoggingInterceptor {
     void intercept(StructuredLogMessage message);
 }

--- a/driver-core/src/main/com/mongodb/internal/logging/StructuredLoggingInterceptor.java
+++ b/driver-core/src/main/com/mongodb/internal/logging/StructuredLoggingInterceptor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.logging;
+
+/**
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+public interface StructuredLoggingInterceptor {
+    void intercept(StructuredLogMessage message);
+}

--- a/driver-core/src/main/com/mongodb/internal/logging/package-info.java
+++ b/driver-core/src/main/com/mongodb/internal/logging/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains classes that manage binding to MongoDB servers for various operations.
+ */
+
+@NonNullApi
+package com.mongodb.internal.logging;
+
+import com.mongodb.lang.NonNullApi;

--- a/driver-core/src/test/resources/unified-test-format/command-logging/command.json
+++ b/driver-core/src/test/resources/unified-test-format/command-logging/command.json
@@ -1,0 +1,213 @@
+{
+  "description": "command-logging",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeLogMessages": {
+          "command": "debug"
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "logging-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "logging-tests-collection"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "logging-tests-collection",
+      "databaseName": "logging-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "A successful command",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "ping": 1
+            },
+            "commandName": "ping"
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-tests",
+                "commandName": "ping",
+                "command": {
+                  "$$matchAsDocument": {
+                    "$$matchAsRoot": {
+                      "ping": 1,
+                      "$db": "logging-tests"
+                    }
+                  }
+                },
+                "requestId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "ping",
+                "reply": {
+                  "$$type": "string"
+                },
+                "requestId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "durationMS": {
+                  "$$type": [
+                    "double",
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "A failed command",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-tests",
+                "commandName": "find",
+                "command": {
+                  "$$type": "string"
+                },
+                "requestId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command failed",
+                "commandName": "find",
+                "failure": {
+                  "$$exists": true
+                },
+                "requestId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "durationMS": {
+                  "$$type": [
+                    "double",
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/command-logging/driver-connection-id.json
+++ b/driver-core/src/test/resources/unified-test-format/command-logging/driver-connection-id.json
@@ -1,0 +1,146 @@
+{
+  "description": "driver-connection-id",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeLogMessages": {
+          "command": "debug"
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "logging-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "logging-tests-collection"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "logging-tests-collection",
+      "databaseName": "logging-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "A successful command",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "ping": 1
+            },
+            "commandName": "ping"
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-tests",
+                "commandName": "ping",
+                "driverConnectionId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "ping",
+                "driverConnectionId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "A failed command",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-tests",
+                "commandName": "find",
+                "driverConnectionId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command failed",
+                "commandName": "find",
+                "driverConnectionId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/command-logging/no-handshake-messages.json
+++ b/driver-core/src/test/resources/unified-test-format/command-logging/no-handshake-messages.json
@@ -1,0 +1,94 @@
+{
+  "description": "no-handshake-command-logs",
+  "schemaVersion": "1.13",
+  "tests": [
+    {
+      "description": "Handshake commands should not generate log messages",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "observeLogMessages": {
+                    "command": "debug"
+                  },
+                  "observeEvents": [
+                    "connectionCreatedEvent",
+                    "connectionReadyEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "database",
+                  "client": "client",
+                  "databaseName": "logging-tests"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "ping": 1
+            },
+            "commandName": "ping"
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "connectionCreatedEvent": {}
+            },
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "connectionReadyEvent": {}
+            },
+            "count": 1
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-tests",
+                "commandName": "ping"
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/command-logging/no-heartbeat-messages.json
+++ b/driver-core/src/test/resources/unified-test-format/command-logging/no-heartbeat-messages.json
@@ -1,0 +1,91 @@
+{
+  "description": "no-heartbeat-command-logs",
+  "schemaVersion": "1.13",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "single",
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Heartbeat commands should not generate log messages",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "observeLogMessages": {
+                    "command": "debug"
+                  },
+                  "observeEvents": [
+                    "serverDescriptionChangedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "database",
+                  "client": "client",
+                  "databaseName": "logging-tests"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "serverDescriptionChangedEvent": {}
+            },
+            "count": 1
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "ping": 1
+            },
+            "commandName": "ping"
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-tests",
+                "commandName": "ping"
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/command-logging/operation-id.json
+++ b/driver-core/src/test/resources/unified-test-format/command-logging/operation-id.json
@@ -1,0 +1,198 @@
+{
+  "description": "operation-id",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeLogMessages": {
+          "command": "debug"
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "logging-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "logging-tests-collection"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "logging-tests-collection",
+      "databaseName": "logging-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Successful bulk write command log messages include operationIds",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "x": 1
+                  }
+                }
+              },
+              {
+                "deleteOne": {
+                  "filter": {
+                    "x": 1
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-tests",
+                "commandName": "insert",
+                "operationId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "insert",
+                "operationId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-tests",
+                "commandName": "delete",
+                "operationId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "delete",
+                "operationId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Failed bulk write command log message includes operationId",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "x": 1
+                  },
+                  "update": [
+                    {
+                      "$invalidOperator": true
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-tests",
+                "commandName": "update",
+                "operationId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command failed",
+                "commandName": "update",
+                "operationId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/command-logging/pre-42-server-connection-id.json
+++ b/driver-core/src/test/resources/unified-test-format/command-logging/pre-42-server-connection-id.json
@@ -1,0 +1,119 @@
+{
+  "description": "pre-42-server-connection-id",
+  "schemaVersion": "1.13",
+  "runOnRequirements": [
+    {
+      "maxServerVersion": "4.0.99"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeLogMessages": {
+          "command": "debug"
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "logging-server-connection-id-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "logging-tests-collection"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "logging-server-connection-id-tests",
+      "collectionName": "logging-tests-collection",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command log messages do not include server connection id",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "commandName": "insert",
+                "serverConnectionId": {
+                  "$$exists": false
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "insert",
+                "serverConnectionId": {
+                  "$$exists": false
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "commandName": "find",
+                "serverConnectionId": {
+                  "$$exists": false
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command failed",
+                "commandName": "find",
+                "serverConnectionId": {
+                  "$$exists": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/command-logging/redacted-commands.json
+++ b/driver-core/src/test/resources/unified-test-format/command-logging/redacted-commands.json
@@ -1,0 +1,1438 @@
+{
+  "description": "redacted-commands",
+  "schemaVersion": "1.13",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "5.0",
+      "auth": false
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "useMultipleMongoses": false,
+        "observeLogMessages": {
+          "command": "debug"
+        }
+      }
+    },
+    {
+      "client": {
+        "id": "failPointClient",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "logging-redaction-tests"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "authenticate command and resulting server-generated error are redacted",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "authenticate",
+            "command": {
+              "authenticate": 1,
+              "mechanism": "MONGODB-X509",
+              "user": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry",
+              "db": "$external"
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "authenticate",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": true,
+              "data": {
+                "message": "Command failed",
+                "commandName": "authenticate",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "network error in response to authenticate is not redacted",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "authenticate"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "authenticate",
+            "command": {
+              "authenticate": 1,
+              "mechanism": "MONGODB-X509",
+              "user": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry"
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "authenticate",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": false,
+              "data": {
+                "message": "Command failed",
+                "commandName": "authenticate",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "saslStart command and resulting server-generated error are redacted",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "saslStart",
+            "command": {
+              "saslStart": 1,
+              "payload": "definitely-invalid-payload",
+              "db": "admin"
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "saslStart",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": true,
+              "data": {
+                "message": "Command failed",
+                "commandName": "saslStart",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "network error in response to saslStart is not redacted",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "saslStart"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "saslStart",
+            "command": {
+              "saslStart": 1,
+              "payload": "ZmFrZXNhc2xwYXlsb2Fk",
+              "mechanism": "MONGODB-X509"
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "saslStart",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": false,
+              "data": {
+                "message": "Command failed",
+                "commandName": "saslStart",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "saslContinue command and resulting server-generated error are redacted",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "saslContinue",
+            "command": {
+              "saslContinue": 1,
+              "conversationId": 0,
+              "payload": "definitely-invalid-payload"
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "saslContinue",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": true,
+              "data": {
+                "message": "Command failed",
+                "commandName": "saslContinue",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "network error in response to saslContinue is not redacted",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "saslContinue"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "saslContinue",
+            "command": {
+              "saslContinue": 1,
+              "conversationId": 0,
+              "payload": "ZmFrZXNhc2xwYXlsb2Fk"
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "saslContinue",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": false,
+              "data": {
+                "message": "Command failed",
+                "commandName": "saslContinue",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "getnonce command and server reply are redacted",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "getnonce",
+            "command": {
+              "getnonce": 1
+            }
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "getnonce",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "getnonce",
+                "reply": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "network error in response to getnonce is not redacted",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "getnonce"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "getnonce",
+            "command": {
+              "getnonce": 1
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "getnonce",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": false,
+              "data": {
+                "message": "Command failed",
+                "commandName": "getnonce",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "createUser command and resulting server-generated error are redacted",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "createUser",
+            "command": {
+              "createUser": "private",
+              "pwd": {},
+              "roles": []
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "createUser",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": true,
+              "data": {
+                "message": "Command failed",
+                "commandName": "createUser",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "network error in response to createUser is not redacted",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "createUser"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "createUser",
+            "command": {
+              "createUser": "private",
+              "pwd": "pwd",
+              "roles": []
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "createUser",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": false,
+              "data": {
+                "message": "Command failed",
+                "commandName": "createUser",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "updateUser command and resulting server-generated error are redacted",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "updateUser",
+            "command": {
+              "updateUser": "private",
+              "pwd": {},
+              "roles": []
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "updateUser",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": true,
+              "data": {
+                "message": "Command failed",
+                "commandName": "updateUser",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "network error in response to updateUser is not redacted",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "updateUser"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "updateUser",
+            "command": {
+              "updateUser": "private",
+              "pwd": "pwd",
+              "roles": []
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "updateUser",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": false,
+              "data": {
+                "message": "Command failed",
+                "commandName": "updateUser",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "copydbgetnonce command and resulting server-generated error are redacted",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.6.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "copydbgetnonce",
+            "command": {
+              "copydbgetnonce": "private"
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "copydbgetnonce",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": true,
+              "data": {
+                "message": "Command failed",
+                "commandName": "copydbgetnonce",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "network error in response to copydbgetnonce is not redacted",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.6.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "copydbgetnonce"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "copydbgetnonce",
+            "command": {
+              "copydbgetnonce": "private"
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "copydbgetnonce",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": false,
+              "data": {
+                "message": "Command failed",
+                "commandName": "copydbgetnonce",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "copydbsaslstart command and resulting server-generated error are redacted",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.0.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "copydbsaslstart",
+            "command": {
+              "copydbsaslstart": "private"
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "copydbsaslstart",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": true,
+              "data": {
+                "message": "Command failed",
+                "commandName": "copydbsaslstart",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "network error in response to copydbsaslstart is not redacted",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.0.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "copydbsaslstart"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "copydbsaslstart",
+            "command": {
+              "copydbsaslstart": "private"
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "copydbgetnonce",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": false,
+              "data": {
+                "message": "Command failed",
+                "commandName": "copydbgetnonce",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "copydb command and resulting server-generated error are redacted",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.0.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "copydb",
+            "command": {
+              "copydb": "private"
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "copydb",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": true,
+              "data": {
+                "message": "Command failed",
+                "commandName": "copydb",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "network error in response to copydb is not redacted",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.0.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "copydb"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "copydb",
+            "command": {
+              "copydb": "private"
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "copydb",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "failureIsRedacted": false,
+              "data": {
+                "message": "Command failed",
+                "commandName": "copydb",
+                "failure": {
+                  "$$exists": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "hello with speculative authenticate command and server reply are redacted",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9"
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "hello",
+            "command": {
+              "hello": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "hello",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "hello",
+                "reply": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "legacy hello with speculative authenticate command and server reply are redacted",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "ismaster",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "ismaster",
+                "reply": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "isMaster",
+                "command": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "isMaster",
+                "reply": {
+                  "$$matchAsDocument": {}
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "hello without speculative authenticate command and server reply are not redacted",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9"
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "hello",
+            "command": {
+              "hello": 1
+            }
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "hello",
+                "command": {
+                  "$$matchAsDocument": {
+                    "$$matchAsRoot": {
+                      "hello": 1
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "hello",
+                "reply": {
+                  "$$matchAsDocument": {
+                    "$$matchAsRoot": {
+                      "ok": 1,
+                      "isWritablePrimary": true
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "legacy hello without speculative authenticate command and server reply are not redacted",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1
+            }
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "ismaster",
+                "command": {
+                  "$$matchAsDocument": {
+                    "$$matchAsRoot": {
+                      "ismaster": 1
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "ismaster",
+                "reply": {
+                  "$$matchAsDocument": {
+                    "$$matchAsRoot": {
+                      "ok": 1,
+                      "ismaster": true
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-redaction-tests",
+                "commandName": "isMaster",
+                "command": {
+                  "$$matchAsDocument": {
+                    "$$matchAsRoot": {
+                      "isMaster": 1
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "isMaster",
+                "reply": {
+                  "$$matchAsDocument": {
+                    "$$matchAsRoot": {
+                      "ok": 1,
+                      "ismaster": true
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/command-logging/server-connection-id.json
+++ b/driver-core/src/test/resources/unified-test-format/command-logging/server-connection-id.json
@@ -1,0 +1,131 @@
+{
+  "description": "server-connection-id",
+  "schemaVersion": "1.13",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.2"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeLogMessages": {
+          "command": "debug"
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "logging-server-connection-id-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "logging-tests-collection"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "logging-server-connection-id-tests",
+      "collectionName": "logging-tests-collection",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command log messages include server connection id",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "commandName": "insert",
+                "serverConnectionId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "insert",
+                "serverConnectionId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "commandName": "find",
+                "serverConnectionId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command failed",
+                "commandName": "find",
+                "serverConnectionId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/command-logging/service-id.json
+++ b/driver-core/src/test/resources/unified-test-format/command-logging/service-id.json
@@ -1,0 +1,207 @@
+{
+  "description": "service-id",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeLogMessages": {
+          "command": "debug"
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "logging-server-connection-id-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "logging-tests-collection"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "logging-server-connection-id-tests",
+      "collectionName": "logging-tests-collection",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command log messages include serviceId when in LB mode",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "load-balanced"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "commandName": "insert",
+                "serviceId": {
+                  "$$type": "string"
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "insert",
+                "serviceId": {
+                  "$$type": "string"
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "commandName": "find",
+                "serviceId": {
+                  "$$type": "string"
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command failed",
+                "commandName": "find",
+                "serviceId": {
+                  "$$type": "string"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "command log messages omit serviceId when not in LB mode",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "single",
+            "replicaset",
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "commandName": "insert",
+                "serviceId": {
+                  "$$exists": false
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "insert",
+                "serviceId": {
+                  "$$exists": false
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "commandName": "find",
+                "serviceId": {
+                  "$$exists": false
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command failed",
+                "commandName": "find",
+                "serviceId": {
+                  "$$exists": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/command-logging/unacknowledged-write.json
+++ b/driver-core/src/test/resources/unified-test-format/command-logging/unacknowledged-write.json
@@ -1,0 +1,136 @@
+{
+  "description": "command-logging",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeLogMessages": {
+          "command": "debug"
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "logging-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "logging-tests-collection",
+        "collectionOptions": {
+          "writeConcern": {
+            "w": 0
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "logging-tests-collection",
+      "databaseName": "logging-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "An unacknowledged write generates a succeeded log message with ok: 1 reply",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-tests",
+                "commandName": "insert",
+                "command": {
+                  "$$matchAsDocument": {
+                    "$$matchAsRoot": {
+                      "insert": "logging-tests-collection",
+                      "$db": "logging-tests"
+                    }
+                  }
+                },
+                "requestId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "insert",
+                "reply": {
+                  "$$matchAsDocument": {
+                    "ok": 1
+                  }
+                },
+                "requestId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "durationMS": {
+                  "$$type": [
+                    "double",
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
@@ -23,12 +23,13 @@ import com.mongodb.ServerAddress
 import com.mongodb.connection.ClusterId
 import com.mongodb.connection.ConnectionDescription
 import com.mongodb.connection.ServerId
-import com.mongodb.internal.diagnostics.logging.Logger
 import com.mongodb.event.CommandFailedEvent
 import com.mongodb.event.CommandListener
 import com.mongodb.event.CommandStartedEvent
 import com.mongodb.event.CommandSucceededEvent
 import com.mongodb.internal.IgnorableRequestContext
+import com.mongodb.internal.diagnostics.logging.Logger
+import com.mongodb.internal.logging.StructuredLogger
 import com.mongodb.internal.validator.NoOpFieldNameValidator
 import org.bson.BsonBinary
 import org.bson.BsonDocument
@@ -59,7 +60,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
             isDebugEnabled() >> debugLoggingEnabled
         }
         def sender = new LoggingCommandEventSender([] as Set, [] as Set, connectionDescription, commandListener,
-                IgnorableRequestContext.INSTANCE, message, bsonOutput, logger)
+                IgnorableRequestContext.INSTANCE, message, bsonOutput, new StructuredLogger(logger))
 
         when:
         sender.sendStartedEvent()
@@ -89,7 +90,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def namespace = new MongoNamespace('test.driver')
         def messageSettings = MessageSettings.builder().maxWireVersion(THREE_DOT_SIX_WIRE_VERSION).build()
         def commandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def replyDocument = new BsonDocument('ok', new BsonInt32(1))
+        def replyDocument = new BsonDocument('ok', new BsonInt32(42))
         def failureException = new MongoInternalException('failure!')
         def message = new CommandMessage(namespace, commandDocument, new NoOpFieldNameValidator(), ReadPreference.primary(),
                 messageSettings, MULTIPLE, null)
@@ -99,8 +100,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
             isDebugEnabled() >> true
         }
         def sender = new LoggingCommandEventSender([] as Set, [] as Set, connectionDescription, commandListener,
-                IgnorableRequestContext.INSTANCE, message, bsonOutput,
-                logger)
+                IgnorableRequestContext.INSTANCE, message, bsonOutput, new StructuredLogger(logger))
         when:
         sender.sendStartedEvent()
         sender.sendSucceededEventForOneWayCommand()
@@ -109,25 +109,29 @@ class LoggingCommandEventSenderSpecification extends Specification {
 
         then:
         1 * logger.debug {
-            it == "Sending command \'{\"ping\": 1, \"\$db\": \"test\"}\' with request id ${message.getId()} to database test " +
-                    "on connection [connectionId{localValue:${connectionDescription.connectionId.localValue}}] " +
-                    'to server 127.0.0.1:27017'
+            it == "Command \"ping\" started on database test using a connection with driver-generated ID " +
+                    "${connectionDescription.connectionId.localValue} and server-generated ID " +
+                    "${connectionDescription.connectionId.serverValue} to 127.0.0.1:27017. The " +
+                    "request ID is ${message.getId()}. Command: {\"ping\": 1, \"\$db\": \"test\"}"
         }
         1 * logger.debug {
-            it.matches("Execution of one-way command with request id ${message.getId()} completed successfully in \\d+\\.\\d+ ms " +
-                    "on connection \\[connectionId\\{localValue:${connectionDescription.connectionId.localValue}\\}] " +
-                    'to server 127\\.0\\.0\\.1:27017')
+            it.matches("Command \"ping\" succeeded in \\d+\\.\\d+ ms using a connection with driver-generated ID " +
+                    "${connectionDescription.connectionId.localValue} and server-generated ID " +
+                    "${connectionDescription.connectionId.serverValue} to 127.0.0.1:27017. The " +
+                    "request ID is ${message.getId()}. Command reply: \\{\"ok\": 1}")
         }
         1 * logger.debug {
-            it.matches("Execution of command with request id ${message.getId()} completed successfully in \\d+\\.\\d+ ms " +
-                    "on connection \\[connectionId\\{localValue:${connectionDescription.connectionId.localValue}\\}] " +
-                    'to server 127\\.0\\.0\\.1:27017')
+            it.matches("Command \"ping\" succeeded in \\d+\\.\\d+ ms using a connection with driver-generated ID " +
+                    "${connectionDescription.connectionId.localValue} and server-generated ID " +
+                    "${connectionDescription.connectionId.serverValue} to 127.0.0.1:27017. The " +
+                    "request ID is ${message.getId()}. Command reply: \\{\"ok\": 42}")
         }
         1 * logger.debug({
-            it.matches("Execution of command with request id ${message.getId()} failed to complete successfully in \\d+\\.\\d+ ms " +
-                    "on connection \\[connectionId\\{localValue:${connectionDescription.connectionId.localValue}\\}] " +
-                    'to server 127\\.0\\.0\\.1:27017')
-        }, failureException)
+            it.matches("Command \"ping\" failed in \\d+\\.\\d+ ms using a connection with driver-generated ID " +
+                    "${connectionDescription.connectionId.localValue} and server-generated ID " +
+                    "${connectionDescription.connectionId.serverValue} to 127.0.0.1:27017. The " +
+                    "request ID is ${message.getId()}.")
+       }, failureException)
 
         where:
         commandListener << [null, Stub(CommandListener)]
@@ -146,17 +150,18 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def logger = Mock(Logger) {
             isDebugEnabled() >> true
         }
-        def sender = new LoggingCommandEventSender([] as Set, [] as Set, connectionDescription, null, null, message, bsonOutput, logger)
+        def sender = new LoggingCommandEventSender([] as Set, [] as Set, connectionDescription, null, null, message, bsonOutput,
+                new StructuredLogger(logger))
 
         when:
         sender.sendStartedEvent()
 
         then:
         1 * logger.debug {
-            it == "Sending command \'{\"fake\": {\"\$binary\": {\"base64\": \"${'A' * 967} ...\' " +
-                    "with request id ${message.getId()} to database test " +
-                    "on connection [connectionId{localValue:${connectionDescription.connectionId.localValue}}] " +
-                    'to server 127.0.0.1:27017'
+            it == "Command \"fake\" started on database test using a connection with driver-generated ID " +
+                    "${connectionDescription.connectionId.localValue} and server-generated ID " +
+                    "${connectionDescription.connectionId.serverValue} to 127.0.0.1:27017. The " +
+                    "request ID is ${message.getId()}. Command: {\"fake\": {\"\$binary\": {\"base64\": \"${'A' * 967} ..."
         }
     }
 
@@ -174,17 +179,17 @@ class LoggingCommandEventSenderSpecification extends Specification {
             isDebugEnabled() >> true
         }
         def sender = new LoggingCommandEventSender(['createUser'] as Set, [] as Set, connectionDescription, null,
-                IgnorableRequestContext.INSTANCE, message, bsonOutput, logger)
+                IgnorableRequestContext.INSTANCE, message, bsonOutput, new StructuredLogger(logger))
 
         when:
         sender.sendStartedEvent()
 
         then:
         1 * logger.debug {
-            it == "Sending command \'{\"createUser\": ...\' " +
-                    "with request id ${message.getId()} to database test " +
-                    "on connection [connectionId{localValue:${connectionDescription.connectionId.localValue}}] " +
-                    'to server 127.0.0.1:27017'
+            it == "Command \"createUser\" started on database test using a connection with driver-generated ID " +
+                    "${connectionDescription.connectionId.localValue} and server-generated ID " +
+                    "${connectionDescription.connectionId.serverValue} to 127.0.0.1:27017. The " +
+                    "request ID is ${message.getId()}. Command: {}"
         }
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
@@ -22,6 +22,7 @@ import com.mongodb.ReadPreference
 import com.mongodb.ServerAddress
 import com.mongodb.connection.ClusterId
 import com.mongodb.connection.ConnectionDescription
+import com.mongodb.connection.ConnectionId
 import com.mongodb.connection.ServerId
 import com.mongodb.event.CommandFailedEvent
 import com.mongodb.event.CommandListener
@@ -86,7 +87,9 @@ class LoggingCommandEventSenderSpecification extends Specification {
 
     def 'should log events'() {
         given:
-        def connectionDescription = new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress()))
+        def serverId = new ServerId(new ClusterId(), new ServerAddress())
+        def connectionDescription = new ConnectionDescription(serverId)
+                .withConnectionId(new ConnectionId(serverId, 42, 1000))
         def namespace = new MongoNamespace('test.driver')
         def messageSettings = MessageSettings.builder().maxWireVersion(THREE_DOT_SIX_WIRE_VERSION).build()
         def commandDocument = new BsonDocument('ping', new BsonInt32(1))
@@ -139,7 +142,9 @@ class LoggingCommandEventSenderSpecification extends Specification {
 
     def 'should log large command with ellipses'() {
         given:
-        def connectionDescription = new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress()))
+        def serverId = new ServerId(new ClusterId(), new ServerAddress())
+        def connectionDescription = new ConnectionDescription(serverId)
+                .withConnectionId(new ConnectionId(serverId, 42, 1000))
         def namespace = new MongoNamespace('test.driver')
         def messageSettings = MessageSettings.builder().maxWireVersion(THREE_DOT_SIX_WIRE_VERSION).build()
         def commandDocument = new BsonDocument('fake', new BsonBinary(new byte[2048]))
@@ -167,7 +172,9 @@ class LoggingCommandEventSenderSpecification extends Specification {
 
     def 'should log redacted command with ellipses'() {
         given:
-        def connectionDescription = new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress()))
+        def serverId = new ServerId(new ClusterId(), new ServerAddress())
+        def connectionDescription = new ConnectionDescription(serverId)
+                .withConnectionId(new ConnectionId(serverId, 42, 1000))
         def namespace = new MongoNamespace('test.driver')
         def messageSettings = MessageSettings.builder().maxWireVersion(THREE_DOT_SIX_WIRE_VERSION).build()
         def commandDocument = new BsonDocument('createUser', new BsonString('private'))

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/CommandLoggingTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/CommandLoggingTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.unified;
+
+import com.mongodb.lang.Nullable;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
+import static org.junit.Assume.assumeFalse;
+
+public class CommandLoggingTest extends UnifiedReactiveStreamsTest {
+    public CommandLoggingTest(@SuppressWarnings("unused") final String fileDescription,
+                              @SuppressWarnings("unused") final String testDescription,
+                              final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
+                              final BsonArray initialData, final BsonDocument definition) {
+        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+        // The driver does not currently support operation identifiers
+        assumeFalse(fileDescription.equals("operation-id"));
+        // The driver has a hack where getLastError command is executed as part of the handshake in order to get a connectionId
+        // even when the hello command response doesn't contain it.
+        assumeFalse(fileDescription.equals("pre-42-server-connection-id"));
+    }
+
+    @Parameterized.Parameters(name = "{0}: {1}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        return getTestData("unified-test-format/command-logging");
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/CommandLoggingTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/CommandLoggingTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.unified;
+
+import com.mongodb.lang.Nullable;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
+import static com.mongodb.ClusterFixture.isServerlessTest;
+import static org.junit.Assume.assumeFalse;
+
+public class CommandLoggingTest extends UnifiedSyncTest {
+
+
+    public CommandLoggingTest(@SuppressWarnings("unused") final String fileDescription,
+                              @SuppressWarnings("unused") final String testDescription,
+                              final String schemaVersion,
+                              @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
+                              final BsonDocument definition) {
+        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+        assumeFalse(isServerlessTest());
+        // The driver does not currently support operation identifiers
+        assumeFalse(fileDescription.equals("operation-id"));
+        // The driver has a hack where getLastError command is executed as part of the handshake in order to get a connectionId
+        // even when the hello command response doesn't contain it.
+        assumeFalse(fileDescription.equals("pre-42-server-connection-id"));
+    }
+
+    @Parameterized.Parameters(name = "{0}: {1}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        return getTestData("unified-test-format/command-logging");
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/ContextElement.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/ContextElement.java
@@ -21,6 +21,7 @@ import com.mongodb.event.CommandEvent;
 import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandStartedEvent;
 import com.mongodb.event.CommandSucceededEvent;
+import com.mongodb.internal.logging.StructuredLogMessage;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
@@ -141,6 +142,11 @@ abstract class ContextElement {
                     + "   Count: " + count + "\n";
         }
     }
+    public static ContextElement ofLogMessages(final String client, final BsonArray expectedMessages,
+            final List<StructuredLogMessage> actualMessages) {
+        return new LogMessageMatchingContextElement(client, expectedMessages, actualMessages);
+    }
+
 
     private static class TestContextContextElement extends ContextElement {
         private final BsonDocument definition;
@@ -370,6 +376,30 @@ abstract class ContextElement {
                     + "   event position: " + eventPosition + "\n"
                     + "   expected event: " + expectedEvent + "\n"
                     + "   actual event:   " + connectionPoolEventToDocument(actualEvent) + "\n";
+        }
+    }
+
+
+    private static class LogMessageMatchingContextElement extends ContextElement {
+        private final String client;
+        private final BsonArray expectedMessages;
+        private final List<StructuredLogMessage> actualMessages;
+
+        LogMessageMatchingContextElement(final String client, final BsonArray expectedMessages,
+                final List<StructuredLogMessage> actualMessages) {
+            super();
+            this.client = client;
+            this.expectedMessages = expectedMessages;
+            this.actualMessages = actualMessages;
+        }
+
+        @Override
+        public String toString() {
+            // TODO: fix this up to be like the others
+            return "Log Message Matching Context\n"
+                    + "client='" + client + '\''
+                    + ", expectedMessages=" + expectedMessages
+                    + ", actualMessages=" + actualMessages;
         }
     }
 

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/ContextElement.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/ContextElement.java
@@ -395,11 +395,14 @@ abstract class ContextElement {
 
         @Override
         public String toString() {
-            // TODO: fix this up to be like the others
             return "Log Message Matching Context\n"
-                    + "client='" + client + '\''
-                    + ", expectedMessages=" + expectedMessages
-                    + ", actualMessages=" + actualMessages;
+                    + "   client='" + client + '\'' + "\n"
+                    + "   expectedMessages="
+                    + new BsonDocument("messages", expectedMessages).toJson(JsonWriterSettings.builder().indent(true).build()) + "\n"
+                    + "   actualMessages="
+                    + new BsonDocument("messages", new BsonArray(actualMessages.stream()
+                    .map(LogMatcher::asDocument).collect(Collectors.toList())))
+                    .toJson(JsonWriterSettings.builder().indent(true).build()) + "\n";
         }
     }
 

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/EventMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/EventMatcher.java
@@ -23,8 +23,10 @@ import com.mongodb.event.CommandStartedEvent;
 import com.mongodb.event.CommandSucceededEvent;
 import com.mongodb.event.ConnectionCheckOutFailedEvent;
 import com.mongodb.event.ConnectionClosedEvent;
+import com.mongodb.event.ConnectionCreatedEvent;
 import com.mongodb.event.ConnectionPoolClearedEvent;
 import com.mongodb.event.ConnectionPoolReadyEvent;
+import com.mongodb.event.ConnectionReadyEvent;
 import com.mongodb.event.ServerDescriptionChangedEvent;
 import com.mongodb.internal.connection.TestConnectionPoolListener;
 import com.mongodb.internal.connection.TestServerListener;
@@ -183,6 +185,12 @@ final class EventMatcher {
             case "poolReadyEvent":
                 eventClass = ConnectionPoolReadyEvent.class;
                 break;
+            case "connectionCreatedEvent":
+                eventClass = ConnectionCreatedEvent.class;
+                break;
+            case "connectionReadyEvent":
+                eventClass = ConnectionReadyEvent.class;
+                break;
             default:
                 throw new UnsupportedOperationException("Unsupported event: " + event.getFirstKey());
         }
@@ -252,6 +260,9 @@ final class EventMatcher {
         }
         @SuppressWarnings("OptionalGetWithoutIsPresent")
         BsonDocument expectedEventContents = expectedEvent.values().stream().findFirst().get().asDocument();
+        if (expectedEventContents.isEmpty()) {
+            return expectedEventContents;
+        }
         if (expectedEventContents.size() != 1 || !expectedEventContents.getFirstKey().equals("newDescription")
                 || expectedEventContents.getDocument("newDescription").size() != 1) {
             throw new UnsupportedOperationException("Unsupported event contents " + expectedEvent);
@@ -261,6 +272,9 @@ final class EventMatcher {
 
     private static boolean serverDescriptionChangedEventMatches(final BsonDocument expectedEventContents,
             final ServerDescriptionChangedEvent event) {
+        if (expectedEventContents.isEmpty()) {
+            return true;
+        }
         String newType = expectedEventContents.getDocument("newDescription").getString("type").getValue();
         //noinspection SwitchStatementWithTooFewBranches
         switch (newType) {

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/LogMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/LogMatcher.java
@@ -56,7 +56,7 @@ final class LogMatcher {
         context.pop();
     }
 
-    private static BsonDocument asDocument(final StructuredLogMessage message) {
+     static BsonDocument asDocument(final StructuredLogMessage message) {
         BsonDocument document = new BsonDocument();
         document.put("component", new BsonString(message.getLoggerName().substring(message.getLoggerName().lastIndexOf(".") + 1)));
         document.put("level", new BsonString(message.getLevel()));

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/LogMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/LogMatcher.java
@@ -57,8 +57,8 @@ final class LogMatcher {
 
      static BsonDocument asDocument(final StructuredLogMessage message) {
         BsonDocument document = new BsonDocument();
-        document.put("component", new BsonString(message.getLoggerName().substring(message.getLoggerName().lastIndexOf(".") + 1)));
-        document.put("level", new BsonString(message.getLevel()));
+        document.put("component", new BsonString(message.getComponent().name().toLowerCase()));
+        document.put("level", new BsonString(message.getLevel().name().toLowerCase()));
         document.put("hasFailure", BsonBoolean.valueOf(message.getException() != null));
         document.put("failureIsRedacted",
                 BsonBoolean.valueOf(message.getException() != null && exceptionIsRedacted(message.getException())));

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/LogMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/LogMatcher.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.unified;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.internal.logging.StructuredLogMessage;
+import org.bson.BsonArray;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+final class LogMatcher {
+    private final ValueMatcher valueMatcher;
+    private final AssertionContext context;
+
+    LogMatcher(final ValueMatcher valueMatcher, final AssertionContext context) {
+
+        this.valueMatcher = valueMatcher;
+        this.context = context;
+    }
+
+    void assertLogMessageEquality(final String client, final BsonArray expectedMessages, final List<StructuredLogMessage> actualMessages) {
+        context.push(ContextElement.ofLogMessages(client, expectedMessages, actualMessages));
+
+        assertEquals(context.getMessage("Number of log messages must be the same"), expectedMessages.size(), actualMessages.size());
+
+        for (int i = 0; i < expectedMessages.size(); i++) {
+            BsonDocument expectedMessageAsDocument = expectedMessages.get(i).asDocument().clone();
+            expectedMessageAsDocument.remove("failureIsRedacted");
+            valueMatcher.assertValuesMatch(expectedMessageAsDocument, asDocument(actualMessages.get(i)));
+        }
+
+        context.pop();
+    }
+
+    private static BsonDocument asDocument(final StructuredLogMessage message) {
+        BsonDocument document = new BsonDocument();
+        document.put("component", new BsonString(message.getLoggerName().substring(message.getLoggerName().lastIndexOf(".") + 1)));
+        document.put("level", new BsonString(message.getLevel()));
+        document.put("hasFailure", BsonBoolean.valueOf(message.getException() != null && exceptionIsUnredacted(message.getException())));
+
+        BsonDocument dataDocument = new BsonDocument();
+        dataDocument.put("message", new BsonString(message.getMessageId()));
+        if (message.getException() != null) {
+            dataDocument.put("failure", new BsonString(message.getException().toString()));
+        }
+        for (StructuredLogMessage.Entry entry : message.getEntries()) {
+            dataDocument.put(entry.getName(), asBsonValue(entry.getValue()));
+        }
+        document.put("data", dataDocument);
+
+        return document;
+    }
+
+    private static boolean exceptionIsUnredacted(final Throwable exception) {
+        return exception instanceof MongoCommandException && !((MongoCommandException) exception).getResponse().isEmpty();
+    }
+
+    private static BsonValue asBsonValue(final Object value) {
+        if (value == null) {
+            return BsonNull.VALUE;
+        } else if (value instanceof String) {
+            return new BsonString((String) value);
+        } else if (value instanceof Integer) {
+            return new BsonInt32((Integer) value);
+        } else if (value instanceof Long) {
+            return new BsonInt64((Long) value);
+        } else if (value instanceof Double) {
+            return new BsonDouble((Double) value);
+        } else if (value instanceof Boolean) {
+            return BsonBoolean.valueOf((Boolean) value);
+        } else {
+            return new BsonString(value.toString());
+        }
+    }
+
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/TestLoggingInterceptor.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/TestLoggingInterceptor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.unified;
+
+import com.mongodb.internal.logging.StructuredLogMessage;
+import com.mongodb.internal.logging.StructuredLogger;
+import com.mongodb.internal.logging.StructuredLoggingInterceptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestLoggingInterceptor implements StructuredLoggingInterceptor, AutoCloseable {
+
+    private final List<StructuredLogMessage> messages = new ArrayList<>();
+    private final String applicationName;
+
+    public TestLoggingInterceptor(final String applicationName) {
+        this.applicationName = requireNonNull(applicationName);
+        StructuredLogger.addInterceptor(applicationName, this);
+    }
+
+    @Override
+    public void intercept(final StructuredLogMessage message) {
+        messages.add(message);
+    }
+
+    @Override
+    public void close() {
+        StructuredLogger.removeInterceptor(applicationName);
+    }
+
+    public List<StructuredLogMessage> getMessages() {
+        return messages;
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/TestLoggingInterceptor.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/TestLoggingInterceptor.java
@@ -19,6 +19,7 @@ package com.mongodb.client.unified;
 import com.mongodb.internal.logging.StructuredLogMessage;
 import com.mongodb.internal.logging.StructuredLogger;
 import com.mongodb.internal.logging.StructuredLoggingInterceptor;
+import com.mongodb.lang.NonNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +37,7 @@ public class TestLoggingInterceptor implements StructuredLoggingInterceptor, Aut
     }
 
     @Override
-    public void intercept(final StructuredLogMessage message) {
+    public synchronized void intercept(@NonNull final StructuredLogMessage message) {
         messages.add(message);
     }
 
@@ -45,7 +46,7 @@ public class TestLoggingInterceptor implements StructuredLoggingInterceptor, Aut
         StructuredLogger.removeInterceptor(applicationName);
     }
 
-    public List<StructuredLogMessage> getMessages() {
-        return messages;
+    public synchronized List<StructuredLogMessage> getMessages() {
+        return new ArrayList<>(messages);
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/ValueMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/ValueMatcher.java
@@ -75,7 +75,6 @@ final class ValueMatcher {
                         expected = expectedDocument.getString("$$matchesHexBytes");
                         break;
                     case "$$matchAsRoot":
-                        // TODO: figure out why no logic was needed here to get tests to pass
                         expected = expectedDocument.getDocument("$$matchAsRoot");
                         break;
                     default:

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/ValueMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/ValueMatcher.java
@@ -74,6 +74,10 @@ final class ValueMatcher {
                     case "$$matchesHexBytes":
                         expected = expectedDocument.getString("$$matchesHexBytes");
                         break;
+                    case "$$matchAsRoot":
+                        // TODO: figure out why no logic was needed here to get tests to pass
+                        expected = expectedDocument.getDocument("$$matchAsRoot");
+                        break;
                     default:
                         throw new UnsupportedOperationException("Unsupported special operator: " + expectedDocument.getFirstKey());
                 }
@@ -86,6 +90,7 @@ final class ValueMatcher {
                 assertTrue(context.getMessage("Actual value must be a document but is " + actual.getBsonType()), actual.isDocument());
                 BsonDocument actualDocument = actual.asDocument();
                 expectedDocument.forEach((key, value) -> {
+                    BsonValue actualValue = actualDocument.get(key);
                     if (value.isDocument() && value.asDocument().size() == 1 && value.asDocument().getFirstKey().startsWith("$$")) {
                         switch (value.asDocument().getFirstKey()) {
                             case "$$exists":
@@ -98,10 +103,11 @@ final class ValueMatcher {
                                 }
                                 return;
                             case "$$type":
+                                assertTrue(context.getMessage("Actual document must contain key " + key), actualDocument.containsKey(key));
                                 assertExpectedType(actualDocument.get(key), value.asDocument().get("$$type"));
                                 return;
                             case "$$unsetOrMatches":
-                                if (!actualDocument.containsKey(key)) {
+                                if (actualValue == null) {
                                     return;
                                 }
                                 value = value.asDocument().get("$$unsetOrMatches");
@@ -115,13 +121,17 @@ final class ValueMatcher {
                             case "$$sessionLsid":
                                 value = entities.getSessionIdentifier(value.asDocument().getString("$$sessionLsid").getValue());
                                 break;
+                            case "$$matchAsDocument":
+                                actualValue = BsonDocument.parse(actualValue.asString().getValue());
+                                value = value.asDocument().getDocument("$$matchAsDocument");
+                                break;
                             default:
                                 throw new UnsupportedOperationException("Unsupported special operator: " + value.asDocument().getFirstKey());
                         }
                     }
 
-                    assertTrue(context.getMessage("Actual document must contain key " + key), actualDocument.containsKey(key));
-                    assertValuesMatch(value, actualDocument.get(key), key, -1);
+                    assertNotNull(context.getMessage("Actual document must contain key " + key), actualValue);
+                    assertValuesMatch(value, actualValue, key, -1);
                 });
             } else if (expected.isArray()) {
                 assertTrue(context.getMessage("Actual value must be an array but is " + actual.getBsonType()), actual.isArray());


### PR DESCRIPTION
* Align command logging messages to specification
* Add command logging unified tests

One leftover that I opened a separate ticket for:

* Support for max document length: this involves plumbing the value all the way down from MongoClientSettings

JAVA-4752
JAVA-4753
