### PR TITLE
Javadoc for expressions, part 2

### DIFF
--- a/driver-core/src/main/com/mongodb/annotations/Sealed.java
+++ b/driver-core/src/main/com/mongodb/annotations/Sealed.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ * Copyright 2010 The Guava Authors
+ * Copyright 2011 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Signifies that the annotated class or interface should be treated as sealed:
+ * it must not be extended or implemented.
+ *
+ * <p>Using such classes and interfaces is no different from using ordinary
+ * unannotated classes and interfaces.
+ *
+ * <p>This annotation does not imply that the API is experimental or
+ * {@link Beta}, or that the quality or performance of the API is inferior.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+@Documented
+@Sealed
+public @interface Sealed {
+}

--- a/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
@@ -105,6 +105,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      * The {@linkplain #gt(Expression) largest} value all the values of
      * {@code this} array, or the {@code other} value if this array is empty.
      *
+     * @mongodb.server.release 5.2
      * @param other the other value.
      * @return the resulting value.
      */
@@ -114,6 +115,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      * The {@linkplain #lt(Expression) smallest} value all the values of
      * {@code this} array, or the {@code other} value if this array is empty.
      *
+     * @mongodb.server.release 5.2
      * @param other the other value.
      * @return the resulting value.
      */
@@ -124,6 +126,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      * {@code this} array, or all elements if the array contains fewer than
      * {@code n} elements.
      *
+     * @mongodb.server.release 5.2
      * @param n the number of elements.
      * @return the resulting value.
      */
@@ -134,6 +137,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      * {@code this} array, or all elements if the array contains fewer than
      * {@code n} elements.
      *
+     * @mongodb.server.release 5.2
      * @param n the number of elements.
      * @return the resulting value.
      */

--- a/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
@@ -247,6 +247,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      * the array is not empty.
      * If the array is empty then the behaviour of the API is not defined.
      *
+     * @mongodb.server.release 4.4
      * @return the resulting value.
      */
     @MqlUnchecked(PRESENT)
@@ -259,6 +260,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      * the array is not empty.
      * If the array is empty then the behaviour of the API is not defined.
      *
+     * @mongodb.server.release 4.4
      * @return the resulting value.
      */
     T last();

--- a/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
@@ -20,7 +20,6 @@ import java.util.function.Function;
 
 import static com.mongodb.client.model.expressions.Expressions.of;
 import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.PRESENT;
-import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.NON_EMPTY;
 
 /**
  * An array {@link Expression value} in the context of the MongoDB Query
@@ -58,67 +57,267 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      */
     IntegerExpression size();
 
+    /**
+     * True if any value in {@code this} array satisfies the predicate.
+     *
+     * @param predicate the predicate.
+     * @return the resulting value.
+     */
     BooleanExpression any(Function<? super T, BooleanExpression> predicate);
 
+    /**
+     * True if all values in {@code this} array satisfy the predicate.
+     *
+     * @param predicate the predicate.
+     * @return the resulting value.
+     */
     BooleanExpression all(Function<? super T, BooleanExpression> predicate);
 
+    /**
+     * The sum of adding together all the values of {@code this} array,
+     * via the provided {@code mapper}. Returns 0 if the array is empty.
+     *
+     * <p>The mapper may be used to transform the values of {@code this} array
+     * into {@linkplain NumberExpression numbers}. If no transformation is
+     * necessary, then the identify function {@code array.sum(v -> v)} should
+     * be used.
+     *
+     * @param mapper the mapper function.
+     * @return the resulting value.
+     */
     NumberExpression sum(Function<? super T, ? extends NumberExpression> mapper);
 
+    /**
+     * The product of multiplying together all the values of {@code this} array,
+     * via the provided {@code mapper}. Returns 1 if the array is empty.
+     *
+     * <p>The mapper may be used to transform the values of {@code this} array
+     * into {@linkplain NumberExpression numbers}. If no transformation is
+     * necessary, then the identify function {@code array.multiply(v -> v)}
+     * should be used.
+     *
+     * @param mapper the mapper function.
+     * @return the resulting value.
+     */
     NumberExpression multiply(Function<? super T, ? extends NumberExpression> mapper);
 
+    /**
+     * The {@linkplain #gt(Expression) largest} value all the values of
+     * {@code this} array, or the {@code other} value if this array is empty.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
     T max(T other);
 
+    /**
+     * The {@linkplain #lt(Expression) smallest} value all the values of
+     * {@code this} array, or the {@code other} value if this array is empty.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
     T min(T other);
 
+    /**
+     * The {@linkplain #gt(Expression) largest} {@code n} elements of
+     * {@code this} array, or all elements if the array contains fewer than
+     * {@code n} elements.
+     *
+     * @param n the number of elements.
+     * @return the resulting value.
+     */
     ArrayExpression<T> maxN(IntegerExpression n);
+
+    /**
+     * The {@linkplain #lt(Expression) smallest} {@code n} elements of
+     * {@code this} array, or all elements if the array contains fewer than
+     * {@code n} elements.
+     *
+     * @param n the number of elements.
+     * @return the resulting value.
+     */
     ArrayExpression<T> minN(IntegerExpression n);
 
+    /**
+     * The string-concatenation of all the values of {@code this} array,
+     * via the provided {@code mapper}. Returns the empty string if the array
+     * is empty.
+     *
+     * <p>The mapper may be used to transform the values of {@code this} array
+     * into {@linkplain StringExpression strings}. If no transformation is
+     * necessary, then the identify function {@code array.join(v -> v)} should
+     * be used.
+     *
+     * @param mapper the mapper function.
+     * @return the resulting value.
+     */
     StringExpression join(Function<? super T, StringExpression> mapper);
 
+    /**
+     * The array-concatenation of all the array values of {@code this} array,
+     * via the provided {@code mapper}. Returns the empty array if the array
+     * is empty.
+     *
+     * <p>The mapper may be used to transform the values of {@code this} array
+     * into {@linkplain ArrayExpression arrays}. If no transformation is
+     * necessary, then the identify function {@code array.concat(v -> v)} should
+     * be used.
+     *
+     * @param mapper the mapper function.
+     * @return the resulting value.
+     * @param <R> the type of the elements of the array.
+     */
     <R extends Expression> ArrayExpression<R> concat(Function<? super T, ? extends ArrayExpression<? extends R>> mapper);
 
+    /**
+     * The set union of all the array values of {@code this} array,
+     * via the provided {@code mapper}. Returns the empty array if the array
+     * is empty.
+     *
+     * <p>The mapper may be used to transform the values of {@code this} array
+     * into {@linkplain ArrayExpression arrays}. If no transformation is
+     * necessary, then the identify function {@code array.union(v -> v)} should
+     * be used.
+     *
+     * @param mapper the mapper function.
+     * @return the resulting value.
+     * @param <R> the type of the elements of the array.
+     */
     <R extends Expression> ArrayExpression<R> union(Function<? super T, ? extends ArrayExpression<? extends R>> mapper);
 
+    /**
+     * The {@linkplain MapExpression map} value corresponding to the
+     * {@linkplain EntryExpression entry} values of {@code this} array,
+     * via the provided {@code mapper}. Returns the empty array if the array
+     * is empty.
+     *
+     * <p>The mapper may be used to transform the values of {@code this} array
+     * into {@linkplain EntryExpression entries}. If no transformation is
+     * necessary, then the identify function {@code array.union(v -> v)} should
+     * be used.
+     *
+     * @see MapExpression#entrySet()
+     * @param mapper the mapper function.
+     * @return the resulting value.
+     * @param <R> the type of the resulting map's values.
+     */
     <R extends Expression> MapExpression<R> asMap(Function<? super T, ? extends EntryExpression<? extends R>> mapper);
 
     /**
-     * user asserts that i is in bounds for the array
+     * Returns the element at the provided index {@code i} for
+     * {@code this} array.
      *
-     * @param i
-     * @return
+     * <p>Warning: The use of this method is an assertion that
+     * the index {@code i} is in bounds for the array.
+     * If the index is out of bounds for this array, then
+     * the behaviour of the API is not defined.
+     *
+     * @param i the index.
+     * @return the resulting value.
      */
     @MqlUnchecked(PRESENT)
     T elementAt(IntegerExpression i);
 
+    /**
+     * Returns the element at the provided index {@code i} for
+     * {@code this} array.
+     *
+     * <p>Warning: The use of this method is an assertion that
+     * the index {@code i} is in bounds for the array.
+     * If the index is out of bounds for this array, then
+     * the behaviour of the API is not defined.
+     *
+     * @param i the index.
+     * @return the resulting value.
+     */
+    @MqlUnchecked(PRESENT)
     default T elementAt(final int i) {
         return this.elementAt(of(i));
     }
 
     /**
-     * user asserts that array is not empty
-     * @return
+     * Returns the first element of {@code this} array.
+     *
+     * <p>Warning: The use of this method is an assertion that
+     * the array is not empty.
+     * If the array is empty then the behaviour of the API is not defined.
+     *
+     * @return the resulting value.
      */
-    @MqlUnchecked(NON_EMPTY)
+    @MqlUnchecked(PRESENT)
     T first();
 
     /**
-     * user asserts that array is not empty
-     * @return
+     * Returns the last element of {@code this} array.
+     *
+     * <p>Warning: The use of this method is an assertion that
+     * the array is not empty.
+     * If the array is empty then the behaviour of the API is not defined.
+     *
+     * @return the resulting value.
      */
     T last();
 
-    BooleanExpression contains(T contains);
+    /**
+     * True if {@code this} array contains a value that is
+     * {@linkplain #eq equal} to the provided {@code value}.
+     *
+     * @param value the value.
+     * @return the resulting value.
+     */
+    BooleanExpression contains(T value);
 
-    ArrayExpression<T> concat(ArrayExpression<? extends T> array);
+    /**
+     * The result of concatenating {@code this} array first with
+     * the {@code other} array ensuing.
+     *
+     * @param other the other array.
+     * @return the resulting array.
+     */
+    ArrayExpression<T> concat(ArrayExpression<? extends T> other);
 
+    /**
+     * The subarray of {@code this} array, from the {@code start} index
+     * inclusive, and continuing for the specified {@code length}, up to
+     * the end of the array.
+     *
+     * @param start start index
+     * @param length length
+     * @return the resulting value
+     */
     ArrayExpression<T> slice(IntegerExpression start, IntegerExpression length);
 
+    /**
+     * The subarray of {@code this} array, from the {@code start} index
+     * inclusive, and continuing for the specified {@code length}, or
+     * to the end of the array.
+     *
+     * @param start start index
+     * @param length length
+     * @return the resulting value
+     */
     default ArrayExpression<T> slice(final int start, final int length) {
         return this.slice(of(start), of(length));
     }
 
-    ArrayExpression<T> union(ArrayExpression<? extends T> set);
+    /**
+     * The set-union of {@code this} array and the {@code other} array ensuing,
+     * containing only the distinct values of both.
+     * No guarantee is made regarding order.
+     *
+     * @param other the other array.
+     * @return the resulting array.
+     */
+    ArrayExpression<T> union(ArrayExpression<? extends T> other);
 
+
+    /**
+     * An array containing only the distinct values of {@code this} array.
+     * No guarantee is made regarding order.
+     *
+     * @return the resulting value
+     */
     ArrayExpression<T> distinct();
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/ArrayExpression.java
@@ -16,6 +16,9 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Sealed;
+
 import java.util.function.Function;
 
 import static com.mongodb.client.model.expressions.Expressions.of;
@@ -27,7 +30,10 @@ import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.PRESEN
  * certain type. It is also known as a finite mathematical sequence.
  *
  * @param <T> the type of the elements
+ * @since 4.9.0
  */
+@Sealed
+@Beta(Beta.Reason.CLIENT)
 public interface ArrayExpression<T extends Expression> extends Expression {
 
     /**
@@ -58,7 +64,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
     IntegerExpression size();
 
     /**
-     * True if any value in {@code this} array satisfies the predicate.
+     * Whether any value in {@code this} array satisfies the predicate.
      *
      * @param predicate the predicate.
      * @return the resulting value.
@@ -66,7 +72,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
     BooleanExpression any(Function<? super T, BooleanExpression> predicate);
 
     /**
-     * True if all values in {@code this} array satisfy the predicate.
+     * Whether all values in {@code this} array satisfy the predicate.
      *
      * @param predicate the predicate.
      * @return the resulting value.
@@ -79,7 +85,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      *
      * <p>The mapper may be used to transform the values of {@code this} array
      * into {@linkplain NumberExpression numbers}. If no transformation is
-     * necessary, then the identify function {@code array.sum(v -> v)} should
+     * necessary, then the identity function {@code array.sum(v -> v)} should
      * be used.
      *
      * @param mapper the mapper function.
@@ -93,7 +99,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      *
      * <p>The mapper may be used to transform the values of {@code this} array
      * into {@linkplain NumberExpression numbers}. If no transformation is
-     * necessary, then the identify function {@code array.multiply(v -> v)}
+     * necessary, then the identity function {@code array.multiply(v -> v)}
      * should be used.
      *
      * @param mapper the mapper function.
@@ -150,7 +156,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      *
      * <p>The mapper may be used to transform the values of {@code this} array
      * into {@linkplain StringExpression strings}. If no transformation is
-     * necessary, then the identify function {@code array.join(v -> v)} should
+     * necessary, then the identity function {@code array.join(v -> v)} should
      * be used.
      *
      * @param mapper the mapper function.
@@ -159,13 +165,14 @@ public interface ArrayExpression<T extends Expression> extends Expression {
     StringExpression join(Function<? super T, StringExpression> mapper);
 
     /**
-     * The array-concatenation of all the array values of {@code this} array,
+     * The {@linkplain #concat(ArrayExpression) array-concatenation}
+     * of all the array values of {@code this} array,
      * via the provided {@code mapper}. Returns the empty array if the array
      * is empty.
      *
      * <p>The mapper may be used to transform the values of {@code this} array
      * into {@linkplain ArrayExpression arrays}. If no transformation is
-     * necessary, then the identify function {@code array.concat(v -> v)} should
+     * necessary, then the identity function {@code array.concat(v -> v)} should
      * be used.
      *
      * @param mapper the mapper function.
@@ -175,13 +182,14 @@ public interface ArrayExpression<T extends Expression> extends Expression {
     <R extends Expression> ArrayExpression<R> concat(Function<? super T, ? extends ArrayExpression<? extends R>> mapper);
 
     /**
-     * The set union of all the array values of {@code this} array,
+     * The {@linkplain #union(ArrayExpression) set-union}
+     * of all the array values of {@code this} array,
      * via the provided {@code mapper}. Returns the empty array if the array
      * is empty.
      *
      * <p>The mapper may be used to transform the values of {@code this} array
      * into {@linkplain ArrayExpression arrays}. If no transformation is
-     * necessary, then the identify function {@code array.union(v -> v)} should
+     * necessary, then the identity function {@code array.union(v -> v)} should
      * be used.
      *
      * @param mapper the mapper function.
@@ -193,12 +201,12 @@ public interface ArrayExpression<T extends Expression> extends Expression {
     /**
      * The {@linkplain MapExpression map} value corresponding to the
      * {@linkplain EntryExpression entry} values of {@code this} array,
-     * via the provided {@code mapper}. Returns the empty array if the array
+     * via the provided {@code mapper}. Returns the empty map if the array
      * is empty.
      *
      * <p>The mapper may be used to transform the values of {@code this} array
      * into {@linkplain EntryExpression entries}. If no transformation is
-     * necessary, then the identify function {@code array.union(v -> v)} should
+     * necessary, then the identity function {@code array.union(v -> v)} should
      * be used.
      *
      * @see MapExpression#entrySet()
@@ -215,7 +223,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      * <p>Warning: The use of this method is an assertion that
      * the index {@code i} is in bounds for the array.
      * If the index is out of bounds for this array, then
-     * the behaviour of the API is not defined.
+     * the behaviour of the API is not specified.
      *
      * @param i the index.
      * @return the resulting value.
@@ -230,7 +238,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      * <p>Warning: The use of this method is an assertion that
      * the index {@code i} is in bounds for the array.
      * If the index is out of bounds for this array, then
-     * the behaviour of the API is not defined.
+     * the behaviour of the API is not specified.
      *
      * @param i the index.
      * @return the resulting value.
@@ -245,7 +253,7 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      *
      * <p>Warning: The use of this method is an assertion that
      * the array is not empty.
-     * If the array is empty then the behaviour of the API is not defined.
+     * If the array is empty then the behaviour of the API is not specified.
      *
      * @mongodb.server.release 4.4
      * @return the resulting value.
@@ -258,15 +266,16 @@ public interface ArrayExpression<T extends Expression> extends Expression {
      *
      * <p>Warning: The use of this method is an assertion that
      * the array is not empty.
-     * If the array is empty then the behaviour of the API is not defined.
+     * If the array is empty then the behaviour of the API is not specified.
      *
      * @mongodb.server.release 4.4
      * @return the resulting value.
      */
+    @MqlUnchecked(PRESENT)
     T last();
 
     /**
-     * True if {@code this} array contains a value that is
+     * Whether {@code this} array contains a value that is
      * {@linkplain #eq equal} to the provided {@code value}.
      *
      * @param value the value.

--- a/driver-core/src/main/com/mongodb/client/model/expressions/BooleanExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/BooleanExpression.java
@@ -16,12 +16,19 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Sealed;
+
 import java.util.function.Function;
 
 /**
  * A boolean {@linkplain Expression value} in the context of the
  * MongoDB Query Language (MQL).
+ *
+ * @since 4.9.0
  */
+@Sealed
+@Beta(Beta.Reason.CLIENT)
 public interface BooleanExpression extends Expression {
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Branches.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Branches.java
@@ -127,6 +127,7 @@ public final class Branches<T extends Expression> {
      * {@linkplain Expression#isBooleanOr(BooleanExpression) being a boolean}
      * produces a value specified by the {@code mapping}.
      *
+     * @mongodb.server.release 4.4
      * @param mapping the mapping.
      * @return the appended sequence of checks.
      * @param <R> the type of the produced value.
@@ -140,6 +141,7 @@ public final class Branches<T extends Expression> {
      * {@linkplain Expression#isIntegerOr(IntegerExpression) being an integer}
      * produces a value specified by the {@code mapping}.
      *
+     * @mongodb.server.release 4.4
      * @param mapping the mapping.
      * @return the appended sequence of checks.
      * @param <R> the type of the produced value.

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Branches.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Branches.java
@@ -16,6 +16,9 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Beta;
+import com.mongodb.assertions.Assertions;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -28,10 +31,12 @@ import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE_A
  * to succeed will produce the value that it specifies. If no check succeeds,
  * then the operation
  * {@linkplain BranchesIntermediary#defaults(Function) defaults} to a default
- * value, or if none is specified, the operation causes an error.
+ * value, or if none is specified, the operation will cause an error.
  *
  * @param <T> the type of the values that may be checked.
+ * @since 4.9.0
  */
+@Beta(Beta.Reason.CLIENT)
 public final class Branches<T extends Expression> {
 
     Branches() {
@@ -59,6 +64,8 @@ public final class Branches<T extends Expression> {
      * @return the appended sequence of checks.
      */
     public <R extends Expression> BranchesIntermediary<T, R> is(final Function<? super T, BooleanExpression> predicate, final Function<? super T, ? extends R> mapping) {
+        Assertions.notNull("predicate", predicate);
+        Assertions.notNull("mapping", mapping);
         return with(value -> new SwitchCase<>(predicate.apply(value), mapping.apply(value)));
     }
 
@@ -74,6 +81,8 @@ public final class Branches<T extends Expression> {
      * @return the appended sequence of checks.
      */
     public <R extends Expression> BranchesIntermediary<T, R> eq(final T v, final Function<? super T, ? extends R> mapping) {
+        Assertions.notNull("v", v);
+        Assertions.notNull("mapping", mapping);
         return is(value -> value.eq(v), mapping);
     }
 
@@ -89,6 +98,8 @@ public final class Branches<T extends Expression> {
      * @return the appended sequence of checks.
      */
     public <R extends Expression> BranchesIntermediary<T, R> lt(final T v, final Function<? super T, ? extends R> mapping) {
+        Assertions.notNull("v", v);
+        Assertions.notNull("mapping", mapping);
         return is(value -> value.lt(v), mapping);
     }
 
@@ -104,6 +115,8 @@ public final class Branches<T extends Expression> {
      * @return the appended sequence of checks.
      */
     public <R extends Expression> BranchesIntermediary<T, R> lte(final T v, final Function<? super T, ? extends R> mapping) {
+        Assertions.notNull("v", v);
+        Assertions.notNull("mapping", mapping);
         return is(value -> value.lte(v), mapping);
     }
 
@@ -119,12 +132,13 @@ public final class Branches<T extends Expression> {
      * @param <R> the type of the produced value.
      */
     public <R extends Expression> BranchesIntermediary<T, R> isBoolean(final Function<? super BooleanExpression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isBoolean(), v -> mapping.apply((BooleanExpression) v));
     }
 
     /**
      * A successful check for
-     * {@linkplain Expression#isBooleanOr(BooleanExpression) being a boolean}
+     * {@linkplain Expression#isNumberOr(NumberExpression) being a number}
      * produces a value specified by the {@code mapping}.
      *
      * @mongodb.server.release 4.4
@@ -133,6 +147,7 @@ public final class Branches<T extends Expression> {
      * @param <R> the type of the produced value.
      */
     public <R extends Expression> BranchesIntermediary<T, R> isNumber(final Function<? super NumberExpression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isNumber(), v -> mapping.apply((NumberExpression) v));
     }
 
@@ -147,6 +162,7 @@ public final class Branches<T extends Expression> {
      * @param <R> the type of the produced value.
      */
     public <R extends Expression> BranchesIntermediary<T, R> isInteger(final Function<? super IntegerExpression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isInteger(), v -> mapping.apply((IntegerExpression) v));
     }
 
@@ -160,6 +176,7 @@ public final class Branches<T extends Expression> {
      * @param <R> the type of the produced value.
      */
     public <R extends Expression> BranchesIntermediary<T, R> isString(final Function<? super StringExpression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isString(), v -> mapping.apply((StringExpression) v));
     }
 
@@ -173,6 +190,7 @@ public final class Branches<T extends Expression> {
      * @param <R> the type of the produced value.
      */
     public <R extends Expression> BranchesIntermediary<T, R> isDate(final Function<? super DateExpression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isDate(), v -> mapping.apply((DateExpression) v));
     }
 
@@ -192,32 +210,32 @@ public final class Branches<T extends Expression> {
      */
     @SuppressWarnings("unchecked")
     public <R extends Expression, Q extends Expression> BranchesIntermediary<T, R> isArray(final Function<? super ArrayExpression<@MqlUnchecked(TYPE_ARGUMENT) Q>, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isArray(), v -> mapping.apply((ArrayExpression<Q>) v));
     }
 
     /**
      * A successful check for
      * {@linkplain Expression#isDocumentOr(DocumentExpression) being a document}
+     * (or document-like value, see
+     * {@link MapExpression} and {@link EntryExpression})
      * produces a value specified by the {@code mapping}.
-     *
-     * <p>Note: Any value considered to be a document by this API
-     * will also be considered a map, and vice-versa.
      *
      * @param mapping the mapping.
      * @return the appended sequence of checks.
      * @param <R> the type of the produced value.
      */
     public <R extends Expression> BranchesIntermediary<T, R> isDocument(final Function<? super DocumentExpression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isDocumentOrMap(), v -> mapping.apply((DocumentExpression) v));
     }
 
     /**
      * A successful check for
      * {@linkplain Expression#isMapOr(MapExpression) being a map}
+     * (or map-like value, see
+     * {@link DocumentExpression} and {@link EntryExpression})
      * produces a value specified by the {@code mapping}.
-     *
-     * <p>Note: Any value considered to be a map by this API
-     * will also be considered a document, and vice-versa.
      *
      * <p>Warning: The type argument of the map is not
      * enforced by the API. The use of this method is an
@@ -230,6 +248,7 @@ public final class Branches<T extends Expression> {
      */
     @SuppressWarnings("unchecked")
     public <R extends Expression, Q extends Expression> BranchesIntermediary<T, R> isMap(final Function<? super MapExpression<@MqlUnchecked(TYPE_ARGUMENT) Q>, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isDocumentOrMap(), v -> mapping.apply((MapExpression<Q>) v));
     }
 
@@ -243,6 +262,7 @@ public final class Branches<T extends Expression> {
      * @param <R> the type of the produced value.
      */
     public <R extends Expression> BranchesIntermediary<T, R> isNull(final Function<? super Expression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isNull(), v -> mapping.apply(v));
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Branches.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Branches.java
@@ -22,6 +22,16 @@ import java.util.function.Function;
 
 import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE_ARGUMENT;
 
+/**
+ * Branches are used in {@linkplain Expression#switchOn}, and
+ * define a sequence of checks that will be performed. The first check
+ * to succeed will produce the value that it specifies. If no check succeeds,
+ * then the operation
+ * {@linkplain BranchesIntermediary#defaults(Function) defaults} to a default
+ * value, or if none is specified, the operation causes an error.
+ *
+ * @param <T> the type of the values that may be checked.
+ */
 public final class Branches<T extends Expression> {
 
     Branches() {
@@ -39,61 +49,198 @@ public final class Branches<T extends Expression> {
 
     // is fn
 
-    public <T extends Expression, R extends Expression> BranchesIntermediary<T, R> is(final Function<? super T, BooleanExpression> o, final Function<? super T, ? extends R> r) {
-        return with(value -> new SwitchCase<>(o.apply(value), r.apply(value)));
+    /**
+     * A successful check for the specified {@code predicate}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param predicate the predicate.
+     * @param mapping the mapping.
+     * @param <R> the type of the produced value.
+     * @return the appended sequence of checks.
+     */
+    public <R extends Expression> BranchesIntermediary<T, R> is(final Function<? super T, BooleanExpression> predicate, final Function<? super T, ? extends R> mapping) {
+        return with(value -> new SwitchCase<>(predicate.apply(value), mapping.apply(value)));
     }
 
     // eq lt lte
 
-    public <R extends Expression> BranchesIntermediary<T, R> eq(final T v, final Function<? super T, ? extends R> r) {
-        return is(value -> value.eq(v), r);
+    /**
+     * A successful check for {@linkplain Expression#eq equality}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param v the value to check against.
+     * @param mapping the mapping.
+     * @param <R> the type of the produced value.
+     * @return the appended sequence of checks.
+     */
+    public <R extends Expression> BranchesIntermediary<T, R> eq(final T v, final Function<? super T, ? extends R> mapping) {
+        return is(value -> value.eq(v), mapping);
     }
 
-    public <R extends Expression> BranchesIntermediary<T, R> lt(final T v, final Function<? super T, ? extends R> r) {
-        return is(value -> value.lt(v), r);
+    /**
+     * A successful check for being
+     * {@linkplain Expression#lt less than}
+     * the provided value {@code v}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param v the value to check against.
+     * @param mapping the mapping.
+     * @param <R> the type of the produced value.
+     * @return the appended sequence of checks.
+     */
+    public <R extends Expression> BranchesIntermediary<T, R> lt(final T v, final Function<? super T, ? extends R> mapping) {
+        return is(value -> value.lt(v), mapping);
     }
 
-    public <R extends Expression> BranchesIntermediary<T, R> lte(final T v, final Function<? super T, ? extends R> r) {
-        return is(value -> value.lte(v), r);
+    /**
+     * A successful check for being
+     * {@linkplain Expression#lte less than or equal to}
+     * the provided value {@code v}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param v the value to check against.
+     * @param mapping the mapping.
+     * @param <R> the type of the produced value.
+     * @return the appended sequence of checks.
+     */
+    public <R extends Expression> BranchesIntermediary<T, R> lte(final T v, final Function<? super T, ? extends R> mapping) {
+        return is(value -> value.lte(v), mapping);
     }
 
     // is type
 
-    public <R extends Expression> BranchesIntermediary<T, R> isBoolean(final Function<? super BooleanExpression, ? extends R> r) {
-        return is(v -> mqlEx(v).isBoolean(), v -> r.apply((BooleanExpression) v));
+    /**
+     * A successful check for
+     * {@linkplain Expression#isBooleanOr(BooleanExpression) being a boolean}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     * @param <R> the type of the produced value.
+     */
+    public <R extends Expression> BranchesIntermediary<T, R> isBoolean(final Function<? super BooleanExpression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isBoolean(), v -> mapping.apply((BooleanExpression) v));
     }
 
-    public <R extends Expression> BranchesIntermediary<T, R> isNumber(final Function<? super NumberExpression, ? extends R> r) {
-        return is(v -> mqlEx(v).isNumber(), v -> r.apply((NumberExpression) v));
+    /**
+     * A successful check for
+     * {@linkplain Expression#isBooleanOr(BooleanExpression) being a boolean}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     * @param <R> the type of the produced value.
+     */
+    public <R extends Expression> BranchesIntermediary<T, R> isNumber(final Function<? super NumberExpression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isNumber(), v -> mapping.apply((NumberExpression) v));
     }
 
-    public <R extends Expression> BranchesIntermediary<T, R> isInteger(final Function<? super IntegerExpression, ? extends R> r) {
-        return is(v -> mqlEx(v).isInteger(), v -> r.apply((IntegerExpression) v));
+    /**
+     * A successful check for
+     * {@linkplain Expression#isIntegerOr(IntegerExpression) being an integer}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     * @param <R> the type of the produced value.
+     */
+    public <R extends Expression> BranchesIntermediary<T, R> isInteger(final Function<? super IntegerExpression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isInteger(), v -> mapping.apply((IntegerExpression) v));
     }
 
-    public <R extends Expression> BranchesIntermediary<T, R> isString(final Function<? super StringExpression, ? extends R> r) {
-        return is(v -> mqlEx(v).isString(), v -> r.apply((StringExpression) v));
+    /**
+     * A successful check for
+     * {@linkplain Expression#isStringOr(StringExpression) being a string}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     * @param <R> the type of the produced value.
+     */
+    public <R extends Expression> BranchesIntermediary<T, R> isString(final Function<? super StringExpression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isString(), v -> mapping.apply((StringExpression) v));
     }
 
-    public <R extends Expression> BranchesIntermediary<T, R> isDate(final Function<? super DateExpression, ? extends R> r) {
-        return is(v -> mqlEx(v).isDate(), v -> r.apply((DateExpression) v));
+    /**
+     * A successful check for
+     * {@linkplain Expression#isDateOr(DateExpression) being a date}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     * @param <R> the type of the produced value.
+     */
+    public <R extends Expression> BranchesIntermediary<T, R> isDate(final Function<? super DateExpression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isDate(), v -> mapping.apply((DateExpression) v));
     }
 
+    /**
+     * A successful check for
+     * {@linkplain Expression#isArrayOr(ArrayExpression) being an array}
+     * produces a value specified by the {@code mapping}.
+     *
+     * <p>Warning: The type argument of the array is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the type argument is correct.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     * @param <R> the type of the produced value.
+     * @param <Q> the type of the array.
+     */
     @SuppressWarnings("unchecked")
-    public <R extends Expression, Q extends Expression> BranchesIntermediary<T, R> isArray(final Function<? super ArrayExpression<@MqlUnchecked(TYPE_ARGUMENT) Q>, ? extends R> r) {
-        return is(v -> mqlEx(v).isArray(), v -> r.apply((ArrayExpression<Q>) v));
+    public <R extends Expression, Q extends Expression> BranchesIntermediary<T, R> isArray(final Function<? super ArrayExpression<@MqlUnchecked(TYPE_ARGUMENT) Q>, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isArray(), v -> mapping.apply((ArrayExpression<Q>) v));
     }
 
-    public <R extends Expression> BranchesIntermediary<T, R> isDocument(final Function<? super DocumentExpression, ? extends R> r) {
-        return is(v -> mqlEx(v).isDocumentOrMap(), v -> r.apply((DocumentExpression) v));
+    /**
+     * A successful check for
+     * {@linkplain Expression#isDocumentOr(DocumentExpression) being a document}
+     * produces a value specified by the {@code mapping}.
+     *
+     * <p>Note: Any value considered to be a document by this API
+     * will also be considered a map, and vice-versa.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     * @param <R> the type of the produced value.
+     */
+    public <R extends Expression> BranchesIntermediary<T, R> isDocument(final Function<? super DocumentExpression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isDocumentOrMap(), v -> mapping.apply((DocumentExpression) v));
     }
 
+    /**
+     * A successful check for
+     * {@linkplain Expression#isMapOr(MapExpression) being a map}
+     * produces a value specified by the {@code mapping}.
+     *
+     * <p>Note: Any value considered to be a map by this API
+     * will also be considered a document, and vice-versa.
+     *
+     * <p>Warning: The type argument of the map is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the type argument is correct.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     * @param <R> the type of the produced value.
+     * @param <Q> the type of the array.
+     */
     @SuppressWarnings("unchecked")
-    public <R extends Expression, Q extends Expression> BranchesIntermediary<T, R> isMap(final Function<? super MapExpression<Q>, ? extends R> r) {
-        return is(v -> mqlEx(v).isDocumentOrMap(), v -> r.apply((MapExpression<Q>) v));
+    public <R extends Expression, Q extends Expression> BranchesIntermediary<T, R> isMap(final Function<? super MapExpression<@MqlUnchecked(TYPE_ARGUMENT) Q>, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isDocumentOrMap(), v -> mapping.apply((MapExpression<Q>) v));
     }
 
-    public <R extends Expression> BranchesIntermediary<T, R> isNull(final Function<? super Expression, ? extends R> r) {
-        return is(v -> mqlEx(v).isNull(), v -> r.apply(v));
+    /**
+     * A successful check for
+     * {@linkplain Expressions#ofNull()} being the null value}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     * @param <R> the type of the produced value.
+     */
+    public <R extends Expression> BranchesIntermediary<T, R> isNull(final Function<? super Expression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isNull(), v -> mapping.apply(v));
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/BranchesIntermediary.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/BranchesIntermediary.java
@@ -116,6 +116,7 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * {@linkplain Expression#isBooleanOr(BooleanExpression) being a boolean}
      * produces a value specified by the {@code mapping}.
      *
+     * @mongodb.server.release 4.4
      * @param mapping the mapping.
      * @return the appended sequence of checks.
      */
@@ -128,6 +129,7 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * {@linkplain Expression#isIntegerOr(IntegerExpression) being an integer}
      * produces a value specified by the {@code mapping}.
      *
+     * @mongodb.server.release 4.4
      * @param mapping the mapping.
      * @return the appended sequence of checks.
      */

--- a/driver-core/src/main/com/mongodb/client/model/expressions/BranchesIntermediary.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/BranchesIntermediary.java
@@ -20,6 +20,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+/**
+ * See {@link Branches}.
+ *
+ * @param <T> the type of the values that may be checked.
+ * @param <R> the type of the value produced.
+ */
 public final class BranchesIntermediary<T extends Expression, R extends Expression> extends BranchesTerminal<T, R> {
     BranchesIntermediary(final List<Function<T, SwitchCase<R>>> branches) {
         super(branches, null);
@@ -37,66 +43,197 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
 
     // is fn
 
-    public BranchesIntermediary<T, R> is(final Function<? super T, BooleanExpression> o, final Function<? super T, ? extends R> r) {
-        return this.with(value -> new SwitchCase<>(o.apply(value), r.apply(value)));
+    /**
+     * A successful check for the specified {@code predicate}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param predicate the predicate.
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     */
+    public BranchesIntermediary<T, R> is(final Function<? super T, BooleanExpression> predicate, final Function<? super T, ? extends R> mapping) {
+        return this.with(value -> new SwitchCase<>(predicate.apply(value), mapping.apply(value)));
     }
 
     // eq lt lte
 
-    public BranchesIntermediary<T, R> eq(final T v, final Function<? super T, ? extends R> r) {
-        return is(value -> value.eq(v), r);
+    /**
+     * A successful check for {@linkplain Expression#eq equality}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param v the value to check against.
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     */
+    public BranchesIntermediary<T, R> eq(final T v, final Function<? super T, ? extends R> mapping) {
+        return is(value -> value.eq(v), mapping);
     }
 
-    public BranchesIntermediary<T, R> lt(final T v, final Function<? super T, ? extends R> r) {
-        return is(value -> value.lt(v), r);
+    /**
+     * A successful check for being
+     * {@linkplain Expression#lt less than}
+     * the provided value {@code v}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param v the value to check against.
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     */
+    public BranchesIntermediary<T, R> lt(final T v, final Function<? super T, ? extends R> mapping) {
+        return is(value -> value.lt(v), mapping);
     }
 
-    public BranchesIntermediary<T, R> lte(final T v, final Function<? super T, ? extends R> r) {
-        return is(value -> value.lte(v), r);
+    /**
+     * A successful check for being
+     * {@linkplain Expression#lte less than or equal to}
+     * the provided value {@code v}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param v the value to check against.
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     */
+    public BranchesIntermediary<T, R> lte(final T v, final Function<? super T, ? extends R> mapping) {
+        return is(value -> value.lte(v), mapping);
     }
 
     // is type
 
-    public BranchesIntermediary<T, R> isBoolean(final Function<? super BooleanExpression, ? extends R> r) {
-        return is(v -> mqlEx(v).isBoolean(), v -> r.apply((BooleanExpression) v));
+    /**
+     * A successful check for
+     * {@linkplain Expression#isBooleanOr(BooleanExpression) being a boolean}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     */
+    public BranchesIntermediary<T, R> isBoolean(final Function<? super BooleanExpression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isBoolean(), v -> mapping.apply((BooleanExpression) v));
     }
 
-    public BranchesIntermediary<T, R> isNumber(final Function<? super NumberExpression, ? extends R> r) {
-        return is(v -> mqlEx(v).isNumber(), v -> r.apply((NumberExpression) v));
+    /**
+     * A successful check for
+     * {@linkplain Expression#isBooleanOr(BooleanExpression) being a boolean}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     */
+    public BranchesIntermediary<T, R> isNumber(final Function<? super NumberExpression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isNumber(), v -> mapping.apply((NumberExpression) v));
     }
 
-    public BranchesIntermediary<T, R> isInteger(final Function<? super IntegerExpression, ? extends R> r) {
-        return is(v -> mqlEx(v).isInteger(), v -> r.apply((IntegerExpression) v));
+    /**
+     * A successful check for
+     * {@linkplain Expression#isIntegerOr(IntegerExpression) being an integer}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     */
+    public BranchesIntermediary<T, R> isInteger(final Function<? super IntegerExpression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isInteger(), v -> mapping.apply((IntegerExpression) v));
     }
 
-    public BranchesIntermediary<T, R> isString(final Function<? super StringExpression, ? extends R> r) {
-        return is(v -> mqlEx(v).isString(), v -> r.apply((StringExpression) v));
+    /**
+     * A successful check for
+     * {@linkplain Expression#isStringOr(StringExpression) being a string}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     */
+    public BranchesIntermediary<T, R> isString(final Function<? super StringExpression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isString(), v -> mapping.apply((StringExpression) v));
     }
 
-    public BranchesIntermediary<T, R> isDate(final Function<? super DateExpression, ? extends R> r) {
-        return is(v -> mqlEx(v).isDate(), v -> r.apply((DateExpression) v));
+    /**
+     * A successful check for
+     * {@linkplain Expression#isDateOr(DateExpression) being a date}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     */
+    public BranchesIntermediary<T, R> isDate(final Function<? super DateExpression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isDate(), v -> mapping.apply((DateExpression) v));
     }
 
+    /**
+     * A successful check for
+     * {@linkplain Expression#isArrayOr(ArrayExpression) being an array}
+     * produces a value specified by the {@code mapping}.
+     *
+     * <p>Warning: The type argument of the array is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the type argument is correct.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     * @param <Q> the type of the array.
+     */
     @SuppressWarnings("unchecked")
-    public <Q extends Expression> BranchesIntermediary<T, R> isArray(final Function<? super ArrayExpression<Q>, ? extends R> r) {
-        return is(v -> mqlEx(v).isArray(), v -> r.apply((ArrayExpression<Q>) v));
+    public <Q extends Expression> BranchesIntermediary<T, R> isArray(final Function<? super ArrayExpression<Q>, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isArray(), v -> mapping.apply((ArrayExpression<Q>) v));
     }
 
-    public BranchesIntermediary<T, R> isDocument(final Function<? super DocumentExpression, ? extends R> r) {
-        return is(v -> mqlEx(v).isDocumentOrMap(), v -> r.apply((DocumentExpression) v));
+    /**
+     * A successful check for
+     * {@linkplain Expression#isDocumentOr(DocumentExpression) being a document}
+     * produces a value specified by the {@code mapping}.
+     *
+     * <p>Note: Any value considered to be a document by this API
+     * will also be considered a map, and vice-versa.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     */
+    public BranchesIntermediary<T, R> isDocument(final Function<? super DocumentExpression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isDocumentOrMap(), v -> mapping.apply((DocumentExpression) v));
     }
 
+    /**
+     * A successful check for
+     * {@linkplain Expression#isMapOr(MapExpression) being a map}
+     * produces a value specified by the {@code mapping}.
+     *
+     * <p>Note: Any value considered to be a map by this API
+     * will also be considered a document, and vice-versa.
+     *
+     * <p>Warning: The type argument of the map is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the type argument is correct.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     * @param <Q> the type of the array.
+     */
     @SuppressWarnings("unchecked")
-    public <Q extends Expression> BranchesIntermediary<T, R> isMap(final Function<? super MapExpression<Q>, ? extends R> r) {
-        return is(v -> mqlEx(v).isDocumentOrMap(), v -> r.apply((MapExpression<Q>) v));
+    public <Q extends Expression> BranchesIntermediary<T, R> isMap(final Function<? super MapExpression<Q>, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isDocumentOrMap(), v -> mapping.apply((MapExpression<Q>) v));
     }
 
-    public BranchesIntermediary<T, R> isNull(final Function<? super Expression, ? extends R> r) {
-        return is(v -> mqlEx(v).isNull(), v -> r.apply(v));
+    /**
+     * A successful check for
+     * {@linkplain Expressions#ofNull()} being the null value}
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     */
+    public BranchesIntermediary<T, R> isNull(final Function<? super Expression, ? extends R> mapping) {
+        return is(v -> mqlEx(v).isNull(), v -> mapping.apply(v));
     }
 
-    public BranchesTerminal<T, R> defaults(final Function<? super T, ? extends R> r) {
-        return this.withDefault(value -> r.apply(value));
+    /**
+     * If no other check succeeds,
+     * produces a value specified by the {@code mapping}.
+     *
+     * @param mapping the mapping.
+     * @return the appended sequence of checks.
+     */
+    public BranchesTerminal<T, R> defaults(final Function<? super T, ? extends R> mapping) {
+        return this.withDefault(value -> mapping.apply(value));
     }
 
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/BranchesIntermediary.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/BranchesIntermediary.java
@@ -16,16 +16,23 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Beta;
+import com.mongodb.assertions.Assertions;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
+
+import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE_ARGUMENT;
 
 /**
  * See {@link Branches}.
  *
  * @param <T> the type of the values that may be checked.
  * @param <R> the type of the value produced.
+ * @since 4.9.0
  */
+@Beta(Beta.Reason.CLIENT)
 public final class BranchesIntermediary<T extends Expression, R extends Expression> extends BranchesTerminal<T, R> {
     BranchesIntermediary(final List<Function<T, SwitchCase<R>>> branches) {
         super(branches, null);
@@ -52,6 +59,8 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * @return the appended sequence of checks.
      */
     public BranchesIntermediary<T, R> is(final Function<? super T, BooleanExpression> predicate, final Function<? super T, ? extends R> mapping) {
+        Assertions.notNull("predicate", predicate);
+        Assertions.notNull("mapping", mapping);
         return this.with(value -> new SwitchCase<>(predicate.apply(value), mapping.apply(value)));
     }
 
@@ -66,6 +75,8 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * @return the appended sequence of checks.
      */
     public BranchesIntermediary<T, R> eq(final T v, final Function<? super T, ? extends R> mapping) {
+        Assertions.notNull("v", v);
+        Assertions.notNull("mapping", mapping);
         return is(value -> value.eq(v), mapping);
     }
 
@@ -80,6 +91,8 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * @return the appended sequence of checks.
      */
     public BranchesIntermediary<T, R> lt(final T v, final Function<? super T, ? extends R> mapping) {
+        Assertions.notNull("v", v);
+        Assertions.notNull("mapping", mapping);
         return is(value -> value.lt(v), mapping);
     }
 
@@ -94,6 +107,8 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * @return the appended sequence of checks.
      */
     public BranchesIntermediary<T, R> lte(final T v, final Function<? super T, ? extends R> mapping) {
+        Assertions.notNull("v", v);
+        Assertions.notNull("mapping", mapping);
         return is(value -> value.lte(v), mapping);
     }
 
@@ -108,12 +123,13 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * @return the appended sequence of checks.
      */
     public BranchesIntermediary<T, R> isBoolean(final Function<? super BooleanExpression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isBoolean(), v -> mapping.apply((BooleanExpression) v));
     }
 
     /**
      * A successful check for
-     * {@linkplain Expression#isBooleanOr(BooleanExpression) being a boolean}
+     * {@linkplain Expression#isNumberOr(NumberExpression) being a number}
      * produces a value specified by the {@code mapping}.
      *
      * @mongodb.server.release 4.4
@@ -121,6 +137,7 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * @return the appended sequence of checks.
      */
     public BranchesIntermediary<T, R> isNumber(final Function<? super NumberExpression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isNumber(), v -> mapping.apply((NumberExpression) v));
     }
 
@@ -134,6 +151,7 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * @return the appended sequence of checks.
      */
     public BranchesIntermediary<T, R> isInteger(final Function<? super IntegerExpression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isInteger(), v -> mapping.apply((IntegerExpression) v));
     }
 
@@ -146,6 +164,7 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * @return the appended sequence of checks.
      */
     public BranchesIntermediary<T, R> isString(final Function<? super StringExpression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isString(), v -> mapping.apply((StringExpression) v));
     }
 
@@ -158,6 +177,7 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * @return the appended sequence of checks.
      */
     public BranchesIntermediary<T, R> isDate(final Function<? super DateExpression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isDate(), v -> mapping.apply((DateExpression) v));
     }
 
@@ -172,35 +192,35 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      *
      * @param mapping the mapping.
      * @return the appended sequence of checks.
-     * @param <Q> the type of the array.
+     * @param <Q> the type of the elements of the resulting array.
      */
     @SuppressWarnings("unchecked")
-    public <Q extends Expression> BranchesIntermediary<T, R> isArray(final Function<? super ArrayExpression<Q>, ? extends R> mapping) {
+    public <Q extends Expression> BranchesIntermediary<T, R> isArray(final Function<? super ArrayExpression<@MqlUnchecked(TYPE_ARGUMENT) Q>, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isArray(), v -> mapping.apply((ArrayExpression<Q>) v));
     }
 
     /**
      * A successful check for
      * {@linkplain Expression#isDocumentOr(DocumentExpression) being a document}
+     * (or document-like value, see
+     * {@link MapExpression} and {@link EntryExpression})
      * produces a value specified by the {@code mapping}.
-     *
-     * <p>Note: Any value considered to be a document by this API
-     * will also be considered a map, and vice-versa.
      *
      * @param mapping the mapping.
      * @return the appended sequence of checks.
      */
     public BranchesIntermediary<T, R> isDocument(final Function<? super DocumentExpression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isDocumentOrMap(), v -> mapping.apply((DocumentExpression) v));
     }
 
     /**
      * A successful check for
      * {@linkplain Expression#isMapOr(MapExpression) being a map}
+     * (or map-like value, see
+     * {@link DocumentExpression} and {@link EntryExpression})
      * produces a value specified by the {@code mapping}.
-     *
-     * <p>Note: Any value considered to be a map by this API
-     * will also be considered a document, and vice-versa.
      *
      * <p>Warning: The type argument of the map is not
      * enforced by the API. The use of this method is an
@@ -211,7 +231,8 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * @param <Q> the type of the array.
      */
     @SuppressWarnings("unchecked")
-    public <Q extends Expression> BranchesIntermediary<T, R> isMap(final Function<? super MapExpression<Q>, ? extends R> mapping) {
+    public <Q extends Expression> BranchesIntermediary<T, R> isMap(final Function<? super MapExpression<@MqlUnchecked(TYPE_ARGUMENT) Q>, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isDocumentOrMap(), v -> mapping.apply((MapExpression<Q>) v));
     }
 
@@ -224,6 +245,7 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * @return the appended sequence of checks.
      */
     public BranchesIntermediary<T, R> isNull(final Function<? super Expression, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return is(v -> mqlEx(v).isNull(), v -> mapping.apply(v));
     }
 
@@ -235,6 +257,7 @@ public final class BranchesIntermediary<T extends Expression, R extends Expressi
      * @return the appended sequence of checks.
      */
     public BranchesTerminal<T, R> defaults(final Function<? super T, ? extends R> mapping) {
+        Assertions.notNull("mapping", mapping);
         return this.withDefault(value -> mapping.apply(value));
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/expressions/BranchesTerminal.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/BranchesTerminal.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Beta;
 import com.mongodb.lang.Nullable;
 
 import java.util.List;
@@ -27,7 +28,9 @@ import java.util.function.Function;
  *
  * @param <T> the type of the values that may be checked.
  * @param <R> the type of the value produced.
+ * @since 4.9.0
  */
+@Beta(Beta.Reason.CLIENT)
 public class BranchesTerminal<T extends Expression, R extends Expression> {
 
     private final List<Function<T, SwitchCase<R>>> branches;

--- a/driver-core/src/main/com/mongodb/client/model/expressions/BranchesTerminal.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/BranchesTerminal.java
@@ -21,6 +21,13 @@ import com.mongodb.lang.Nullable;
 import java.util.List;
 import java.util.function.Function;
 
+/**
+ * See {@link Branches}. This is the terminal branch, to which no additional
+ * checks may be added, since the default value has been specified.
+ *
+ * @param <T> the type of the values that may be checked.
+ * @param <R> the type of the value produced.
+ */
 public class BranchesTerminal<T extends Expression, R extends Expression> {
 
     private final List<Function<T, SwitchCase<R>>> branches;
@@ -32,16 +39,16 @@ public class BranchesTerminal<T extends Expression, R extends Expression> {
         this.defaults = defaults;
     }
 
-    protected BranchesTerminal<T, R> withDefault(final Function<T, R> defaults) {
+    BranchesTerminal<T, R> withDefault(final Function<T, R> defaults) {
         return new BranchesTerminal<>(branches, defaults);
     }
 
-    protected List<Function<T, SwitchCase<R>>> getBranches() {
+    List<Function<T, SwitchCase<R>>> getBranches() {
         return branches;
     }
 
     @Nullable
-    protected Function<T, R> getDefaults() {
+    Function<T, R> getDefaults() {
         return defaults;
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/DateExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/DateExpression.java
@@ -16,6 +16,9 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Sealed;
+
 import java.util.function.Function;
 
 /**
@@ -24,7 +27,10 @@ import java.util.function.Function;
  * milliseconds since the Unix epoch, and does not track the timezone.
  *
  * @mongodb.driver.manual reference/operator/aggregation/dateToString/ Format Specifiers, UTC Offset, and Olson Timezone Identifier
+ * @since 4.9.0
  */
+@Sealed
+@Beta(Beta.Reason.CLIENT)
 public interface DateExpression extends Expression {
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
@@ -16,6 +16,9 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Sealed;
+import com.mongodb.assertions.Assertions;
 import org.bson.conversions.Bson;
 
 import java.time.Instant;
@@ -28,14 +31,21 @@ import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE;
 import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE_ARGUMENT;
 
 /**
- * Expresses a document value. A document is an ordered set of fields, where the
- * key is a string value, mapping to a value of any other expression type.
+ * A document {@link Expression value} in the context of the MongoDB Query
+ * Language (MQL). A document is a finite set of fields, where the field
+ * name is a string, together with a value of any other
+ * {@linkplain Expression type in the type hierarchy}.
+ * No field name is repeated.
+ *
+ * @since 4.9.0
  */
+@Sealed
+@Beta(Beta.Reason.CLIENT)
 public interface DocumentExpression extends Expression {
 
     /**
-     * True if {@code this} document has a field with the provided
-     * {@code fieldName}.
+     * Whether {@code this} document has a field with the provided
+     * {@code fieldName} (if a field is set to null, it is present).
      *
      * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
@@ -60,16 +70,11 @@ public interface DocumentExpression extends Expression {
      */
     DocumentExpression setField(String fieldName, Expression value);
 
-
     /**
      * Returns a document with the same fields as {@code this} document, but
-     * with the {@code fieldName} field set to the specified {@code value}.
+     * excluding the field with the specified {@code fieldName}.
      *
      * <p>This does not affect the original document.
-     *
-     * <p>Warning: Users should take care to assign values, such that the types
-     * of those values correspond to the types of ensuing {@code get...}
-     * invocations, since this API has no way of verifying this correspondence.
      *
      * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
@@ -81,14 +86,8 @@ public interface DocumentExpression extends Expression {
      * Returns the {@linkplain Expression} value of the field
      * with the provided {@code fieldName}.
      *
-     * <p>Use of this method is an assertion that the field exists.
-     *
-     * <p>Warning: The type of the values of the resulting map are not
-     * enforced by the API. The specification of a type by the user is an
-     * unchecked assertion that all map values are of that type.
-     * If the map contains multiple types (such as both nulls and integers)
-     * then a super-type encompassing all types must be chosen, and
-     * if necessary the elements should be individually type-checked when used.
+     * <p>Warning: Use of this method is an assertion that the document
+     * {@linkplain #has(String) has} the named field.
      *
      * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
@@ -103,7 +102,8 @@ public interface DocumentExpression extends Expression {
      *
      * <p>Warning: The type and presence of the resulting value is not
      * enforced by the API. The use of this method is an
-     * unchecked assertion that the field is present and
+     * unchecked assertion that the document
+     * {@linkplain #has(String) has} the named field and
      * the field value is of the specified type.
      *
      * @mongodb.server.release 5.0
@@ -138,6 +138,7 @@ public interface DocumentExpression extends Expression {
      * @return the resulting value.
      */
     default BooleanExpression getBoolean(final String fieldName, final boolean other) {
+        Assertions.notNull("fieldName", fieldName);
         return getBoolean(fieldName, of(other));
     }
 
@@ -147,7 +148,8 @@ public interface DocumentExpression extends Expression {
      *
      * <p>Warning: The type and presence of the resulting value is not
      * enforced by the API. The use of this method is an
-     * unchecked assertion that the field is present and
+     * unchecked assertion that the document
+     * {@linkplain #has(String) has} the named field and
      * the field value is of the specified type.
      *
      * @mongodb.server.release 5.0
@@ -182,6 +184,8 @@ public interface DocumentExpression extends Expression {
      * @return the resulting value.
      */
     default NumberExpression getNumber(final String fieldName, final Number other) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("other", other);
         return getNumber(fieldName, Expressions.numberToExpression(other));
     }
 
@@ -191,7 +195,8 @@ public interface DocumentExpression extends Expression {
      *
      * <p>Warning: The type and presence of the resulting value is not
      * enforced by the API. The use of this method is an
-     * unchecked assertion that the field is present and
+     * unchecked assertion that the document
+     * {@linkplain #has(String) has} the named field and
      * the field value is of the specified type.
      *
      * @mongodb.server.release 5.0
@@ -226,6 +231,7 @@ public interface DocumentExpression extends Expression {
      * @return the resulting value.
      */
     default IntegerExpression getInteger(final String fieldName, final int other) {
+        Assertions.notNull("fieldName", fieldName);
         return getInteger(fieldName, of(other));
     }
 
@@ -241,6 +247,7 @@ public interface DocumentExpression extends Expression {
      * @return the resulting value.
      */
     default IntegerExpression getInteger(final String fieldName, final long other) {
+        Assertions.notNull("fieldName", fieldName);
         return getInteger(fieldName, of(other));
     }
 
@@ -250,7 +257,8 @@ public interface DocumentExpression extends Expression {
      *
      * <p>Warning: The type and presence of the resulting value is not
      * enforced by the API. The use of this method is an
-     * unchecked assertion that the field is present and
+     * unchecked assertion that the document
+     * {@linkplain #has(String) has} the named field and
      * the field value is of the specified type.
      *
      * @mongodb.server.release 5.0
@@ -285,6 +293,8 @@ public interface DocumentExpression extends Expression {
      * @return the resulting value.
      */
     default StringExpression getString(final String fieldName, final String other) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("other", other);
         return getString(fieldName, of(other));
     }
 
@@ -294,7 +304,8 @@ public interface DocumentExpression extends Expression {
      *
      * <p>Warning: The type and presence of the resulting value is not
      * enforced by the API. The use of this method is an
-     * unchecked assertion that the field is present and
+     * unchecked assertion that the document
+     * {@linkplain #has(String) has} the named field and
      * the field value is of the specified type.
      *
      * @mongodb.server.release 5.0
@@ -329,6 +340,8 @@ public interface DocumentExpression extends Expression {
      * @return the resulting value.
      */
     default DateExpression getDate(final String fieldName, final Instant other) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("other", other);
         return getDate(fieldName, of(other));
     }
 
@@ -338,7 +351,8 @@ public interface DocumentExpression extends Expression {
      *
      * <p>Warning: The type and presence of the resulting value is not
      * enforced by the API. The use of this method is an
-     * unchecked assertion that the field is present and
+     * unchecked assertion that the document
+     * {@linkplain #has(String) has} the named field and
      * the field value is of the specified type.
      *
      * @mongodb.server.release 5.0
@@ -351,11 +365,10 @@ public interface DocumentExpression extends Expression {
     /**
      * Returns the {@linkplain DocumentExpression document} value of the field
      * with the provided {@code fieldName},
-     * or the {@code other} value if the field is not a (child) document
-     * or if the document {@linkplain #has} no such field.
-     *
-     * <p>Note: Any field considered to be a document by this API
-     * will also be considered a map, and vice-versa.
+     * or the {@code other} value
+     * if the document {@linkplain #has} no such field,
+     * or if the specified field is not a (child) document
+     * (or other {@linkplain Expression#isDocumentOr document-like value}.
      *
      * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
@@ -367,11 +380,10 @@ public interface DocumentExpression extends Expression {
     /**
      * Returns the {@linkplain DocumentExpression document} value of the field
      * with the provided {@code fieldName},
-     * or the {@code other} value if the field is not a (child) document
-     * or if the document {@linkplain #has} no such field.
-     *
-     * <p>Note: Any field considered to be a document by this API
-     * will also be considered a map, and vice-versa.
+     * or the {@code other} value
+     * if the document {@linkplain #has} no such field,
+     * or if the specified field is not a (child) document
+     * (or other {@linkplain Expression#isDocumentOr document-like value}.
      *
      * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
@@ -379,6 +391,8 @@ public interface DocumentExpression extends Expression {
      * @return the resulting value.
      */
     default DocumentExpression getDocument(final String fieldName, final Bson other) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("other", other);
         return getDocument(fieldName, of(other));
     }
 
@@ -388,25 +402,27 @@ public interface DocumentExpression extends Expression {
      *
      * <p>Warning: The type and presence of the resulting value is not
      * enforced by the API. The use of this method is an
-     * unchecked assertion that the field is present and
-     * the field value is of the specified type.
+     * unchecked assertion that the document
+     * {@linkplain #has(String) has} the named field,
+     * and the field value is of the specified raw type,
+     * and the field value's type has the specified type argument.
      *
      * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @return the resulting value.
      * @param <T> the type.
      */
-    @MqlUnchecked({PRESENT, TYPE, TYPE_ARGUMENT})
-    <T extends Expression> MapExpression<T> getMap(String fieldName);
+    @MqlUnchecked({PRESENT, TYPE})
+    <T extends Expression> MapExpression<@MqlUnchecked(TYPE_ARGUMENT) T> getMap(String fieldName);
+
 
     /**
      * Returns the {@linkplain MapExpression map} value of the field
      * with the provided {@code fieldName},
-     * or the {@code other} value if the field is not a map
-     * or if the document {@linkplain #has} no such field.
-     *
-     * <p>Note: Any field considered to be a document by this API
-     * will also be considered a map, and vice-versa.
+     * or the {@code other} value
+     * if the document {@linkplain #has} no such field,
+     * or if the specified field is not a map
+     * (or other {@linkplain Expression#isMapOr} map-like value}).
      *
      * <p>Warning: The type argument of the resulting value is not
      * enforced by the API. The use of this method is an
@@ -418,17 +434,15 @@ public interface DocumentExpression extends Expression {
      * @return the resulting value.
      * @param <T> the type.
      */
-    @MqlUnchecked({TYPE_ARGUMENT})
-    <T extends Expression> MapExpression<T> getMap(String fieldName, MapExpression<? extends T> other);
+    <T extends Expression> MapExpression<T> getMap(String fieldName, MapExpression<@MqlUnchecked(TYPE_ARGUMENT) ? extends T> other);
 
     /**
      * Returns the {@linkplain MapExpression map} value of the field
      * with the provided {@code fieldName},
-     * or the {@code other} value if the field is not a map
-     * or if the document {@linkplain #has} no such field.
-     *
-     * <p>Note: Any field considered to be a document by this API
-     * will also be considered a map, and vice-versa.
+     * or the {@code other} value
+     * if the document {@linkplain #has} no such field,
+     * or if the specified field is not a map
+     * (or other {@linkplain Expression#isMapOr} map-like value}).
      *
      * <p>Warning: The type argument of the resulting value is not
      * enforced by the API. The use of this method is an
@@ -440,8 +454,9 @@ public interface DocumentExpression extends Expression {
      * @return the resulting value.
      * @param <T> the type.
      */
-    @MqlUnchecked({TYPE_ARGUMENT})
-    default <T extends Expression> MapExpression<T> getMap(final String fieldName, final Bson other) {
+    default <T extends Expression> MapExpression<@MqlUnchecked(TYPE_ARGUMENT) T> getMap(final String fieldName, final Bson other) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("other", other);
         return getMap(fieldName, ofMap(other));
     }
 
@@ -451,16 +466,18 @@ public interface DocumentExpression extends Expression {
      *
      * <p>Warning: The type and presence of the resulting value is not
      * enforced by the API. The use of this method is an
-     * unchecked assertion that the field is present and
-     * the field value is of the specified type.
+     * unchecked assertion that the document
+     * {@linkplain #has(String) has} the named field,
+     * and the field value is of the specified raw type,
+     * and the field value's type has the specified type argument.
      *
      * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @return the resulting value.
      * @param <T> the type.
      */
-    @MqlUnchecked({PRESENT, TYPE, TYPE_ARGUMENT})
-    <T extends Expression> ArrayExpression<T> getArray(String fieldName);
+    @MqlUnchecked({PRESENT, TYPE})
+    <T extends Expression> ArrayExpression<@MqlUnchecked(TYPE_ARGUMENT) T> getArray(String fieldName);
 
     /**
      * Returns the {@linkplain ArrayExpression array} value of the field
@@ -478,8 +495,7 @@ public interface DocumentExpression extends Expression {
      * @return the resulting value.
      * @param <T> the type.
      */
-    @MqlUnchecked({TYPE_ARGUMENT})
-    <T extends Expression> ArrayExpression<T> getArray(String fieldName, ArrayExpression<? extends T> other);
+    <T extends Expression> ArrayExpression<@MqlUnchecked(TYPE_ARGUMENT) T> getArray(String fieldName, ArrayExpression<? extends T> other);
 
     /**
      * Returns a document with the same fields as {@code this} document, but

--- a/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
@@ -25,6 +25,7 @@ import static com.mongodb.client.model.expressions.Expressions.of;
 import static com.mongodb.client.model.expressions.Expressions.ofMap;
 import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.PRESENT;
 import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE;
+import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE_ARGUMENT;
 
 /**
  * Expresses a document value. A document is an ordered set of fields, where the
@@ -32,7 +33,6 @@ import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE;
  */
 public interface DocumentExpression extends Expression {
 
-    DocumentExpression setField(String fieldName, Expression exp);
     /**
      * True if {@code this} document has a field with the provided
      * {@code fieldName}.
@@ -42,78 +42,442 @@ public interface DocumentExpression extends Expression {
      */
     BooleanExpression has(String fieldName);
 
+    /**
+     * Returns a document with the same fields as {@code this} document, but
+     * with the {@code fieldName} field set to the specified {@code value}.
+     *
+     * <p>This does not affect the original document.
+     *
+     * <p>Warning: Users should take care to assign values, such that the types
+     * of those values correspond to the types of ensuing {@code get...}
+     * invocations, since this API has no way of verifying this correspondence.
+     *
+     * @param fieldName the name of the field.
+     * @param value the value.
+     * @return the resulting document.
+     */
+    DocumentExpression setField(String fieldName, Expression value);
 
+
+    /**
+     * Returns a document with the same fields as {@code this} document, but
+     * with the {@code fieldName} field set to the specified {@code value}.
+     *
+     * <p>This does not affect the original document.
+     *
+     * <p>Warning: Users should take care to assign values, such that the types
+     * of those values correspond to the types of ensuing {@code get...}
+     * invocations, since this API has no way of verifying this correspondence.
+     *
+     * @param fieldName the name of the field.
+     * @return the resulting document.
+     */
     DocumentExpression unsetField(String fieldName);
 
+    /**
+     * Returns the {@linkplain Expression} value of the field
+     * with the provided {@code fieldName}.
+     *
+     * <p>Use of this method is an assertion that the field exists.
+     *
+     * <p>Warning: The type of the values of the resulting map are not
+     * enforced by the API. The specification of a type by the user is an
+     * unchecked assertion that all map values are of that type.
+     * If the map contains multiple types (such as both nulls and integers)
+     * then a super-type encompassing all types must be chosen, and
+     * if necessary the elements should be individually type-checked when used.
+     *
+     * @param fieldName the name of the field.
+     * @return the resulting value.
+     */
     @MqlUnchecked(PRESENT)
     Expression getField(String fieldName);
 
+    /**
+     * Returns the {@linkplain BooleanExpression boolean} value of the field
+     * with the provided {@code fieldName}.
+     *
+     * <p>Warning: The type and presence of the resulting value is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the field is present and
+     * the field value is of the specified type.
+     *
+     * @param fieldName the name of the field.
+     * @return the resulting value.
+     */
     @MqlUnchecked({PRESENT, TYPE})
     BooleanExpression getBoolean(String fieldName);
 
+    /**
+     * Returns the {@linkplain BooleanExpression boolean} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not a boolean
+     * or if the document {@linkplain #has} no such field.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     BooleanExpression getBoolean(String fieldName, BooleanExpression other);
 
+    /**
+     * Returns the {@linkplain BooleanExpression boolean} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not a boolean
+     * or if the document {@linkplain #has} no such field.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     default BooleanExpression getBoolean(final String fieldName, final boolean other) {
         return getBoolean(fieldName, of(other));
     }
 
+    /**
+     * Returns the {@linkplain NumberExpression number} value of the field
+     * with the provided {@code fieldName}.
+     *
+     * <p>Warning: The type and presence of the resulting value is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the field is present and
+     * the field value is of the specified type.
+     *
+     * @param fieldName the name of the field.
+     * @return the resulting value.
+     */
+    @MqlUnchecked({PRESENT, TYPE})
     NumberExpression getNumber(String fieldName);
 
+    /**
+     * Returns the {@linkplain NumberExpression number} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not a number
+     * or if the document {@linkplain #has} no such field.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     NumberExpression getNumber(String fieldName, NumberExpression other);
 
+    /**
+     * Returns the {@linkplain NumberExpression number} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not a number
+     * or if the document {@linkplain #has} no such field.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     default NumberExpression getNumber(final String fieldName, final Number other) {
         return getNumber(fieldName, Expressions.numberToExpression(other));
     }
 
+    /**
+     * Returns the {@linkplain IntegerExpression integer} value of the field
+     * with the provided {@code fieldName}.
+     *
+     * <p>Warning: The type and presence of the resulting value is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the field is present and
+     * the field value is of the specified type.
+     *
+     * @param fieldName the name of the field.
+     * @return the resulting value.
+     */
+    @MqlUnchecked({PRESENT, TYPE})
     IntegerExpression getInteger(String fieldName);
 
+    /**
+     * Returns the {@linkplain IntegerExpression integer} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not an integer
+     * or if the document {@linkplain #has} no such field.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     IntegerExpression getInteger(String fieldName, IntegerExpression other);
 
+    /**
+     * Returns the {@linkplain IntegerExpression integer} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not an integer
+     * or if the document {@linkplain #has} no such field.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     default IntegerExpression getInteger(final String fieldName, final int other) {
         return getInteger(fieldName, of(other));
     }
 
+    /**
+     * Returns the {@linkplain IntegerExpression integer} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not an integer
+     * or if the document {@linkplain #has} no such field.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     default IntegerExpression getInteger(final String fieldName, final long other) {
         return getInteger(fieldName, of(other));
     }
 
-
+    /**
+     * Returns the {@linkplain StringExpression string} value of the field
+     * with the provided {@code fieldName}.
+     *
+     * <p>Warning: The type and presence of the resulting value is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the field is present and
+     * the field value is of the specified type.
+     *
+     * @param fieldName the name of the field.
+     * @return the resulting value.
+     */
+    @MqlUnchecked({PRESENT, TYPE})
     StringExpression getString(String fieldName);
 
+    /**
+     * Returns the {@linkplain StringExpression string} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not a string
+     * or if the document {@linkplain #has} no such field.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     StringExpression getString(String fieldName, StringExpression other);
 
+    /**
+     * Returns the {@linkplain StringExpression string} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not a string
+     * or if the document {@linkplain #has} no such field.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     default StringExpression getString(final String fieldName, final String other) {
         return getString(fieldName, of(other));
     }
 
+    /**
+     * Returns the {@linkplain DateExpression date} value of the field
+     * with the provided {@code fieldName}.
+     *
+     * <p>Warning: The type and presence of the resulting value is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the field is present and
+     * the field value is of the specified type.
+     *
+     * @param fieldName the name of the field.
+     * @return the resulting value.
+     */
+    @MqlUnchecked({PRESENT, TYPE})
     DateExpression getDate(String fieldName);
+
+    /**
+     * Returns the {@linkplain DateExpression date} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not a date
+     * or if the document {@linkplain #has} no such field.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     DateExpression getDate(String fieldName, DateExpression other);
 
+    /**
+     * Returns the {@linkplain DateExpression date} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not a date
+     * or if the document {@linkplain #has} no such field.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     default DateExpression getDate(final String fieldName, final Instant other) {
         return getDate(fieldName, of(other));
     }
 
+    /**
+     * Returns the {@linkplain DocumentExpression document} value of the field
+     * with the provided {@code fieldName}.
+     *
+     * <p>Warning: The type and presence of the resulting value is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the field is present and
+     * the field value is of the specified type.
+     *
+     * @param fieldName the name of the field.
+     * @return the resulting value.
+     */
+    @MqlUnchecked({PRESENT, TYPE})
     DocumentExpression getDocument(String fieldName);
+
+    /**
+     * Returns the {@linkplain DocumentExpression document} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not a (child) document
+     * or if the document {@linkplain #has} no such field.
+     *
+     * <p>Note: Any field considered to be a document by this API
+     * will also be considered a map, and vice-versa.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     DocumentExpression getDocument(String fieldName, DocumentExpression other);
 
+    /**
+     * Returns the {@linkplain DocumentExpression document} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not a (child) document
+     * or if the document {@linkplain #has} no such field.
+     *
+     * <p>Note: Any field considered to be a document by this API
+     * will also be considered a map, and vice-versa.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     default DocumentExpression getDocument(final String fieldName, final Bson other) {
         return getDocument(fieldName, of(other));
     }
 
+    /**
+     * Returns the {@linkplain MapExpression map} value of the field
+     * with the provided {@code fieldName}.
+     *
+     * <p>Warning: The type and presence of the resulting value is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the field is present and
+     * the field value is of the specified type.
+     *
+     * @param fieldName the name of the field.
+     * @return the resulting value.
+     * @param <T> the type.
+     */
+    @MqlUnchecked({PRESENT, TYPE, TYPE_ARGUMENT})
     <T extends Expression> MapExpression<T> getMap(String fieldName);
+
+    /**
+     * Returns the {@linkplain MapExpression map} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not a map
+     * or if the document {@linkplain #has} no such field.
+     *
+     * <p>Note: Any field considered to be a document by this API
+     * will also be considered a map, and vice-versa.
+     *
+     * <p>Warning: The type argument of the resulting value is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the type argument is correct.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     * @param <T> the type.
+     */
+    @MqlUnchecked({TYPE_ARGUMENT})
     <T extends Expression> MapExpression<T> getMap(String fieldName, MapExpression<? extends T> other);
 
+    /**
+     * Returns the {@linkplain MapExpression map} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not a map
+     * or if the document {@linkplain #has} no such field.
+     *
+     * <p>Note: Any field considered to be a document by this API
+     * will also be considered a map, and vice-versa.
+     *
+     * <p>Warning: The type argument of the resulting value is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the type argument is correct.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     * @param <T> the type.
+     */
+    @MqlUnchecked({TYPE_ARGUMENT})
     default <T extends Expression> MapExpression<T> getMap(final String fieldName, final Bson other) {
         return getMap(fieldName, ofMap(other));
     }
 
+    /**
+     * Returns the {@linkplain ArrayExpression array} value of the field
+     * with the provided {@code fieldName}.
+     *
+     * <p>Warning: The type and presence of the resulting value is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the field is present and
+     * the field value is of the specified type.
+     *
+     * @param fieldName the name of the field.
+     * @return the resulting value.
+     * @param <T> the type.
+     */
+    @MqlUnchecked({PRESENT, TYPE, TYPE_ARGUMENT})
     <T extends Expression> ArrayExpression<T> getArray(String fieldName);
 
+    /**
+     * Returns the {@linkplain ArrayExpression array} value of the field
+     * with the provided {@code fieldName},
+     * or the {@code other} value if the field is not an array
+     * or if the document {@linkplain #has} no such field.
+     *
+     * <p>Warning: The type argument of the resulting value is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the type argument is correct.
+     *
+     * @param fieldName the name of the field.
+     * @param other the other value.
+     * @return the resulting value.
+     * @param <T> the type.
+     */
+    @MqlUnchecked({TYPE_ARGUMENT})
     <T extends Expression> ArrayExpression<T> getArray(String fieldName, ArrayExpression<? extends T> other);
 
+    /**
+     * Returns a document with the same fields as {@code this} document, but
+     * with any fields present in the {@code other} document overwritten with
+     * the fields of that other document. That is, fields from both this and the
+     * other document are merged, with the other document having priority.
+     *
+     * <p>This does not affect the original document.
+     *
+     * @param other the other document.
+     * @return the resulting value.
+     */
     DocumentExpression merge(DocumentExpression other);
 
-    MapExpression<Expression> asMap();
+    /**
+     * {@code this} document as a {@linkplain MapExpression map}.
+     *
+     * <p>Warning: The type argument of the resulting value is not
+     * enforced by the API. The use of this method is an
+     * unchecked assertion that the type argument is correct.
+     *
+     * @return the resulting value.
+     * @param <T> the type.
+     */
+
+    <T extends Expression> MapExpression<T> asMap();
 
     /**
      * The result of passing {@code this} value to the provided function.

--- a/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
@@ -33,6 +33,15 @@ import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE;
 public interface DocumentExpression extends Expression {
 
     DocumentExpression setField(String fieldName, Expression exp);
+    /**
+     * True if {@code this} document has a field with the provided
+     * {@code fieldName}.
+     *
+     * @param fieldName the name of the field.
+     * @return the resulting value.
+     */
+    BooleanExpression has(String fieldName);
+
 
     DocumentExpression unsetField(String fieldName);
 

--- a/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/DocumentExpression.java
@@ -37,6 +37,7 @@ public interface DocumentExpression extends Expression {
      * True if {@code this} document has a field with the provided
      * {@code fieldName}.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @return the resulting value.
      */
@@ -52,6 +53,7 @@ public interface DocumentExpression extends Expression {
      * of those values correspond to the types of ensuing {@code get...}
      * invocations, since this API has no way of verifying this correspondence.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param value the value.
      * @return the resulting document.
@@ -69,6 +71,7 @@ public interface DocumentExpression extends Expression {
      * of those values correspond to the types of ensuing {@code get...}
      * invocations, since this API has no way of verifying this correspondence.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @return the resulting document.
      */
@@ -87,6 +90,7 @@ public interface DocumentExpression extends Expression {
      * then a super-type encompassing all types must be chosen, and
      * if necessary the elements should be individually type-checked when used.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @return the resulting value.
      */
@@ -102,6 +106,7 @@ public interface DocumentExpression extends Expression {
      * unchecked assertion that the field is present and
      * the field value is of the specified type.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @return the resulting value.
      */
@@ -114,6 +119,7 @@ public interface DocumentExpression extends Expression {
      * or the {@code other} value if the field is not a boolean
      * or if the document {@linkplain #has} no such field.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -126,6 +132,7 @@ public interface DocumentExpression extends Expression {
      * or the {@code other} value if the field is not a boolean
      * or if the document {@linkplain #has} no such field.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -143,6 +150,7 @@ public interface DocumentExpression extends Expression {
      * unchecked assertion that the field is present and
      * the field value is of the specified type.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @return the resulting value.
      */
@@ -155,6 +163,7 @@ public interface DocumentExpression extends Expression {
      * or the {@code other} value if the field is not a number
      * or if the document {@linkplain #has} no such field.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -167,6 +176,7 @@ public interface DocumentExpression extends Expression {
      * or the {@code other} value if the field is not a number
      * or if the document {@linkplain #has} no such field.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -184,6 +194,7 @@ public interface DocumentExpression extends Expression {
      * unchecked assertion that the field is present and
      * the field value is of the specified type.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @return the resulting value.
      */
@@ -196,6 +207,7 @@ public interface DocumentExpression extends Expression {
      * or the {@code other} value if the field is not an integer
      * or if the document {@linkplain #has} no such field.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -208,6 +220,7 @@ public interface DocumentExpression extends Expression {
      * or the {@code other} value if the field is not an integer
      * or if the document {@linkplain #has} no such field.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -222,6 +235,7 @@ public interface DocumentExpression extends Expression {
      * or the {@code other} value if the field is not an integer
      * or if the document {@linkplain #has} no such field.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -239,6 +253,7 @@ public interface DocumentExpression extends Expression {
      * unchecked assertion that the field is present and
      * the field value is of the specified type.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @return the resulting value.
      */
@@ -251,6 +266,7 @@ public interface DocumentExpression extends Expression {
      * or the {@code other} value if the field is not a string
      * or if the document {@linkplain #has} no such field.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -263,6 +279,7 @@ public interface DocumentExpression extends Expression {
      * or the {@code other} value if the field is not a string
      * or if the document {@linkplain #has} no such field.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -280,6 +297,7 @@ public interface DocumentExpression extends Expression {
      * unchecked assertion that the field is present and
      * the field value is of the specified type.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @return the resulting value.
      */
@@ -292,6 +310,7 @@ public interface DocumentExpression extends Expression {
      * or the {@code other} value if the field is not a date
      * or if the document {@linkplain #has} no such field.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -304,6 +323,7 @@ public interface DocumentExpression extends Expression {
      * or the {@code other} value if the field is not a date
      * or if the document {@linkplain #has} no such field.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -321,6 +341,7 @@ public interface DocumentExpression extends Expression {
      * unchecked assertion that the field is present and
      * the field value is of the specified type.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @return the resulting value.
      */
@@ -336,6 +357,7 @@ public interface DocumentExpression extends Expression {
      * <p>Note: Any field considered to be a document by this API
      * will also be considered a map, and vice-versa.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -351,6 +373,7 @@ public interface DocumentExpression extends Expression {
      * <p>Note: Any field considered to be a document by this API
      * will also be considered a map, and vice-versa.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -368,6 +391,7 @@ public interface DocumentExpression extends Expression {
      * unchecked assertion that the field is present and
      * the field value is of the specified type.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @return the resulting value.
      * @param <T> the type.
@@ -388,6 +412,7 @@ public interface DocumentExpression extends Expression {
      * enforced by the API. The use of this method is an
      * unchecked assertion that the type argument is correct.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -409,6 +434,7 @@ public interface DocumentExpression extends Expression {
      * enforced by the API. The use of this method is an
      * unchecked assertion that the type argument is correct.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.
@@ -428,6 +454,7 @@ public interface DocumentExpression extends Expression {
      * unchecked assertion that the field is present and
      * the field value is of the specified type.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @return the resulting value.
      * @param <T> the type.
@@ -445,6 +472,7 @@ public interface DocumentExpression extends Expression {
      * enforced by the API. The use of this method is an
      * unchecked assertion that the type argument is correct.
      *
+     * @mongodb.server.release 5.0
      * @param fieldName the name of the field.
      * @param other the other value.
      * @return the resulting value.

--- a/driver-core/src/main/com/mongodb/client/model/expressions/EntryExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/EntryExpression.java
@@ -16,6 +16,9 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Sealed;
+
 import static com.mongodb.client.model.expressions.Expressions.of;
 
 /**
@@ -25,12 +28,15 @@ import static com.mongodb.client.model.expressions.Expressions.of;
  * {@linkplain Expression value}. Entries are used with
  * {@linkplain MapExpression maps}.
  *
- * Entries are {@linkplain Expression#isDocumentOr document-like} and
+ * <p>Entries are {@linkplain Expression#isDocumentOr document-like} and
  * {@linkplain Expression#isMapOr map-like}, unless the method returning the
  * entry specifies otherwise.
  *
  * @param <T> The type of the value
+ * @since 4.9.0
  */
+@Sealed
+@Beta(Beta.Reason.CLIENT)
 public interface EntryExpression<T extends Expression> extends Expression {
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/expressions/EntryExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/EntryExpression.java
@@ -36,6 +36,7 @@ public interface EntryExpression<T extends Expression> extends Expression {
     /**
      * The key of {@code this} entry.
      *
+     * @mongodb.server.release 5.0
      * @return the key.
      */
     StringExpression getKey();
@@ -43,6 +44,7 @@ public interface EntryExpression<T extends Expression> extends Expression {
     /**
      * The value of {@code this} entry.
      *
+     * @mongodb.server.release 5.0
      * @return the value.
      */
     T getValue();
@@ -51,6 +53,7 @@ public interface EntryExpression<T extends Expression> extends Expression {
      * An entry with the same key as {@code this} entry, and the
      * specified {@code value}.
      *
+     * @mongodb.server.release 5.0
      * @param value the value.
      * @return the resulting entry.
      */
@@ -60,6 +63,7 @@ public interface EntryExpression<T extends Expression> extends Expression {
      * An entry with the same value as {@code this} entry, and the
      * specified {@code key}.
      *
+     * @mongodb.server.release 5.0
      * @param key the key.
      * @return the resulting entry.
      */
@@ -69,6 +73,7 @@ public interface EntryExpression<T extends Expression> extends Expression {
      * An entry with the same value as {@code this} entry, and the
      * specified {@code key}.
      *
+     * @mongodb.server.release 5.0
      * @param key the key.
      * @return the resulting entry.
      */

--- a/driver-core/src/main/com/mongodb/client/model/expressions/EntryExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/EntryExpression.java
@@ -32,13 +32,46 @@ import static com.mongodb.client.model.expressions.Expressions.of;
  * @param <T> The type of the value
  */
 public interface EntryExpression<T extends Expression> extends Expression {
+
+    /**
+     * The key of {@code this} entry.
+     *
+     * @return the key.
+     */
     StringExpression getKey();
 
+    /**
+     * The value of {@code this} entry.
+     *
+     * @return the value.
+     */
     T getValue();
 
-    EntryExpression<T> setValue(T val);
+    /**
+     * An entry with the same key as {@code this} entry, and the
+     * specified {@code value}.
+     *
+     * @param value the value.
+     * @return the resulting entry.
+     */
+    EntryExpression<T> setValue(T value);
 
+    /**
+     * An entry with the same value as {@code this} entry, and the
+     * specified {@code key}.
+     *
+     * @param key the key.
+     * @return the resulting entry.
+     */
     EntryExpression<T> setKey(StringExpression key);
+
+    /**
+     * An entry with the same value as {@code this} entry, and the
+     * specified {@code key}.
+     *
+     * @param key the key.
+     * @return the resulting entry.
+     */
     default EntryExpression<T> setKey(final String key) {
         return setKey(of(key));
     }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
@@ -165,6 +165,7 @@ public interface Expression {
      * {@code this} is a number, or the {@code other} number value if
      * {@code this} is null, or is missing, or is of any other non-number type.
      *
+     * @mongodb.server.release 4.4
      * @param other the other value.
      * @return the resulting value.
      */

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
@@ -16,7 +16,8 @@
 
 package com.mongodb.client.model.expressions;
 
-import com.mongodb.annotations.Evolving;
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Sealed;
 
 import java.util.function.Function;
 
@@ -81,12 +82,14 @@ import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE_A
  * context, users are strongly discouraged from relying on behaviour that is not
  * part of this API).
  *
- * <p>Users should treat these interfaces as sealed, and should not create
- * implementations.
+ * <p>This API should be treated as sealed:
+ * it must not be extended or implemented (unless explicitly allowed).
  *
  * @see Expressions
+ * @since 4.9.0
  */
-@Evolving
+@Sealed
+@Beta(Beta.Reason.CLIENT)
 public interface Expression {
 
     /**
@@ -222,7 +225,7 @@ public interface Expression {
 
     /**
      * {@code this} value as a {@linkplain DocumentExpression document} if
-     * {@code this} is a document or document-like value (see
+     * {@code this} is a document (or document-like value, see
      * {@link MapExpression} and {@link EntryExpression})
      * or the {@code other} document value if {@code this} is null,
      * or is missing, or is of any other non-document type.
@@ -235,7 +238,7 @@ public interface Expression {
 
     /**
      * {@code this} value as a {@linkplain MapExpression map} if
-     * {@code this} is a map or map-like value (see
+     * {@code this} is a map (or map-like value, see
      * {@link DocumentExpression} and {@link EntryExpression})
      * or the {@code other} map value if {@code this} is null,
      * or is missing, or is of any other non-map type.
@@ -251,7 +254,7 @@ public interface Expression {
      * @return the resulting value.
      * @param <T> the type of the values of the resulting map.
      */
-    <T extends Expression> MapExpression<T> isMapOr(MapExpression<? extends T> other);
+    <T extends Expression> MapExpression<T> isMapOr(MapExpression<@MqlUnchecked(TYPE_ARGUMENT) ? extends T> other);
 
     /**
      * The {@linkplain StringExpression string} representation of {@code this} value.

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
@@ -175,6 +175,7 @@ public interface Expression {
      * {@code this} is an integer, or the {@code other} integer value if
      * {@code this} is null, or is missing, or is of any other non-integer type.
      *
+     * @mongodb.server.release 5.2
      * @param other the other value.
      * @return the resulting value.
      */

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
@@ -81,7 +81,6 @@ import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE_A
  * context, users are strongly discouraged from relying on behaviour that is not
  * part of this API).
  *
- *
  * <p>Users should treat these interfaces as sealed, and should not create
  * implementations.
  *
@@ -228,6 +227,7 @@ public interface Expression {
      *
      * @param other the other value.
      * @return the resulting value.
+     * @param <T> the type.
      */
     <T extends DocumentExpression> T isDocumentOr(T other);
 
@@ -254,7 +254,7 @@ public interface Expression {
     /**
      * The {@linkplain StringExpression string} representation of {@code this} value.
      *
-     * <p>This may cause an error to be produced if the type cannot be converted
+     * <p>This will cause an error if the type cannot be converted
      * to a {@linkplain StringExpression string}, as is the case with
      * {@linkplain ArrayExpression arrays},
      * {@linkplain DocumentExpression documents},

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expression.java
@@ -264,6 +264,7 @@ public interface Expression {
      * {@linkplain EntryExpression entries}, and the
      * {@linkplain Expressions#ofNull() null value}.
      *
+     * @mongodb.server.release 4.0
      * @see StringExpression#parseDate()
      * @see StringExpression#parseInteger()
      * @return the resulting value.

--- a/driver-core/src/main/com/mongodb/client/model/expressions/ExpressionCodecProvider.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/ExpressionCodecProvider.java
@@ -24,19 +24,16 @@ import org.bson.codecs.configuration.CodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 
 /**
- * Provides Codec instances for MQL expressions.
+ * Provides Codec instances for the {@link Expression MQL API}.
  *
  * <p>Responsible for converting values and computations expressed using the
- * driver's implementation of the {@link Expression} API into the corresponding
+ * driver's implementation of the {@link Expression MQL API} into the corresponding
  * values and computations expressed in MQL BSON. Booleans are converted to BSON
  * booleans, documents to BSON documents, and so on. The specific structure
  * representing numbers is preserved where possible (that is, number literals
  * specified as Java longs are converted into BSON int64, and so on).
  *
- * <p>This API is marked Beta because it may be replaced with a generalized
- * mechanism for converting expressions. This would only affect users who use
- * MqlExpressionCodecProvider directly in custom codec providers. This Beta
- * annotation does not imply that the Expressions API in general is Beta.
+ * @since 4.9.0
  */
 @Beta(Beta.Reason.CLIENT)
 @Immutable

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expressions.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expressions.java
@@ -58,6 +58,14 @@ public final class Expressions {
         return new MqlExpression<>((codecRegistry) -> new AstPlaceholder(new BsonBoolean(of)));
     }
 
+    /**
+     * Returns an {@linkplain ArrayExpression array} of
+     * {@linkplain BooleanExpression booleans} corresponding to
+     * the provided {@code boolean} primitives.
+     *
+     * @param array the array.
+     * @return the resulting value.
+     */
     public static ArrayExpression<BooleanExpression> ofBooleanArray(final boolean... array) {
         Assertions.notNull("array", array);
         List<BsonValue> list = new ArrayList<>();
@@ -78,6 +86,14 @@ public final class Expressions {
         return new MqlExpression<>((codecRegistry) -> new AstPlaceholder(new BsonInt32(of)));
     }
 
+    /**
+     * Returns an {@linkplain ArrayExpression array} of
+     * {@linkplain IntegerExpression integers} corresponding to
+     * the provided {@code int} primitives.
+     *
+     * @param array the array.
+     * @return the resulting value.
+     */
     public static ArrayExpression<IntegerExpression> ofIntegerArray(final int... array) {
         Assertions.notNull("array", array);
         List<BsonValue> list = new ArrayList<>();
@@ -98,6 +114,14 @@ public final class Expressions {
         return new MqlExpression<>((codecRegistry) -> new AstPlaceholder(new BsonInt64(of)));
     }
 
+    /**
+     * Returns an {@linkplain ArrayExpression array} of
+     * {@linkplain IntegerExpression integers} corresponding to
+     * the provided {@code long} primitives.
+     *
+     * @param array the array.
+     * @return the resulting value.
+     */
     public static ArrayExpression<IntegerExpression> ofIntegerArray(final long... array) {
         Assertions.notNull("array", array);
         List<BsonValue> list = new ArrayList<>();
@@ -118,6 +142,14 @@ public final class Expressions {
         return new MqlExpression<>((codecRegistry) -> new AstPlaceholder(new BsonDouble(of)));
     }
 
+    /**
+     * Returns an {@linkplain ArrayExpression array} of
+     * {@linkplain NumberExpression numbers} corresponding to
+     * the provided {@code double} primitives.
+     *
+     * @param array the array.
+     * @return the resulting value.
+     */
     public static ArrayExpression<NumberExpression> ofNumberArray(final double... array) {
         Assertions.notNull("array", array);
         List<BsonValue> list = new ArrayList<>();
@@ -129,7 +161,7 @@ public final class Expressions {
 
     /**
      * Returns a {@linkplain NumberExpression number} value corresponding to
-     * the provided {@link Decimal128}
+     * the provided {@link Decimal128}.
      *
      * @param of the {@link Decimal128}.
      * @return the resulting value.
@@ -139,6 +171,14 @@ public final class Expressions {
         return new MqlExpression<>((codecRegistry) -> new AstPlaceholder(new BsonDecimal128(of)));
     }
 
+    /**
+     * Returns an {@linkplain ArrayExpression array} of
+     * {@linkplain NumberExpression numbers} corresponding to
+     * the provided {@link Decimal128 Decimal128s}.
+     *
+     * @param array the array.
+     * @return the resulting value.
+     */
     public static ArrayExpression<NumberExpression> ofNumberArray(final Decimal128... array) {
         Assertions.notNull("array", array);
         List<BsonValue> result = new ArrayList<>();
@@ -148,7 +188,6 @@ public final class Expressions {
         }
         return new MqlExpression<>((cr) -> new AstPlaceholder(new BsonArray(result)));
     }
-
 
     /**
      * Returns a {@linkplain DateExpression date and time} value corresponding to
@@ -162,6 +201,14 @@ public final class Expressions {
         return new MqlExpression<>((codecRegistry) -> new AstPlaceholder(new BsonDateTime(of.toEpochMilli())));
     }
 
+    /**
+     * Returns an {@linkplain ArrayExpression array} of
+     * {@linkplain DateExpression dates} corresponding to
+     * the provided {@link Instant Instants}.
+     *
+     * @param array the array.
+     * @return the resulting value.
+     */
     public static ArrayExpression<DateExpression> ofDateArray(final Instant... array) {
         Assertions.notNull("array", array);
         List<BsonValue> result = new ArrayList<>();
@@ -184,6 +231,14 @@ public final class Expressions {
         return new MqlExpression<>((codecRegistry) -> new AstPlaceholder(new BsonString(of)));
     }
 
+    /**
+     * Returns an {@linkplain ArrayExpression array} of
+     * {@linkplain StringExpression strings} corresponding to
+     * the provided {@link String Strings}.
+     *
+     * @param array the array.
+     * @return the resulting value.
+     */
     public static ArrayExpression<StringExpression> ofStringArray(final String... array) {
         Assertions.notNull("array", array);
         List<BsonValue> result = new ArrayList<>();
@@ -268,6 +323,12 @@ public final class Expressions {
         });
     }
 
+    /**
+     * Returns an empty {@linkplain MapExpression map} value.
+     *
+     * @param <T> the type of the resulting map's values.
+     * @return the resulting map value.
+     */
     public static <T extends Expression> MapExpression<T> ofMap() {
         return ofMap(new BsonDocument());
     }
@@ -284,8 +345,8 @@ public final class Expressions {
      * if necessary the elements should be individually type-checked when used.
      *
      * @param map the map as a {@link Bson Bson document}.
-     * @return the resulting map value.
      * @param <T> the type of the resulting map's values.
+     * @return the resulting map value.
      */
     public static <T extends Expression> MapExpression<T> ofMap(final Bson map) {
         Assertions.notNull("map", map);

--- a/driver-core/src/main/com/mongodb/client/model/expressions/Expressions.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/Expressions.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Beta;
 import com.mongodb.assertions.Assertions;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
@@ -36,12 +37,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.mongodb.client.model.expressions.MqlExpression.AstPlaceholder;
-import static com.mongodb.client.model.expressions.MqlExpression.extractBsonValue;
+import static com.mongodb.client.model.expressions.MqlExpression.toBsonValue;
+import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.TYPE_ARGUMENT;
 
 /**
  * Convenience methods related to {@link Expression}, used primarily to
  * produce values in the context of the MongoDB Query Language (MQL).
+ *
+ * @since 4.9.0
  */
+@Beta(Beta.Reason.CLIENT)
 public final class Expressions {
 
     private Expressions() {}
@@ -174,7 +179,7 @@ public final class Expressions {
     /**
      * Returns an {@linkplain ArrayExpression array} of
      * {@linkplain NumberExpression numbers} corresponding to
-     * the provided {@link Decimal128 Decimal128s}.
+     * the provided {@link Decimal128}s.
      *
      * @param array the array.
      * @return the resulting value.
@@ -204,7 +209,7 @@ public final class Expressions {
     /**
      * Returns an {@linkplain ArrayExpression array} of
      * {@linkplain DateExpression dates} corresponding to
-     * the provided {@link Instant Instants}.
+     * the provided {@link Instant}s.
      *
      * @param array the array.
      * @return the resulting value.
@@ -234,7 +239,7 @@ public final class Expressions {
     /**
      * Returns an {@linkplain ArrayExpression array} of
      * {@linkplain StringExpression strings} corresponding to
-     * the provided {@link String Strings}.
+     * the provided {@link String}s.
      *
      * @param array the array.
      * @return the resulting value.
@@ -278,7 +283,7 @@ public final class Expressions {
      * @return a reference to the current value as a map.
      * @param <R> the type of the map's values.
      */
-    public static <R extends Expression> MapExpression<R> currentAsMap() {
+    public static <R extends Expression> MapExpression<@MqlUnchecked(TYPE_ARGUMENT) R> currentAsMap() {
         return new MqlExpression<>((cr) -> new AstPlaceholder(new BsonString("$$CURRENT")))
                 .assertImplementsAllExpressions();
     }
@@ -317,8 +322,8 @@ public final class Expressions {
         Assertions.notNull("v", v);
         return new MqlExpression<>((cr) -> {
             BsonDocument document = new BsonDocument();
-            document.put("k", extractBsonValue(cr, k));
-            document.put("v", extractBsonValue(cr, v));
+            document.put("k", toBsonValue(cr, k));
+            document.put("v", toBsonValue(cr, v));
             return new AstPlaceholder(document);
         });
     }
@@ -348,7 +353,7 @@ public final class Expressions {
      * @param <T> the type of the resulting map's values.
      * @return the resulting map value.
      */
-    public static <T extends Expression> MapExpression<T> ofMap(final Bson map) {
+    public static <T extends Expression> MapExpression<@MqlUnchecked(TYPE_ARGUMENT) T> ofMap(final Bson map) {
         Assertions.notNull("map", map);
         return new MqlExpression<>((cr) -> new AstPlaceholder(new BsonDocument("$literal",
                 map.toBsonDocument(BsonDocument.class, cr))));

--- a/driver-core/src/main/com/mongodb/client/model/expressions/IntegerExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/IntegerExpression.java
@@ -109,6 +109,7 @@ public interface IntegerExpression extends NumberExpression {
      * The {@linkplain DateExpression date} corresponding to {@code this} value
      * when taken to be the number of milliseconds since the Unix epoch.
      *
+     * @mongodb.server.release 4.0
      * @return the resulting value.
      */
     DateExpression millisecondsToDate();

--- a/driver-core/src/main/com/mongodb/client/model/expressions/IntegerExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/IntegerExpression.java
@@ -16,6 +16,9 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Sealed;
+
 import java.util.function.Function;
 
 /**
@@ -23,7 +26,11 @@ import java.util.function.Function;
  * Language (MQL). Integers are a subset of {@linkplain NumberExpression numbers},
  * and so, for example, the integer 0 and the number 0 are
  * {@linkplain #eq(Expression) equal}.
+ *
+ * @since 4.9.0
  */
+@Sealed
+@Beta(Beta.Reason.CLIENT)
 public interface IntegerExpression extends NumberExpression {
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
@@ -21,45 +21,162 @@ import java.util.function.Function;
 import static com.mongodb.client.model.expressions.Expressions.of;
 import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.PRESENT;
 
+/**
+ * A map {@link Expression value} in the context of the MongoDB Query
+ * Language (MQL). An map is a finite, unordered a set of
+ * {@link EntryExpression entries} of a certain type, such that no entry key
+ * is repeated. It is a mapping from keys to values.
+ *
+ * @param <T> the type of the elements
+ */
 public interface MapExpression<T extends Expression> extends Expression {
 
+    /**
+     * True if {@code this} map has a value (including null) for
+     * the provided key.
+     *
+     * @param key the key.
+     * @return the resulting value.
+     */
     BooleanExpression has(StringExpression key);
 
-    default BooleanExpression has(String key) {
+    /**
+     * True if {@code this} map has a value (including null) for
+     * the provided key.
+     *
+     * @param key the key.
+     * @return the resulting value.
+     */
+    default BooleanExpression has(final String key) {
         return has(of(key));
     }
 
-    // TODO-END doc "user asserts"
+    /**
+     * The value corresponding to the provided key.
+     *
+     * <p>Warning: The use of this method is an unchecked assertion that
+     * the key is present (which may be confirmed via {@link #has}). See
+     * {@link #get(StringExpression, Expression)} for a typesafe variant.
+     *
+     * @param key the key.
+     * @return the value.
+     */
     @MqlUnchecked(PRESENT)
     T get(StringExpression key);
 
-    // TODO-END doc "user asserts"
+    /**
+     * The value corresponding to the provided key.
+     *
+     * <p>Warning: The use of this method is an unchecked assertion that
+     * the key is present (which may be confirmed via {@link #has}). See
+     * {@link #get(StringExpression, Expression)} for a typesafe variant.
+     *
+     * @param key the key.
+     * @return the value.
+     */
     default T get(final String key) {
         return get(of(key));
     }
 
+    /**
+     * The value corresponding to the provided {@code key}, or the
+     * {@code other} value if an entry for the key is not present.
+     *
+     * @param key the key.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     T get(StringExpression key, T other);
 
+    /**
+     * The value corresponding to the provided {@code key}, or the
+     * {@code other} value if an entry for the key is not present.
+     *
+     * @param key the key.
+     * @param other the other value.
+     * @return the resulting value.
+     */
     default T get(final String key, final T other) {
         return get(of(key), other);
     }
 
+    /**
+     * Returns a map with the same entries as {@code this} map, but with
+     * the specified {@code key} set to the specified {@code value}.
+     *
+     * <p>This does not affect the original map.
+     *
+     * @param key the key.
+     * @param value the value.
+     * @return the resulting value.
+     */
     MapExpression<T> set(StringExpression key, T value);
 
+    /**
+     * Returns a map with the same entries as {@code this} map, but with
+     * the specified {@code key} set to the specified {@code value}.
+     *
+     * <p>This does not affect the original map.
+     *
+     * @param key the key.
+     * @param value the value.
+     * @return the resulting value.
+     */
     default MapExpression<T> set(final String key, final T value) {
         return set(of(key), value);
     }
 
+    /**
+     * Returns a map with the same entries as {@code this} map, but with
+     * the specified {@code key} absent.
+     *
+     * <p>This does not affect the original map.
+     *
+     * @param key the key.
+     * @return the resulting value.
+     */
     MapExpression<T> unset(StringExpression key);
 
+    /**
+     * Returns a map with the same entries as {@code this} map, but with
+     * the specified {@code key} absent.
+     *
+     * <p>This does not affect the original map.
+     *
+     * @param key the key.
+     * @return the resulting value.
+     */
     default MapExpression<T> unset(final String key) {
         return unset(of(key));
     }
 
-    MapExpression<T> merge(MapExpression<? extends T> map);
+    /**
+     * Returns a map with the same entries as {@code this} map, but with
+     * any keys present in the {@code other} map overwritten with the
+     * values of that other map. That is, entries from both this and the
+     * other map are merged, with the other map having priority.
+     *
+     * <p>This does not affect the original map.
+     *
+     * @param other the other map.
+     * @return the resulting value.
+     */
+    MapExpression<T> merge(MapExpression<? extends T> other);
 
+    /**
+     * The {@linkplain EntryExpression entries} of this map as an array.
+     *
+     * @see ArrayExpression#asMap
+     * @return the resulting value.
+     */
     ArrayExpression<EntryExpression<T>> entrySet();
 
+    /**
+     * {@code this} map as a {@linkplain DocumentExpression document}.
+     *
+     * @return the resulting value.
+     * @param <R> the resulting type.
+     */
     <R extends DocumentExpression> R asDocument();
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MapExpression.java
@@ -16,6 +16,10 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Sealed;
+import com.mongodb.assertions.Assertions;
+
 import java.util.function.Function;
 
 import static com.mongodb.client.model.expressions.Expressions.of;
@@ -23,16 +27,19 @@ import static com.mongodb.client.model.expressions.MqlUnchecked.Unchecked.PRESEN
 
 /**
  * A map {@link Expression value} in the context of the MongoDB Query
- * Language (MQL). An map is a finite, unordered a set of
- * {@link EntryExpression entries} of a certain type, such that no entry key
- * is repeated. It is a mapping from keys to values.
+ * Language (MQL). A map is a finite set of
+ * {@link EntryExpression entries} of a certain type.
+ * No entry key is repeated. It is a mapping from keys to values.
  *
- * @param <T> the type of the elements
+ * @param <T> the type of the entry values
+ * @since 4.9.0
  */
+@Sealed
+@Beta(Beta.Reason.CLIENT)
 public interface MapExpression<T extends Expression> extends Expression {
 
     /**
-     * True if {@code this} map has a value (including null) for
+     * Whether {@code this} map has a value (including null) for
      * the provided key.
      *
      * @param key the key.
@@ -41,7 +48,7 @@ public interface MapExpression<T extends Expression> extends Expression {
     BooleanExpression has(StringExpression key);
 
     /**
-     * True if {@code this} map has a value (including null) for
+     * Whether {@code this} map has a value (including null) for
      * the provided key.
      *
      * @param key the key.
@@ -74,13 +81,16 @@ public interface MapExpression<T extends Expression> extends Expression {
      * @param key the key.
      * @return the value.
      */
+    @MqlUnchecked(PRESENT)
     default T get(final String key) {
+        Assertions.notNull("key", key);
         return get(of(key));
     }
 
     /**
      * The value corresponding to the provided {@code key}, or the
-     * {@code other} value if an entry for the key is not present.
+     * {@code other} value if an entry for the key is not
+     * {@linkplain #has(StringExpression) present}.
      *
      * @param key the key.
      * @param other the other value.
@@ -90,13 +100,16 @@ public interface MapExpression<T extends Expression> extends Expression {
 
     /**
      * The value corresponding to the provided {@code key}, or the
-     * {@code other} value if an entry for the key is not present.
+     * {@code other} value if an entry for the key is not
+     * {@linkplain #has(StringExpression) present}.
      *
      * @param key the key.
      * @param other the other value.
      * @return the resulting value.
      */
     default T get(final String key, final T other) {
+        Assertions.notNull("key", key);
+        Assertions.notNull("other", other);
         return get(of(key), other);
     }
 
@@ -123,12 +136,15 @@ public interface MapExpression<T extends Expression> extends Expression {
      * @return the resulting value.
      */
     default MapExpression<T> set(final String key, final T value) {
+        Assertions.notNull("key", key);
+        Assertions.notNull("value", value);
         return set(of(key), value);
     }
 
     /**
-     * Returns a map with the same entries as {@code this} map, but with
-     * the specified {@code key} absent.
+     * Returns a map with the same entries as {@code this} map, but which
+     * {@linkplain #has(StringExpression) has} no entry with the specified
+     * {@code key}.
      *
      * <p>This does not affect the original map.
      *
@@ -138,8 +154,9 @@ public interface MapExpression<T extends Expression> extends Expression {
     MapExpression<T> unset(StringExpression key);
 
     /**
-     * Returns a map with the same entries as {@code this} map, but with
-     * the specified {@code key} absent.
+     * Returns a map with the same entries as {@code this} map, but which
+     * {@linkplain #has(StringExpression) has} no entry with the specified
+     * {@code key}.
      *
      * <p>This does not affect the original map.
      *
@@ -147,6 +164,7 @@ public interface MapExpression<T extends Expression> extends Expression {
      * @return the resulting value.
      */
     default MapExpression<T> unset(final String key) {
+        Assertions.notNull("key", key);
         return unset(of(key));
     }
 
@@ -165,6 +183,7 @@ public interface MapExpression<T extends Expression> extends Expression {
 
     /**
      * The {@linkplain EntryExpression entries} of this map as an array.
+     * No guarantee is made regarding order.
      *
      * @see ArrayExpression#asMap
      * @return the resulting value.

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
@@ -880,8 +880,8 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public StringExpression concat(final StringExpression concat) {
-        return new MqlExpression<>(ast("$concat", concat));
+    public StringExpression concat(final StringExpression other) {
+        return new MqlExpression<>(ast("$concat", other));
     }
 
     @Override
@@ -972,8 +972,8 @@ final class MqlExpression<T extends Expression>
 
     @SuppressWarnings("unchecked")
     @Override
-    public MapExpression<Expression> asMap() {
-        return (MapExpression<Expression>) this;
+    public <Q extends Expression> MapExpression<Q> asMap() {
+        return (MapExpression<Q>) this;
     }
 
     @SuppressWarnings("unchecked")

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.assertions.Assertions;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
@@ -96,7 +97,7 @@ final class MqlExpression<T extends Expression>
         return (cr) -> {
             BsonArray value = new BsonArray();
             value.add(this.toBsonValue(cr));
-            value.add(extractBsonValue(cr, param1));
+            value.add(toBsonValue(cr, param1));
             return new AstPlaceholder(new BsonDocument(name, value));
         };
     }
@@ -105,8 +106,8 @@ final class MqlExpression<T extends Expression>
         return (cr) -> {
             BsonArray value = new BsonArray();
             value.add(this.toBsonValue(cr));
-            value.add(extractBsonValue(cr, param1));
-            value.add(extractBsonValue(cr, param2));
+            value.add(toBsonValue(cr, param1));
+            value.add(toBsonValue(cr, param2));
             return new AstPlaceholder(new BsonDocument(name, value));
         };
     }
@@ -116,7 +117,7 @@ final class MqlExpression<T extends Expression>
      * the only implementation of Expression and all subclasses, so this will
      * not mis-cast an expression as anything else.
      */
-    static BsonValue extractBsonValue(final CodecRegistry cr, final Expression expression) {
+    static BsonValue toBsonValue(final CodecRegistry cr, final Expression expression) {
         return ((MqlExpression<?>) expression).toBsonValue(cr);
     }
 
@@ -146,16 +147,20 @@ final class MqlExpression<T extends Expression>
 
     @Override
     public BooleanExpression or(final BooleanExpression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$or", other));
     }
 
     @Override
     public BooleanExpression and(final BooleanExpression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$and", other));
     }
 
     @Override
     public <R extends Expression> R cond(final R ifTrue, final R ifFalse) {
+        Assertions.notNull("ifTrue", ifTrue);
+        Assertions.notNull("ifFalse", ifFalse);
         return newMqlExpression(ast("$cond", ifTrue, ifFalse));
     }
 
@@ -174,108 +179,138 @@ final class MqlExpression<T extends Expression>
 
     @Override
     public Expression getField(final String fieldName) {
+        Assertions.notNull("fieldName", fieldName);
         return new MqlExpression<>(getFieldInternal(fieldName));
     }
 
     @Override
     public BooleanExpression getBoolean(final String fieldName) {
+        Assertions.notNull("fieldName", fieldName);
         return new MqlExpression<>(getFieldInternal(fieldName));
     }
 
     @Override
     public BooleanExpression getBoolean(final String fieldName, final BooleanExpression other) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("other", other);
         return getBoolean(fieldName).isBooleanOr(other);
     }
 
     @Override
     public NumberExpression getNumber(final String fieldName) {
+        Assertions.notNull("fieldName", fieldName);
         return new MqlExpression<>(getFieldInternal(fieldName));
     }
 
     @Override
     public NumberExpression getNumber(final String fieldName, final NumberExpression other) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("other", other);
         return getNumber(fieldName).isNumberOr(other);
     }
 
     @Override
     public IntegerExpression getInteger(final String fieldName) {
+        Assertions.notNull("fieldName", fieldName);
         return new MqlExpression<>(getFieldInternal(fieldName));
     }
 
     @Override
     public IntegerExpression getInteger(final String fieldName, final IntegerExpression other) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("other", other);
         return getInteger(fieldName).isIntegerOr(other);
     }
 
     @Override
     public StringExpression getString(final String fieldName) {
+        Assertions.notNull("fieldName", fieldName);
         return new MqlExpression<>(getFieldInternal(fieldName));
     }
 
     @Override
     public StringExpression getString(final String fieldName, final StringExpression other) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("other", other);
         return getString(fieldName).isStringOr(other);
     }
 
     @Override
     public DateExpression getDate(final String fieldName) {
+        Assertions.notNull("fieldName", fieldName);
         return new MqlExpression<>(getFieldInternal(fieldName));
     }
 
     @Override
     public DateExpression getDate(final String fieldName, final DateExpression other) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("other", other);
         return getDate(fieldName).isDateOr(other);
     }
 
     @Override
     public DocumentExpression getDocument(final String fieldName) {
+        Assertions.notNull("fieldName", fieldName);
         return new MqlExpression<>(getFieldInternal(fieldName));
     }
 
     @Override
-    public <R extends Expression> MapExpression<R> getMap(final String field) {
-        return new MqlExpression<>(getFieldInternal(field));
+    public <R extends Expression> MapExpression<R> getMap(final String fieldName) {
+        Assertions.notNull("fieldName", fieldName);
+        return new MqlExpression<>(getFieldInternal(fieldName));
     }
 
     @Override
-    public <R extends Expression> MapExpression<R> getMap(final String field, final MapExpression<? extends R> other) {
-        return getMap(field).isMapOr(other);
+    public <R extends Expression> MapExpression<R> getMap(final String fieldName, final MapExpression<? extends R> other) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("other", other);
+        return getMap(fieldName).isMapOr(other);
     }
 
     @Override
     public DocumentExpression getDocument(final String fieldName, final DocumentExpression other) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("other", other);
         return getDocument(fieldName).isDocumentOr(other);
     }
 
     @Override
     public <R extends Expression> ArrayExpression<R> getArray(final String fieldName) {
+        Assertions.notNull("fieldName", fieldName);
         return new MqlExpression<>(getFieldInternal(fieldName));
     }
 
     @Override
     public <R extends Expression> ArrayExpression<R> getArray(final String fieldName, final ArrayExpression<? extends R> other) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("other", other);
         return getArray(fieldName).isArrayOr(other);
     }
 
     @Override
     public DocumentExpression merge(final DocumentExpression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$mergeObjects", other));
     }
 
     @Override
-    public DocumentExpression setField(final String fieldName, final Expression exp) {
-        return setFieldInternal(fieldName, exp);
+    public DocumentExpression setField(final String fieldName, final Expression value) {
+        Assertions.notNull("fieldName", fieldName);
+        Assertions.notNull("value", value);
+        return setFieldInternal(fieldName, value);
     }
 
-    private MqlExpression<T> setFieldInternal(final String fieldName, final Expression exp) {
+    private MqlExpression<T> setFieldInternal(final String fieldName, final Expression value) {
+        Assertions.notNull("fieldName", fieldName);
         return newMqlExpression((cr) -> astDoc("$setField", new BsonDocument()
                 .append("field", new BsonString(fieldName))
                 .append("input", this.toBsonValue(cr))
-                .append("value", extractBsonValue(cr, exp))));
+                .append("value", toBsonValue(cr, value))));
     }
 
     @Override
     public DocumentExpression unsetField(final String fieldName) {
+        Assertions.notNull("fieldName", fieldName);
         return newMqlExpression((cr) -> astDoc("$unsetField", new BsonDocument()
                 .append("field", new BsonString(fieldName))
                 .append("input", this.toBsonValue(cr))));
@@ -285,92 +320,110 @@ final class MqlExpression<T extends Expression>
 
     @Override
     public <R extends Expression> R passTo(final Function<? super Expression, ? extends R> f) {
+        Assertions.notNull("f", f);
         return f.apply(this.assertImplementsAllExpressions());
     }
 
     @Override
-    public <R extends Expression> R switchOn(final Function<Branches<Expression>, ? extends BranchesTerminal<Expression, ? extends R>> switchMap) {
-        return switchMapInternal(this.assertImplementsAllExpressions(), switchMap.apply(new Branches<>()));
+    public <R extends Expression> R switchOn(final Function<Branches<Expression>, ? extends BranchesTerminal<Expression, ? extends R>> mapping) {
+        Assertions.notNull("mapping", mapping);
+        return switchMapInternal(this.assertImplementsAllExpressions(), mapping.apply(new Branches<>()));
     }
 
     @Override
     public <R extends Expression> R passBooleanTo(final Function<? super BooleanExpression, ? extends R> f) {
+        Assertions.notNull("f", f);
         return f.apply(this.assertImplementsAllExpressions());
     }
 
     @Override
-    public <R extends Expression> R switchBooleanOn(final Function<Branches<BooleanExpression>, ? extends BranchesTerminal<BooleanExpression, ? extends R>> switchMap) {
-        return switchMapInternal(this.assertImplementsAllExpressions(), switchMap.apply(new Branches<>()));
+    public <R extends Expression> R switchBooleanOn(final Function<Branches<BooleanExpression>, ? extends BranchesTerminal<BooleanExpression, ? extends R>> mapping) {
+        Assertions.notNull("mapping", mapping);
+        return switchMapInternal(this.assertImplementsAllExpressions(), mapping.apply(new Branches<>()));
     }
 
     @Override
     public <R extends Expression> R passIntegerTo(final Function<? super IntegerExpression, ? extends R> f) {
+        Assertions.notNull("f", f);
         return f.apply(this.assertImplementsAllExpressions());
     }
 
     @Override
-    public <R extends Expression> R switchIntegerOn(final Function<Branches<IntegerExpression>, ? extends BranchesTerminal<IntegerExpression, ? extends R>> switchMap) {
-        return switchMapInternal(this.assertImplementsAllExpressions(), switchMap.apply(new Branches<>()));
+    public <R extends Expression> R switchIntegerOn(final Function<Branches<IntegerExpression>, ? extends BranchesTerminal<IntegerExpression, ? extends R>> mapping) {
+        Assertions.notNull("mapping", mapping);
+        return switchMapInternal(this.assertImplementsAllExpressions(), mapping.apply(new Branches<>()));
     }
 
     @Override
     public <R extends Expression> R passNumberTo(final Function<? super NumberExpression, ? extends R> f) {
+        Assertions.notNull("f", f);
         return f.apply(this.assertImplementsAllExpressions());
     }
 
     @Override
-    public <R extends Expression> R switchNumberOn(final Function<Branches<NumberExpression>, ? extends BranchesTerminal<NumberExpression, ? extends R>> switchMap) {
-        return switchMapInternal(this.assertImplementsAllExpressions(), switchMap.apply(new Branches<>()));
+    public <R extends Expression> R switchNumberOn(final Function<Branches<NumberExpression>, ? extends BranchesTerminal<NumberExpression, ? extends R>> mapping) {
+        Assertions.notNull("mapping", mapping);
+        return switchMapInternal(this.assertImplementsAllExpressions(), mapping.apply(new Branches<>()));
     }
 
     @Override
     public <R extends Expression> R passStringTo(final Function<? super StringExpression, ? extends R> f) {
+        Assertions.notNull("f", f);
         return f.apply(this.assertImplementsAllExpressions());
     }
 
     @Override
-    public <R extends Expression> R switchStringOn(final Function<Branches<StringExpression>, ? extends BranchesTerminal<StringExpression, ? extends R>> switchMap) {
-        return switchMapInternal(this.assertImplementsAllExpressions(), switchMap.apply(new Branches<>()));
+    public <R extends Expression> R switchStringOn(final Function<Branches<StringExpression>, ? extends BranchesTerminal<StringExpression, ? extends R>> mapping) {
+        Assertions.notNull("mapping", mapping);
+        return switchMapInternal(this.assertImplementsAllExpressions(), mapping.apply(new Branches<>()));
     }
 
     @Override
     public <R extends Expression> R passDateTo(final Function<? super DateExpression, ? extends R> f) {
+        Assertions.notNull("f", f);
         return f.apply(this.assertImplementsAllExpressions());
     }
 
     @Override
-    public <R extends Expression> R switchDateOn(final Function<Branches<DateExpression>, ? extends BranchesTerminal<DateExpression, ? extends R>> switchMap) {
-        return switchMapInternal(this.assertImplementsAllExpressions(), switchMap.apply(new Branches<>()));
+    public <R extends Expression> R switchDateOn(final Function<Branches<DateExpression>, ? extends BranchesTerminal<DateExpression, ? extends R>> mapping) {
+        Assertions.notNull("mapping", mapping);
+        return switchMapInternal(this.assertImplementsAllExpressions(), mapping.apply(new Branches<>()));
     }
 
     @Override
     public <R extends Expression> R passArrayTo(final Function<? super ArrayExpression<T>, ? extends R> f) {
+        Assertions.notNull("f", f);
         return f.apply(this.assertImplementsAllExpressions());
     }
 
     @Override
-    public <R extends Expression> R switchArrayOn(final Function<Branches<ArrayExpression<T>>, ? extends BranchesTerminal<ArrayExpression<T>, ? extends R>> switchMap) {
-        return switchMapInternal(this.assertImplementsAllExpressions(), switchMap.apply(new Branches<>()));
+    public <R extends Expression> R switchArrayOn(final Function<Branches<ArrayExpression<T>>, ? extends BranchesTerminal<ArrayExpression<T>, ? extends R>> mapping) {
+        Assertions.notNull("mapping", mapping);
+        return switchMapInternal(this.assertImplementsAllExpressions(), mapping.apply(new Branches<>()));
     }
 
     @Override
     public <R extends Expression> R passMapTo(final Function<? super MapExpression<T>, ? extends R> f) {
+        Assertions.notNull("f", f);
         return f.apply(this.assertImplementsAllExpressions());
     }
 
     @Override
-    public <R extends Expression> R switchMapOn(final Function<Branches<MapExpression<T>>, ? extends BranchesTerminal<MapExpression<T>, ? extends R>> switchMap) {
-        return switchMapInternal(this.assertImplementsAllExpressions(), switchMap.apply(new Branches<>()));
+    public <R extends Expression> R switchMapOn(final Function<Branches<MapExpression<T>>, ? extends BranchesTerminal<MapExpression<T>, ? extends R>> mapping) {
+        Assertions.notNull("mapping", mapping);
+        return switchMapInternal(this.assertImplementsAllExpressions(), mapping.apply(new Branches<>()));
     }
 
     @Override
     public <R extends Expression> R passDocumentTo(final Function<? super DocumentExpression, ? extends R> f) {
+        Assertions.notNull("f", f);
         return f.apply(this.assertImplementsAllExpressions());
     }
 
     @Override
-    public <R extends Expression> R switchDocumentOn(final Function<Branches<DocumentExpression>, ? extends BranchesTerminal<DocumentExpression, ? extends R>> switchMap) {
-        return switchMapInternal(this.assertImplementsAllExpressions(), switchMap.apply(new Branches<>()));
+    public <R extends Expression> R switchDocumentOn(final Function<Branches<DocumentExpression>, ? extends BranchesTerminal<DocumentExpression, ? extends R>> mapping) {
+        Assertions.notNull("mapping", mapping);
+        return switchMapInternal(this.assertImplementsAllExpressions(), mapping.apply(new Branches<>()));
     }
 
     private <T0 extends Expression, R0 extends Expression> R0 switchMapInternal(
@@ -380,12 +433,12 @@ final class MqlExpression<T extends Expression>
             for (Function<T0, SwitchCase<R0>> fn : construct.getBranches()) {
                 SwitchCase<R0> result = fn.apply(value);
                 branches.add(new BsonDocument()
-                        .append("case", extractBsonValue(cr, result.getCaseValue()))
-                        .append("then", extractBsonValue(cr, result.getThenValue())));
+                        .append("case", toBsonValue(cr, result.getCaseValue()))
+                        .append("then", toBsonValue(cr, result.getThenValue())));
             }
             BsonDocument switchBson = new BsonDocument().append("branches", branches);
             if (construct.getDefaults() != null) {
-                switchBson = switchBson.append("default", extractBsonValue(cr, construct.getDefaults().apply(value)));
+                switchBson = switchBson.append("default", toBsonValue(cr, construct.getDefaults().apply(value)));
             }
             return astDoc("$switch", switchBson);
         });
@@ -393,53 +446,61 @@ final class MqlExpression<T extends Expression>
 
     @Override
     public BooleanExpression eq(final Expression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$eq", other));
     }
 
     @Override
     public BooleanExpression ne(final Expression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$ne", other));
     }
 
     @Override
     public BooleanExpression gt(final Expression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$gt", other));
     }
 
     @Override
     public BooleanExpression gte(final Expression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$gte", other));
     }
 
     @Override
     public BooleanExpression lt(final Expression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$lt", other));
     }
 
     @Override
     public BooleanExpression lte(final Expression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$lte", other));
     }
 
-    public BooleanExpression isBoolean() {
+    BooleanExpression isBoolean() {
         return new MqlExpression<>(astWrapped("$type")).eq(of("bool"));
     }
 
     @Override
     public BooleanExpression isBooleanOr(final BooleanExpression other) {
+        Assertions.notNull("other", other);
         return this.isBoolean().cond(this, other);
     }
 
-    public BooleanExpression isNumber() {
+    BooleanExpression isNumber() {
         return new MqlExpression<>(astWrapped("$isNumber"));
     }
 
     @Override
     public NumberExpression isNumberOr(final NumberExpression other) {
+        Assertions.notNull("other", other);
         return this.isNumber().cond(this, other);
     }
 
-    public BooleanExpression isInteger() {
+    BooleanExpression isInteger() {
         return switchOn(on -> on
                 .isNumber(v -> v.round().eq(v))
                 .defaults(v -> of(false)));
@@ -447,6 +508,7 @@ final class MqlExpression<T extends Expression>
 
     @Override
     public IntegerExpression isIntegerOr(final IntegerExpression other) {
+        Assertions.notNull("other", other);
         /*
         The server does not evaluate both branches of and/or/cond unless needed.
         However, the server has a pipeline optimization stage prior to
@@ -456,37 +518,33 @@ final class MqlExpression<T extends Expression>
         otherwise we could just use:
         this.isNumber().and(this.eq(this.round()))
         */
-
         return this.switchOn(on -> on
                 .isNumber(v -> (IntegerExpression) v.round().eq(v).cond(v, other))
                 .defaults(v -> other));
     }
 
-    public BooleanExpression isString() {
+    BooleanExpression isString() {
         return new MqlExpression<>(astWrapped("$type")).eq(of("string"));
     }
 
     @Override
     public StringExpression isStringOr(final StringExpression other) {
+        Assertions.notNull("other", other);
         return this.isString().cond(this, other);
     }
 
-    public BooleanExpression isDate() {
+    BooleanExpression isDate() {
         return ofStringArray("date").contains(new MqlExpression<>(astWrapped("$type")));
     }
 
     @Override
     public DateExpression isDateOr(final DateExpression other) {
+        Assertions.notNull("other", other);
         return this.isDate().cond(this, other);
     }
 
-    public BooleanExpression isArray() {
+    BooleanExpression isArray() {
         return new MqlExpression<>(astWrapped("$isArray"));
-    }
-
-    private Expression ifNull(final Expression ifNull) {
-        return new MqlExpression<>(ast("$ifNull", ifNull, ofNull()))
-                .assertImplementsAllExpressions();
     }
 
     /**
@@ -500,6 +558,7 @@ final class MqlExpression<T extends Expression>
     @SuppressWarnings("unchecked")
     @Override
     public <R extends Expression> ArrayExpression<R> isArrayOr(final ArrayExpression<? extends R> other) {
+        Assertions.notNull("other", other);
         return (ArrayExpression<R>) this.isArray().cond(this.assertImplementsAllExpressions(), other);
     }
 
@@ -509,11 +568,13 @@ final class MqlExpression<T extends Expression>
 
     @Override
     public <R extends DocumentExpression> R isDocumentOr(final R other) {
+        Assertions.notNull("other", other);
         return this.isDocumentOrMap().cond(this.assertImplementsAllExpressions(), other);
     }
 
     @Override
     public <R extends Expression> MapExpression<R> isMapOr(final MapExpression<? extends R> other) {
+        Assertions.notNull("other", other);
         MqlExpression<?> isMap = (MqlExpression<?>) this.isDocumentOrMap();
         return newMqlExpression(isMap.ast("$cond", this.assertImplementsAllExpressions(), other));
     }
@@ -530,7 +591,7 @@ final class MqlExpression<T extends Expression>
     private Function<CodecRegistry, AstPlaceholder> convertInternal(final String to, final Expression other) {
         return (cr) -> astDoc("$convert", new BsonDocument()
                 .append("input", this.fn.apply(cr).bsonValue)
-                .append("onError", extractBsonValue(cr, other))
+                .append("onError", toBsonValue(cr, other))
                 .append("to", new BsonString(to)));
     }
 
@@ -544,43 +605,47 @@ final class MqlExpression<T extends Expression>
 
     @Override
     public <R extends Expression> ArrayExpression<R> map(final Function<? super T, ? extends R> in) {
+        Assertions.notNull("in", in);
         T varThis = variable("$$this");
         return new MqlExpression<>((cr) -> astDoc("$map", new BsonDocument()
                 .append("input", this.toBsonValue(cr))
-                .append("in", extractBsonValue(cr, in.apply(varThis)))));
+                .append("in", toBsonValue(cr, in.apply(varThis)))));
     }
 
     @Override
     public ArrayExpression<T> filter(final Function<? super T, ? extends BooleanExpression> predicate) {
+        Assertions.notNull("predicate", predicate);
         T varThis = variable("$$this");
         return new MqlExpression<>((cr) -> astDoc("$filter", new BsonDocument()
                 .append("input", this.toBsonValue(cr))
-                .append("cond", extractBsonValue(cr, predicate.apply(varThis)))));
+                .append("cond", toBsonValue(cr, predicate.apply(varThis)))));
     }
 
-    public ArrayExpression<T> sort() {
+    ArrayExpression<T> sort() {
         return new MqlExpression<>((cr) -> astDoc("$sortArray", new BsonDocument()
                 .append("input", this.toBsonValue(cr))
                 .append("sortBy", new BsonInt32(1))));
     }
 
-    public T reduce(final T initialValue, final BinaryOperator<T> in) {
+    private T reduce(final T initialValue, final BinaryOperator<T> in) {
         T varThis = variable("$$this");
         T varValue = variable("$$value");
         return newMqlExpression((cr) -> astDoc("$reduce", new BsonDocument()
                 .append("input", this.toBsonValue(cr))
-                .append("initialValue", extractBsonValue(cr, initialValue))
-                .append("in", extractBsonValue(cr, in.apply(varValue, varThis)))));
+                .append("initialValue", toBsonValue(cr, initialValue))
+                .append("in", toBsonValue(cr, in.apply(varValue, varThis)))));
     }
 
     @Override
     public BooleanExpression any(final Function<? super T, BooleanExpression> predicate) {
+        Assertions.notNull("predicate", predicate);
         MqlExpression<BooleanExpression> array = (MqlExpression<BooleanExpression>) this.map(predicate);
         return array.reduce(of(false), (a, b) -> a.or(b));
     }
 
     @Override
     public BooleanExpression all(final Function<? super T, BooleanExpression> predicate) {
+        Assertions.notNull("predicate", predicate);
         MqlExpression<BooleanExpression> array = (MqlExpression<BooleanExpression>) this.map(predicate);
         return array.reduce(of(true), (a, b) -> a.and(b));
     }
@@ -588,6 +653,7 @@ final class MqlExpression<T extends Expression>
     @SuppressWarnings("unchecked")
     @Override
     public NumberExpression sum(final Function<? super T, ? extends NumberExpression> mapper) {
+        Assertions.notNull("mapper", mapper);
         // no sum that returns IntegerExpression, both have same erasure
         MqlExpression<NumberExpression> array = (MqlExpression<NumberExpression>) this.map(mapper);
         return array.reduce(of(0), (a, b) -> a.add(b));
@@ -596,36 +662,42 @@ final class MqlExpression<T extends Expression>
     @SuppressWarnings("unchecked")
     @Override
     public NumberExpression multiply(final Function<? super T, ? extends NumberExpression> mapper) {
+        Assertions.notNull("mapper", mapper);
         MqlExpression<NumberExpression> array = (MqlExpression<NumberExpression>) this.map(mapper);
         return array.reduce(of(1), (NumberExpression a, NumberExpression b) -> a.multiply(b));
     }
 
     @Override
     public T max(final T other) {
+        Assertions.notNull("other", other);
         return this.size().eq(of(0)).cond(other, this.maxN(of(1)).first());
     }
 
     @Override
     public T min(final T other) {
+        Assertions.notNull("other", other);
         return this.size().eq(of(0)).cond(other, this.minN(of(1)).first());
     }
 
     @Override
     public ArrayExpression<T> maxN(final IntegerExpression n) {
+        Assertions.notNull("n", n);
         return newMqlExpression((CodecRegistry cr) -> astDoc("$maxN", new BsonDocument()
-                .append("input", extractBsonValue(cr, this))
-                .append("n", extractBsonValue(cr, n))));
+                .append("input", toBsonValue(cr, this))
+                .append("n", toBsonValue(cr, n))));
     }
 
     @Override
     public ArrayExpression<T> minN(final IntegerExpression n) {
+        Assertions.notNull("n", n);
         return newMqlExpression((CodecRegistry cr) -> astDoc("$minN", new BsonDocument()
-                .append("input", extractBsonValue(cr, this))
-                .append("n", extractBsonValue(cr, n))));
+                .append("input", toBsonValue(cr, this))
+                .append("n", toBsonValue(cr, n))));
     }
 
     @Override
     public StringExpression join(final Function<? super T, StringExpression> mapper) {
+        Assertions.notNull("mapper", mapper);
         MqlExpression<StringExpression> array = (MqlExpression<StringExpression>) this.map(mapper);
         return array.reduce(of(""), (a, b) -> a.concat(b));
     }
@@ -633,6 +705,7 @@ final class MqlExpression<T extends Expression>
     @SuppressWarnings("unchecked")
     @Override
     public <R extends Expression> ArrayExpression<R> concat(final Function<? super T, ? extends ArrayExpression<? extends R>> mapper) {
+        Assertions.notNull("mapper", mapper);
         MqlExpression<ArrayExpression<R>> array = (MqlExpression<ArrayExpression<R>>) this.map(mapper);
         return array.reduce(Expressions.ofArray(), (a, b) -> a.concat(b));
     }
@@ -640,6 +713,8 @@ final class MqlExpression<T extends Expression>
     @SuppressWarnings("unchecked")
     @Override
     public <R extends Expression> ArrayExpression<R> union(final Function<? super T, ? extends ArrayExpression<? extends R>> mapper) {
+        Assertions.notNull("mapper", mapper);
+        Assertions.notNull("mapper", mapper);
         MqlExpression<ArrayExpression<R>> array = (MqlExpression<ArrayExpression<R>>) this.map(mapper);
         return array.reduce(Expressions.ofArray(), (a, b) -> a.union(b));
     }
@@ -650,8 +725,9 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public T elementAt(final IntegerExpression at) {
-        return new MqlExpression<>(ast("$arrayElemAt", at))
+    public T elementAt(final IntegerExpression i) {
+        Assertions.notNull("i", i);
+        return new MqlExpression<>(ast("$arrayElemAt", i))
                 .assertImplementsAllExpressions();
     }
 
@@ -668,31 +744,36 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public BooleanExpression contains(final T item) {
+    public BooleanExpression contains(final T value) {
+        Assertions.notNull("value", value);
         String name = "$in";
         return new MqlExpression<>((cr) -> {
-            BsonArray value = new BsonArray();
-            value.add(extractBsonValue(cr, item));
-            value.add(this.toBsonValue(cr));
-            return new AstPlaceholder(new BsonDocument(name, value));
+            BsonArray array = new BsonArray();
+            array.add(toBsonValue(cr, value));
+            array.add(this.toBsonValue(cr));
+            return new AstPlaceholder(new BsonDocument(name, array));
         }).assertImplementsAllExpressions();
     }
 
     @Override
-    public ArrayExpression<T> concat(final ArrayExpression<? extends T> array) {
-        return new MqlExpression<>(ast("$concatArrays", array))
+    public ArrayExpression<T> concat(final ArrayExpression<? extends T> other) {
+        Assertions.notNull("other", other);
+        return new MqlExpression<>(ast("$concatArrays", other))
                 .assertImplementsAllExpressions();
     }
 
     @Override
     public ArrayExpression<T> slice(final IntegerExpression start, final IntegerExpression length) {
+        Assertions.notNull("start", start);
+        Assertions.notNull("length", length);
         return new MqlExpression<>(ast("$slice", start, length))
                 .assertImplementsAllExpressions();
     }
 
     @Override
-    public ArrayExpression<T> union(final ArrayExpression<? extends T> set) {
-        return new MqlExpression<>(ast("$setUnion", set))
+    public ArrayExpression<T> union(final ArrayExpression<? extends T> other) {
+        Assertions.notNull("other", other);
+        return new MqlExpression<>(ast("$setUnion", other))
                 .assertImplementsAllExpressions();
     }
 
@@ -706,27 +787,32 @@ final class MqlExpression<T extends Expression>
      *  @see NumberExpression */
 
     @Override
-    public IntegerExpression multiply(final NumberExpression n) {
-        return newMqlExpression(ast("$multiply", n));
+    public IntegerExpression multiply(final NumberExpression other) {
+        Assertions.notNull("other", other);
+        return newMqlExpression(ast("$multiply", other));
     }
 
     @Override
-    public NumberExpression add(final NumberExpression n) {
-        return new MqlExpression<>(ast("$add", n));
+    public NumberExpression add(final NumberExpression other) {
+        Assertions.notNull("other", other);
+        return new MqlExpression<>(ast("$add", other));
     }
 
     @Override
-    public NumberExpression divide(final NumberExpression n) {
-        return new MqlExpression<>(ast("$divide", n));
+    public NumberExpression divide(final NumberExpression other) {
+        Assertions.notNull("other", other);
+        return new MqlExpression<>(ast("$divide", other));
     }
 
     @Override
     public NumberExpression max(final NumberExpression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$max", other));
     }
 
     @Override
     public NumberExpression min(final NumberExpression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$min", other));
     }
 
@@ -737,11 +823,13 @@ final class MqlExpression<T extends Expression>
 
     @Override
     public NumberExpression round(final IntegerExpression place) {
+        Assertions.notNull("place", place);
         return new MqlExpression<>(ast("$round", place));
     }
 
     @Override
     public IntegerExpression multiply(final IntegerExpression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$multiply", other));
     }
 
@@ -756,28 +844,33 @@ final class MqlExpression<T extends Expression>
     }
 
     @Override
-    public NumberExpression subtract(final NumberExpression n) {
-        return new MqlExpression<>(ast("$subtract", n));
+    public NumberExpression subtract(final NumberExpression other) {
+        Assertions.notNull("other", other);
+        return new MqlExpression<>(ast("$subtract", other));
     }
 
     @Override
     public IntegerExpression add(final IntegerExpression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$add", other));
     }
 
     @Override
-    public IntegerExpression subtract(final IntegerExpression i) {
-        return new MqlExpression<>(ast("$subtract", i));
+    public IntegerExpression subtract(final IntegerExpression other) {
+        Assertions.notNull("other", other);
+        return new MqlExpression<>(ast("$subtract", other));
     }
 
     @Override
-    public IntegerExpression max(final IntegerExpression i) {
-        return new MqlExpression<>(ast("$max", i));
+    public IntegerExpression max(final IntegerExpression other) {
+        Assertions.notNull("other", other);
+        return new MqlExpression<>(ast("$max", other));
     }
 
     @Override
-    public IntegerExpression min(final IntegerExpression i) {
-        return new MqlExpression<>(ast("$min", i));
+    public IntegerExpression min(final IntegerExpression other) {
+        Assertions.notNull("other", other);
+        return new MqlExpression<>(ast("$min", other));
     }
 
     /** @see DateExpression */
@@ -785,80 +878,95 @@ final class MqlExpression<T extends Expression>
     private MqlExpression<Expression> usingTimezone(final String name, final StringExpression timezone) {
         return new MqlExpression<>((cr) -> astDoc(name, new BsonDocument()
                 .append("date", this.toBsonValue(cr))
-                .append("timezone", extractBsonValue(cr, timezone))));
+                .append("timezone", toBsonValue(cr, timezone))));
     }
 
     @Override
     public IntegerExpression year(final StringExpression timezone) {
+        Assertions.notNull("timezone", timezone);
         return usingTimezone("$year", timezone);
     }
 
     @Override
     public IntegerExpression month(final StringExpression timezone) {
+        Assertions.notNull("timezone", timezone);
         return usingTimezone("$month", timezone);
     }
 
     @Override
     public IntegerExpression dayOfMonth(final StringExpression timezone) {
+        Assertions.notNull("timezone", timezone);
         return usingTimezone("$dayOfMonth", timezone);
     }
 
     @Override
     public IntegerExpression dayOfWeek(final StringExpression timezone) {
+        Assertions.notNull("timezone", timezone);
         return usingTimezone("$dayOfWeek", timezone);
     }
 
     @Override
     public IntegerExpression dayOfYear(final StringExpression timezone) {
+        Assertions.notNull("timezone", timezone);
         return usingTimezone("$dayOfYear", timezone);
     }
 
     @Override
     public IntegerExpression hour(final StringExpression timezone) {
+        Assertions.notNull("timezone", timezone);
         return usingTimezone("$hour", timezone);
     }
 
     @Override
     public IntegerExpression minute(final StringExpression timezone) {
+        Assertions.notNull("timezone", timezone);
         return usingTimezone("$minute", timezone);
     }
 
     @Override
     public IntegerExpression second(final StringExpression timezone) {
+        Assertions.notNull("timezone", timezone);
         return usingTimezone("$second", timezone);
     }
 
     @Override
     public IntegerExpression week(final StringExpression timezone) {
+        Assertions.notNull("timezone", timezone);
         return usingTimezone("$week", timezone);
     }
 
     @Override
     public IntegerExpression millisecond(final StringExpression timezone) {
+        Assertions.notNull("timezone", timezone);
         return usingTimezone("$millisecond", timezone);
     }
 
     @Override
     public StringExpression asString(final StringExpression timezone, final StringExpression format) {
+        Assertions.notNull("timezone", timezone);
+        Assertions.notNull("format", format);
         return newMqlExpression((cr) -> astDoc("$dateToString", new BsonDocument()
                 .append("date", this.toBsonValue(cr))
-                .append("format", extractBsonValue(cr, format))
-                .append("timezone", extractBsonValue(cr, timezone))));
+                .append("format", toBsonValue(cr, format))
+                .append("timezone", toBsonValue(cr, timezone))));
     }
 
     @Override
     public DateExpression parseDate(final StringExpression timezone, final StringExpression format) {
+        Assertions.notNull("timezone", timezone);
+        Assertions.notNull("format", format);
         return newMqlExpression((cr) -> astDoc("$dateFromString", new BsonDocument()
                 .append("dateString", this.toBsonValue(cr))
-                .append("format", extractBsonValue(cr, format))
-                .append("timezone", extractBsonValue(cr, timezone))));
+                .append("format", toBsonValue(cr, format))
+                .append("timezone", toBsonValue(cr, timezone))));
     }
 
     @Override
     public DateExpression parseDate(final StringExpression format) {
+        Assertions.notNull("format", format);
         return newMqlExpression((cr) -> astDoc("$dateFromString", new BsonDocument()
                 .append("dateString", this.toBsonValue(cr))
-                .append("format", extractBsonValue(cr, format))));
+                .append("format", toBsonValue(cr, format))));
     }
 
     @Override
@@ -881,6 +989,7 @@ final class MqlExpression<T extends Expression>
 
     @Override
     public StringExpression concat(final StringExpression other) {
+        Assertions.notNull("other", other);
         return new MqlExpression<>(ast("$concat", other));
     }
 
@@ -896,22 +1005,28 @@ final class MqlExpression<T extends Expression>
 
     @Override
     public StringExpression substr(final IntegerExpression start, final IntegerExpression length) {
+        Assertions.notNull("start", start);
+        Assertions.notNull("length", length);
         return new MqlExpression<>(ast("$substrCP", start, length));
     }
 
     @Override
     public StringExpression substrBytes(final IntegerExpression start, final IntegerExpression length) {
+        Assertions.notNull("start", start);
+        Assertions.notNull("length", length);
         return new MqlExpression<>(ast("$substrBytes", start, length));
     }
 
     @Override
     public BooleanExpression has(final StringExpression key) {
+        Assertions.notNull("key", key);
         return get(key).ne(ofRem());
     }
 
 
     @Override
     public BooleanExpression has(final String fieldName) {
+        Assertions.notNull("fieldName", fieldName);
         return this.has(of(fieldName));
     }
 
@@ -926,35 +1041,43 @@ final class MqlExpression<T extends Expression>
 
     @Override
     public T get(final StringExpression key) {
+        Assertions.notNull("key", key);
         return newMqlExpression((cr) -> astDoc("$getField", new BsonDocument()
                 .append("input", this.fn.apply(cr).bsonValue)
-                .append("field", extractBsonValue(cr, key))));
+                .append("field", toBsonValue(cr, key))));
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public T get(final StringExpression key, final T other) {
-        return (T) ((MqlExpression<?>) get(key)).ifNull(other);
+        Assertions.notNull("key", key);
+        Assertions.notNull("other", other);
+        MqlExpression<?> mqlExpression = (MqlExpression<?>) get(key);
+        return (T) mqlExpression.eq(ofRem()).cond(other, mqlExpression);
     }
 
     @Override
     public MapExpression<T> set(final StringExpression key, final T value) {
+        Assertions.notNull("key", key);
+        Assertions.notNull("value", value);
         return newMqlExpression((cr) -> astDoc("$setField", new BsonDocument()
-                .append("field", extractBsonValue(cr, key))
+                .append("field", toBsonValue(cr, key))
                 .append("input", this.toBsonValue(cr))
-                .append("value", extractBsonValue(cr, value))));
+                .append("value", toBsonValue(cr, value))));
     }
 
     @Override
     public MapExpression<T> unset(final StringExpression key) {
+        Assertions.notNull("key", key);
         return newMqlExpression((cr) -> astDoc("$unsetField", new BsonDocument()
-                .append("field", extractBsonValue(cr, key))
+                .append("field", toBsonValue(cr, key))
                 .append("input", this.toBsonValue(cr))));
     }
 
     @Override
-    public MapExpression<T> merge(final MapExpression<? extends T> map) {
-        return new MqlExpression<>(ast("$mergeObjects", map));
+    public MapExpression<T> merge(final MapExpression<? extends T> other) {
+        Assertions.notNull("other", other);
+        return new MqlExpression<>(ast("$mergeObjects", other));
     }
 
     @Override
@@ -965,6 +1088,7 @@ final class MqlExpression<T extends Expression>
     @Override
     public <R extends Expression> MapExpression<R> asMap(
             final Function<? super T, ? extends EntryExpression<? extends R>> mapper) {
+        Assertions.notNull("mapper", mapper);
         @SuppressWarnings("unchecked")
         MqlExpression<EntryExpression<? extends R>> array = (MqlExpression<EntryExpression<? extends R>>) this.map(mapper);
         return newMqlExpression(array.astWrapped("$arrayToObject"));

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlExpression.java
@@ -597,7 +597,7 @@ final class MqlExpression<T extends Expression>
     @Override
     public NumberExpression multiply(final Function<? super T, ? extends NumberExpression> mapper) {
         MqlExpression<NumberExpression> array = (MqlExpression<NumberExpression>) this.map(mapper);
-        return array.reduce(of(0), (NumberExpression a, NumberExpression b) -> a.multiply(b));
+        return array.reduce(of(1), (NumberExpression a, NumberExpression b) -> a.multiply(b));
     }
 
     @Override
@@ -907,6 +907,12 @@ final class MqlExpression<T extends Expression>
     @Override
     public BooleanExpression has(final StringExpression key) {
         return get(key).ne(ofRem());
+    }
+
+
+    @Override
+    public BooleanExpression has(final String fieldName) {
+        return this.has(of(fieldName));
     }
 
     static <R extends Expression> R ofRem() {

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlUnchecked.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlUnchecked.java
@@ -15,6 +15,8 @@
  */
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Sealed;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -31,6 +33,7 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.METHOD, ElementType.TYPE_USE})
+@Sealed
 public @interface MqlUnchecked {
     /**
      * @return A hint on the user assertion the API relies on.
@@ -42,7 +45,8 @@ public @interface MqlUnchecked {
      */
     enum Unchecked {
         /**
-         * The API relies on the values it encounters being of the type
+         * The API relies on the values it encounters being of the
+         * (raw or non-parameterized) type
          * implied, specified by, or inferred from the user code.
          *
          * <p>For example, {@link DocumentExpression#getBoolean(String)}
@@ -59,8 +63,6 @@ public @interface MqlUnchecked {
          * {@linkplain ArrayExpression array} raw type,
          * but relies on the elements of the array being of
          * the type derived from the user code.
-         *
-         * <p>One may think of it as a more specific version of {@link #TYPE}.</p>
          */
         TYPE_ARGUMENT,
         /**

--- a/driver-core/src/main/com/mongodb/client/model/expressions/MqlUnchecked.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/MqlUnchecked.java
@@ -43,32 +43,35 @@ public @interface MqlUnchecked {
     enum Unchecked {
         /**
          * The API relies on the values it encounters being of the type
-         * implied/specified by or inferred from the user code.
-         * For example, {@link com.mongodb.client.model.expressions.DocumentExpression#getBoolean(String)}
+         * implied, specified by, or inferred from the user code.
+         *
+         * <p>For example, {@link DocumentExpression#getBoolean(String)}
          * relies on the values of the document field being of the
-         * {@linkplain com.mongodb.client.model.expressions.BooleanExpression boolean} type.
+         * {@linkplain BooleanExpression boolean} type.
          */
         TYPE,
         /**
          * The API checks the raw type, but relies on the type argument
-         * implied/specified by or inferred from the user code being correct.
-         * For example, {@link com.mongodb.client.model.expressions.Expression#isArrayOr(ArrayExpression)}
+         * implied, specified by, or inferred from user code.
+         *
+         * <p>For example, {@link Expression#isArrayOr(ArrayExpression)}
          * checks that the value is of the
-         * {@linkplain com.mongodb.client.model.expressions.ArrayExpression array} raw type,
-         * but relies on the elements of the array being of the type derived from the user code.
+         * {@linkplain ArrayExpression array} raw type,
+         * but relies on the elements of the array being of
+         * the type derived from the user code.
          *
          * <p>One may think of it as a more specific version of {@link #TYPE}.</p>
          */
         TYPE_ARGUMENT,
         /**
-         * The API relies on the array being non-empty.
-         * For example, {@link com.mongodb.client.model.expressions.ArrayExpression#first()}.
-         */
-        NON_EMPTY,
-        /**
-         * The API relies on the element identified by index, name, etc., being present in the
-         * {@linkplain com.mongodb.client.model.expressions.DocumentExpression document} involved.
-         * For example, {@link com.mongodb.client.model.expressions.DocumentExpression#getField(String)}.
+         * The presence of the specified value is not checked by the API.
+         * The use of the annotated method is an unchecked assertion that the
+         * specified (whether by index, name, key, position, or otherwise)
+         * element is present in the structure involved.
+         *
+         * <p>For example, {@link DocumentExpression#getField(String)} relies
+         * on the field being present, and {@link ArrayExpression#first} relies
+         * on the array being non-empty.
          */
         PRESENT,
     }

--- a/driver-core/src/main/com/mongodb/client/model/expressions/NumberExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/NumberExpression.java
@@ -16,6 +16,10 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Sealed;
+import com.mongodb.assertions.Assertions;
+
 import java.util.function.Function;
 
 /**
@@ -23,7 +27,11 @@ import java.util.function.Function;
  * Language (MQL). {@linkplain IntegerExpression Integers} are a subset of
  * numbers, and so, for example, the integer 0 and the number 0 are
  * {@linkplain #eq(Expression) equal}.
+ *
+ * @since 4.9.0
  */
+@Sealed
+@Beta(Beta.Reason.CLIENT)
 public interface NumberExpression extends Expression {
 
     /**
@@ -41,6 +49,7 @@ public interface NumberExpression extends Expression {
      * @return the resulting value.
      */
     default NumberExpression multiply(final Number other) {
+        Assertions.notNull("other", other);
         return this.multiply(Expressions.numberToExpression(other));
     }
 
@@ -63,6 +72,7 @@ public interface NumberExpression extends Expression {
      * @return the resulting value.
      */
     default NumberExpression divide(final Number other) {
+        Assertions.notNull("other", other);
         return this.divide(Expressions.numberToExpression(other));
     }
 
@@ -81,6 +91,7 @@ public interface NumberExpression extends Expression {
      * @return the resulting value.
      */
     default NumberExpression add(final Number other) {
+        Assertions.notNull("other", other);
         return this.add(Expressions.numberToExpression(other));
     }
 
@@ -99,6 +110,7 @@ public interface NumberExpression extends Expression {
      * @return the resulting value.
      */
     default NumberExpression subtract(final Number other) {
+        Assertions.notNull("other", other);
         return this.subtract(Expressions.numberToExpression(other));
     }
 

--- a/driver-core/src/main/com/mongodb/client/model/expressions/NumberExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/NumberExpression.java
@@ -123,6 +123,7 @@ public interface NumberExpression extends Expression {
     /**
      * The integer result of rounding {@code this} to the nearest even value.
      *
+     * @mongodb.server.release 4.2
      * @return the resulting value.
      */
     IntegerExpression round();

--- a/driver-core/src/main/com/mongodb/client/model/expressions/StringExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/StringExpression.java
@@ -25,34 +25,142 @@ import static com.mongodb.client.model.expressions.Expressions.of;
  */
 public interface StringExpression extends Expression {
 
+    /**
+     * Converts {@code this} string to lowercase.
+     *
+     * @return the resulting value.
+     */
     StringExpression toLower();
 
+    /**
+     * Converts {@code this} string to uppercase.
+     *
+     * @return the resulting value.
+     */
     StringExpression toUpper();
 
-    StringExpression concat(StringExpression concat);
+    /**
+     * The concatenation of {@code this} string, followed by
+     * the {@code other} string.
+     *
+     * @param other the other value.
+     * @return the resulting value.
+     */
+    StringExpression concat(StringExpression other);
 
+    /**
+     * The number of UTF-8 code points in {@code this} string.
+     *
+     * @return the resulting value.
+     */
     IntegerExpression strLen();
 
+    /**
+     * The number of UTF-8 encoded bytes in {@code this} string.
+     *
+     * @return the resulting value.
+     */
     IntegerExpression strLenBytes();
 
+    /**
+     * The substring of {@code this} string, from the {@code start} index
+     * inclusive, and including the specified {@code length}, up to
+     * the end of the string.
+     *
+     * <p>Warning: the index position is in UTF-8 code points, not in
+     * UTF-8 encoded bytes.
+     *
+     * @param start the start index in UTF-8 code points.
+     * @param length the length in UTF-8 code points.
+     * @return the resulting value.
+     */
     StringExpression substr(IntegerExpression start, IntegerExpression length);
 
+    /**
+     * The substring of {@code this} string, from the {@code start} index
+     * inclusive, and including the specified {@code length}, up to
+     * the end of the string.
+     *
+     * <p>Warning: the index position is in UTF-8 code points, not in
+     * UTF-8 encoded bytes.
+     *
+     * @param start the start index in UTF-8 code points.
+     * @param length the length in UTF-8 code points.
+     * @return the resulting value.
+     */
     default StringExpression substr(final int start, final int length) {
         return this.substr(of(start), of(length));
     }
 
+    /**
+     * The substring of {@code this} string, from the {@code start} index
+     * inclusive, and including the specified {@code length}, up to
+     * the end of the string.
+     *
+     * <p>The index position is in UTF-8 encoded bytes, not in
+     * UTF-8 code points.
+     *
+     * @param start the start index in UTF-8 encoded bytes.
+     * @param length the length in UTF-8 encoded bytes.
+     * @return the resulting value.
+     */
     StringExpression substrBytes(IntegerExpression start, IntegerExpression length);
 
+    /**
+     * The substring of {@code this} string, from the {@code start} index
+     * inclusive, and including the specified {@code length}, up to
+     * the end of the string.
+     *
+     * <p>The index position is in UTF-8 encoded bytes, not in
+     * UTF-8 code points.
+     *
+     * @param start the start index in UTF-8 encoded bytes.
+     * @param length the length in UTF-8 encoded bytes.
+     * @return the resulting value.
+     */
     default StringExpression substrBytes(final int start, final int length) {
         return this.substrBytes(of(start), of(length));
     }
 
+    /**
+     * Converts {@code this} string to an {@linkplain IntegerExpression integer}.
+     *
+     * <p>This will cause an error if this string does not represent an integer.
+     *
+     * @return the resulting value.
+     */
     IntegerExpression parseInteger();
 
+    /**
+     * Converts {@code this} string to a {@linkplain DateExpression date}.
+     *
+     * <p>This will cause an error if this string does not represent a valid
+     * date string (such as "2018-03-20", "2018-03-20T12:00:00Z", or
+     * "2018-03-20T12:00:00+0500").
+     *
+     * @return the resulting value.
+     */
     DateExpression parseDate();
 
+    /**
+     * Converts {@code this} string to a {@linkplain DateExpression date},
+     * using the specified {@code format}.
+     *
+     * @mongodb.driver.manual reference/operator/aggregation/dateToString/#std-label-format-specifiers Format Specifiers
+     * @param format the format.
+     * @return the resulting value.
+     */
     DateExpression parseDate(StringExpression format);
 
+    /**
+     * Converts {@code this} string to a {@linkplain DateExpression date},
+     * using the specified {@code timezone} and {@code format}.
+     *
+     * @mongodb.driver.manual reference/operator/aggregation/dateToString/#std-label-format-specifiers Format Specifiers
+     * @param format the format.
+     * @param timezone the UTC Offset or Olson Timezone Identifier.
+     * @return the resulting value.
+     */
     DateExpression parseDate(StringExpression timezone, StringExpression format);
 
     /**

--- a/driver-core/src/main/com/mongodb/client/model/expressions/StringExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/StringExpression.java
@@ -16,13 +16,21 @@
 
 package com.mongodb.client.model.expressions;
 
+import com.mongodb.annotations.Beta;
+import com.mongodb.annotations.Sealed;
+
 import java.util.function.Function;
 
 import static com.mongodb.client.model.expressions.Expressions.of;
 
 /**
- * Expresses a string value.
+ * A string {@linkplain Expression value} in the context of the MongoDB Query
+ * Language (MQL).
+ *
+ * @since 4.9.0
  */
+@Sealed
+@Beta(Beta.Reason.CLIENT)
 public interface StringExpression extends Expression {
 
     /**
@@ -49,7 +57,7 @@ public interface StringExpression extends Expression {
     StringExpression concat(StringExpression other);
 
     /**
-     * The number of UTF-8 code points in {@code this} string.
+     * The number of Unicode code points in {@code this} string.
      *
      * @return the resulting value.
      */
@@ -67,11 +75,11 @@ public interface StringExpression extends Expression {
      * inclusive, and including the specified {@code length}, up to
      * the end of the string.
      *
-     * <p>Warning: the index position is in UTF-8 code points, not in
+     * <p>Warning: the index position is in Unicode code points, not in
      * UTF-8 encoded bytes.
      *
-     * @param start the start index in UTF-8 code points.
-     * @param length the length in UTF-8 code points.
+     * @param start the start index in Unicode code points.
+     * @param length the length in Unicode code points.
      * @return the resulting value.
      */
     StringExpression substr(IntegerExpression start, IntegerExpression length);
@@ -81,11 +89,11 @@ public interface StringExpression extends Expression {
      * inclusive, and including the specified {@code length}, up to
      * the end of the string.
      *
-     * <p>Warning: the index position is in UTF-8 code points, not in
+     * <p>Warning: the index position is in Unicode code points, not in
      * UTF-8 encoded bytes.
      *
-     * @param start the start index in UTF-8 code points.
-     * @param length the length in UTF-8 code points.
+     * @param start the start index in Unicode code points.
+     * @param length the length in Unicode code points.
      * @return the resulting value.
      */
     default StringExpression substr(final int start, final int length) {
@@ -98,7 +106,7 @@ public interface StringExpression extends Expression {
      * the end of the string.
      *
      * <p>The index position is in UTF-8 encoded bytes, not in
-     * UTF-8 code points.
+     * Unicode code points.
      *
      * @param start the start index in UTF-8 encoded bytes.
      * @param length the length in UTF-8 encoded bytes.
@@ -112,7 +120,7 @@ public interface StringExpression extends Expression {
      * the end of the string.
      *
      * <p>The index position is in UTF-8 encoded bytes, not in
-     * UTF-8 code points.
+     * Unicode code points.
      *
      * @param start the start index in UTF-8 encoded bytes.
      * @param length the length in UTF-8 encoded bytes.
@@ -135,20 +143,35 @@ public interface StringExpression extends Expression {
     /**
      * Converts {@code this} string to a {@linkplain DateExpression date}.
      *
-     * <p>This will cause an error if this string does not represent a valid
+     * <p>This method behaves like {@link #parseDate(StringExpression)},
+     * with the default format, which is {@code "%Y-%m-%dT%H:%M:%S.%LZ"}.
+     *
+     * <p>Will cause an error if this string does not represent a valid
      * date string (such as "2018-03-20", "2018-03-20T12:00:00Z", or
      * "2018-03-20T12:00:00+0500").
      *
+     * @see DateExpression#asString()
+     * @see DateExpression#asString(StringExpression, StringExpression)
      * @return the resulting value.
      */
     DateExpression parseDate();
 
     /**
      * Converts {@code this} string to a {@linkplain DateExpression date},
-     * using the specified {@code format}.
+     * using the specified {@code format}. UTC is assumed if the timezone
+     * offset element is not specified in the format.
      *
+     * <p>Will cause an error if {@code this} string does not match the
+     * specified {@code format}.
+     * Will cause an error if an element is specified that is finer-grained
+     * than an element that is not specified, with year being coarsest
+     * (for example, minute is specified, but hour is not).
+     * Omitted finer-grained elements will be parsed to 0.
+     *
+     * @see DateExpression#asString()
+     * @see DateExpression#asString(StringExpression, StringExpression)
      * @mongodb.server.release 4.0
-     * @mongodb.driver.manual reference/operator/aggregation/dateToString/#std-label-format-specifiers Format Specifiers
+     * @mongodb.driver.manual reference/operator/aggregation/dateFromString/ Format Specifiers, UTC Offset, and Olson Timezone Identifier
      * @param format the format.
      * @return the resulting value.
      */
@@ -158,7 +181,19 @@ public interface StringExpression extends Expression {
      * Converts {@code this} string to a {@linkplain DateExpression date},
      * using the specified {@code timezone} and {@code format}.
      *
-     * @mongodb.driver.manual reference/operator/aggregation/dateToString/#std-label-format-specifiers Format Specifiers
+
+     * <p>Will cause an error if {@code this} string does not match the
+     * specified {@code format}.
+     * Will cause an error if an element is specified that is finer-grained
+     * than an element that is not specified, with year being coarsest
+     * (for example, minute is specified, but hour is not).
+     * Omitted finer-grained elements will be parsed to 0.
+     * Will cause an error if the format includes an offset or
+     * timezone, even if it matches the supplied {@code timezone}.
+     *
+     * @see DateExpression#asString()
+     * @see DateExpression#asString(StringExpression, StringExpression)
+     * @mongodb.driver.manual reference/operator/aggregation/dateFromString/ Format Specifiers, UTC Offset, and Olson Timezone Identifier
      * @param format the format.
      * @param timezone the UTC Offset or Olson Timezone Identifier.
      * @return the resulting value.

--- a/driver-core/src/main/com/mongodb/client/model/expressions/StringExpression.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/StringExpression.java
@@ -127,6 +127,7 @@ public interface StringExpression extends Expression {
      *
      * <p>This will cause an error if this string does not represent an integer.
      *
+     * @mongodb.server.release 4.0
      * @return the resulting value.
      */
     IntegerExpression parseInteger();
@@ -146,6 +147,7 @@ public interface StringExpression extends Expression {
      * Converts {@code this} string to a {@linkplain DateExpression date},
      * using the specified {@code format}.
      *
+     * @mongodb.server.release 4.0
      * @mongodb.driver.manual reference/operator/aggregation/dateToString/#std-label-format-specifiers Format Specifiers
      * @param format the format.
      * @return the resulting value.

--- a/driver-core/src/main/com/mongodb/client/model/expressions/package-info.java
+++ b/driver-core/src/main/com/mongodb/client/model/expressions/package-info.java
@@ -15,11 +15,12 @@
  */
 
 /**
- * API for MQL expressions.
- *
  * @see com.mongodb.client.model.expressions.Expression
  * @see com.mongodb.client.model.expressions.Expressions
+ * @since 4.9.0
  */
+@Beta(Beta.Reason.CLIENT)
 @NonNullApi
 package com.mongodb.client.model.expressions;
+import com.mongodb.annotations.Beta;
 import com.mongodb.lang.NonNullApi;

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/ArithmeticExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/ArithmeticExpressionsFunctionalTest.java
@@ -22,11 +22,13 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.model.expressions.Expressions.numberToExpression;
 import static com.mongodb.client.model.expressions.Expressions.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @SuppressWarnings("ConstantConditions")
 class ArithmeticExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
@@ -225,6 +227,7 @@ class ArithmeticExpressionsFunctionalTest extends AbstractExpressionsFunctionalT
 
     @Test
     public void roundTest() {
+        assumeTrue(serverVersionAtLeast(4, 2));
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/round/
         IntegerExpression actual = of(5.5).round();
         assertExpression(

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/ArrayExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/ArrayExpressionsFunctionalTest.java
@@ -338,12 +338,9 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/arrayElemAt/
         assertExpression(
                 Arrays.asList(1, 2, 3).get(0),
-                // 0.0 is a valid integer value
-                array123.elementAt(of(0.0).isIntegerOr(of(-1))),
+                array123.elementAt(of(0)),
                 // MQL:
-                "{'$arrayElemAt': [[1, 2, 3], {'$switch': {'branches': [{'case': "
-                        + "{'$isNumber': [0.0]}, 'then': {'$cond': "
-                        + "[{'$eq': [{'$round': 0.0}, 0.0]}, 0.0, -1]}}], 'default': -1}}]} ");
+                "{'$arrayElemAt': [[1, 2, 3], 0]}");
         // negatives
         assertExpression(
                 Arrays.asList(1, 2, 3).get(3 - 1),
@@ -365,10 +362,17 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertThrows(MongoCommandException.class, () -> assertExpression(
                 MISSING,
                 array123.elementAt(of(Long.MAX_VALUE))));
+
+        // 0.0 is a valid integer value
+        assumeTrue(serverVersionAtLeast(4, 4)); // isNumber
+        assertExpression(
+                Arrays.asList(1, 2, 3).get(0),
+                array123.elementAt(of(0.0).isIntegerOr(of(-1))));
     }
 
     @Test
     public void firstTest() {
+        assumeTrue(serverVersionAtLeast(4, 4));
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/first/
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/first-array-element/
         assertExpression(
@@ -386,6 +390,7 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void lastTest() {
+        assumeTrue(serverVersionAtLeast(4, 4));
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/last-array-element/
         assertExpression(
                 new LinkedList<>(Arrays.asList(1, 2, 3)).getLast(),

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/ArrayExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/ArrayExpressionsFunctionalTest.java
@@ -201,6 +201,19 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
     }
 
     @Test
+    public void reduceMultiplyTest() {
+        assertExpression(
+                6,
+                ofIntegerArray(1, 2, 3).multiply(a -> a),
+                "{'$reduce': {'input': {'$map': {'input': [1, 2, 3], 'in': '$$this'}}, "
+                        + "'initialValue': 1, 'in': {'$multiply': ['$$value', '$$this']}}}");
+        // empty array:
+        assertExpression(
+                1,
+                ofIntegerArray().multiply(a -> a));
+    }
+
+    @Test
     public void reduceMaxTest() {
         assertExpression(
                 3,

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/ArrayExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/ArrayExpressionsFunctionalTest.java
@@ -43,7 +43,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @SuppressWarnings({"Convert2MethodRef"})
 class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
     // https://www.mongodb.com/docs/manual/reference/operator/aggregation/#array-expression-operators
-    // (Incomplete)
 
     private final ArrayExpression<IntegerExpression> array123 = ofIntegerArray(1, 2, 3);
     private final ArrayExpression<BooleanExpression> arrayTTF = ofBooleanArray(true, true, false);
@@ -115,7 +114,6 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
                 Stream.of(true, true, false)
                         .filter(v -> v).collect(Collectors.toList()),
                 arrayTTF.filter(v -> v),
-                // MQL:
                 "{'$filter': {'input': [true, true, false], 'cond': '$$this'}}");
     }
 
@@ -126,7 +124,6 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
                 Stream.of(true, true, false)
                         .map(v -> !v).collect(Collectors.toList()),
                 arrayTTF.map(v -> v.not()),
-                // MQL:
                 "{'$map': {'input': [true, true, false], 'in': {'$not': '$$this'}}}");
     }
 
@@ -137,7 +134,6 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertExpression(
                 Stream.of(3, 1, 2)
                         .sorted().collect(Collectors.toList()), sort(integerExpressionArrayExpression),
-                // MQL:
                 "{'$sortArray': {'input': [3, 1, 2], 'sortBy': 1}}");
     }
 
@@ -305,7 +301,6 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertExpression(
                 Arrays.asList(1, 2, 3),
                 sort(ofArray(ofIntegerArray(1, 2), ofIntegerArray(1, 3)).union(v -> v)),
-                // MQL:
                 "{'$sortArray': {'input': {'$reduce': {'input': "
                         + "{'$map': {'input': [[1, 2], [1, 3]], 'in': '$$this'}}, "
                         + "'initialValue': [], 'in': {'$setUnion': ['$$value', '$$this']}}}, 'sortBy': 1}}");
@@ -324,12 +319,10 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertExpression(
                 Arrays.asList(1, 2, 3).size(),
                 array123.size(),
-                // MQL:
                 "{'$size': [[1, 2, 3]]}");
         assertExpression(
                 0,
                 ofIntegerArray().size(),
-                // MQL:
                 "{'$size': [[]]}");
     }
 
@@ -339,7 +332,6 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertExpression(
                 Arrays.asList(1, 2, 3).get(0),
                 array123.elementAt(of(0)),
-                // MQL:
                 "{'$arrayElemAt': [[1, 2, 3], 0]}");
         // negatives
         assertExpression(
@@ -378,13 +370,11 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertExpression(
                 new LinkedList<>(Arrays.asList(1, 2, 3)).getFirst(),
                 array123.first(),
-                // MQL:
                 "{'$first': [[1, 2, 3]]}");
 
         assertExpression(
                 MISSING,
                 ofIntegerArray().first(),
-                // MQL:
                 "{'$first': [[]]}");
     }
 
@@ -395,13 +385,11 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertExpression(
                 new LinkedList<>(Arrays.asList(1, 2, 3)).getLast(),
                 array123.last(),
-                // MQL:
                 "{'$last': [[1, 2, 3]]}");
 
         assertExpression(
                 MISSING,
                 ofIntegerArray().last(),
-                // MQL:
                 "{'$last': [[]]}");
     }
 
@@ -412,7 +400,6 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertExpression(
                 Arrays.asList(1, 2, 3).contains(2),
                 array123.contains(of(2)),
-                // MQL:
                 "{'$in': [2, [1, 2, 3]]}");
     }
 
@@ -423,7 +410,6 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
                 Stream.concat(Stream.of(1, 2, 3), Stream.of(1, 2, 3))
                         .collect(Collectors.toList()),
                 ofIntegerArray(1, 2, 3).concat(ofIntegerArray(1, 2, 3)),
-                // MQL:
                 "{'$concatArrays': [[1, 2, 3], [1, 2, 3]]}");
         // mixed types:
         assertExpression(
@@ -437,7 +423,6 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertExpression(
                 Arrays.asList(1, 2, 3).subList(1, 3),
                 array123.slice(1, 10),
-                // MQL:
                 "{'$slice': [[1, 2, 3], 1, 10]}");
 
         ArrayExpression<IntegerExpression> array12345 = ofIntegerArray(1, 2, 3, 4, 5);
@@ -460,7 +445,6 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertExpression(
                 Arrays.asList(1, 2, 3),
                 sort(array123.union(array123)),
-                // MQL:
                 "{'$sortArray': {'input': {'$setUnion': [[1, 2, 3], [1, 2, 3]]}, 'sortBy': 1}}");
         // mixed types:
         assertExpression(

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/ArrayExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/ArrayExpressionsFunctionalTest.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.model.expressions.Expressions.of;
 import static com.mongodb.client.model.expressions.Expressions.ofArray;
 import static com.mongodb.client.model.expressions.Expressions.ofBooleanArray;
@@ -37,6 +38,7 @@ import static com.mongodb.client.model.expressions.Expressions.ofIntegerArray;
 import static com.mongodb.client.model.expressions.Expressions.ofNumberArray;
 import static com.mongodb.client.model.expressions.Expressions.ofStringArray;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @SuppressWarnings({"Convert2MethodRef"})
 class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
@@ -141,6 +143,7 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @SuppressWarnings("unchecked")
     private static ArrayExpression<? extends NumberExpression> sort(final ArrayExpression<? extends NumberExpression> array) {
+        assumeTrue(serverVersionAtLeast(5, 2)); // due to sort
         MqlExpression<? extends NumberExpression> mqlArray = (MqlExpression<? extends NumberExpression>) array;
         return mqlArray.sort();
     }
@@ -215,6 +218,7 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void reduceMaxTest() {
+        assumeTrue(serverVersionAtLeast(5, 2));
         assertExpression(
                 3,
                 ofIntegerArray(1, 2, 3).max(of(9)),
@@ -227,6 +231,7 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void reduceMinTest() {
+        assumeTrue(serverVersionAtLeast(5, 2));
         assertExpression(
                 1,
                 ofIntegerArray(1, 2, 3).min(of(9)),
@@ -239,6 +244,7 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void reduceMaxNTest() {
+        assumeTrue(serverVersionAtLeast(5, 2));
         assertExpression(
                 Arrays.asList(3, 2),
                 ofIntegerArray(3, 1, 2).maxN(of(2)));
@@ -253,6 +259,7 @@ class ArrayExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void reduceMinNTest() {
+        assumeTrue(serverVersionAtLeast(5, 2));
         assertExpression(
                 Arrays.asList(1, 2),
                 ofIntegerArray(3, 1, 2).minN(of(2)));

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/ControlExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/ControlExpressionsFunctionalTest.java
@@ -22,11 +22,13 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.util.function.Function;
 
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.model.expressions.Expressions.of;
 import static com.mongodb.client.model.expressions.Expressions.ofArray;
 import static com.mongodb.client.model.expressions.Expressions.ofIntegerArray;
 import static com.mongodb.client.model.expressions.Expressions.ofMap;
 import static com.mongodb.client.model.expressions.Expressions.ofNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class ControlExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
@@ -107,6 +109,8 @@ class ControlExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest
 
     @Test
     public void switchTypesTest() {
+        // isIntegerOr relies on switch short-circuiting, which only happens after 5.2
+        assumeTrue(serverVersionAtLeast(5, 2));
         Function<Expression, StringExpression> label = expr -> expr.switchOn(on -> on
                 .isBoolean(v -> v.asString().concat(of(" - bool")))
                 // integer should be checked before string

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/DocumentExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/DocumentExpressionsFunctionalTest.java
@@ -261,4 +261,17 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
         DocumentExpression d = ofDoc("{a: 1}");
         assertSame(d, d.asMap());
     }
+
+
+    @Test
+    public void hasTest() {
+        DocumentExpression d = ofDoc("{a: 1}");
+        assertExpression(
+                true,
+                d.has("a"),
+                "{'$ne': [{'$getField': {'input': {'$literal': {'a': 1}}, 'field': 'a'}}, '$$REMOVE']}");
+        assertExpression(
+                false,
+                d.has("not_a"));
+    }
 }

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/DocumentExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/DocumentExpressionsFunctionalTest.java
@@ -25,11 +25,13 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.util.Arrays;
 
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.model.expressions.Expressions.of;
 import static com.mongodb.client.model.expressions.Expressions.ofIntegerArray;
 import static com.mongodb.client.model.expressions.Expressions.ofMap;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @SuppressWarnings("ConstantConditions")
 class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
@@ -69,6 +71,7 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
 
     @Test
     public void getFieldTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/getField/ (100)
         // these count as assertions by the user that the value is of the correct type
 
@@ -112,6 +115,7 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
 
     @Test
     public void getFieldOrTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         // convenience
         assertExpression(true, ofDoc("{a: true}").getBoolean("a", false));
         assertExpression(1.0, ofDoc("{a: 1.0}").getNumber("a", 99));
@@ -160,6 +164,7 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
 
     @Test
     public void getFieldMissingTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         // missing fields
         assertExpression(
                 BsonDocument.parse("{'a': 1}"),
@@ -182,6 +187,7 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
 
     @Test
     public void setFieldTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/
         // Placing a field based on a literal:
         assertExpression(
@@ -231,6 +237,7 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
 
     @Test
     public void unsetFieldTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField (unset)
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/unsetField/
         assertExpression(
                 BsonDocument.parse("{}"), // map.remove("a")
@@ -265,6 +272,7 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
 
     @Test
     public void hasTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         DocumentExpression d = ofDoc("{a: 1}");
         assertExpression(
                 true,

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/DocumentExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/DocumentExpressionsFunctionalTest.java
@@ -193,21 +193,18 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
         assertExpression(
                 BsonDocument.parse("{a: 1, r: 2}"), // map.put("r", 2)
                 a1.setField("r", of(2)),
-                // MQL:
                 "{'$setField': {'field': 'r', 'input': {'$literal': {'a': 1}}, 'value': 2}}");
 
         // Placing a null value:
         assertExpression(
                 BsonDocument.parse("{a: 1, r: null}"), // map.put("r", null)
                 a1.setField("r", Expressions.ofNull()),
-                // MQL:
                 "{'$setField': {'field': 'r', 'input': {'$literal': {'a': 1}}, 'value': null}}");
 
         // Replacing a field based on its prior value:
         assertExpression(
                 BsonDocument.parse("{a: 3}"), // map.put("a", map.get("a") * 3)
                 a1.setField("a", a1.getInteger("a").multiply(3)),
-                // MQL:
                 "{'$setField': {'field': 'a', 'input': {'$literal': {'a': 1}}, 'value': "
                         + "{'$multiply': [{'$getField': {'input': {'$literal': {'a': 1}}, 'field': 'a'}}, 3]}}}");
 
@@ -215,7 +212,6 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
         assertExpression(
                 BsonDocument.parse("{'a': {'x': 1, 'y': 2}, r: 10}"),
                 ax1ay2.setField("r", ax1ay2.getDocument("a").getInteger("x").multiply(10)),
-                // MQL:
                 "{'$setField': {'field': 'r', 'input': {'$literal': {'a': {'x': 1, 'y': 2}}}, "
                         + "'value': {'$multiply': ["
                         + "  {'$getField': {'input': {'$getField': {'input': {'$literal': {'a': {'x': 1, 'y': 2}}}, "
@@ -242,7 +238,6 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
         assertExpression(
                 BsonDocument.parse("{}"), // map.remove("a")
                 a1.unsetField("a"),
-                // MQL:
                 "{'$unsetField': {'field': 'a', 'input': {'$literal': {'a': 1}}}}");
     }
 
@@ -273,13 +268,16 @@ class DocumentExpressionsFunctionalTest extends AbstractExpressionsFunctionalTes
     @Test
     public void hasTest() {
         assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
-        DocumentExpression d = ofDoc("{a: 1}");
+        DocumentExpression d = ofDoc("{a: 1, null: null}");
         assertExpression(
                 true,
                 d.has("a"),
-                "{'$ne': [{'$getField': {'input': {'$literal': {'a': 1}}, 'field': 'a'}}, '$$REMOVE']}");
+                "{'$ne': [{'$getField': {'input': {'$literal': {'a': 1, 'null': null}}, 'field': 'a'}}, '$$REMOVE']}");
         assertExpression(
                 false,
                 d.has("not_a"));
+        assertExpression(
+                true,
+                d.has("null"));
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
@@ -76,21 +76,27 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
                 mapKey123.unset("key"));
         // "other" parameter
         assertExpression(
-                1,
+                null,
                 ofMap(Document.parse("{ 'null': null }")).get("null", of(1)));
     }
 
     @Test
     public void hasTest() {
         assumeTrue(serverVersionAtLeast(5, 0)); // get/setField (unset)
-        MapExpression<Expression> e = ofMap(BsonDocument.parse("{key: 1}"));
+        MapExpression<Expression> e = ofMap(BsonDocument.parse("{key: 1, null: null}"));
         assertExpression(
                 true,
                 e.has(of("key")),
-                "{'$ne': [{'$getField': {'input': {'$literal': {'key': 1}}, 'field': 'key'}}, '$$REMOVE']}");
+                "{'$ne': [{'$getField': {'input': {'$literal': {'key': 1, 'null': null}}, 'field': 'key'}}, '$$REMOVE']}");
         assertExpression(
                 false,
                 e.has("not_key"));
+        assertExpression(
+                true,
+                e.has("null"));
+        // consistency:
+        assertExpression(true, e.has("null"));
+        assertExpression(null, e.get("null", of(1)));
     }
 
     @Test

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
@@ -77,15 +77,15 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
     }
 
     @Test
-    public void hasMapTest() {
+    public void hasTest() {
+        MapExpression<Expression> e = ofMap(BsonDocument.parse("{key: 1}"));
         assertExpression(
                 true,
-                mapKey123.has(of("key")),
-                "{'$ne': [{'$getField': {'input': {'$setField': {'field': 'key', 'input': "
-                        + "{'$literal': {}}, 'value': 123}}, 'field': 'key'}}, '$$REMOVE']}");
+                e.has(of("key")),
+                "{'$ne': [{'$getField': {'input': {'$literal': {'key': 1}}, 'field': 'key'}}, '$$REMOVE']}");
         assertExpression(
                 false,
-                mapKey123.has("not_key"));
+                e.has("not_key"));
     }
 
     @Test

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/MapExpressionsFunctionalTest.java
@@ -22,12 +22,14 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.model.expressions.Expressions.of;
 import static com.mongodb.client.model.expressions.Expressions.ofArray;
 import static com.mongodb.client.model.expressions.Expressions.ofEntry;
 import static com.mongodb.client.model.expressions.Expressions.ofMap;
 import static com.mongodb.client.model.expressions.Expressions.ofStringArray;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
@@ -38,23 +40,25 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void literalsTest() {
-        // map
-        assertExpression(
-                Document.parse("{key: 123}"),
-                mapKey123,
-                "{'$setField': {'field': 'key', 'input': {'$literal': {}}, 'value': 123}}");
-        assertExpression(
-                Document.parse("{keyA: 1, keyB: 2}"),
-                ofMap(Document.parse("{keyA: 1, keyB: 2}")),
-                "{'$literal': {'keyA': 1, 'keyB': 2}}");
         // entry
         assertExpression(
                 Document.parse("{k: 'keyA', v: 1}"),
                 ofEntry(of("keyA"), of(1)));
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField (unset)
+        // map
+        assertExpression(
+                Document.parse("{keyA: 1, keyB: 2}"),
+                ofMap(Document.parse("{keyA: 1, keyB: 2}")),
+                "{'$literal': {'keyA': 1, 'keyB': 2}}");
+        assertExpression(
+                Document.parse("{key: 123}"),
+                mapKey123,
+                "{'$setField': {'field': 'key', 'input': {'$literal': {}}, 'value': 123}}");
     }
 
     @Test
     public void getSetMapTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         // get
         assertExpression(
                 123,
@@ -78,6 +82,7 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void hasTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField (unset)
         MapExpression<Expression> e = ofMap(BsonDocument.parse("{key: 1}"));
         assertExpression(
                 true,
@@ -90,6 +95,7 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void getSetEntryTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         EntryExpression<IntegerExpression> entryA1 = ofEntry(of("keyA"), of(1));
         assertExpression(
                 Document.parse("{k: 'keyA', 'v': 33}"),
@@ -110,6 +116,7 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
                 ofArray(ofEntry(of("keyA"), of(1))).asMap(v -> v),
                 "{'$arrayToObject': [{'$map': {'input': [{'k': 'keyA', 'v': 1}], 'in': '$$this'}}]}");
 
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         assertExpression(
                 Document.parse("{'keyA': 55}"),
                 ofArray(ofEntry(of("keyA"), of(1))).asMap(v -> v.setValue(of(55))),
@@ -142,6 +149,7 @@ class MapExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void entrySetTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/objectToArray/ (23)
         assertExpression(
                 Arrays.asList(Document.parse("{'k': 'k1', 'v': 1}")),

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/NotNullApiTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/NotNullApiTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model.expressions;
+
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
+import org.bson.types.Decimal128;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static com.mongodb.assertions.Assertions.fail;
+import static com.mongodb.client.model.expressions.Expressions.of;
+import static com.mongodb.client.model.expressions.Expressions.ofArray;
+import static com.mongodb.client.model.expressions.Expressions.ofMap;
+import static com.mongodb.client.model.expressions.Expressions.ofNull;
+
+class NotNullApiTest {
+
+    @Test
+    public void notNullApiTest() {
+        Map<Class<?>, Object> mapping = new HashMap<>();
+        Map<Class<?>, Object> paramMapping = new HashMap<>();
+
+        // to test:
+        mapping.put(Expressions.class, null);
+        mapping.put(BooleanExpression.class, of(true));
+        mapping.put(IntegerExpression.class, of(1));
+        mapping.put(NumberExpression.class, of(1.0));
+        mapping.put(StringExpression.class, of(""));
+        mapping.put(DateExpression.class, of(Instant.now()));
+        mapping.put(DocumentExpression.class, of(BsonDocument.parse("{}")));
+        mapping.put(MapExpression.class, ofMap(BsonDocument.parse("{}")));
+        mapping.put(ArrayExpression.class, ofArray());
+        mapping.put(Expression.class, ofNull());
+        mapping.put(Branches.class, new Branches<>());
+        mapping.put(BranchesIntermediary.class, new BranchesIntermediary<>(Collections.emptyList()));
+        mapping.put(BranchesTerminal.class, new BranchesTerminal<>(Collections.emptyList(), null));
+
+        // additional params from classes not tested:
+        paramMapping.put(String.class, "");
+        paramMapping.put(Instant.class, Instant.now());
+        paramMapping.put(Bson.class, BsonDocument.parse("{}"));
+        paramMapping.put(Function.class, Function.identity());
+        paramMapping.put(Number.class, 1);
+        paramMapping.put(int.class, 1);
+        paramMapping.put(boolean.class, true);
+        paramMapping.put(long.class, 1L);
+        paramMapping.put(Object.class, new Object());
+        paramMapping.put(Decimal128.class, new Decimal128(1));
+        putArray(paramMapping, Expression.class);
+        putArray(paramMapping, boolean.class);
+        putArray(paramMapping, long.class);
+        putArray(paramMapping, int.class);
+        putArray(paramMapping, double.class);
+        putArray(paramMapping, Decimal128.class);
+        putArray(paramMapping, Instant.class);
+        putArray(paramMapping, String.class);
+
+        checkNotNullApi(mapping, paramMapping);
+    }
+
+    private void putArray(final Map<Class<?>, Object> paramMapping, final Class<?> componentType) {
+        final Object o = Array.newInstance(componentType, 0);
+        paramMapping.put(o.getClass(), o);
+    }
+
+    private void checkNotNullApi(
+            final Map<Class<?>, Object> mapping,
+            final Map<Class<?>, Object> paramMapping) {
+        Map<Class<?>, Object> allParams = new HashMap<>();
+        allParams.putAll(mapping);
+        allParams.putAll(paramMapping);
+        List<String> uncheckedMethods = new ArrayList<>();
+        for (Map.Entry<Class<?>, Object> entry : mapping.entrySet()) {
+            Object instance = entry.getValue();
+            Class<?> clazz = entry.getKey();
+            Method[] methods = clazz.getDeclaredMethods();
+            for (Method method : methods) {
+                if (!Modifier.isPublic(method.getModifiers())) {
+                    continue;
+                }
+                boolean failed = false;
+                for (int i = 0; i < method.getParameterCount(); i++) {
+                    if (method.getParameterTypes()[i].isPrimitive()) {
+                        continue;
+                    }
+                    if (method.toString().endsWith(".equals(java.lang.Object)")) {
+                        continue;
+                    }
+                    Object[] args = createArgs(allParams, method);
+                    args[i] = null; // set one parameter to null
+                    try {
+                        // the method needs to throw due to Assertions.notNull:
+                        method.invoke(instance, args);
+                        failed = true;
+                    } catch (Exception e) {
+                        Throwable cause = e.getCause();
+                        if (!(cause instanceof IllegalArgumentException)) {
+                            failed = true;
+                            continue;
+                        }
+                        StackTraceElement[] trace = cause.getStackTrace();
+                        if (!method.getName().equals(trace[1].getMethodName())) {
+                            failed = true;
+                        }
+                        if (!"notNull".equals(trace[0].getMethodName())) {
+                            failed = true;
+                        }
+                    }
+                }
+                if (failed) {
+                    uncheckedMethods.add("> " + method);
+                }
+            }
+        }
+        if (uncheckedMethods.size() > 0) {
+            fail("Assertions.notNull must be called on parameter from "
+                    + uncheckedMethods.size() + " methods:\n"
+                    + String.join("\n", uncheckedMethods));
+        }
+    }
+
+    private Object[] createArgs(final Map<Class<?>, ?> mapping, final Method method) {
+        Object[] args = new Object[method.getParameterCount()];
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        for (int j = 0; j < parameterTypes.length; j++) {
+            Class<?> p = parameterTypes[j];
+            Object arg = mapping.get(p);
+            if (arg == null) {
+                throw new IllegalArgumentException("mappings did not contain parameter of type: "
+                        + p + " for method " + method);
+            }
+            args[j] = arg;
+        }
+        return args;
+    }
+
+}

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/StringExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/StringExpressionsFunctionalTest.java
@@ -130,6 +130,10 @@ class StringExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest 
                 "abc".substring(1, 1 + 1),
                 of("abc").substr(of(1), of(1)),
                 "{'$substrCP': ['abc', 1, 1]}");
+        assertExpression(
+                "bc",
+                of("abc").substr(of(1), of(100)),
+                "{'$substrCP': ['abc', 1, 100]}");
 
         // unicode
         assertExpression(

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/TypeExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/TypeExpressionsFunctionalTest.java
@@ -56,6 +56,7 @@ class TypeExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void isNumberOrTest() {
+        assumeTrue(serverVersionAtLeast(4, 4));
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/isNumber/
         assertExpression(1, of(1).isNumberOr(of(99)), "{'$cond': [{'$isNumber': [1]}, 1, 99]}");
         // other numeric values:

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/TypeExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/TypeExpressionsFunctionalTest.java
@@ -263,6 +263,24 @@ class TypeExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
         assertExpression(
                 longVal,
                 of(longVal + "").parseInteger());
+
+        // failures
+        assertThrows(MongoCommandException.class, () ->
+            assertExpression(
+                    "",
+                    of(BsonDocument.parse("{a:'1.5'}")).getString("a").parseInteger()));
+        assertThrows(MongoCommandException.class, () ->
+            assertExpression(
+                    "",
+                    of(BsonDocument.parse("{a:'not an integer'}")).getString("a").parseInteger()));
+        assertThrows(MongoCommandException.class, () ->
+            assertExpression(
+                    "",
+                    of("1.5").parseInteger()));
+        assertThrows(MongoCommandException.class, () ->
+            assertExpression(
+                    "",
+                    of("not an integer").parseInteger()));
     }
 
     // non-string

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/TypeExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/TypeExpressionsFunctionalTest.java
@@ -173,6 +173,7 @@ class TypeExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void asStringTest() {
+        assumeTrue(serverVersionAtLeast(4, 0));
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/toString/
         // asString, since toString conflicts
         assertExpression("false", of(false).asString(), "{'$toString': [false]}");
@@ -198,6 +199,7 @@ class TypeExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void dateAsStringTest() {
+        assumeTrue(serverVersionAtLeast(4, 0));
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateToString/
         final Instant instant = Instant.parse("2007-12-03T10:15:30.005Z");
         DateExpression date = of(instant);
@@ -229,6 +231,7 @@ class TypeExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void parseDateTest() {
+        assumeTrue(serverVersionAtLeast(4, 0));
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateToString/
         String dateString = "2007-12-03T10:15:30.005Z";
         assertExpression(
@@ -253,6 +256,7 @@ class TypeExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void parseIntegerTest() {
+        assumeTrue(serverVersionAtLeast(4, 0));
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/toInt/
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/toLong/
         assertExpression(
@@ -292,6 +296,7 @@ class TypeExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void millisecondsToDateTest() {
+        assumeTrue(serverVersionAtLeast(4, 0));
         // https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDate/
         assertExpression(
                 Instant.ofEpochMilli(1234),

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/TypeExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/TypeExpressionsFunctionalTest.java
@@ -252,6 +252,20 @@ class TypeExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
                     .parseDate(of("%Y-%m-%dT%H:%M:%S.%L%z")),
                 "{'$dateFromString': {'dateString': '2007-12-03T10:15:30.005+01:00', "
                         + "'format': '%Y-%m-%dT%H:%M:%S.%L%z'}}");
+
+        // missing items:
+        assertExpression(
+                Instant.parse("2007-12-03T10:15:00.000Z"),
+                of("2007-12-03T10:15").parseDate(of("%Y-%m-%dT%H:%M")));
+        assertThrows(MongoCommandException.class, () -> assertExpression(
+                "an incomplete date/time string has been found, with elements missing",
+                of("-12-03T10:15").parseDate(of("-%m-%dT%H:%M")).asString()));
+        assertThrows(MongoCommandException.class, () -> assertExpression(
+                "an incomplete date/time string has been found, with elements missing",
+                of("2007--03T10:15").parseDate(of("%Y--%dT%H:%M")).asString()));
+        assertThrows(MongoCommandException.class, () -> assertExpression(
+                "an incomplete date/time string has been found, with elements missing",
+                of("").parseDate(of("")).asString()));
     }
 
     @Test

--- a/driver-core/src/test/functional/com/mongodb/client/model/expressions/TypeExpressionsFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/expressions/TypeExpressionsFunctionalTest.java
@@ -28,12 +28,14 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.model.expressions.Expressions.of;
 import static com.mongodb.client.model.expressions.Expressions.ofIntegerArray;
 import static com.mongodb.client.model.expressions.Expressions.ofMap;
 import static com.mongodb.client.model.expressions.Expressions.ofNull;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class TypeExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
     // https://www.mongodb.com/docs/manual/reference/operator/aggregation/#type-expression-operators
@@ -67,6 +69,8 @@ class TypeExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
     @Test
     public void isIntegerOr() {
+        // isIntegerOr relies on switch short-circuiting, which only happens after 5.2
+        assumeTrue(serverVersionAtLeast(5, 2));
         assertExpression(
                 1,
                 of(1).isIntegerOr(of(99)),

--- a/driver-sync/src/test/functional/com/mongodb/client/model/expressions/InContextExpressionsFunctionalTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/model/expressions/InContextExpressionsFunctionalTest.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.model.Accumulators.sum;
 import static com.mongodb.client.model.Aggregates.match;
 import static com.mongodb.client.model.Aggregates.project;
@@ -46,6 +47,7 @@ import static com.mongodb.client.model.expressions.Expressions.current;
 import static com.mongodb.client.model.expressions.Expressions.of;
 import static com.mongodb.client.model.expressions.Expressions.ofArray;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class InContextExpressionsFunctionalTest extends AbstractExpressionsFunctionalTest {
 
@@ -77,6 +79,7 @@ class InContextExpressionsFunctionalTest extends AbstractExpressionsFunctionalTe
 
     @Test
     public void findTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         col.insertMany(Arrays.asList(
                 Document.parse("{_id: 1, x: 0, y: 2}"),
                 Document.parse("{_id: 2, x: 0, y: 3}"),
@@ -94,6 +97,7 @@ class InContextExpressionsFunctionalTest extends AbstractExpressionsFunctionalTe
 
     @Test
     public void matchTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         col.insertMany(Arrays.asList(
                 Document.parse("{_id: 1, x: 0, y: 2}"),
                 Document.parse("{_id: 2, x: 0, y: 3}"),
@@ -109,6 +113,7 @@ class InContextExpressionsFunctionalTest extends AbstractExpressionsFunctionalTe
 
     @Test
     public void currentAsMapMatchTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         col.insertMany(Arrays.asList(
                 Document.parse("{_id: 1, x: 0, y: 2}"),
                 Document.parse("{_id: 2, x: 0, y: 3}"),
@@ -127,6 +132,7 @@ class InContextExpressionsFunctionalTest extends AbstractExpressionsFunctionalTe
 
     @Test
     public void projectTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         col.insertMany(Arrays.asList(
                 Document.parse("{_id: 1, x: 0, y: 2}")));
 
@@ -153,6 +159,7 @@ class InContextExpressionsFunctionalTest extends AbstractExpressionsFunctionalTe
 
     @Test
     public void projectTest2() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         col.insertMany(Arrays.asList(Document.parse("{_id: 0, x: 1}")));
 
         // new, nestedArray
@@ -177,6 +184,7 @@ class InContextExpressionsFunctionalTest extends AbstractExpressionsFunctionalTe
 
     @Test
     public void groupTest() {
+        assumeTrue(serverVersionAtLeast(5, 0)); // get/setField
         col.insertMany(Arrays.asList(
                 Document.parse("{t: 0, a: 1}"),
                 Document.parse("{t: 0, a: 2}"),


### PR DESCRIPTION
The remaining docs for [JAVA-4799](https://jira.mongodb.org/browse/JAVA-4799), continuing #1059.

Also adds `has` to document, and a fix to multiply (found while writing docs).