### PR TITLE
Deprecate `Parameterizable`, introduce default `CodecProvider.get(Class<T>, List<Type>, CodecRegistry)` instead

### DIFF
--- a/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/DataClassCodecProvider.kt
+++ b/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/DataClassCodecProvider.kt
@@ -18,9 +18,13 @@ package org.bson.codecs.kotlin
 import org.bson.codecs.Codec
 import org.bson.codecs.configuration.CodecProvider
 import org.bson.codecs.configuration.CodecRegistry
+import java.lang.reflect.Type
 
 /** A Kotlin reflection based Codec Provider for data classes */
 public class DataClassCodecProvider : CodecProvider {
     override fun <T : Any> get(clazz: Class<T>, registry: CodecRegistry): Codec<T>? =
-        DataClassCodec.create(clazz.kotlin, registry)
+        get(clazz, emptyList(), registry)
+
+    override fun <T : Any> get(clazz: Class<T>, typeArguments: List<Type>, registry: CodecRegistry): Codec<T>? =
+        DataClassCodec.create(clazz.kotlin, registry, typeArguments)
 }

--- a/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/DataClassCodecProviderTest.kt
+++ b/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/DataClassCodecProviderTest.kt
@@ -16,23 +16,16 @@
 package org.bson.codecs.kotlin
 
 import com.mongodb.MongoClientSettings
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
-import org.bson.BsonDocument
-import org.bson.BsonDocumentReader
-import org.bson.BsonDocumentWriter
-import org.bson.codecs.DecoderContext
-import org.bson.codecs.EncoderContext
 import org.bson.codecs.configuration.CodecConfigurationException
-import org.bson.codecs.kotlin.samples.DataClassEmbedded
 import org.bson.codecs.kotlin.samples.DataClassParameterized
-import org.bson.codecs.kotlin.samples.DataClassWithParameterizedDataClass
 import org.bson.codecs.kotlin.samples.DataClassWithSimpleValues
 import org.bson.conversions.Bson
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class DataClassCodecProviderTest {
 
@@ -52,27 +45,9 @@ class DataClassCodecProviderTest {
     }
 
     @Test
-    fun shouldReturnRawDataClassCodecForParameterizedDataClass() {
-        val provider = DataClassCodecProvider()
-        val codec = provider.get(DataClassParameterized::class.java, Bson.DEFAULT_CODEC_REGISTRY)
-
-        assertNotNull(codec)
-        assertTrue { codec is DataClassCodec.Companion.RawDataClassCodec }
-        assertEquals(DataClassParameterized::class.java, codec.encoderClass)
-
+    fun shouldRequireTypeArgumentsForDataClassParameterized() {
         assertThrows<CodecConfigurationException> {
-            val writer = BsonDocumentWriter(BsonDocument())
-            val dataClass =
-                DataClassWithParameterizedDataClass(
-                    "myId", DataClassParameterized(2.0, "myString", listOf(DataClassEmbedded("embedded1"))))
-            codec.encode(writer, dataClass.parameterizedDataClass, EncoderContext.builder().build())
-        }
-
-        assertThrows<CodecConfigurationException> {
-            val value =
-                BsonDocument.parse(
-                    """{"number": 2.0, "string": "myString", "parameterizedList": [{"name": "embedded1"}]}""")
-            codec.decode(BsonDocumentReader(value), DecoderContext.builder().build())
+            DataClassCodecProvider().get(DataClassParameterized::class.java, Bson.DEFAULT_CODEC_REGISTRY)
         }
     }
 

--- a/bson-record-codec/src/main/org/bson/codecs/record/RecordCodecProvider.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/RecordCodecProvider.java
@@ -20,6 +20,11 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 
+import java.lang.reflect.Type;
+import java.util.List;
+
+import static org.bson.assertions.Assertions.assertNotNull;
+
 /**
  * Provides Codec instances for Java records.
  *
@@ -27,13 +32,18 @@ import org.bson.codecs.configuration.CodecRegistry;
  * @see Record
  */
 public final class RecordCodecProvider implements CodecProvider {
-    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
-        if (!clazz.isRecord()) {
+        return get(clazz, List.of(), registry);
+    }
+
+    @Override
+    public <T> Codec<T> get(final Class<T> clazz, final List<Type> typeArguments, final CodecRegistry registry) {
+        if (!assertNotNull(clazz).isRecord()) {
             return null;
         }
-
-        return (Codec<T>) new RecordCodec(clazz, registry);
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Codec<T> result = new RecordCodec(clazz, assertNotNull(typeArguments), registry);
+        return result;
     }
 }

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
@@ -27,6 +27,7 @@ import org.bson.BsonString;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 import org.bson.codecs.configuration.CodecConfigurationException;
+import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.record.samples.TestRecordEmbedded;
 import org.bson.codecs.record.samples.TestRecordParameterized;
 import org.bson.codecs.record.samples.TestRecordWithDeprecatedAnnotations;
@@ -67,7 +68,7 @@ public class RecordCodecTest {
 
     @Test
     public void testRecordWithDeprecatedAnnotations() {
-        var codec = new RecordCodec<>(TestRecordWithDeprecatedAnnotations.class, Bson.DEFAULT_CODEC_REGISTRY);
+        var codec = createRecordCodec(TestRecordWithDeprecatedAnnotations.class, Bson.DEFAULT_CODEC_REGISTRY);
         var identifier = new ObjectId();
         var testRecord = new TestRecordWithDeprecatedAnnotations("Lucas", 14, List.of("soccer", "basketball"), identifier.toHexString());
 
@@ -95,7 +96,7 @@ public class RecordCodecTest {
 
     @Test
     public void testRecordWithPojoAnnotations() {
-        var codec = new RecordCodec<>(TestRecordWithPojoAnnotations.class, Bson.DEFAULT_CODEC_REGISTRY);
+        var codec = createRecordCodec(TestRecordWithPojoAnnotations.class, Bson.DEFAULT_CODEC_REGISTRY);
         var identifier = new ObjectId();
         var testRecord = new TestRecordWithPojoAnnotations("Lucas", 14, List.of("soccer", "basketball"), identifier.toHexString());
 
@@ -123,7 +124,7 @@ public class RecordCodecTest {
 
     @Test
     public void testRecordWithNestedListOfRecords() {
-        var codec = new RecordCodec<>(TestRecordWithListOfRecords.class,
+        var codec = createRecordCodec(TestRecordWithListOfRecords.class,
                 fromProviders(new RecordCodecProvider(), Bson.DEFAULT_CODEC_REGISTRY));
         var identifier = new ObjectId();
         var testRecord = new TestRecordWithListOfRecords(identifier, List.of(new TestRecordEmbedded("embedded")));
@@ -150,7 +151,7 @@ public class RecordCodecTest {
 
     @Test
     public void testRecordWithNestedListOfListOfRecords() {
-        var codec = new RecordCodec<>(TestRecordWithListOfListOfRecords.class,
+        var codec = createRecordCodec(TestRecordWithListOfListOfRecords.class,
                 fromProviders(new RecordCodecProvider(), Bson.DEFAULT_CODEC_REGISTRY));
         var identifier = new ObjectId();
         var testRecord = new TestRecordWithListOfListOfRecords(identifier, List.of(List.of(new TestRecordEmbedded("embedded"))));
@@ -178,7 +179,7 @@ public class RecordCodecTest {
 
     @Test
     public void testRecordWithNestedMapOfRecords() {
-        var codec = new RecordCodec<>(TestRecordWithMapOfRecords.class,
+        var codec = createRecordCodec(TestRecordWithMapOfRecords.class,
                 fromProviders(new RecordCodecProvider(), Bson.DEFAULT_CODEC_REGISTRY));
         var identifier = new ObjectId();
         var testRecord = new TestRecordWithMapOfRecords(identifier,
@@ -206,7 +207,7 @@ public class RecordCodecTest {
 
     @Test
     public void testRecordWithNestedMapOfListRecords() {
-        var codec = new RecordCodec<>(TestRecordWithMapOfListOfRecords.class,
+        var codec = createRecordCodec(TestRecordWithMapOfListOfRecords.class,
                 fromProviders(new RecordCodecProvider(), Bson.DEFAULT_CODEC_REGISTRY));
         var identifier = new ObjectId();
         var testRecord = new TestRecordWithMapOfListOfRecords(identifier,
@@ -236,7 +237,7 @@ public class RecordCodecTest {
 
     @Test
     public void testRecordWithNestedParameterizedRecord() {
-        var codec = new RecordCodec<>(TestRecordWithParameterizedRecord.class,
+        var codec = createRecordCodec(TestRecordWithParameterizedRecord.class,
                 fromProviders(new RecordCodecProvider(), Bson.DEFAULT_CODEC_REGISTRY));
         var identifier = new ObjectId();
         var testRecord = new TestRecordWithParameterizedRecord(identifier,
@@ -267,7 +268,7 @@ public class RecordCodecTest {
 
     @Test
     public void testRecordWithNestedParameterizedRecordWithDifferentlyOrderedTypeParameters() {
-        var codec = new RecordCodec<>(TestRecordWithNestedParameterizedRecord.class,
+        var codec = createRecordCodec(TestRecordWithNestedParameterizedRecord.class,
                 fromProviders(new RecordCodecProvider(), Bson.DEFAULT_CODEC_REGISTRY));
         var identifier = new ObjectId();
         var testRecord = new TestRecordWithNestedParameterizedRecord(identifier,
@@ -301,7 +302,7 @@ public class RecordCodecTest {
 
     @Test
     public void testRecordWithNulls() {
-        var codec = new RecordCodec<>(TestRecordWithDeprecatedAnnotations.class, Bson.DEFAULT_CODEC_REGISTRY);
+        var codec = createRecordCodec(TestRecordWithDeprecatedAnnotations.class, Bson.DEFAULT_CODEC_REGISTRY);
         var identifier = new ObjectId();
         var testRecord = new TestRecordWithDeprecatedAnnotations(null, 14, null, identifier.toHexString());
 
@@ -326,7 +327,7 @@ public class RecordCodecTest {
 
     @Test
     public void testRecordWithExtraData() {
-        var codec = new RecordCodec<>(TestRecordWithDeprecatedAnnotations.class, Bson.DEFAULT_CODEC_REGISTRY);
+        var codec = createRecordCodec(TestRecordWithDeprecatedAnnotations.class, Bson.DEFAULT_CODEC_REGISTRY);
         var identifier = new ObjectId();
         var testRecord = new TestRecordWithDeprecatedAnnotations("Felix", 13, List.of("rugby", "badminton"), identifier.toHexString());
 
@@ -376,36 +377,40 @@ public class RecordCodecTest {
     @Test
     public void testExceptionsForAnnotationsNotOnRecordComponent() {
         assertThrows(CodecConfigurationException.class, () ->
-                new RecordCodec<>(TestRecordWithIllegalBsonIdOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
+                createRecordCodec(TestRecordWithIllegalBsonIdOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
         assertThrows(CodecConfigurationException.class, () ->
-                new RecordCodec<>(TestRecordWithIllegalBsonIdOnCanonicalConstructor.class, Bson.DEFAULT_CODEC_REGISTRY));
+                createRecordCodec(TestRecordWithIllegalBsonIdOnCanonicalConstructor.class, Bson.DEFAULT_CODEC_REGISTRY));
 
         assertThrows(CodecConfigurationException.class, () ->
-                new RecordCodec<>(TestRecordWithIllegalBsonPropertyOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
+                createRecordCodec(TestRecordWithIllegalBsonPropertyOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
         assertThrows(CodecConfigurationException.class, () ->
-                new RecordCodec<>(TestRecordWithIllegalBsonPropertyOnCanonicalConstructor.class, Bson.DEFAULT_CODEC_REGISTRY));
+                createRecordCodec(TestRecordWithIllegalBsonPropertyOnCanonicalConstructor.class, Bson.DEFAULT_CODEC_REGISTRY));
 
         assertThrows(CodecConfigurationException.class, () ->
-                new RecordCodec<>(TestRecordWithIllegalBsonRepresentationOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
+                createRecordCodec(TestRecordWithIllegalBsonRepresentationOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
     }
 
     @Test
     public void testExceptionsForUnsupportedAnnotations() {
         assertThrows(CodecConfigurationException.class, () ->
-                new RecordCodec<>(TestRecordWithIllegalBsonDiscriminatorOnRecord.class, Bson.DEFAULT_CODEC_REGISTRY));
+                createRecordCodec(TestRecordWithIllegalBsonDiscriminatorOnRecord.class, Bson.DEFAULT_CODEC_REGISTRY));
 
         assertThrows(CodecConfigurationException.class, () ->
-                new RecordCodec<>(TestRecordWithIllegalBsonCreatorOnConstructor.class, Bson.DEFAULT_CODEC_REGISTRY));
+                createRecordCodec(TestRecordWithIllegalBsonCreatorOnConstructor.class, Bson.DEFAULT_CODEC_REGISTRY));
         assertThrows(CodecConfigurationException.class, () ->
-                new RecordCodec<>(TestRecordWithIllegalBsonCreatorOnMethod.class, Bson.DEFAULT_CODEC_REGISTRY));
+                createRecordCodec(TestRecordWithIllegalBsonCreatorOnMethod.class, Bson.DEFAULT_CODEC_REGISTRY));
 
         assertThrows(CodecConfigurationException.class, () ->
-                new RecordCodec<>(TestRecordWithIllegalBsonIgnoreOnComponent.class, Bson.DEFAULT_CODEC_REGISTRY));
+                createRecordCodec(TestRecordWithIllegalBsonIgnoreOnComponent.class, Bson.DEFAULT_CODEC_REGISTRY));
         assertThrows(CodecConfigurationException.class, () ->
-                new RecordCodec<>(TestRecordWithIllegalBsonIgnoreOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
+                createRecordCodec(TestRecordWithIllegalBsonIgnoreOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
         assertThrows(CodecConfigurationException.class, () ->
-                new RecordCodec<>(TestRecordWithIllegalBsonExtraElementsOnComponent.class, Bson.DEFAULT_CODEC_REGISTRY));
+                createRecordCodec(TestRecordWithIllegalBsonExtraElementsOnComponent.class, Bson.DEFAULT_CODEC_REGISTRY));
         assertThrows(CodecConfigurationException.class, () ->
-                new RecordCodec<>(TestRecordWithIllegalBsonExtraElementsOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
+                createRecordCodec(TestRecordWithIllegalBsonExtraElementsOnAccessor.class, Bson.DEFAULT_CODEC_REGISTRY));
+    }
+
+    private static <T extends Record> RecordCodec<T> createRecordCodec(final Class<T> clazz, final CodecRegistry registry) {
+        return new RecordCodec<>(clazz, List.of(), registry);
     }
 }

--- a/bson/src/main/org/bson/codecs/CollectionCodec.java
+++ b/bson/src/main/org/bson/codecs/CollectionCodec.java
@@ -20,18 +20,15 @@ import org.bson.BsonReader;
 import org.bson.BsonWriter;
 import org.bson.Transformer;
 import org.bson.UuidRepresentation;
-import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.configuration.CodecRegistry;
 
-import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
 
 import static org.bson.assertions.Assertions.notNull;
-import static org.bson.codecs.ContainerCodecHelper.getCodec;
 
 /**
- * A parameterized Codec for {@code Collection<Object>}.
+ * A codec for {@code Collection<Object>}.
  *
  * <p>Supports {@link Collection}, {@link List}, {@link java.util.AbstractCollection}, {@link java.util.AbstractList},
  * {@link java.util.Set}, {@link java.util.NavigableSet}, {@link java.util.SortedSet}, {@link java.util.AbstractSet} or any
@@ -47,7 +44,7 @@ import static org.bson.codecs.ContainerCodecHelper.getCodec;
  */
 @SuppressWarnings("rawtypes")
 final class CollectionCodec<C extends Collection<Object>> extends AbstractCollectionCodec<Object, C>
-        implements OverridableUuidRepresentationCodec<C>, Parameterizable {
+        implements OverridableUuidRepresentationCodec<C> {
 
     private final CodecRegistry registry;
     private final BsonTypeCodecMap bsonTypeCodecMap;
@@ -74,17 +71,6 @@ final class CollectionCodec<C extends Collection<Object>> extends AbstractCollec
         this.bsonTypeCodecMap = bsonTypeCodecMap;
         this.valueTransformer = valueTransformer != null ? valueTransformer : (value) -> value;
         this.uuidRepresentation = uuidRepresentation;
-    }
-
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public Codec<?> parameterize(final CodecRegistry codecRegistry, final List<Type> types) {
-        if (types.size() != 1) {
-            throw new CodecConfigurationException("Expected only one parameterized type for an Iterable, but found " + types.size());
-        }
-
-        return new ParameterizedCollectionCodec(getCodec(codecRegistry, types.get(0)), getEncoderClass());
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/MapCodecV2.java
+++ b/bson/src/main/org/bson/codecs/MapCodecV2.java
@@ -20,18 +20,14 @@ import org.bson.BsonReader;
 import org.bson.BsonWriter;
 import org.bson.Transformer;
 import org.bson.UuidRepresentation;
-import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.configuration.CodecRegistry;
 
-import java.lang.reflect.Type;
-import java.util.List;
 import java.util.Map;
 
 import static org.bson.assertions.Assertions.notNull;
-import static org.bson.codecs.ContainerCodecHelper.getCodec;
 
 /**
- * A parameterized Codec for {@code Map<String, Object>}.
+ * A codec for {@code Map<String, Object>}.
  *
  * <p>Supports {@link Map}, {@link java.util.NavigableMap}, {@link java.util.AbstractMap} or any concrete class that implements {@code
  * Map} and has a public no-args constructor. If the type argument is {@code Map<String, Object>}, it constructs
@@ -44,7 +40,7 @@ import static org.bson.codecs.ContainerCodecHelper.getCodec;
  */
 @SuppressWarnings("rawtypes")
 final class MapCodecV2<M extends Map<String, Object>> extends AbstractMapCodec<Object, M>
-        implements OverridableUuidRepresentationCodec<M>, Parameterizable {
+        implements OverridableUuidRepresentationCodec<M> {
 
     private final BsonTypeCodecMap bsonTypeCodecMap;
     private final CodecRegistry registry;
@@ -83,20 +79,6 @@ final class MapCodecV2<M extends Map<String, Object>> extends AbstractMapCodec<O
             return this;
         }
         return new MapCodecV2<>(registry, bsonTypeCodecMap, valueTransformer, uuidRepresentation, getEncoderClass());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public Codec<?> parameterize(final CodecRegistry codecRegistry, final List<Type> types) {
-        if (types.size() != 2) {
-            throw new CodecConfigurationException("Expected two parameterized type for an Iterable, but found "
-                    + types.size());
-        }
-        Type genericTypeOfMapKey = types.get(0);
-        if (!genericTypeOfMapKey.getTypeName().equals("java.lang.String")) {
-            throw new CodecConfigurationException("Unsupported key type for Map: " + genericTypeOfMapKey.getTypeName());
-        }
-        return new ParameterizedMapCodec(getCodec(codecRegistry, types.get(1)), getEncoderClass());
     }
 
     @Override

--- a/bson/src/main/org/bson/codecs/Parameterizable.java
+++ b/bson/src/main/org/bson/codecs/Parameterizable.java
@@ -16,6 +16,7 @@
 
 package org.bson.codecs;
 
+import org.bson.codecs.configuration.CodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 
 import java.lang.reflect.Type;
@@ -26,7 +27,13 @@ import java.util.List;
  * An interface indicating that a Codec is for a type that can be parameterized by generic types.
  *
  * @since 4.8
+ * @deprecated Since 4.10. Instead of implementing {@link Parameterizable} for a custom {@link Codec},
+ * users should implement {@link CodecProvider#get(Class, List, CodecRegistry)} for a custom {@link CodecProvider}.
  */
+@Deprecated
+// After releasing this interface, we realized that our implementations of `Parameterizable.parameterize` were doing what
+// `CodecProvider.get` is supposed to be doing. As a result, we introduced a new default method to `CodecProvider`,
+// and deprecated `Parameterizable`.
 public interface Parameterizable {
     /**
      * Recursively parameterize the codec with the given registry and generic type arguments.

--- a/bson/src/main/org/bson/codecs/configuration/CodecProvider.java
+++ b/bson/src/main/org/bson/codecs/configuration/CodecProvider.java
@@ -18,6 +18,10 @@ package org.bson.codecs.configuration;
 
 import org.bson.codecs.Codec;
 
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.List;
+
 /**
  * A provider of {@code Codec} instances.  Typically, an instance of a class implementing this interface would be used to construct a
  * {@code CodecRegistry}.
@@ -34,10 +38,34 @@ public interface CodecProvider {
     /**
      * Get a {@code Codec} using the given context, which includes, most importantly, the Class for which a {@code Codec} is required.
      *
+     * <p>This method is called only if {@link #get(Class, List, CodecRegistry)} is not properly overridden.</p>
+     *
      * @param clazz the Class for which to get a Codec
      * @param registry the registry to use for resolving dependent Codec instances
      * @param <T> the type of the class for which a Codec is required
      * @return the Codec instance, which may be null, if this source is unable to provide one for the requested Class
      */
     <T> Codec<T> get(Class<T> clazz, CodecRegistry registry);
+
+    /**
+     * Get a {@code Codec} using the given context, which includes, most importantly, the Class for which a {@code Codec} is required.
+     *
+     * <p>The default implementation delegates to {@link #get(Class, CodecRegistry)}, thus ignoring {@code typeArguments}.</p>
+     *
+     * @param clazz the Class for which to get a Codec
+     * @param typeArguments The type arguments for the {@code clazz}. The size of the list is either equal to the
+     * number of type parameters of the {@code clazz}, or is zero.
+     * For example, if {@code clazz} is {@link Collection}{@code .class}, then the size of {@code typeArguments} is one,
+     * since {@link Collection} has a single type parameter.
+     * The list may be {@linkplain List#isEmpty() empty} either because the {@code clazz} is not generic,
+     * or because another {@link CodecProvider} did not propagate {@code clazz}'s type arguments via the {@code registry},
+     * which may if that {@link CodecProvider} does not properly override {@link #get(Class, List, CodecRegistry)}.
+     * @param registry the registry to use for resolving dependent Codec instances
+     * @return the Codec instance, which may be null, if this source is unable to provide one for the requested Class
+     * @param <T> the type of the class for which a Codec is required
+     * @since 4.10
+     */
+    default <T> Codec<T> get(Class<T> clazz, List<Type> typeArguments, CodecRegistry registry) {
+        return get(clazz, registry);
+    }
 }

--- a/bson/src/main/org/bson/codecs/configuration/CodecProvider.java
+++ b/bson/src/main/org/bson/codecs/configuration/CodecProvider.java
@@ -38,7 +38,8 @@ public interface CodecProvider {
     /**
      * Get a {@code Codec} using the given context, which includes, most importantly, the Class for which a {@code Codec} is required.
      *
-     * <p>This method is called only if {@link #get(Class, List, CodecRegistry)} is not properly overridden.</p>
+     * <p>This method is called only if {@link #get(Class, List, CodecRegistry)} is not overridden,
+     * or is overridden such that it calls this method.</p>
      *
      * @param clazz the Class for which to get a Codec
      * @param registry the registry to use for resolving dependent Codec instances
@@ -50,7 +51,8 @@ public interface CodecProvider {
     /**
      * Get a {@code Codec} using the given context, which includes, most importantly, the Class for which a {@code Codec} is required.
      *
-     * <p>The default implementation delegates to {@link #get(Class, CodecRegistry)}, thus ignoring {@code typeArguments}.</p>
+     * <p>The default implementation delegates to {@link #get(Class, CodecRegistry)}, thus not propagating {@code typeArguments}
+     * when it uses the {@code registry}.</p>
      *
      * @param clazz the Class for which to get a Codec
      * @param typeArguments The type arguments for the {@code clazz}. The size of the list is either equal to the
@@ -58,8 +60,7 @@ public interface CodecProvider {
      * For example, if {@code clazz} is {@link Collection}{@code .class}, then the size of {@code typeArguments} is one,
      * since {@link Collection} has a single type parameter.
      * The list may be {@linkplain List#isEmpty() empty} either because the {@code clazz} is not generic,
-     * or because another {@link CodecProvider} did not propagate {@code clazz}'s type arguments via the {@code registry},
-     * which may happen if that {@link CodecProvider} does not properly override {@link #get(Class, List, CodecRegistry)}.
+     * or because another {@link CodecProvider} did not propagate {@code clazz}'s type arguments to the {@code registry} when using it.
      * @param registry the registry to use for resolving dependent Codec instances
      * @return the Codec instance, which may be null, if this source is unable to provide one for the requested Class
      * @param <T> the type of the class for which a Codec is required

--- a/bson/src/main/org/bson/codecs/configuration/CodecProvider.java
+++ b/bson/src/main/org/bson/codecs/configuration/CodecProvider.java
@@ -59,7 +59,7 @@ public interface CodecProvider {
      * since {@link Collection} has a single type parameter.
      * The list may be {@linkplain List#isEmpty() empty} either because the {@code clazz} is not generic,
      * or because another {@link CodecProvider} did not propagate {@code clazz}'s type arguments via the {@code registry},
-     * which may if that {@link CodecProvider} does not properly override {@link #get(Class, List, CodecRegistry)}.
+     * which may happen if that {@link CodecProvider} does not properly override {@link #get(Class, List, CodecRegistry)}.
      * @param registry the registry to use for resolving dependent Codec instances
      * @return the Codec instance, which may be null, if this source is unable to provide one for the requested Class
      * @param <T> the type of the class for which a Codec is required

--- a/bson/src/main/org/bson/codecs/configuration/CodecProvider.java
+++ b/bson/src/main/org/bson/codecs/configuration/CodecProvider.java
@@ -38,7 +38,7 @@ public interface CodecProvider {
     /**
      * Get a {@code Codec} using the given context, which includes, most importantly, the Class for which a {@code Codec} is required.
      *
-     * <p>This method is called only if {@link #get(Class, List, CodecRegistry)} is not overridden,
+     * <p>This method is called by the driver only if {@link #get(Class, List, CodecRegistry)} is not overridden,
      * or is overridden such that it calls this method.</p>
      *
      * @param clazz the Class for which to get a Codec

--- a/bson/src/main/org/bson/codecs/configuration/OverridableUuidRepresentationCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/configuration/OverridableUuidRepresentationCodecProvider.java
@@ -20,7 +20,12 @@ import org.bson.UuidRepresentation;
 import org.bson.codecs.Codec;
 import org.bson.codecs.OverridableUuidRepresentationCodec;
 
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+
 import static org.bson.assertions.Assertions.notNull;
+import static org.bson.internal.ProvidersCodecRegistry.getFromCodecProvider;
 
 final class OverridableUuidRepresentationCodecProvider implements CodecProvider {
 
@@ -33,11 +38,17 @@ final class OverridableUuidRepresentationCodecProvider implements CodecProvider 
     }
 
     @Override
-    @SuppressWarnings({"unchecked"})
     public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
-        Codec<T> codec = wrapped.get(clazz, registry);
+        return get(clazz, Collections.emptyList(), registry);
+    }
+
+    @Override
+    public <T> Codec<T> get(final Class<T> clazz, final List<Type> typeArguments, final CodecRegistry registry) {
+        Codec<T> codec = getFromCodecProvider(wrapped, clazz, typeArguments, registry);
         if (codec instanceof OverridableUuidRepresentationCodec) {
-            return ((OverridableUuidRepresentationCodec<T>) codec).withUuidRepresentation(uuidRepresentation);
+            @SuppressWarnings("unchecked")
+            Codec<T> codecWithUuidRepresentation = ((OverridableUuidRepresentationCodec<T>) codec).withUuidRepresentation(uuidRepresentation);
+            codec = codecWithUuidRepresentation;
         }
         return codec;
     }

--- a/bson/src/main/org/bson/internal/ChildCodecRegistry.java
+++ b/bson/src/main/org/bson/internal/ChildCodecRegistry.java
@@ -21,6 +21,7 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecRegistry;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -84,7 +85,12 @@ class ChildCodecRegistry<T> implements CodecRegistry {
 
     @Override
     public <U> Codec<U> get(final Class<U> clazz, final CodecRegistry registry) {
-        return this.registry.get(clazz, registry);
+        return get(clazz, Collections.emptyList(), registry);
+    }
+
+    @Override
+    public <U> Codec<U> get(final Class<U> clazz, final List<Type> typeArguments, final CodecRegistry registry) {
+        return this.registry.get(clazz, typeArguments, registry);
     }
 
     private <U> Boolean hasCycles(final Class<U> theClass) {

--- a/bson/src/main/org/bson/internal/ChildCodecRegistry.java
+++ b/bson/src/main/org/bson/internal/ChildCodecRegistry.java
@@ -72,7 +72,6 @@ class ChildCodecRegistry<T> implements CodecRegistry {
     @Override
     public <U> Codec<U> get(final Class<U> clazz, final List<Type> typeArguments) {
         notNull("typeArguments", typeArguments);
-        isTrueArgument("typeArguments is not empty", !typeArguments.isEmpty());
         isTrueArgument(format("typeArguments size should equal the number of type parameters in class %s, but is %d",
                         clazz, typeArguments.size()),
                 clazz.getTypeParameters().length == typeArguments.size());

--- a/bson/src/main/org/bson/internal/ProvidersCodecRegistry.java
+++ b/bson/src/main/org/bson/internal/ProvidersCodecRegistry.java
@@ -53,7 +53,6 @@ public final class ProvidersCodecRegistry implements CycleDetectingCodecRegistry
     @Override
     public <T> Codec<T> get(final Class<T> clazz, final List<Type> typeArguments) {
         notNull("typeArguments", typeArguments);
-        isTrueArgument("typeArguments is not empty", !typeArguments.isEmpty());
         isTrueArgument(format("typeArguments size should equal the number of type parameters in class %s, but is %d",
                         clazz, typeArguments.size()),
                 clazz.getTypeParameters().length == typeArguments.size());

--- a/bson/src/test/unit/org/bson/codecs/CollectionCodecProviderTest.java
+++ b/bson/src/test/unit/org/bson/codecs/CollectionCodecProviderTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class CollectionCodecProviderTest {
+    @Test
+    void shouldReturnNullForNonCollection() {
+        CollectionCodecProvider provider = new CollectionCodecProvider();
+        assertNull(provider.get(String.class, Bson.DEFAULT_CODEC_REGISTRY));
+    }
+
+    @Test
+    void shouldReturnCollectionCodecForCollection() {
+        CollectionCodecProvider provider = new CollectionCodecProvider();
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        Codec<Set<Object>> codec = (Codec<Set<Object>>) (Codec) provider.get(Set.class, Bson.DEFAULT_CODEC_REGISTRY);
+        assertTrue(codec instanceof CollectionCodec);
+        CollectionCodec<Set<Object>> recordCodec = (CollectionCodec<Set<Object>>) codec;
+        assertEquals(Set.class, recordCodec.getEncoderClass());
+    }
+
+    @Test
+    public void shouldReturnCollectionCodecForCollectionUsingDefaultRegistry() {
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        Codec<Set<Object>> codec = (Codec<Set<Object>>) (Codec) Bson.DEFAULT_CODEC_REGISTRY.get(Set.class);
+        assertTrue(codec instanceof CollectionCodec);
+        CollectionCodec<Set<Object>> recordCodec = (CollectionCodec<Set<Object>>) codec;
+        assertEquals(Set.class, recordCodec.getEncoderClass());
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/CollectionCodecSpecification.groovy
+++ b/bson/src/test/unit/org/bson/codecs/CollectionCodecSpecification.groovy
@@ -30,6 +30,7 @@ import java.lang.reflect.ParameterizedType
 import java.time.Instant
 import java.util.concurrent.CopyOnWriteArrayList
 
+import static java.util.Arrays.asList
 import static org.bson.BsonDocument.parse
 import static org.bson.UuidRepresentation.C_SHARP_LEGACY
 import static org.bson.UuidRepresentation.JAVA_LEGACY
@@ -195,15 +196,15 @@ class CollectionCodecSpecification extends Specification {
 
     def 'should parameterize'() {
         given:
-        def codec = new CollectionCodec(REGISTRY, new BsonTypeClassMap(), null, Collection)
+        def codec = fromProviders(new Jsr310CodecProvider(), REGISTRY).get(
+                Collection,
+                asList(((ParameterizedType) Container.getMethod('getInstants').genericReturnType).actualTypeArguments))
         def writer = new BsonDocumentWriter(new BsonDocument())
         def reader = new BsonDocumentReader(writer.getDocument())
         def instants = [
                 ['firstMap': [Instant.ofEpochMilli(1), Instant.ofEpochMilli(2)]],
                 ['secondMap': [Instant.ofEpochMilli(3), Instant.ofEpochMilli(4)]]]
         when:
-        codec = codec.parameterize(fromProviders(new Jsr310CodecProvider(), REGISTRY),
-                Arrays.asList(((ParameterizedType) Container.getMethod('getInstants').genericReturnType).actualTypeArguments))
         writer.writeStartDocument()
         writer.writeName('instants')
         codec.encode(writer, instants, EncoderContext.builder().build())

--- a/bson/src/test/unit/org/bson/codecs/MapCodecProviderTest.java
+++ b/bson/src/test/unit/org/bson/codecs/MapCodecProviderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class MapCodecProviderTest {
+    @Test
+    void shouldReturnNullForNonMap() {
+        MapCodecProvider provider = new MapCodecProvider();
+        assertNull(provider.get(String.class, Bson.DEFAULT_CODEC_REGISTRY));
+    }
+
+    @Test
+    void shouldReturnMapCodecForMap() {
+        MapCodecProvider provider = new MapCodecProvider();
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        Codec<Map<String, Object>> codec = (Codec<Map<String, Object>>) (Codec) provider.get(Map.class, Bson.DEFAULT_CODEC_REGISTRY);
+        assertTrue(codec instanceof MapCodecV2);
+        MapCodecV2<Map<String, Object>> recordCodec = (MapCodecV2<Map<String, Object>>) codec;
+        assertEquals(Map.class, recordCodec.getEncoderClass());
+    }
+
+    @Test
+    public void shouldReturnMapCodecForMapUsingDefaultRegistry() {
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        Codec<Map<String, Object>> codec = (Codec<Map<String, Object>>) (Codec) Bson.DEFAULT_CODEC_REGISTRY.get(Map.class);
+        assertTrue(codec instanceof MapCodecV2);
+        MapCodecV2<Map<String, Object>> recordCodec = (MapCodecV2<Map<String, Object>>) codec;
+        assertEquals(Map.class, recordCodec.getEncoderClass());
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/MapCodecV2Specification.groovy
+++ b/bson/src/test/unit/org/bson/codecs/MapCodecV2Specification.groovy
@@ -254,15 +254,16 @@ class MapCodecV2Specification extends Specification {
 
     def 'should parameterize'() {
         given:
-        def codec = new MapCodecV2(REGISTRY, new BsonTypeClassMap(), null, Map)
+        def codec = fromProviders(new Jsr310CodecProvider(), REGISTRY).get(
+                Map,
+                asList(((ParameterizedType) Container.getMethod('getInstants').genericReturnType).actualTypeArguments))
+
         def writer = new BsonDocumentWriter(new BsonDocument())
         def reader = new BsonDocumentReader(writer.getDocument())
         def instants =
                 ['firstMap': [Instant.ofEpochMilli(1), Instant.ofEpochMilli(2)],
                  'secondMap': [Instant.ofEpochMilli(3), Instant.ofEpochMilli(4)]]
         when:
-        codec = codec.parameterize(fromProviders(new Jsr310CodecProvider(), REGISTRY),
-                asList(((ParameterizedType) Container.getMethod('getInstants').genericReturnType).actualTypeArguments))
         writer.writeStartDocument()
         writer.writeName('instants')
         codec.encode(writer, instants, EncoderContext.builder().build())

--- a/bson/src/test/unit/org/bson/codecs/configuration/CodeRegistriesSpecification.groovy
+++ b/bson/src/test/unit/org/bson/codecs/configuration/CodeRegistriesSpecification.groovy
@@ -16,19 +16,33 @@
 
 package org.bson.codecs.configuration
 
+import org.bson.BsonArray
+import org.bson.BsonDateTime
+import org.bson.BsonDocument
+import org.bson.BsonDocumentReader
+import org.bson.BsonDocumentWriter
 import org.bson.BsonInt32
 import org.bson.codecs.BsonInt32Codec
 import org.bson.codecs.BsonValueCodecProvider
+import org.bson.codecs.CollectionCodecProvider
+import org.bson.codecs.DecoderContext
+import org.bson.codecs.EncoderContext
 import org.bson.codecs.IntegerCodec
 import org.bson.codecs.LongCodec
+import org.bson.codecs.MapCodecProvider
 import org.bson.codecs.UuidCodec
 import org.bson.codecs.ValueCodecProvider
+import org.bson.codecs.jsr310.Jsr310CodecProvider
 import org.bson.internal.ProvidersCodecRegistry
 import spock.lang.Specification
+
+import java.lang.reflect.ParameterizedType
+import java.time.Instant
 
 import static CodecRegistries.fromCodecs
 import static CodecRegistries.fromProviders
 import static CodecRegistries.fromRegistries
+import static java.util.Arrays.asList
 import static org.bson.UuidRepresentation.STANDARD
 import static org.bson.UuidRepresentation.UNSPECIFIED
 import static org.bson.codecs.configuration.CodecRegistries.withUuidRepresentation
@@ -90,5 +104,49 @@ class CodeRegistriesSpecification extends Specification {
 
         then:
         uuidCodec.getUuidRepresentation() == STANDARD
+    }
+
+    def 'withUuidRepresentation should not break parameterization'() {
+        given:
+        def registry = fromProviders(
+                new Jsr310CodecProvider(),
+                new ValueCodecProvider(),
+                withUuidRepresentation(fromProviders(new CollectionCodecProvider()), STANDARD),
+                withUuidRepresentation(fromProviders(new MapCodecProvider()), STANDARD)
+        )
+        def codec = registry.get(Collection, asList(
+                ((ParameterizedType) CodeRegistriesSpecification.getMethod('parameterizedTypeProvider').genericReturnType)
+                        .actualTypeArguments))
+        def writer = new BsonDocumentWriter(new BsonDocument())
+        def reader = new BsonDocumentReader(writer.getDocument())
+        def value = [
+                ['firstMap': [Instant.ofEpochMilli(1), Instant.ofEpochMilli(2)]],
+                ['secondMap': [Instant.ofEpochMilli(3), Instant.ofEpochMilli(4)]]]
+        when:
+        writer.writeStartDocument()
+        writer.writeName('value')
+        codec.encode(writer, value, EncoderContext.builder().build())
+        writer.writeEndDocument()
+
+        then:
+        writer.getDocument() == new BsonDocument()
+                .append('value', new BsonArray(
+                        [
+                                new BsonDocument('firstMap', new BsonArray([new BsonDateTime(1), new BsonDateTime(2)])),
+                                new BsonDocument('secondMap', new BsonArray([new BsonDateTime(3), new BsonDateTime(4)]))
+                        ]))
+
+        when:
+        reader.readStartDocument()
+        reader.readName('value')
+        def decodedValue = codec.decode(reader, DecoderContext.builder().build())
+
+        then:
+        decodedValue == value
+    }
+
+    @SuppressWarnings('unused')
+    List<Map<String, List<Instant>>> parameterizedTypeProvider() {
+        []
     }
 }

--- a/driver-core/src/main/com/mongodb/Jep395RecordCodecProvider.java
+++ b/driver-core/src/main/com/mongodb/Jep395RecordCodecProvider.java
@@ -22,13 +22,20 @@ import org.bson.codecs.configuration.CodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.record.RecordCodecProvider;
 
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
+import static org.bson.internal.ProvidersCodecRegistry.getFromCodecProvider;
 
 
 /**
  * A CodecProvider for Java Records.
- *
- * <p>Requires java.lang.Record support - eg Java 17 or greater.</p>
+ * Delegates to {@code org.bson.codecs.record.RecordCodecProvider}.
+ * If neither the runtime supports {@code java.lang.Record}, which was introduced in Java SE 17,
+ * nor {@code org.bson.codecs.record.RecordCodecProvider} is available,
+ * {@linkplain CodecProvider#get(Class, CodecRegistry) provides} {@code null}.
  *
  * @since 4.6
  */
@@ -53,10 +60,18 @@ public class Jep395RecordCodecProvider implements CodecProvider {
     @Override
     @Nullable
     public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
-        return RECORD_CODEC_PROVIDER != null ? RECORD_CODEC_PROVIDER.get(clazz, registry) : null;
+        return get(clazz, Collections.emptyList(), registry);
+    }
+
+    @Override
+    @Nullable
+    public <T> Codec<T> get(final Class<T> clazz, final List<Type> typeArguments, final CodecRegistry registry) {
+        return RECORD_CODEC_PROVIDER != null ? getFromCodecProvider(RECORD_CODEC_PROVIDER, clazz, typeArguments, registry) : null;
     }
 
     /**
+     * This method is not part of the public API and may be removed or changed at any time.
+     *
      * @return true if records are supported
      */
     @VisibleForTesting(otherwise = PRIVATE)
@@ -64,4 +79,3 @@ public class Jep395RecordCodecProvider implements CodecProvider {
         return RECORD_CODEC_PROVIDER != null;
     }
 }
-


### PR DESCRIPTION
Turns out, we don't even need to introduce `ParameterizedCodecProvider` to replace `Parameterizable`. All we need is a new default method on `CodecProvider`. And the cost of still supporting `Parameterizable` is really small: a single `if` block in `ProvidersCodecRegistry.getFromCodecProvider`.

I also refactored `RecordCodec`, `CollectionCodec`, `MapCodecV2`, `org.bson.codecs.kotlin.DataClassCodec` such that they no longer implement `Parameterizable`.

### How is this related to JAVA-4954?

JAVA-4954 is about trying to improve `PojoCodecImpl` to be more like `RecordCodec`. Given that we discovered a better alternative to `Parameterizable`, which can be implemented without breaking public API, it seems worth making the improvement before trying to refactor `PojoCodecImpl`. Otherwise, we will likely have to refactor `PojoCodecImpl` again in the future.

JAVA-4967