### PR TITLE
Build: Make bson-kotlin and bson-kotlinx optional

### DIFF
--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -37,8 +37,8 @@ def classifiers = ["linux-x86_64", "linux-aarch_64", "osx-x86_64", "osx-aarch_64
 dependencies {
     api project(path: ':bson', configuration: 'default')
     implementation project(path: ':bson-record-codec', configuration: 'default')
-    implementation project(path: ':bson-kotlin', configuration: 'default')
-    implementation project(path: ':bson-kotlinx', configuration: 'default')
+    implementation project(path: ':bson-kotlin', configuration: 'default'), optional
+    implementation project(path: ':bson-kotlinx', configuration: 'default'), optional
 
     implementation "com.github.jnr:jnr-unixsocket:$jnrUnixsocketVersion", optional
     api platform("io.netty:netty-bom:$nettyVersion")

--- a/driver-kotlin-coroutine/build.gradle.kts
+++ b/driver-kotlin-coroutine/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
 
     api(project(path = ":bson", configuration = "default"))
     api(project(path = ":driver-reactive-streams", configuration = "default"))
+    implementation(project(path = ":bson-kotlin", configuration = "default"))
 
     testImplementation("org.jetbrains.kotlin:kotlin-reflect")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")

--- a/driver-kotlin-sync/build.gradle.kts
+++ b/driver-kotlin-sync/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("org.jetbrains.kotlin.jvm")
     `java-library`
-    kotlin("plugin.serialization")
 
     // Test based plugins
     id("com.diffplug.spotless")
@@ -62,6 +61,7 @@ dependencies {
 
     api(project(path = ":bson", configuration = "default"))
     api(project(path = ":driver-sync", configuration = "default"))
+    implementation(project(path = ":bson-kotlin", configuration = "default"))
 
     testImplementation("org.jetbrains.kotlin:kotlin-reflect")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
@@ -73,7 +73,6 @@ dependencies {
     integrationTestImplementation("org.jetbrains.kotlin:kotlin-test-junit")
     integrationTestImplementation(project(path = ":driver-sync"))
     integrationTestImplementation(project(path = ":driver-core"))
-    integrationTestImplementation(project(path = ":bson-kotlinx"))
 }
 
 kotlin { explicitApi() }


### PR DESCRIPTION
Reduce the dependency tree for driver-core by making the kotlin dependencies optional.

Kotlin-coroutine and Kotlin-sync now take a hard dependency on bson-kotlin. So they will work out the box. Users will now have to opt into bson-kotlinx support.

JAVA-5036