### PR TITLE
Bson-kotlinx

### DIFF
--- a/bson-kotlinx/build.gradle.kts
+++ b/bson-kotlinx/build.gradle.kts
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import io.gitlab.arturbosch.detekt.Detekt
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "1.8.10"
+    kotlin("plugin.serialization") version "1.8.10"
+    `java-library`
+
+    // Test based plugins
+    id("com.diffplug.spotless")
+    id("org.jetbrains.dokka") version "1.7.20"
+    id("io.gitlab.arturbosch.detekt") version "1.21.0"
+}
+
+repositories {
+    mavenCentral()
+    google()
+}
+
+base.archivesName.set("bson-kotlinx")
+
+description = "Bson Kotlinx Codecs"
+
+ext.set("pomName", "Bson Kotlinx")
+
+dependencies {
+    // Align versions of all Kotlin components
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+
+    implementation(platform("org.jetbrains.kotlinx:kotlinx-serialization-bom:1.5.0"))
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core")
+
+    api(project(path = ":bson", configuration = "default"))
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
+    testImplementation(project(path = ":driver-core", configuration = "default"))
+}
+
+kotlin { explicitApi() }
+
+tasks.withType<KotlinCompile> { kotlinOptions.jvmTarget = "1.8" }
+
+// ===========================
+//     Code Quality checks
+// ===========================
+spotless {
+    kotlinGradle {
+        ktfmt("0.39").dropboxStyle().configure { it.setMaxWidth(120) }
+        trimTrailingWhitespace()
+        indentWithSpaces()
+        endWithNewline()
+        licenseHeaderFile(rootProject.file("config/mongodb.license"), "(group|plugins|import|buildscript|rootProject)")
+    }
+
+    kotlin {
+        target("**/*.kt")
+        ktfmt().dropboxStyle().configure { it.setMaxWidth(120) }
+        trimTrailingWhitespace()
+        indentWithSpaces()
+        endWithNewline()
+        licenseHeaderFile(rootProject.file("config/mongodb.license"))
+    }
+
+    format("extraneous") {
+        target("*.xml", "*.yml", "*.md")
+        trimTrailingWhitespace()
+        indentWithSpaces()
+        endWithNewline()
+    }
+}
+
+tasks.named("check") { dependsOn("spotlessApply") }
+
+detekt {
+    allRules = true // fail build on any finding
+    buildUponDefaultConfig = true // preconfigure defaults
+    config = rootProject.files("config/detekt/detekt.yml") // point to your custom config defining rules to run,
+    // overwriting default behavior
+    baseline = rootProject.file("config/detekt/baseline.xml") // a way of suppressing issues before introducing detekt
+    source =
+        files(
+            file("src/main/kotlin"),
+            file("src/test/kotlin"),
+            file("src/integrationTest/kotlin"),
+        )
+}
+
+tasks.withType<Detekt>().configureEach {
+    reports {
+        html.required.set(true) // observe findings in your browser with structure and code snippets
+        xml.required.set(true) // checkstyle like format mainly for integrations like Jenkins
+        txt.required.set(false) // similar to the console output, contains issue signature to manually edit
+    }
+}
+
+spotbugs { showProgress.set(true) }
+
+// ===========================
+//     Test Configuration
+// ===========================
+tasks.create("kCheck") {
+    description = "Runs all the kotlin checks"
+    group = "verification"
+
+    dependsOn("clean", "check")
+    tasks.findByName("check")?.mustRunAfter("clean")
+}
+
+tasks.test { useJUnitPlatform() }
+
+// ===========================
+//     Dokka Configuration
+// ===========================
+val dokkaOutputDir = "${rootProject.buildDir}/docs/${base.archivesName.get()}"
+
+tasks.dokkaHtml.configure {
+    outputDirectory.set(file(dokkaOutputDir))
+    moduleName.set(base.archivesName.get())
+}
+
+val cleanDokka by tasks.register<Delete>("cleanDokka") { delete(dokkaOutputDir) }
+
+project.parent?.tasks?.named("docs") {
+    dependsOn(tasks.dokkaHtml)
+    mustRunAfter(cleanDokka)
+}
+
+tasks.javadocJar.configure {
+    dependsOn(cleanDokka, tasks.dokkaHtml)
+    archiveClassifier.set("javadoc")
+    from(dokkaOutputDir)
+}

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonConfiguration.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonConfiguration.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.kotlinx
+
+/**
+ * Bson Configuration for serialization
+ *
+ * Usage example with codecs:
+ * ```
+ * val codec = KotlinSerializerCodec.create(mykClass, bsonConfiguration = BsonConfiguration(encodeDefaults = false))
+ * ```
+ *
+ * @property encodeDefaults encode default values, defaults to true
+ * @property explicitNulls encode null values, defaults to false
+ * @property classDiscriminator class discriminator to use when encoding polymorphic types
+ */
+public data class BsonConfiguration(
+    val encodeDefaults: Boolean = true,
+    val explicitNulls: Boolean = false,
+    val classDiscriminator: String = "_t",
+)

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonDecoder.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonDecoder.kt
@@ -82,7 +82,7 @@ internal open class DefaultBsonDecoder(
         initElementNullsIndexes(descriptor)
 
         val name: String? =
-            when (reader.state!!) {
+            when (reader.state ?: error("State of reader may not be null.")) {
                 AbstractBsonReader.State.NAME -> reader.readName()
                 AbstractBsonReader.State.VALUE -> reader.currentName
                 AbstractBsonReader.State.TYPE -> {
@@ -91,11 +91,14 @@ internal open class DefaultBsonDecoder(
                 }
                 AbstractBsonReader.State.END_OF_DOCUMENT,
                 AbstractBsonReader.State.END_OF_ARRAY -> {
-                    val indexOfNullableElement = elementsIsNullableIndexes!!.indexOfFirst { it }
+                    val isNullableIndexes =
+                        elementsIsNullableIndexes ?: error("elementsIsNullableIndexes may not be null.")
+                    val indexOfNullableElement = isNullableIndexes.indexOfFirst { it }
+
                     return if (indexOfNullableElement == -1) {
                         DECODE_DONE
                     } else {
-                        elementsIsNullableIndexes!![indexOfNullableElement] = false
+                        isNullableIndexes[indexOfNullableElement] = false
                         indexOfNullableElement
                     }
                 }

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonDecoder.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonDecoder.kt
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.kotlinx
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.SerialKind
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.descriptors.elementDescriptors
+import kotlinx.serialization.encoding.AbstractDecoder
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.CompositeDecoder.Companion.DECODE_DONE
+import kotlinx.serialization.encoding.CompositeDecoder.Companion.UNKNOWN_NAME
+import kotlinx.serialization.modules.SerializersModule
+import org.bson.AbstractBsonReader
+import org.bson.BsonInvalidOperationException
+import org.bson.BsonReader
+import org.bson.BsonType
+import org.bson.BsonValue
+import org.bson.codecs.BsonValueCodec
+import org.bson.codecs.DecoderContext
+import org.bson.types.ObjectId
+
+/**
+ * The BsonDecoder interface
+ *
+ * For custom serialization handlers
+ */
+public sealed interface BsonDecoder {
+
+    /** @return the decoded ObjectId */
+    public fun decodeObjectId(): ObjectId
+    /** @return the decoded BsonValue */
+    public fun decodeBsonValue(): BsonValue
+
+    /** @return the BsonReader */
+    public fun reader(): BsonReader
+}
+
+@ExperimentalSerializationApi
+internal open class DefaultBsonDecoder(
+    internal val reader: AbstractBsonReader,
+    override val serializersModule: SerializersModule,
+    internal val configuration: BsonConfiguration
+) : BsonDecoder, AbstractDecoder() {
+
+    companion object {
+        val validKeyKinds = setOf(PrimitiveKind.STRING, PrimitiveKind.CHAR, SerialKind.ENUM)
+        val bsonValueCodec = BsonValueCodec()
+    }
+
+    private var elementsIsNullableIndexes: BooleanArray? = null
+
+    private fun initElementNullsIndexes(descriptor: SerialDescriptor) {
+        if (elementsIsNullableIndexes != null) return
+        val elementIndexes = BooleanArray(descriptor.elementsCount)
+        descriptor.elementDescriptors.withIndex().forEach {
+            elementIndexes[it.index] = !descriptor.isElementOptional(it.index) && it.value.isNullable
+        }
+        elementsIsNullableIndexes = elementIndexes
+    }
+
+    @Suppress("ReturnCount")
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        initElementNullsIndexes(descriptor)
+
+        val name: String? =
+            when (reader.state!!) {
+                AbstractBsonReader.State.NAME -> reader.readName()
+                AbstractBsonReader.State.VALUE -> reader.currentName
+                AbstractBsonReader.State.TYPE -> {
+                    reader.readBsonType()
+                    return decodeElementIndex(descriptor)
+                }
+                AbstractBsonReader.State.END_OF_DOCUMENT,
+                AbstractBsonReader.State.END_OF_ARRAY -> {
+                    val indexOfNullableElement = elementsIsNullableIndexes!!.indexOfFirst { it }
+                    return if (indexOfNullableElement == -1) {
+                        DECODE_DONE
+                    } else {
+                        elementsIsNullableIndexes!![indexOfNullableElement] = false
+                        indexOfNullableElement
+                    }
+                }
+                else -> null
+            }
+
+        return name?.let {
+            val index = descriptor.getElementIndex(it)
+            return if (index == UNKNOWN_NAME) {
+                reader.skipValue()
+                decodeElementIndex(descriptor)
+            } else {
+                index
+            }
+        }
+            ?: UNKNOWN_NAME
+    }
+
+    @Suppress("ReturnCount")
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeDecoder {
+        when (descriptor.kind) {
+            is StructureKind.LIST -> {
+                reader.readStartArray()
+                return BsonArrayDecoder(reader, serializersModule, configuration)
+            }
+            is PolymorphicKind -> {
+                reader.readStartDocument()
+                return PolymorphicDecoder(reader, serializersModule, configuration)
+            }
+            is StructureKind.CLASS,
+            StructureKind.OBJECT -> {
+                val current = reader.currentBsonType
+                if (current == null || current == BsonType.DOCUMENT) {
+                    reader.readStartDocument()
+                }
+            }
+            is StructureKind.MAP -> {
+                reader.readStartDocument()
+                return BsonDocumentDecoder(reader, serializersModule, configuration)
+            }
+            else -> throw SerializationException("Primitives are not supported at top-level")
+        }
+        return DefaultBsonDecoder(reader, serializersModule, configuration)
+    }
+
+    override fun endStructure(descriptor: SerialDescriptor) {
+        when (descriptor.kind) {
+            is StructureKind.LIST -> reader.readEndArray()
+            is StructureKind.MAP,
+            StructureKind.CLASS,
+            StructureKind.OBJECT -> reader.readEndDocument()
+            else -> super.endStructure(descriptor)
+        }
+    }
+
+    override fun decodeByte(): Byte = decodeInt().toByte()
+    override fun decodeChar(): Char = decodeString().single()
+    override fun decodeFloat(): Float = decodeDouble().toFloat()
+    override fun decodeShort(): Short = decodeInt().toShort()
+    override fun decodeBoolean(): Boolean = readOrThrow({ reader.readBoolean() }, BsonType.BOOLEAN)
+    override fun decodeDouble(): Double = readOrThrow({ reader.readDouble() }, BsonType.DOUBLE)
+    override fun decodeInt(): Int = readOrThrow({ reader.readInt32() }, BsonType.INT32)
+    override fun decodeLong(): Long = readOrThrow({ reader.readInt64() }, BsonType.INT64)
+    override fun decodeString(): String = readOrThrow({ reader.readString() }, BsonType.STRING)
+
+    override fun decodeNull(): Nothing? {
+        if (reader.state == AbstractBsonReader.State.VALUE) {
+            readOrThrow({ reader.readNull() }, BsonType.NULL)
+        }
+        return null
+    }
+
+    override fun decodeEnum(enumDescriptor: SerialDescriptor): Int = enumDescriptor.getElementIndex(decodeString())
+    override fun decodeNotNullMark(): Boolean {
+        return reader.state != AbstractBsonReader.State.END_OF_DOCUMENT && reader.currentBsonType != BsonType.NULL
+    }
+
+    override fun decodeObjectId(): ObjectId = readOrThrow({ reader.readObjectId() }, BsonType.OBJECT_ID)
+    override fun decodeBsonValue(): BsonValue = bsonValueCodec.decode(reader, DecoderContext.builder().build())
+    override fun reader(): BsonReader = reader
+
+    private inline fun <T> readOrThrow(action: () -> T, bsonType: BsonType): T {
+        return try {
+            action()
+        } catch (e: BsonInvalidOperationException) {
+            throw BsonInvalidOperationException(
+                "Reading field '${reader.currentName}' failed expected $bsonType type but found:" +
+                    " ${reader.currentBsonType}.",
+                e)
+        }
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private class BsonArrayDecoder(
+    reader: AbstractBsonReader,
+    serializersModule: SerializersModule,
+    configuration: BsonConfiguration
+) : DefaultBsonDecoder(reader, serializersModule, configuration) {
+    private var index = 0
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        val nextType = reader.readBsonType()
+        if (nextType == BsonType.END_OF_DOCUMENT) return DECODE_DONE
+        return index++
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private class PolymorphicDecoder(
+    reader: AbstractBsonReader,
+    serializersModule: SerializersModule,
+    configuration: BsonConfiguration
+) : DefaultBsonDecoder(reader, serializersModule, configuration) {
+    private var index = 0
+
+    override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T =
+        deserializer.deserialize(DefaultBsonDecoder(reader, serializersModule, configuration))
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        return when (index) {
+            0 -> index++
+            1 -> index++
+            else -> DECODE_DONE
+        }
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+private class BsonDocumentDecoder(
+    reader: AbstractBsonReader,
+    serializersModule: SerializersModule,
+    configuration: BsonConfiguration
+) : DefaultBsonDecoder(reader, serializersModule, configuration) {
+
+    private var index = 0
+    private var isKey = false
+
+    override fun decodeString(): String {
+        return if (isKey) {
+            reader.readName()
+        } else {
+            super.decodeString()
+        }
+    }
+
+    override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
+        val keyKind = descriptor.getElementDescriptor(0).kind
+        if (!validKeyKinds.contains(keyKind)) {
+            throw SerializationException(
+                "Invalid key type for ${descriptor.serialName}. Expected STRING or ENUM but found: `${keyKind}`")
+        }
+
+        if (!isKey) {
+            isKey = true
+            val nextType = reader.readBsonType()
+            if (nextType == BsonType.END_OF_DOCUMENT) return DECODE_DONE
+        } else {
+            isKey = false
+        }
+        return index++
+    }
+}

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.kotlinx
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.SerialKind
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.encoding.AbstractEncoder
+import kotlinx.serialization.encoding.CompositeEncoder
+import kotlinx.serialization.modules.SerializersModule
+import org.bson.BsonValue
+import org.bson.BsonWriter
+import org.bson.codecs.BsonValueCodec
+import org.bson.codecs.EncoderContext
+import org.bson.types.ObjectId
+
+/**
+ * The BsonEncoder interface
+ *
+ * For custom serialization handlers
+ */
+public sealed interface BsonEncoder {
+
+    /**
+     * Encodes an ObjectId
+     *
+     * @param value the ObjectId
+     */
+    public fun encodeObjectId(value: ObjectId)
+
+    /**
+     * Encodes a BsonValue
+     *
+     * @param value the BsonValue
+     */
+    public fun encodeBsonValue(value: BsonValue)
+
+    /** @return the BsonWriter */
+    public fun writer(): BsonWriter
+}
+
+@ExperimentalSerializationApi
+internal class DefaultBsonEncoder(
+    private val writer: BsonWriter,
+    override val serializersModule: SerializersModule,
+    private val configuration: BsonConfiguration
+) : BsonEncoder, AbstractEncoder() {
+
+    companion object {
+        val validKeyKinds = setOf(PrimitiveKind.STRING, PrimitiveKind.CHAR, SerialKind.ENUM)
+        val bsonValueCodec = BsonValueCodec()
+    }
+
+    private var isPolymorphic = false
+    private var state = STATE.VALUE
+    private var mapState = MapState()
+    private var deferredElementName: String? = null
+
+    override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int): Boolean =
+        configuration.encodeDefaults
+
+    override fun beginStructure(descriptor: SerialDescriptor): CompositeEncoder {
+        when (descriptor.kind) {
+            is StructureKind.LIST -> writer.writeStartArray()
+            is PolymorphicKind -> {
+                writer.writeStartDocument()
+                writer.writeName(configuration.classDiscriminator)
+                isPolymorphic = true
+            }
+            is StructureKind.CLASS,
+            StructureKind.OBJECT -> {
+                if (isPolymorphic) {
+                    isPolymorphic = false
+                } else {
+                    writer.writeStartDocument()
+                }
+            }
+            is StructureKind.MAP -> {
+                writer.writeStartDocument()
+                mapState = MapState()
+            }
+            else -> throw SerializationException("Primitives are not supported at top-level")
+        }
+        return super.beginStructure(descriptor)
+    }
+
+    override fun endStructure(descriptor: SerialDescriptor) {
+        when (descriptor.kind) {
+            is StructureKind.LIST -> writer.writeEndArray()
+            StructureKind.MAP,
+            StructureKind.CLASS,
+            StructureKind.OBJECT -> writer.writeEndDocument()
+            else -> super.endStructure(descriptor)
+        }
+    }
+
+    override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
+        when (descriptor.kind) {
+            is StructureKind.CLASS -> {
+                val elementName = descriptor.getElementName(index)
+                if (descriptor.getElementDescriptor(index).isNullable) {
+                    deferredElementName = elementName
+                } else {
+                    encodeName(elementName)
+                }
+            }
+            is StructureKind.MAP -> {
+                if (index == 0) {
+                    val keyKind = descriptor.getElementDescriptor(index).kind
+                    if (!validKeyKinds.contains(keyKind)) {
+                        throw SerializationException(
+                            """Invalid key type for ${descriptor.serialName}.
+                                | Expected STRING or ENUM but found: `${keyKind}`."""
+                                .trimMargin())
+                    }
+                }
+                state = mapState.nextState()
+            }
+            else -> {}
+        }
+        return true
+    }
+
+    override fun <T : Any> encodeNullableSerializableValue(serializer: SerializationStrategy<T>, value: T?) {
+        deferredElementName?.let {
+            if (value != null || configuration.explicitNulls) {
+                encodeName(it)
+                super.encodeNullableSerializableValue(serializer, value)
+            }
+        }
+            ?: super.encodeNullableSerializableValue(serializer, value)
+    }
+
+    override fun encodeByte(value: Byte) = encodeInt(value.toInt())
+    override fun encodeChar(value: Char) = encodeString(value.toString())
+    override fun encodeFloat(value: Float) = encodeDouble(value.toDouble())
+    override fun encodeShort(value: Short) = encodeInt(value.toInt())
+
+    override fun encodeBoolean(value: Boolean) = writer.writeBoolean(value)
+    override fun encodeDouble(value: Double) = writer.writeDouble(value)
+    override fun encodeInt(value: Int) = writer.writeInt32(value)
+    override fun encodeLong(value: Long) = writer.writeInt64(value)
+    override fun encodeNull() = writer.writeNull()
+
+    override fun encodeString(value: String) {
+        when (state) {
+            STATE.NAME -> encodeName(value)
+            STATE.VALUE -> writer.writeString(value)
+        }
+    }
+
+    override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) {
+        val value = enumDescriptor.getElementName(index)
+        when (state) {
+            STATE.NAME -> encodeName(value)
+            STATE.VALUE -> writer.writeString(value)
+        }
+    }
+
+    override fun encodeObjectId(value: ObjectId) {
+        writer.writeObjectId(value)
+    }
+
+    override fun encodeBsonValue(value: BsonValue) {
+        bsonValueCodec.encode(writer, value, EncoderContext.builder().build())
+    }
+
+    override fun writer(): BsonWriter = writer
+
+    private fun encodeName(value: Any) {
+        writer.writeName(value.toString())
+        deferredElementName = null
+        state = STATE.VALUE
+    }
+
+    private enum class STATE {
+        NAME,
+        VALUE
+    }
+
+    private class MapState {
+        var currentState: STATE = STATE.VALUE
+
+        fun getState(): STATE = currentState
+
+        fun nextState(): STATE {
+            currentState =
+                when (currentState) {
+                    STATE.VALUE -> STATE.NAME
+                    STATE.NAME -> STATE.VALUE
+                }
+            return getState()
+        }
+    }
+}

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonSerializers.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonSerializers.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.kotlinx
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.plus
+import org.bson.BsonArray
+import org.bson.BsonBinary
+import org.bson.BsonBoolean
+import org.bson.BsonDateTime
+import org.bson.BsonDbPointer
+import org.bson.BsonDecimal128
+import org.bson.BsonDocument
+import org.bson.BsonDouble
+import org.bson.BsonInt32
+import org.bson.BsonInt64
+import org.bson.BsonJavaScript
+import org.bson.BsonJavaScriptWithScope
+import org.bson.BsonMaxKey
+import org.bson.BsonMinKey
+import org.bson.BsonNull
+import org.bson.BsonObjectId
+import org.bson.BsonRegularExpression
+import org.bson.BsonString
+import org.bson.BsonSymbol
+import org.bson.BsonTimestamp
+import org.bson.BsonUndefined
+import org.bson.BsonValue
+import org.bson.RawBsonArray
+import org.bson.RawBsonDocument
+import org.bson.types.ObjectId
+
+/**
+ * The default serializers module
+ *
+ * Handles:
+ * - ObjectId serialization
+ * - BsonValue serialization
+ */
+@ExperimentalSerializationApi
+public val defaultSerializersModule: SerializersModule =
+    ObjectIdSerializer.serializersModule + BsonValueSerializer.serializersModule
+
+@ExperimentalSerializationApi
+@Serializer(forClass = ObjectId::class)
+public object ObjectIdSerializer : KSerializer<ObjectId> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ObjectIdSerializer", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: ObjectId) {
+        when (encoder) {
+            is BsonEncoder -> encoder.encodeObjectId(value)
+            else -> throw SerializationException("ObjectId is not supported by ${encoder::class}")
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): ObjectId {
+        return when (decoder) {
+            is BsonDecoder -> decoder.decodeObjectId()
+            else -> throw SerializationException("ObjectId is not supported by ${decoder::class}")
+        }
+    }
+
+    public val serializersModule: SerializersModule = SerializersModule {
+        contextual(ObjectId::class, ObjectIdSerializer)
+    }
+}
+
+@ExperimentalSerializationApi
+@Serializer(forClass = BsonValue::class)
+public object BsonValueSerializer : KSerializer<BsonValue> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BsonValueSerializer", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: BsonValue) {
+        when (encoder) {
+            is BsonEncoder -> encoder.encodeBsonValue(value)
+            else -> throw SerializationException("BsonValues are not supported by ${encoder::class}")
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): BsonValue {
+        return when (decoder) {
+            is BsonDecoder -> decoder.decodeBsonValue()
+            else -> throw SerializationException("BsonValues are not supported by ${decoder::class}")
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    public val serializersModule: SerializersModule = SerializersModule {
+        contextual(BsonNull::class, BsonValueSerializer as KSerializer<BsonNull>)
+        contextual(BsonArray::class, BsonValueSerializer as KSerializer<BsonArray>)
+        contextual(BsonBinary::class, BsonValueSerializer as KSerializer<BsonBinary>)
+        contextual(BsonBoolean::class, BsonValueSerializer as KSerializer<BsonBoolean>)
+        contextual(BsonDateTime::class, BsonValueSerializer as KSerializer<BsonDateTime>)
+        contextual(BsonDbPointer::class, BsonValueSerializer as KSerializer<BsonDbPointer>)
+        contextual(BsonDocument::class, BsonValueSerializer as KSerializer<BsonDocument>)
+        contextual(BsonDouble::class, BsonValueSerializer as KSerializer<BsonDouble>)
+        contextual(BsonInt32::class, BsonValueSerializer as KSerializer<BsonInt32>)
+        contextual(BsonInt64::class, BsonValueSerializer as KSerializer<BsonInt64>)
+        contextual(BsonDecimal128::class, BsonValueSerializer as KSerializer<BsonDecimal128>)
+        contextual(BsonMaxKey::class, BsonValueSerializer as KSerializer<BsonMaxKey>)
+        contextual(BsonMinKey::class, BsonValueSerializer as KSerializer<BsonMinKey>)
+        contextual(BsonJavaScript::class, BsonValueSerializer as KSerializer<BsonJavaScript>)
+        contextual(BsonJavaScriptWithScope::class, BsonValueSerializer as KSerializer<BsonJavaScriptWithScope>)
+        contextual(BsonObjectId::class, BsonValueSerializer as KSerializer<BsonObjectId>)
+        contextual(BsonRegularExpression::class, BsonValueSerializer as KSerializer<BsonRegularExpression>)
+        contextual(BsonString::class, BsonValueSerializer as KSerializer<BsonString>)
+        contextual(BsonSymbol::class, BsonValueSerializer as KSerializer<BsonSymbol>)
+        contextual(BsonTimestamp::class, BsonValueSerializer as KSerializer<BsonTimestamp>)
+        contextual(BsonUndefined::class, BsonValueSerializer as KSerializer<BsonUndefined>)
+        contextual(BsonDocument::class, BsonValueSerializer as KSerializer<BsonDocument>)
+        contextual(RawBsonDocument::class, BsonValueSerializer as KSerializer<RawBsonDocument>)
+        contextual(RawBsonArray::class, BsonValueSerializer as KSerializer<RawBsonArray>)
+    }
+}

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodec.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodec.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.kotlinx
+
+import kotlin.reflect.KClass
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.findAnnotations
+import kotlin.reflect.full.primaryConstructor
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.serializer
+import org.bson.AbstractBsonReader
+import org.bson.BsonReader
+import org.bson.BsonWriter
+import org.bson.codecs.Codec
+import org.bson.codecs.DecoderContext
+import org.bson.codecs.EncoderContext
+import org.bson.codecs.configuration.CodecConfigurationException
+import org.bson.codecs.pojo.annotations.BsonCreator
+import org.bson.codecs.pojo.annotations.BsonDiscriminator
+import org.bson.codecs.pojo.annotations.BsonExtraElements
+import org.bson.codecs.pojo.annotations.BsonId
+import org.bson.codecs.pojo.annotations.BsonIgnore
+import org.bson.codecs.pojo.annotations.BsonProperty
+import org.bson.codecs.pojo.annotations.BsonRepresentation
+
+/**
+ * The Kotlin serializer codec which utilizes the kotlinx serialization module.
+ *
+ * Use the [create] method to create the codec
+ */
+@OptIn(ExperimentalSerializationApi::class, InternalSerializationApi::class)
+public class KotlinSerializerCodec<T : Any>
+private constructor(
+    private val kClass: KClass<T>,
+    private val serializer: KSerializer<T>,
+    private val serializersModule: SerializersModule,
+    private val bsonConfiguration: BsonConfiguration
+) : Codec<T> {
+
+    /** KotlinSerializerCodec companion object */
+    public companion object {
+
+        /**
+         * Creates a `Codec<T>` for the kClass or returns null if there is no serializer available.
+         *
+         * @param T The codec type
+         * @param serializersModule the serializiers module to use
+         * @param bsonConfiguration the bson configuration for serializing
+         * @return the codec
+         */
+        public inline fun <reified T : Any> create(
+            serializersModule: SerializersModule = defaultSerializersModule,
+            bsonConfiguration: BsonConfiguration = BsonConfiguration()
+        ): Codec<T>? = create(T::class, serializersModule, bsonConfiguration)
+
+        /**
+         * Creates a `Codec<T>` for the kClass or returns null if there is no serializer available.
+         *
+         * @param T The codec type
+         * @param kClass the KClass for the codec
+         * @param serializersModule the serializiers module to use
+         * @param bsonConfiguration the bson configuration for serializing
+         * @return the codec
+         */
+        @Suppress("SwallowedException")
+        public fun <T : Any> create(
+            kClass: KClass<T>,
+            serializersModule: SerializersModule = defaultSerializersModule,
+            bsonConfiguration: BsonConfiguration = BsonConfiguration()
+        ): Codec<T>? {
+            return try {
+                create(kClass, kClass.serializer(), serializersModule, bsonConfiguration)
+            } catch (exception: SerializationException) {
+                null
+            }
+        }
+
+        /**
+         * Creates a `Codec<T>` for the kClass using the supplied serializer
+         *
+         * @param T The codec type
+         * @param kClass the KClass for the codec
+         * @param serializer the KSerializer to use
+         * @param serializersModule the serializiers module to use
+         * @param bsonConfiguration the bson configuration for serializing
+         * @return the codec
+         */
+        public fun <T : Any> create(
+            kClass: KClass<T>,
+            serializer: KSerializer<T>,
+            serializersModule: SerializersModule,
+            bsonConfiguration: BsonConfiguration
+        ): Codec<T> {
+            validateAnnotations(kClass)
+            return KotlinSerializerCodec(kClass, serializer, serializersModule, bsonConfiguration)
+        }
+
+        private fun <R : Any> validateAnnotations(kClass: KClass<R>) {
+            codecConfigurationRequires(kClass.findAnnotation<BsonDiscriminator>() == null) {
+                """Annotation 'BsonDiscriminator' is not supported with kotlin serialization,
+                    | but found on ${kClass.simpleName}. Use `BsonConfiguration` with `KotlinSerializerCodec.create`
+                    | to configure a discriminator."""
+                    .trimMargin()
+            }
+
+            codecConfigurationRequires(kClass.constructors.all { it.findAnnotations<BsonCreator>().isEmpty() }) {
+                """Annotation 'BsonCreator' is not supported with kotlin serialization,
+                    | but found in ${kClass.simpleName}."""
+                    .trimMargin()
+            }
+
+            kClass.primaryConstructor?.parameters?.map { param ->
+                codecConfigurationRequires(param.findAnnotations<BsonId>().isEmpty()) {
+                    """Annotation 'BsonId' is not supported with kotlin serialization,
+                        | found on the parameter for ${param.name}. Use `@SerialName("_id")` instead."""
+                        .trimMargin()
+                }
+
+                codecConfigurationRequires(param.findAnnotations<BsonProperty>().isEmpty()) {
+                    """Annotation 'BsonProperty' is not supported with kotlin serialization,
+                        | found on the parameter for ${param.name}. Use `@SerialName` instead."""
+                        .trimMargin()
+                }
+
+                codecConfigurationRequires(param.findAnnotations<BsonIgnore>().isEmpty()) {
+                    """Annotation 'BsonIgnore' is not supported with kotlinx serialization,
+                        | found on the parameter for ${param.name}. Use `@Transient` annotation to ignore a property."""
+                        .trimMargin()
+                }
+
+                codecConfigurationRequires(param.findAnnotations<BsonExtraElements>().isEmpty()) {
+                    """Annotation 'BsonExtraElements' is not supported with kotlinx serialization,
+                        | found on the parameter for ${param.name}."""
+                        .trimMargin()
+                }
+
+                codecConfigurationRequires(param.findAnnotations<BsonRepresentation>().isEmpty()) {
+                    """Annotation 'BsonRepresentation' is not supported with kotlinx serialization,
+                        | found on the parameter for ${param.name}."""
+                        .trimMargin()
+                }
+            }
+        }
+        private fun codecConfigurationRequires(value: Boolean, lazyMessage: () -> String) {
+            if (!value) {
+                throw CodecConfigurationException(lazyMessage.invoke())
+            }
+        }
+    }
+
+    override fun encode(writer: BsonWriter, value: T, encoderContext: EncoderContext) {
+        serializer.serialize(DefaultBsonEncoder(writer, serializersModule, bsonConfiguration), value)
+    }
+
+    override fun getEncoderClass(): Class<T> = kClass.java
+
+    override fun decode(reader: BsonReader, decoderContext: DecoderContext): T {
+        require(reader is AbstractBsonReader)
+        return serializer.deserialize(DefaultBsonDecoder(reader, serializersModule, bsonConfiguration))
+    }
+}

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecProvider.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecProvider.kt
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.bson.codecs.kotlinx
 
-include ':bson'
-include ':bson-record-codec'
-include ':driver-benchmarks'
-include ':driver-workload-executor'
-include ':driver-core'
-include ':driver-legacy'
-include ':driver-sync'
-include ':driver-reactive-streams'
-include ':bson-kotlin'
-include ':bson-kotlinx'
-include ':driver-kotlin-sync'
-include ':bson-scala'
-include ':driver-scala'
-include 'util:spock'
-include 'util:taglets'
+import org.bson.codecs.Codec
+import org.bson.codecs.configuration.CodecProvider
+import org.bson.codecs.configuration.CodecRegistry
+
+/**
+ * A Kotlin Serialization based Codec Provider
+ *
+ * The underlying class must be annotated with the `@Serializable`.
+ */
+public class KotlinSerializerCodecProvider : CodecProvider {
+
+    override fun <T : Any> get(clazz: Class<T>, registry: CodecRegistry): Codec<T>? =
+        KotlinSerializerCodec.create(clazz.kotlin)
+}

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecProviderTest.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecProviderTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.kotlinx
+
+import com.mongodb.MongoClientSettings
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.bson.codecs.kotlinx.samples.DataClassParameterized
+import org.bson.codecs.kotlinx.samples.DataClassWithSimpleValues
+import org.bson.conversions.Bson
+import org.junit.jupiter.api.Test
+
+class KotlinSerializerCodecProviderTest {
+
+    data class NotMarkedSerializable(val t: String)
+
+    @Test
+    fun shouldReturnNullForNonSerializableClass() {
+        assertNull(KotlinSerializerCodecProvider().get(NotMarkedSerializable::class.java, Bson.DEFAULT_CODEC_REGISTRY))
+    }
+
+    @Test
+    fun shouldReturnKotlinSerializerCodecForDataClass() {
+        val provider = KotlinSerializerCodecProvider()
+        val codec = provider.get(DataClassWithSimpleValues::class.java, Bson.DEFAULT_CODEC_REGISTRY)
+
+        assertNotNull(codec)
+        assertTrue { codec is KotlinSerializerCodec }
+        assertEquals(DataClassWithSimpleValues::class.java, codec.encoderClass)
+    }
+
+    @Test
+    fun shouldReturnNullFoRawParameterizedDataClass() {
+        val codec = KotlinSerializerCodecProvider().get(DataClassParameterized::class.java, Bson.DEFAULT_CODEC_REGISTRY)
+        assertNull(codec)
+    }
+
+    @Test
+    fun shouldReturnKotlinSerializerCodecUsingDefaultRegistry() {
+        val codec = MongoClientSettings.getDefaultCodecRegistry().get(DataClassWithSimpleValues::class.java)
+
+        assertNotNull(codec)
+        assertTrue { codec is KotlinSerializerCodec }
+        assertEquals(DataClassWithSimpleValues::class.java, codec.encoderClass)
+    }
+}

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
@@ -1,0 +1,600 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.kotlinx
+
+import kotlin.test.assertEquals
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.modules.SerializersModule
+import org.bson.BsonDocument
+import org.bson.BsonDocumentReader
+import org.bson.BsonDocumentWriter
+import org.bson.BsonInvalidOperationException
+import org.bson.codecs.DecoderContext
+import org.bson.codecs.EncoderContext
+import org.bson.codecs.configuration.CodecConfigurationException
+import org.bson.codecs.kotlinx.samples.DataClassEmbedded
+import org.bson.codecs.kotlinx.samples.DataClassKey
+import org.bson.codecs.kotlinx.samples.DataClassListOfDataClasses
+import org.bson.codecs.kotlinx.samples.DataClassListOfListOfDataClasses
+import org.bson.codecs.kotlinx.samples.DataClassListOfSealed
+import org.bson.codecs.kotlinx.samples.DataClassMapOfDataClasses
+import org.bson.codecs.kotlinx.samples.DataClassMapOfListOfDataClasses
+import org.bson.codecs.kotlinx.samples.DataClassNestedParameterizedTypes
+import org.bson.codecs.kotlinx.samples.DataClassParameterized
+import org.bson.codecs.kotlinx.samples.DataClassSealed
+import org.bson.codecs.kotlinx.samples.DataClassSealedA
+import org.bson.codecs.kotlinx.samples.DataClassSealedB
+import org.bson.codecs.kotlinx.samples.DataClassSealedC
+import org.bson.codecs.kotlinx.samples.DataClassSelfReferential
+import org.bson.codecs.kotlinx.samples.DataClassWithAnnotations
+import org.bson.codecs.kotlinx.samples.DataClassWithBooleanMapKey
+import org.bson.codecs.kotlinx.samples.DataClassWithBsonConstructor
+import org.bson.codecs.kotlinx.samples.DataClassWithBsonDiscriminator
+import org.bson.codecs.kotlinx.samples.DataClassWithBsonExtraElements
+import org.bson.codecs.kotlinx.samples.DataClassWithBsonId
+import org.bson.codecs.kotlinx.samples.DataClassWithBsonIgnore
+import org.bson.codecs.kotlinx.samples.DataClassWithBsonProperty
+import org.bson.codecs.kotlinx.samples.DataClassWithBsonRepresentation
+import org.bson.codecs.kotlinx.samples.DataClassWithCollections
+import org.bson.codecs.kotlinx.samples.DataClassWithDataClassMapKey
+import org.bson.codecs.kotlinx.samples.DataClassWithDefaults
+import org.bson.codecs.kotlinx.samples.DataClassWithEmbedded
+import org.bson.codecs.kotlinx.samples.DataClassWithEncodeDefault
+import org.bson.codecs.kotlinx.samples.DataClassWithEnum
+import org.bson.codecs.kotlinx.samples.DataClassWithEnumMapKey
+import org.bson.codecs.kotlinx.samples.DataClassWithFailingInit
+import org.bson.codecs.kotlinx.samples.DataClassWithMutableList
+import org.bson.codecs.kotlinx.samples.DataClassWithMutableMap
+import org.bson.codecs.kotlinx.samples.DataClassWithMutableSet
+import org.bson.codecs.kotlinx.samples.DataClassWithNestedParameterized
+import org.bson.codecs.kotlinx.samples.DataClassWithNestedParameterizedDataClass
+import org.bson.codecs.kotlinx.samples.DataClassWithNulls
+import org.bson.codecs.kotlinx.samples.DataClassWithObjectIdAndBsonDocument
+import org.bson.codecs.kotlinx.samples.DataClassWithPair
+import org.bson.codecs.kotlinx.samples.DataClassWithParameterizedDataClass
+import org.bson.codecs.kotlinx.samples.DataClassWithRequired
+import org.bson.codecs.kotlinx.samples.DataClassWithSequence
+import org.bson.codecs.kotlinx.samples.DataClassWithSimpleValues
+import org.bson.codecs.kotlinx.samples.DataClassWithTriple
+import org.bson.codecs.kotlinx.samples.Key
+import org.bson.types.ObjectId
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@OptIn(ExperimentalSerializationApi::class)
+class KotlinSerializerCodecTest {
+    private val numberLong = "\$numberLong"
+    private val emptyDocument = "{}"
+    private val altConfiguration =
+        BsonConfiguration(encodeDefaults = false, classDiscriminator = "_t", explicitNulls = true)
+
+    @Test
+    fun testDataClassWithSimpleValues() {
+        val expected =
+            """{"char": "c", "byte": 0, "short": 1, "int": 22, "long": {"$numberLong": "42"}, "float": 4.0,
+                | "double": 4.2, "boolean": true, "string": "String"}"""
+                .trimMargin()
+        val dataClass = DataClassWithSimpleValues('c', 0, 1, 22, 42L, 4.0f, 4.2, true, "String")
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithComplexTypes() {
+        val expected =
+            """{
+            | "listSimple": ["a", "b", "c", "d"],
+            | "listList":  [["a", "b"], [], ["c", "d"]],
+            | "listMap":  [{"a": 1, "b": 2}, {}, {"c": 3, "d": 4}],
+            | "mapSimple": {"a": 1, "b": 2, "c": 3, "d": 4},
+            | "mapList": {"a": ["a", "b"], "b": [], "c": ["c", "d"]},
+            | "mapMap" : {"a": {"a": 1, "b": 2}, "b": {}, "c": {"c": 3, "d": 4}}
+            |}"""
+                .trimMargin()
+
+        val dataClass =
+            DataClassWithCollections(
+                listOf("a", "b", "c", "d"),
+                listOf(listOf("a", "b"), emptyList(), listOf("c", "d")),
+                listOf(mapOf("a" to 1, "b" to 2), emptyMap(), mapOf("c" to 3, "d" to 4)),
+                mapOf("a" to 1, "b" to 2, "c" to 3, "d" to 4),
+                mapOf("a" to listOf("a", "b"), "b" to emptyList(), "c" to listOf("c", "d")),
+                mapOf("a" to mapOf("a" to 1, "b" to 2), "b" to emptyMap(), "c" to mapOf("c" to 3, "d" to 4)))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithDefaults() {
+        val expectedDefault =
+            """{
+            | "boolean": false,
+            | "string": "String",
+            | "listSimple": ["a", "b", "c"]
+            |}"""
+                .trimMargin()
+
+        val defaultDataClass = DataClassWithDefaults()
+        assertRoundTrips(expectedDefault, defaultDataClass)
+        assertRoundTrips(emptyDocument, defaultDataClass, altConfiguration)
+
+        val expectedSomeOverrides = """{"boolean": true, "listSimple": ["a"]}"""
+        val someOverridesDataClass = DataClassWithDefaults(boolean = true, listSimple = listOf("a"))
+        assertRoundTrips(expectedSomeOverrides, someOverridesDataClass, altConfiguration)
+    }
+
+    @Test
+    fun testDataClassWithNulls() {
+        val expectedNulls =
+            """{
+            | "boolean": null,
+            | "string": null,
+            | "listSimple": null
+            |}"""
+                .trimMargin()
+
+        val dataClass = DataClassWithNulls(null, null, null)
+        assertRoundTrips(emptyDocument, dataClass)
+        assertRoundTrips(expectedNulls, dataClass, altConfiguration)
+    }
+
+    @Test
+    fun testDataClassSelfReferential() {
+        val expected =
+            """{"name": "tree",
+            | "left": {"name": "L", "left": {"name": "LL"}, "right": {"name": "LR"}},
+            | "right": {"name": "R",
+            |           "left": {"name": "RL",
+            |             "left": {"name": "RLL"},
+            |             "right": {"name": "RLR"}},
+            |           "right": {"name": "RR"}}
+            |}"""
+                .trimMargin()
+        val dataClass =
+            DataClassSelfReferential(
+                "tree",
+                DataClassSelfReferential("L", DataClassSelfReferential("LL"), DataClassSelfReferential("LR")),
+                DataClassSelfReferential(
+                    "R",
+                    DataClassSelfReferential("RL", DataClassSelfReferential("RLL"), DataClassSelfReferential("RLR")),
+                    DataClassSelfReferential("RR")))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithEmbedded() {
+        val expected = """{"id": "myId", "embedded": {"name": "embedded1"}}"""
+        val dataClass = DataClassWithEmbedded("myId", DataClassEmbedded("embedded1"))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassListOfDataClasses() {
+        val expected = """{"id": "myId", "nested": [{"name": "embedded1"}, {"name": "embedded2"}]}"""
+        val dataClass =
+            DataClassListOfDataClasses("myId", listOf(DataClassEmbedded("embedded1"), DataClassEmbedded("embedded2")))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassListOfListOfDataClasses() {
+        val expected = """{"id": "myId", "nested": [[{"name": "embedded1"}], [{"name": "embedded2"}]]}"""
+        val dataClass =
+            DataClassListOfListOfDataClasses(
+                "myId", listOf(listOf(DataClassEmbedded("embedded1")), listOf(DataClassEmbedded("embedded2"))))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassMapOfDataClasses() {
+        val expected = """{"id": "myId", "nested": {"first": {"name": "embedded1"}, "second": {"name": "embedded2"}}}"""
+        val dataClass =
+            DataClassMapOfDataClasses(
+                "myId", mapOf("first" to DataClassEmbedded("embedded1"), "second" to DataClassEmbedded("embedded2")))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassMapOfListOfDataClasses() {
+        val expected =
+            """{"id": "myId", "nested": {"first": [{"name": "embedded1"}], "second": [{"name": "embedded2"}]}}"""
+        val dataClass =
+            DataClassMapOfListOfDataClasses(
+                "myId",
+                mapOf(
+                    "first" to listOf(DataClassEmbedded("embedded1")),
+                    "second" to listOf(DataClassEmbedded("embedded2"))))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithParameterizedDataClass() {
+        val expected =
+            """{"id": "myId",
+            | "parameterizedDataClass": {"number": 2.0, "string": "myString",
+            |                            "parameterizedList": [{"name": "embedded1"}]}
+            |}"""
+                .trimMargin()
+        val dataClass =
+            DataClassWithParameterizedDataClass(
+                "myId", DataClassParameterized(2.0, "myString", listOf(DataClassEmbedded("embedded1"))))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithNestedParameterizedDataClass() {
+        val expected =
+            """{"id": "myId",
+            |"nestedParameterized": {
+            |  "parameterizedDataClass":
+            |  {"number": 4.2, "string": "myString", "parameterizedList": [{"name": "embedded1"}]},
+            |  "other": "myOtherString"
+            | }
+            |}"""
+                .trimMargin()
+        val dataClass =
+            DataClassWithNestedParameterizedDataClass(
+                "myId",
+                DataClassWithNestedParameterized(
+                    DataClassParameterized(4.2, "myString", listOf(DataClassEmbedded("embedded1"))), "myOtherString"))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithPair() {
+        val expected = """{"pair": {"first": "a", "second": 1}}"""
+        val dataClass = DataClassWithPair("a" to 1)
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithTriple() {
+        val expected = """{"triple": {"first": "a", "second": 1, "third": 2.1}}"""
+        val dataClass = DataClassWithTriple(Triple("a", 1, 2.1))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassNestedParameterizedTypes() {
+        val expected =
+            """{
+            |"triple": {
+            |  "first": "0",
+            |  "second": {"first": 1, "second": {"first": 1.2, "second": {"first": "1.3", "second": 1.3}}},
+            |  "third":  {"first": 2, "second": {"first": 2.1, "second": "two dot two"},
+            |             "third": {"first": "3.1", "second": {"first": 3.2, "second": "three dot two" },
+            |                       "third": 3.3 }}
+            | }
+            |}"""
+                .trimMargin()
+        val dataClass =
+            DataClassNestedParameterizedTypes(
+                Triple(
+                    "0",
+                    Pair(1, Pair(1.2, Pair("1.3", 1.3))),
+                    Triple(2, Pair(2.1, "two dot two"), Triple("3.1", Pair(3.2, "three dot two"), 3.3))))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithMutableList() {
+        val expected = """{"value": ["A", "B", "C"]}"""
+        val dataClass = DataClassWithMutableList(mutableListOf("A", "B", "C"))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithMutableSet() {
+        val expected = """{"value": ["A", "B", "C"]}"""
+        val dataClass = DataClassWithMutableSet(mutableSetOf("A", "B", "C"))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithMutableMap() {
+        val expected = """{"value": {"a": "A", "b": "B", "c": "C"}}"""
+        val dataClass = DataClassWithMutableMap(mutableMapOf("a" to "A", "b" to "B", "c" to "C"))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithAnnotations() {
+        val expected = """{"_id": "id", "nom": "name", "string": "string"}"""
+        val dataClass = DataClassWithAnnotations("id", "name", "string")
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithEncodeDefault() {
+        val expectedDefault =
+            """{
+            | "boolean": false,
+            | "listSimple": ["a", "b", "c"]
+            |}"""
+                .trimMargin()
+
+        val defaultDataClass = DataClassWithEncodeDefault()
+        assertRoundTrips(expectedDefault, defaultDataClass)
+        assertRoundTrips("""{"listSimple": ["a", "b", "c"]}""", defaultDataClass, altConfiguration)
+
+        val expectedSomeOverrides = """{"string": "STRING", "listSimple": ["a"]}"""
+        val someOverridesDataClass = DataClassWithEncodeDefault(string = "STRING", listSimple = listOf("a"))
+        assertRoundTrips(expectedSomeOverrides, someOverridesDataClass, altConfiguration)
+    }
+
+    @Test
+    fun testDataClassWithRequired() {
+        val expectedDefault =
+            """{
+            | "boolean": false,
+            | "string": "String",
+            | "listSimple": ["a", "b", "c"]
+            |}"""
+                .trimMargin()
+
+        val defaultDataClass = DataClassWithRequired()
+        assertRoundTrips(expectedDefault, defaultDataClass)
+
+        assertThrows<MissingFieldException> { deserialize<DataClassWithRequired>(BsonDocument()) }
+    }
+
+    @Test
+    fun testDataClassWithEnum() {
+        val expected = """{"value": "A"}"""
+
+        val dataClass = DataClassWithEnum(Key.A)
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithEnumKeyMap() {
+        val expected = """{"map": {"A": true, "B": false}}"""
+
+        val dataClass = DataClassWithEnumMapKey(mapOf(Key.A to true, Key.B to false))
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithSequence() {
+        val dataClass = DataClassWithSequence(listOf("A", "B", "C").asSequence())
+        assertThrows<SerializationException> { serialize(dataClass) }
+    }
+
+    @Test
+    fun testDataClassWithBooleanKeyMap() {
+        val dataClass = DataClassWithBooleanMapKey(mapOf(true to true, false to false))
+        assertThrows<SerializationException> { serialize(dataClass) }
+        assertThrows<SerializationException> {
+            deserialize<DataClassWithBooleanMapKey>(BsonDocument.parse("""{"map": {"true": true}}"""))
+        }
+    }
+
+    @Test
+    fun testDataClassWithDataClassKeyMap() {
+        val dataClass = DataClassWithDataClassMapKey(mapOf(DataClassKey("A") to true, DataClassKey("A") to false))
+        assertThrows<SerializationException> { serialize(dataClass) }
+        assertThrows<SerializationException> {
+            deserialize<DataClassWithDataClassMapKey>(BsonDocument.parse("""{"map": {"A": true}}"""))
+        }
+    }
+
+    @Test
+    fun testDataClassEmbeddedWithExtraData() {
+        val expected =
+            """{
+            | "extraA": "extraA",
+            | "name": "NAME",
+            | "extraB": "extraB"
+            |}"""
+                .trimMargin()
+
+        val dataClass = DataClassEmbedded("NAME")
+        assertDecodesTo(BsonDocument.parse(expected), dataClass)
+    }
+
+    @Test
+    fun testDataClassWithObjectIdAndBsonDocument() {
+        val subDocument =
+            """{
+    | "_id": 1,
+    | "arrayEmpty": [],
+    | "arraySimple": [{"${'$'}numberInt": "1"}, {"${'$'}numberInt": "2"}, {"${'$'}numberInt": "3"}],
+    | "arrayComplex": [{"a": {"${'$'}numberInt": "1"}}, {"a": {"${'$'}numberInt": "2"}}],
+    | "arrayMixedTypes": [{"${'$'}numberInt": "1"}, {"${'$'}numberInt": "2"}, true,
+    |  [{"${'$'}numberInt": "1"}, {"${'$'}numberInt": "2"}, {"${'$'}numberInt": "3"}],
+    |  {"a": {"${'$'}numberInt": "2"}}],
+    | "arrayComplexMixedTypes": [{"a": {"${'$'}numberInt": "1"}}, {"a": "a"}],
+    | "binary": {"${'$'}binary": {"base64": "S2Fma2Egcm9ja3Mh", "subType": "00"}},
+    | "boolean": true,
+    | "code": {"${'$'}code": "int i = 0;"},
+    | "codeWithScope": {"${'$'}code": "int x = y", "${'$'}scope": {"y": {"${'$'}numberInt": "1"}}},
+    | "dateTime": {"${'$'}date": {"${'$'}numberLong": "1577836801000"}},
+    | "decimal128": {"${'$'}numberDecimal": "1.0"},
+    | "documentEmpty": {},
+    | "document": {"a": {"${'$'}numberInt": "1"}},
+    | "double": {"${'$'}numberDouble": "62.0"},
+    | "int32": {"${'$'}numberInt": "42"},
+    | "int64": {"${'$'}numberLong": "52"},
+    | "maxKey": {"${'$'}maxKey": 1},
+    | "minKey": {"${'$'}minKey": 1},
+    | "null": null,
+    | "objectId": {"${'$'}oid": "5f3d1bbde0ca4d2829c91e1d"},
+    | "regex": {"${'$'}regularExpression": {"pattern": "^test.*regex.*xyz$", "options": "i"}},
+    | "string": "the fox ...",
+    | "symbol": {"${'$'}symbol": "ruby stuff"},
+    | "timestamp": {"${'$'}timestamp": {"t": 305419896, "i": 5}},
+    | "undefined": {"${'$'}undefined": true}
+    | }"""
+                .trimMargin()
+        val expected = """{"objectId": {"${'$'}oid": "111111111111111111111111"}, "bsonDocument": $subDocument}"""
+
+        val dataClass =
+            DataClassWithObjectIdAndBsonDocument(ObjectId("111111111111111111111111"), BsonDocument.parse(subDocument))
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassSealed() {
+        val expectedA = """{"a": "string"}"""
+        val dataClassA = DataClassSealedA("string")
+        assertRoundTrips(expectedA, dataClassA)
+
+        val expectedB = """{"b": 1}"""
+        val dataClassB = DataClassSealedB(1)
+        assertRoundTrips(expectedB, dataClassB)
+
+        val expectedC = """{"c": "String"}"""
+        val dataClassC = DataClassSealedC("String")
+        assertRoundTrips(expectedC, dataClassC)
+
+        val expectedDataClassSealedA = """{"_t": "org.bson.codecs.kotlinx.samples.DataClassSealedA", "a": "string"}"""
+        val dataClassSealedA = DataClassSealedA("string") as DataClassSealed
+        assertRoundTrips(expectedDataClassSealedA, dataClassSealedA)
+
+        val expectedDataClassSealedB = """{"_t": "org.bson.codecs.kotlinx.samples.DataClassSealedB", "b": 1}"""
+        val dataClassSealedB = DataClassSealedB(1) as DataClassSealed
+        assertRoundTrips(expectedDataClassSealedB, dataClassSealedB)
+
+        val expectedDataClassSealedC = """{"_t": "C", "c": "String"}"""
+        val dataClassSealedC = DataClassSealedC("String") as DataClassSealed
+        assertRoundTrips(expectedDataClassSealedC, dataClassSealedC)
+
+        val dataClassListOfSealed = DataClassListOfSealed(listOf(dataClassA, dataClassB, dataClassC))
+        val expectedListOfSealed =
+            """{"items": [$expectedDataClassSealedA, $expectedDataClassSealedB, $expectedDataClassSealedC]}"""
+        assertRoundTrips(expectedListOfSealed, dataClassListOfSealed)
+
+        val expectedListOfSealedDiscriminator = expectedListOfSealed.replace("_t", "#class")
+        assertRoundTrips(
+            expectedListOfSealedDiscriminator, dataClassListOfSealed, BsonConfiguration(classDiscriminator = "#class"))
+    }
+
+    @Test
+    fun testDataFailures() {
+        assertThrows<MissingFieldException>("Missing data") {
+            val codec = KotlinSerializerCodec.create(DataClassWithSimpleValues::class)
+            codec?.decode(BsonDocumentReader(BsonDocument()), DecoderContext.builder().build())
+        }
+
+        assertThrows<BsonInvalidOperationException>("Invalid types") {
+            val data =
+                BsonDocument.parse(
+                    """{"char": 123, "short": "2", "int": 22, "long": "ok", "float": true, "double": false,
+            | "boolean": "true", "string": 99}"""
+                        .trimMargin())
+            val codec = KotlinSerializerCodec.create<DataClassWithSimpleValues>()
+            codec?.decode(BsonDocumentReader(data), DecoderContext.builder().build())
+        }
+
+        assertThrows<MissingFieldException>("Invalid complex types") {
+            val data = BsonDocument.parse("""{"_id": "myId", "embedded": 123}""")
+            val codec = KotlinSerializerCodec.create<DataClassWithEmbedded>()
+            codec?.decode(BsonDocumentReader(data), DecoderContext.builder().build())
+        }
+
+        assertThrows<IllegalArgumentException>("Failing init") {
+            val data = BsonDocument.parse("""{"id": "myId"}""")
+            val codec = KotlinSerializerCodec.create<DataClassWithFailingInit>()
+            codec?.decode(BsonDocumentReader(data), DecoderContext.builder().build())
+        }
+    }
+
+    @Test
+    fun testInvalidAnnotations() {
+        assertThrows<CodecConfigurationException> { KotlinSerializerCodec.create(DataClassWithBsonId::class) }
+        assertThrows<CodecConfigurationException> { KotlinSerializerCodec.create(DataClassWithBsonProperty::class) }
+        assertThrows<CodecConfigurationException> {
+            KotlinSerializerCodec.create(DataClassWithBsonDiscriminator::class)
+        }
+        assertThrows<CodecConfigurationException> { KotlinSerializerCodec.create(DataClassWithBsonConstructor::class) }
+        assertThrows<CodecConfigurationException> { KotlinSerializerCodec.create(DataClassWithBsonIgnore::class) }
+        assertThrows<CodecConfigurationException> {
+            KotlinSerializerCodec.create(DataClassWithBsonExtraElements::class)
+        }
+        assertThrows<CodecConfigurationException> {
+            KotlinSerializerCodec.create(DataClassWithBsonRepresentation::class)
+        }
+    }
+
+    private inline fun <reified T : Any> assertRoundTrips(
+        expected: String,
+        value: T,
+        configuration: BsonConfiguration = BsonConfiguration(),
+        serializersModule: SerializersModule = defaultSerializersModule
+    ) {
+        assertDecodesTo(
+            assertEncodesTo(expected, value, serializersModule, configuration), value, serializersModule, configuration)
+    }
+
+    private inline fun <reified T : Any> assertEncodesTo(
+        json: String,
+        value: T,
+        serializersModule: SerializersModule = defaultSerializersModule,
+        configuration: BsonConfiguration = BsonConfiguration()
+    ): BsonDocument {
+        val expected = BsonDocument.parse(json)
+        val actual = serialize(value, serializersModule, configuration)
+        assertEquals(expected, actual)
+        return actual
+    }
+
+    private inline fun <reified T : Any> serialize(
+        value: T,
+        serializersModule: SerializersModule = defaultSerializersModule,
+        configuration: BsonConfiguration = BsonConfiguration()
+    ): BsonDocument {
+        val document = BsonDocument()
+        val writer = BsonDocumentWriter(document)
+        val codec = KotlinSerializerCodec.create(T::class, serializersModule, configuration)!!
+        codec.encode(writer, value, EncoderContext.builder().build())
+        writer.flush()
+        return document
+    }
+
+    private inline fun <reified T : Any> assertDecodesTo(
+        value: BsonDocument,
+        expected: T,
+        serializersModule: SerializersModule = defaultSerializersModule,
+        configuration: BsonConfiguration = BsonConfiguration()
+    ) {
+        assertEquals(expected, deserialize(value, serializersModule, configuration))
+    }
+    private inline fun <reified T : Any> deserialize(
+        value: BsonDocument,
+        serializersModule: SerializersModule = defaultSerializersModule,
+        configuration: BsonConfiguration = BsonConfiguration()
+    ): T {
+        val codec = KotlinSerializerCodec.create(T::class, serializersModule, configuration)!!
+        return codec.decode(BsonDocumentReader(value), DecoderContext.builder().build())
+    }
+}

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
@@ -18,6 +18,7 @@ package org.bson.codecs.kotlinx.samples
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -176,6 +177,19 @@ data class DataClassWithObjectIdAndBsonDocument(
 @Serializable @SerialName("C") data class DataClassSealedC(val c: String) : DataClassSealed()
 
 @Serializable data class DataClassListOfSealed(val items: List<DataClassSealed>)
+
+interface DataClassOpen
+
+@Serializable data class DataClassOpenA(val a: String) : DataClassOpen
+
+@Serializable data class DataClassOpenB(val b: Int) : DataClassOpen
+
+@Serializable data class DataClassContainsOpen(val open: DataClassOpen)
+
+@JvmInline
+@Serializable value class ValueClass(val s: String)
+
+@Serializable data class DataClassContainsValueClass(val value: ValueClass)
 
 @Serializable data class DataClassWithBsonId(@BsonId val id: String)
 

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.kotlinx.samples
+
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Required
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.bson.BsonDocument
+import org.bson.BsonType
+import org.bson.codecs.pojo.annotations.BsonCreator
+import org.bson.codecs.pojo.annotations.BsonDiscriminator
+import org.bson.codecs.pojo.annotations.BsonExtraElements
+import org.bson.codecs.pojo.annotations.BsonId
+import org.bson.codecs.pojo.annotations.BsonIgnore
+import org.bson.codecs.pojo.annotations.BsonProperty
+import org.bson.codecs.pojo.annotations.BsonRepresentation
+import org.bson.types.ObjectId
+
+@Serializable
+data class DataClassWithSimpleValues(
+    val char: Char,
+    val byte: Byte,
+    val short: Short,
+    val int: Int,
+    val long: Long,
+    val float: Float,
+    val double: Double,
+    val boolean: Boolean,
+    val string: String
+)
+
+@Serializable
+data class DataClassWithCollections(
+    val listSimple: List<String>,
+    val listList: List<List<String>>,
+    val listMap: List<Map<String, Int>>,
+    val mapSimple: Map<String, Int>,
+    val mapList: Map<String, List<String>>,
+    val mapMap: Map<String, Map<String, Int>>
+)
+
+@Serializable
+data class DataClassWithDefaults(
+    val boolean: Boolean = false,
+    val string: String = "String",
+    val listSimple: List<String> = listOf("a", "b", "c")
+)
+
+@Serializable data class DataClassWithNulls(val boolean: Boolean?, val string: String?, val listSimple: List<String?>?)
+
+@Serializable
+data class DataClassSelfReferential(
+    val name: String,
+    val left: DataClassSelfReferential? = null,
+    val right: DataClassSelfReferential? = null
+)
+
+@Serializable data class DataClassEmbedded(val name: String)
+
+@Serializable data class DataClassWithEmbedded(val id: String, val embedded: DataClassEmbedded)
+
+@Serializable data class DataClassListOfDataClasses(val id: String, val nested: List<DataClassEmbedded>)
+
+@Serializable data class DataClassListOfListOfDataClasses(val id: String, val nested: List<List<DataClassEmbedded>>)
+
+@Serializable data class DataClassMapOfDataClasses(val id: String, val nested: Map<String, DataClassEmbedded>)
+
+@Serializable
+data class DataClassMapOfListOfDataClasses(val id: String, val nested: Map<String, List<DataClassEmbedded>>)
+
+@Serializable
+data class DataClassWithParameterizedDataClass(
+    val id: String,
+    val parameterizedDataClass: DataClassParameterized<Double, DataClassEmbedded>
+)
+
+@Serializable
+data class DataClassParameterized<N : Number, T>(val number: N, val string: String, val parameterizedList: List<T>)
+
+@Serializable
+data class DataClassWithNestedParameterizedDataClass(
+    val id: String,
+    val nestedParameterized: DataClassWithNestedParameterized<DataClassEmbedded, String, Double>
+)
+
+@Serializable
+data class DataClassWithNestedParameterized<A, B, C : Number>(
+    val parameterizedDataClass: DataClassParameterized<C, A>,
+    val other: B
+)
+
+@Serializable data class DataClassWithPair(val pair: Pair<String, Int>)
+
+@Serializable data class DataClassWithTriple(val triple: Triple<String, Int, Double>)
+
+@Serializable
+data class DataClassNestedParameterizedTypes(
+    val triple:
+        Triple<
+            String,
+            Pair<Int, Pair<Double, Pair<String, Double>>>,
+            Triple<Int, Pair<Double, String>, Triple<String, Pair<Double, String>, Double>>>
+)
+
+@Serializable data class DataClassWithMutableList(val value: MutableList<String>)
+
+@Serializable data class DataClassWithMutableSet(val value: MutableSet<String>)
+
+@Serializable data class DataClassWithMutableMap(val value: MutableMap<String, String>)
+
+@Serializable
+data class DataClassWithAnnotations(
+    @SerialName("_id") val id: String,
+    @SerialName("nom") val name: String,
+    val string: String
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class DataClassWithEncodeDefault(
+    val boolean: Boolean = false,
+    @EncodeDefault(EncodeDefault.Mode.NEVER) val string: String = "String",
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS) val listSimple: List<String> = listOf("a", "b", "c")
+)
+
+@Serializable
+data class DataClassWithRequired(
+    val boolean: Boolean = false,
+    @Required val string: String = "String",
+    @Required val listSimple: List<String> = listOf("a", "b", "c")
+)
+
+@Serializable data class DataClassWithBooleanMapKey(val map: Map<Boolean, Boolean>)
+
+enum class Key {
+    A,
+    B
+}
+
+@Serializable data class DataClassWithEnum(val value: Key)
+
+@Serializable data class DataClassWithEnumMapKey(val map: Map<Key, Boolean>)
+
+@Serializable data class DataClassKey(val value: String)
+
+@Serializable data class DataClassWithDataClassMapKey(val map: Map<DataClassKey, Boolean>)
+
+@Serializable
+data class DataClassWithObjectIdAndBsonDocument(
+    @Contextual val objectId: ObjectId,
+    @Contextual val bsonDocument: BsonDocument
+)
+
+@Serializable sealed class DataClassSealed
+
+@Serializable data class DataClassSealedA(val a: String) : DataClassSealed()
+
+@Serializable data class DataClassSealedB(val b: Int) : DataClassSealed()
+
+@Serializable @SerialName("C") data class DataClassSealedC(val c: String) : DataClassSealed()
+
+@Serializable data class DataClassListOfSealed(val items: List<DataClassSealed>)
+
+@Serializable data class DataClassWithBsonId(@BsonId val id: String)
+
+@Serializable data class DataClassWithBsonProperty(@BsonProperty("_id") val id: String)
+
+@BsonDiscriminator @Serializable data class DataClassWithBsonDiscriminator(val id: String)
+
+@Serializable data class DataClassWithBsonIgnore(val id: String, @BsonIgnore val ignored: String)
+
+@Serializable
+data class DataClassWithBsonExtraElements(val id: String, @BsonExtraElements val extraElements: Map<String, String>)
+
+@Serializable
+data class DataClassWithBsonConstructor(val id: String, val count: Int) {
+    @BsonCreator constructor(id: String) : this(id, -1)
+}
+
+@Serializable data class DataClassWithBsonRepresentation(@BsonRepresentation(BsonType.STRING) val id: Int)
+
+@Serializable
+data class DataClassWithFailingInit(val id: String) {
+    init {
+        require(false)
+    }
+}
+
+@Serializable data class DataClassWithSequence(val value: Sequence<String>)

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -252,4 +252,9 @@
         <Method name="~.*validateAnnotations.*"/>
         <Bug pattern="UC_USELESS_OBJECT"/>
     </Match>
+    <Match>
+        <Class name="org.bson.codecs.kotlinx.KotlinSerializerCodec$Companion"/>
+        <Method name="~.*validateAnnotations.*"/>
+        <Bug pattern="UC_USELESS_OBJECT"/>
+    </Match>
 </FindBugsFilter>

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     api project(path: ':bson', configuration: 'default')
     implementation project(path: ':bson-record-codec', configuration: 'default')
     implementation project(path: ':bson-kotlin', configuration: 'default')
+    implementation project(path: ':bson-kotlinx', configuration: 'default')
 
     implementation "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
     api platform("io.netty:netty-bom:$nettyVersion")

--- a/driver-core/src/main/com/mongodb/KotlinCodecProvider.java
+++ b/driver-core/src/main/com/mongodb/KotlinCodecProvider.java
@@ -20,28 +20,39 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.kotlin.DataClassCodecProvider;
-
+import org.bson.codecs.kotlinx.KotlinSerializerCodecProvider;
 
 /**
  * A CodecProvider for Kotlin data classes.
  *
- * <p>Requires the bson-kotlin package.</p>
+ * <p>Requires the bson-kotlin package and / or the bson-kotlinx package.</p>
  *
  * @since 4.10
  */
-public class KotlinDataClassCodecProvider implements CodecProvider {
+public class KotlinCodecProvider implements CodecProvider {
 
     @Nullable
+    private static final CodecProvider KOTLIN_SERIALIZABLE_CODEC_PROVIDER;
+    @Nullable
     private static final CodecProvider DATA_CLASS_CODEC_PROVIDER;
-    static {
 
-        CodecProvider possibleCodecProvider;
+    static {
+        CodecProvider possibleCodecProvider = null;
+
+        try {
+            Class.forName("org.bson.codecs.kotlinx.KotlinSerializerCodecProvider"); // Kotlinx bson canary test
+            possibleCodecProvider = new KotlinSerializerCodecProvider();
+        } catch (ClassNotFoundException e) {
+            // No kotlinx support
+        }
+        KOTLIN_SERIALIZABLE_CODEC_PROVIDER = possibleCodecProvider;
+
+        possibleCodecProvider = null;
         try {
             Class.forName("org.bson.codecs.kotlin.DataClassCodecProvider"); // Kotlin bson canary test
             possibleCodecProvider = new DataClassCodecProvider();
         } catch (ClassNotFoundException e) {
             // No kotlin data class support
-            possibleCodecProvider = null;
         }
         DATA_CLASS_CODEC_PROVIDER = possibleCodecProvider;
     }
@@ -49,7 +60,15 @@ public class KotlinDataClassCodecProvider implements CodecProvider {
     @Override
     @Nullable
     public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
-        return DATA_CLASS_CODEC_PROVIDER != null ? DATA_CLASS_CODEC_PROVIDER.get(clazz, registry) : null;
+        Codec<T> codec = null;
+        if (KOTLIN_SERIALIZABLE_CODEC_PROVIDER != null) {
+            codec = KOTLIN_SERIALIZABLE_CODEC_PROVIDER.get(clazz, registry);
+        }
+
+        if (codec == null && DATA_CLASS_CODEC_PROVIDER != null) {
+            codec = DATA_CLASS_CODEC_PROVIDER.get(clazz, registry);
+        }
+        return codec;
     }
 
 }

--- a/driver-core/src/main/com/mongodb/MongoClientSettings.java
+++ b/driver-core/src/main/com/mongodb/MongoClientSettings.java
@@ -19,8 +19,8 @@ package com.mongodb;
 import com.mongodb.annotations.Immutable;
 import com.mongodb.annotations.NotThreadSafe;
 import com.mongodb.client.gridfs.codecs.GridFSFileCodecProvider;
-import com.mongodb.client.model.mql.ExpressionCodecProvider;
 import com.mongodb.client.model.geojson.codecs.GeoJsonCodecProvider;
+import com.mongodb.client.model.mql.ExpressionCodecProvider;
 import com.mongodb.connection.ClusterSettings;
 import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.connection.ServerSettings;
@@ -79,7 +79,7 @@ public final class MongoClientSettings {
                     new EnumCodecProvider(),
                     new ExpressionCodecProvider(),
                     new Jep395RecordCodecProvider(),
-                    new KotlinDataClassCodecProvider()));
+                    new KotlinCodecProvider()));
 
     private final ReadPreference readPreference;
     private final WriteConcern writeConcern;
@@ -128,7 +128,7 @@ public final class MongoClientSettings {
      * <li>{@link org.bson.codecs.EnumCodecProvider}</li>
      * <li>{@link ExpressionCodecProvider}</li>
      * <li>{@link com.mongodb.Jep395RecordCodecProvider}</li>
-     * <li>{@link com.mongodb.KotlinDataClassCodecProvider}</li>
+     * <li>{@link com.mongodb.KotlinCodecProvider}</li>
      * </ul>
      *
      * <p>

--- a/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
+++ b/driver-scala/src/test/scala/org/mongodb/scala/ApiAliasAndCompanionSpec.scala
@@ -57,7 +57,7 @@ class ApiAliasAndCompanionSpec extends BaseSpec {
       "FutureResultCallback",
       "Jep395RecordCodecProvider",
       "KerberosSubjectProvider",
-      "KotlinDataClassCodecProvider",
+      "KotlinCodecProvider",
       "MongoClients",
       "NonNull",
       "NonNullApi",


### PR DESCRIPTION
Library adds the initial Kotlinx serialization support via the codec registry. Not intended to be used outside the code registry. Bson annotations are not supported by the kotlinx serialization framework. Kotlinx annotations should be used instead, where appropriate.

Supports Kotlin data types, ObjectId and BsonValues. Alternative types should provide their own serializers. See the kotlinx serialization documentation for more information.

JAVA-4873