### PR TITLE
Override Iterator#forEachRemaining in MongoCursor

### DIFF
--- a/driver-kotlin-sync/src/test/kotlin/com/mongodb/kotlin/client/MongoCursorTest.kt
+++ b/driver-kotlin-sync/src/test/kotlin/com/mongodb/kotlin/client/MongoCursorTest.kt
@@ -33,7 +33,9 @@ class MongoCursorTest {
     @Test
     fun shouldHaveTheSameMethods() {
         val jMongoCursorFunctions =
-            JMongoCursor::class.declaredFunctions.map { it.name }
+            JMongoCursor::class
+                .declaredFunctions
+                .map { it.name }
                 // exclude since this method has a default implementation in MongoCursor interface
                 .filterNot { it == "forEachRemaining" }
                 .toSet()

--- a/driver-kotlin-sync/src/test/kotlin/com/mongodb/kotlin/client/MongoCursorTest.kt
+++ b/driver-kotlin-sync/src/test/kotlin/com/mongodb/kotlin/client/MongoCursorTest.kt
@@ -32,7 +32,11 @@ import org.mockito.kotlin.whenever
 class MongoCursorTest {
     @Test
     fun shouldHaveTheSameMethods() {
-        val jMongoCursorFunctions = JMongoCursor::class.declaredFunctions.map { it.name }.toSet()
+        val jMongoCursorFunctions =
+            JMongoCursor::class.declaredFunctions.map { it.name }
+                // exclude since this method has a default implementation in MongoCursor interface
+                .filterNot { it == "forEachRemaining" }
+                .toSet()
         val kMongoCursorFunctions =
             MongoCursorImpl::class.declaredFunctions.map { it.name }.toSet() +
                 MongoCursorImpl::class

--- a/driver-sync/src/main/com/mongodb/client/MongoCursor.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoCursor.java
@@ -23,6 +23,7 @@ import com.mongodb.lang.Nullable;
 
 import java.io.Closeable;
 import java.util.Iterator;
+import java.util.function.Consumer;
 
 /**
  * The Mongo Cursor interface implementing the iterator protocol.
@@ -96,4 +97,13 @@ public interface MongoCursor<TResult> extends Iterator<TResult>, Closeable {
      * @return ServerAddress
      */
     ServerAddress getServerAddress();
+
+    @Override
+    default void forEachRemaining(final Consumer<? super TResult> action) {
+        try {
+            Iterator.super.forEachRemaining(action);
+        } finally {
+            close();
+        }
+    }
 }

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoBatchCursorAdapterSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoBatchCursorAdapterSpecification.groovy
@@ -184,4 +184,23 @@ class MongoBatchCursorAdapterSpecification extends Specification {
         then:
         cursor.available() == 0
     }
+
+    def 'should close cursor in forEachRemaining if there is an exception'() {
+        given:
+        def firstBatch = [new Document('x', 1)]
+
+        def batchCursor = Mock(BatchCursor)
+        batchCursor.hasNext() >>> [true, true]
+        batchCursor.next() >>> [firstBatch]
+        def cursor = new MongoBatchCursorAdapter(batchCursor)
+
+        when:
+        cursor.forEachRemaining {
+            throw new IllegalStateException('test')
+        }
+
+        then:
+        thrown(IllegalStateException)
+        1 * batchCursor.close()
+    }
 }


### PR DESCRIPTION
The override of the default implementation ensures that the cursor is closed even if an exception is thrown.

JAVA-5085