### PR TITLE
JAVA-4966 : Fix Macro for sealed trait

### DIFF
--- a/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/CaseClassCodec.scala
+++ b/bson-scala/src/main/scala/org/mongodb/scala/bson/codecs/macrocodecs/CaseClassCodec.scala
@@ -85,8 +85,12 @@ private[codecs] object CaseClassCodec {
     val codecName = TypeName(s"${classTypeName}MacroCodec")
 
     // Type checkers
-    def isCaseClass(t: Type): Boolean =
+    def isCaseClass(t: Type): Boolean = {
+      // https://github.com/scala/bug/issues/7755
+      val _ = t.typeSymbol.typeSignature
       t.typeSymbol.isClass && t.typeSymbol.asClass.isCaseClass && !t.typeSymbol.isModuleClass
+    }
+
     def isCaseObject(t: Type): Boolean = t.typeSymbol.isModuleClass && t.typeSymbol.asClass.isCaseClass
     def isMap(t: Type): Boolean = t.baseClasses.contains(mapTypeSymbol)
     def isOption(t: Type): Boolean = t.typeSymbol == definitions.OptionClass


### PR DESCRIPTION
https://jira.mongodb.org/browse/JAVA-4966

If the sealed trait and the Macro are not defined is the same module, we have the following error `No known subclasses of the sealed trait`
Add a `val _` to make sure that `isCaseClass` returns the correct value.  This "hack" is described in https://github.com/scala/bug/issues/7755

It's complicated to test that, because it requires having multi modules. But this change solved the issue in my project.