### PR TITLE
Cleanup documentation referring to removed property

### DIFF
--- a/driver-core/src/main/com/mongodb/MongoClientSettings.java
+++ b/driver-core/src/main/com/mongodb/MongoClientSettings.java
@@ -899,8 +899,8 @@ public final class MongoClientSettings {
     }
 
     /**
-     * Gets the connection-specific settings wrapped in a settings object.   This settings object uses the values for connectTimeout,
-     * socketTimeout and socketKeepAlive.
+     * Gets the connection-specific settings wrapped in a settings object.   This settings object uses the values for connectTimeout
+     * and socketTimeout.
      *
      * @return a SocketSettings object populated with the connection settings from this {@code MongoClientSettings} instance.
      * @see SocketSettings


### PR DESCRIPTION
This should have probably been removed in this [commit](https://github.com/mongodb/mongo-java-driver/commit/dfcf57f3dfea23609bfe911b788cc347173d4d76).

Maybe the modified sentence in this PR should just be completely removed so there is not duplication of documentation and actual properties in the class. If you would like that let me know and I can remove the entire sentence.