### PR TITLE
Kotlinx serialization decoding optional ObjectId / BsonValues fails to hydrate properly

### DIFF
--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
@@ -73,6 +73,7 @@ import org.bson.codecs.kotlinx.samples.DataClassWithNestedParameterized
 import org.bson.codecs.kotlinx.samples.DataClassWithNestedParameterizedDataClass
 import org.bson.codecs.kotlinx.samples.DataClassWithNulls
 import org.bson.codecs.kotlinx.samples.DataClassWithObjectIdAndBsonDocument
+import org.bson.codecs.kotlinx.samples.DataClassWithOptionalObjectIdAndBsonDocument
 import org.bson.codecs.kotlinx.samples.DataClassWithPair
 import org.bson.codecs.kotlinx.samples.DataClassWithParameterizedDataClass
 import org.bson.codecs.kotlinx.samples.DataClassWithRequired
@@ -470,6 +471,52 @@ class KotlinSerializerCodecTest {
         val dataClass =
             DataClassWithObjectIdAndBsonDocument(ObjectId("111111111111111111111111"), BsonDocument.parse(subDocument))
         assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithOptionalObjectIdAndBsonDocument() {
+        val subDocument =
+            """{
+    | "_id": 1,
+    | "arrayEmpty": [],
+    | "arraySimple": [{"${'$'}numberInt": "1"}, {"${'$'}numberInt": "2"}, {"${'$'}numberInt": "3"}],
+    | "arrayComplex": [{"a": {"${'$'}numberInt": "1"}}, {"a": {"${'$'}numberInt": "2"}}],
+    | "arrayMixedTypes": [{"${'$'}numberInt": "1"}, {"${'$'}numberInt": "2"}, true,
+    |  [{"${'$'}numberInt": "1"}, {"${'$'}numberInt": "2"}, {"${'$'}numberInt": "3"}],
+    |  {"a": {"${'$'}numberInt": "2"}}],
+    | "arrayComplexMixedTypes": [{"a": {"${'$'}numberInt": "1"}}, {"a": "a"}],
+    | "binary": {"${'$'}binary": {"base64": "S2Fma2Egcm9ja3Mh", "subType": "00"}},
+    | "boolean": true,
+    | "code": {"${'$'}code": "int i = 0;"},
+    | "codeWithScope": {"${'$'}code": "int x = y", "${'$'}scope": {"y": {"${'$'}numberInt": "1"}}},
+    | "dateTime": {"${'$'}date": {"${'$'}numberLong": "1577836801000"}},
+    | "decimal128": {"${'$'}numberDecimal": "1.0"},
+    | "documentEmpty": {},
+    | "document": {"a": {"${'$'}numberInt": "1"}},
+    | "double": {"${'$'}numberDouble": "62.0"},
+    | "int32": {"${'$'}numberInt": "42"},
+    | "int64": {"${'$'}numberLong": "52"},
+    | "maxKey": {"${'$'}maxKey": 1},
+    | "minKey": {"${'$'}minKey": 1},
+    | "null": null,
+    | "objectId": {"${'$'}oid": "5f3d1bbde0ca4d2829c91e1d"},
+    | "regex": {"${'$'}regularExpression": {"pattern": "^test.*regex.*xyz$", "options": "i"}},
+    | "string": "the fox ...",
+    | "symbol": {"${'$'}symbol": "ruby stuff"},
+    | "timestamp": {"${'$'}timestamp": {"t": 305419896, "i": 5}},
+    | "undefined": {"${'$'}undefined": true}
+    | }"""
+                .trimMargin()
+        val expected = """{"objectId": {"${'$'}oid": "111111111111111111111111"}, "bsonDocument": $subDocument}"""
+
+        val dataClass =
+            DataClassWithOptionalObjectIdAndBsonDocument(
+                ObjectId("111111111111111111111111"), BsonDocument.parse(subDocument))
+        assertRoundTrips(expected, dataClass)
+
+        val expectedWithNulls = """{}"""
+        val dataClassWithNulls = DataClassWithOptionalObjectIdAndBsonDocument(null, null)
+        assertRoundTrips(expectedWithNulls, dataClassWithNulls)
     }
 
     @Test

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
@@ -167,6 +167,12 @@ data class DataClassWithObjectIdAndBsonDocument(
     @Contextual val bsonDocument: BsonDocument
 )
 
+@Serializable
+data class DataClassWithOptionalObjectIdAndBsonDocument(
+    @Contextual val objectId: ObjectId?,
+    @Contextual val bsonDocument: BsonDocument?
+)
+
 @Serializable sealed class DataClassSealed
 
 @Serializable data class DataClassSealedA(val a: String) : DataClassSealed()

--- a/driver-kotlin-sync/build.gradle.kts
+++ b/driver-kotlin-sync/build.gradle.kts
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("org.jetbrains.kotlin.jvm")
     `java-library`
+    kotlin("plugin.serialization")
 
     // Test based plugins
     id("com.diffplug.spotless")
@@ -72,7 +73,7 @@ dependencies {
     integrationTestImplementation("org.jetbrains.kotlin:kotlin-test-junit")
     integrationTestImplementation(project(path = ":driver-sync"))
     integrationTestImplementation(project(path = ":driver-core"))
-    integrationTestImplementation(project(path = ":bson"))
+    integrationTestImplementation(project(path = ":bson-kotlinx"))
 }
 
 kotlin { explicitApi() }


### PR DESCRIPTION
Found when writing the documentation:

The DefaultBsonDecoder required extra handling to ensure it did not try to double decode optional values and overwrite them with a null value.

Tracking currentIndex and processed status allows the default decoder to correctly track if all elements have been processed and report the correct value when calling decodeElementIndex.

JAVA-5031