### PR TITLE
Fix the "database name is too long" error that happens when running against Serverless

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionAutoDataKeysTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionAutoDataKeysTest.java
@@ -88,7 +88,7 @@ public abstract class AbstractClientSideEncryptionAutoDataKeysTest {
                         provider -> provider.name, provider -> provider.propertiesSupplier)))
                 .build());
         client.getDatabase(KEY_VAULT_NAMESPACE.getDatabaseName()).drop();
-        db = client.getDatabase(AbstractClientSideEncryptionAutoDataKeysTest.class.getSimpleName());
+        db = client.getDatabase("test");
         db.drop();
     }
 

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionAutoDataKeysTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionAutoDataKeysTest.java
@@ -88,7 +88,7 @@ public abstract class AbstractClientSideEncryptionAutoDataKeysTest {
                         provider -> provider.name, provider -> provider.propertiesSupplier)))
                 .build());
         client.getDatabase(KEY_VAULT_NAMESPACE.getDatabaseName()).drop();
-        db = client.getDatabase("test");
+        db = client.getDatabase("autoDataKeysTest");
         db.drop();
     }
 


### PR DESCRIPTION
JAVA-4679