### PR TITLE
Add operation identifier to retry logs.

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -613,9 +613,8 @@ final class CommandOperationHelper {
             int oneBasedAttempt = retryState.attempt() + 1;
             long operationId = operationContext.getId();
             LOGGER.debug(commandDescription == null
-                    ? format("Retrying the operation with operation ID %s due to the error \"%s\". Attempt number: #%d", operationId,
-                    exception,
-                    oneBasedAttempt)
+                    ? format("Retrying the operation with operation ID %s due to the error \"%s\". Attempt number: #%d",
+                    operationId, exception, oneBasedAttempt)
                     : format("Retrying the operation '%s' with operation ID %s due to the error \"%s\". Attempt number: #%d",
                     commandDescription, operationId, exception, oneBasedAttempt));
         }

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -613,9 +613,11 @@ final class CommandOperationHelper {
             int oneBasedAttempt = retryState.attempt() + 1;
             long operationId = operationContext.getId();
             LOGGER.debug(commandDescription == null
-                    ? format("Retrying the operation due to the error \"%s\"; attempt #%d; operation ID %s", exception, oneBasedAttempt, operationId)
-                    : format("Retrying the operation '%s' due to the error \"%s\"; attempt #%d; operation ID %s",
-                            commandDescription, exception, oneBasedAttempt, operationId));
+                    ? format("Retrying the operation with operation ID %s due to the error \"%s\". Attempt number: #%d", operationId,
+                    exception,
+                    oneBasedAttempt)
+                    : format("Retrying the operation '%s' with operation ID %s due to the error \"%s\". Attempt number: #%d",
+                    commandDescription, operationId, exception, oneBasedAttempt));
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
@@ -317,7 +317,7 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
         RetryState retryState = initialRetryState(retryReads);
-        Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () ->
+        Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, binding.getOperationContext(), () ->
             withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), binding.getSessionContext()));
                 try {
@@ -338,7 +338,7 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
         RetryState retryState = initialRetryState(retryReads);
         binding.retain();
         AsyncCallbackSupplier<AsyncBatchCursor<T>> asyncRead = CommandOperationHelper.<AsyncBatchCursor<T>>decorateReadWithRetries(
-                retryState, funcCallback ->
+                retryState, binding.getOperationContext(), funcCallback ->
                     withAsyncSourceAndConnection(binding::getReadConnectionSource, false, funcCallback,
                             (source, connection, releasingCallback) -> {
                                 if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(),

--- a/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
@@ -141,7 +141,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
         RetryState retryState = initialRetryState(retryReads);
-        Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () ->
+        Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, binding.getOperationContext(), () ->
             withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), binding.getSessionContext()));
                 try {
@@ -161,7 +161,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
         RetryState retryState = initialRetryState(retryReads);
         binding.retain();
         AsyncCallbackSupplier<AsyncBatchCursor<T>> asyncRead = CommandOperationHelper.<AsyncBatchCursor<T>>decorateReadWithRetries(
-                retryState, funcCallback ->
+                retryState, binding.getOperationContext(), funcCallback ->
                     withAsyncSourceAndConnection(binding::getReadConnectionSource, false, funcCallback,
                             (source, connection, releasingCallback) -> {
                                 if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(),

--- a/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
@@ -119,7 +119,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
         RetryState retryState = initialRetryState(retryReads);
-        Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, () ->
+        Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, binding.getOperationContext(), () ->
             withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), binding.getSessionContext()));
                 try {
@@ -139,7 +139,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
         RetryState retryState = initialRetryState(retryReads);
         binding.retain();
         AsyncCallbackSupplier<AsyncBatchCursor<T>> asyncRead = CommandOperationHelper.<AsyncBatchCursor<T>>decorateReadWithRetries(
-                retryState, funcCallback ->
+                retryState, binding.getOperationContext(), funcCallback ->
                     withAsyncSourceAndConnection(binding::getReadConnectionSource, false, funcCallback,
                             (source, connection, releasingCallback) -> {
                                 if (retryState.breakAndCompleteIfRetryAnd(() -> !canRetryRead(source.getServerDescription(),

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -365,7 +365,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
                             bulkWriteBatch.addResult(
                                     (BsonDocument) ((MongoWriteConcernWithResponseException) prospectiveFailedResult).getResponse());
                             BulkWriteTracker.attachNext(retryState, bulkWriteBatch);
-                        });
+                });
             }
         }
     }
@@ -384,7 +384,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
                             bulkWriteBatch.addResult(
                                     (BsonDocument) ((MongoWriteConcernWithResponseException) prospectiveFailedResult).getResponse());
                             BulkWriteTracker.attachNext(retryState, bulkWriteBatch);
-                        });
+                });
             }
         }
         return false;

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -36,6 +36,7 @@ import com.mongodb.internal.bulk.WriteRequest;
 import com.mongodb.internal.connection.AsyncConnection;
 import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.connection.MongoWriteConcernWithResponseException;
+import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.internal.connection.ProtocolHelper;
 import com.mongodb.internal.operation.retry.AttachmentKeys;
 import com.mongodb.internal.session.SessionContext;
@@ -137,19 +138,20 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
         return retryWrites;
     }
 
-    private <R> Supplier<R> decorateWriteWithRetries(final RetryState retryState, final Supplier<R> writeFunction) {
+    private <R> Supplier<R> decorateWriteWithRetries(final RetryState retryState, final OperationContext operationContext,
+            final Supplier<R> writeFunction) {
         return new RetryingSyncSupplier<>(retryState, CommandOperationHelper::chooseRetryableWriteException,
                 this::shouldAttemptToRetryWrite, () -> {
-            logRetryExecute(retryState);
+            logRetryExecute(retryState, operationContext);
             return writeFunction.get();
         });
     }
 
-    private <R> AsyncCallbackSupplier<R> decorateWriteWithRetries(final RetryState retryState,
+    private <R> AsyncCallbackSupplier<R> decorateWriteWithRetries(final RetryState retryState, final OperationContext operationContext,
             final AsyncCallbackSupplier<R> writeFunction) {
         return new RetryingAsyncCallbackSupplier<>(retryState, CommandOperationHelper::chooseRetryableWriteException,
                 this::shouldAttemptToRetryWrite, callback -> {
-            logRetryExecute(retryState);
+            logRetryExecute(retryState, operationContext);
             writeFunction.get(callback);
         });
     }
@@ -182,7 +184,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
          * and the code related to the attempt tracking in `BulkWriteTracker` will be removed. */
         RetryState retryState = new RetryState();
         BulkWriteTracker.attachNew(retryState, retryWrites);
-        Supplier<BulkWriteResult> retryingBulkWrite = decorateWriteWithRetries(retryState, () ->
+        Supplier<BulkWriteResult> retryingBulkWrite = decorateWriteWithRetries(retryState, binding.getOperationContext(), () ->
             withSourceAndConnection(binding::getWriteConnectionSource, true, (source, connection) -> {
                 ConnectionDescription connectionDescription = connection.getDescription();
                 // attach `maxWireVersion` ASAP because it is used to check whether we can retry
@@ -214,6 +216,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
         BulkWriteTracker.attachNew(retryState, retryWrites);
         binding.retain();
         AsyncCallbackSupplier<BulkWriteResult> retryingBulkWrite = this.<BulkWriteResult>decorateWriteWithRetries(retryState,
+                binding.getOperationContext(),
                 funcCallback ->
             withAsyncSourceAndConnection(binding::getWriteConnectionSource, true, funcCallback,
                     (source, connection, releasingCallback) -> {
@@ -362,7 +365,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
                             bulkWriteBatch.addResult(
                                     (BsonDocument) ((MongoWriteConcernWithResponseException) prospectiveFailedResult).getResponse());
                             BulkWriteTracker.attachNext(retryState, bulkWriteBatch);
-                });
+                        });
             }
         }
     }
@@ -381,7 +384,7 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
                             bulkWriteBatch.addResult(
                                     (BsonDocument) ((MongoWriteConcernWithResponseException) prospectiveFailedResult).getResponse());
                             BulkWriteTracker.attachNext(retryState, bulkWriteBatch);
-                });
+                        });
             }
         }
         return false;


### PR DESCRIPTION
This PR adds logging of the `OperationContext` object to the `CommandOperationHelper.logRetryExecute()` method. The `OperationContext` object provides context information about the operation being executed, such as the operation id.

Logging  the `OperationContext` object  can be useful for troubleshooting, as it allows us to track the execution of specific operations.

[JAVA-4939](https://jira.mongodb.org/browse/JAVA-4939)