### PR TITLE
fix: ensure no NPE is thrown with SerializedFluxSink

### DIFF
--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
@@ -24,6 +24,7 @@ import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 import reactor.util.context.Context;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -95,7 +96,10 @@ class BatchCursorFlux<T> implements Publisher<T> {
                         })
                         .doOnSuccess(results -> {
                             if (results != null) {
-                                results.forEach(sink::next);
+                                results
+                                        .stream()
+                                        .filter(Objects::nonNull)
+                                        .forEach(sink::next);
                                 calculateDemand(-results.size());
                             }
                             if (batchCursor.isClosed()) {

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorFluxTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorFluxTest.java
@@ -46,6 +46,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -321,6 +323,32 @@ public class BatchCursorFluxTest {
                     )
                     .collectList()
                     .block(TIMEOUT_DURATION);
+
+            assertFalse(errorDropped.get());
+        } finally {
+            Hooks.resetOnErrorDropped();
+        }
+    }
+
+    @Test
+    @DisplayName("Ensure no NPE is thrown on null in result set")
+    public void testNoNPEOnNull() {
+        try {
+            AtomicBoolean errorDropped = new AtomicBoolean();
+            Hooks.onErrorDropped(t -> errorDropped.set(true));
+
+            Document doc = new Document("x", null);
+            Document doc2 = new Document("x", "hello");
+
+            Mono.from(collection.insertMany(Arrays.asList(doc, doc2))).block();
+
+            TestSubscriber<String> subscriber = new TestSubscriber<>();
+
+            collection.distinct("x", String.class).subscribe(subscriber);
+
+            subscriber.requestMore(1);
+
+            subscriber.assertReceivedOnNext(Arrays.asList("hello"));
 
             assertFalse(errorDropped.get());
         } finally {


### PR DESCRIPTION
Hi there 👋,

We use Mongodb reactive stream driver with akka-stream and had an issue when trying to upgrade our mongodb driver from 4.1.x to 4.9.0. The same code which was working with 4.1.x does not work anymore with 4.9.0. 
We tracked downed the issue and it's happening since the addition of reactor to this project. 

The issue is that when performing a find/distinct which returns `null` values, when the results are used in a `SerializedFluxSink` a NullPointerException is thrown and everything stops.
This is because `SerializedFluxSink.next` performs a call to `Object.requireNonNull()`.

To fix this NPE we filter out null values from the results.

I'm not sure this is the appropriate way to test/fix, suggestions are welcome.
In the meantime we workaround this on our side by filtering out null values in the query.

Thanks