### PR TITLE
Reload expansions before deleting Azure resources

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -1857,6 +1857,10 @@ task_groups:
         params:
           file: testazurekms-expansions.yml
     teardown_group:
+      # Load expansions again. The setup task may have failed before running `expansions.update`.
+      - command: expansions.update
+        params:
+          file: testazurekms-expansions.yml
       - command: shell.exec
         params:
           shell: "bash"


### PR DESCRIPTION
JAVA-4926

# Summary
- Reload expansions before deleting Azure resources

Verified with this patch: https://spruce.mongodb.com/version/64305c55d1fe07ff5999c510/

# Background & Motivation

This is an improvement to the `testazurekms_task_group` added as part of DRIVERS-2411. https://github.com/mongodb/mongo-c-driver/pull/1234 explains this improvement.
