### PR TITLE
Stop creating the ECC collection in v2 of queryable encryption

### DIFF
--- a/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
+++ b/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
@@ -214,6 +214,7 @@ public final class AutoEncryptionSettings {
          * @param encryptedFieldsMap the mapping of the collection namespace to the encryptedFields
          * @return this
          * @since 4.7
+         * @mongodb.server.release 7.0
          */
         @Beta(Beta.Reason.SERVER)
         public Builder encryptedFieldsMap(final Map<String, BsonDocument> encryptedFieldsMap) {
@@ -462,6 +463,7 @@ public final class AutoEncryptionSettings {
      *
      * @return the mapping of the collection namespaces to encryptedFields
      * @since 4.7
+     * @mongodb.server.release 7.0
      */
     @Beta(Beta.Reason.SERVER)
     @Nullable

--- a/driver-core/src/main/com/mongodb/client/model/CreateCollectionOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/CreateCollectionOptions.java
@@ -17,6 +17,7 @@
 package com.mongodb.client.model;
 
 import com.mongodb.AutoEncryptionSettings;
+import com.mongodb.annotations.Beta;
 import com.mongodb.lang.Nullable;
 import org.bson.conversions.Bson;
 
@@ -350,8 +351,9 @@ public class CreateCollectionOptions {
      * <p>Note: If not set the driver will lookup the namespace in {@link AutoEncryptionSettings#getEncryptedFieldsMap()}</p>
      * @return the encrypted fields document
      * @since 4.7
-     * @mongodb.server.release 6.0
+     * @mongodb.server.release 7.0
      */
+    @Beta(Beta.Reason.SERVER)
     @Nullable
     public Bson getEncryptedFields() {
         return encryptedFields;
@@ -366,8 +368,9 @@ public class CreateCollectionOptions {
      * @return this
      * @since 4.7
      * @mongodb.driver.manual core/security-client-side-encryption/ In-use encryption
-     * @mongodb.server.release 6.0
+     * @mongodb.server.release 7.0
      */
+    @Beta(Beta.Reason.SERVER)
     public CreateCollectionOptions encryptedFields(@Nullable final Bson encryptedFields) {
         this.encryptedFields = encryptedFields;
         return this;

--- a/driver-core/src/main/com/mongodb/client/model/DropCollectionOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/DropCollectionOptions.java
@@ -17,6 +17,7 @@
 package com.mongodb.client.model;
 
 import com.mongodb.AutoEncryptionSettings;
+import com.mongodb.annotations.Beta;
 import com.mongodb.lang.Nullable;
 import org.bson.conversions.Bson;
 
@@ -36,7 +37,9 @@ public class DropCollectionOptions {
      * <p>Note: If not set the driver will lookup the namespace in {@link AutoEncryptionSettings#getEncryptedFieldsMap()}</p>
      * @return the encrypted fields document
      * @since 4.7
+     * @mongodb.server.release 7.0
      */
+    @Beta(Beta.Reason.SERVER)
     @Nullable
     public Bson getEncryptedFields() {
         return encryptedFields;
@@ -50,8 +53,10 @@ public class DropCollectionOptions {
      * @param encryptedFields the encrypted fields document
      * @return this
      * @since 4.7
+     * @mongodb.server.release 7.0
      * @mongodb.driver.manual core/security-client-side-encryption/ In-use encryption
      */
+    @Beta(Beta.Reason.SERVER)
     public DropCollectionOptions encryptedFields(@Nullable final Bson encryptedFields) {
         this.encryptedFields = encryptedFields;
         return this;

--- a/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
@@ -145,8 +145,6 @@ public class DropCollectionOperation implements AsyncWriteOperation<Void>, Write
      * <li>Drop the collection collectionName.
      * <li>Drop the collection with name encryptedFields["escCollection"].
      *    If encryptedFields["escCollection"] is not set, use the collection name enxcol_.<collectionName>.esc.</li>
-     * <li>Drop the collection with name encryptedFields["eccCollection"].
-     *    If encryptedFields["eccCollection"] is not set, use the collection name enxcol_.<collectionName>.ecc.</li>
      * <li>Drop the collection with name encryptedFields["ecocCollection"].
      *    If encryptedFields["ecocCollection"] is not set, use the collection name enxcol_.<collectionName>.ecoc.</li>
      * </ol>
@@ -160,7 +158,6 @@ public class DropCollectionOperation implements AsyncWriteOperation<Void>, Write
         } else  {
             return asList(
                     () -> getDropEncryptedFieldsCollectionCommand(encryptedFields, "esc"),
-                    () -> getDropEncryptedFieldsCollectionCommand(encryptedFields, "ecc"),
                     () -> getDropEncryptedFieldsCollectionCommand(encryptedFields, "ecoc"),
                     this::dropCollectionCommand
             );

--- a/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
@@ -31,6 +31,7 @@ public final class ServerVersionHelper {
     public static final int FOUR_DOT_FOUR_WIRE_VERSION = 9;
     public static final int FIVE_DOT_ZERO_WIRE_VERSION = 12;
     public static final int SIX_DOT_ZERO_WIRE_VERSION = 17;
+    private static final int SEVEN_DOT_ZERO_WIRE_VERSION = 21;
 
     public static boolean serverIsAtLeastVersionFourDotZero(final ConnectionDescription description) {
         return description.getMaxWireVersion() >= FOUR_DOT_ZERO_WIRE_VERSION;
@@ -58,6 +59,10 @@ public final class ServerVersionHelper {
 
     public static boolean serverIsLessThanVersionFourDotFour(final ConnectionDescription description) {
         return description.getMaxWireVersion() < FOUR_DOT_FOUR_WIRE_VERSION;
+    }
+
+    public static boolean serverIsLessThanVersionSevenDotZero(final ConnectionDescription description) {
+        return description.getMaxWireVersion() < SEVEN_DOT_ZERO_WIRE_VERSION;
     }
 
     private ServerVersionHelper() {

--- a/driver-core/src/test/functional/com/mongodb/client/CommandMonitoringTestHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/CommandMonitoringTestHelper.java
@@ -291,37 +291,25 @@ public final class CommandMonitoringTestHelper {
         BsonDocument command = getWritableCloneOfCommand(event.getCommand());
 
         massageCommand(event, command);
-
+        // The null-treatment below stems from
+        // https://github.com/mongodb/specifications/blob/master/source/transactions/tests/README.rst#null-values
         if (lsidMap == null) {
             command.remove("lsid");
         } else if (command.containsKey("lsid")) {
             command.put("lsid", lsidMap.get(command.getString("lsid").getValue()));
         }
-
-        if (command.containsKey("txnNumber") && command.isNull("txnNumber")) {
-            command.remove("txnNumber");
+        for (String nullableFieldName : new String[] {"txnNumber", "stmtId", "startTransaction", "autocommit", "maxTimeMS", "writeConcern",
+                "allowDiskUse", "readConcern", "encryptedFields"}) {
+            if (command.isNull(nullableFieldName)) {
+                command.remove(nullableFieldName);
+            }
         }
-        if (command.containsKey("stmtId") && command.isNull("stmtId")) {
-            command.remove("stmtId");
-        }
-        if (command.containsKey("startTransaction") && command.isNull("startTransaction")) {
-            command.remove("startTransaction");
-        }
-        if (command.containsKey("autocommit") && command.isNull("autocommit")) {
-            command.remove("autocommit");
-        }
-        if (command.containsKey("maxTimeMS") && command.isNull("maxTimeMS")) {
-            command.remove("maxTimeMS");
-        }
-        if (command.containsKey("writeConcern") && command.isNull("writeConcern")) {
-            command.remove("writeConcern");
-        }
-        if (command.containsKey("allowDiskUse") && command.isNull("allowDiskUse")) {
-            command.remove("allowDiskUse");
-        }
-        if (command.containsKey("readConcern")) {
-            if (command.isNull("readConcern")) {
-                command.remove("readConcern");
+        if (command.containsKey("encryptedFields")) {
+            BsonDocument encryptedFields = command.getDocument("encryptedFields");
+            for (String nullableFieldName : new String[] {"escCollection", "ecocCollection", "eccCollection"}) {
+                if (encryptedFields.isNull(nullableFieldName)) {
+                    encryptedFields.remove(nullableFieldName);
+                }
             }
         }
         command.remove("recoveryToken");

--- a/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-Date.json
+++ b/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-Date.json
@@ -1,7 +1,4 @@
 {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
         {
             "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-Decimal.json
+++ b/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-Decimal.json
@@ -1,7 +1,4 @@
 {
-  "escCollection": "enxcol_.default.esc",
-  "eccCollection": "enxcol_.default.ecc",
-  "ecocCollection": "enxcol_.default.ecoc",
   "fields": [
     {
       "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-DecimalPrecision.json
+++ b/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-DecimalPrecision.json
@@ -1,7 +1,4 @@
 {
-  "escCollection": "enxcol_.default.esc",
-  "eccCollection": "enxcol_.default.ecc",
-  "ecocCollection": "enxcol_.default.ecoc",
   "fields": [
     {
       "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-Double.json
+++ b/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-Double.json
@@ -1,7 +1,4 @@
 {
-  "escCollection": "enxcol_.default.esc",
-  "eccCollection": "enxcol_.default.ecc",
-  "ecocCollection": "enxcol_.default.ecoc",
   "fields": [
     {
       "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-DoublePrecision.json
+++ b/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-DoublePrecision.json
@@ -1,7 +1,4 @@
 {
-  "escCollection": "enxcol_.default.esc",
-  "eccCollection": "enxcol_.default.ecc",
-  "ecocCollection": "enxcol_.default.ecoc",
   "fields": [
     {
       "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-Int.json
+++ b/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-Int.json
@@ -1,7 +1,4 @@
 {
-  "escCollection": "enxcol_.default.esc",
-  "eccCollection": "enxcol_.default.ecc",
-  "ecocCollection": "enxcol_.default.ecoc",
   "fields": [
     {
       "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-Long.json
+++ b/driver-core/src/test/resources/client-side-encryption-data/encryptedFields-Range-Long.json
@@ -1,7 +1,4 @@
 {
-  "escCollection": "enxcol_.default.esc",
-  "eccCollection": "enxcol_.default.ecc",
-  "ecocCollection": "enxcol_.default.ecoc",
   "fields": [
     {
       "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption-data/encryptedFields.json
+++ b/driver-core/src/test/resources/client-side-encryption-data/encryptedFields.json
@@ -1,7 +1,4 @@
 {
-  "escCollection": "enxcol_.default.esc",
-  "eccCollection": "enxcol_.default.ecc",
-  "ecocCollection": "enxcol_.default.ecoc",
   "fields": [
     {
       "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-BypassQueryAnalysis.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-BypassQueryAnalysis.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -153,7 +150,44 @@
                   }
                 }
               ],
-              "ordered": true
+              "ordered": true,
+              "encryptionInformation": {
+                "type": 1,
+                "schema": {
+                  "default.default": {
+                    "escCollection": "enxcol_.default.esc",
+                    "ecocCollection": "enxcol_.default.ecoc",
+                    "fields": [
+                      {
+                        "keyId": {
+                          "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                          }
+                        },
+                        "path": "encryptedIndexed",
+                        "bsonType": "string",
+                        "queries": {
+                          "queryType": "equality",
+                          "contention": {
+                            "$numberLong": "0"
+                          }
+                        }
+                      },
+                      {
+                        "keyId": {
+                          "$binary": {
+                            "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                          }
+                        },
+                        "path": "encryptedUnindexed",
+                        "bsonType": "string"
+                      }
+                    ]
+                  }
+                }
+              }
             },
             "command_name": "insert"
           }

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Compact.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Compact.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-CreateCollection-OldServer.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-CreateCollection-OldServer.json
@@ -1,0 +1,62 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "6.0.0",
+      "maxServerVersion": "6.3.99",
+      "topology": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "tests": [
+    {
+      "description": "driver returns an error if creating a QEv2 collection on unsupported server",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                      "subType": "04"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          },
+          "result": {
+            "errorContains": "Driver support of Queryable Encryption is incompatible with server. Upgrade server to use Queryable Encryption."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-CreateCollection.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-CreateCollection.json
@@ -22,9 +22,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -65,7 +62,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -111,15 +108,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -153,21 +141,6 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
@@ -185,9 +158,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "enxcol_.encryptedCollection.esc",
-                "eccCollection": "enxcol_.encryptedCollection.ecc",
-                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
+                "escCollection": null,
+                "ecocCollection": null,
+                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -243,12 +216,6 @@
                       "subType": "04",
                       "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
                     }
-                  },
-                  "queries": {
-                    "queryType": "equality",
-                    "contention": {
-                      "$numberLong": "0"
-                    }
                   }
                 }
               ]
@@ -280,7 +247,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -326,15 +293,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -368,21 +326,6 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
@@ -400,6 +343,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
+                "escCollection": null,
+                "ecocCollection": null,
+                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -408,12 +354,6 @@
                       "$binary": {
                         "subType": "04",
                         "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
-                      }
-                    },
-                    "queries": {
-                      "queryType": "equality",
-                      "contention": {
-                        "$numberLong": "0"
                       }
                     }
                   }
@@ -461,12 +401,6 @@
                       "subType": "04",
                       "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
                     }
-                  },
-                  "queries": {
-                    "queryType": "equality",
-                    "contention": {
-                      "$numberLong": "0"
-                    }
                   }
                 }
               ]
@@ -498,7 +432,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -535,14 +469,6 @@
           "object": "database",
           "arguments": {
             "collection": "encryptedCollection"
-          }
-        },
-        {
-          "name": "assertCollectionNotExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
-            "collection": "enxcol_.encryptedCollection.ecc"
           }
         },
         {
@@ -584,15 +510,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -612,21 +529,6 @@
           "command_started_event": {
             "command": {
               "create": "enxcol_.encryptedCollection.esc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
               "clusteredIndex": {
                 "key": {
                   "_id": 1
@@ -667,12 +569,6 @@
                         "subType": "04",
                         "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
                       }
-                    },
-                    "queries": {
-                      "queryType": "equality",
-                      "contention": {
-                        "$numberLong": "0"
-                      }
                     }
                   }
                 ]
@@ -711,15 +607,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -732,235 +619,6 @@
               "drop": "encryptedCollection"
             },
             "command_name": "drop",
-            "database_name": "default"
-          }
-        }
-      ]
-    },
-    {
-      "description": "encryptedFieldsMap with cyclic entries does not loop",
-      "clientOptions": {
-        "autoEncryptOpts": {
-          "kmsProviders": {
-            "aws": {}
-          },
-          "encryptedFieldsMap": {
-            "default.encryptedCollection": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
-              "fields": [
-                {
-                  "path": "firstName",
-                  "bsonType": "string",
-                  "keyId": {
-                    "$binary": {
-                      "subType": "04",
-                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
-                    }
-                  }
-                }
-              ]
-            },
-            "default.encryptedCollection.esc": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
-              "fields": [
-                {
-                  "path": "firstName",
-                  "bsonType": "string",
-                  "keyId": {
-                    "$binary": {
-                      "subType": "04",
-                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "operations": [
-        {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "encryptedCollection"
-          }
-        },
-        {
-          "name": "createCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "encryptedCollection"
-          }
-        },
-        {
-          "name": "assertCollectionExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
-            "collection": "enxcol_.encryptedCollection.esc"
-          }
-        },
-        {
-          "name": "assertCollectionExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
-            "collection": "enxcol_.encryptedCollection.ecc"
-          }
-        },
-        {
-          "name": "assertCollectionExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
-            "collection": "enxcol_.encryptedCollection.ecoc"
-          }
-        },
-        {
-          "name": "assertCollectionExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
-            "collection": "encryptedCollection"
-          }
-        },
-        {
-          "name": "assertIndexExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
-            "collection": "encryptedCollection",
-            "index": "__safeContent___1"
-          }
-        }
-      ],
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.esc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.ecoc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "create": "enxcol_.encryptedCollection.esc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "create": "enxcol_.encryptedCollection.ecoc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "create": "encryptedCollection",
-              "encryptedFields": {
-                "escCollection": "enxcol_.encryptedCollection.esc",
-                "eccCollection": "enxcol_.encryptedCollection.ecc",
-                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
-                "fields": [
-                  {
-                    "path": "firstName",
-                    "bsonType": "string",
-                    "keyId": {
-                      "$binary": {
-                        "subType": "04",
-                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "createIndexes": "encryptedCollection",
-              "indexes": [
-                {
-                  "name": "__safeContent___1",
-                  "key": {
-                    "__safeContent__": 1
-                  }
-                }
-              ]
-            },
-            "command_name": "createIndexes",
             "database_name": "default"
           }
         }
@@ -975,9 +633,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1060,9 +715,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1103,7 +755,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -1149,15 +801,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -1191,21 +834,6 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
@@ -1223,9 +851,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "enxcol_.encryptedCollection.esc",
-                "eccCollection": "enxcol_.encryptedCollection.ecc",
-                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
+                "escCollection": null,
+                "ecocCollection": null,
+                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1279,9 +907,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1303,9 +928,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1330,7 +952,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -1376,15 +998,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -1418,21 +1031,6 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
@@ -1450,9 +1048,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "enxcol_.encryptedCollection.esc",
-                "eccCollection": "enxcol_.encryptedCollection.ecc",
-                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
+                "escCollection": null,
+                "ecocCollection": null,
+                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1511,9 +1109,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1544,15 +1139,6 @@
           "command_started_event": {
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1595,9 +1181,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1619,9 +1202,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1646,7 +1226,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -1684,9 +1264,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1715,14 +1292,6 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "enxcol_.encryptedCollection.ecc"
-          }
-        },
-        {
-          "name": "assertCollectionNotExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
             "collection": "enxcol_.encryptedCollection.ecoc"
           }
         },
@@ -1740,15 +1309,6 @@
           "command_started_event": {
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1790,21 +1350,6 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
@@ -1822,9 +1367,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "enxcol_.encryptedCollection.esc",
-                "eccCollection": "enxcol_.encryptedCollection.ecc",
-                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
+                "escCollection": null,
+                "ecocCollection": null,
+                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1876,15 +1421,6 @@
           "command_started_event": {
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1927,9 +1463,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1951,9 +1484,6 @@
           "arguments": {
             "collection": "encryptedCollection",
             "encryptedFields": {
-              "escCollection": "enxcol_.encryptedCollection.esc",
-              "eccCollection": "enxcol_.encryptedCollection.ecc",
-              "ecocCollection": "enxcol_.encryptedCollection.ecoc",
               "fields": [
                 {
                   "path": "firstName",
@@ -1978,7 +1508,7 @@
           }
         },
         {
-          "name": "assertCollectionExists",
+          "name": "assertCollectionNotExists",
           "object": "testRunner",
           "arguments": {
             "database": "default",
@@ -2030,14 +1560,6 @@
           "object": "testRunner",
           "arguments": {
             "database": "default",
-            "collection": "enxcol_.encryptedCollection.ecc"
-          }
-        },
-        {
-          "name": "assertCollectionNotExists",
-          "object": "testRunner",
-          "arguments": {
-            "database": "default",
             "collection": "enxcol_.encryptedCollection.ecoc"
           }
         },
@@ -2055,15 +1577,6 @@
           "command_started_event": {
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -2105,21 +1618,6 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc",
-              "clusteredIndex": {
-                "key": {
-                  "_id": 1
-                },
-                "unique": true
-              }
-            },
-            "command_name": "create",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "create": "enxcol_.encryptedCollection.ecoc",
               "clusteredIndex": {
                 "key": {
@@ -2137,9 +1635,9 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": "enxcol_.encryptedCollection.esc",
-                "eccCollection": "enxcol_.encryptedCollection.ecc",
-                "ecocCollection": "enxcol_.encryptedCollection.ecoc",
+                "escCollection": null,
+                "ecocCollection": null,
+                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -2211,15 +1709,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "enxcol_.encryptedCollection.ecc"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
             "command_name": "drop",
@@ -2233,6 +1722,53 @@
             },
             "command_name": "drop",
             "database_name": "default"
+          }
+        }
+      ]
+    },
+    {
+      "description": "encryptedFields are consulted for metadata collection names",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "invalid_esc_name",
+              "ecocCollection": "invalid_ecoc_name",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          },
+          "result": {
+            "errorContains": "Encrypted State Collection name should follow"
           }
         }
       ]

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -180,7 +177,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -236,12 +232,12 @@
                   "limit": 1
                 }
               ],
+              "ordered": true,
               "encryptionInformation": {
                 "type": 1,
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-EncryptedFields-vs-EncryptedFieldsMap.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-EncryptedFields-vs-EncryptedFieldsMap.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -95,9 +92,6 @@
           },
           "encryptedFieldsMap": {
             "default.default": {
-              "escCollection": "enxcol_.default.esc",
-              "eccCollection": "enxcol_.default.ecc",
-              "ecocCollection": "enxcol_.default.ecoc",
               "fields": []
             }
           }

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-EncryptedFields-vs-jsonSchema.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-EncryptedFields-vs-jsonSchema.json
@@ -18,9 +18,6 @@
     "bsonType": "object"
   },
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -187,7 +184,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -243,7 +239,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-EncryptedFieldsMap-defaults.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-EncryptedFieldsMap-defaults.json
@@ -74,9 +74,9 @@
                 },
                 "schema": {
                   "default.default": {
-                    "fields": [],
                     "escCollection": "enxcol_.default.esc",
-                    "ecocCollection": "enxcol_.default.ecoc"
+                    "ecocCollection": "enxcol_.default.ecoc",
+                    "fields": []
                   }
                 }
               },

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -187,7 +184,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -248,7 +244,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -429,7 +424,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -492,7 +486,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-InsertFind-Indexed.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-InsertFind-Indexed.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -183,7 +180,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -239,7 +235,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-InsertFind-Unindexed.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-InsertFind-Unindexed.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-MissingKey.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-MissingKey.json
@@ -23,9 +23,6 @@
     }
   ],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Aggregate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -217,7 +214,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -275,7 +271,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -339,7 +334,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Correctness.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -206,7 +203,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -264,7 +260,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -323,12 +318,12 @@
                   "limit": 1
                 }
               ],
+              "ordered": true,
               "encryptionInformation": {
                 "type": 1,
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -221,7 +218,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -279,7 +275,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -345,7 +340,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-InsertFind.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -213,7 +210,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -271,7 +267,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -330,7 +325,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -217,7 +214,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -275,7 +271,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -347,7 +342,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Aggregate.json
@@ -12,9 +12,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -197,7 +194,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -245,7 +241,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -299,7 +294,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Correctness.json
@@ -12,9 +12,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Delete.json
@@ -12,9 +12,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -188,7 +185,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -236,7 +232,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -285,12 +280,12 @@
                   "limit": 1
                 }
               ],
+              "ordered": true,
               "encryptionInformation": {
                 "type": 1,
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
@@ -12,9 +12,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -199,7 +196,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -247,7 +243,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -303,7 +298,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-InsertFind.json
@@ -12,9 +12,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -193,7 +190,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -241,7 +237,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -290,7 +285,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Update.json
@@ -12,9 +12,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -197,7 +194,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -245,7 +241,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -307,7 +302,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -208,7 +205,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -265,7 +261,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -328,7 +323,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -199,7 +196,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -256,7 +252,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -314,12 +309,12 @@
                   "limit": 1
                 }
               ],
+              "ordered": true,
               "encryptionInformation": {
                 "type": 1,
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -210,7 +207,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -267,7 +263,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -332,7 +327,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -204,7 +201,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -261,7 +257,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -319,7 +314,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -208,7 +205,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -265,7 +261,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -336,7 +331,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Aggregate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -199,7 +196,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -247,7 +243,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -301,7 +296,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Correctness.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -190,7 +187,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -238,7 +234,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -287,12 +282,12 @@
                   "limit": 1
                 }
               ],
+              "ordered": true,
               "encryptionInformation": {
                 "type": 1,
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -201,7 +198,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -249,7 +245,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -305,7 +300,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-InsertFind.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -195,7 +192,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -243,7 +239,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -292,7 +287,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -199,7 +196,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -247,7 +243,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -309,7 +304,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -208,7 +205,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -265,7 +261,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -328,7 +323,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -199,7 +196,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -256,7 +252,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -314,12 +309,12 @@
                   "limit": 1
                 }
               ],
+              "ordered": true,
               "encryptionInformation": {
                 "type": 1,
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -210,7 +207,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -267,7 +263,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -332,7 +327,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -204,7 +201,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -261,7 +257,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -319,7 +314,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -208,7 +205,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -265,7 +261,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -336,7 +331,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Aggregate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -205,7 +202,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -259,7 +255,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -319,7 +314,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Correctness.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -196,7 +193,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -250,7 +246,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -305,12 +300,12 @@
                   "limit": 1
                 }
               ],
+              "ordered": true,
               "encryptionInformation": {
                 "type": 1,
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -207,7 +204,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -261,7 +257,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -323,7 +318,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-InsertFind.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -201,7 +198,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -255,7 +251,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -310,7 +305,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -205,7 +202,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -259,7 +255,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -327,7 +322,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Aggregate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -205,7 +202,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -259,7 +255,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -319,7 +314,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Correctness.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Delete.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -196,7 +193,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -250,7 +246,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -305,12 +300,12 @@
                   "limit": 1
                 }
               ],
+              "ordered": true,
               "encryptionInformation": {
                 "type": 1,
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -207,7 +204,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -261,7 +257,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -323,7 +318,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-InsertFind.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -201,7 +198,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -255,7 +251,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -310,7 +305,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -205,7 +202,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -259,7 +255,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -327,7 +322,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-WrongType.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-WrongType.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Update.json
@@ -14,9 +14,6 @@
   "collection_name": "default",
   "data": [],
   "encrypted_fields": {
-    "escCollection": "enxcol_.default.esc",
-    "eccCollection": "enxcol_.default.ecc",
-    "ecocCollection": "enxcol_.default.ecoc",
     "fields": [
       {
         "keyId": {
@@ -187,7 +184,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -247,12 +243,12 @@
                   }
                 }
               ],
+              "ordered": true,
               "encryptionInformation": {
                 "type": 1,
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -433,7 +429,6 @@
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {
@@ -495,12 +490,12 @@
                   }
                 }
               ],
+              "ordered": true,
               "encryptionInformation": {
                 "type": 1,
                 "schema": {
                   "default.default": {
                     "escCollection": "enxcol_.default.esc",
-                    "eccCollection": "enxcol_.default.ecc",
                     "ecocCollection": "enxcol_.default.ecoc",
                     "fields": [
                       {

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-validatorAndPartialFieldExpression.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-validatorAndPartialFieldExpression.json
@@ -30,9 +30,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.default.esc",
-              "eccCollection": "enxcol_.default.ecc",
-              "ecocCollection": "enxcol_.default.ecoc",
               "fields": [
                 {
                   "keyId": {
@@ -109,9 +106,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.default.esc",
-              "eccCollection": "enxcol_.default.ecc",
-              "ecocCollection": "enxcol_.default.ecoc",
               "fields": [
                 {
                   "keyId": {
@@ -183,9 +177,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.default.esc",
-              "eccCollection": "enxcol_.default.ecc",
-              "ecocCollection": "enxcol_.default.ecoc",
               "fields": [
                 {
                   "keyId": {
@@ -263,9 +254,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.default.esc",
-              "eccCollection": "enxcol_.default.ecc",
-              "ecocCollection": "enxcol_.default.ecoc",
               "fields": [
                 {
                   "keyId": {
@@ -346,9 +334,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.default.esc",
-              "eccCollection": "enxcol_.default.ecc",
-              "ecocCollection": "enxcol_.default.ecoc",
               "fields": [
                 {
                   "keyId": {
@@ -443,9 +428,6 @@
           },
           "encryptedFieldsMap": {
             "default.encryptedCollection": {
-              "escCollection": "enxcol_.default.esc",
-              "eccCollection": "enxcol_.default.ecc",
-              "ecocCollection": "enxcol_.default.ecoc",
               "fields": [
                 {
                   "keyId": {

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/vault/ClientEncryption.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/vault/ClientEncryption.java
@@ -212,7 +212,7 @@ public interface ClientEncryption extends Closeable {
      * {@linkplain MongoUpdatedEncryptedFieldsException#getEncryptedFields() available} to the caller.</p>
      *
      * @since 4.9
-     * @mongodb.server.release 6.0
+     * @mongodb.server.release 7.0
      * @mongodb.driver.manual reference/command/create Create Command
      */
     @Beta(Beta.Reason.SERVER)

--- a/driver-scala/src/main/scala/org/mongodb/scala/vault/ClientEncryption.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/vault/ClientEncryption.scala
@@ -123,7 +123,7 @@ case class ClientEncryption(private val wrapped: JClientEncryption) extends Clos
    * Produces MongoUpdatedEncryptedFieldsException` if an exception happens after creating at least one data key.
    * This exception makes the updated `encryptedFields` available to the caller.
    * @since 4.9
-   * @note Requires MongoDB 6.0 or greater.
+   * @note Requires MongoDB 7.0 or greater.
    * @see [[https://www.mongodb.com/docs/manual/reference/command/create/ Create Command]]
    */
   @Beta(Array(Beta.Reason.SERVER))

--- a/driver-sync/src/main/com/mongodb/client/vault/ClientEncryption.java
+++ b/driver-sync/src/main/com/mongodb/client/vault/ClientEncryption.java
@@ -214,7 +214,7 @@ public interface ClientEncryption extends Closeable {
      * {@linkplain MongoUpdatedEncryptedFieldsException#getEncryptedFields() available} to the caller.
      *
      * @since 4.9
-     * @mongodb.server.release 6.0
+     * @mongodb.server.release 7.0
      * @mongodb.driver.manual reference/command/create Create Command
      */
     @Beta(Beta.Reason.SERVER)


### PR DESCRIPTION
- Reviewing commit by commit allows skipping the commit that synchronizes the tests with the specs repo.
- Creating a collection with `encryptedFields` specified now requires MongoDB 7.0+, which is why I specified `@mongodb.server.release 7.0` everywhere `encryptedFields` is used (the driver does not do the check when dropping a collection, but it still does not seem meaningful to document `DropCollectionOptions.encryptedFields` any different than other places).
- `CreateCollectionOptions.encryptedFields`/`DropCollectionOptions.encryptedFields` were not documented as `@Beta`, which appears to be a mistake, given that the whole queryable encryption feature is in preview. I documented them as such.


JAVA-4858