### PR TITLE
Fix duplicate retry log messages

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
@@ -46,7 +46,6 @@ import static com.mongodb.internal.operation.CommandOperationHelper.createReadCo
 import static com.mongodb.internal.operation.CommandOperationHelper.decorateReadWithRetries;
 import static com.mongodb.internal.operation.CommandOperationHelper.initialRetryState;
 import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError;
-import static com.mongodb.internal.operation.CommandOperationHelper.logRetryExecute;
 import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError;
 import static com.mongodb.internal.operation.CursorHelper.getCursorDocumentFromBatchSize;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
@@ -120,9 +119,8 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
         RetryState retryState = initialRetryState(retryReads);
-        Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () -> {
-            logRetryExecute(retryState);
-            return withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection) -> {
+        Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () ->
+            withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), binding.getSessionContext()));
                 try {
                     return createReadCommandAndExecute(retryState, binding, source, namespace.getDatabaseName(), getCommandCreator(),
@@ -131,8 +129,8 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
                     return rethrowIfNotNamespaceError(e, createEmptyBatchCursor(namespace, decoder,
                             source.getServerDescription().getAddress(), batchSize));
                 }
-            });
-        });
+            })
+        );
         return read.get();
     }
 
@@ -141,8 +139,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
         RetryState retryState = initialRetryState(retryReads);
         binding.retain();
         AsyncCallbackSupplier<AsyncBatchCursor<T>> asyncRead = CommandOperationHelper.<AsyncBatchCursor<T>>decorateReadWithRetries(
-                retryState, funcCallback -> {
-                    logRetryExecute(retryState);
+                retryState, funcCallback ->
                     withAsyncSourceAndConnection(binding::getReadConnectionSource, false, funcCallback,
                             (source, connection, releasingCallback) -> {
                                 if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(),
@@ -157,8 +154,8 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
                                                 releasingCallback.onResult(result != null ? result : emptyAsyncCursor(source), null);
                                             }
                                         });
-                            });
-                }).whenComplete(binding::release);
+                            })
+                ).whenComplete(binding::release);
         asyncRead.get(errorHandlingCallback(callback, LOGGER));
     }
 


### PR DESCRIPTION
The code that logs retries is now added by the `decorate*WithRetries` methods. Sometimes, this may result in us not logging even the short description of the command that is being retried, because currently we know the command (we create it) only after checking out a connection and checking if the server supports retries. So if the first attempt fails at a point before we create the command (e.g., because of the `MongoConnectionPoolClearedException`), we don't do `retryState.attach(AttachmentKeys.commandDescriptionSupplier(), command::getFirstKey, false)`, and the retrying attempt does not have the information about the command that it retries. This situation will be improved when [Log operation ID when retrying](https://jira.mongodb.org/browse/JAVA-4939) is done.

# Log messages examples
## Before the PR
For each retry attempt we emitted two corresponding log messages. It looked either like
```
> Retrying the operation aggregate ... attempt #2
> Retrying the operation aggregate ... attempt #2
```
or like
```
> Retrying an operation ... attempt #2
> Retrying the operation aggregate ... attempt #2
```

Note how in the second example the first message does not provide a description (`aggregate`) of operation that was being retried. This is because when a retry attempt starts, it may have no information on what command is bing retried, if the first attempt failed too soon to create the command and leave its description for the retry attempt to use.

The first of the two messages in each example is from the start of a retry attempt, the second message is from a point at which the retry attempt is guaranteed to know what is being retried (this point is somewhere in the middle of a retry attempt).

## After the PR
For each retry attempt we emit one corresponding log message. It looks either like

```
> Retrying the operation 'aggregate' ... attempt #2
```

or, if the information on the retrying command is not yet available

```
> Retrying the operation ... attempt #2
```

The message comes from the start of a retry attempt.

So now we don't duplicate retry messages, and don't log them from the middle of a retry attempt, but as a result, we may sometimes not log the description of the retried command. Logging operation ID will allow users to correlate this messages with previous log messages to still see what is being retried, which is why I filed [Log operation ID when retrying](https://jira.mongodb.org/browse/JAVA-4939). Alternatively, we may refactor our code to propagate the description of the retried command from the higher API level (the one that is closer to the user), but I don't think we should do that.

JAVA-4910