### PR TITLE
Remove specialization-related conditional logic from `PojoCodecImpl` by introducing `LazyPropertyModelCodec.NeedsSpecializationCodec`

### DIFF
--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoTestCase.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoTestCase.java
@@ -176,11 +176,11 @@ abstract class PojoTestCase {
         return builder;
     }
 
-    <T> PojoCodecImpl<T> getCodec(final PojoCodecProvider.Builder builder, final Class<T> clazz) {
-        return (PojoCodecImpl<T>) getCodecRegistry(builder).get(clazz);
+    <T> PojoCodec<T> getCodec(final PojoCodecProvider.Builder builder, final Class<T> clazz) {
+        return (PojoCodec<T>) getCodecRegistry(builder).get(clazz);
     }
 
-    <T> PojoCodecImpl<T> getCodec(final Class<T> clazz) {
+    <T> PojoCodec<T> getCodec(final Class<T> clazz) {
         return getCodec(getPojoCodecProviderBuilder(clazz), clazz);
     }
 


### PR DESCRIPTION
This PR moves some of the conditional logic from `PojoCodecImpl` under the rug, thus allegedly simplifying `PojoCodecImpl`, but not the POJO codec implementation overall.

I still have no idea about the following:

- What "specialization" means and why it exists?
- Why there is two "unusable" types codecs; previously it was `LazyPropertyModelCodec` and some instances of `PojoCodecImpl`, now its `LazyPropertyModelCodec` and all instances of `NeedsSpecializationCodec`?
- Why is it so happens that `NeedsSpecializationCodec` is always (I judge based on the existing tests) replaced by `LazyPropertyModelCodec` with a usable codec instance?

JAVA-4954