### PR TITLE
Add support for managing Atlas search indexes.

### DIFF
--- a/driver-core/src/main/com/mongodb/assertions/Assertions.java
+++ b/driver-core/src/main/com/mongodb/assertions/Assertions.java
@@ -51,6 +51,29 @@ public final class Assertions {
     }
 
     /**
+     * Throw IllegalArgumentException if the values is null or contains null.
+     *
+     * @param name  the parameter name
+     * @param values the values that should not contain null.
+     * @param <T>   the value type
+     * @return the values
+     * @throws java.lang.IllegalArgumentException if value is null
+     */
+    public static <T> Iterable<T> notNullElements(final String name, final Iterable<T> values) {
+        if (values == null) {
+            throw new IllegalArgumentException(name + " can not be null");
+        }
+
+        for (T value : values) {
+            if (value == null){
+                throw new IllegalArgumentException(name + " can not contain null");
+            }
+        }
+
+        return values;
+    }
+
+    /**
      * Throw IllegalArgumentException if the value is null.
      *
      * @param name  the parameter name

--- a/driver-core/src/main/com/mongodb/client/model/SearchIndexModel.java
+++ b/driver-core/src/main/com/mongodb/client/model/SearchIndexModel.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model;
+
+import com.mongodb.lang.Nullable;
+import org.bson.conversions.Bson;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+/**
+ * A model describing the creation of a single Atlas Search index.
+ *
+ * @since 4.11
+ * @mongodb.server.release 7.0
+ */
+public class SearchIndexModel {
+    private final String name;
+    private final Bson definition;
+
+    /**
+     * Construct an instance with the given Atlas Search index definition.
+     *
+     * @param definition the search index definition.
+     */
+    public SearchIndexModel(final Bson definition) {
+        this(null, definition);
+    }
+
+    /**
+     * Construct an instance with the given Atlas Search name and index definition.
+     *
+     * @param name       the search index name
+     * @param definition the search index definition.
+     */
+    public SearchIndexModel(@Nullable final String name, final Bson definition) {
+        this.definition = notNull("definition", definition);
+        this.name = name;
+    }
+
+    /**
+     * Get the Atlas Search index definition.
+     *
+     * @return the index definition.
+     */
+    public Bson getDefinition() {
+        return definition;
+    }
+
+    /**
+     * Get the Atlas Search index name.
+     *
+     * @return the search index name.
+     */
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return "SearchIndexModel{"
+                + "name=" + name
+                + ", definition=" + definition
+                + '}';
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/AbstractDropIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AbstractDropIndexOperation.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoNamespace;
+import com.mongodb.WriteConcern;
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.binding.AsyncWriteBinding;
+import com.mongodb.internal.binding.WriteBinding;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonDocument;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeCommand;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError;
+import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError;
+import static com.mongodb.internal.operation.CommandOperationHelper.writeConcernErrorTransformer;
+import static com.mongodb.internal.operation.CommandOperationHelper.writeConcernErrorWriteTransformer;
+import static com.mongodb.internal.operation.OperationHelper.LOGGER;
+import static com.mongodb.internal.operation.OperationHelper.releasingCallback;
+import static com.mongodb.internal.operation.OperationHelper.withAsyncConnection;
+import static com.mongodb.internal.operation.OperationHelper.withConnection;
+
+/**
+ * An operation that drops an index.
+ *
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+public abstract class AbstractDropIndexOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
+    private final MongoNamespace namespace;
+    private final String indexName;
+    private final WriteConcern writeConcern;
+
+    public AbstractDropIndexOperation(final MongoNamespace namespace, final String indexName, @Nullable final WriteConcern writeConcern) {
+        this.namespace = notNull("namespace", namespace);
+        this.indexName = notNull("indexName", indexName);
+        this.writeConcern = writeConcern;
+    }
+
+    public AbstractDropIndexOperation(final MongoNamespace namespace, @Nullable final WriteConcern writeConcern) {
+        this.namespace = notNull("namespace", namespace);
+        this.indexName = null;
+        this.writeConcern = writeConcern;
+    }
+
+    @Override
+    public Void execute(final WriteBinding binding) {
+        return withConnection(binding, connection -> {
+            try {
+                executeCommand(binding, namespace.getDatabaseName(), buildCommand(), connection,
+                        writeConcernErrorTransformer());
+            } catch (MongoCommandException e) {
+                rethrowIfNotNamespaceError(e);
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
+        withAsyncConnection(binding, (connection, t) -> {
+            SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
+            if (t != null) {
+                errHandlingCallback.onResult(null, t);
+            } else {
+                SingleResultCallback<Void> releasingCallback = releasingCallback(errHandlingCallback, connection);
+                executeCommandAsync(binding, namespace.getDatabaseName(),
+                        buildCommand(), connection, writeConcernErrorWriteTransformer(),
+                        (result, t1) -> {
+                            if (t1 != null && !isNamespaceError(t1)) {
+                                releasingCallback.onResult(null, t1);
+                            } else {
+                                releasingCallback.onResult(result, null);
+                            }
+                        });
+            }
+        });
+    }
+
+    abstract BsonDocument buildCommand();
+
+    public MongoNamespace getNamespace() {
+        return namespace;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public WriteConcern getWriteConcern() {
+        return writeConcern;
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/AbstractWriteSearchIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AbstractWriteSearchIndexOperation.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoNamespace;
+import com.mongodb.WriteConcern;
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.binding.AsyncWriteBinding;
+import com.mongodb.internal.binding.WriteBinding;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonDocument;
+
+import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeCommand;
+import static com.mongodb.internal.operation.CommandOperationHelper.executeCommandAsync;
+import static com.mongodb.internal.operation.CommandOperationHelper.writeConcernErrorTransformer;
+import static com.mongodb.internal.operation.CommandOperationHelper.writeConcernErrorWriteTransformer;
+import static com.mongodb.internal.operation.OperationHelper.LOGGER;
+import static com.mongodb.internal.operation.OperationHelper.releasingCallback;
+import static com.mongodb.internal.operation.OperationHelper.withAsyncConnection;
+import static com.mongodb.internal.operation.OperationHelper.withConnection;
+
+/**
+ * An abstract class for defining operations for managing Atlas Search indexes.
+ *
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+abstract class AbstractWriteSearchIndexOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
+    private final MongoNamespace namespace;
+    private final WriteConcern writeConcern;
+
+    AbstractWriteSearchIndexOperation(final MongoNamespace mongoNamespace, @Nullable final WriteConcern writeConcern) {
+        this.namespace = mongoNamespace;
+        this.writeConcern = writeConcern;
+    }
+
+    @Override
+    public Void execute(final WriteBinding binding) {
+        return withConnection(binding, connection -> {
+            try {
+                executeCommand(binding, namespace.getDatabaseName(), buildCommand(), connection, writeConcernErrorTransformer());
+            } catch (MongoCommandException mongoCommandException){
+                handleCommandException(mongoCommandException);
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
+        withAsyncConnection(binding, (connection, connectionException) -> {
+            SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
+            if (connectionException != null) {
+                errHandlingCallback.onResult(null, connectionException);
+            } else {
+                SingleResultCallback<Void> completionCallback = releasingCallback(errHandlingCallback, connection);
+                try {
+                    executeCommandAsync(binding, namespace.getDatabaseName(),
+                            buildCommand(), connection, writeConcernErrorWriteTransformer(),
+                            getCommandExecutionCallback(completionCallback));
+                } catch (Throwable commandExecutionException) {
+                    completionCallback.onResult(null, commandExecutionException);
+                }
+            }
+        });
+    }
+
+    SingleResultCallback<Void> getCommandExecutionCallback(final SingleResultCallback<Void> completionCallback) {
+        return (result, commandExecutionException) -> completionCallback.onResult(null, commandExecutionException);
+    }
+
+    void handleCommandException(final MongoCommandException mongoCommandException) {
+        throw mongoCommandException;
+    }
+
+    abstract BsonDocument buildCommand();
+
+    public MongoNamespace getNamespace() {
+        return namespace;
+    }
+
+    public WriteConcern getWriteConcern() {
+        return writeConcern;
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateOperation.java
@@ -106,7 +106,7 @@ public class AggregateOperation<T> implements AsyncExplainableReadOperation<Asyn
         return wrapped.getComment();
     }
 
-    public AggregateOperation<T> comment(final BsonValue comment) {
+    public AggregateOperation<T> comment(@Nullable final BsonValue comment) {
         wrapped.comment(comment);
         return this;
     }
@@ -178,4 +178,5 @@ public class AggregateOperation<T> implements AsyncExplainableReadOperation<Asyn
     Decoder<T> getDecoder() {
         return wrapped.getDecoder();
     }
+
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
@@ -156,7 +156,7 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
         return comment;
     }
 
-    AggregateOperationImpl<T> comment(final BsonValue comment) {
+    AggregateOperationImpl<T> comment(@Nullable final BsonValue comment) {
         this.comment = comment;
         return this;
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
@@ -40,6 +40,7 @@ import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.InsertOneOptions;
 import com.mongodb.client.model.RenameCollectionOptions;
 import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.model.changestream.FullDocument;
@@ -48,6 +49,7 @@ import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.client.model.AggregationLevel;
 import com.mongodb.internal.client.model.FindOptions;
 import com.mongodb.internal.client.model.changestream.ChangeStreamLevel;
+import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
 import org.bson.BsonValue;
@@ -136,11 +138,12 @@ public final class AsyncOperations<TDocument> {
     public <TResult> AsyncExplainableReadOperation<AsyncBatchCursor<TResult>> aggregate(final List<? extends Bson> pipeline,
             final Class<TResult> resultClass,
             final long maxTimeMS, final long maxAwaitTimeMS,
-            final Integer batchSize,
-            final Collation collation, final Bson hint,
-            final String hintString,
-            final BsonValue comment,
-            final Bson variables,
+            @Nullable final Integer batchSize,
+            final Collation collation,
+            @Nullable final Bson hint,
+            @Nullable final String hintString,
+            @Nullable final BsonValue comment,
+            @Nullable final Bson variables,
             final Boolean allowDiskUse,
             final AggregationLevel aggregationLevel) {
         return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, batchSize, collation, hint, hintString, comment,
@@ -272,6 +275,29 @@ public final class AsyncOperations<TDocument> {
 
     public AsyncWriteOperation<Void> createIndexes(final List<IndexModel> indexes, final CreateIndexOptions options) {
         return operations.createIndexes(indexes, options);
+    }
+
+    public AsyncWriteOperation<Void> createSearchIndexes(final List<SearchIndexModel> indexes) {
+        return operations.createSearchIndexes(indexes);
+    }
+
+    public AsyncWriteOperation<Void> updateSearchIndex(final String indexName, final Bson definition) {
+        return operations.updateSearchIndex(indexName, definition);
+    }
+
+    public AsyncWriteOperation<Void> dropSearchIndex(final String indexName) {
+        return operations.dropSearchIndex(indexName);
+    }
+
+    public <TResult> AsyncExplainableReadOperation<AsyncBatchCursor<TResult>> listSearchIndexes(final Class<TResult> resultClass,
+                                                                                      final long maxTimeMS, final long maxAwaitTimeMS,
+                                                                                      @Nullable final String indexName,
+                                                                                      @Nullable final Integer batchSize,
+                                                                                      @Nullable final Collation collation,
+                                                                                      @Nullable final BsonValue comment,
+                                                                                      @Nullable final Boolean allowDiskUse) {
+        return operations.listSearchIndexes(resultClass, maxTimeMS, maxAwaitTimeMS, indexName, batchSize, collation,
+                comment, allowDiskUse);
     }
 
     public AsyncWriteOperation<Void> dropIndex(final String indexName, final DropIndexOptions options) {

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -242,8 +242,11 @@ final class CommandOperationHelper {
             final Connection connection) {
         BsonDocument command = commandCreator.create(source.getServerDescription(), connection.getDescription());
         retryState.attach(AttachmentKeys.commandDescriptionSupplier(), command::getFirstKey, false);
-        return transformer.apply(assertNotNull(connection.command(database, command, new NoOpFieldNameValidator(),
-                source.getReadPreference(), decoder, binding)), source, connection);
+
+        D result = connection.command(database, command, new NoOpFieldNameValidator(),
+                source.getReadPreference(), decoder, binding);
+
+        return transformer.apply(assertNotNull(result), source, connection);
     }
 
     /* Write Binding Helpers */

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateSearchIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateSearchIndexesOperation.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.WriteConcern;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
+
+/**
+ * An operation that creates one or more Atlas Search indexes.
+ *
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+public class CreateSearchIndexesOperation extends AbstractWriteSearchIndexOperation {
+    private static final String COMMAND_NAME = "createSearchIndexes";
+    private final List<SearchIndexRequest> indexRequests;
+
+    public CreateSearchIndexesOperation(final MongoNamespace namespace, final List<SearchIndexRequest> indexRequests,
+                                        @Nullable final WriteConcern writeConcern) {
+        super(namespace, writeConcern);
+        this.indexRequests = notNull("indexRequests", indexRequests);
+    }
+
+    private BsonArray convert(final List<SearchIndexRequest> requests) {
+        return requests.stream()
+                .map(this::convert)
+                .collect(Collectors.toCollection(BsonArray::new));
+    }
+
+    private BsonDocument convert(final SearchIndexRequest request) {
+        BsonDocument bsonIndexRequest = new BsonDocument();
+        String searchIndexName = request.getSearchIndexName();
+        if (searchIndexName != null) {
+            bsonIndexRequest.append("name", new BsonString(searchIndexName));
+        }
+        bsonIndexRequest.append("definition", request.getDefinition());
+        return bsonIndexRequest;
+    }
+
+    @Override
+    BsonDocument buildCommand() {
+        BsonDocument command = new BsonDocument(COMMAND_NAME, new BsonString(getNamespace().getCollectionName()));
+        command.put("indexes", convert(indexRequests));
+        appendWriteConcernToCommand(getWriteConcern(), command);
+        return command;
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/DropSearchIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropSearchIndexOperation.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoNamespace;
+import com.mongodb.WriteConcern;
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+
+import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError;
+import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
+
+/**
+ * An operation that drops an Alas Search index.
+ *
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+class DropSearchIndexOperation extends AbstractWriteSearchIndexOperation {
+    private static final String COMMAND_NAME = "dropSearchIndex";
+    private final String indexName;
+
+    DropSearchIndexOperation(final MongoNamespace namespace, final String indexName, @Nullable final WriteConcern writeConcern) {
+        super(namespace, writeConcern);
+        this.indexName = indexName;
+    }
+
+    @Override
+    SingleResultCallback<Void> getCommandExecutionCallback(final SingleResultCallback<Void> completionCallback) {
+        return (result, commandExecutionException) -> {
+            if (commandExecutionException != null && !isNamespaceError(commandExecutionException)) {
+                completionCallback.onResult(null, commandExecutionException);
+            } else {
+                completionCallback.onResult(result, null);
+            }
+        };
+    }
+
+    @Override
+    void handleCommandException(final MongoCommandException mongoCommandException) {
+        rethrowIfNotNamespaceError(mongoCommandException);
+    }
+
+    @Override
+    BsonDocument buildCommand() {
+        BsonDocument command = new BsonDocument(COMMAND_NAME, new BsonString(getNamespace().getCollectionName()));
+        command.put("name", new BsonString(indexName));
+        appendWriteConcernToCommand(getWriteConcern(), command);
+        return command;
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/IndexHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/IndexHelper.java
@@ -17,6 +17,7 @@
 package com.mongodb.internal.operation;
 
 import com.mongodb.client.model.IndexModel;
+import com.mongodb.client.model.SearchIndexModel;
 import org.bson.BsonDocument;
 import org.bson.BsonNumber;
 import org.bson.BsonString;
@@ -49,6 +50,26 @@ public final class IndexHelper {
             }
         }
         return indexNames;
+    }
+
+    /**
+     * Get a list of Atlas Search index names for the given list of {@link SearchIndexModel}.
+     *
+     * @param indexes the search index models
+     * @return the list of search index names.
+     */
+    public static List<String> getSearchIndexNames(final List<SearchIndexModel> indexes) {
+        List<String> indexNames = new ArrayList<>();
+        //TODO consider making a stream
+        for (SearchIndexModel model : indexes) {
+            indexNames.add(getSearchIndexName(model));
+        }
+        return indexNames;
+    }
+
+    public static String getSearchIndexName(final SearchIndexModel model) {
+        String name = model.getName();
+        return  name != null ? name : "default";
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
@@ -152,7 +152,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
                                                 releasingCallback.onResult(null, t);
                                             } else {
                                                 releasingCallback.onResult(result != null ? result : emptyAsyncCursor(source), null);
-                                            }
+                                             }
                                         });
                             })
                 ).whenComplete(binding::release);

--- a/driver-core/src/main/com/mongodb/internal/operation/ListSearchIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListSearchIndexesOperation.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+import com.mongodb.ExplainVerbosity;
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.model.Collation;
+import com.mongodb.internal.async.AsyncBatchCursor;
+import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.binding.AsyncReadBinding;
+import com.mongodb.internal.binding.ReadBinding;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.codecs.Decoder;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.assertions.Assertions.assertNotNull;
+import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceError;
+import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError;
+import static com.mongodb.internal.operation.OperationHelper.createEmptyAsyncBatchCursor;
+import static com.mongodb.internal.operation.OperationHelper.createEmptyBatchCursor;
+
+
+public class ListSearchIndexesOperation<T>
+        implements AsyncExplainableReadOperation<AsyncBatchCursor<T>>, ExplainableReadOperation<BatchCursor<T>> {
+    private final MongoNamespace namespace;
+    private final Decoder<T> decoder;
+    private final Boolean allowDiskUse;
+    private final Integer batchSize;
+    private final Collation collation;
+    private final BsonValue comment;
+    private final long maxAwaitTimeMS;
+    private final long maxTimeMS;
+    private final String indexName;
+
+    public ListSearchIndexesOperation(final MongoNamespace namespace,
+                                      final Decoder<T> decoder,
+                                      final long maxTimeMS, final long maxAwaitTimeMS,
+                                      @Nullable final String indexName,
+                                      @Nullable final Integer batchSize,
+                                      @Nullable final Collation collation,
+                                      @Nullable final BsonValue comment,
+                                      @Nullable final Boolean allowDiskUse) {
+        this.namespace = namespace;
+        this.decoder = decoder;
+        this.maxTimeMS = maxTimeMS;
+        this.maxAwaitTimeMS = maxAwaitTimeMS;
+        this.batchSize = batchSize == null ? 0 : batchSize;
+        this.collation = collation;
+        this.comment = comment;
+        this.allowDiskUse = allowDiskUse;
+        this.indexName = indexName;
+    }
+
+    @Override
+    public BatchCursor<T> execute(final ReadBinding binding) {
+        try {
+            return getAggregateOperation().execute(binding);
+        } catch (MongoCommandException exception) {
+            return rethrowIfNotNamespaceError(exception, createEmptyBatchCursor(namespace, decoder,
+                    exception.getServerAddress(), batchSize));
+        }
+    }
+
+    @Override
+    public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
+        getAggregateOperation().executeAsync(binding, (cursor, exception) -> {
+            if (exception != null && !isNamespaceError(exception)) {
+                callback.onResult(null, exception);
+            } else {
+                if (exception == null) {
+                    callback.onResult(cursor, null);
+                    return;
+                }
+                MongoCommandException commandException = (MongoCommandException) assertNotNull(exception);
+
+                AsyncBatchCursor<T> emptyAsyncBatchCursor = createEmptyAsyncBatchCursor(namespace, commandException.getServerAddress());
+                callback.onResult(emptyAsyncBatchCursor, null);
+            }
+        });
+    }
+
+    public <R> ReadOperation<R> asExplainableOperation(@Nullable final ExplainVerbosity verbosity, final Decoder<R> resultDecoder) {
+        return getAggregateOperation().asExplainableOperation(verbosity, resultDecoder);
+    }
+
+    public <R> AsyncReadOperation<R> asAsyncExplainableOperation(@Nullable final ExplainVerbosity verbosity,
+                                                                 final Decoder<R> resultDecoder) {
+        return getAggregateOperation().asAsyncExplainableOperation(verbosity, resultDecoder);
+    }
+
+    private AggregateOperation<T> getAggregateOperation() {
+        BsonDocument searchDefinition = getSearchDefinition();
+        BsonDocument bsonDocument = new BsonDocument("$listSearchIndexes", searchDefinition);
+
+        return new AggregateOperation<>(namespace, Collections.singletonList(bsonDocument), decoder)
+                .collation(collation)
+                .comment(comment)
+                .allowDiskUse(allowDiskUse)
+                .batchSize(batchSize)
+                .maxAwaitTime(maxAwaitTimeMS, TimeUnit.MILLISECONDS)
+                .maxTime(maxTimeMS, TimeUnit.MILLISECONDS);
+    }
+
+    @NotNull
+    private BsonDocument getSearchDefinition() {
+        if (indexName == null) {
+            return new BsonDocument();
+        }
+        return new BsonDocument("name", new BsonString(indexName));
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
@@ -255,9 +255,15 @@ final class OperationHelper {
 
     static <T> AsyncBatchCursor<T> cursorDocumentToAsyncBatchCursor(final BsonDocument cursorDocument, final Decoder<T> decoder,
             final BsonValue comment, final AsyncConnectionSource source, final AsyncConnection connection, final int batchSize) {
+      return cursorDocumentToAsyncBatchCursor(cursorDocument, decoder, 0, comment, source, connection, batchSize);
+    }
+
+    static <T> AsyncBatchCursor<T> cursorDocumentToAsyncBatchCursor(final BsonDocument cursorDocument, final Decoder<T> decoder,
+                                                                    final long maxAwaitTimeMS,
+                                                                    final BsonValue comment, final AsyncConnectionSource source, final AsyncConnection connection, final int batchSize) {
         return new AsyncQueryBatchCursor<>(OperationHelper.cursorDocumentToQueryResult(cursorDocument,
                 source.getServerDescription().getAddress()),
-                0, batchSize, 0, decoder, comment, source, connection, cursorDocument);
+                0, batchSize, maxAwaitTimeMS, decoder, comment, source, connection, cursorDocument);
     }
 
 

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -46,6 +46,7 @@ import com.mongodb.client.model.RenameCollectionOptions;
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.ReturnDocument;
+import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.UpdateManyModel;
 import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.UpdateOptions;
@@ -79,6 +80,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.notNull;
@@ -228,9 +230,9 @@ final class Operations<TDocument> {
 
     <TResult> AggregateOperation<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,
                                                     final long maxTimeMS, final long maxAwaitTimeMS, @Nullable final Integer batchSize,
-                                                    final Collation collation, @Nullable final Bson hint, @Nullable final String hintString,
-                                                    final BsonValue comment,
-                                                    final Bson variables, final Boolean allowDiskUse,
+                                                    @Nullable final Collation collation, @Nullable final Bson hint,
+                                                    @Nullable final String hintString, @Nullable final BsonValue comment,
+                                                    @Nullable final Bson variables, @Nullable final Boolean allowDiskUse,
                                                     final AggregationLevel aggregationLevel) {
         return new AggregateOperation<>(assertNotNull(namespace), assertNotNull(toBsonDocumentList(pipeline)),
                 codecRegistry.get(resultClass), aggregationLevel)
@@ -644,6 +646,37 @@ final class Operations<TDocument> {
                 .commitQuorum(createIndexOptions.getCommitQuorum());
     }
 
+    CreateSearchIndexesOperation createSearchIndexes(final List<SearchIndexModel> indexes) {
+        List<SearchIndexRequest> indexRequests = indexes.stream()
+                .map(this::createSearchIndexRequest)
+                .collect(Collectors.toList());
+
+        return new CreateSearchIndexesOperation(assertNotNull(namespace), indexRequests, writeConcern);
+    }
+
+    public UpdateSearchIndexesOperation updateSearchIndex(final String name, final Bson definition) {
+        return new UpdateSearchIndexesOperation(assertNotNull(namespace), name, toBsonDocument(definition), writeConcern);
+    }
+
+
+    public DropSearchIndexOperation dropSearchIndex(final String indexName) {
+        return new DropSearchIndexOperation(assertNotNull(namespace), indexName, writeConcern);
+    }
+
+
+    public <TResult> ListSearchIndexesOperation<TResult> listSearchIndexes(final Class<TResult> resultClass,
+                                                                                      final long maxTimeMS, final long maxAwaitTimeMS,
+                                                                                      @Nullable final String indexName,
+                                                                                      @Nullable final Integer batchSize,
+                                                                                      @Nullable final Collation collation,
+                                                                                      @Nullable final BsonValue comment,
+                                                                                      @Nullable final Boolean allowDiskUse) {
+
+
+        return new ListSearchIndexesOperation<>(assertNotNull(namespace),
+                codecRegistry.get(resultClass), maxTimeMS, maxAwaitTimeMS, indexName, batchSize, collation, comment, allowDiskUse);
+    }
+
     DropIndexOperation dropIndex(final String indexName, final DropIndexOptions dropIndexOptions) {
         return new DropIndexOperation(assertNotNull(namespace), indexName, writeConcern)
                 .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
@@ -733,4 +766,13 @@ final class Operations<TDocument> {
         return bsonDocumentList;
     }
 
+    private SearchIndexRequest createSearchIndexRequest(final SearchIndexModel model) {
+        BsonDocument definition = assertNotNull(toBsonDocument(model.getDefinition()));
+        String indexName = model.getName();
+
+        SearchIndexRequest indexRequest = new SearchIndexRequest();
+        indexRequest.setSearchIndexName(indexName);
+        indexRequest.setDefinition(definition);
+        return indexRequest;
+    }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/SearchIndexRequest.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SearchIndexRequest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+import com.mongodb.lang.Nullable;
+import org.bson.BsonDocument;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+/**
+ * The settings to apply to the creation of a search index.
+ *
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+public class SearchIndexRequest {
+    private BsonDocument definition;
+    private String searchIndexName;
+
+    @Nullable
+    public BsonDocument getDefinition() {
+        return definition;
+    }
+
+    public void setDefinition(final BsonDocument definition) {
+        notNull("definition", definition);
+        this.definition = definition;
+    }
+
+   @Nullable
+    public String getSearchIndexName() {
+        return searchIndexName;
+    }
+
+    public void setSearchIndexName(@Nullable final String searchIndexName) {
+        this.searchIndexName = searchIndexName;
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -40,6 +40,7 @@ import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.InsertOneOptions;
 import com.mongodb.client.model.RenameCollectionOptions;
 import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.model.changestream.FullDocument;
@@ -113,10 +114,10 @@ public final class SyncOperations<TDocument> {
                                                                               final Class<TResult> resultClass,
                                                                               final long maxTimeMS, final long maxAwaitTimeMS,
                                                                               @Nullable final Integer batchSize,
-                                                                              final Collation collation, final Bson hint,
-                                                                              final String hintString,
+                                                                              final Collation collation, @Nullable final Bson hint,
+                                                                              @Nullable final String hintString,
                                                                               final BsonValue comment,
-                                                                              final Bson variables,
+                                                                              @Nullable final Bson variables,
                                                                               final Boolean allowDiskUse,
                                                                               final AggregationLevel aggregationLevel) {
         return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, batchSize, collation, hint, hintString, comment,
@@ -247,6 +248,30 @@ public final class SyncOperations<TDocument> {
 
     public WriteOperation<Void> createIndexes(final List<IndexModel> indexes, final CreateIndexOptions options) {
         return operations.createIndexes(indexes, options);
+    }
+
+    public WriteOperation<Void> createSearchIndexes(final List<SearchIndexModel> indexes) {
+        return operations.createSearchIndexes(indexes);
+    }
+
+    public WriteOperation<Void> updateSearchIndex(final String indexName, final Bson definition) {
+        return operations.updateSearchIndex(indexName, definition);
+    }
+
+    public WriteOperation<Void> dropSearchIndex(final String indexName) {
+        return operations.dropSearchIndex(indexName);
+    }
+
+
+    public <TResult> ExplainableReadOperation<BatchCursor<TResult>> listSearchIndexes(final Class<TResult> resultClass,
+                                                                           final long maxTimeMS, final long maxAwaitTimeMS,
+                                                                           @Nullable final String indexName,
+                                                                           @Nullable final Integer batchSize,
+                                                                           @Nullable final Collation collation,
+                                                                           @Nullable final BsonValue comment,
+                                                                           @Nullable final Boolean allowDiskUse) {
+        return operations.listSearchIndexes(resultClass, maxTimeMS, maxAwaitTimeMS, indexName, batchSize, collation,
+               comment, allowDiskUse);
     }
 
     public WriteOperation<Void> dropIndex(final String indexName, final DropIndexOptions options) {

--- a/driver-core/src/main/com/mongodb/internal/operation/UpdateSearchIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/UpdateSearchIndexesOperation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.WriteConcern;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
+
+/**
+ * An operation that updates an Atlas Search index.
+ *
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+public class UpdateSearchIndexesOperation extends AbstractWriteSearchIndexOperation {
+    private static final String COMMAND_NAME = "updateSearchIndex";
+    private final String indexName;
+    private final BsonDocument definition;
+
+    public UpdateSearchIndexesOperation(final MongoNamespace namespace, final String indexName, final BsonDocument definition,
+                                        @Nullable final WriteConcern writeConcern) {
+        super(namespace, writeConcern);
+        this.indexName = indexName;
+        this.definition = definition;
+    }
+
+    @Override
+    BsonDocument buildCommand() {
+        BsonDocument command = new BsonDocument(COMMAND_NAME, new BsonString(getNamespace().getCollectionName()));
+        command.append("name", new BsonString(indexName));
+        command.append("definition", definition);
+        appendWriteConcernToCommand(getWriteConcern(), command);
+        return command;
+    }
+}
+

--- a/driver-core/src/test/resources/logback-test.xml
+++ b/driver-core/src/test/resources/logback-test.xml
@@ -7,11 +7,11 @@
     </appender>
 
     <!--<logger name="org.mongodb.driver.connection" level="TRACE" additivity="true"/>-->
-    <!--<logger name="org.mongodb.driver.cluster" level="TRACE" additivity="true"/>-->
+    <logger name="org.mongodb.driver.cluster" level="ERROR" additivity="false"/>
     <!--<logger name="org.mongodb.driver.protocol" level="TRACE" additivity="true"/>-->
     <!--<logger name="org.mongodb.driver.operation" level="TRACE" additivity="true"/>-->
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/driver-core/src/test/resources/unified-test-format/index-management/tests/createSearchIndex.json
+++ b/driver-core/src/test/resources/unified-test-format/index-management/tests/createSearchIndex.json
@@ -1,0 +1,134 @@
+{
+  "description": "createSearchIndex",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "runOnRequirements": [
+    {
+      "minServerVersion": "7.0.0",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "tests": [
+    {
+      "description": "no name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "mappings": {
+                  "dynamic": true
+                }
+              }
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      }
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "mappings": {
+                  "dynamic": true
+                }
+              },
+              "name": "test index"
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/index-management/tests/createSearchIndexes.json
+++ b/driver-core/src/test/resources/unified-test-format/index-management/tests/createSearchIndexes.json
@@ -1,0 +1,169 @@
+{
+  "description": "createSearchIndexes",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "runOnRequirements": [
+    {
+      "minServerVersion": "7.0.0",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "tests": [
+    {
+      "description": "empty index definition array",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": []
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "no name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "mappings": {
+                    "dynamic": true
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      }
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "mappings": {
+                    "dynamic": true
+                  }
+                },
+                "name": "test index"
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/index-management/tests/dropSearchIndex.json
+++ b/driver-core/src/test/resources/unified-test-format/index-management/tests/dropSearchIndex.json
@@ -1,0 +1,73 @@
+{
+  "description": "dropSearchIndex",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "runOnRequirements": [
+    {
+      "minServerVersion": "7.0.0",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "tests": [
+    {
+      "description": "sends the correct command",
+      "operations": [
+        {
+          "name": "dropSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "name": "test index"
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "dropSearchIndex": "collection0",
+                  "name": "test index",
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/index-management/tests/listSearchIndexes.json
+++ b/driver-core/src/test/resources/unified-test-format/index-management/tests/listSearchIndexes.json
@@ -1,0 +1,153 @@
+{
+  "description": "listSearchIndexes",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "runOnRequirements": [
+    {
+      "minServerVersion": "7.0.0",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "tests": [
+    {
+      "description": "when no name is provided, it does not populate the filter",
+      "operations": [
+        {
+          "name": "listSearchIndexes",
+          "object": "collection0",
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$listSearchIndexes": {}
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "when a name is provided, it is present in the filter",
+      "operations": [
+        {
+          "name": "listSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "name": "test index"
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$listSearchIndexes": {
+                        "name": "test index"
+                      }
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "aggregation cursor options are supported",
+      "operations": [
+        {
+          "name": "listSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "name": "test index",
+            "aggregationOptions": {
+              "batchSize": 10
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "cursor": {
+                    "batchSize": 10
+                  },
+                  "pipeline": [
+                    {
+                      "$listSearchIndexes": {
+                        "name": "test index"
+                      }
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-core/src/test/resources/unified-test-format/index-management/tests/updateSearchIndex.json
+++ b/driver-core/src/test/resources/unified-test-format/index-management/tests/updateSearchIndex.json
@@ -1,0 +1,75 @@
+{
+  "description": "updateSearchIndex",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "runOnRequirements": [
+    {
+      "minServerVersion": "7.0.0",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "tests": [
+    {
+      "description": "sends the correct command",
+      "operations": [
+        {
+          "name": "updateSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "name": "test index",
+            "definition": {}
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "updateSearchIndex": "collection0",
+                  "name": "test index",
+                  "definition": {},
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/syncadapter/SyncListSearchIndexesIterable.kt
+++ b/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/syncadapter/SyncListSearchIndexesIterable.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.kotlin.client.coroutine.syncadapter
+
+import com.mongodb.ExplainVerbosity
+import com.mongodb.client.ListSearchIndexesIterable
+import com.mongodb.client.model.Collation
+import com.mongodb.kotlin.client.coroutine.ListSearchIndexesFlow
+import kotlinx.coroutines.runBlocking
+import org.bson.BsonValue
+import org.bson.Document
+import java.util.concurrent.TimeUnit
+import com.mongodb.client.ListSearchIndexesIterable as JListSearchIndexesIterable
+
+data class SyncListSearchIndexesIterable<T : Any>(val wrapped: ListSearchIndexesFlow<T>) :
+        JListSearchIndexesIterable<T>, SyncMongoIterable<T>(wrapped) {
+    override fun batchSize(batchSize: Int): SyncListSearchIndexesIterable<T> = apply { wrapped.batchSize(batchSize) }
+    override fun name(indexName: String): SyncListSearchIndexesIterable<T> = apply { wrapped.name(indexName) }
+
+    override fun allowDiskUse(allowDiskUse: Boolean?): ListSearchIndexesIterable<T> = apply {
+        wrapped.allowDiskUse(allowDiskUse)
+    }
+
+    override fun maxTime(maxTime: Long, timeUnit: TimeUnit): SyncListSearchIndexesIterable<T> = apply {
+        wrapped.maxTime(maxTime, timeUnit)
+    }
+
+    override fun maxAwaitTime(maxAwaitTime: Long, timeUnit: TimeUnit): ListSearchIndexesIterable<T> = apply {
+        wrapped.maxAwaitTime(maxAwaitTime, timeUnit)
+    }
+
+    override fun collation(collation: Collation?): ListSearchIndexesIterable<T> = apply {
+        wrapped.collation(collation)
+    }
+
+    override fun comment(comment: String?): SyncListSearchIndexesIterable<T> = apply { wrapped.comment(comment) }
+    override fun comment(comment: BsonValue?): SyncListSearchIndexesIterable<T> = apply { wrapped.comment(comment) }
+    override fun explain(): Document = runBlocking { wrapped.explain() }
+
+    override fun explain(verbosity: ExplainVerbosity): Document = runBlocking { wrapped.explain(verbosity) }
+
+    override fun <E : Any> explain(explainResultClass: Class<E>): E = runBlocking {
+        wrapped.explain(explainResultClass)
+    }
+
+    override fun <E : Any> explain(explainResultClass: Class<E>, verbosity: ExplainVerbosity): E = runBlocking {
+        wrapped.explain(explainResultClass, verbosity)
+    }
+}

--- a/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/syncadapter/SyncMongoCollection.kt
+++ b/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/syncadapter/SyncMongoCollection.kt
@@ -22,32 +22,9 @@ import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
 import com.mongodb.WriteConcern
 import com.mongodb.bulk.BulkWriteResult
-import com.mongodb.client.AggregateIterable
-import com.mongodb.client.ChangeStreamIterable
-import com.mongodb.client.ClientSession
-import com.mongodb.client.DistinctIterable
-import com.mongodb.client.FindIterable
-import com.mongodb.client.ListIndexesIterable
-import com.mongodb.client.MapReduceIterable
+import com.mongodb.client.*
+import com.mongodb.client.model.*
 import com.mongodb.client.MongoCollection as JMongoCollection
-import com.mongodb.client.model.BulkWriteOptions
-import com.mongodb.client.model.CountOptions
-import com.mongodb.client.model.CreateIndexOptions
-import com.mongodb.client.model.DeleteOptions
-import com.mongodb.client.model.DropCollectionOptions
-import com.mongodb.client.model.DropIndexOptions
-import com.mongodb.client.model.EstimatedDocumentCountOptions
-import com.mongodb.client.model.FindOneAndDeleteOptions
-import com.mongodb.client.model.FindOneAndReplaceOptions
-import com.mongodb.client.model.FindOneAndUpdateOptions
-import com.mongodb.client.model.IndexModel
-import com.mongodb.client.model.IndexOptions
-import com.mongodb.client.model.InsertManyOptions
-import com.mongodb.client.model.InsertOneOptions
-import com.mongodb.client.model.RenameCollectionOptions
-import com.mongodb.client.model.ReplaceOptions
-import com.mongodb.client.model.UpdateOptions
-import com.mongodb.client.model.WriteModel
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.InsertManyResult
 import com.mongodb.client.result.InsertOneResult
@@ -397,6 +374,33 @@ data class SyncMongoCollection<T : Any>(val wrapped: MongoCollection<T>) : JMong
     override fun drop(clientSession: ClientSession, dropCollectionOptions: DropCollectionOptions) = runBlocking {
         wrapped.drop(clientSession.unwrapped(), dropCollectionOptions)
     }
+
+    override fun createSearchIndex(name: String, definition: Bson) = runBlocking {
+        wrapped.createSearchIndex(name, definition)
+    }
+
+    override fun createSearchIndex(definition: Bson) = runBlocking {
+        wrapped.createSearchIndex(definition)
+    }
+
+    override fun createSearchIndexes(searchIndexModels: MutableList<SearchIndexModel>): MutableList<String> =
+            runBlocking {
+                wrapped.createSearchIndexes(searchIndexModels).toCollection(mutableListOf())
+            }
+
+    override fun updateSearchIndex(indexName: String, definition: Bson) = runBlocking {
+        wrapped.updateSearchIndex(indexName, definition)
+    }
+
+    override fun dropSearchIndex(indexName: String) = runBlocking {
+        wrapped.dropSearchIndex(indexName)
+    }
+
+    override fun listSearchIndexes(): ListSearchIndexesIterable<Document> =
+            SyncListSearchIndexesIterable(wrapped.listSearchIndexes())
+
+    override fun <R : Any> listSearchIndexes(resultClass: Class<R>): ListSearchIndexesIterable<R> =
+            SyncListSearchIndexesIterable(wrapped.listSearchIndexes(resultClass = resultClass))
 
     override fun createIndex(keys: Bson): String = runBlocking { wrapped.createIndex(keys) }
 

--- a/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/ListSearchIndexesFlow.kt
+++ b/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/ListSearchIndexesFlow.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.kotlin.client.coroutine
+
+import com.mongodb.ExplainVerbosity
+import com.mongodb.client.model.Collation
+import com.mongodb.reactivestreams.client.ListSearchIndexesPublisher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.reactive.awaitSingle
+import org.bson.BsonValue
+import org.bson.Document
+import java.util.concurrent.TimeUnit
+
+/**
+ * Flow implementation for list Atlas Search index operations.
+ *
+ * @param T The type of the result.
+ * @see [List Atlas Search indexes](https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes)
+ */
+public class ListSearchIndexesFlow<T : Any>(private val wrapped: ListSearchIndexesPublisher<T>) : Flow<T> by wrapped.asFlow() {
+
+    /**
+     * Sets an Atlas Search index name for this operation. A null value means no index name is set.
+     *
+     * @param indexName Atlas Search index name.
+     * @return this
+     */
+    public fun name(indexName: String): ListSearchIndexesFlow<T> = apply {
+        wrapped.name(indexName);
+    }
+
+    /**
+     * Enables writing to temporary files. A null value indicates that it's unspecified.
+     *
+     * @param allowDiskUse true if writing to temporary files is enabled
+     * @return this
+     * @see [Aggregation command](https://www.mongodb.com/docs/manual/reference/command/aggregate/)
+     */
+    public fun allowDiskUse(allowDiskUse: Boolean?): ListSearchIndexesFlow<T> = apply { wrapped.allowDiskUse(allowDiskUse) }
+
+    /**
+     * Sets the number of documents to return per batch.
+     *
+     * @param batchSize the batch size
+     * @return this
+     * @see [Batch Size](https://www.mongodb.com/docs/manual/reference/method/cursor.batchSize/#cursor.batchSize)
+     */
+    public fun batchSize(batchSize: Int): ListSearchIndexesFlow<T> = apply { wrapped.batchSize(batchSize) }
+
+    /**
+     * Sets the maximum execution time on the server for this operation.
+     *
+     * @param maxTime the max time
+     * @param timeUnit the time unit, defaults to Milliseconds
+     * @return this
+     */
+    public fun maxTime(maxTime: Long, timeUnit: TimeUnit = TimeUnit.MILLISECONDS): ListSearchIndexesFlow<T> = apply {
+        wrapped.maxTime(maxTime, timeUnit)
+    }
+
+    /**
+     * The maximum amount of time for the server to wait on new documents to satisfy a `$changeStream` aggregation.
+     *
+     * A zero value will be ignored.
+     *
+     * @param maxAwaitTime the max await time
+     * @param timeUnit the time unit to return the result in, defaults to Milliseconds
+     * @return the maximum await execution time in the given time unit
+     */
+    public fun maxAwaitTime(maxAwaitTime: Long, timeUnit: TimeUnit = TimeUnit.MILLISECONDS): ListSearchIndexesFlow<T> = apply {
+        wrapped.maxAwaitTime(maxAwaitTime, timeUnit)
+    }
+
+    /**
+     * Sets the collation options
+     *
+     * A null value represents the server default.
+     *
+     * @param collation the collation options to use
+     * @return this
+     */
+    public fun collation(collation: Collation?): ListSearchIndexesFlow<T> = apply { wrapped.collation(collation) }
+
+    /**
+     * Sets the comment for this operation. A null value means no comment is set.
+     *
+     * @param comment the comment
+     * @return this
+     */
+    public fun comment(comment: String?): ListSearchIndexesFlow<T> = apply { wrapped.comment(comment) }
+
+    /**
+     * Sets the comment for this operation. A null value means no comment is set.
+     *
+     * The comment can be any valid BSON type for server versions 4.4 and above. Server versions between 3.6 and 4.2
+     * only support string as comment, and providing a non-string type will result in a server-side error.
+     *
+     * @param comment the comment
+     * @return this
+     */
+    public fun comment(comment: BsonValue?): ListSearchIndexesFlow<T> = apply { wrapped.comment(comment) }
+
+    /**
+     * Explain the execution plan for this operation with the given verbosity level
+     *
+     * @param R the type of the document class
+     * @param verbosity the verbosity of the explanation
+     * @return the execution plan
+     * @see [Explain command](https://www.mongodb.com/docs/manual/reference/command/explain/)
+     */
+    @JvmName("explainDocument")
+    public suspend fun explain(verbosity: ExplainVerbosity? = null): Document = explain<Document>(verbosity)
+
+    /**
+     * Explain the execution plan for this operation with the given verbosity level
+     *
+     * @param R the type of the document class
+     * @param resultClass the result document type.
+     * @param verbosity the verbosity of the explanation
+     * @return the execution plan
+     * @see [Explain command](https://www.mongodb.com/docs/manual/reference/command/explain/)
+     */
+    public suspend fun <R : Any> explain(resultClass: Class<R>, verbosity: ExplainVerbosity? = null): R =
+            if (verbosity == null) wrapped.explain(resultClass).awaitSingle()
+            else wrapped.explain(resultClass, verbosity).awaitSingle()
+
+    /**
+     * Explain the execution plan for this operation with the given verbosity level
+     *
+     * @param R the type of the document class
+     * @param verbosity the verbosity of the explanation
+     * @return the execution plan
+     * @see [Explain command](https://www.mongodb.com/docs/manual/reference/command/explain/)
+     */
+    public suspend inline fun <reified R : Any> explain(verbosity: ExplainVerbosity? = null): R =
+            explain(R::class.java, verbosity)
+
+    public override suspend fun collect(collector: FlowCollector<T>): Unit = wrapped.asFlow().collect(collector)
+}

--- a/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/MongoCollection.kt
+++ b/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/MongoCollection.kt
@@ -20,24 +20,7 @@ import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
 import com.mongodb.WriteConcern
 import com.mongodb.bulk.BulkWriteResult
-import com.mongodb.client.model.BulkWriteOptions
-import com.mongodb.client.model.CountOptions
-import com.mongodb.client.model.CreateIndexOptions
-import com.mongodb.client.model.DeleteOptions
-import com.mongodb.client.model.DropCollectionOptions
-import com.mongodb.client.model.DropIndexOptions
-import com.mongodb.client.model.EstimatedDocumentCountOptions
-import com.mongodb.client.model.FindOneAndDeleteOptions
-import com.mongodb.client.model.FindOneAndReplaceOptions
-import com.mongodb.client.model.FindOneAndUpdateOptions
-import com.mongodb.client.model.IndexModel
-import com.mongodb.client.model.IndexOptions
-import com.mongodb.client.model.InsertManyOptions
-import com.mongodb.client.model.InsertOneOptions
-import com.mongodb.client.model.RenameCollectionOptions
-import com.mongodb.client.model.ReplaceOptions
-import com.mongodb.client.model.UpdateOptions
-import com.mongodb.client.model.WriteModel
+import com.mongodb.client.model.*
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.InsertManyResult
 import com.mongodb.client.result.InsertOneResult
@@ -1233,6 +1216,89 @@ public class MongoCollection<T : Any>(private val wrapped: JMongoCollection<T>) 
     public suspend fun drop(clientSession: ClientSession, options: DropCollectionOptions = DropCollectionOptions()) {
         wrapped.drop(clientSession.wrapped, options).awaitFirstOrNull()
     }
+
+    /**
+     * Create an Atlas Search index for the collection.
+     *
+     * @param indexName  the name of the search index to create.
+     * @param definition the search index mapping definition.
+     * @return the search index name.
+     * @see [Create search indexes](https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/)
+     */
+    public suspend fun createSearchIndex(indexName: String, definition: Bson): String =
+        wrapped.createSearchIndex(indexName, definition).awaitSingle()
+
+    /**
+     * Create an Atlas Search index with the default name for the collection.
+     *
+     * @param definition the search index mapping definition.
+     * @return the search index name.
+     * @see [Create search indexes](https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/)
+     */
+    public suspend fun createSearchIndex(definition: Bson): String =
+        wrapped.createSearchIndex(definition).awaitSingle()
+
+    /**
+     * Create one or more Atlas Search indexes for the collection.
+     * <p>
+     * The name can be omitted for a single index, in which case a name will be the default.
+     * </p>
+     *
+     * @param searchIndexModels the search index models.
+     * @return the search index names.
+     * @see [Create search indexes](https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/)
+     */
+    public fun createSearchIndexes(searchIndexModels: List<SearchIndexModel>): Flow<String> =
+        wrapped.createSearchIndexes(searchIndexModels).asFlow()
+
+    /**
+     * Update an Atlas Search index in the collection.
+     *
+     * @param indexName  the name of the search index to update.
+     * @param definition the search index mapping definition.
+     * @see [Update search index](https://www.mongodb.com/docs/manual/reference/command/updateSearchIndex/)
+     */
+    public suspend fun updateSearchIndex(indexName: String, definition: Bson) {
+        wrapped.updateSearchIndex(indexName, definition).awaitSingle()
+    }
+
+    /**
+     * Drop an Atlas Search index given its name.
+     *
+     * @param indexName the name of the search index to remove.
+     * @see [Drop search index](https://www.mongodb.com/docs/manual/reference/command/dropSearchIndex/)
+     */
+    public suspend fun dropSearchIndex(indexName: String) {
+        wrapped.dropSearchIndex(indexName).awaitSingle()
+    }
+
+    /**
+     * Get all the Atlas Search indexes in this collection.
+     *
+     * @return the list search indexes iterable interface.
+     * @see [List search indexes](https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes)
+     */
+    @JvmName("listSearchIndexesAsDocument") public fun listSearchIndexes(): ListSearchIndexesFlow<Document> = listSearchIndexes<Document>()
+
+    /**
+     * Get all the Atlas Search indexes in this collection.
+     *
+     * @param R the class to decode each document into.
+     * @param resultClass the target document type of the iterable.
+     * @return the list search indexes iterable interface.
+     * @see [List search indexes](https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes)
+     */
+    public fun <R : Any> listSearchIndexes(resultClass: Class<R>): ListSearchIndexesFlow<R> =
+            ListSearchIndexesFlow(wrapped.listSearchIndexes(resultClass))
+
+    /**
+     * Get all the Atlas Search indexes in this collection.
+     *
+     * @param R the class to decode each document into.
+     * @return the list search indexes iterable interface.
+     * @see [List search indexes]](https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes)
+     */
+    public inline fun <reified R : Any> listSearchIndexes(): ListSearchIndexesFlow<R> = listSearchIndexes(R::class.java)
 
     /**
      * Create an index with the given keys and options.

--- a/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/ListSearchIndexesIterable.kt
+++ b/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/ListSearchIndexesIterable.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.kotlin.client
+
+import com.mongodb.client.ListSearchIndexesIterable as JListSearchIndexesIterable
+import java.util.concurrent.TimeUnit
+import org.bson.BsonValue
+
+/**
+ * Iterable like implementation for list index operations.
+ *
+ * @param T The type of the result.
+ * @see [List indexes](https://www.mongodb.com/docs/manual/reference/command/listIndexes/)
+ */
+public class ListSearchIndexesIterable<T : Any>(private val wrapped: JListSearchIndexesIterable<T>) : MongoIterable<T>(wrapped) {
+    /**
+     * Sets the maximum execution time on the server for this operation.
+     *
+     * @param maxTime the max time
+     * @param timeUnit the time unit, defaults to Milliseconds
+     * @return this
+     * @see [Max Time](https://www.mongodb.com/docs/manual/reference/operator/meta/maxTimeMS/)
+     */
+    public fun maxTime(maxTime: Long, timeUnit: TimeUnit = TimeUnit.MILLISECONDS): ListSearchIndexesIterable<T> = apply {
+        wrapped.maxTime(maxTime, timeUnit)
+    }
+
+    /**
+     * Sets the number of documents to return per batch.
+     *
+     * @param batchSize the batch size
+     * @return this
+     * @see [Batch Size](https://www.mongodb.com/docs/manual/reference/method/cursor.batchSize/#cursor.batchSize)
+     */
+    public override fun batchSize(batchSize: Int): ListSearchIndexesIterable<T> = apply { wrapped.batchSize(batchSize) }
+
+    /**
+     * Sets the comment for this operation. A null value means no comment is set.
+     *
+     * @param comment the comment
+     * @return this
+     */
+    public fun comment(comment: String?): ListSearchIndexesIterable<T> = apply { wrapped.comment(comment) }
+
+    /**
+     * Sets the comment for this operation. A null value means no comment is set.
+     *
+     * @param comment the comment
+     * @return this
+     */
+    public fun comment(comment: BsonValue?): ListSearchIndexesIterable<T> = apply { wrapped.comment(comment) }
+}

--- a/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoCollection.kt
+++ b/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoCollection.kt
@@ -20,25 +20,8 @@ import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
 import com.mongodb.WriteConcern
 import com.mongodb.bulk.BulkWriteResult
+import com.mongodb.client.model.*
 import com.mongodb.client.MongoCollection as JMongoCollection
-import com.mongodb.client.model.BulkWriteOptions
-import com.mongodb.client.model.CountOptions
-import com.mongodb.client.model.CreateIndexOptions
-import com.mongodb.client.model.DeleteOptions
-import com.mongodb.client.model.DropCollectionOptions
-import com.mongodb.client.model.DropIndexOptions
-import com.mongodb.client.model.EstimatedDocumentCountOptions
-import com.mongodb.client.model.FindOneAndDeleteOptions
-import com.mongodb.client.model.FindOneAndReplaceOptions
-import com.mongodb.client.model.FindOneAndUpdateOptions
-import com.mongodb.client.model.IndexModel
-import com.mongodb.client.model.IndexOptions
-import com.mongodb.client.model.InsertManyOptions
-import com.mongodb.client.model.InsertOneOptions
-import com.mongodb.client.model.RenameCollectionOptions
-import com.mongodb.client.model.ReplaceOptions
-import com.mongodb.client.model.UpdateOptions
-import com.mongodb.client.model.WriteModel
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.InsertManyResult
 import com.mongodb.client.result.InsertOneResult
@@ -1105,6 +1088,90 @@ public class MongoCollection<T : Any>(private val wrapped: JMongoCollection<T>) 
      */
     public fun drop(clientSession: ClientSession, options: DropCollectionOptions = DropCollectionOptions()): Unit =
         wrapped.drop(clientSession.wrapped, options)
+
+    /**
+     * Create an Atlas Search index for the collection.
+     *
+     * @param indexName  the name of the search index to create.
+     * @param definition the search index mapping definition.
+     * @return the search index name.
+     * @see [Create search indexes](https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/)
+     */
+    public fun createSearchIndex(indexName: String, definition: Bson): String =
+            wrapped.createSearchIndex(indexName, definition)
+
+    /**
+     * Create an Atlas Search index with the default name for the collection.
+     *
+     * @param definition the search index mapping definition.
+     * @return the search index name.
+     * @see [Create search indexes](https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/)
+     */
+    public fun createSearchIndex(definition: Bson): String =
+            wrapped.createSearchIndex(definition)
+
+    /**
+     * Create one or more Atlas Search indexes for the collection.
+     * <p>
+     * The name can be omitted for a single index, in which case a name will be the default.
+     * </p>
+     *
+     * @param searchIndexModels the search index models.
+     * @return the search index names.
+     * @see [Create search indexes](https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/)
+     */
+    public fun createSearchIndexes(searchIndexModels: List<SearchIndexModel>): List<String> =
+            wrapped.createSearchIndexes(searchIndexModels)
+
+    /**
+     * Update an Atlas Search index in the collection.
+     *
+     * @param indexName  the name of the search index to update.
+     * @param definition the search index mapping definition.
+     * @see [Update search index](https://www.mongodb.com/docs/manual/reference/command/updateSearchIndex/)
+     */
+    public fun updateSearchIndex(indexName: String, definition: Bson) {
+        wrapped.updateSearchIndex(indexName, definition)
+    }
+
+    /**
+     * Drop an Atlas Search index given its name.
+     *
+     * @param indexName the name of the search index to remove.
+     * @see [Drop search index](https://www.mongodb.com/docs/manual/reference/command/dropSearchIndex/)
+     */
+    public fun dropSearchIndex(indexName: String) {
+        wrapped.dropSearchIndex(indexName)
+    }
+
+    /**
+     * Get all the Atlas Search indexes in this collection.
+     *
+     * @return the list search indexes iterable interface.
+     * @see [List search indexes](https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes)
+     */
+    @JvmName("listSearchIndexesAsDocument") public fun listSearchIndexes(): ListSearchIndexesIterable<Document> = listSearchIndexes<Document>()
+
+    /**
+     * Get all the Atlas Search indexes in this collection.
+     *
+     * @param R the class to decode each document into.
+     * @param resultClass the target document type of the iterable.
+     * @return the list search indexes iterable interface.
+     * @see [List search indexes](https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes)
+     */
+    public fun <R : Any> listSearchIndexes(resultClass: Class<R>): ListSearchIndexesIterable<R> =
+            ListSearchIndexesIterable(wrapped.listSearchIndexes(resultClass))
+
+    /**
+     * Get all the Atlas Search indexes in this collection.
+     *
+     * @param R the class to decode each document into.
+     * @return the list search indexes iterable interface.
+     * @see [List search indexes]](https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes)
+     */
+    public inline fun <reified R : Any> listSearchIndexes(): ListSearchIndexesIterable<R> = listSearchIndexes(R::class.java)
+
 
     /**
      * Create an index with the given keys and options.

--- a/driver-kotlin-sync/src/test/kotlin/com/mongodb/kotlin/client/MongoIterableTest.kt
+++ b/driver-kotlin-sync/src/test/kotlin/com/mongodb/kotlin/client/MongoIterableTest.kt
@@ -22,7 +22,6 @@ import kotlin.test.assertContentEquals
 import org.bson.Document
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ListSearchIndexesPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ListSearchIndexesPublisher.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client;
+
+import com.mongodb.ExplainVerbosity;
+import com.mongodb.client.model.Collation;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonValue;
+import org.bson.Document;
+import org.reactivestreams.Publisher;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A specific {@link Publisher} interface for listing Atlas Search indexes.
+ *
+ * @param <TResult> The type of the result.
+ * @since 4.11
+ * @mongodb.server.release 7.0
+ */
+public interface ListSearchIndexesPublisher<TResult> extends Publisher<TResult> {
+
+    /**
+     * Sets the index name for this operation. A null value means no index name is set.
+     *
+     * @param indexName the index name.
+     * @return this
+     */
+    ListSearchIndexesPublisher<TResult> name(@Nullable String indexName);
+
+    /**
+     * Enables writing to temporary files. A null value indicates that it's unspecified.
+     *
+     * @param allowDiskUse true if writing to temporary files is enabled
+     * @return this
+     * @mongodb.driver.manual reference/command/aggregate/ Aggregation
+     */
+    ListSearchIndexesPublisher<TResult> allowDiskUse(@Nullable Boolean allowDiskUse);
+
+    /**
+     * Sets the number of documents to return per batch.
+     *
+     * @param batchSize the batch size
+     * @return this
+     * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
+     */
+    ListSearchIndexesPublisher<TResult> batchSize(int batchSize);
+
+    /**
+     * Sets the maximum execution time on the server for this operation.
+     *
+     * @param maxTime  the max time
+     * @param timeUnit the time unit, which may not be null
+     * @return this
+     * @mongodb.driver.manual reference/method/cursor.maxTimeMS/#cursor.maxTimeMS Max Time
+     */
+    ListSearchIndexesPublisher<TResult> maxTime(long maxTime, TimeUnit timeUnit);
+
+    /**
+     * The maximum amount of time for the server to wait on new documents to satisfy a {@code $changeStream} aggregation.
+     * <p>
+     * A zero value will be ignored.
+     *
+     * @param maxAwaitTime  the max await time
+     * @param timeUnit the time unit to return the result in
+     * @return the maximum await execution time in the given time unit
+     */
+    ListSearchIndexesPublisher<TResult> maxAwaitTime(long maxAwaitTime, TimeUnit timeUnit);
+
+    /**
+     * Sets the collation options
+     *
+     * <p>A null value represents the server default.</p>
+     *
+     * @param collation the collation options to use
+     * @return this
+     */
+    ListSearchIndexesPublisher<TResult> collation(@Nullable Collation collation);
+
+    /**
+     * Sets the comment for this operation. A null value means no comment is set.
+     *
+     * @param comment the comment
+     * @return this
+     */
+    ListSearchIndexesPublisher<TResult> comment(@Nullable String comment);
+
+    /**
+     * Sets the comment for this operation. A null value means no comment is set.
+     *
+     * <p>The comment can be any valid BSON type for server versions 4.4 and above.
+     * Server versions between 3.6 and 4.2 only support string as comment,
+     * and providing a non-string type will result in a server-side error.
+     *
+     * @param comment the comment
+     * @return this
+     */
+    ListSearchIndexesPublisher<TResult> comment(@Nullable BsonValue comment);
+
+    /**
+     * Helper to return a publisher limited to the first result.
+     *
+     * @return a Publisher which will contain a single item.
+     */
+    Publisher<TResult> first();
+
+    /**
+     * Explain the execution plan for this operation with the server's default verbosity level
+     *
+     * @return the execution plan
+     * @mongodb.driver.manual reference/command/explain/
+     */
+    Publisher<Document> explain();
+
+    /**
+     * Explain the execution plan for this operation with the given verbosity level
+     *
+     * @param verbosity the verbosity of the explanation
+     * @return the execution plan
+     * @mongodb.driver.manual reference/command/explain/
+     */
+    Publisher<Document> explain(ExplainVerbosity verbosity);
+
+    /**
+     * Explain the execution plan for this operation with the server's default verbosity level
+     *
+     * @param <E> the type of the document class
+     * @param explainResultClass the document class to decode into
+     * @return the execution plan
+     * @mongodb.driver.manual reference/command/explain/
+     */
+    <E> Publisher<E> explain(Class<E> explainResultClass);
+
+    /**
+     * Explain the execution plan for this operation with the given verbosity level
+     *
+     * @param <E> the type of the document class
+     * @param explainResultClass the document class to decode into
+     * @param verbosity            the verbosity of the explanation
+     * @return the execution plan
+     * @mongodb.driver.manual reference/command/explain/
+     */
+    <E> Publisher<E> explain(Class<E> explainResultClass, ExplainVerbosity verbosity);
+}

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoCollection.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoCollection.java
@@ -38,6 +38,7 @@ import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.InsertOneOptions;
 import com.mongodb.client.model.RenameCollectionOptions;
 import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.DeleteResult;
@@ -1404,6 +1405,84 @@ public interface MongoCollection<TDocument> {
      * @mongodb.server.release 6.0
      */
     Publisher<Void> drop(ClientSession clientSession, DropCollectionOptions dropCollectionOptions);
+
+
+    /**
+     * Create an Atlas Search index for the collection.
+     *
+     * @param indexName  the name of the search index to create.
+     * @param definition Atlas Search index mapping definition.
+     * @return an empty publisher that indicates when the operation has completed with the search index name.
+     * @mongodb.server.release 7.0
+     * @mongodb.driver.manual reference/command/createSearchIndexes/ Create Search indexes
+     * @since 4.11
+     */
+    Publisher<String> createSearchIndex(String indexName, Bson definition);
+    /**
+     * Create an Atlas Search index with the default name for the collection.
+     *
+     * @param definition Atlas Search index mapping definition.
+     * @return an empty publisher that indicates when the operation has completed with the default search index name.
+     * @mongodb.server.release 7.0
+     * @mongodb.driver.manual reference/command/createSearchIndexes/ Create Search indexes
+     * @since 4.11
+     */
+    Publisher<String> createSearchIndex(Bson definition);
+
+    /**
+     * Create one or more Atlas Search indexes for the collection.
+     * <p>
+     * The name can be omitted for a single index, in which case a name will be the default.
+     * </p>
+     *
+     * @param searchIndexModels the search index models.
+     * @return an empty publisher that indicates when the operation has completed with the search index names.
+     * @mongodb.server.release 7.0
+     * @mongodb.driver.manual reference/command/createSearchIndexes/ Create Search indexes
+     * @since 4.11
+     */
+    Publisher<String> createSearchIndexes(List<SearchIndexModel> searchIndexModels);
+    /**
+     * Update an Atlas Search index in the collection.
+     *
+     * @param indexName  the name of the search index to update.
+     * @param definition Atlas Search index definition.
+     * @return an empty publisher that indicates when the operation has completed.
+     * @mongodb.server.release 7.0
+     * @mongodb.driver.manual reference/command/updateSearchIndex/ Update Search index
+     * @since 4.11
+     */
+    Publisher<Void> updateSearchIndex(String indexName, Bson definition);
+    /**
+     * Drop an Atlas Search index given its name.
+     *
+     * @param indexName the name of the search index to remove.
+     * @return an empty publisher that indicates when the operation has completed.
+     * @mongodb.server.release 7.0
+     * @mongodb.driver.manual reference/command/dropSearchIndex/ Drop Search index
+     * @since 4.11
+     */
+    Publisher<Void> dropSearchIndex(String indexName);
+
+    /**
+     * Get all Atlas Search indexes in this collection.
+     *
+     * @return the fluent list search indexes interface.
+     * @since 4.11
+     * @mongodb.server.release 7.0
+     */
+    ListSearchIndexesPublisher<Document> listSearchIndexes();
+
+    /**
+     * Get all Atlas Search indexes in this collection.
+     *
+     * @param resultClass the class to decode each document into.
+     * @param <TResult>   the target document type of the iterable.
+     * @return the fluent list search indexes interface.
+     * @since 4.11
+     * @mongodb.server.release 7.0
+     */
+    <TResult> ListSearchIndexesPublisher<TResult> listSearchIndexes(Class<TResult> resultClass);
 
     /**
      * Creates an index.

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListSearchIndexesPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListSearchIndexesPublisherImpl.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.internal;
+
+import com.mongodb.ExplainVerbosity;
+import com.mongodb.client.model.Collation;
+import com.mongodb.internal.async.AsyncBatchCursor;
+import com.mongodb.internal.operation.AsyncExplainableReadOperation;
+import com.mongodb.internal.operation.AsyncReadOperation;
+import com.mongodb.lang.NonNull;
+import com.mongodb.lang.Nullable;
+import com.mongodb.reactivestreams.client.ListSearchIndexesPublisher;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.Document;
+import org.reactivestreams.Publisher;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+final class ListSearchIndexesPublisherImpl<T> extends BatchCursorPublisher<T> implements ListSearchIndexesPublisher<T> {
+    private Boolean allowDiskUse;
+    private long maxTimeMS;
+    private long maxAwaitTimeMS;
+    private Collation collation;
+    private BsonValue comment;
+    private String indexName;
+
+    ListSearchIndexesPublisherImpl(
+            final MongoOperationPublisher<T> mongoOperationPublisher) {
+        super(null, mongoOperationPublisher);
+    }
+
+    @Override
+    public ListSearchIndexesPublisher<T> name(@Nullable final String indexName) {
+        this.indexName = indexName;
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesPublisher<T> allowDiskUse(@Nullable final Boolean allowDiskUse) {
+        this.allowDiskUse = allowDiskUse;
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesPublisher<T> batchSize(final int batchSize) {
+        super.batchSize(batchSize);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesPublisher<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+        notNull("timeUnit", timeUnit);
+        this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesPublisher<T> maxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
+        notNull("timeUnit", timeUnit);
+        this.maxAwaitTimeMS = TimeUnit.MILLISECONDS.convert(maxAwaitTime, timeUnit);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesPublisher<T> collation(@Nullable final Collation collation) {
+        this.collation = collation;
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesPublisher<T> comment(@Nullable final String comment) {
+        this.comment = comment != null ? new BsonString(comment) : null;
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesPublisher<T> comment(@Nullable final BsonValue comment) {
+        this.comment = comment;
+        return this;
+    }
+
+    @Override
+    public Publisher<Document> explain() {
+        return publishExplain(Document.class, null);
+    }
+
+    @Override
+    public Publisher<Document> explain(final ExplainVerbosity verbosity) {
+        notNull("verbosity", verbosity);
+
+        return publishExplain(Document.class, verbosity);
+    }
+
+    @Override
+    public <E> Publisher<E> explain(final Class<E> explainResultClass) {
+        notNull("explainResultClass", explainResultClass);
+        return publishExplain(explainResultClass, null);
+    }
+
+    @Override
+    public <E> Publisher<E> explain(final Class<E> explainResultClass, final ExplainVerbosity verbosity) {
+        notNull("verbosity", verbosity);
+        return publishExplain(explainResultClass, verbosity);
+    }
+
+    private <E> Publisher<E> publishExplain(final Class<E> explainResultClass, @Nullable final ExplainVerbosity verbosity) {
+        notNull("explainDocumentClass", explainResultClass);
+        return getMongoOperationPublisher().createReadOperationMono(() ->
+                asAggregateOperation(1).asAsyncExplainableOperation(verbosity,
+                        getCodecRegistry().get(explainResultClass)), getClientSession());
+    }
+
+    @Override
+    AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
+        return asAggregateOperation(initialBatchSize);
+    }
+
+    private AsyncExplainableReadOperation<AsyncBatchCursor<T>> asAggregateOperation(final int initialBatchSize) {
+        BsonDocument searchDefinition = new BsonDocument("name", getIndexName());
+        BsonDocument bsonDocument = new BsonDocument("$listSearchIndexes", searchDefinition);
+
+        return getOperations().listSearchIndexes(getDocumentClass(), maxTimeMS, maxAwaitTimeMS, indexName, getBatchSize(), collation,
+                comment,
+                allowDiskUse);
+    }
+
+    @NonNull
+    private BsonValue getIndexName() {
+        return indexName == null ? new BsonDocument() : new BsonString(indexName);
+    }
+}

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoCollectionImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoCollectionImpl.java
@@ -37,6 +37,7 @@ import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.InsertOneOptions;
 import com.mongodb.client.model.RenameCollectionOptions;
 import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.DeleteResult;
@@ -51,6 +52,7 @@ import com.mongodb.reactivestreams.client.ClientSession;
 import com.mongodb.reactivestreams.client.DistinctPublisher;
 import com.mongodb.reactivestreams.client.FindPublisher;
 import com.mongodb.reactivestreams.client.ListIndexesPublisher;
+import com.mongodb.reactivestreams.client.ListSearchIndexesPublisher;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import org.bson.BsonDocument;
 import org.bson.Document;
@@ -63,6 +65,7 @@ import java.util.List;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.assertions.Assertions.notNullElements;
 
 
 final class MongoCollectionImpl<T> implements MongoCollection<T> {
@@ -645,6 +648,53 @@ final class MongoCollectionImpl<T> implements MongoCollection<T> {
     @Override
     public Publisher<Void> drop(final ClientSession clientSession, final DropCollectionOptions dropCollectionOptions) {
         return mongoOperationPublisher.dropCollection(notNull("clientSession", clientSession), dropCollectionOptions);
+    }
+
+    @Override
+    public Publisher<String> createSearchIndex(final String indexName, final Bson definition) {
+        notNull("indexName", indexName);
+        notNull("definition", definition);
+
+        return mongoOperationPublisher.createSearchIndex(indexName, definition);
+    }
+
+    @Override
+    public Publisher<String> createSearchIndex(final Bson definition) {
+        notNull("definition", definition);
+
+        return mongoOperationPublisher.createSearchIndex(null, definition);
+    }
+
+    @Override
+    public Publisher<String> createSearchIndexes(final List<SearchIndexModel> searchIndexModels) {
+        notNullElements("searchIndexModels", searchIndexModels);
+
+        return mongoOperationPublisher.createSearchIndexes(searchIndexModels);
+    }
+
+    @Override
+    public Publisher<Void> updateSearchIndex(final String indexName, final Bson definition) {
+        notNull("indexName", indexName);
+        notNull("definition", definition);
+
+        return mongoOperationPublisher.updateSearchIndex(null, indexName, definition);
+    }
+
+    @Override
+    public Publisher<Void> dropSearchIndex(final String indexName) {
+        notNull("name", indexName);
+        
+        return mongoOperationPublisher.dropSearchIndex(null, indexName);
+    }
+
+    @Override
+    public ListSearchIndexesPublisher<Document> listSearchIndexes() {
+      return listSearchIndexes(Document.class);
+    }
+
+    @Override
+    public <TResult> ListSearchIndexesPublisher<TResult> listSearchIndexes(final Class<TResult> tResultClass) {
+        return new ListSearchIndexesPublisherImpl<>(mongoOperationPublisher.withDocumentClass(tResultClass));
     }
 
     @Override

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
@@ -47,6 +47,7 @@ import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.InsertOneOptions;
 import com.mongodb.client.model.RenameCollectionOptions;
 import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.DeleteResult;
@@ -381,6 +382,30 @@ public final class MongoOperationPublisher<T> {
         return createWriteOperationMono(() -> operations.createIndexes(notNull("indexes", indexes),
                                                                        notNull("options", options)), clientSession)
                 .thenMany(Flux.fromIterable(IndexHelper.getIndexNames(indexes, getCodecRegistry())));
+    }
+
+    Publisher<String> createSearchIndex(@Nullable final String name, final Bson definition) {
+        SearchIndexModel searchIndexModel = new SearchIndexModel(name, definition);
+
+        return createSearchIndexes(singletonList(searchIndexModel));
+    }
+    Publisher<String> createSearchIndexes(final List<SearchIndexModel> indexes) {
+        return createWriteOperationMono(() -> operations.createSearchIndexes(indexes), null)
+                .thenMany(Flux.fromIterable(IndexHelper.getSearchIndexNames(indexes)));
+    }
+
+
+    public Publisher<Void> updateSearchIndex(@Nullable final ClientSession clientSession, final String name, final Bson definition) {
+       return createWriteOperationMono(() -> operations.updateSearchIndex(name, definition), clientSession);
+    }
+
+
+    public Publisher<Void> dropSearchIndex(@Nullable final ClientSession clientSession, final String indexName) {
+        return createWriteOperationMono(() -> operations.dropSearchIndex(indexName), clientSession);
+    }
+
+    public Publisher<Void> listSearchIndexes(@Nullable final ClientSession clientSession, final String indexName) {
+        return createWriteOperationMono(() -> operations.dropSearchIndex(indexName), clientSession);
     }
 
     Publisher<Void> dropIndex(@Nullable final ClientSession clientSession, final String indexName, final DropIndexOptions options) {

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncListSearchIndexesIterable.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncListSearchIndexesIterable.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.syncadapter;
+
+import com.mongodb.ExplainVerbosity;
+import com.mongodb.client.ListSearchIndexesIterable;
+import com.mongodb.client.model.Collation;
+import com.mongodb.reactivestreams.client.ListSearchIndexesPublisher;
+import org.bson.BsonValue;
+import org.bson.Document;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
+import static com.mongodb.reactivestreams.client.syncadapter.ContextHelper.CONTEXT;
+import static java.util.Objects.requireNonNull;
+
+public class SyncListSearchIndexesIterable<T> extends SyncMongoIterable<T> implements ListSearchIndexesIterable<T> {
+    private final ListSearchIndexesPublisher<T> wrapped;
+
+    SyncListSearchIndexesIterable(final ListSearchIndexesPublisher<T> wrapped) {
+        super(wrapped);
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
+        wrapped.maxTime(maxTime, timeUnit);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<T> maxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
+        wrapped.maxAwaitTime(maxAwaitTime, timeUnit);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<T> collation(final Collation collation) {
+        wrapped.collation(collation);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<T> name(final String indexName) {
+        wrapped.name(indexName);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<T> allowDiskUse(final Boolean allowDiskUse) {
+        wrapped.allowDiskUse(allowDiskUse);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<T> batchSize(final int batchSize) {
+        wrapped.batchSize(batchSize);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<T> comment(final String comment) {
+        wrapped.comment(comment);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<T> comment(final BsonValue comment) {
+        wrapped.comment(comment);
+        return this;
+    }
+
+    @Override
+    public Document explain() {
+        return requireNonNull(Mono.from(wrapped.explain()).contextWrite(CONTEXT).block(TIMEOUT_DURATION));
+    }
+
+    @Override
+    public Document explain(final ExplainVerbosity verbosity) {
+        return requireNonNull(Mono.from(wrapped.explain(verbosity)).contextWrite(CONTEXT).block(TIMEOUT_DURATION));
+    }
+
+    @Override
+    public <E> E explain(final Class<E> explainResultClass) {
+        return requireNonNull(Mono.from(wrapped.explain(explainResultClass)).contextWrite(CONTEXT).block(TIMEOUT_DURATION));
+    }
+
+    @Override
+    public <E> E explain(final Class<E> explainResultClass, final ExplainVerbosity verbosity) {
+        return requireNonNull(Mono.from(wrapped.explain(explainResultClass, verbosity)).contextWrite(CONTEXT).block(TIMEOUT_DURATION));
+    }
+}

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCollection.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCollection.java
@@ -27,6 +27,7 @@ import com.mongodb.client.ClientSession;
 import com.mongodb.client.DistinctIterable;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.ListIndexesIterable;
+import com.mongodb.client.ListSearchIndexesIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.CountOptions;
@@ -44,6 +45,7 @@ import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.InsertOneOptions;
 import com.mongodb.client.model.RenameCollectionOptions;
 import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.DeleteResult;
@@ -53,6 +55,7 @@ import com.mongodb.client.result.UpdateResult;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -643,6 +646,46 @@ class SyncMongoCollection<T> implements MongoCollection<T> {
     @Override
     public void drop(final ClientSession clientSession, final DropCollectionOptions dropCollectionOptions) {
         Mono.from(wrapped.drop(unwrap(clientSession), dropCollectionOptions)).contextWrite(CONTEXT).block(TIMEOUT_DURATION);
+    }
+
+    @Override
+    public String createSearchIndex(final String name, final Bson definition) {
+        return requireNonNull(Mono.from(wrapped.createSearchIndex(name, definition)).contextWrite(CONTEXT)
+                .block(TIMEOUT_DURATION));
+    }
+
+    @Override
+    public String createSearchIndex(final Bson definition) {
+        return requireNonNull(Mono.from(wrapped.createSearchIndex(definition)).contextWrite(CONTEXT)
+                .block(TIMEOUT_DURATION));
+    }
+
+    @Override
+    public List<String> createSearchIndexes(final List<SearchIndexModel> searchIndexModels) {
+        return requireNonNull(Flux.from(wrapped.createSearchIndexes(searchIndexModels)).contextWrite(CONTEXT).collectList()
+                .block(TIMEOUT_DURATION));
+    }
+
+    @Override
+    public void updateSearchIndex(final String name, final Bson definition) {
+        Mono.from(wrapped.updateSearchIndex(name, definition)).contextWrite(CONTEXT)
+                .block(TIMEOUT_DURATION);
+    }
+
+    @Override
+    public void dropSearchIndex(final String indexName) {
+        Mono.from(wrapped.dropSearchIndex(indexName)).contextWrite(CONTEXT)
+                .block(TIMEOUT_DURATION);
+    }
+
+    @Override
+    public ListSearchIndexesIterable<Document> listSearchIndexes() {
+        return listSearchIndexes(Document.class);
+    }
+
+    @Override
+    public <TResult> ListSearchIndexesIterable<TResult> listSearchIndexes(final Class<TResult> tResultClass) {
+        return new SyncListSearchIndexesIterable<>(wrapped.listSearchIndexes(tResultClass));
     }
 
     @Override

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/IndexManagmentTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/IndexManagmentTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.unified;
+
+import com.mongodb.lang.Nullable;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
+public class IndexManagmentTest extends UnifiedReactiveStreamsTest {
+
+    public IndexManagmentTest(@SuppressWarnings("unused") final String fileDescription,
+                              @SuppressWarnings("unused") final String testDescription,
+                              final String schemaVersion,
+                              @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
+                              final BsonDocument definition) {
+        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+    }
+
+    @Parameterized.Parameters(name = "{0}: {1}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        return getTestData("unified-test-format/index-management/tests");
+    }
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/ListSearchIndexesObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/ListSearchIndexesObservable.scala
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mongodb.scala
+
+import com.mongodb.ExplainVerbosity
+import com.mongodb.reactivestreams.client.ListSearchIndexesPublisher
+import org.mongodb.scala.bson.BsonValue
+import org.mongodb.scala.bson.DefaultHelper.DefaultsTo
+import org.mongodb.scala.model.Collation
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.Duration
+import scala.reflect.ClassTag
+
+/**
+ * Observable interface for ListSearchIndexes.
+ *
+ * @param wrapped the underlying java ListSearchIndexesPublisher
+ * @tparam TResult The type of the result.
+ * @since 4.11
+ */
+case class ListSearchIndexesObservable[TResult](wrapped: ListSearchIndexesPublisher[TResult]) extends Observable[TResult] {
+
+  /**
+   * Sets an Atlas Search index name for this operation. A null value means no index name is set.
+   *
+   * @param indexName Atlas Search index name.
+   * @note Requires MongoDB 7.0 or greater
+   */
+  def name(indexName: String): ListSearchIndexesObservable[TResult] = {
+    wrapped.name(indexName)
+    this
+  }
+
+  /**
+   * Enables writing to temporary files. A null value indicates that it's unspecified.
+   *
+   * @param allowDiskUse true if writing to temporary files is enabled.
+   * @return this.
+   * @see [[https://www.mongodb.com/docs/manual/reference/command/aggregate/ Aggregation]]
+   */
+  def allowDiskUse(allowDiskUse: Boolean): ListSearchIndexesObservable[TResult] = {
+    wrapped.allowDiskUse(allowDiskUse)
+    this
+  }
+
+  /**
+   * Sets the maximum execution time on the server for this operation.
+   *
+   * @param duration the duration.
+   * @return this.
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/meta/maxTimeMS/ Max Time]]
+   */
+  def maxTime(duration: Duration): ListSearchIndexesObservable[TResult] = {
+    wrapped.maxTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    this
+  }
+
+  /**
+   * Sets the maximum await execution time on the server for this operation.
+   *
+   * @param duration the duration.
+   * @return this.
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater.
+   * @see [[https://www.mongodb.com/docs/manual/reference/method/cursor.maxAwaitTimeMS/ Max Await Time]]
+   */
+  def maxAwaitTime(duration: Duration): ListSearchIndexesObservable[TResult] = {
+    wrapped.maxAwaitTime(duration.toMillis, TimeUnit.MILLISECONDS)
+    this
+  }
+
+  /**
+   * Sets the collation options
+   *
+   * @param collation the collation options to use.
+   * @return this.
+   * @since 1.2
+   * @note A null value represents the server default.
+   * @note Requires MongoDB 3.4 or greater.
+   */
+  def collation(collation: Collation): ListSearchIndexesObservable[TResult] = {
+    wrapped.collation(collation)
+    this
+  }
+
+  /**
+   * Sets the comment for this operation. A null value means no comment is set.
+   *
+   * @param comment the comment.
+   * @return this.
+   * @since 2.2
+   * @note Requires MongoDB 3.6 or greater.
+   */
+  def comment(comment: String): ListSearchIndexesObservable[TResult] = {
+    wrapped.comment(comment)
+    this
+  }
+
+  /**
+   * Sets the comment for this operation. A null value means no comment is set.
+   *
+   * @param comment the comment
+   * @return this
+   * @since 4.6
+   * @note The comment can be any valid BSON type for server versions 4.4 and above.
+   *       Server versions between 3.6 and 4.2 only support
+   *       string as comment, and providing a non-string type will result in a server-side error.
+   */
+  def comment(comment: BsonValue): ListSearchIndexesObservable[TResult] = {
+    wrapped.comment(comment)
+    this
+  }
+
+  /**
+   * Sets the number of documents to return per batch.
+   *
+   * @param batchSize the batch size.
+   * @return this.
+   * @since 2.7
+   */
+  def batchSize(batchSize: Int): ListSearchIndexesObservable[TResult] = {
+    wrapped.batchSize(batchSize)
+    this
+  }
+
+  /**
+   * Helper to return a single observable limited to the first result.
+   *
+   * @return a single observable which will the first result.
+   * @since 4.0
+   */
+  def first(): SingleObservable[TResult] = wrapped.first()
+
+  /**
+   * Explain the execution plan for this operation with the server's default verbosity level.
+   *
+   * @tparam ExplainResult The type of the result.
+   * @return the execution plan.
+   * @since 4.2
+   * @note Requires MongoDB 3.6 or greater.
+   */
+  def explain[ExplainResult]()(
+    implicit e: ExplainResult DefaultsTo Document,
+    ct: ClassTag[ExplainResult]
+  ): SingleObservable[ExplainResult] =
+    wrapped.explain[ExplainResult](ct)
+
+  /**
+   * Explain the execution plan for this operation with the given verbosity level.
+   *
+   * @tparam ExplainResult The type of the result.
+   * @param verbosity the verbosity of the explanation.
+   * @return the execution plan.
+   * @since 4.2
+   * @note Requires MongoDB 3.6 or greater.
+   */
+  def explain[ExplainResult](
+                              verbosity: ExplainVerbosity
+                            )(implicit e: ExplainResult DefaultsTo Document, ct: ClassTag[ExplainResult]): SingleObservable[ExplainResult] =
+    wrapped.explain[ExplainResult](ct, verbosity)
+
+  override def subscribe(observer: Observer[_ >: TResult]): Unit = wrapped.subscribe(observer)
+}

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoCollection.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoCollection.scala
@@ -1369,6 +1369,82 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
   def drop(clientSession: ClientSession, dropCollectionOptions: DropCollectionOptions): SingleObservable[Void] =
     wrapped.drop(clientSession, dropCollectionOptions)
 
+
+  /**
+   * Create an Atlas Search index for the collection.
+   *
+   * @param indexName  the name of the search index to create.
+   * @param definition the search index mapping definition.
+   * @return an empty Observable that indicates when the operation has completed
+   * @since 4.11
+   * @note Requires MongoDB 7.0 or greater
+   * @see [[https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/ Create Search Indexes]]
+   */
+  def createSearchIndex(indexName: String, definition: Bson): SingleObservable[String] =
+    wrapped.createSearchIndex(indexName, definition)
+
+  /**
+   * Create an Atlas Search index for the collection.
+   *
+   * @param definition the search index mapping definition.
+   * @return an empty Observable that indicates when the operation has completed.
+   * @since 4.11
+   * @note Requires MongoDB 7.0 or greater
+   * @see [[https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/ Create Search Indexes]]
+   */
+  def createSearchIndex(definition: Bson): SingleObservable[String] = wrapped.createSearchIndex(definition)
+
+
+  /**
+   * Create one or more Atlas Search indexes for the collection.
+   * <p>
+   * The name can be omitted for a single index, in which case a name will be the default.
+   * </p>
+   *
+   * @param searchIndexModels the search index models.
+   * @return a Observable with the names of the search indexes.
+   * @since 4.11
+   * @note Requires MongoDB 7.0 or greater
+   * @see [[https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/ Create Search Indexes]]
+   */
+  def createSearchIndexes(searchIndexModels: List[SearchIndexModel]):  Observable[String] = wrapped.createSearchIndexes(searchIndexModels.asJava)
+
+  /**
+   * Update an Atlas Search index in the collection.
+   *
+   * @param indexName  the name of the search index to update.
+   * @param definition the search index mapping definition.
+   * @return an empty Observable that indicates when the operation has completed.
+   * @since 4.11
+   * @note Requires MongoDB 7.0 or greater
+   * @see [[https://www.mongodb.com/docs/manual/reference/command/updateSearchIndex/ Update Search Index]]
+   */
+  def updateSearchIndex(indexName: String, definition: Bson): SingleObservable[Void] = wrapped.updateSearchIndex(indexName, definition)
+
+
+  /**
+   * Drop an Atlas Search index given its name.
+   *
+   * @param indexName the name of the search index to remove.
+   * @return an empty Observable that indicates when the operation has completed.
+   * @since 4.11
+   * @note Requires MongoDB 7.0 or greater
+   * @see [[https://www.mongodb.com/docs/manual/reference/command/dropSearchIndex/ Drop Search Index]]
+   */
+  def dropSearchIndex(indexName: String): SingleObservable[Void] = wrapped.dropSearchIndex(indexName)
+
+  /**
+   *  Get all Atlas Search indexes in this collection.
+   *
+   * @tparam C the target document type of the observable.
+   * @return the fluent list search indexes interface
+   * @since 4.11
+   * @note Requires MongoDB 7.0 or greater
+   * @see [[https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes List Search Indexes]]
+   */
+  def listSearchIndexes[C]()(implicit e: C DefaultsTo Document, ct: ClassTag[C]): ListSearchIndexesObservable[C] =
+    ListSearchIndexesObservable(wrapped.listSearchIndexes(ct))
+
   /**
    * [[https://www.mongodb.com/docs/manual/reference/command/createIndexes Create Index]]
    * @param key     an object describing the index key(s), which may not be null. This can be of any type for which a `Codec` is

--- a/driver-scala/src/main/scala/org/mongodb/scala/model/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/model/package.scala
@@ -477,6 +477,35 @@ package object model {
   }
 
   /**
+   * A model describing the creation of a single Atlas Search index.
+   */
+  type SearchIndexModel = com.mongodb.client.model.SearchIndexModel
+
+  /**
+   * A model describing the creation of a single Atlas Search index.
+   */
+  object SearchIndexModel {
+
+    /**
+     * Construct an instance with the given search index definition.
+     *
+     * @param definition the search index mapping definition.
+     * @return the SearchIndexModel
+     */
+    def apply(definition: Bson): SearchIndexModel = new com.mongodb.client.model.SearchIndexModel(definition)
+
+    /**
+     * Construct an instance with the given search index name and definition.
+     *
+     * @param indexName the name of the search index to create.
+     * @param definition the search index mapping definition.
+     * @return the SearchIndexModel
+     */
+    def apply(indexName: String, definition: Bson): SearchIndexModel =
+      new com.mongodb.client.model.SearchIndexModel(indexName, definition)
+  }
+
+  /**
    * A model describing the creation of a single index.
    */
   type IndexModel = com.mongodb.client.model.IndexModel

--- a/driver-sync/src/main/com/mongodb/client/ListSearchIndexesIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/ListSearchIndexesIterable.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.ExplainVerbosity;
+import com.mongodb.client.model.Collation;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonValue;
+import org.bson.Document;
+
+import java.util.concurrent.TimeUnit;
+/**
+ * Iterable for listing Atlas Search indexes.
+ * This interface contains aggregate options and that of applied to {@code $listSearchIndexes} operation.
+ *
+ * @param <TResult> The type of the result.
+ * @mongodb.driver.manual reference/command/aggregate/ Aggregation
+ * @since 4.11
+ * @mongodb.server.release 7.0
+ */
+public interface ListSearchIndexesIterable<TResult> extends MongoIterable<TResult> {
+
+    /**
+     * Sets the index name for this operation. A null value means no index name is set.
+     *
+     * @param indexName the index name.
+     * @return this.
+     */
+    ListSearchIndexesIterable<TResult> name(@Nullable String indexName);
+
+    /**
+     * Enables writing to temporary files. A null value indicates that it's unspecified.
+     *
+     * @param allowDiskUse true if writing to temporary files is enabled.
+     * @return this.
+     * @mongodb.driver.manual reference/command/aggregate/ Aggregation
+     */
+    ListSearchIndexesIterable<TResult> allowDiskUse(@Nullable Boolean allowDiskUse);
+
+    /**
+     * Sets the number of documents to return per batch.
+     *
+     * @param batchSize the batch size.
+     * @return this.
+     * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
+     */
+    ListSearchIndexesIterable<TResult> batchSize(int batchSize);
+
+    /**
+     * Sets the maximum execution time on the server for this operation.
+     *
+     * @param maxTime  the max time.
+     * @param timeUnit the time unit, which may not be null.
+     * @return this.
+     * @mongodb.driver.manual reference/method/cursor.maxTimeMS/#cursor.maxTimeMS Max Time
+     */
+    ListSearchIndexesIterable<TResult> maxTime(long maxTime, TimeUnit timeUnit);
+
+    /**
+     * The maximum amount of time for the server to wait on new documents to satisfy a {@code $changeStream} aggregation.
+     * <p>
+     * A zero value will be ignored.
+     *
+     * @param maxAwaitTime the max await time.
+     * @param timeUnit     the time unit to return the result in.
+     * @return the maximum await execution time in the given time unit.
+     */
+    ListSearchIndexesIterable<TResult> maxAwaitTime(long maxAwaitTime, TimeUnit timeUnit);
+
+    /**
+     * Sets the collation options
+     *
+     * <p>A null value represents the server default.</p>
+     *
+     * @param collation the collation options to use
+     * @return this
+     */
+    ListSearchIndexesIterable<TResult> collation(@Nullable Collation collation);
+
+    /**
+     * Sets the comment for this operation. A null value means no comment is set.
+     *
+     * @param comment the comment.
+     * @return this
+     */
+    ListSearchIndexesIterable<TResult> comment(@Nullable String comment);
+
+    /**
+     * Sets the comment for this operation. A null value means no comment is set.
+     *
+     * <p>The comment can be any valid BSON type for server versions 4.4 and above.
+     * Server versions between 3.6 and 4.2 only support string as comment,
+     * and providing a non-string type will result in a server-side error.
+     *
+     * @param comment the comment.
+     * @return this.
+     */
+    ListSearchIndexesIterable<TResult> comment(@Nullable BsonValue comment);
+
+    /**
+     * Explain the execution plan for this operation with the server's default verbosity level.
+     *
+     * @return the execution plan.
+     * @mongodb.driver.manual reference/command/explain/
+     */
+    Document explain();
+
+    /**
+     * Explain the execution plan for this operation with the given verbosity level.
+     *
+     * @param verbosity the verbosity of the explanation.
+     * @return the execution plan.
+     * @mongodb.driver.manual reference/command/explain/
+     */
+    Document explain(ExplainVerbosity verbosity);
+
+    /**
+     * Explain the execution plan for this operation with the server's default verbosity level.
+     *
+     * @param <E>                the type of the document class.
+     * @param explainResultClass the document class to decode into.
+     * @return the execution plan.
+     * @mongodb.driver.manual reference/command/explain/
+     */
+    <E> E explain(Class<E> explainResultClass);
+
+    /**
+     * Explain the execution plan for this operation with the given verbosity level.
+     *
+     * @param <E>                the type of the document class.
+     * @param explainResultClass the document class to decode into.
+     * @param verbosity          the verbosity of the explanation.
+     * @return the execution plan.
+     * @mongodb.driver.manual reference/command/explain/
+     */
+    <E> E explain(Class<E> explainResultClass, ExplainVerbosity verbosity);
+}

--- a/driver-sync/src/main/com/mongodb/client/MongoCollection.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoCollection.java
@@ -38,6 +38,7 @@ import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.InsertOneOptions;
 import com.mongodb.client.model.RenameCollectionOptions;
 import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.DeleteResult;
@@ -1692,6 +1693,84 @@ public interface MongoCollection<TDocument> {
      * @mongodb.server.release 6.0
      */
     void drop(ClientSession clientSession, DropCollectionOptions dropCollectionOptions);
+
+    /**
+     * Create an Atlas Search index for the collection.
+     *
+     * @param indexName  the name of the search index to create.
+     * @param definition the search index mapping definition.
+     * @return the search index name.
+     * @mongodb.server.release 7.0
+     * @mongodb.driver.manual reference/command/createSearchIndexes/ Create Search indexes
+     * @since 4.11
+     */
+    String createSearchIndex(String indexName, Bson definition);
+
+    /**
+     * Create an Atlas Search index with the default name for the collection.
+     *
+     * @param definition the search index mapping definition.
+     * @return the search index name.
+     * @mongodb.server.release 7.0
+     * @mongodb.driver.manual reference/command/createSearchIndexes/ Create Search indexes
+     * @since 4.11
+     */
+    String createSearchIndex(Bson definition);
+
+    /**
+     * Create one or more Atlas Search indexes for the collection.
+     * <p>
+     * The name can be omitted for a single index, in which case a name will be the default.
+     * </p>
+     *
+     * @param searchIndexModels the search index models.
+     * @return the search index names.
+     * @mongodb.server.release 7.0
+     * @mongodb.driver.manual reference/command/createSearchIndexes/ Create Search indexes
+     * @since 4.11
+     */
+    List<String> createSearchIndexes(List<SearchIndexModel> searchIndexModels);
+
+    /**
+     * Update an Atlas Search index in the collection.
+     *
+     * @param indexName  the name of the search index to update.
+     * @param definition the search index mapping definition.
+     * @mongodb.server.release 7.0
+     * @mongodb.driver.manual reference/command/updateSearchIndex/ Update Search index
+     * @since 4.11
+     */
+    void updateSearchIndex(String indexName, Bson definition);
+
+    /**
+     * Drop an Atlas Search index given its name.
+     *
+     * @param indexName the name of the search index to remove.
+     * @mongodb.server.release 7.0
+     * @mongodb.driver.manual reference/command/dropSearchIndex/ Drop Search index
+     * @since 4.11
+     */
+    void dropSearchIndex(String indexName);
+
+    /**
+     * Get all Atlas Search indexes in this collection.
+     *
+     * @return the list search indexes iterable interface.
+     * @since 4.11
+     * @mongodb.server.release 7.0
+     */
+    ListSearchIndexesIterable<Document> listSearchIndexes();
+
+    /**
+     * Get all Atlas Search indexes in this collection.
+     *
+     * @param resultClass the class to decode each document into.
+     * @param <TResult>   the target document type of the iterable.
+     * @return the list search indexes iterable interface.
+     * @since 4.11
+     * @mongodb.server.release 7.0
+     */
+    <TResult> ListSearchIndexesIterable<TResult> listSearchIndexes(Class<TResult> resultClass);
 
     /**
      * Create an index with the given keys.

--- a/driver-sync/src/main/com/mongodb/client/internal/ListSearchIndexesIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ListSearchIndexesIterableImpl.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.internal;
+
+import com.mongodb.ExplainVerbosity;
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.client.ListSearchIndexesIterable;
+import com.mongodb.client.model.Collation;
+import com.mongodb.internal.operation.BatchCursor;
+import com.mongodb.internal.operation.ExplainableReadOperation;
+import com.mongodb.internal.operation.ReadOperation;
+import com.mongodb.internal.operation.SyncOperations;
+import com.mongodb.lang.Nullable;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.Document;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+public class ListSearchIndexesIterableImpl<TResult> extends MongoIterableImpl<TResult> implements ListSearchIndexesIterable<TResult> {
+    private final SyncOperations<BsonDocument> operations;
+    private final Class<TResult> resultClass;
+    private Boolean allowDiskUse;
+    private long maxTimeMS;
+    private long maxAwaitTimeMS;
+    private Collation collation;
+    private BsonValue comment;
+    private String indexName;
+    private CodecRegistry codecRegistry;
+
+    public ListSearchIndexesIterableImpl(final MongoNamespace namespace, final OperationExecutor executor,
+                                         final ReadConcern readConcern, final Class<TResult> resultClass,
+                                         final CodecRegistry codecRegistry, final ReadPreference readPreference) {
+        super(null, executor, readConcern, readPreference, false);
+
+        this.resultClass = notNull("resultClass", resultClass);
+        this.operations = new SyncOperations<>(namespace, BsonDocument.class, readPreference, codecRegistry, false);
+        this.codecRegistry = codecRegistry;
+    }
+
+    @Override
+    public ReadOperation<BatchCursor<TResult>> asReadOperation() {
+        return asAggregateOperation();
+    }
+
+
+    @Override
+    public ListSearchIndexesIterable<TResult> allowDiskUse(@Nullable final Boolean allowDiskUse) {
+        this.allowDiskUse = allowDiskUse;
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<TResult> batchSize(final int batchSize) {
+        super.batchSize(batchSize);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
+        notNull("timeUnit", timeUnit);
+        this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<TResult> maxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
+        notNull("timeUnit", timeUnit);
+        this.maxAwaitTimeMS = TimeUnit.MILLISECONDS.convert(maxAwaitTime, timeUnit);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<TResult> collation(@Nullable final Collation collation) {
+        this.collation = collation;
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<TResult> comment(@Nullable final String comment) {
+        this.comment = comment == null ? null : new BsonString(comment);
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<TResult> comment(@Nullable final BsonValue comment) {
+        this.comment = comment;
+        return this;
+    }
+
+    @Override
+    public ListSearchIndexesIterable<TResult> name(@Nullable final String indexName) {
+        this.indexName = indexName;
+        return this;
+    }
+
+    @Override
+    public Document explain() {
+        return executeExplain(Document.class, null);
+    }
+
+    @Override
+    public Document explain(final ExplainVerbosity verbosity) {
+        return executeExplain(Document.class, notNull("verbosity", verbosity));
+    }
+
+    @Override
+    public <E> E explain(final Class<E> explainDocumentClass) {
+        return executeExplain(explainDocumentClass, null);
+    }
+
+    @Override
+    public <E> E explain(final Class<E> explainResultClass, final ExplainVerbosity verbosity) {
+        return executeExplain(explainResultClass, verbosity);
+    }
+
+    private <E> E executeExplain(final Class<E> explainResultClass, @Nullable final ExplainVerbosity verbosity) {
+        notNull("explainDocumentClass", explainResultClass);
+        return getExecutor().execute(asAggregateOperation().asExplainableOperation(verbosity, codecRegistry.get(explainResultClass)),
+                getReadPreference(), getReadConcern(), getClientSession());
+    }
+
+    private ExplainableReadOperation<BatchCursor<TResult>> asAggregateOperation() {
+        return operations.listSearchIndexes(resultClass, maxTimeMS, maxAwaitTimeMS, indexName, getBatchSize(), collation, comment,
+                allowDiskUse);
+    }
+}

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
@@ -35,6 +35,7 @@ import com.mongodb.client.ClientSession;
 import com.mongodb.client.DistinctIterable;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.ListIndexesIterable;
+import com.mongodb.client.ListSearchIndexesIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.CountOptions;
@@ -48,6 +49,7 @@ import com.mongodb.client.model.FindOneAndReplaceOptions;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
 import com.mongodb.client.model.IndexModel;
 import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.InsertOneOptions;
 import com.mongodb.client.model.RenameCollectionOptions;
@@ -78,6 +80,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.assertions.Assertions.notNullElements;
 import static com.mongodb.internal.bulk.WriteRequest.Type.DELETE;
 import static com.mongodb.internal.bulk.WriteRequest.Type.INSERT;
 import static com.mongodb.internal.bulk.WriteRequest.Type.REPLACE;
@@ -811,6 +814,53 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
         executeDrop(clientSession, dropCollectionOptions);
     }
 
+    @Override
+    public String createSearchIndex(final String indexName, final Bson definition) {
+        notNull("indexName", indexName);
+        notNull("definition", definition);
+
+        return executeCreateSearchIndex(definition, indexName);
+    }
+
+    @Override
+    public String createSearchIndex(final Bson definition) {
+        notNull("definition", definition);
+
+        return executeCreateSearchIndex(definition, null);
+    }
+
+    @Override
+    public List<String> createSearchIndexes(final List<SearchIndexModel> searchIndexModels) {
+        notNullElements("searchIndexModels", searchIndexModels);
+
+        return executeCreateSearchIndexes(searchIndexModels);
+    }
+
+    @Override
+    public void updateSearchIndex(final String indexName, final Bson definition) {
+        notNull("indexName", indexName);
+        notNull("definition", definition);
+
+        executor.execute(operations.updateSearchIndex(indexName, definition), readConcern, null);
+    }
+
+    @Override
+    public void dropSearchIndex(final String indexName) {
+        notNull("indexName", indexName);
+
+        executor.execute(operations.dropSearchIndex(indexName), readConcern, null);
+    }
+
+    @Override
+    public ListSearchIndexesIterable<Document> listSearchIndexes() {
+        return createListSearchIndexesIterable(Document.class);
+    }
+
+    @Override
+    public <TResult> ListSearchIndexesIterable<TResult> listSearchIndexes(final Class<TResult> tResultClass) {
+        return createListSearchIndexesIterable(tResultClass);
+    }
+
     private void executeDrop(@Nullable final ClientSession clientSession, final DropCollectionOptions dropCollectionOptions) {
         executor.execute(operations.dropCollection(dropCollectionOptions, autoEncryptionSettings), readConcern, clientSession);
     }
@@ -863,6 +913,17 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
         return IndexHelper.getIndexNames(indexes, codecRegistry);
     }
 
+    private List<String> executeCreateSearchIndexes(final List<SearchIndexModel> searchIndexModels) {
+        executor.execute(operations.createSearchIndexes(searchIndexModels), readConcern, null);
+        return IndexHelper.getSearchIndexNames(searchIndexModels);
+    }
+    private String executeCreateSearchIndex(final Bson definition, final String indexName) {
+        SearchIndexModel searchIndexModel = new SearchIndexModel(indexName, definition);
+
+        executor.execute(operations.createSearchIndexes(singletonList(searchIndexModel)), readConcern, null);
+        return IndexHelper.getSearchIndexName(searchIndexModel);
+    }
+
     @Override
     public ListIndexesIterable<Document> listIndexes() {
         return listIndexes(Document.class);
@@ -888,6 +949,11 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                                                                              final Class<TResult> resultClass) {
         return new ListIndexesIterableImpl<>(clientSession, getNamespace(), resultClass, codecRegistry, ReadPreference.primary(),
                 executor, retryReads);
+    }
+
+    private <TResult> ListSearchIndexesIterable<TResult> createListSearchIndexesIterable(final Class<TResult> resultClass) {
+        return new ListSearchIndexesIterableImpl<>(getNamespace(), executor, readConcern,
+                resultClass, codecRegistry, readPreference);
     }
 
     @Override

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/IndexManagmentTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/IndexManagmentTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.unified;
+
+import com.mongodb.lang.Nullable;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
+
+public class IndexManagmentTest extends UnifiedSyncTest {
+
+    public IndexManagmentTest(@SuppressWarnings("unused") final String fileDescription,
+                              @SuppressWarnings("unused") final String testDescription,
+                              final String schemaVersion,
+                              @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
+                              final BsonDocument definition) {
+        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+    }
+
+    @Parameterized.Parameters(name = "{0}: {1}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        return getTestData("unified-test-format/index-management/tests");
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -412,6 +412,16 @@ public abstract class UnifiedTest {
                     return crudHelper.executeModifyCollection(operation);
                 case "rename":
                     return crudHelper.executeRenameCollection(operation);
+                case "createSearchIndex":
+                    return crudHelper.executeCreateSearchIndex(operation);
+                case "createSearchIndexes":
+                    return crudHelper.executeCreateSearchIndexes(operation);
+                case "updateSearchIndex":
+                    return crudHelper.executeUpdateSearchIndex(operation);
+                case "dropSearchIndex":
+                    return crudHelper.executeDropSearchIndex(operation);
+                case "listSearchIndexes":
+                    return crudHelper.executeListSearchIndexes(operation);
                 case "createIndex":
                     return crudHelper.executeCreateIndex(operation);
                 case "dropIndex":


### PR DESCRIPTION
- Add new collection helpers that allow users to define their search indexes directly within their code.
- Implement unified tests to ensure the proper command structure and format.

JAVA-4983