### PR TITLE
Ensure BatchCursorFlux does not drop an error

### DIFF
--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursor.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursor.java
@@ -21,21 +21,29 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 
-import static com.mongodb.reactivestreams.client.internal.MongoOperationPublisher.sinkToCallback;
-
 /**
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class BatchCursor<T> implements AutoCloseable {
 
     private final AsyncBatchCursor<T> wrapped;
+    private volatile boolean cursorClosed = false;
 
     public BatchCursor(final AsyncBatchCursor<T> wrapped) {
         this.wrapped = wrapped;
     }
 
     public Publisher<List<T>> next() {
-        return Mono.create(sink -> wrapped.next(sinkToCallback(sink)));
+        return Mono.create(sink -> wrapped.next(
+                (result, t) -> {
+                    if (t != null && !cursorClosed) {
+                        sink.error(t);
+                    } else if (result == null) {
+                        sink.success();
+                    } else {
+                        sink.success(result);
+                    }
+                }));
     }
 
     public void setBatchSize(final int batchSize) {
@@ -51,6 +59,7 @@ public class BatchCursor<T> implements AutoCloseable {
     }
 
     public void close() {
+        cursorClosed = true;
         wrapped.close();
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursor.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursor.java
@@ -17,13 +17,11 @@ package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.internal.async.AsyncBatchCursor;
 import org.reactivestreams.Publisher;
-import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.function.Supplier;
 
-import static com.mongodb.reactivestreams.client.internal.MongoOperationPublisher.sinkToCallback;
 
 /**
  * <p>This class is not part of the public API and may be removed or changed at any time</p>

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
@@ -84,7 +84,7 @@ class BatchCursorFlux<T> implements Publisher<T> {
                 sink.complete();
             } else {
                 batchCursor.setBatchSize(calculateBatchSize(sink.requestedFromDownstream()));
-                Mono.from(batchCursor.nextWithSink(sink))
+                Mono.from(batchCursor.next(() -> sink.isCancelled()))
                         .doOnCancel(this::closeCursor)
                         .doOnError((e) -> {
                             try {

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
@@ -84,7 +84,7 @@ class BatchCursorFlux<T> implements Publisher<T> {
                 sink.complete();
             } else {
                 batchCursor.setBatchSize(calculateBatchSize(sink.requestedFromDownstream()));
-                Mono.from(batchCursor.next())
+                Mono.from(batchCursor.nextWithSink(sink))
                         .doOnCancel(this::closeCursor)
                         .doOnError((e) -> {
                             try {

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorFluxTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorFluxTest.java
@@ -344,9 +344,9 @@ public class BatchCursorFluxTest {
         subscriber.assertReceivedOnNext(docs.subList(0, 100));
         assertCommandNames(asList("find", "getMore"));
 
-         BsonDocument getMoreCommand = commandListener.getCommandStartedEvents().stream()
+        BsonDocument getMoreCommand = commandListener.getCommandStartedEvents().stream()
                 .filter(e -> e.getCommandName().equals("getMore"))
-                .map(e -> ((CommandStartedEvent)e).getCommand())
+                .map(e -> ((CommandStartedEvent) e).getCommand())
                 .findFirst()
                 .get();
 


### PR DESCRIPTION
The BatchCursor class can be closed by the BatchCursorFlux class but there is no signalling for the BatchCursor onNext publisher.

This leads to a next() called after the cursor was closed error and that breaks the reactive streams spec as the error ends up being dropped.

JAVA-4849