### PR TITLE
Added ClientSideOperationTimeout class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,6 +157,7 @@ configure(scalaProjects) {
                     "-unchecked",
                     "-language:reflectiveCalls",
                     "-Wconf:cat=deprecation:ws,any:e",
+                    "-Wconf:msg=While parsing annotations in:silent",
                     "-Xlint:strict-unsealed-patmat"
             ]
         }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -122,7 +122,7 @@
 
         <module name="MethodLength"/>
         <module name="ParameterNumber">
-            <property name="max" value="13"/>
+            <property name="max" value="12"/>
         </module>
 
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -122,7 +122,7 @@
 
         <module name="MethodLength"/>
         <module name="ParameterNumber">
-            <property name="max" value="12"/>
+            <property name="max" value="13"/>
         </module>
 
 

--- a/driver-core/src/main/com/mongodb/internal/ClientSideOperationTimeout.java
+++ b/driver-core/src/main/com/mongodb/internal/ClientSideOperationTimeout.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal;
+
+import com.mongodb.lang.Nullable;
+
+import java.util.Objects;
+
+import static com.mongodb.assertions.Assertions.assertNotNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Client Side Operation Timeout.
+ *
+ * <p>Includes support for the deprecated {@code maxTimeMS} and {@code maxCommitTimeMS} operation configurations</p>
+ */
+public class ClientSideOperationTimeout {
+
+    private final Long timeoutMS;
+    private final long maxAwaitTimeMS;
+
+    // Deprecated operation based operation timeouts
+    private final long maxTimeMS;
+    private final long maxCommitTimeMS;
+
+    @Nullable
+    private Timeout timeout;
+
+    public ClientSideOperationTimeout(@Nullable final Long timeoutMS,
+                                      final long maxAwaitTimeMS,
+                                      final long maxTimeMS,
+                                      final long maxCommitTimeMS) {
+        this.timeoutMS = timeoutMS;
+        this.maxAwaitTimeMS = maxAwaitTimeMS;
+        this.maxTimeMS = timeoutMS == null ? maxTimeMS : 0;
+        this.maxCommitTimeMS = timeoutMS == null ? maxCommitTimeMS : 0;
+
+        if (timeoutMS != null) {
+            if (timeoutMS == 0) {
+                this.timeout = Timeout.infinite();
+            } else {
+                this.timeout = Timeout.startNow(timeoutMS, MILLISECONDS);
+            }
+        }
+    }
+
+    /**
+     * Allows for the differentiation between users explicitly setting a global operation timeout via {@code timeoutMS}.
+     *
+     * @return true if a timeout has been set.
+     */
+    public boolean hasTimeoutMS() {
+        return timeoutMS != null;
+    }
+
+    /**
+     * Checks the expiry of the timeout.
+     *
+     * @return true if the timeout has been set and it has expired
+     */
+    public boolean expired() {
+        return timeout != null && timeout.expired();
+    }
+
+    /**
+     * Returns the remaining {@code timeoutMS} if set or the {@code alternativeTimeoutMS}.
+     *
+     * @param alternativeTimeoutMS the alternative timeout.
+     * @return timeout to use.
+     */
+    public long timeoutOrAlternative(final long alternativeTimeoutMS) {
+        if (timeoutMS == null) {
+            return alternativeTimeoutMS;
+        } else if (timeoutMS == 0) {
+            return timeoutMS;
+        } else {
+            return timeoutRemainingMS();
+        }
+    }
+
+    /**
+     * Calculates the minimum timeout value between two possible timeouts.
+     *
+     * @param alternativeTimeoutMS the alternative timeout
+     * @return the minimum value to use.
+     */
+    public long calculateMin(final long alternativeTimeoutMS) {
+        if (timeoutMS == null) {
+            return alternativeTimeoutMS;
+        } else if (timeoutMS == 0) {
+            return alternativeTimeoutMS;
+        } else if (alternativeTimeoutMS == 0) {
+            return timeoutRemainingMS();
+        } else {
+            return Math.min(timeoutRemainingMS(), alternativeTimeoutMS);
+        }
+    }
+
+    public long getMaxAwaitTimeMS() {
+        return maxAwaitTimeMS;
+    }
+
+    public long getMaxTimeMS() {
+        return timeoutOrAlternative(maxTimeMS);
+    }
+
+    public long getMaxCommitTimeMS() {
+        return timeoutOrAlternative(maxCommitTimeMS);
+    }
+
+    private long timeoutRemainingMS() {
+        assertNotNull(timeout);
+        return timeout.isInfinite() ? 0 : timeout.remaining(MILLISECONDS);
+    }
+
+    @Override
+    public String toString() {
+        return "ClientSideOperationTimeout{"
+                + "timeoutMS=" + timeoutMS
+                + ", maxAwaitTimeMS=" + maxAwaitTimeMS
+                + ", maxTimeMS=" + maxTimeMS
+                + ", maxCommitTimeMS=" + maxCommitTimeMS
+                + '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ClientSideOperationTimeout that = (ClientSideOperationTimeout) o;
+        return maxAwaitTimeMS == that.maxAwaitTimeMS && maxTimeMS == that.maxTimeMS && maxCommitTimeMS == that.maxCommitTimeMS
+                && Objects.equals(timeoutMS, that.timeoutMS);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timeoutMS, maxAwaitTimeMS, maxTimeMS, maxCommitTimeMS);
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/ClientSideOperationTimeout.java
+++ b/driver-core/src/main/com/mongodb/internal/ClientSideOperationTimeout.java
@@ -20,6 +20,7 @@ import com.mongodb.lang.Nullable;
 import java.util.Objects;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
+import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -43,6 +44,7 @@ public class ClientSideOperationTimeout {
                                       final long maxAwaitTimeMS,
                                       final long maxTimeMS,
                                       final long maxCommitTimeMS) {
+        isTrueArgument("timeoutMS must be >= 0", timeoutMS == null || timeoutMS >= 0);
         this.timeoutMS = timeoutMS;
         this.maxAwaitTimeMS = maxAwaitTimeMS;
         this.maxTimeMS = timeoutMS == null ? maxTimeMS : 0;

--- a/driver-core/src/main/com/mongodb/internal/ClientSideOperationTimeouts.java
+++ b/driver-core/src/main/com/mongodb/internal/ClientSideOperationTimeouts.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal;
+
+import com.mongodb.lang.Nullable;
+
+/**
+ * A factory for creating {@link ClientSideOperationTimeout} instances
+ */
+public final class ClientSideOperationTimeouts {
+
+    public static final ClientSideOperationTimeout NO_TIMEOUT = create(null, 0, 0, 0);
+
+    public static ClientSideOperationTimeout create(@Nullable final Long timeoutMS) {
+        return create(timeoutMS, 0);
+    }
+
+    public static ClientSideOperationTimeout create(@Nullable final Long timeoutMS, final long maxTimeMS) {
+        return create(timeoutMS, maxTimeMS, 0);
+    }
+
+    public static ClientSideOperationTimeout create(@Nullable final Long timeoutMS,
+                                                    final long maxTimeMS,
+                                                    final long maxAwaitTimeMS) {
+        return new ClientSideOperationTimeout(timeoutMS, maxAwaitTimeMS, maxTimeMS, 0);
+    }
+
+    public static ClientSideOperationTimeout create(@Nullable final Long timeoutMS,
+                                                    final long maxTimeMS,
+                                                    final long maxAwaitTimeMS,
+                                                    final long maxCommitMS) {
+        return new ClientSideOperationTimeout(timeoutMS, maxAwaitTimeMS, maxTimeMS, maxCommitMS);
+    }
+
+    public static ClientSideOperationTimeout withMaxCommitMS(@Nullable final Long timeoutMS,
+                                                             @Nullable final Long maxCommitMS) {
+        return create(timeoutMS, 0, 0, maxCommitMS != null ? maxCommitMS : 0);
+    }
+
+    private ClientSideOperationTimeouts() {
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/AbortTransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AbortTransactionOperation.java
@@ -18,6 +18,7 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.Function;
 import com.mongodb.WriteConcern;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 
@@ -31,8 +32,8 @@ import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreat
 public class AbortTransactionOperation extends TransactionOperation {
     private BsonDocument recoveryToken;
 
-    public AbortTransactionOperation(final WriteConcern writeConcern) {
-        super(writeConcern);
+    public AbortTransactionOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final WriteConcern writeConcern) {
+        super(clientSideOperationTimeout, writeConcern);
     }
 
     public AbortTransactionOperation recoveryToken(@Nullable final BsonDocument recoveryToken) {
@@ -49,7 +50,9 @@ public class AbortTransactionOperation extends TransactionOperation {
     CommandCreator getCommandCreator() {
         CommandCreator creator = super.getCommandCreator();
         if (recoveryToken != null) {
-            return (serverDescription, connectionDescription) -> creator.create(serverDescription, connectionDescription).append("recoveryToken", recoveryToken);
+            return (clientSideOperationTimeout, serverDescription, connectionDescription) ->
+                    creator.create(clientSideOperationTimeout, serverDescription, connectionDescription)
+                            .append("recoveryToken", recoveryToken);
         }
         return creator;
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateOperation.java
@@ -19,6 +19,7 @@ package com.mongodb.internal.operation;
 import com.mongodb.ExplainVerbosity;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.model.Collation;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
@@ -31,7 +32,6 @@ import org.bson.BsonValue;
 import org.bson.codecs.Decoder;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.internal.operation.ExplainHelper.asExplainCommand;
 import static com.mongodb.internal.operation.ServerVersionHelper.MIN_WIRE_VERSION;
@@ -44,13 +44,14 @@ import static com.mongodb.internal.operation.ServerVersionHelper.MIN_WIRE_VERSIO
 public class AggregateOperation<T> implements AsyncExplainableReadOperation<AsyncBatchCursor<T>>, ExplainableReadOperation<BatchCursor<T>> {
     private final AggregateOperationImpl<T> wrapped;
 
-    public AggregateOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline, final Decoder<T> decoder) {
-        this(namespace, pipeline, decoder, AggregationLevel.COLLECTION);
+    public AggregateOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final List<BsonDocument> pipeline, final Decoder<T> decoder) {
+        this(clientSideOperationTimeout, namespace, pipeline, decoder, AggregationLevel.COLLECTION);
     }
 
-    public AggregateOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline, final Decoder<T> decoder,
-                              final AggregationLevel aggregationLevel) {
-        this.wrapped = new AggregateOperationImpl<>(namespace, pipeline, decoder, aggregationLevel);
+    public AggregateOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final List<BsonDocument> pipeline, final Decoder<T> decoder, final AggregationLevel aggregationLevel) {
+        this.wrapped = new AggregateOperationImpl<>(clientSideOperationTimeout, namespace, pipeline, decoder, aggregationLevel);
     }
 
     public List<BsonDocument> getPipeline() {
@@ -72,24 +73,6 @@ public class AggregateOperation<T> implements AsyncExplainableReadOperation<Asyn
 
     public AggregateOperation<T> batchSize(@Nullable final Integer batchSize) {
         wrapped.batchSize(batchSize);
-        return this;
-    }
-
-    public long getMaxAwaitTime(final TimeUnit timeUnit) {
-        return wrapped.getMaxAwaitTime(timeUnit);
-    }
-
-    public AggregateOperation<T> maxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
-        wrapped.maxAwaitTime(maxAwaitTime, timeUnit);
-        return this;
-    }
-
-    public long getMaxTime(final TimeUnit timeUnit) {
-        return wrapped.getMaxTime(timeUnit);
-    }
-
-    public AggregateOperation<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
-        wrapped.maxTime(maxTime, timeUnit);
         return this;
     }
 
@@ -159,24 +142,20 @@ public class AggregateOperation<T> implements AsyncExplainableReadOperation<Asyn
     }
 
     public <R> ReadOperation<R> asExplainableOperation(@Nullable final ExplainVerbosity verbosity, final Decoder<R> resultDecoder) {
-        return new CommandReadOperation<>(getNamespace().getDatabaseName(),
-                asExplainCommand(wrapped.getCommand(NoOpSessionContext.INSTANCE, MIN_WIRE_VERSION), verbosity),
-                resultDecoder);
+        return new CommandReadOperation<>(wrapped.getClientSideOperationTimeout(), getNamespace().getDatabaseName(),
+                asExplainCommand(wrapped.getCommand(wrapped.getClientSideOperationTimeout(), NoOpSessionContext.INSTANCE, MIN_WIRE_VERSION),
+                        verbosity), resultDecoder);
     }
 
     public <R> AsyncReadOperation<R> asAsyncExplainableOperation(@Nullable final ExplainVerbosity verbosity,
                                                                  final Decoder<R> resultDecoder) {
-        return new CommandReadOperation<>(getNamespace().getDatabaseName(),
-                asExplainCommand(wrapped.getCommand(NoOpSessionContext.INSTANCE, MIN_WIRE_VERSION), verbosity),
-                resultDecoder);
+        return new CommandReadOperation<>(wrapped.getClientSideOperationTimeout(), getNamespace().getDatabaseName(),
+                asExplainCommand(wrapped.getCommand(wrapped.getClientSideOperationTimeout(), NoOpSessionContext.INSTANCE, MIN_WIRE_VERSION),
+                        verbosity), resultDecoder);
     }
-
 
     MongoNamespace getNamespace() {
         return wrapped.getNamespace();
     }
 
-    Decoder<T> getDecoder() {
-        return wrapped.getDecoder();
-    }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
@@ -19,6 +19,7 @@ package com.mongodb.internal.operation;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.model.Collation;
 import com.mongodb.connection.ConnectionDescription;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
@@ -38,7 +39,6 @@ import org.bson.codecs.Decoder;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.isTrueArgument;
@@ -59,6 +59,7 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
     private static final String FIRST_BATCH = "firstBatch";
     private static final List<String> FIELD_NAMES_WITH_RESULT = Arrays.asList(RESULT, FIRST_BATCH);
 
+    private final ClientSideOperationTimeout clientSideOperationTimeout;
     private final MongoNamespace namespace;
     private final List<BsonDocument> pipeline;
     private final Decoder<T> decoder;
@@ -71,18 +72,20 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
     private Collation collation;
     private BsonValue comment;
     private BsonValue hint;
-    private long maxAwaitTimeMS;
-    private long maxTimeMS;
     private BsonDocument variables;
 
-    AggregateOperationImpl(final MongoNamespace namespace, final List<BsonDocument> pipeline, final Decoder<T> decoder,
-                           final AggregationLevel aggregationLevel) {
-        this(namespace, pipeline, decoder, defaultAggregateTarget(notNull("aggregationLevel", aggregationLevel),
-                notNull("namespace", namespace).getCollectionName()), defaultPipelineCreator(pipeline));
+    AggregateOperationImpl(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final List<BsonDocument> pipeline, final Decoder<T> decoder, final AggregationLevel aggregationLevel) {
+        this(clientSideOperationTimeout, namespace, pipeline, decoder,
+                defaultAggregateTarget(notNull("aggregationLevel", aggregationLevel),
+                        notNull("namespace", namespace).getCollectionName()),
+                defaultPipelineCreator(pipeline));
     }
 
-    AggregateOperationImpl(final MongoNamespace namespace, final List<BsonDocument> pipeline, final Decoder<T> decoder,
-                           final AggregateTarget aggregateTarget, final PipelineCreator pipelineCreator) {
+    AggregateOperationImpl(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final List<BsonDocument> pipeline, final Decoder<T> decoder, final AggregateTarget aggregateTarget,
+            final PipelineCreator pipelineCreator) {
+        this.clientSideOperationTimeout = notNull("clientSideOperationTimeout", clientSideOperationTimeout);
         this.namespace = notNull("namespace", namespace);
         this.pipeline = notNull("pipeline", pipeline);
         this.decoder = notNull("decoder", decoder);
@@ -117,30 +120,6 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
 
     AggregateOperationImpl<T> batchSize(@Nullable final Integer batchSize) {
         this.batchSize = batchSize;
-        return this;
-    }
-
-    long getMaxAwaitTime(final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        return timeUnit.convert(maxAwaitTimeMS, TimeUnit.MILLISECONDS);
-    }
-
-    AggregateOperationImpl<T> maxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        isTrueArgument("maxAwaitTime >= 0", maxAwaitTime >= 0);
-        this.maxAwaitTimeMS = TimeUnit.MILLISECONDS.convert(maxAwaitTime, timeUnit);
-        return this;
-    }
-
-    long getMaxTime(final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        return timeUnit.convert(maxTimeMS, TimeUnit.MILLISECONDS);
-    }
-
-    AggregateOperationImpl<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        isTrueArgument("maxTime >= 0", maxTime >= 0);
-        this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
@@ -182,6 +161,10 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
         return hint;
     }
 
+    public ClientSideOperationTimeout getClientSideOperationTimeout() {
+        return clientSideOperationTimeout;
+    }
+
     AggregateOperationImpl<T> hint(@Nullable final BsonValue hint) {
         isTrueArgument("BsonString or BsonDocument", hint == null || hint.isDocument() || hint.isString());
         this.hint = hint;
@@ -190,30 +173,34 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
 
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
-        return executeRetryableRead(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
-                CommandResultDocumentCodec.create(decoder, FIELD_NAMES_WITH_RESULT), transformer(), retryReads);
+        return executeRetryableRead(clientSideOperationTimeout, binding, namespace.getDatabaseName(),
+                getCommandCreator(binding.getSessionContext()), CommandResultDocumentCodec.create(decoder, FIELD_NAMES_WITH_RESULT),
+                transformer(), retryReads);
     }
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
         SingleResultCallback<AsyncBatchCursor<T>> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
-       executeRetryableReadAsync(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
-               CommandResultDocumentCodec.create(this.decoder, FIELD_NAMES_WITH_RESULT), asyncTransformer(), retryReads,
+       executeRetryableReadAsync(clientSideOperationTimeout, binding, namespace.getDatabaseName(),
+               getCommandCreator(binding.getSessionContext()), CommandResultDocumentCodec.create(this.decoder, FIELD_NAMES_WITH_RESULT),
+               asyncTransformer(), retryReads,
                errHandlingCallback);
     }
 
     private CommandCreator getCommandCreator(final SessionContext sessionContext) {
-        return (serverDescription, connectionDescription) -> getCommand(sessionContext, connectionDescription.getMaxWireVersion());
+        return (clientSideOperationTimeout, serverDescription, connectionDescription) ->
+                getCommand(clientSideOperationTimeout, sessionContext, connectionDescription.getMaxWireVersion());
     }
 
-    BsonDocument getCommand(final SessionContext sessionContext, final int maxWireVersion) {
+    BsonDocument getCommand(final ClientSideOperationTimeout clientSideOperationTimeout, final SessionContext sessionContext,
+            final int maxWireVersion) {
         BsonDocument commandDocument = new BsonDocument("aggregate", aggregateTarget.create());
 
         appendReadConcernToCommand(sessionContext, maxWireVersion, commandDocument);
         commandDocument.put("pipeline", pipelineCreator.create());
+        long maxTimeMS = clientSideOperationTimeout.getMaxTimeMS();
         if (maxTimeMS > 0) {
-            commandDocument.put("maxTimeMS", maxTimeMS > Integer.MAX_VALUE
-                    ? new BsonInt64(maxTimeMS) : new BsonInt32((int) maxTimeMS));
+            commandDocument.put("maxTimeMS", new BsonInt64(maxTimeMS));
         }
         BsonDocument cursor = new BsonDocument();
         if (batchSize != null) {
@@ -247,6 +234,7 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
     private CommandReadTransformer<BsonDocument, QueryBatchCursor<T>> transformer() {
         return (result, source, connection) -> {
             QueryResult<T> queryResult = createQueryResult(result, connection.getDescription());
+            long maxAwaitTimeMS = clientSideOperationTimeout.getMaxAwaitTimeMS();
             return new QueryBatchCursor<>(queryResult, 0, batchSize != null ? batchSize : 0, maxAwaitTimeMS, decoder, comment,
                     source, connection, result);
         };
@@ -255,6 +243,7 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
     private CommandReadTransformerAsync<BsonDocument, AsyncBatchCursor<T>> asyncTransformer() {
         return (result, source, connection) -> {
             QueryResult<T> queryResult = createQueryResult(result, connection.getDescription());
+            long maxAwaitTimeMS = clientSideOperationTimeout.getMaxAwaitTimeMS();
             return new AsyncQueryBatchCursor<>(queryResult, 0, batchSize != null ? batchSize : 0, maxAwaitTimeMS, decoder,
                     comment, source, connection, result);
         };

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
@@ -22,6 +22,7 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.mongodb.assertions.Assertions;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackBiFunction;
@@ -153,6 +154,7 @@ final class AsyncOperationHelper {
     }
 
     static <D, T> void executeRetryableReadAsync(
+            final ClientSideOperationTimeout clientSideOperationTimeout,
             final AsyncReadBinding binding,
             final String database,
             final CommandCreator commandCreator,
@@ -160,11 +162,12 @@ final class AsyncOperationHelper {
             final CommandReadTransformerAsync<D, T> transformer,
             final boolean retryReads,
             final SingleResultCallback<T> callback) {
-        executeRetryableReadAsync(binding, binding::getReadConnectionSource, database, commandCreator, decoder, transformer, retryReads,
-                callback);
+        executeRetryableReadAsync(clientSideOperationTimeout, binding, binding::getReadConnectionSource, database, commandCreator,
+                decoder, transformer, retryReads, callback);
     }
 
     static <D, T> void executeRetryableReadAsync(
+            final ClientSideOperationTimeout clientSideOperationTimeout,
             final AsyncReadBinding binding,
             final AsyncCallbackSupplier<AsyncConnectionSource> sourceAsyncSupplier,
             final String database,
@@ -185,11 +188,8 @@ final class AsyncOperationHelper {
                                             releasingCallback)) {
                                         return;
                                     }
-                                    createReadCommandAndExecuteAsync(retryState, binding, source,
-                                            database, commandCreator,
-                                            decoder, transformer,
-                                            connection,
-                                            releasingCallback);
+                                    createReadCommandAndExecuteAsync(clientSideOperationTimeout, retryState, binding, source, database,
+                                            commandCreator, decoder, transformer, connection, releasingCallback);
                                 })
         ).whenComplete(binding::release);
         asyncRead.get(errorHandlingCallback(callback, OperationHelper.LOGGER));
@@ -209,6 +209,7 @@ final class AsyncOperationHelper {
     }
 
     static <T, R> void executeRetryableWriteAsync(
+            final ClientSideOperationTimeout clientSideOperationTimeout,
             final AsyncWriteBinding binding,
             final String database,
             @Nullable final ReadPreference readPreference,
@@ -243,7 +244,7 @@ final class AsyncOperationHelper {
                                     .map(previousAttemptCommand -> {
                                         Assertions.assertFalse(firstAttempt);
                                         return retryCommandModifier.apply(previousAttemptCommand);
-                                    }).orElseGet(() -> commandCreator.create(source.getServerDescription(), connection.getDescription()));
+                                    }).orElseGet(() -> commandCreator.create(clientSideOperationTimeout, source.getServerDescription(), connection.getDescription()));
                             // attach `maxWireVersion`, `retryableCommandFlag` ASAP because they are used to check whether we should retry
                             retryState.attach(AttachmentKeys.maxWireVersion(), maxWireVersion, true)
                                     .attach(AttachmentKeys.retryableCommandFlag(), isRetryWritesEnabled(command), true)
@@ -262,6 +263,7 @@ final class AsyncOperationHelper {
     }
 
     static <D, T> void createReadCommandAndExecuteAsync(
+            final ClientSideOperationTimeout clientSideOperationTimeout,
             final RetryState retryState,
             final AsyncReadBinding binding,
             final AsyncConnectionSource source,
@@ -273,7 +275,7 @@ final class AsyncOperationHelper {
             final SingleResultCallback<T> callback) {
         BsonDocument command;
         try {
-            command = commandCreator.create(source.getServerDescription(), connection.getDescription());
+            command = commandCreator.create(clientSideOperationTimeout, source.getServerDescription(), connection.getDescription());
             retryState.attach(AttachmentKeys.commandDescriptionSupplier(), command::getFirstKey, false);
         } catch (IllegalArgumentException e) {
             callback.onResult(null, e);

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
@@ -69,9 +69,9 @@ public final class AsyncOperations<TDocument> {
 
     public AsyncOperations(final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
             final CodecRegistry codecRegistry, final ReadConcern readConcern, final WriteConcern writeConcern,
-            final boolean retryWrites, final boolean retryReads) {
+            final boolean retryWrites, final boolean retryReads,  @Nullable final Long timeoutMS) {
         this.operations = new Operations<>(namespace, documentClass, readPreference, codecRegistry, readConcern, writeConcern,
-                retryWrites, retryReads);
+                retryWrites, retryReads, timeoutMS);
     }
 
     public MongoNamespace getNamespace() {
@@ -104,6 +104,11 @@ public final class AsyncOperations<TDocument> {
 
     public boolean isRetryReads() {
         return operations.isRetryReads();
+    }
+
+    @Nullable
+    public Long getTimeoutMS() {
+        return operations.getTimeoutMS();
     }
 
     public AsyncReadOperation<Long> countDocuments(final Bson filter, final CountOptions options) {

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncQueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncQueryBatchCursor.java
@@ -55,9 +55,9 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.operation.CursorHelper.getNumberToReturn;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
-import static com.mongodb.internal.operation.SyncOperationHelper.getMoreCursorDocumentToQueryResult;
 import static com.mongodb.internal.operation.QueryHelper.translateCommandException;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionFourDotFour;
+import static com.mongodb.internal.operation.SyncOperationHelper.getMoreCursorDocumentToQueryResult;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 

--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.AsyncAggregateResponseBatchCursor;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
@@ -40,7 +41,6 @@ import org.bson.codecs.RawBsonDocumentCodec;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncReadConnectionSource;
@@ -65,15 +65,16 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
     private boolean showExpandedEvents;
 
 
-    public ChangeStreamOperation(final MongoNamespace namespace, final FullDocument fullDocument,
-            final FullDocumentBeforeChange fullDocumentBeforeChange, final List<BsonDocument> pipeline, final Decoder<T> decoder) {
-        this(namespace, fullDocument, fullDocumentBeforeChange, pipeline, decoder, ChangeStreamLevel.COLLECTION);
+    public ChangeStreamOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final FullDocument fullDocument, final FullDocumentBeforeChange fullDocumentBeforeChange,
+            final List<BsonDocument> pipeline, final Decoder<T> decoder) {
+        this(clientSideOperationTimeout, namespace, fullDocument, fullDocumentBeforeChange, pipeline, decoder, ChangeStreamLevel.COLLECTION);
     }
 
-    public ChangeStreamOperation(final MongoNamespace namespace, final FullDocument fullDocument,
-            final FullDocumentBeforeChange fullDocumentBeforeChange, final List<BsonDocument> pipeline,
+    public ChangeStreamOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final FullDocument fullDocument, final FullDocumentBeforeChange fullDocumentBeforeChange, final List<BsonDocument> pipeline,
             final Decoder<T> decoder, final ChangeStreamLevel changeStreamLevel) {
-        this.wrapped = new AggregateOperationImpl<>(namespace, pipeline, RAW_BSON_DOCUMENT_CODEC,
+        this.wrapped = new AggregateOperationImpl<>(clientSideOperationTimeout, namespace, pipeline, RAW_BSON_DOCUMENT_CODEC,
                 getAggregateTarget(), getPipelineCreator());
         this.fullDocument = notNull("fullDocument", fullDocument);
         this.fullDocumentBeforeChange = notNull("fullDocumentBeforeChange", fullDocumentBeforeChange);
@@ -121,15 +122,6 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
 
     public ChangeStreamOperation<T> batchSize(@Nullable final Integer batchSize) {
         wrapped.batchSize(batchSize);
-        return this;
-    }
-
-    public long getMaxAwaitTime(final TimeUnit timeUnit) {
-        return wrapped.getMaxAwaitTime(timeUnit);
-    }
-
-    public ChangeStreamOperation<T> maxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
-        wrapped.maxAwaitTime(maxAwaitTime, timeUnit);
         return this;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -28,6 +28,7 @@ import com.mongodb.MongoSocketException;
 import com.mongodb.assertions.Assertions;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.function.RetryState;
 import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.internal.operation.OperationHelper.ResourceSupplierInternalException;
@@ -48,7 +49,8 @@ final class CommandOperationHelper {
 
 
     interface CommandCreator {
-        BsonDocument create(ServerDescription serverDescription, ConnectionDescription connectionDescription);
+        BsonDocument create(ClientSideOperationTimeout clientSideOperationTimeout, ServerDescription serverDescription,
+                ConnectionDescription connectionDescription);
     }
 
 

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
@@ -59,7 +59,7 @@ public class CommandReadOperation<T> implements AsyncReadOperation<T>, ReadOpera
                 (result, source, connection) -> result, false, callback);
     }
 
-    // TODO - JAVA-5098 - should the command be modified for CSOT?
+    // TODO (CSOT) - JAVA-5098 - should the command be modified for CSOT?
     private CommandCreator getCommandCreator() {
         return (clientSideOperationTimeout, serverDescription, connectionDescription) -> command;
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.operation;
 
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
 import com.mongodb.internal.binding.ReadBinding;
@@ -33,11 +34,14 @@ import static com.mongodb.internal.operation.SyncOperationHelper.executeRetryabl
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class CommandReadOperation<T> implements AsyncReadOperation<T>, ReadOperation<T> {
+    private final ClientSideOperationTimeout clientSideOperationTimeout;
     private final String databaseName;
     private final BsonDocument command;
     private final Decoder<T> decoder;
 
-    public CommandReadOperation(final String databaseName, final BsonDocument command, final Decoder<T> decoder) {
+    public CommandReadOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final String databaseName,
+            final BsonDocument command, final Decoder<T> decoder) {
+        this.clientSideOperationTimeout = notNull("clientSideOperationTimeout", clientSideOperationTimeout);
         this.databaseName = notNull("databaseName", databaseName);
         this.command = notNull("command", command);
         this.decoder = notNull("decoder", decoder);
@@ -45,16 +49,18 @@ public class CommandReadOperation<T> implements AsyncReadOperation<T>, ReadOpera
 
     @Override
     public T execute(final ReadBinding binding) {
-        return executeRetryableRead(binding, databaseName, getCommandCreator(), decoder, (result, source, connection) -> result, false);
+        return executeRetryableRead(clientSideOperationTimeout, binding, databaseName, getCommandCreator(), decoder,
+                (result, source, connection) -> result, false);
     }
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<T> callback) {
-        executeRetryableReadAsync(binding, databaseName, getCommandCreator(), decoder, (result, source, connection) -> result,
-                false, callback);
+        executeRetryableReadAsync(clientSideOperationTimeout, binding, databaseName, getCommandCreator(), decoder,
+                (result, source, connection) -> result, false, callback);
     }
 
+    // TODO - JAVA-5098 - should the command be modified for CSOT?
     private CommandCreator getCommandCreator() {
-        return (serverDescription, connectionDescription) -> command;
+        return (clientSideOperationTimeout, serverDescription, connectionDescription) -> command;
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/CommitTransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommitTransactionOperation.java
@@ -25,22 +25,19 @@ import com.mongodb.MongoSocketException;
 import com.mongodb.MongoTimeoutException;
 import com.mongodb.MongoWriteConcernException;
 import com.mongodb.WriteConcern;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
-import org.bson.BsonInt32;
-import org.bson.BsonInt64;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL;
-import static com.mongodb.assertions.Assertions.isTrueArgument;
-import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
 import static com.mongodb.internal.operation.CommandOperationHelper.RETRYABLE_WRITE_ERROR_LABEL;
+import static com.mongodb.internal.operation.DocumentHelper.putIfNotZero;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -52,40 +49,20 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class CommitTransactionOperation extends TransactionOperation {
     private final boolean alreadyCommitted;
     private BsonDocument recoveryToken;
-    private Long maxCommitTimeMS;
 
-    public CommitTransactionOperation(final WriteConcern writeConcern) {
-        this(writeConcern, false);
+    public CommitTransactionOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final WriteConcern writeConcern) {
+        this(clientSideOperationTimeout, writeConcern, false);
     }
 
-    public CommitTransactionOperation(final WriteConcern writeConcern, final boolean alreadyCommitted) {
-        super(writeConcern);
+    public CommitTransactionOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final WriteConcern writeConcern,
+            final boolean alreadyCommitted) {
+        super(clientSideOperationTimeout, writeConcern);
         this.alreadyCommitted = alreadyCommitted;
     }
 
     public CommitTransactionOperation recoveryToken(@Nullable final BsonDocument recoveryToken) {
         this.recoveryToken = recoveryToken;
         return this;
-    }
-
-    public CommitTransactionOperation maxCommitTime(@Nullable final Long maxCommitTime, final TimeUnit timeUnit) {
-        if (maxCommitTime == null) {
-            this.maxCommitTimeMS = null;
-        } else {
-            notNull("timeUnit", timeUnit);
-            isTrueArgument("maxCommitTime > 0", maxCommitTime > 0);
-            this.maxCommitTimeMS = MILLISECONDS.convert(maxCommitTime, timeUnit);
-        }
-        return this;
-    }
-
-    @Nullable
-    public Long getMaxCommitTime(final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        if (maxCommitTimeMS == null) {
-            return null;
-        }
-        return timeUnit.convert(maxCommitTimeMS, MILLISECONDS);
     }
 
     @Override
@@ -143,20 +120,20 @@ public class CommitTransactionOperation extends TransactionOperation {
 
     @Override
     CommandCreator getCommandCreator() {
-        CommandCreator creator = (serverDescription, connectionDescription) -> {
-            BsonDocument command = CommitTransactionOperation.super.getCommandCreator().create(serverDescription,
-                    connectionDescription);
-            if (maxCommitTimeMS != null) {
-                command.append("maxTimeMS",
-                        maxCommitTimeMS > Integer.MAX_VALUE
-                        ? new BsonInt64(maxCommitTimeMS) : new BsonInt32(maxCommitTimeMS.intValue()));
-            }
+        CommandCreator creator = (clientSideOperationTimeout, serverDescription, connectionDescription) -> {
+            BsonDocument command = CommitTransactionOperation.super.getCommandCreator()
+                    .create(clientSideOperationTimeout, serverDescription, connectionDescription);
+            long maxCommitTimeMS = clientSideOperationTimeout.getMaxCommitTimeMS();
+            putIfNotZero(command, "maxTimeMS", maxCommitTimeMS);
             return command;
         };
         if (alreadyCommitted) {
-            return (serverDescription, connectionDescription) -> getRetryCommandModifier().apply(creator.create(serverDescription, connectionDescription));
+            return (clientSideOperationTimeout, serverDescription, connectionDescription) ->
+                    getRetryCommandModifier().apply(creator.create(clientSideOperationTimeout, serverDescription, connectionDescription));
         } else if (recoveryToken != null) {
-                return (serverDescription, connectionDescription) -> creator.create(serverDescription, connectionDescription).append("recoveryToken", recoveryToken);
+                return (clientSideOperationTimeout, serverDescription, connectionDescription) ->
+                        creator.create(clientSideOperationTimeout, serverDescription, connectionDescription)
+                                .append("recoveryToken", recoveryToken);
         }
         return creator;
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
@@ -26,6 +26,7 @@ import com.mongodb.client.model.TimeSeriesOptions;
 import com.mongodb.client.model.ValidationAction;
 import com.mongodb.client.model.ValidationLevel;
 import com.mongodb.connection.ConnectionDescription;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -71,6 +72,7 @@ public class CreateCollectionOperation implements AsyncWriteOperation<Void>, Wri
     private static final BsonDocument ENCRYPT_CLUSTERED_INDEX = BsonDocument.parse("{key: {_id: 1}, unique: true}");
     private static final BsonArray SAFE_CONTENT_ARRAY = new BsonArray(
             singletonList(BsonDocument.parse("{key: {__safeContent__: 1}, name: '__safeContent___1'}")));
+    private final ClientSideOperationTimeout clientSideOperationTimeout;
     private final String databaseName;
     private final String collectionName;
     private final WriteConcern writeConcern;
@@ -92,11 +94,9 @@ public class CreateCollectionOperation implements AsyncWriteOperation<Void>, Wri
     private String clusteredIndexName;
     private BsonDocument encryptedFields;
 
-    public CreateCollectionOperation(final String databaseName, final String collectionName) {
-        this(databaseName, collectionName, null);
-    }
-
-    public CreateCollectionOperation(final String databaseName, final String collectionName, @Nullable final WriteConcern writeConcern) {
+    public CreateCollectionOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final String databaseName,
+            final String collectionName, @Nullable final WriteConcern writeConcern) {
+        this.clientSideOperationTimeout = notNull("clientSideOperationTimeout", clientSideOperationTimeout);
         this.databaseName = notNull("databaseName", databaseName);
         this.collectionName = notNull("collectionName", collectionName);
         this.writeConcern = writeConcern;

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
@@ -18,6 +18,7 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -47,6 +48,7 @@ import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConce
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class CreateViewOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
+    private final ClientSideOperationTimeout clientSideOperationTimeout;
     private final String databaseName;
     private final String viewName;
     private final String viewOn;
@@ -54,8 +56,9 @@ public class CreateViewOperation implements AsyncWriteOperation<Void>, WriteOper
     private final WriteConcern writeConcern;
     private Collation collation;
 
-    public CreateViewOperation(final String databaseName, final String viewName, final String viewOn, final List<BsonDocument> pipeline,
-                               final WriteConcern writeConcern) {
+    public CreateViewOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final String databaseName,
+            final String viewName, final String viewOn, final List<BsonDocument> pipeline, final WriteConcern writeConcern) {
+        this.clientSideOperationTimeout = notNull("clientSideOperationTimeout", clientSideOperationTimeout);
         this.databaseName = notNull("databaseName", databaseName);
         this.viewName = notNull("viewName", viewName);
         this.viewOn = notNull("viewOn", viewOn);

--- a/driver-core/src/main/com/mongodb/internal/operation/DistinctOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DistinctOperation.java
@@ -19,6 +19,7 @@ package com.mongodb.internal.operation;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.model.Collation;
 import com.mongodb.connection.ConnectionDescription;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
@@ -31,8 +32,6 @@ import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.codecs.Codec;
 import org.bson.codecs.Decoder;
-
-import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
@@ -54,16 +53,18 @@ import static com.mongodb.internal.operation.SyncOperationHelper.executeRetryabl
 public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
     private static final String VALUES = "values";
 
+    private final ClientSideOperationTimeout clientSideOperationTimeout;
     private final MongoNamespace namespace;
     private final String fieldName;
     private final Decoder<T> decoder;
     private boolean retryReads;
     private BsonDocument filter;
-    private long maxTimeMS;
     private Collation collation;
     private BsonValue comment;
 
-    public DistinctOperation(final MongoNamespace namespace, final String fieldName, final Decoder<T> decoder) {
+    public DistinctOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final String fieldName, final Decoder<T> decoder) {
+        this.clientSideOperationTimeout = notNull("clientSideOperationTimeout", clientSideOperationTimeout);
         this.namespace = notNull("namespace", namespace);
         this.fieldName = notNull("fieldName", fieldName);
         this.decoder = notNull("decoder", decoder);
@@ -87,17 +88,6 @@ public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor
         return retryReads;
     }
 
-    public long getMaxTime(final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        return timeUnit.convert(maxTimeMS, TimeUnit.MILLISECONDS);
-    }
-
-    public DistinctOperation<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
-        return this;
-    }
-
     public Collation getCollation() {
         return collation;
     }
@@ -119,14 +109,15 @@ public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor
 
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
-        return executeRetryableRead(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
-                createCommandDecoder(), transformer(), retryReads);
+        return executeRetryableRead(clientSideOperationTimeout, binding, namespace.getDatabaseName(),
+                getCommandCreator(binding.getSessionContext()), createCommandDecoder(), transformer(), retryReads);
     }
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        executeRetryableReadAsync(binding, namespace.getDatabaseName(), getCommandCreator(binding.getSessionContext()),
-                createCommandDecoder(), asyncTransformer(), retryReads, errorHandlingCallback(callback, LOGGER));
+        executeRetryableReadAsync(clientSideOperationTimeout, binding, namespace.getDatabaseName(),
+                getCommandCreator(binding.getSessionContext()), createCommandDecoder(), asyncTransformer(), retryReads,
+                errorHandlingCallback(callback, LOGGER));
     }
 
     private Codec<BsonDocument> createCommandDecoder() {
@@ -153,19 +144,17 @@ public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor
     }
 
     private CommandCreator getCommandCreator(final SessionContext sessionContext) {
-        return (serverDescription, connectionDescription) -> getCommand(sessionContext, connectionDescription);
-    }
-
-    private BsonDocument getCommand(final SessionContext sessionContext, final ConnectionDescription connectionDescription) {
-        BsonDocument commandDocument = new BsonDocument("distinct", new BsonString(namespace.getCollectionName()));
-        appendReadConcernToCommand(sessionContext, connectionDescription.getMaxWireVersion(), commandDocument);
-        commandDocument.put("key", new BsonString(fieldName));
-        putIfNotNull(commandDocument, "query", filter);
-        putIfNotZero(commandDocument, "maxTimeMS", maxTimeMS);
-        if (collation != null) {
-            commandDocument.put("collation", collation.asDocument());
-        }
-        putIfNotNull(commandDocument, "comment", comment);
-        return commandDocument;
+        return (clientSideOperationTimeout, serverDescription, connectionDescription) -> {
+            BsonDocument commandDocument = new BsonDocument("distinct", new BsonString(namespace.getCollectionName()));
+            appendReadConcernToCommand(sessionContext, connectionDescription.getMaxWireVersion(), commandDocument);
+            commandDocument.put("key", new BsonString(fieldName));
+            putIfNotNull(commandDocument, "query", filter);
+            putIfNotZero(commandDocument, "maxTimeMS", clientSideOperationTimeout.getMaxTimeMS());
+            if (collation != null) {
+                commandDocument.put("collation", collation.asDocument());
+            }
+            putIfNotNull(commandDocument, "comment", comment);
+            return commandDocument;
+        };
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/DocumentHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DocumentHelper.java
@@ -59,6 +59,12 @@ final class DocumentHelper {
         }
     }
 
+    static void putIfNotNull(final BsonDocument command, final String key, @Nullable final Boolean value) {
+        if (value != null) {
+            command.put(key, new BsonBoolean(value));
+        }
+    }
+
     static void putIfNotZero(final BsonDocument command, final String key, final int value) {
         if (value != 0) {
             command.put(key, new BsonInt32(value));

--- a/driver-core/src/main/com/mongodb/internal/operation/DropDatabaseOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropDatabaseOperation.java
@@ -17,6 +17,7 @@
 package com.mongodb.internal.operation;
 
 import com.mongodb.WriteConcern;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -43,14 +44,13 @@ import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConce
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class DropDatabaseOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
+    private final ClientSideOperationTimeout clientSideOperationTimeout;
     private final String databaseName;
     private final WriteConcern writeConcern;
 
-    public DropDatabaseOperation(final String databaseName) {
-        this(databaseName, null);
-    }
-
-    public DropDatabaseOperation(final String databaseName, @Nullable final WriteConcern writeConcern) {
+    public DropDatabaseOperation(final ClientSideOperationTimeout clientSideOperationTimeout,
+            final String databaseName, @Nullable final WriteConcern writeConcern) {
+        this.clientSideOperationTimeout = notNull("clientSideOperationTimeout", clientSideOperationTimeout);
         this.databaseName = notNull("databaseName", databaseName);
         this.writeConcern = writeConcern;
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndDeleteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndDeleteOperation.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
 import com.mongodb.connection.ConnectionDescription;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonBoolean;
@@ -29,8 +30,6 @@ import org.bson.FieldNameValidator;
 import org.bson.codecs.Decoder;
 import org.bson.conversions.Bson;
 
-import java.util.concurrent.TimeUnit;
-
 /**
  * An operation that atomically finds and deletes a single document.
  *
@@ -38,9 +37,9 @@ import java.util.concurrent.TimeUnit;
  */
 public class FindAndDeleteOperation<T> extends BaseFindAndModifyOperation<T> {
 
-    public FindAndDeleteOperation(final MongoNamespace namespace, final WriteConcern writeConcern, final boolean retryWrites,
-                                  final Decoder<T> decoder) {
-        super(namespace, writeConcern, retryWrites, decoder);
+    public FindAndDeleteOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final WriteConcern writeConcern, final boolean retryWrites, final Decoder<T> decoder) {
+        super(clientSideOperationTimeout, namespace, writeConcern, retryWrites, decoder);
     }
 
     @Override
@@ -52,12 +51,6 @@ public class FindAndDeleteOperation<T> extends BaseFindAndModifyOperation<T> {
     @Override
     public FindAndDeleteOperation<T> projection(@Nullable final BsonDocument projection) {
         super.projection(projection);
-        return this;
-    }
-
-    @Override
-    public FindAndDeleteOperation<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
-        super.maxTime(maxTime, timeUnit);
         return this;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
 import com.mongodb.connection.ConnectionDescription;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.validator.MappedFieldNameValidator;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.internal.validator.ReplacingDocumentFieldNameValidator;
@@ -33,7 +34,6 @@ import org.bson.conversions.Bson;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.operation.DocumentHelper.putIfTrue;
@@ -49,9 +49,9 @@ public class FindAndReplaceOperation<T> extends BaseFindAndModifyOperation<T> {
     private boolean upsert;
     private Boolean bypassDocumentValidation;
 
-    public FindAndReplaceOperation(final MongoNamespace namespace, final WriteConcern writeConcern, final boolean retryWrites,
-                                   final Decoder<T> decoder, final BsonDocument replacement) {
-        super(namespace, writeConcern, retryWrites, decoder);
+    public FindAndReplaceOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final WriteConcern writeConcern, final boolean retryWrites, final Decoder<T> decoder, final BsonDocument replacement) {
+        super(clientSideOperationTimeout, namespace, writeConcern, retryWrites, decoder);
         this.replacement = notNull("replacement", replacement);
     }
 
@@ -95,12 +95,6 @@ public class FindAndReplaceOperation<T> extends BaseFindAndModifyOperation<T> {
     @Override
     public FindAndReplaceOperation<T> projection(@Nullable final BsonDocument projection) {
         super.projection(projection);
-        return this;
-    }
-
-    @Override
-    public FindAndReplaceOperation<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
-        super.maxTime(maxTime, timeUnit);
         return this;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndUpdateOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndUpdateOperation.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
 import com.mongodb.connection.ConnectionDescription;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.validator.MappedFieldNameValidator;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.internal.validator.UpdateFieldNameValidator;
@@ -35,7 +36,6 @@ import org.bson.conversions.Bson;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
@@ -54,16 +54,16 @@ public class FindAndUpdateOperation<T> extends BaseFindAndModifyOperation<T> {
     private Boolean bypassDocumentValidation;
     private List<BsonDocument> arrayFilters;
 
-    public FindAndUpdateOperation(final MongoNamespace namespace, final WriteConcern writeConcern, final boolean retryWrites,
-                                  final Decoder<T> decoder, final BsonDocument update) {
-        super(namespace, writeConcern, retryWrites, decoder);
+    public FindAndUpdateOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final WriteConcern writeConcern, final boolean retryWrites, final Decoder<T> decoder, final BsonDocument update) {
+        super(clientSideOperationTimeout, namespace, writeConcern, retryWrites, decoder);
         this.update = notNull("update", update);
         this.updatePipeline = null;
     }
 
-    public FindAndUpdateOperation(final MongoNamespace namespace, final WriteConcern writeConcern, final boolean retryWrites,
-                                  final Decoder<T> decoder, final List<BsonDocument> update) {
-        super(namespace, writeConcern, retryWrites, decoder);
+    public FindAndUpdateOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final WriteConcern writeConcern, final boolean retryWrites, final Decoder<T> decoder, final List<BsonDocument> update) {
+        super(clientSideOperationTimeout, namespace, writeConcern, retryWrites, decoder);
         this.updatePipeline = update;
         this.update = null;
     }
@@ -123,12 +123,6 @@ public class FindAndUpdateOperation<T> extends BaseFindAndModifyOperation<T> {
     @Override
     public FindAndUpdateOperation<T> projection(@Nullable final BsonDocument projection) {
         super.projection(projection);
-        return this;
-    }
-
-    @Override
-    public FindAndUpdateOperation<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
-        super.maxTime(maxTime, timeUnit);
         return this;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
@@ -18,6 +18,7 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackSupplier;
@@ -26,15 +27,12 @@ import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.binding.AsyncReadBinding;
 import com.mongodb.internal.binding.ReadBinding;
 import com.mongodb.lang.Nullable;
-import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
-import org.bson.BsonInt64;
 import org.bson.BsonValue;
 import org.bson.codecs.Codec;
 import org.bson.codecs.Decoder;
 
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.notNull;
@@ -50,6 +48,8 @@ import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceE
 import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError;
 import static com.mongodb.internal.operation.CursorHelper.getCursorDocumentFromBatchSize;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
+import static com.mongodb.internal.operation.DocumentHelper.putIfNotZero;
+import static com.mongodb.internal.operation.DocumentHelper.putIfTrue;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.OperationHelper.canRetryRead;
 import static com.mongodb.internal.operation.OperationHelper.createEmptyBatchCursor;
@@ -67,16 +67,18 @@ import static com.mongodb.internal.operation.SyncOperationHelper.withSourceAndCo
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
+    private final ClientSideOperationTimeout clientSideOperationTimeout;
     private final String databaseName;
     private final Decoder<T> decoder;
     private boolean retryReads;
     private BsonDocument filter;
     private int batchSize;
-    private long maxTimeMS;
     private boolean nameOnly;
     private BsonValue comment;
 
-    public ListCollectionsOperation(final String databaseName, final Decoder<T> decoder) {
+    public ListCollectionsOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final String databaseName,
+            final Decoder<T> decoder) {
+        this.clientSideOperationTimeout = notNull("clientSideOperationTimeout", clientSideOperationTimeout);
         this.databaseName = notNull("databaseName", databaseName);
         this.decoder = notNull("decoder", decoder);
     }
@@ -108,17 +110,6 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
         return this;
     }
 
-    public long getMaxTime(final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        return timeUnit.convert(maxTimeMS, TimeUnit.MILLISECONDS);
-    }
-
-    public ListCollectionsOperation<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
-        return this;
-    }
-
     public ListCollectionsOperation<T> retryReads(final boolean retryReads) {
         this.retryReads = retryReads;
         return this;
@@ -145,8 +136,8 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
             withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), binding.getSessionContext()));
                 try {
-                    return createReadCommandAndExecute(retryState, binding, source, databaseName, getCommandCreator(),
-                            createCommandDecoder(), commandTransformer(), connection);
+                    return createReadCommandAndExecute(clientSideOperationTimeout, retryState, binding, source, databaseName,
+                            getCommandCreator(), createCommandDecoder(), commandTransformer(), connection);
                 } catch (MongoCommandException e) {
                     return rethrowIfNotNamespaceError(e, createEmptyBatchCursor(createNamespace(), decoder,
                             source.getServerDescription().getAddress(), batchSize));
@@ -168,8 +159,8 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
                                         binding.getSessionContext()), releasingCallback)) {
                                     return;
                                 }
-                                createReadCommandAndExecuteAsync(retryState, binding, source, databaseName, getCommandCreator(), createCommandDecoder(),
-                                        asyncTransformer(), connection, (result, t) -> {
+                                createReadCommandAndExecuteAsync(clientSideOperationTimeout, retryState, binding, source, databaseName,
+                                        getCommandCreator(), createCommandDecoder(), asyncTransformer(), connection, (result, t) -> {
                                             if (t != null && !isNamespaceError(t)) {
                                                 releasingCallback.onResult(null, t);
                                             } else {
@@ -198,23 +189,15 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
     }
 
     private CommandOperationHelper.CommandCreator getCommandCreator() {
-        return (serverDescription, connectionDescription) -> getCommand();
-    }
-
-    private BsonDocument getCommand() {
-        BsonDocument command = new BsonDocument("listCollections", new BsonInt32(1))
-                .append("cursor", getCursorDocumentFromBatchSize(batchSize == 0 ? null : batchSize));
-        if (filter != null) {
-            command.append("filter", filter);
-        }
-        if (nameOnly) {
-            command.append("nameOnly", BsonBoolean.TRUE);
-        }
-        if (maxTimeMS > 0) {
-            command.put("maxTimeMS", new BsonInt64(maxTimeMS));
-        }
-        putIfNotNull(command, "comment", comment);
-        return command;
+        return (clientSideOperationTimeout, serverDescription, connectionDescription) -> {
+            BsonDocument command = new BsonDocument("listCollections", new BsonInt32(1))
+                    .append("cursor", getCursorDocumentFromBatchSize(batchSize == 0 ? null : batchSize));
+            putIfNotNull(command, "filter", filter);
+            putIfTrue(command, "nameOnly", nameOnly);
+            putIfNotZero(command, "maxTimeMS", clientSideOperationTimeout.getMaxTimeMS());
+            putIfNotNull(command, "comment", comment);
+            return command;
+        };
     }
 
     private Codec<BsonDocument> createCommandDecoder() {

--- a/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
@@ -18,6 +18,7 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackSupplier;
@@ -27,13 +28,11 @@ import com.mongodb.internal.binding.AsyncReadBinding;
 import com.mongodb.internal.binding.ReadBinding;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
-import org.bson.BsonInt64;
 import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.codecs.Codec;
 import org.bson.codecs.Decoder;
 
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.notNull;
@@ -50,6 +49,7 @@ import static com.mongodb.internal.operation.CommandOperationHelper.isNamespaceE
 import static com.mongodb.internal.operation.CommandOperationHelper.rethrowIfNotNamespaceError;
 import static com.mongodb.internal.operation.CursorHelper.getCursorDocumentFromBatchSize;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
+import static com.mongodb.internal.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.OperationHelper.canRetryRead;
 import static com.mongodb.internal.operation.OperationHelper.createEmptyBatchCursor;
@@ -66,14 +66,17 @@ import static com.mongodb.internal.operation.SyncOperationHelper.withSourceAndCo
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
+    private final ClientSideOperationTimeout clientSideOperationTimeout;
     private final MongoNamespace namespace;
     private final Decoder<T> decoder;
     private boolean retryReads;
     private int batchSize;
-    private long maxTimeMS;
+
     private BsonValue comment;
 
-    public ListIndexesOperation(final MongoNamespace namespace, final Decoder<T> decoder) {
+    public ListIndexesOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final Decoder<T> decoder) {
+        this.clientSideOperationTimeout = notNull("clientSideOperationTimeout", clientSideOperationTimeout);
         this.namespace = notNull("namespace", namespace);
         this.decoder = notNull("decoder", decoder);
     }
@@ -84,17 +87,6 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
 
     public ListIndexesOperation<T> batchSize(final int batchSize) {
         this.batchSize = batchSize;
-        return this;
-    }
-
-    public long getMaxTime(final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        return timeUnit.convert(maxTimeMS, TimeUnit.MILLISECONDS);
-    }
-
-    public ListIndexesOperation<T> maxTime(final long maxTime, final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
         return this;
     }
 
@@ -124,8 +116,8 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
             withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), binding.getSessionContext()));
                 try {
-                    return createReadCommandAndExecute(retryState, binding, source, namespace.getDatabaseName(), getCommandCreator(),
-                            createCommandDecoder(), transformer(), connection);
+                    return createReadCommandAndExecute(clientSideOperationTimeout, retryState, binding, source, namespace.getDatabaseName(),
+                            getCommandCreator(), createCommandDecoder(), transformer(), connection);
                 } catch (MongoCommandException e) {
                     return rethrowIfNotNamespaceError(e, createEmptyBatchCursor(namespace, decoder,
                             source.getServerDescription().getAddress(), batchSize));
@@ -147,8 +139,9 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
                                         binding.getSessionContext()), releasingCallback)) {
                                     return;
                                 }
-                                createReadCommandAndExecuteAsync(retryState, binding, source, namespace.getDatabaseName(), getCommandCreator(),
-                                        createCommandDecoder(), asyncTransformer(), connection, (result, t) -> {
+                                createReadCommandAndExecuteAsync(clientSideOperationTimeout, retryState, binding, source,
+                                        namespace.getDatabaseName(), getCommandCreator(), createCommandDecoder(), asyncTransformer(),
+                                        connection, (result, t) -> {
                                             if (t != null && !isNamespaceError(t)) {
                                                 releasingCallback.onResult(null, t);
                                             } else {
@@ -165,17 +158,14 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
     }
 
     private CommandCreator getCommandCreator() {
-        return (serverDescription, connectionDescription) -> getCommand();
-    }
+        return (clientSideOperationTimeout, serverDescription, connectionDescription) -> {
+            BsonDocument command = new BsonDocument("listIndexes", new BsonString(namespace.getCollectionName()))
+                    .append("cursor", getCursorDocumentFromBatchSize(batchSize == 0 ? null : batchSize));
 
-    private BsonDocument getCommand() {
-        BsonDocument command = new BsonDocument("listIndexes", new BsonString(namespace.getCollectionName()))
-                .append("cursor", getCursorDocumentFromBatchSize(batchSize == 0 ? null : batchSize));
-        if (maxTimeMS > 0) {
-            command.put("maxTimeMS", new BsonInt64(maxTimeMS));
-        }
-        putIfNotNull(command, "comment", comment);
-        return command;
+            putIfNotZero(command, "maxTimeMS", clientSideOperationTimeout.getMaxTimeMS());
+            putIfNotNull(command, "comment", comment);
+            return command;
+        };
     }
 
     private CommandReadTransformer<BsonDocument, BatchCursor<T>> transformer() {

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -22,6 +22,7 @@ import com.mongodb.WriteConcern;
 import com.mongodb.assertions.Assertions;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.connection.ConnectionDescription;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackLoop;
 import com.mongodb.internal.async.function.AsyncCallbackRunnable;
@@ -76,6 +77,7 @@ import static com.mongodb.internal.operation.SyncOperationHelper.withSourceAndCo
  */
 public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteResult>, WriteOperation<BulkWriteResult> {
     private static final FieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
+    private final ClientSideOperationTimeout clientSideOperationTimeout;
     private final MongoNamespace namespace;
     private final List<? extends WriteRequest> writeRequests;
     private final boolean ordered;
@@ -85,11 +87,13 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
     private BsonValue comment;
     private BsonDocument variables;
 
-    public MixedBulkWriteOperation(final MongoNamespace namespace, final List<? extends WriteRequest> writeRequests,
-                                   final boolean ordered, final WriteConcern writeConcern, final boolean retryWrites) {
-        this.ordered = ordered;
+    public MixedBulkWriteOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final List<? extends WriteRequest> writeRequests, final boolean ordered, final WriteConcern writeConcern,
+            final boolean retryWrites) {
+        this.clientSideOperationTimeout = notNull("clientSideOperationTimeout", clientSideOperationTimeout);
         this.namespace = notNull("namespace", namespace);
         this.writeRequests = notNull("writes", writeRequests);
+        this.ordered = ordered;
         this.writeConcern = notNull("writeConcern", writeConcern);
         this.retryWrites = retryWrites;
         isTrueArgument("writes is not an empty list", !writeRequests.isEmpty());

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -54,6 +54,7 @@ import com.mongodb.client.model.ValidationOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
+import com.mongodb.internal.ClientSideOperationTimeouts;
 import com.mongodb.internal.bulk.DeleteRequest;
 import com.mongodb.internal.bulk.IndexRequest;
 import com.mongodb.internal.bulk.InsertRequest;
@@ -97,10 +98,12 @@ final class Operations<TDocument> {
     private final WriteConcern writeConcern;
     private final boolean retryWrites;
     private final boolean retryReads;
+    @Nullable
+    private final Long timeoutMS;
 
     Operations(@Nullable final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
             final CodecRegistry codecRegistry, final ReadConcern readConcern, final WriteConcern writeConcern, final boolean retryWrites,
-            final boolean retryReads) {
+            final boolean retryReads, @Nullable final Long timeoutMS) {
         this.namespace = namespace;
         this.documentClass = documentClass;
         this.readPreference = readPreference;
@@ -109,6 +112,7 @@ final class Operations<TDocument> {
         this.writeConcern = writeConcern;
         this.retryWrites = retryWrites;
         this.retryReads = retryReads;
+        this.timeoutMS = timeoutMS;
     }
 
     @Nullable
@@ -144,13 +148,19 @@ final class Operations<TDocument> {
         return retryReads;
     }
 
+    @Nullable
+    public Long getTimeoutMS() {
+        return timeoutMS;
+    }
+
     CountDocumentsOperation countDocuments(final Bson filter, final CountOptions options) {
-        CountDocumentsOperation operation = new CountDocumentsOperation(assertNotNull(namespace))
+
+        CountDocumentsOperation operation = new CountDocumentsOperation(
+                ClientSideOperationTimeouts.create(timeoutMS, options.getMaxTime(MILLISECONDS)),  assertNotNull(namespace))
                 .retryReads(retryReads)
                 .filter(toBsonDocument(filter))
                 .skip(options.getSkip())
                 .limit(options.getLimit())
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                 .collation(options.getCollation())
                 .comment(options.getComment());
         if (options.getHint() != null) {
@@ -162,9 +172,9 @@ final class Operations<TDocument> {
     }
 
     EstimatedDocumentCountOperation estimatedDocumentCount(final EstimatedDocumentCountOptions options) {
-        return new EstimatedDocumentCountOperation(assertNotNull(namespace))
+        return new EstimatedDocumentCountOperation(ClientSideOperationTimeouts.create(timeoutMS, options.getMaxTime(MILLISECONDS)),
+                assertNotNull(namespace))
                 .retryReads(retryReads)
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                 .comment(options.getComment());
     }
 
@@ -185,14 +195,14 @@ final class Operations<TDocument> {
 
     private <TResult> FindOperation<TResult> createFindOperation(final MongoNamespace findNamespace, @Nullable final Bson filter,
                                                                  final Class<TResult> resultClass, final FindOptions options) {
-        FindOperation<TResult> operation = new FindOperation<>(findNamespace, codecRegistry.get(resultClass))
+        FindOperation<TResult> operation = new FindOperation<>(
+                ClientSideOperationTimeouts.create(timeoutMS, options.getMaxTime(MILLISECONDS), options.getMaxAwaitTime(MILLISECONDS)),
+                findNamespace, codecRegistry.get(resultClass))
                 .retryReads(retryReads)
                 .filter(filter == null ? new BsonDocument() : filter.toBsonDocument(documentClass, codecRegistry))
                 .batchSize(options.getBatchSize())
                 .skip(options.getSkip())
                 .limit(options.getLimit())
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                .maxAwaitTime(options.getMaxAwaitTime(MILLISECONDS), MILLISECONDS)
                 .projection(toBsonDocument(options.getProjection()))
                 .sort(toBsonDocument(options.getSort()))
                 .cursorType(options.getCursorType())
@@ -216,29 +226,25 @@ final class Operations<TDocument> {
         return operation;
     }
 
-    <TResult> DistinctOperation<TResult> distinct(final String fieldName, @Nullable final Bson filter,
-                                                         final Class<TResult> resultClass, final long maxTimeMS,
-                                                         final Collation collation, final BsonValue comment) {
-        return new DistinctOperation<>(assertNotNull(namespace), fieldName, codecRegistry.get(resultClass))
+    <TResult> DistinctOperation<TResult> distinct(final String fieldName, @Nullable final Bson filter, final Class<TResult> resultClass,
+            final long maxTimeMS, final Collation collation, final BsonValue comment) {
+        return new DistinctOperation<>(ClientSideOperationTimeouts.create(timeoutMS, maxTimeMS), assertNotNull(namespace),
+                fieldName, codecRegistry.get(resultClass))
                 .retryReads(retryReads)
                 .filter(filter == null ? null : filter.toBsonDocument(documentClass, codecRegistry))
-                .maxTime(maxTimeMS, MILLISECONDS)
                 .collation(collation)
                 .comment(comment);
-
     }
 
     <TResult> AggregateOperation<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,
-                                                    final long maxTimeMS, final long maxAwaitTimeMS, @Nullable final Integer batchSize,
-                                                    final Collation collation, @Nullable final Bson hint, @Nullable final String hintString,
-                                                    final BsonValue comment,
-                                                    final Bson variables, final Boolean allowDiskUse,
-                                                    final AggregationLevel aggregationLevel) {
-        return new AggregateOperation<>(assertNotNull(namespace), assertNotNull(toBsonDocumentList(pipeline)),
-                codecRegistry.get(resultClass), aggregationLevel)
+            final long maxTimeMS, final long maxAwaitTimeMS, @Nullable final Integer batchSize,
+            final Collation collation, @Nullable final Bson hint, @Nullable final String hintString,
+            final BsonValue comment,
+            final Bson variables, final Boolean allowDiskUse,
+            final AggregationLevel aggregationLevel) {
+        return new AggregateOperation<>(ClientSideOperationTimeouts.create(timeoutMS, maxTimeMS, maxAwaitTimeMS), assertNotNull(namespace),
+                assertNotNull(toBsonDocumentList(pipeline)), codecRegistry.get(resultClass), aggregationLevel)
                 .retryReads(retryReads)
-                .maxTime(maxTimeMS, MILLISECONDS)
-                .maxAwaitTime(maxAwaitTimeMS, MILLISECONDS)
                 .allowDiskUse(allowDiskUse)
                 .batchSize(batchSize)
                 .collation(collation)
@@ -251,9 +257,8 @@ final class Operations<TDocument> {
             final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
             final Collation collation, @Nullable final Bson hint, @Nullable final String hintString, final BsonValue comment,
             final Bson variables, final AggregationLevel aggregationLevel) {
-        return new AggregateToCollectionOperation(assertNotNull(namespace), assertNotNull(toBsonDocumentList(pipeline)),
-                readConcern, writeConcern, aggregationLevel)
-                .maxTime(maxTimeMS, MILLISECONDS)
+        return new AggregateToCollectionOperation(ClientSideOperationTimeouts.create(timeoutMS, maxTimeMS), assertNotNull(namespace),
+                assertNotNull(toBsonDocumentList(pipeline)), readConcern, writeConcern, aggregationLevel)
                 .allowDiskUse(allowDiskUse)
                 .bypassDocumentValidation(bypassDocumentValidation)
                 .collation(collation)
@@ -271,11 +276,11 @@ final class Operations<TDocument> {
                                                                 final com.mongodb.client.model.MapReduceAction action,
                                                                 final boolean nonAtomic, final boolean sharded,
                                                                 final Boolean bypassDocumentValidation, final Collation collation) {
-        MapReduceToCollectionOperation operation = new MapReduceToCollectionOperation(assertNotNull(namespace),
-                new BsonJavaScript(mapFunction), new BsonJavaScript(reduceFunction), collectionName, writeConcern)
+        MapReduceToCollectionOperation operation = new MapReduceToCollectionOperation(
+                ClientSideOperationTimeouts.create(timeoutMS, maxTimeMS), assertNotNull(namespace), new BsonJavaScript(mapFunction),
+                new BsonJavaScript(reduceFunction), collectionName, writeConcern)
                 .filter(toBsonDocument(filter))
                 .limit(limit)
-                .maxTime(maxTimeMS, MILLISECONDS)
                 .jsMode(jsMode)
                 .scope(toBsonDocument(scope))
                 .sort(toBsonDocument(sort))
@@ -294,20 +299,15 @@ final class Operations<TDocument> {
     }
 
     <TResult> MapReduceWithInlineResultsOperation<TResult> mapReduce(final String mapFunction, final String reduceFunction,
-                                                                            @Nullable final String finalizeFunction,
-                                                                            final Class<TResult> resultClass,
-                                                                            final Bson filter, final int limit,
-                                                                            final long maxTimeMS, final boolean jsMode, final Bson scope,
-                                                                            final Bson sort, final boolean verbose,
-                                                                            final Collation collation) {
+            @Nullable final String finalizeFunction, final Class<TResult> resultClass, final Bson filter, final int limit,
+            final long maxTimeMS, final boolean jsMode, final Bson scope, final Bson sort, final boolean verbose,
+            final Collation collation) {
         MapReduceWithInlineResultsOperation<TResult> operation =
-                new MapReduceWithInlineResultsOperation<>(assertNotNull(namespace),
-                        new BsonJavaScript(mapFunction),
-                        new BsonJavaScript(reduceFunction),
+                new MapReduceWithInlineResultsOperation<>(ClientSideOperationTimeouts.create(timeoutMS, maxTimeMS),
+                        assertNotNull(namespace), new BsonJavaScript(mapFunction), new BsonJavaScript(reduceFunction),
                         codecRegistry.get(resultClass))
                         .filter(toBsonDocument(filter))
                         .limit(limit)
-                        .maxTime(maxTimeMS, MILLISECONDS)
                         .jsMode(jsMode)
                         .scope(toBsonDocument(scope))
                         .sort(toBsonDocument(sort))
@@ -320,11 +320,11 @@ final class Operations<TDocument> {
     }
 
     FindAndDeleteOperation<TDocument> findOneAndDelete(final Bson filter, final FindOneAndDeleteOptions options) {
-        return new FindAndDeleteOperation<>(assertNotNull(namespace), writeConcern, retryWrites, getCodec())
+        return new FindAndDeleteOperation<>(ClientSideOperationTimeouts.create(timeoutMS, options.getMaxTime(MILLISECONDS)),
+                assertNotNull(namespace), writeConcern, retryWrites, getCodec())
                 .filter(toBsonDocument(filter))
                 .projection(toBsonDocument(options.getProjection()))
                 .sort(toBsonDocument(options.getSort()))
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                 .collation(options.getCollation())
                 .hint(options.getHint())
                 .hintString(options.getHintString())
@@ -334,14 +334,13 @@ final class Operations<TDocument> {
 
     FindAndReplaceOperation<TDocument> findOneAndReplace(final Bson filter, final TDocument replacement,
                                                                 final FindOneAndReplaceOptions options) {
-        return new FindAndReplaceOperation<>(assertNotNull(namespace), writeConcern, retryWrites, getCodec(),
-                documentToBsonDocument(replacement))
+        return new FindAndReplaceOperation<>(ClientSideOperationTimeouts.create(timeoutMS, options.getMaxTime(MILLISECONDS)),
+                assertNotNull(namespace), writeConcern, retryWrites, getCodec(), documentToBsonDocument(replacement))
                 .filter(toBsonDocument(filter))
                 .projection(toBsonDocument(options.getProjection()))
                 .sort(toBsonDocument(options.getSort()))
                 .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
                 .upsert(options.isUpsert())
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                 .bypassDocumentValidation(options.getBypassDocumentValidation())
                 .collation(options.getCollation())
                 .hint(options.getHint())
@@ -351,14 +350,13 @@ final class Operations<TDocument> {
     }
 
     FindAndUpdateOperation<TDocument> findOneAndUpdate(final Bson filter, final Bson update, final FindOneAndUpdateOptions options) {
-        return new FindAndUpdateOperation<>(assertNotNull(namespace), writeConcern, retryWrites, getCodec(),
-                assertNotNull(toBsonDocument(update)))
+        return new FindAndUpdateOperation<>(ClientSideOperationTimeouts.create(timeoutMS, options.getMaxTime(MILLISECONDS)),
+                assertNotNull(namespace), writeConcern, retryWrites, getCodec(), assertNotNull(toBsonDocument(update)))
                 .filter(toBsonDocument(filter))
                 .projection(toBsonDocument(options.getProjection()))
                 .sort(toBsonDocument(options.getSort()))
                 .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
                 .upsert(options.isUpsert())
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                 .bypassDocumentValidation(options.getBypassDocumentValidation())
                 .collation(options.getCollation())
                 .arrayFilters(toBsonDocumentList(options.getArrayFilters()))
@@ -370,14 +368,13 @@ final class Operations<TDocument> {
 
     FindAndUpdateOperation<TDocument> findOneAndUpdate(final Bson filter, final List<? extends Bson> update,
                                                        final FindOneAndUpdateOptions options) {
-        return new FindAndUpdateOperation<>(assertNotNull(namespace), writeConcern, retryWrites, getCodec(),
-                assertNotNull(toBsonDocumentList(update)))
+        return new FindAndUpdateOperation<>(ClientSideOperationTimeouts.create(timeoutMS, options.getMaxTime(MILLISECONDS)),
+                assertNotNull(namespace), writeConcern, retryWrites, getCodec(), assertNotNull(toBsonDocumentList(update)))
                 .filter(toBsonDocument(filter))
                 .projection(toBsonDocument(options.getProjection()))
                 .sort(toBsonDocument(options.getSort()))
                 .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
                 .upsert(options.isUpsert())
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                 .bypassDocumentValidation(options.getBypassDocumentValidation())
                 .collation(options.getCollation())
                 .arrayFilters(toBsonDocumentList(options.getArrayFilters()))
@@ -434,8 +431,7 @@ final class Operations<TDocument> {
                         .comment(options.getComment()).let(options.getLet()));
     }
 
-    MixedBulkWriteOperation insertMany(final List<? extends TDocument> documents,
-                                              final InsertManyOptions options) {
+    MixedBulkWriteOperation insertMany(final List<? extends TDocument> documents, final InsertManyOptions options) {
         notNull("documents", documents);
         List<InsertRequest> requests = new ArrayList<>(documents.size());
         for (TDocument document : documents) {
@@ -448,13 +444,14 @@ final class Operations<TDocument> {
             requests.add(new InsertRequest(documentToBsonDocument(document)));
         }
 
-        return new MixedBulkWriteOperation(assertNotNull(namespace), requests, options.isOrdered(), writeConcern, retryWrites)
-                .bypassDocumentValidation(options.getBypassDocumentValidation()).comment(options.getComment());
+        return new MixedBulkWriteOperation(ClientSideOperationTimeouts.create(timeoutMS), assertNotNull(namespace),
+                requests, options.isOrdered(), writeConcern, retryWrites)
+                .bypassDocumentValidation(options.getBypassDocumentValidation())
+                .comment(options.getComment());
     }
 
     @SuppressWarnings("unchecked")
-    MixedBulkWriteOperation bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests,
-                                             final BulkWriteOptions options) {
+    MixedBulkWriteOperation bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests, final BulkWriteOptions options) {
         notNull("requests", requests);
         List<WriteRequest> writeRequests = new ArrayList<>(requests.size());
         for (WriteModel<? extends TDocument> writeModel : requests) {
@@ -469,9 +466,8 @@ final class Operations<TDocument> {
                 writeRequest = new InsertRequest(documentToBsonDocument(document));
             } else if (writeModel instanceof ReplaceOneModel) {
                 ReplaceOneModel<TDocument> replaceOneModel = (ReplaceOneModel<TDocument>) writeModel;
-                writeRequest = new UpdateRequest(assertNotNull(toBsonDocument(replaceOneModel.getFilter())), documentToBsonDocument(replaceOneModel
-                        .getReplacement()),
-                        WriteRequest.Type.REPLACE)
+                writeRequest = new UpdateRequest(assertNotNull(toBsonDocument(replaceOneModel.getFilter())),
+                        documentToBsonDocument(replaceOneModel.getReplacement()), WriteRequest.Type.REPLACE)
                         .upsert(replaceOneModel.getReplaceOptions().isUpsert())
                         .collation(replaceOneModel.getReplaceOptions().getCollation())
                         .hint(replaceOneModel.getReplaceOptions().getHint())
@@ -516,7 +512,8 @@ final class Operations<TDocument> {
             writeRequests.add(writeRequest);
         }
 
-        return new MixedBulkWriteOperation(assertNotNull(namespace), writeRequests, options.isOrdered(), writeConcern, retryWrites)
+        return new MixedBulkWriteOperation(ClientSideOperationTimeouts.create(timeoutMS), assertNotNull(namespace), writeRequests,
+                options.isOrdered(), writeConcern, retryWrites)
                 .bypassDocumentValidation(options.getBypassDocumentValidation())
                 .comment(options.getComment())
                 .let(toBsonDocument(options.getLet()));
@@ -525,20 +522,20 @@ final class Operations<TDocument> {
     <TResult> CommandReadOperation<TResult> commandRead(final Bson command, final Class<TResult> resultClass) {
         notNull("command", command);
         notNull("resultClass", resultClass);
-        return new CommandReadOperation<>(assertNotNull(namespace).getDatabaseName(), assertNotNull(toBsonDocument(command)),
-                codecRegistry.get(resultClass));
+        return new CommandReadOperation<>(ClientSideOperationTimeouts.create(timeoutMS), assertNotNull(namespace).getDatabaseName(),
+                                          assertNotNull(toBsonDocument(command)), codecRegistry.get(resultClass));
     }
 
 
     DropDatabaseOperation dropDatabase() {
-        return new DropDatabaseOperation(assertNotNull(namespace).getDatabaseName(), getWriteConcern());
+        return new DropDatabaseOperation(ClientSideOperationTimeouts.create(timeoutMS), assertNotNull(namespace).getDatabaseName(),
+                getWriteConcern());
     }
-
 
     CreateCollectionOperation createCollection(final String collectionName, final CreateCollectionOptions createCollectionOptions,
             @Nullable final AutoEncryptionSettings autoEncryptionSettings) {
-        CreateCollectionOperation operation = new CreateCollectionOperation(assertNotNull(namespace).getDatabaseName(),
-                collectionName, writeConcern)
+        CreateCollectionOperation operation = new CreateCollectionOperation(ClientSideOperationTimeouts.create(timeoutMS),
+                assertNotNull(namespace).getDatabaseName(), collectionName, writeConcern)
                 .collation(createCollectionOptions.getCollation())
                 .capped(createCollectionOptions.isCapped())
                 .sizeInBytes(createCollectionOptions.getSizeInBytes())
@@ -580,7 +577,8 @@ final class Operations<TDocument> {
     DropCollectionOperation dropCollection(
             final DropCollectionOptions dropCollectionOptions,
             @Nullable final AutoEncryptionSettings autoEncryptionSettings) {
-        DropCollectionOperation operation = new DropCollectionOperation(assertNotNull(namespace), writeConcern);
+        DropCollectionOperation operation = new DropCollectionOperation(ClientSideOperationTimeouts.create(timeoutMS),
+                assertNotNull(namespace), writeConcern);
         Bson encryptedFields = dropCollectionOptions.getEncryptedFields();
         if (encryptedFields != null) {
             operation.encryptedFields(assertNotNull(toBsonDocument(encryptedFields)));
@@ -597,16 +595,16 @@ final class Operations<TDocument> {
 
     RenameCollectionOperation renameCollection(final MongoNamespace newCollectionNamespace,
                                                       final RenameCollectionOptions renameCollectionOptions) {
-        return new RenameCollectionOperation(assertNotNull(namespace), newCollectionNamespace, writeConcern)
-                .dropTarget(renameCollectionOptions.isDropTarget());
+        return new RenameCollectionOperation(ClientSideOperationTimeouts.create(timeoutMS), assertNotNull(namespace),
+                newCollectionNamespace, writeConcern).dropTarget(renameCollectionOptions.isDropTarget());
     }
 
     CreateViewOperation createView(final String viewName, final String viewOn, final List<? extends Bson> pipeline,
             final CreateViewOptions createViewOptions) {
         notNull("options", createViewOptions);
         notNull("pipeline", pipeline);
-        return new CreateViewOperation(assertNotNull(namespace).getDatabaseName(), viewName, viewOn,
-                assertNotNull(toBsonDocumentList(pipeline)), writeConcern).collation(createViewOptions.getCollation());
+        return new CreateViewOperation(ClientSideOperationTimeouts.create(timeoutMS), assertNotNull(namespace).getDatabaseName(), viewName,
+                viewOn, assertNotNull(toBsonDocumentList(pipeline)), writeConcern).collation(createViewOptions.getCollation());
     }
 
     @SuppressWarnings("deprecation")
@@ -641,8 +639,8 @@ final class Operations<TDocument> {
                     .hidden(model.getOptions().isHidden())
             );
         }
-        return new CreateIndexesOperation(assertNotNull(namespace), indexRequests, writeConcern)
-                .maxTime(createIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS)
+        return new CreateIndexesOperation(ClientSideOperationTimeouts.create(timeoutMS, createIndexOptions.getMaxTime(MILLISECONDS)),
+                assertNotNull(namespace), indexRequests, writeConcern)
                 .commitQuorum(createIndexOptions.getCommitQuorum());
     }
 
@@ -668,46 +666,41 @@ final class Operations<TDocument> {
     }
 
 
-    <TResult> ListSearchIndexesOperation<TResult> listSearchIndexes(final Class<TResult> resultClass,
-                                                                                      final long maxTimeMS,
-                                                                                      @Nullable final String indexName,
-                                                                                      @Nullable final Integer batchSize,
-                                                                                      @Nullable final Collation collation,
-                                                                                      @Nullable final BsonValue comment,
-                                                                                      @Nullable final Boolean allowDiskUse) {
+    <TResult> ListSearchIndexesOperation<TResult> listSearchIndexes(final Class<TResult> resultClass, final long maxTimeMS,
+            @Nullable final String indexName, @Nullable final Integer batchSize, @Nullable final Collation collation,
+            @Nullable final BsonValue comment, @Nullable final Boolean allowDiskUse) {
 
-
-        return new ListSearchIndexesOperation<>(assertNotNull(namespace), codecRegistry.get(resultClass), maxTimeMS,
-                indexName, batchSize, collation, comment, allowDiskUse, retryReads);
+        return new ListSearchIndexesOperation<>(ClientSideOperationTimeouts.create(timeoutMS, maxTimeMS), assertNotNull(namespace),
+                codecRegistry.get(resultClass), indexName, batchSize, collation, comment, allowDiskUse, retryReads);
     }
 
     DropIndexOperation dropIndex(final String indexName, final DropIndexOptions dropIndexOptions) {
-        return new DropIndexOperation(assertNotNull(namespace), indexName, writeConcern)
-                .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
+        return new DropIndexOperation(ClientSideOperationTimeouts.create(timeoutMS, dropIndexOptions.getMaxTime(MILLISECONDS)),
+                assertNotNull(namespace), indexName, writeConcern);
     }
 
     DropIndexOperation dropIndex(final Bson keys, final DropIndexOptions dropIndexOptions) {
-        return new DropIndexOperation(assertNotNull(namespace), keys.toBsonDocument(BsonDocument.class, codecRegistry), writeConcern)
-                .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
+        return new DropIndexOperation(ClientSideOperationTimeouts.create(timeoutMS, dropIndexOptions.getMaxTime(MILLISECONDS)),
+                assertNotNull(namespace), keys.toBsonDocument(BsonDocument.class, codecRegistry), writeConcern);
     }
 
     <TResult> ListCollectionsOperation<TResult> listCollections(final String databaseName, final Class<TResult> resultClass,
                                                                 final Bson filter, final boolean collectionNamesOnly,
                                                                 @Nullable final Integer batchSize, final long maxTimeMS,
                                                                 final BsonValue comment) {
-        return new ListCollectionsOperation<>(databaseName, codecRegistry.get(resultClass))
+        return new ListCollectionsOperation<>(ClientSideOperationTimeouts.create(timeoutMS, maxTimeMS), databaseName,
+                codecRegistry.get(resultClass))
                 .retryReads(retryReads)
                 .filter(toBsonDocument(filter))
                 .nameOnly(collectionNamesOnly)
                 .batchSize(batchSize == null ? 0 : batchSize)
-                .maxTime(maxTimeMS, MILLISECONDS)
                 .comment(comment);
     }
 
     <TResult> ListDatabasesOperation<TResult> listDatabases(final Class<TResult> resultClass, final Bson filter,
                                                             final Boolean nameOnly, final long maxTimeMS,
                                                             final Boolean authorizedDatabasesOnly, final BsonValue comment) {
-        return new ListDatabasesOperation<>(codecRegistry.get(resultClass)).maxTime(maxTimeMS, MILLISECONDS)
+        return new ListDatabasesOperation<>(ClientSideOperationTimeouts.create(timeoutMS, maxTimeMS), codecRegistry.get(resultClass))
                 .retryReads(retryReads)
                 .filter(toBsonDocument(filter))
                 .nameOnly(nameOnly)
@@ -717,10 +710,10 @@ final class Operations<TDocument> {
 
     <TResult> ListIndexesOperation<TResult> listIndexes(final Class<TResult> resultClass, @Nullable final Integer batchSize,
                                                                final long maxTimeMS, final BsonValue comment) {
-        return new ListIndexesOperation<>(assertNotNull(namespace), codecRegistry.get(resultClass))
+        return new ListIndexesOperation<>(ClientSideOperationTimeouts.create(timeoutMS, maxTimeMS), assertNotNull(namespace),
+                codecRegistry.get(resultClass))
                 .retryReads(retryReads)
                 .batchSize(batchSize == null ? 0 : batchSize)
-                .maxTime(maxTimeMS, MILLISECONDS)
                 .comment(comment);
     }
 
@@ -729,12 +722,14 @@ final class Operations<TDocument> {
             final Decoder<TResult> decoder, final ChangeStreamLevel changeStreamLevel, @Nullable final Integer batchSize,
             final Collation collation, final BsonValue comment, final long maxAwaitTimeMS, final BsonDocument resumeToken,
             final BsonTimestamp startAtOperationTime, final BsonDocument startAfter, final boolean showExpandedEvents) {
-        return new ChangeStreamOperation<>(assertNotNull(namespace), fullDocument, fullDocumentBeforeChange,
+        return new ChangeStreamOperation<>(ClientSideOperationTimeouts.create(timeoutMS, 0, maxAwaitTimeMS),
+                assertNotNull(namespace),
+                fullDocument,
+                fullDocumentBeforeChange,
                 assertNotNull(toBsonDocumentList(pipeline)), decoder, changeStreamLevel)
                 .batchSize(batchSize)
                 .collation(collation)
                 .comment(comment)
-                .maxAwaitTime(maxAwaitTimeMS, MILLISECONDS)
                 .resumeAfter(resumeToken)
                 .startAtOperationTime(startAtOperationTime)
                 .startAfter(startAfter)

--- a/driver-core/src/main/com/mongodb/internal/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/QueryBatchCursor.java
@@ -59,9 +59,9 @@ import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.operation.CursorHelper.getNumberToReturn;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
-import static com.mongodb.internal.operation.SyncOperationHelper.getMoreCursorDocumentToQueryResult;
 import static com.mongodb.internal.operation.QueryHelper.translateCommandException;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionFourDotFour;
+import static com.mongodb.internal.operation.SyncOperationHelper.getMoreCursorDocumentToQueryResult;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 

--- a/driver-core/src/main/com/mongodb/internal/operation/RenameCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/RenameCollectionOperation.java
@@ -18,6 +18,7 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -48,17 +49,15 @@ import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConce
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class RenameCollectionOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
+    private final ClientSideOperationTimeout clientSideOperationTimeout;
     private final MongoNamespace originalNamespace;
     private final MongoNamespace newNamespace;
     private final WriteConcern writeConcern;
     private boolean dropTarget;
 
-    public RenameCollectionOperation(final MongoNamespace originalNamespace, final MongoNamespace newNamespace) {
-        this(originalNamespace, newNamespace, null);
-    }
-
-    public RenameCollectionOperation(final MongoNamespace originalNamespace, final MongoNamespace newNamespace,
-                                     @Nullable final WriteConcern writeConcern) {
+    public RenameCollectionOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace originalNamespace,
+            final MongoNamespace newNamespace, @Nullable final WriteConcern writeConcern) {
+        this.clientSideOperationTimeout = notNull("clientSideOperationTimeout", clientSideOperationTimeout);
         this.originalNamespace = notNull("originalNamespace", originalNamespace);
         this.newNamespace = notNull("newNamespace", newNamespace);
         this.writeConcern = writeConcern;

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
@@ -19,6 +19,7 @@ package com.mongodb.internal.operation;
 import com.mongodb.MongoException;
 import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackBiFunction;
@@ -167,16 +168,19 @@ final class SyncOperationHelper {
     }
 
     static <D, T> T executeRetryableRead(
+            final ClientSideOperationTimeout clientSideOperationTimeout,
             final ReadBinding binding,
             final String database,
             final CommandCreator commandCreator,
             final Decoder<D> decoder,
             final CommandReadTransformer<D, T> transformer,
             final boolean retryReads) {
-        return executeRetryableRead(binding, binding::getReadConnectionSource, database, commandCreator, decoder, transformer, retryReads);
+        return executeRetryableRead(clientSideOperationTimeout, binding, binding::getReadConnectionSource, database, commandCreator,
+                decoder, transformer, retryReads);
     }
 
     static <D, T> T executeRetryableRead(
+            final ClientSideOperationTimeout clientSideOperationTimeout,
             final ReadBinding binding,
             final Supplier<ConnectionSource> readConnectionSourceSupplier,
             final String database,
@@ -188,7 +192,8 @@ final class SyncOperationHelper {
         Supplier<T> read = decorateReadWithRetries(retryState, binding.getOperationContext(), () ->
                 withSourceAndConnection(readConnectionSourceSupplier, false, (source, connection) -> {
                     retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(source.getServerDescription(), binding.getSessionContext()));
-                    return createReadCommandAndExecute(retryState, binding, source, database, commandCreator, decoder, transformer, connection);
+                    return createReadCommandAndExecute(clientSideOperationTimeout, retryState, binding, source, database,
+                            commandCreator, decoder, transformer, connection);
                 })
         );
         return read.get();
@@ -212,6 +217,7 @@ final class SyncOperationHelper {
     }
 
     static <T, R> R executeRetryableWrite(
+            final ClientSideOperationTimeout clientSideOperationTimeout,
             final WriteBinding binding,
             final String database,
             @Nullable final ReadPreference readPreference,
@@ -234,7 +240,7 @@ final class SyncOperationHelper {
                             .map(previousAttemptCommand -> {
                                 assertFalse(firstAttempt);
                                 return retryCommandModifier.apply(previousAttemptCommand);
-                            }).orElseGet(() -> commandCreator.create(source.getServerDescription(), connection.getDescription()));
+                            }).orElseGet(() -> commandCreator.create(clientSideOperationTimeout, source.getServerDescription(), connection.getDescription()));
                     // attach `maxWireVersion`, `retryableCommandFlag` ASAP because they are used to check whether we should retry
                     retryState.attach(AttachmentKeys.maxWireVersion(), maxWireVersion, true)
                             .attach(AttachmentKeys.retryableCommandFlag(), CommandOperationHelper.isRetryWritesEnabled(command), true)
@@ -260,6 +266,7 @@ final class SyncOperationHelper {
 
     @Nullable
     static <D, T> T createReadCommandAndExecute(
+            final ClientSideOperationTimeout clientSideOperationTimeout,
             final RetryState retryState,
             final ReadBinding binding,
             final ConnectionSource source,
@@ -268,7 +275,7 @@ final class SyncOperationHelper {
             final Decoder<D> decoder,
             final CommandReadTransformer<D, T> transformer,
             final Connection connection) {
-        BsonDocument command = commandCreator.create(source.getServerDescription(), connection.getDescription());
+        BsonDocument command = commandCreator.create(clientSideOperationTimeout, source.getServerDescription(), connection.getDescription());
         retryState.attach(AttachmentKeys.commandDescriptionSupplier(), command::getFirstKey, false);
         return transformer.apply(assertNotNull(connection.command(database, command, new NoOpFieldNameValidator(),
                 source.getReadPreference(), decoder, binding)), source, connection);

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -65,20 +65,20 @@ public final class SyncOperations<TDocument> {
     private final Operations<TDocument> operations;
 
     public SyncOperations(final Class<TDocument> documentClass, final ReadPreference readPreference,
-                          final CodecRegistry codecRegistry, final boolean retryReads) {
-        this(null, documentClass, readPreference, codecRegistry, ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED, true, retryReads);
+                          final CodecRegistry codecRegistry, final boolean retryReads, @Nullable final Long timeoutMS) {
+        this(null, documentClass, readPreference, codecRegistry, ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED, true, retryReads, timeoutMS);
     }
 
     public SyncOperations(final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
-                          final CodecRegistry codecRegistry, final boolean retryReads) {
-        this(namespace, documentClass, readPreference, codecRegistry, ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED, true, retryReads);
+                          final CodecRegistry codecRegistry, final boolean retryReads, @Nullable final Long timeoutMS) {
+        this(namespace, documentClass, readPreference, codecRegistry, ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED, true, retryReads, timeoutMS);
     }
 
     public SyncOperations(@Nullable final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
                           final CodecRegistry codecRegistry, final ReadConcern readConcern, final WriteConcern writeConcern,
-                          final boolean retryWrites, final boolean retryReads) {
+                          final boolean retryWrites, final boolean retryReads, @Nullable final Long timeoutMS) {
         this.operations = new Operations<>(namespace, documentClass, readPreference, codecRegistry, readConcern, writeConcern,
-                retryWrites, retryReads);
+                retryWrites, retryReads, timeoutMS);
     }
 
     public ReadOperation<Long> countDocuments(final Bson filter, final CountOptions options) {
@@ -111,22 +111,16 @@ public final class SyncOperations<TDocument> {
     }
 
     public <TResult> ExplainableReadOperation<BatchCursor<TResult>> aggregate(final List<? extends Bson> pipeline,
-                                                                              final Class<TResult> resultClass,
-                                                                              final long maxTimeMS, final long maxAwaitTimeMS,
-                                                                              @Nullable final Integer batchSize,
-                                                                              final Collation collation, final Bson hint,
-                                                                              final String hintString,
-                                                                              final BsonValue comment,
-                                                                              final Bson variables,
-                                                                              final Boolean allowDiskUse,
-                                                                              final AggregationLevel aggregationLevel) {
+            final Class<TResult> resultClass, final long maxTimeMS, final long maxAwaitTimeMS, @Nullable final Integer batchSize,
+            final Collation collation, final Bson hint, final String hintString, final BsonValue comment, final Bson variables,
+            final Boolean allowDiskUse, final AggregationLevel aggregationLevel) {
         return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, batchSize, collation, hint, hintString, comment,
                 variables, allowDiskUse, aggregationLevel);
     }
 
-    public ReadOperation<Void> aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
+    public AggregateToCollectionOperation aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
             final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
-            final Collation collation, final Bson hint, final String hintString, final BsonValue comment,
+            final Collation collation, @Nullable final Bson hint, @Nullable final String hintString, final BsonValue comment,
             final Bson variables, final AggregationLevel aggregationLevel) {
         return operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation, hint, hintString,
                 comment, variables, aggregationLevel);
@@ -225,7 +219,6 @@ public final class SyncOperations<TDocument> {
     public WriteOperation<Void> dropDatabase() {
         return operations.dropDatabase();
     }
-
 
     public WriteOperation<Void> createCollection(final String collectionName, final CreateCollectionOptions createCollectionOptions,
             @Nullable final AutoEncryptionSettings autoEncryptionSettings) {

--- a/driver-core/src/main/com/mongodb/internal/operation/TransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/TransactionOperation.java
@@ -18,6 +18,7 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.Function;
 import com.mongodb.WriteConcern;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -42,9 +43,11 @@ import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErr
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public abstract class TransactionOperation implements WriteOperation<Void>, AsyncWriteOperation<Void> {
+    private final ClientSideOperationTimeout clientSideOperationTimeout;
     private final WriteConcern writeConcern;
 
-    TransactionOperation(final WriteConcern writeConcern) {
+    TransactionOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final WriteConcern writeConcern) {
+        this.clientSideOperationTimeout = notNull("clientSideOperationTimeout", clientSideOperationTimeout);
         this.writeConcern = notNull("writeConcern", writeConcern);
     }
 
@@ -55,20 +58,20 @@ public abstract class TransactionOperation implements WriteOperation<Void>, Asyn
     @Override
     public Void execute(final WriteBinding binding) {
         isTrue("in transaction", binding.getSessionContext().hasActiveTransaction());
-        return executeRetryableWrite(binding, "admin", null, new NoOpFieldNameValidator(),
+        return executeRetryableWrite(clientSideOperationTimeout, binding, "admin", null, new NoOpFieldNameValidator(),
                 new BsonDocumentCodec(), getCommandCreator(), writeConcernErrorTransformer(), getRetryCommandModifier());
     }
 
     @Override
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
         isTrue("in transaction", binding.getSessionContext().hasActiveTransaction());
-        executeRetryableWriteAsync(binding, "admin", null, new NoOpFieldNameValidator(),
+        executeRetryableWriteAsync(clientSideOperationTimeout, binding, "admin", null, new NoOpFieldNameValidator(),
                 new BsonDocumentCodec(), getCommandCreator(), writeConcernErrorTransformerAsync(), getRetryCommandModifier(),
                 errorHandlingCallback(callback, LOGGER));
     }
 
     CommandCreator getCommandCreator() {
-        return (serverDescription, connectionDescription) -> {
+        return (clientSideOperationTimeout, serverDescription, connectionDescription) -> {
             BsonDocument command = new BsonDocument(getCommandName(), new BsonInt32(1));
             if (!writeConcern.isServerDefault()) {
                 command.put("writeConcern", writeConcern.asDocument());

--- a/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
@@ -64,6 +64,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.TIMEOUT
 import static com.mongodb.ClusterFixture.checkReferenceCountReachesTarget
 import static com.mongodb.ClusterFixture.executeAsync
@@ -109,13 +110,14 @@ class OperationFunctionalSpecification extends Specification {
     }
 
     void acknowledgeWrite(final SingleConnectionBinding binding) {
-        new MixedBulkWriteOperation(getNamespace(), [new InsertRequest(new BsonDocument())], true, ACKNOWLEDGED, false).execute(binding)
+        new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), [new InsertRequest(new BsonDocument())], true,
+                ACKNOWLEDGED, false).execute(binding)
         binding.release()
     }
 
     void acknowledgeWrite(final AsyncSingleConnectionBinding binding) {
-        executeAsync(new MixedBulkWriteOperation(getNamespace(), [new InsertRequest(new BsonDocument())], true, ACKNOWLEDGED, false),
-                binding)
+        executeAsync(new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), [new InsertRequest(new BsonDocument())],
+                true, ACKNOWLEDGED, false), binding)
         binding.release()
     }
 

--- a/driver-core/src/test/functional/com/mongodb/connection/ConnectionSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/ConnectionSpecification.groovy
@@ -23,6 +23,7 @@ import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.codecs.BsonDocumentCodec
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.LEGACY_HELLO
 import static com.mongodb.connection.ConnectionDescription.getDefaultMaxMessageSize
@@ -65,7 +66,7 @@ class ConnectionSpecification extends OperationFunctionalSpecification {
         source?.release()
     }
    private static BsonDocument getHelloResult() {
-        new CommandReadOperation<BsonDocument>('admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)),
-                                               new BsonDocumentCodec()).execute(getBinding())
+        new CommandReadOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), 'admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)),
+                new BsonDocumentCodec()).execute(getBinding())
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/ScramSha256AuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/ScramSha256AuthenticationSpecification.groovy
@@ -35,6 +35,7 @@ import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.createAsyncCluster
 import static com.mongodb.ClusterFixture.createCluster
 import static com.mongodb.ClusterFixture.getBinding
@@ -88,14 +89,14 @@ class ScramSha256AuthenticationSpecification extends Specification {
                 .append('pwd', password)
                 .append('roles', ['root'])
                 .append('mechanisms', mechanisms)
-        new CommandReadOperation<>('admin',
+        new CommandReadOperation<>(CSOT_NO_TIMEOUT.get(), 'admin',
                 new BsonDocumentWrapper<Document>(createUserCommand, new DocumentCodec()), new DocumentCodec())
                 .execute(getBinding())
     }
 
     def dropUser(final String userName) {
-        new CommandReadOperation<>('admin', new BsonDocument('dropUser', new BsonString(userName)),
-            new BsonDocumentCodec()).execute(getBinding())
+        new CommandReadOperation<>(CSOT_NO_TIMEOUT.get(), 'admin', new BsonDocument('dropUser', new BsonString(userName)),
+                new BsonDocumentCodec()).execute(getBinding())
     }
 
     def 'test authentication and authorization'() {
@@ -103,7 +104,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         def cluster = createCluster(credential)
 
         when:
-        new CommandReadOperation<Document>('admin',
+        new CommandReadOperation<Document>(CSOT_NO_TIMEOUT.get(), 'admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
                 .execute(new ClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, getServerApi(),
                         IgnorableRequestContext.INSTANCE))
@@ -125,7 +126,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
 
         when:
         // make this synchronous
-        new CommandReadOperation<Document>('admin',
+        new CommandReadOperation<Document>(CSOT_NO_TIMEOUT.get(), 'admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
                 .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, getServerApi(),
                         IgnorableRequestContext.INSTANCE),
@@ -147,7 +148,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         def cluster = createCluster(credential)
 
         when:
-        new CommandReadOperation<Document>('admin',
+        new CommandReadOperation<Document>(CSOT_NO_TIMEOUT.get(), 'admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
                 .execute(new ClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, getServerApi(),
                         IgnorableRequestContext.INSTANCE))
@@ -168,7 +169,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         def callback = new FutureResultCallback()
 
         when:
-        new CommandReadOperation<Document>('admin',
+        new CommandReadOperation<Document>(CSOT_NO_TIMEOUT.get(), 'admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
                 .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, getServerApi(),
                         IgnorableRequestContext.INSTANCE), callback)
@@ -189,7 +190,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         def cluster = createCluster(credential)
 
         when:
-        new CommandReadOperation<Document>('admin',
+        new CommandReadOperation<Document>(CSOT_NO_TIMEOUT.get(), 'admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
                 .execute(new ClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, getServerApi(),
                         IgnorableRequestContext.INSTANCE))
@@ -210,7 +211,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         def callback = new FutureResultCallback()
 
         when:
-        new CommandReadOperation<Document>('admin',
+        new CommandReadOperation<Document>(CSOT_NO_TIMEOUT.get(), 'admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
                 .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, getServerApi(),
                         IgnorableRequestContext.INSTANCE), callback)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AbortTransactionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AbortTransactionOperationSpecification.groovy
@@ -21,6 +21,7 @@ import org.bson.BsonDocument
 
 import java.util.concurrent.TimeUnit
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.MAJORITY
 
@@ -33,13 +34,13 @@ class AbortTransactionOperationSpecification extends OperationFunctionalSpecific
         def expectedCommand = BsonDocument.parse('{abortTransaction: 1}')
 
         when:
-        def operation = new AbortTransactionOperation(ACKNOWLEDGED)
+        def operation = new AbortTransactionOperation(CSOT_NO_TIMEOUT.get(), ACKNOWLEDGED)
 
         then:
         testOperationInTransaction(operation, [4, 0, 0], expectedCommand, async, cannedResult)
 
         when:
-        operation = new AbortTransactionOperation(MAJORITY)
+        operation = new AbortTransactionOperation(CSOT_NO_TIMEOUT.get(), MAJORITY)
         expectedCommand.put('writeConcern', MAJORITY.asDocument())
 
         then:
@@ -56,14 +57,14 @@ class AbortTransactionOperationSpecification extends OperationFunctionalSpecific
 
         when:
         def writeConcern = MAJORITY.withWTimeout(10, TimeUnit.MILLISECONDS)
-        def operation = new AbortTransactionOperation(writeConcern)
+        def operation = new AbortTransactionOperation(CSOT_NO_TIMEOUT.get(), writeConcern)
 
         then:
         testOperationRetries(operation, [4, 0, 0], expectedCommand, async, cannedResult, true)
 
         when:
         writeConcern = MAJORITY
-        operation = new AbortTransactionOperation(writeConcern)
+        operation = new AbortTransactionOperation(CSOT_NO_TIMEOUT.get(), writeConcern)
         expectedCommand.put('writeConcern', writeConcern.asDocument())
 
         then:
@@ -71,7 +72,7 @@ class AbortTransactionOperationSpecification extends OperationFunctionalSpecific
 
         when:
         writeConcern = ACKNOWLEDGED
-        operation = new AbortTransactionOperation(writeConcern)
+        operation = new AbortTransactionOperation(CSOT_NO_TIMEOUT.get(), writeConcern)
         expectedCommand.remove('writeConcern')
 
         then:

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationProseTestSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationProseTestSpecification.groovy
@@ -33,6 +33,7 @@ import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.getAsyncCluster
 import static com.mongodb.ClusterFixture.getCluster
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
@@ -53,7 +54,7 @@ class ChangeStreamOperationProseTestSpecification extends OperationFunctionalSpe
         given:
         def helper = getHelper()
         def pipeline = [BsonDocument.parse('{$project: {"_id": 0}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
@@ -90,7 +91,7 @@ class ChangeStreamOperationProseTestSpecification extends OperationFunctionalSpe
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
         def failPointDocument = createFailPointDocument('getMore', 10107)
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         def cursor = execute(operation, async)
@@ -123,7 +124,7 @@ class ChangeStreamOperationProseTestSpecification extends OperationFunctionalSpe
     def 'should not resume for aggregation errors'() {
         given:
         def pipeline = [BsonDocument.parse('{$unsupportedStage: {_id: 0}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
@@ -52,6 +52,7 @@ import org.bson.codecs.DocumentCodec
 import org.bson.codecs.ValueCodecProvider
 import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.getAsyncCluster
 import static com.mongodb.ClusterFixture.getCluster
 import static com.mongodb.ClusterFixture.isStandalone
@@ -60,7 +61,6 @@ import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.client.model.changestream.ChangeStreamDocument.createCodec
 import static com.mongodb.internal.connection.ServerHelper.waitForLastRelease
 import static com.mongodb.internal.operation.OperationUnitSpecification.getMaxWireVersionForServerVersion
-import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders
 
 @IgnoreIf({ !(serverVersionAtLeast(3, 6) && !isStandalone()) })
@@ -68,32 +68,29 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
     def 'should have the correct defaults'() {
         when:
-        ChangeStreamOperation operation = new ChangeStreamOperation<Document>(getNamespace(), FullDocument.DEFAULT,
+        ChangeStreamOperation operation = new ChangeStreamOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, [], new DocumentCodec())
 
         then:
         operation.getBatchSize() == null
         operation.getCollation() == null
         operation.getFullDocument() == FullDocument.DEFAULT
-        operation.getMaxAwaitTime(MILLISECONDS) == 0
         operation.getPipeline() == []
         operation.getStartAtOperationTime() == null
     }
 
     def 'should set optional values correctly'() {
         when:
-        ChangeStreamOperation operation = new ChangeStreamOperation<Document>(getNamespace(), FullDocument.UPDATE_LOOKUP,
-                FullDocumentBeforeChange.DEFAULT, [], new DocumentCodec())
+        ChangeStreamOperation operation = new ChangeStreamOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                FullDocument.UPDATE_LOOKUP, FullDocumentBeforeChange.DEFAULT, [], new DocumentCodec())
                 .batchSize(5)
                 .collation(defaultCollation)
-                .maxAwaitTime(15, MILLISECONDS)
                 .startAtOperationTime(new BsonTimestamp(99))
 
         then:
         operation.getBatchSize() == 5
         operation.getCollation() == defaultCollation
         operation.getFullDocument() == FullDocument.UPDATE_LOOKUP
-        operation.getMaxAwaitTime(MILLISECONDS) == 15
         operation.getStartAtOperationTime() == new BsonTimestamp(99)
     }
 
@@ -114,11 +111,10 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
                 .append('cursor', new BsonDocument('id', new BsonInt64(0)).append('ns', new BsonString('db.coll'))
                 .append('firstBatch', new BsonArrayWrapper([])))
 
-        def operation = new ChangeStreamOperation<Document>(namespace, FullDocument.DEFAULT,
-                FullDocumentBeforeChange.DEFAULT, pipeline, new DocumentCodec(), changeStreamLevel)
+        def operation = new ChangeStreamOperation<Document>(CSOT_NO_TIMEOUT.get(), namespace, FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, pipeline, new DocumentCodec(), changeStreamLevel as ChangeStreamLevel)
                 .batchSize(5)
                 .collation(defaultCollation)
-                .maxAwaitTime(15, MILLISECONDS)
                 .startAtOperationTime(new BsonTimestamp())
 
         def expectedCommand = new BsonDocument('aggregate', aggregate)
@@ -151,7 +147,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
@@ -191,7 +187,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
 
@@ -218,7 +214,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "update"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
@@ -246,7 +242,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "replace"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
@@ -274,7 +270,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "delete"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
@@ -302,7 +298,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "invalidate"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
@@ -331,7 +327,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "drop"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
@@ -360,7 +356,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "dropDatabase"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())),
                 ChangeStreamLevel.DATABASE)
@@ -390,8 +386,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "rename"}}')]
-        def operation = new ChangeStreamOperation<ChangeStreamDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
-                FullDocumentBeforeChange.DEFAULT, pipeline,
+        def operation = new ChangeStreamOperation<ChangeStreamDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(),
+                FullDocument.UPDATE_LOOKUP, FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         def newNamespace = new MongoNamespace('JavaDriverTest', 'newCollectionName')
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
@@ -419,7 +415,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         given:
         def helper = getHelper()
         def pipeline = [BsonDocument.parse('{$project: {"_id": 0}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
@@ -443,7 +439,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
@@ -472,7 +468,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
@@ -513,7 +509,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         def cursor = execute(operation, async)
@@ -549,7 +545,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         def cursor = execute(operation, async)
@@ -586,7 +582,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         def cursor = execute(operation, async)
@@ -619,8 +615,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
     def 'should support hasNext on the sync API'() {
         given:
         def helper = getHelper()
-        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange
-                .DEFAULT, [], CODEC)
+        def operation = new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, [], CODEC)
 
         when:
         def cursor = execute(operation, false)
@@ -660,7 +656,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         }
 
         when: 'set resumeAfter'
-        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [], CODEC)
+        new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .resumeAfter(new BsonDocument())
                 .execute(binding)
 
@@ -669,7 +666,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         !changeStream.containsKey('startAtOperationTime')
 
         when: 'set startAfter'
-        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [], CODEC)
+        new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .startAfter(new BsonDocument())
                 .execute(binding)
 
@@ -679,7 +677,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
         when: 'set startAtOperationTime'
         def startAtTime = new BsonTimestamp(42)
-        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [], CODEC)
+        new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .startAtOperationTime(startAtTime)
                 .execute(binding)
 
@@ -717,7 +716,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         }
 
         when: 'set resumeAfter'
-        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [], CODEC)
+        new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .resumeAfter(new BsonDocument())
                 .executeAsync(binding, Stub(SingleResultCallback))
 
@@ -726,7 +726,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         !changeStream.containsKey('startAtOperationTime')
 
         when: 'set startAfter'
-        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [], CODEC)
+        new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .startAfter(new BsonDocument())
                 .executeAsync(binding, Stub(SingleResultCallback))
 
@@ -736,7 +737,8 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
         when: 'set startAtOperationTime'
         def startAtTime = new BsonTimestamp(42)
-        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [], CODEC)
+        new ChangeStreamOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.getNamespace(), FullDocument.DEFAULT,
+                FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .startAtOperationTime(startAtTime)
                 .executeAsync(binding, Stub(SingleResultCallback))
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CommandOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CommandOperationSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation
 
-import util.spock.annotations.Slow
 import com.mongodb.MongoExecutionTimeoutException
 import com.mongodb.OperationFunctionalSpecification
 import org.bson.BsonBinary
@@ -25,93 +24,75 @@ import org.bson.BsonInt32
 import org.bson.BsonString
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.IgnoreIf
+import util.spock.annotations.Slow
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
-import static com.mongodb.ClusterFixture.executeAsync
-import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isSharded
 
 class CommandOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should execute read command'() {
         given:
-        def commandOperation = new CommandReadOperation<BsonDocument>(getNamespace().databaseName,
-                                                                      new BsonDocument('count', new BsonString(getCollectionName())),
-                                                                      new BsonDocumentCodec())
+        def operation = new CommandReadOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), getNamespace().databaseName,
+                new BsonDocument('count', new BsonString(getCollectionName())),
+                new BsonDocumentCodec())
         when:
-        def result = commandOperation.execute(getBinding())
+        def result = execute(operation, async)
 
         then:
         result.getNumber('n').intValue() == 0
+
+
+        where:
+        async << [true, false]
     }
 
-
-    def 'should execute read command asynchronously'() {
-        given:
-        def commandOperation = new CommandReadOperation<BsonDocument>(getNamespace().databaseName,
-                                                                      new BsonDocument('count', new BsonString(getCollectionName())),
-                                                                      new BsonDocumentCodec())
-        when:
-        def result = executeAsync(commandOperation)
-
-        then:
-        result.getNumber('n').intValue() == 0
-    }
 
     @Slow
     def 'should execute command larger than 16MB'() {
+        given:
+        def operation = new CommandReadOperation<>(CSOT_NO_TIMEOUT.get(), getNamespace().databaseName,
+                new BsonDocument('findAndModify', new BsonString(getNamespace().fullName))
+                        .append('query', new BsonDocument('_id', new BsonInt32(42)))
+                        .append('update',
+                                new BsonDocument('_id', new BsonInt32(42))
+                                        .append('b', new BsonBinary(
+                                                new byte[16 * 1024 * 1024 - 30]))),
+                new BsonDocumentCodec())
+
         when:
-        def result = new CommandReadOperation<>(getNamespace().databaseName,
-                                                             new BsonDocument('findAndModify', new BsonString(getNamespace().fullName))
-                                                                     .append('query', new BsonDocument('_id', new BsonInt32(42)))
-                                                                     .append('update',
-                                                                             new BsonDocument('_id', new BsonInt32(42))
-                                                                                     .append('b', new BsonBinary(
-                                                                                     new byte[16 * 1024 * 1024 - 30]))),
-                                                             new BsonDocumentCodec())
-                .execute(getBinding())
+        def result = execute(operation, async)
 
         then:
         result.containsKey('value')
+
+        where:
+        async << [true, false]
     }
 
     @IgnoreIf({ isSharded() })
     def 'should throw execution timeout exception from execute'() {
         given:
-        def commandOperation = new CommandReadOperation<BsonDocument>(getNamespace().databaseName,
-                                                                      new BsonDocument('count', new BsonString(getCollectionName()))
-                                                                              .append('maxTimeMS', new BsonInt32(1)),
-                                                                      new BsonDocumentCodec())
+        def operation = new CommandReadOperation<BsonDocument>(CSOT_MAX_TIME.get(), getNamespace().databaseName,
+                new BsonDocument('count', new BsonString(getCollectionName()))
+                        .append('maxTimeMS', new BsonInt32(99)), // TODO - JAVA-5098 determine the correct course of action here.
+                new BsonDocumentCodec())
         enableMaxTimeFailPoint()
 
         when:
-        commandOperation.execute(getBinding())
+        execute(operation, async)
 
         then:
         thrown(MongoExecutionTimeoutException)
 
         cleanup:
         disableMaxTimeFailPoint()
+
+        where:
+        async << [true, false]
     }
 
-
-    @IgnoreIf({ isSharded() })
-    def 'should throw execution timeout exception from executeAsync'() {
-        given:
-        def commandOperation = new CommandReadOperation<BsonDocument>(getNamespace().databaseName,
-                                                                      new BsonDocument('count', new BsonString(getCollectionName()))
-                                                                              .append('maxTimeMS', new BsonInt32(1)),
-                                                                      new BsonDocumentCodec())
-        enableMaxTimeFailPoint()
-
-        when:
-        executeAsync(commandOperation)
-
-        then:
-        thrown(MongoExecutionTimeoutException)
-
-        cleanup:
-        disableMaxTimeFailPoint()
-    }
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CommitTransactionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CommitTransactionOperationSpecification.groovy
@@ -21,6 +21,7 @@ import org.bson.BsonDocument
 
 import java.util.concurrent.TimeUnit
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.MAJORITY
 
@@ -33,13 +34,13 @@ class CommitTransactionOperationSpecification extends OperationFunctionalSpecifi
         def expectedCommand = BsonDocument.parse('{commitTransaction: 1}')
 
         when:
-        def operation = new CommitTransactionOperation(ACKNOWLEDGED)
+        def operation = new CommitTransactionOperation(CSOT_NO_TIMEOUT.get(), ACKNOWLEDGED)
 
         then:
         testOperationInTransaction(operation, [4, 0, 0], expectedCommand, async, cannedResult)
 
         when:
-        operation = new CommitTransactionOperation(MAJORITY)
+        operation = new CommitTransactionOperation(CSOT_NO_TIMEOUT.get(), MAJORITY)
         expectedCommand.put('writeConcern', MAJORITY.asDocument())
 
         then:
@@ -56,14 +57,14 @@ class CommitTransactionOperationSpecification extends OperationFunctionalSpecifi
 
         when:
         def writeConcern = MAJORITY.withWTimeout(10, TimeUnit.MILLISECONDS)
-        def operation = new CommitTransactionOperation(writeConcern)
+        def operation = new CommitTransactionOperation(CSOT_NO_TIMEOUT.get(), writeConcern)
 
         then:
         testOperationRetries(operation, [4, 0, 0], expectedCommand, async, cannedResult, true)
 
         when:
         writeConcern = MAJORITY
-        operation = new CommitTransactionOperation(writeConcern)
+        operation = new CommitTransactionOperation(CSOT_NO_TIMEOUT.get(), writeConcern)
         expectedCommand.put('writeConcern', writeConcern.withWTimeout(10000, TimeUnit.MILLISECONDS).asDocument())
 
         then:
@@ -71,7 +72,7 @@ class CommitTransactionOperationSpecification extends OperationFunctionalSpecifi
 
         when:
         writeConcern = ACKNOWLEDGED
-        operation = new CommitTransactionOperation(writeConcern)
+        operation = new CommitTransactionOperation(CSOT_NO_TIMEOUT.get(), writeConcern)
         expectedCommand.put('writeConcern', writeConcern.withW('majority').withWTimeout(10000, TimeUnit.MILLISECONDS).asDocument())
 
         then:
@@ -87,7 +88,7 @@ class CommitTransactionOperationSpecification extends OperationFunctionalSpecifi
         def expectedCommand = BsonDocument.parse('{commitTransaction: 1, writeConcern: {w: "majority", wtimeout: 10000}}')
 
         when:
-        def operation = new CommitTransactionOperation(ACKNOWLEDGED, true)
+        def operation = new CommitTransactionOperation(CSOT_NO_TIMEOUT.get(), ACKNOWLEDGED, true)
 
         then:
         testOperationInTransaction(operation, [4, 0, 0], expectedCommand, async, cannedResult, true)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CreateViewOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CreateViewOperationSpecification.groovy
@@ -29,6 +29,7 @@ import org.bson.BsonString
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
@@ -51,7 +52,8 @@ class CreateViewOperationSpecification extends OperationFunctionalSpecification 
         getCollectionHelper().insertDocuments([trueXDocument, falseXDocument])
 
         def pipeline = [new BsonDocument('$match', trueXDocument)]
-        def operation = new CreateViewOperation(getDatabaseName(), viewName, viewOn, pipeline, WriteConcern.ACKNOWLEDGED)
+        def operation = new CreateViewOperation(CSOT_NO_TIMEOUT.get(), getDatabaseName(), viewName, viewOn, pipeline,
+                WriteConcern.ACKNOWLEDGED)
 
         when:
         execute(operation, async)
@@ -79,7 +81,8 @@ class CreateViewOperationSpecification extends OperationFunctionalSpecification 
         assert !collectionNameExists(viewOn)
         assert !collectionNameExists(viewName)
 
-        def operation = new CreateViewOperation(getDatabaseName(), viewName, viewOn, [], WriteConcern.ACKNOWLEDGED)
+        def operation = new CreateViewOperation(CSOT_NO_TIMEOUT.get(), getDatabaseName(), viewName, viewOn, [],
+                WriteConcern.ACKNOWLEDGED)
                 .collation(defaultCollation)
 
         when:
@@ -100,7 +103,7 @@ class CreateViewOperationSpecification extends OperationFunctionalSpecification 
     @IgnoreIf({ serverVersionAtLeast(3, 4) })
     def 'should throw if server version is not 3.4 or greater'() {
         given:
-        def operation = new CreateViewOperation(getDatabaseName(), getCollectionName() + '-view',
+        def operation = new CreateViewOperation(CSOT_NO_TIMEOUT.get(), getDatabaseName(), getCollectionName() + '-view',
                 getCollectionName(), [], WriteConcern.ACKNOWLEDGED)
 
         when:
@@ -120,7 +123,8 @@ class CreateViewOperationSpecification extends OperationFunctionalSpecification 
         def viewNamespace = new MongoNamespace(getDatabaseName(), viewName)
         assert !collectionNameExists(viewName)
 
-        def operation = new CreateViewOperation(getDatabaseName(), viewName, getCollectionName(), [], new WriteConcern(5))
+        def operation = new CreateViewOperation(CSOT_NO_TIMEOUT.get(), getDatabaseName(), viewName, getCollectionName(), [],
+                new WriteConcern(5))
 
         when:
         execute(operation, async)
@@ -138,7 +142,7 @@ class CreateViewOperationSpecification extends OperationFunctionalSpecification 
     }
 
     def getCollectionInfo(String collectionName) {
-        new ListCollectionsOperation(databaseName, new BsonDocumentCodec()).filter(new BsonDocument('name',
+        new ListCollectionsOperation(CSOT_NO_TIMEOUT.get(), databaseName, new BsonDocumentCodec()).filter(new BsonDocument('name',
                 new BsonString(collectionName))).execute(getBinding()).tryNext()?.head()
     }
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DropCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DropCollectionOperationSpecification.groovy
@@ -24,6 +24,8 @@ import org.bson.Document
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
+import static com.mongodb.ClusterFixture.CSOT_TIMEOUT
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
@@ -37,7 +39,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
         assert collectionNameExists(getCollectionName())
 
         when:
-        new DropCollectionOperation(getNamespace()).execute(getBinding())
+        new DropCollectionOperation(CSOT_TIMEOUT.get(), getNamespace(), WriteConcern.ACKNOWLEDGED).execute(getBinding())
 
         then:
         !collectionNameExists(getCollectionName())
@@ -50,7 +52,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
         assert collectionNameExists(getCollectionName())
 
         when:
-        executeAsync(new DropCollectionOperation(getNamespace()))
+        executeAsync(new DropCollectionOperation(CSOT_TIMEOUT.get(), getNamespace(), WriteConcern.ACKNOWLEDGED))
 
         then:
         !collectionNameExists(getCollectionName())
@@ -61,7 +63,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
         def namespace = new MongoNamespace(getDatabaseName(), 'nonExistingCollection')
 
         when:
-        new DropCollectionOperation(namespace).execute(getBinding())
+        new DropCollectionOperation(CSOT_TIMEOUT.get(), namespace, WriteConcern.ACKNOWLEDGED).execute(getBinding())
 
         then:
         !collectionNameExists('nonExistingCollection')
@@ -73,7 +75,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
         def namespace = new MongoNamespace(getDatabaseName(), 'nonExistingCollection')
 
         when:
-        executeAsync(new DropCollectionOperation(namespace))
+        executeAsync(new DropCollectionOperation(CSOT_TIMEOUT.get(), namespace, WriteConcern.ACKNOWLEDGED))
 
         then:
         !collectionNameExists('nonExistingCollection')
@@ -84,7 +86,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentTo', 'createTheCollection'))
         assert collectionNameExists(getCollectionName())
-        def operation = new DropCollectionOperation(getNamespace(), new WriteConcern(5))
+        def operation = new DropCollectionOperation(CSOT_TIMEOUT.get(), getNamespace(), new WriteConcern(5))
 
         when:
         async ? executeAsync(operation) : operation.execute(getBinding())
@@ -99,7 +101,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
     }
 
     def collectionNameExists(String collectionName) {
-        def cursor = new ListCollectionsOperation(databaseName, new DocumentCodec()).execute(getBinding())
+        def cursor = new ListCollectionsOperation(CSOT_NO_TIMEOUT.get(), databaseName, new DocumentCodec()).execute(getBinding())
         if (!cursor.hasNext()) {
             return false
         }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DropIndexOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DropIndexOperationSpecification.groovy
@@ -30,19 +30,20 @@ import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionLessThan
-import static java.util.concurrent.TimeUnit.SECONDS
 
 class DropIndexOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should not error when dropping non-existent index on non-existent collection'() {
         when:
-        execute(new DropIndexOperation(getNamespace(), 'made_up_index_1'), async)
+        execute(new DropIndexOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), 'made_up_index_1', null), async)
 
         then:
         getIndexes().size() == 0
@@ -56,7 +57,7 @@ class DropIndexOperationSpecification extends OperationFunctionalSpecification {
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentThat', 'forces creation of the Collection'))
 
         when:
-        execute(new DropIndexOperation(getNamespace(), 'made_up_index_1'), async)
+        execute(new DropIndexOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), 'made_up_index_1', null), async)
 
         then:
         thrown(MongoException)
@@ -70,7 +71,7 @@ class DropIndexOperationSpecification extends OperationFunctionalSpecification {
         collectionHelper.createIndex(new BsonDocument('theField', new BsonInt32(1)))
 
         when:
-        execute(new DropIndexOperation(getNamespace(), 'theField_1'), async)
+        execute(new DropIndexOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), 'theField_1', null), async)
         List<Document> indexes = getIndexes()
 
         then:
@@ -87,7 +88,7 @@ class DropIndexOperationSpecification extends OperationFunctionalSpecification {
         collectionHelper.createIndex(keys)
 
         when:
-        execute(new DropIndexOperation(getNamespace(), keys), async)
+        execute(new DropIndexOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), keys, null), async)
         List<Document> indexes = getIndexes()
 
         then:
@@ -110,7 +111,7 @@ class DropIndexOperationSpecification extends OperationFunctionalSpecification {
         given:
         def keys = new BsonDocument('theField', new BsonInt32(1))
         collectionHelper.createIndex(keys)
-        def operation = new DropIndexOperation(getNamespace(), keys).maxTime(30, SECONDS)
+        def operation = new DropIndexOperation(CSOT_MAX_TIME.get(), getNamespace(), keys, null)
 
         enableMaxTimeFailPoint()
 
@@ -133,7 +134,7 @@ class DropIndexOperationSpecification extends OperationFunctionalSpecification {
         collectionHelper.createIndex(keys)
 
         when:
-        execute(new DropIndexOperation(getNamespace(), new BsonDocument('theField', new BsonInt64(1))), async)
+        execute(new DropIndexOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), new BsonDocument('theField', new BsonInt64(1)), null), async)
         List<Document> indexes = getIndexes()
 
         then:
@@ -150,7 +151,7 @@ class DropIndexOperationSpecification extends OperationFunctionalSpecification {
         collectionHelper.createIndex(new BsonDocument('theOtherField', new BsonInt32(1)))
 
         when:
-        execute(new DropIndexOperation(getNamespace(), '*'), async)
+        execute(new DropIndexOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), '*', null), async)
         List<Document> indexes = getIndexes()
 
         then:
@@ -165,7 +166,7 @@ class DropIndexOperationSpecification extends OperationFunctionalSpecification {
     def 'should throw on write concern error'() {
         given:
         collectionHelper.createIndex(new BsonDocument('theField', new BsonInt32(1)))
-        def operation = new DropIndexOperation(getNamespace(), 'theField_1', new WriteConcern(5))
+        def operation = new DropIndexOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), 'theField_1', new WriteConcern(5))
 
         when:
         execute(operation, async)
@@ -181,7 +182,7 @@ class DropIndexOperationSpecification extends OperationFunctionalSpecification {
 
     def getIndexes() {
         def indexes = []
-        def cursor = new ListIndexesOperation(getNamespace(), new DocumentCodec()).execute(getBinding())
+        def cursor = new ListIndexesOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), new DocumentCodec()).execute(getBinding())
         while (cursor.hasNext()) {
             indexes.addAll(cursor.next())
         }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndDeleteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndDeleteOperationSpecification.groovy
@@ -34,8 +34,8 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
-import java.util.concurrent.TimeUnit
-
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.configureFailPoint
 import static com.mongodb.ClusterFixture.disableFailPoint
 import static com.mongodb.ClusterFixture.disableOnPrimaryTransactionalWriteFailPoint
@@ -54,7 +54,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
 
     def 'should have the correct defaults'() {
         when:
-        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false, documentCodec)
 
         then:
         operation.getNamespace() == getNamespace()
@@ -63,7 +63,6 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         operation.getFilter() == null
         operation.getSort() == null
         operation.getProjection() == null
-        operation.getMaxTime(TimeUnit.MILLISECONDS) == 0
         operation.getCollation() == null
     }
 
@@ -74,18 +73,16 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         def projection = BsonDocument.parse('{ projection : 1}')
 
         when:
-        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false, documentCodec)
             .filter(filter)
             .sort(sort)
             .projection(projection)
-            .maxTime(10, TimeUnit.MILLISECONDS)
             .collation(defaultCollation)
 
         then:
         operation.getFilter() == filter
         operation.getSort() == sort
         operation.getProjection() == projection
-        operation.getMaxTime(TimeUnit.MILLISECONDS) == 10
         operation.getCollation() == defaultCollation
     }
 
@@ -97,7 +94,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         getCollectionHelper().insertDocuments(new DocumentCodec(), pete, sam)
 
         when:
-        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false, documentCodec)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         Document returnedDocument = execute(operation, async)
 
@@ -118,8 +115,8 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         getWorkerCollectionHelper().insertDocuments(new WorkerCodec(), pete, sam)
 
         when:
-        FindAndDeleteOperation<Worker> operation = new FindAndDeleteOperation<Worker>(getNamespace(), ACKNOWLEDGED, false,
-                workerCodec).filter(new BsonDocument('name', new BsonString('Pete')))
+        FindAndDeleteOperation<Worker> operation = new FindAndDeleteOperation<Worker>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED,
+                false, workerCodec).filter(new BsonDocument('name', new BsonString('Pete')))
         Worker returnedDocument = execute(operation, async)
 
         then:
@@ -138,7 +135,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         CollectionHelper<Document> helper = new CollectionHelper<Document>(documentCodec, getNamespace())
         Document pete = new Document('name', 'Pete').append('job', 'handyman')
         helper.insertDocuments(new DocumentCodec(), pete)
-        def operation = new FindAndDeleteOperation<Document>(getNamespace(), new WriteConcern(5, 1), false,
+        def operation = new FindAndDeleteOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), new WriteConcern(5, 1), false,
                 documentCodec).filter(new BsonDocument('name', new BsonString('Pete')))
 
         when:
@@ -170,7 +167,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
                       "writeConcernError": {"code": 91, "errmsg": "Replication is being shut down"}}}''')
         configureFailPoint(failPoint)
 
-        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndDeleteOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
                 documentCodec).filter(new BsonDocument('name', new BsonString('Pete')))
 
         when:
@@ -196,10 +193,11 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         def includeTxnNumber = retryWrites && writeConcern.isAcknowledged() && serverType != STANDALONE
         def includeWriteConcern = writeConcern.isAcknowledged() && !writeConcern.isServerDefault()
         def cannedResult = new BsonDocument('value', new BsonDocumentWrapper(BsonDocument.parse('{}'), new BsonDocumentCodec()))
-        def operation = new FindAndDeleteOperation<Document>(getNamespace(), writeConcern as WriteConcern,
+        def operation = new FindAndDeleteOperation<Document>(CSOT_MAX_TIME.get(), getNamespace(), writeConcern as WriteConcern,
                 retryWrites as boolean, documentCodec)
         def expectedCommand = new BsonDocument('findAndModify', new BsonString(getNamespace().getCollectionName()))
                 .append('remove', BsonBoolean.TRUE)
+                .append('maxTimeMS', new BsonInt64(100))
 
         if (includeWriteConcern) {
             expectedCommand.put('writeConcern', writeConcern.asDocument())
@@ -220,12 +218,10 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         operation.filter(filter)
                 .sort(sort)
                 .projection(projection)
-                .maxTime(10, TimeUnit.MILLISECONDS)
 
         expectedCommand.append('query', filter)
                 .append('sort', sort)
                 .append('fields', projection)
-                .append('maxTimeMS', new BsonInt64(10))
 
         operation.collation(defaultCollation)
         expectedCommand.append('collation', defaultCollation.asDocument())
@@ -252,7 +248,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         getCollectionHelper().insertDocuments(new DocumentCodec(), pete, sam)
 
         when:
-        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, true, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, true, documentCodec)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         enableOnPrimaryTransactionalWriteFailPoint(BsonDocument.parse('{times: 1}'))
 
@@ -273,7 +269,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
     def 'should retry if the connection initially fails'() {
         when:
         def cannedResult = new BsonDocument('value', new BsonDocumentWrapper(BsonDocument.parse('{}'), new BsonDocumentCodec()))
-        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, true, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, true, documentCodec)
         def expectedCommand = new BsonDocument('findAndModify', new BsonString(getNamespace().getCollectionName()))
                 .append('remove', BsonBoolean.TRUE)
                 .append('txnNumber', new BsonInt64(0))
@@ -287,7 +283,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
 
     def 'should throw original error when retrying and failing'() {
         given:
-        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, true, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, true, documentCodec)
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
         when:
@@ -315,7 +311,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         given:
         def document = Document.parse('{_id: 1, str: "foo"}')
         getCollectionHelper().insertDocuments(document)
-        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false, documentCodec)
                 .filter(BsonDocument.parse('{str: "FOO"}'))
                 .collation(caseInsensitiveCollation)
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndReplaceOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndReplaceOperationSpecification.groovy
@@ -40,8 +40,8 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
-import java.util.concurrent.TimeUnit
-
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.configureFailPoint
 import static com.mongodb.ClusterFixture.disableFailPoint
 import static com.mongodb.ClusterFixture.disableOnPrimaryTransactionalWriteFailPoint
@@ -62,7 +62,8 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
     def 'should have the correct defaults and passed values'() {
         when:
         def replacement = new BsonDocument('replace', new BsonInt32(1))
-        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, replacement)
+        def operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false, documentCodec,
+                replacement)
 
         then:
         operation.getNamespace() == getNamespace()
@@ -72,7 +73,6 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         operation.getFilter() == null
         operation.getSort() == null
         operation.getProjection() == null
-        operation.getMaxTime(TimeUnit.SECONDS) == 0
         operation.getBypassDocumentValidation() == null
         operation.getCollation() == null
     }
@@ -84,9 +84,9 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         def projection = new BsonDocument('projection', new BsonInt32(1))
 
         when:
-        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec,
+        def operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false, documentCodec,
                 new BsonDocument('replace', new BsonInt32(1))).filter(filter).sort(sort).projection(projection)
-                .bypassDocumentValidation(true).maxTime(1, TimeUnit.SECONDS).upsert(true).returnOriginal(false)
+                .bypassDocumentValidation(true).upsert(true).returnOriginal(false)
                 .collation(defaultCollation)
 
         then:
@@ -94,7 +94,6 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         operation.getSort() == sort
         operation.getProjection() == projection
         operation.upsert == true
-        operation.getMaxTime(TimeUnit.SECONDS) == 1
         operation.getBypassDocumentValidation()
         !operation.isReturnOriginal()
         operation.getCollation() == defaultCollation
@@ -110,7 +109,8 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         helper.insertDocuments(new DocumentCodec(), pete, sam)
 
         when:
-        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, jordan)
+        def operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, jordan)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         Document returnedDocument = execute(operation, async)
 
@@ -120,7 +120,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         helper.find().get(0).getString('name') == 'Jordan'
 
         when:
-        operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec,
+        operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false, documentCodec,
                 new BsonDocumentWrapper<Document>(pete, documentCodec))
                 .filter(new BsonDocument('name', new BsonString('Jordan')))
                 .returnOriginal(false)
@@ -144,8 +144,8 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         helper.insertDocuments(new WorkerCodec(), pete, sam)
 
         when:
-        def operation = new FindAndReplaceOperation<Worker>(getNamespace(), ACKNOWLEDGED, false, workerCodec,
-                replacement).filter(new BsonDocument('name', new BsonString('Pete')))
+        def operation = new FindAndReplaceOperation<Worker>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                workerCodec, replacement).filter(new BsonDocument('name', new BsonString('Pete')))
         Worker returnedDocument = execute(operation, async)
 
         then:
@@ -154,7 +154,8 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
 
         when:
         replacement = new BsonDocumentWrapper<Worker>(pete, workerCodec)
-        operation = new FindAndReplaceOperation<Worker>(getNamespace(), ACKNOWLEDGED, false, workerCodec, replacement)
+        operation = new FindAndReplaceOperation<Worker>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false, workerCodec,
+                replacement)
                 .filter(new BsonDocument('name', new BsonString('Jordan')))
                 .returnOriginal(false)
         returnedDocument = execute(operation, async)
@@ -169,7 +170,8 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
     def 'should return null if query fails to match'() {
         when:
         BsonDocument jordan = BsonDocument.parse('{name: "Jordan", job: "sparky"}')
-        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, jordan)
+        def operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, jordan)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         Document returnedDocument = execute(operation, async)
 
@@ -183,7 +185,8 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
     def 'should throw an exception if replacement contains update operators'() {
         given:
         def replacement = new BsonDocumentWrapper<Document>(['$inc': 1] as Document, documentCodec)
-        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, replacement)
+        def operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, replacement)
 
         when:
         execute(operation, async)
@@ -207,7 +210,8 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
 
         when:
         def replacement = new BsonDocument('level', new BsonInt32(9))
-        def operation = new FindAndReplaceOperation<Document>(namespace, ACKNOWLEDGED, false, documentCodec, replacement)
+        def operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), namespace, ACKNOWLEDGED, false,
+                documentCodec, replacement)
         execute(operation, async)
 
         then:
@@ -245,8 +249,9 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         BsonDocument jordan = BsonDocument.parse('{name: "Jordan", job: "sparky"}')
 
         when:
-        def operation = new FindAndReplaceOperation<Document>(getNamespace(), new WriteConcern(5, 1),
-                false, documentCodec, jordan).filter(new BsonDocument('name', new BsonString('Pete')))
+        def operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                new WriteConcern(5, 1), false, documentCodec, jordan)
+                .filter(new BsonDocument('name', new BsonString('Pete')))
         execute(operation, async)
 
         then:
@@ -258,7 +263,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         ex.writeResult.upsertedId == null
 
         when:
-        operation = new FindAndReplaceOperation<Document>(getNamespace(), new WriteConcern(5, 1),
+        operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), new WriteConcern(5, 1),
                 false, documentCodec, jordan).filter(new BsonDocument('name', new BsonString('Bob')))
                 .upsert(true)
         execute(operation, async)
@@ -290,7 +295,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         configureFailPoint(failPoint)
 
         BsonDocument jordan = BsonDocument.parse('{name: "Jordan", job: "sparky"}')
-        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED,
+        def operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED,
                 false, documentCodec, jordan).filter(new BsonDocument('name', new BsonString('Pete')))
 
         when:
@@ -317,9 +322,11 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         def includeWriteConcern = writeConcern.isAcknowledged() && !writeConcern.isServerDefault()
         def cannedResult = new BsonDocument('value', new BsonDocumentWrapper(BsonDocument.parse('{}'), new BsonDocumentCodec()))
         def replacement = BsonDocument.parse('{ replacement: 1}')
-        def operation = new FindAndReplaceOperation<Document>(getNamespace(), writeConcern, retryWrites, documentCodec, replacement)
+        def operation = new FindAndReplaceOperation<Document>(CSOT_MAX_TIME.get(), getNamespace(), writeConcern, retryWrites,
+                documentCodec, replacement)
         def expectedCommand = new BsonDocument('findAndModify', new BsonString(getNamespace().getCollectionName()))
                 .append('update', replacement)
+                .append('maxTimeMS', new BsonInt64(100))
         if (includeWriteConcern) {
             expectedCommand.put('writeConcern', writeConcern.asDocument())
         }
@@ -341,12 +348,10 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
                 .sort(sort)
                 .projection(projection)
                 .bypassDocumentValidation(true)
-                .maxTime(10, TimeUnit.MILLISECONDS)
 
         expectedCommand.append('query', filter)
                 .append('sort', sort)
                 .append('fields', projection)
-                .append('maxTimeMS', new BsonInt64(10))
 
         operation.collation(defaultCollation)
         expectedCommand.append('collation', defaultCollation.asDocument())
@@ -376,7 +381,8 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         helper.insertDocuments(new DocumentCodec(), pete, sam)
 
         when:
-        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, true, documentCodec, jordan)
+        def operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, true,
+                documentCodec, jordan)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
 
         enableOnPrimaryTransactionalWriteFailPoint(BsonDocument.parse('{times: 1}'))
@@ -398,7 +404,8 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         when:
         def cannedResult = new BsonDocument('value', new BsonDocumentWrapper(BsonDocument.parse('{}'), new BsonDocumentCodec()))
         def replacement = BsonDocument.parse('{ replacement: 1}')
-        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, true, documentCodec, replacement)
+        def operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, true,
+                documentCodec, replacement)
         def expectedCommand = new BsonDocument('findAndModify', new BsonString(getNamespace().getCollectionName()))
                 .append('update', replacement)
                 .append('txnNumber', new BsonInt64(0))
@@ -414,7 +421,8 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
     def 'should throw original error when retrying and failing'() {
         given:
         def replacement = BsonDocument.parse('{ replacement: 1}')
-        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, true, documentCodec, replacement)
+        def operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, true,
+                documentCodec, replacement)
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
         when:
@@ -443,7 +451,8 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         def document = Document.parse('{_id: 1, str: "foo"}')
         getCollectionHelper().insertDocuments(document)
         def replacement = BsonDocument.parse('{str: "bar"}')
-        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, replacement)
+        def operation = new FindAndReplaceOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, replacement)
                 .filter(BsonDocument.parse('{str: "FOO"}'))
                 .collation(caseInsensitiveCollation)
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndUpdateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndUpdateOperationSpecification.groovy
@@ -41,8 +41,8 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
-import java.util.concurrent.TimeUnit
-
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.configureFailPoint
 import static com.mongodb.ClusterFixture.disableFailPoint
 import static com.mongodb.ClusterFixture.disableOnPrimaryTransactionalWriteFailPoint
@@ -64,7 +64,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
     def 'should have the correct defaults and passed values'() {
         when:
         def update = new BsonDocument('update', new BsonInt32(1))
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, update)
 
         then:
         operation.getNamespace() == getNamespace()
@@ -74,7 +75,6 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         operation.getFilter() == null
         operation.getSort() == null
         operation.getProjection() == null
-        operation.getMaxTime(TimeUnit.SECONDS) == 0
         operation.getBypassDocumentValidation() == null
         operation.getCollation() == null
     }
@@ -83,7 +83,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
     def 'should have the correct defaults and passed values using update pipelines'() {
         when:
         def updatePipeline = new BsonArray(singletonList(new BsonDocument('update', new BsonInt32(1))))
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, updatePipeline)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, updatePipeline)
 
         then:
         operation.getNamespace() == getNamespace()
@@ -93,7 +94,6 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         operation.getFilter() == null
         operation.getSort() == null
         operation.getProjection() == null
-        operation.getMaxTime(TimeUnit.SECONDS) == 0
         operation.getBypassDocumentValidation() == null
         operation.getCollation() == null
     }
@@ -105,9 +105,12 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         def projection = new BsonDocument('projection', new BsonInt32(1))
 
         when:
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec,
-                new BsonDocument('update', new BsonInt32(1))).filter(filter).sort(sort).projection(projection)
-                .bypassDocumentValidation(true).maxTime(1, TimeUnit.SECONDS).upsert(true)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                ACKNOWLEDGED, false, documentCodec, new BsonDocument('update', new BsonInt32(1)))
+                .filter(filter)
+                .sort(sort)
+                .projection(projection)
+                .bypassDocumentValidation(true).upsert(true)
                 .returnOriginal(false)
                 .collation(defaultCollation)
 
@@ -116,7 +119,6 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         operation.getSort() == sort
         operation.getProjection() == projection
         operation.upsert == true
-        operation.getMaxTime(TimeUnit.SECONDS) == 1
         operation.getBypassDocumentValidation()
         !operation.isReturnOriginal()
         operation.getCollation() == defaultCollation
@@ -130,10 +132,12 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         def projection = new BsonDocument('projection', new BsonInt32(1))
 
         when:
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec,
-                new BsonArray(singletonList(new BsonDocument('update', new BsonInt32(1)))))
-                        .filter(filter).sort(sort).projection(projection)
-                .bypassDocumentValidation(true).maxTime(1, TimeUnit.SECONDS).upsert(true)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, new BsonArray(singletonList(new BsonDocument('update', new BsonInt32(1)))))
+                .filter(filter)
+                .sort(sort)
+                .projection(projection)
+                .bypassDocumentValidation(true).upsert(true)
                 .returnOriginal(false)
                 .collation(defaultCollation)
 
@@ -142,7 +146,6 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         operation.getSort() == sort
         operation.getProjection() == projection
         operation.upsert == true
-        operation.getMaxTime(TimeUnit.SECONDS) == 1
         operation.getBypassDocumentValidation()
         !operation.isReturnOriginal()
         operation.getCollation() == defaultCollation
@@ -158,7 +161,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         def update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         Document returnedDocument = execute(operation, async)
 
@@ -169,7 +173,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
+        operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
                 .returnOriginal(false)
         returnedDocument = execute(operation, async)
@@ -192,7 +197,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         def update = new BsonArray(singletonList(new BsonDocument('$addFields', new BsonDocument('foo', new BsonInt32(1)))))
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
                 .returnOriginal(false)
         Document returnedDocument = execute(operation, false)
@@ -203,7 +209,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         update = new BsonArray(singletonList(new BsonDocument('$addFields', new BsonDocument('foo', new BsonInt32(1)))))
-        operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
+        operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
                 .returnOriginal(false)
         returnedDocument = execute(operation, false)
@@ -223,7 +230,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         def update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        def operation = new FindAndUpdateOperation<Worker>(getNamespace(), ACKNOWLEDGED, false, workerCodec, update)
+        def operation = new FindAndUpdateOperation<Worker>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                workerCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         Worker returnedDocument = execute(operation, async)
 
@@ -234,7 +242,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        operation = new FindAndUpdateOperation<Worker>(getNamespace(), ACKNOWLEDGED, false, workerCodec, update)
+        operation = new FindAndUpdateOperation<Worker>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                workerCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
                 .returnOriginal(false)
         returnedDocument = execute(operation, async)
@@ -257,7 +266,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         def update = new BsonArray(singletonList(new BsonDocument('$project', new BsonDocument('name', new BsonInt32(1)))))
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
                 .returnOriginal(false)
         Document returnedDocument = execute(operation, async)
@@ -273,7 +283,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
     def 'should return null if query fails to match'() {
         when:
         def update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false
+                , documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         Document returnedDocument = execute(operation, async)
 
@@ -287,7 +298,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
     def 'should throw an exception if update contains fields that are not update operators'() {
         given:
         def update = new BsonDocument('x', new BsonInt32(1))
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, update)
 
         when:
         execute(operation, async)
@@ -304,7 +316,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
     def 'should throw an exception if update pipeline contains operations that are not supported'() {
         when:
         def update = new BsonArray(singletonList(new BsonDocument('$foo', new BsonDocument('x', new BsonInt32(1)))))
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, update)
         execute(operation, async)
 
         then:
@@ -312,7 +325,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         update = singletonList(new BsonInt32(1))
-        operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
+        operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, update)
         execute(operation, async)
 
         then:
@@ -333,7 +347,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         def update = new BsonDocument('$inc', new BsonDocument('level', new BsonInt32(-1)))
-        def operation = new FindAndUpdateOperation<Document>(namespace, ACKNOWLEDGED, false, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), namespace, ACKNOWLEDGED, false,
+                documentCodec, update)
         execute(operation, async)
 
         then:
@@ -368,7 +383,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         def update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
 
         when:
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), new WriteConcern(5, 1), false, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                new WriteConcern(5, 1), false, documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         execute(operation, async)
 
@@ -381,7 +397,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         ex.writeResult.upsertedId == null
 
         when:
-        operation = new FindAndUpdateOperation<Document>(getNamespace(), new WriteConcern(5, 1), false, documentCodec, update)
+        operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), new WriteConcern(5, 1), false,
+                documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Bob')))
                 .upsert(true)
         execute(operation, async)
@@ -410,7 +427,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         configureFailPoint(failPoint)
 
         def update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
 
         when:
@@ -437,9 +455,11 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         def includeWriteConcern = writeConcern.isAcknowledged() && !writeConcern.isServerDefault()
         def cannedResult = new BsonDocument('value', new BsonDocumentWrapper(BsonDocument.parse('{}'), new BsonDocumentCodec()))
         def update = BsonDocument.parse('{ update: 1}')
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), writeConcern, retryWrites, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_MAX_TIME.get(), getNamespace(), writeConcern, retryWrites,
+                documentCodec, update)
         def expectedCommand = new BsonDocument('findAndModify', new BsonString(getNamespace().getCollectionName()))
                 .append('update', update)
+                .append('maxTimeMS', new BsonInt64(100))
         if (includeWriteConcern) {
             expectedCommand.put('writeConcern', writeConcern.asDocument())
         }
@@ -461,12 +481,10 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
                 .sort(sort)
                 .projection(projection)
                 .bypassDocumentValidation(true)
-                .maxTime(10, TimeUnit.MILLISECONDS)
 
         expectedCommand.append('query', filter)
                 .append('sort', sort)
                 .append('fields', projection)
-                .append('maxTimeMS', new BsonInt64(10))
 
         operation.collation(defaultCollation)
         expectedCommand.append('collation', defaultCollation.asDocument())
@@ -496,7 +514,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         def update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, true, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, true,
+                documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
 
         enableOnPrimaryTransactionalWriteFailPoint(BsonDocument.parse('{times: 1}'))
@@ -519,7 +538,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         when:
         def cannedResult = new BsonDocument('value', new BsonDocumentWrapper(BsonDocument.parse('{}'), new BsonDocumentCodec()))
         def update = BsonDocument.parse('{ update: 1}')
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, true, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, true,
+                documentCodec, update)
         def expectedCommand = new BsonDocument('findAndModify', new BsonString(getNamespace().getCollectionName()))
                 .append('update', update)
                 .append('txnNumber', new BsonInt64(0))
@@ -535,7 +555,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
     def 'should throw original error when retrying and failing'() {
         given:
         def update = BsonDocument.parse('{ update: 1}')
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, true, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, true,
+                documentCodec, update)
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
         when:
@@ -564,7 +585,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         def document = Document.parse('{_id: 1, str: "foo"}')
         getCollectionHelper().insertDocuments(document)
         def update = BsonDocument.parse('{ $set: {str: "bar"}}')
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, update)
                 .filter(BsonDocument.parse('{str: "FOO"}'))
                 .collation(caseInsensitiveCollation)
 
@@ -586,7 +608,8 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         getCollectionHelper().insertDocuments(documentOne, documentTwo)
         def update = BsonDocument.parse('{ $set: {"y.$[i].b": 2}}')
         def arrayFilters = [BsonDocument.parse('{"i.b": 3}')]
-        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(CSOT_NO_TIMEOUT.get(), getNamespace(), ACKNOWLEDGED, false,
+                documentCodec, update)
                 .returnOriginal(false)
                 .arrayFilters(arrayFilters)
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ListIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ListIndexesOperationSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation
 
-
 import com.mongodb.MongoExecutionTimeoutException
 import com.mongodb.MongoNamespace
 import com.mongodb.OperationFunctionalSpecification
@@ -45,18 +44,19 @@ import org.bson.codecs.Decoder
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isSharded
-import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 class ListIndexesOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should return empty list for nonexistent collection'() {
         given:
-        def operation = new ListIndexesOperation(getNamespace(), new DocumentCodec())
+        def operation = new ListIndexesOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), new DocumentCodec())
 
         when:
         def cursor = operation.execute(getBinding())
@@ -68,7 +68,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
     def 'should return empty list for nonexistent collection asynchronously'() {
         given:
-        def operation = new ListIndexesOperation(getNamespace(), new DocumentCodec())
+        def operation = new ListIndexesOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), new DocumentCodec())
 
         when:
         AsyncBatchCursor cursor = executeAsync(operation)
@@ -82,7 +82,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
     def 'should return default index on Collection that exists'() {
         given:
-        def operation = new ListIndexesOperation(getNamespace(), new DocumentCodec())
+        def operation = new ListIndexesOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), new DocumentCodec())
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentThat', 'forces creation of the Collection'))
 
         when:
@@ -98,7 +98,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
     def 'should return default index on Collection that exists asynchronously'() {
         given:
-        def operation = new ListIndexesOperation(getNamespace(), new DocumentCodec())
+        def operation = new ListIndexesOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), new DocumentCodec())
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentThat', 'forces creation of the Collection'))
 
         when:
@@ -114,11 +114,11 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
     def 'should return created indexes on Collection'() {
         given:
-        def operation = new ListIndexesOperation(getNamespace(), new DocumentCodec())
+        def operation = new ListIndexesOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), new DocumentCodec())
         collectionHelper.createIndex(new BsonDocument('theField', new BsonInt32(1)))
         collectionHelper.createIndex(new BsonDocument('compound', new BsonInt32(1)).append('index', new BsonInt32(-1)))
-        new CreateIndexesOperation(namespace, [new IndexRequest(new BsonDocument('unique', new BsonInt32(1))).unique(true)])
-                .execute(getBinding())
+        new CreateIndexesOperation(CSOT_NO_TIMEOUT.get(), namespace,
+                [new IndexRequest(new BsonDocument('unique', new BsonInt32(1))).unique (true)], null).execute(getBinding())
 
         when:
         BatchCursor cursor = operation.execute(getBinding())
@@ -134,11 +134,11 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
     def 'should return created indexes on Collection asynchronously'() {
         given:
-        def operation = new ListIndexesOperation(getNamespace(), new DocumentCodec())
+        def operation = new ListIndexesOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), new DocumentCodec())
         collectionHelper.createIndex(new BsonDocument('theField', new BsonInt32(1)))
         collectionHelper.createIndex(new BsonDocument('compound', new BsonInt32(1)).append('index', new BsonInt32(-1)))
-        new CreateIndexesOperation(namespace, [new IndexRequest(new BsonDocument('unique', new BsonInt32(1))).unique(true)])
-                .execute(getBinding())
+        new CreateIndexesOperation(CSOT_NO_TIMEOUT.get(), namespace,
+                [new IndexRequest(new BsonDocument('unique', new BsonInt32(1))).unique(true)], null).execute(getBinding())
 
         when:
         def cursor = executeAsync(operation)
@@ -154,7 +154,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
     def 'should use the set batchSize of collections'() {
         given:
-        def operation = new ListIndexesOperation(getNamespace(), new DocumentCodec()).batchSize(2)
+        def operation = new ListIndexesOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), new DocumentCodec()).batchSize(2)
         collectionHelper.createIndex(new BsonDocument('collection1', new BsonInt32(1)))
         collectionHelper.createIndex(new BsonDocument('collection2', new BsonInt32(1)))
         collectionHelper.createIndex(new BsonDocument('collection3', new BsonInt32(1)))
@@ -185,7 +185,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
     def 'should use the set batchSize of collections asynchronously'() {
         given:
-        def operation = new ListIndexesOperation(getNamespace(), new DocumentCodec()).batchSize(2)
+        def operation = new ListIndexesOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), new DocumentCodec()).batchSize(2)
         collectionHelper.createIndex(new BsonDocument('collection1', new BsonInt32(1)))
         collectionHelper.createIndex(new BsonDocument('collection2', new BsonInt32(1)))
         collectionHelper.createIndex(new BsonDocument('collection3', new BsonInt32(1)))
@@ -214,42 +214,25 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
     }
 
     @IgnoreIf({ isSharded() })
-    def 'should throw execution timeout exception from execute'() {
+    def 'should throw execution timeout exception'() {
         given:
-        def operation = new ListIndexesOperation(getNamespace(), new DocumentCodec()).maxTime(1000, MILLISECONDS)
+        def operation = new ListIndexesOperation(CSOT_MAX_TIME.get(), getNamespace(), new DocumentCodec())
         collectionHelper.createIndex(new BsonDocument('collection1', new BsonInt32(1)))
 
         enableMaxTimeFailPoint()
 
         when:
-        operation.execute(getBinding())
+        execute(operation, async)
 
         then:
         thrown(MongoExecutionTimeoutException)
 
         cleanup:
         disableMaxTimeFailPoint()
+
+        where:
+        async << [true, false]
     }
-
-
-    @IgnoreIf({ isSharded() })
-    def 'should throw execution timeout exception from executeAsync'() {
-        given:
-        def operation = new ListIndexesOperation(getNamespace(), new DocumentCodec()).maxTime(1000, MILLISECONDS)
-        collectionHelper.createIndex(new BsonDocument('collection1', new BsonInt32(1)))
-
-        enableMaxTimeFailPoint()
-
-        when:
-        executeAsync(operation)
-
-        then:
-        thrown(MongoExecutionTimeoutException)
-
-        cleanup:
-        disableMaxTimeFailPoint()
-    }
-
 
     def 'should use the readPreference to set secondaryOk'() {
         given:
@@ -264,7 +247,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
             getReadConnectionSource() >> connectionSource
             getReadPreference() >> readPreference
         }
-        def operation = new ListIndexesOperation(helper.namespace, helper.decoder)
+        def operation = new ListIndexesOperation(CSOT_NO_TIMEOUT.get(), helper.namespace, helper.decoder)
 
         when: '3.6.0'
         operation.execute(readBinding)
@@ -290,7 +273,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
             getReadPreference() >> readPreference
             getReadConnectionSource(_) >> { it[0].onResult(connectionSource, null) }
         }
-        def operation = new ListIndexesOperation(helper.namespace, helper.decoder)
+        def operation = new ListIndexesOperation(CSOT_NO_TIMEOUT.get(), helper.namespace, helper.decoder)
 
         when: '3.6.0'
         operation.executeAsync(readBinding, Stub(SingleResultCallback))

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceToCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceToCollectionOperationSpecification.groovy
@@ -37,20 +37,22 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
+import static com.mongodb.ClusterFixture.CSOT_TIMEOUT
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.client.model.Filters.gte
-import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpecification {
     def mapReduceInputNamespace = new MongoNamespace(getDatabaseName(), 'mapReduceInput')
     def mapReduceOutputNamespace = new MongoNamespace(getDatabaseName(), 'mapReduceOutput')
-    def mapReduceOperation = new MapReduceToCollectionOperation(mapReduceInputNamespace,
-                                                                new BsonJavaScript('function(){ emit( this.name , 1 ); }'),
-                                                                new BsonJavaScript('function(key, values){ return values.length; }'),
-                                                                mapReduceOutputNamespace.getCollectionName())
+    def mapReduceOperation = new MapReduceToCollectionOperation(CSOT_NO_TIMEOUT.get(), mapReduceInputNamespace,
+            new BsonJavaScript('function(){ emit( this.name , 1 ); }'),
+            new BsonJavaScript('function(key, values){ return values.length; }'),
+            mapReduceOutputNamespace.getCollectionName(), null)
     def expectedResults = [new BsonDocument('_id', new BsonString('Pete')).append('value', new BsonDouble(2.0)),
                            new BsonDocument('_id', new BsonString('Sam')).append('value', new BsonDouble(1.0))] as Set
     def helper = new CollectionHelper<BsonDocument>(new BsonDocumentCodec(), mapReduceOutputNamespace)
@@ -64,8 +66,8 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
     }
 
     def cleanup() {
-        new DropCollectionOperation(mapReduceInputNamespace).execute(getBinding())
-        new DropCollectionOperation(mapReduceOutputNamespace).execute(getBinding())
+        new DropCollectionOperation(CSOT_TIMEOUT.get(), mapReduceInputNamespace, WriteConcern.ACKNOWLEDGED).execute(getBinding())
+        new DropCollectionOperation(CSOT_TIMEOUT.get(), mapReduceOutputNamespace, WriteConcern.ACKNOWLEDGED).execute(getBinding())
     }
 
     def 'should have the correct defaults'() {
@@ -75,7 +77,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
         def out = 'outCollection'
 
         when:
-        def operation =  new MapReduceToCollectionOperation(getNamespace(), mapF, reduceF, out)
+        def operation =  new MapReduceToCollectionOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), mapF, reduceF, out, null)
 
         then:
         operation.getMapFunction() == mapF
@@ -89,7 +91,6 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
         operation.getLimit() == 0
         operation.getScope() == null
         operation.getSort() == null
-        operation.getMaxTime(MILLISECONDS) == 0
         operation.getBypassDocumentValidation() == null
         operation.getCollation() == null
         !operation.isJsMode()
@@ -112,7 +113,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
         def writeConcern = WriteConcern.MAJORITY
 
         when:
-        def operation =  new MapReduceToCollectionOperation(getNamespace(), mapF, reduceF, out, writeConcern)
+        def operation =  new MapReduceToCollectionOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), mapF, reduceF, out, writeConcern)
                 .action(action)
                 .databaseName(dbName)
                 .finalizeFunction(finalizeF)
@@ -120,7 +121,6 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
                 .limit(10)
                 .scope(scope)
                 .sort(sort)
-                .maxTime(1, MILLISECONDS)
                 .bypassDocumentValidation(true)
                 .collation(defaultCollation)
 
@@ -135,7 +135,6 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
         operation.getLimit() == 10
         operation.getScope() == scope
         operation.getSort() == sort
-        operation.getMaxTime(MILLISECONDS) == 1
         operation.getBypassDocumentValidation() == true
         operation.getCollation() == defaultCollation
     }
@@ -182,10 +181,10 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
         getCollectionHelper().insertDocuments(new BsonDocument())
 
         when:
-        def operation = new MapReduceToCollectionOperation(mapReduceInputNamespace,
+        def operation = new MapReduceToCollectionOperation(CSOT_NO_TIMEOUT.get(), mapReduceInputNamespace,
                 new BsonJavaScript('function(){ emit( "level" , 1 ); }'),
                 new BsonJavaScript('function(key, values){ return values.length; }'),
-                'collectionOut')
+                'collectionOut', null)
         execute(operation, async)
 
         then:
@@ -216,7 +215,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
     def 'should throw on write concern error'() {
         given:
         getCollectionHelper().insertDocuments(new BsonDocument())
-        def operation = new MapReduceToCollectionOperation(mapReduceInputNamespace,
+        def operation = new MapReduceToCollectionOperation(CSOT_NO_TIMEOUT.get(), mapReduceInputNamespace,
                 new BsonJavaScript('function(){ emit( "level" , 1 ); }'),
                 new BsonJavaScript('function(key, values){ return values.length; }'),
                 'collectionOut', new WriteConcern(5))
@@ -248,7 +247,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
         def dbName = 'dbName'
 
         when:
-        def operation =  new MapReduceToCollectionOperation(getNamespace(), mapF, reduceF, out, WriteConcern.MAJORITY)
+        def operation = new MapReduceToCollectionOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), mapF, reduceF, out, WriteConcern.MAJORITY)
         def expectedCommand = new BsonDocument('mapreduce', new BsonString(getCollectionName()))
                 .append('map', mapF)
                 .append('reduce', reduceF)
@@ -263,14 +262,14 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
                 ReadPreference.primary(), false)
 
         when:
-        operation.action(action)
+        operation = new MapReduceToCollectionOperation(CSOT_MAX_TIME.get(), getNamespace(), mapF, reduceF, out, WriteConcern.MAJORITY)
+                .action(action)
                 .databaseName(dbName)
                 .finalizeFunction(finalizeF)
                 .filter(filter)
                 .limit(10)
                 .scope(scope)
                 .sort(sort)
-                .maxTime(10, MILLISECONDS)
                 .bypassDocumentValidation(true)
                 .verbose(true)
 
@@ -281,7 +280,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
                 .append('scope', scope)
                 .append('verbose', BsonBoolean.TRUE)
                 .append('limit', new BsonInt32(10))
-                .append('maxTimeMS', new BsonInt64(10))
+                .append('maxTimeMS', new BsonInt64(100))
 
         if (includeCollation) {
             operation.collation(defaultCollation)
@@ -309,10 +308,10 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
 
         def document = Document.parse('{_id: 1, str: "foo"}')
         getCollectionHelper(mapReduceInputNamespace).insertDocuments(document)
-        def operation = new MapReduceToCollectionOperation(mapReduceInputNamespace,
+        def operation = new MapReduceToCollectionOperation(CSOT_NO_TIMEOUT.get(), mapReduceInputNamespace,
                 new BsonJavaScript('function(){ emit( this._id, this.str ); }'),
                 new BsonJavaScript('function(key, values){ return values; }'),
-                'collectionOut')
+                'collectionOut', null)
                 .filter(BsonDocument.parse('{str: "FOO"}'))
                 .collation(caseInsensitiveCollation)
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceWithInlineResultsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceWithInlineResultsOperationSpecification.groovy
@@ -46,16 +46,17 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.connection.ServerType.STANDALONE
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand
 import static com.mongodb.internal.operation.ServerVersionHelper.MIN_WIRE_VERSION
-import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 class MapReduceWithInlineResultsOperationSpecification extends OperationFunctionalSpecification {
     private final bsonDocumentCodec = new BsonDocumentCodec()
-    def mapReduceOperation = new MapReduceWithInlineResultsOperation<BsonDocument>(
+    def mapReduceOperation = new MapReduceWithInlineResultsOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(),
             getNamespace(),
             new BsonJavaScript('function(){ emit( this.name , 1 ); }'),
             new BsonJavaScript('function(key, values){ return values.length; }'),
@@ -76,7 +77,8 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
         when:
         def mapF = new BsonJavaScript('function(){ }')
         def reduceF = new BsonJavaScript('function(key, values){ }')
-        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(helper.namespace, mapF, reduceF, bsonDocumentCodec)
+        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.namespace, mapF, reduceF,
+                bsonDocumentCodec)
 
         then:
         operation.getMapFunction() == mapF
@@ -85,7 +87,6 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
         operation.getFinalizeFunction() == null
         operation.getScope() == null
         operation.getSort() == null
-        operation.getMaxTime(MILLISECONDS) == 0
         operation.getLimit() == 0
         operation.getCollation() == null
         !operation.isJsMode()
@@ -100,7 +101,8 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
         def finalizeF = new BsonJavaScript('function(key, value){}')
         def mapF = new BsonJavaScript('function(){ }')
         def reduceF = new BsonJavaScript('function(key, values){ }')
-        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(helper.namespace, mapF, reduceF, bsonDocumentCodec)
+        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.namespace,
+                mapF, reduceF, bsonDocumentCodec)
                 .filter(filter)
                 .finalizeFunction(finalizeF)
                 .scope(scope)
@@ -108,7 +110,6 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
                 .jsMode(true)
                 .verbose(true)
                 .limit(20)
-                .maxTime(10, MILLISECONDS)
                 .collation(defaultCollation)
 
         then:
@@ -118,7 +119,6 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
         operation.getFinalizeFunction() == finalizeF
         operation.getScope() == scope
         operation.getSort() == sort
-        operation.getMaxTime(MILLISECONDS) == 10
         operation.getLimit() == 20
         operation.getCollation() == defaultCollation
         operation.isJsMode()
@@ -141,8 +141,8 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
 
     def 'should use the ReadBindings readPreference to set secondaryOk'() {
         when:
-        def operation = new MapReduceWithInlineResultsOperation<Document>(helper.namespace, new BsonJavaScript('function(){ }'),
-                new BsonJavaScript('function(key, values){ }'), bsonDocumentCodec)
+        def operation = new MapReduceWithInlineResultsOperation<Document>(CSOT_NO_TIMEOUT.get(), helper.namespace,
+                new BsonJavaScript('function(){ }'), new BsonJavaScript('function(key, values){ }'), bsonDocumentCodec)
 
         then:
         testOperationSecondaryOk(operation, [3, 4, 0], readPreference, async, helper.commandResult)
@@ -153,12 +153,13 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
 
     def 'should create the expected command'() {
         when:
-        def operation = new MapReduceWithInlineResultsOperation<Document>(helper.namespace, new BsonJavaScript('function(){ }'),
-                new BsonJavaScript('function(key, values){ }'), bsonDocumentCodec)
+        def operation = new MapReduceWithInlineResultsOperation<Document>(CSOT_MAX_TIME.get(), helper.namespace,
+                new BsonJavaScript('function(){ }'), new BsonJavaScript('function(key, values){ }'), bsonDocumentCodec)
         def expectedCommand = new BsonDocument('mapreduce', new BsonString(helper.namespace.getCollectionName()))
             .append('map', operation.getMapFunction())
             .append('reduce', operation.getReduceFunction())
             .append('out', new BsonDocument('inline', new BsonInt32(1)))
+            .append('maxTimeMS', new BsonInt64(100))
 
         then:
         testOperation(operation, serverVersion, expectedCommand, async, helper.commandResult)
@@ -171,7 +172,6 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
                 .jsMode(true)
                 .verbose(true)
                 .limit(20)
-                .maxTime(10, MILLISECONDS)
 
 
         expectedCommand.append('query', operation.getFilter())
@@ -180,7 +180,6 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
                 .append('finalize', operation.getFinalizeFunction())
                 .append('jsMode', BsonBoolean.TRUE)
                 .append('verbose', BsonBoolean.TRUE)
-                .append('maxTimeMS', new BsonInt64(10))
                 .append('limit', new BsonInt32(20))
 
         if (includeCollation) {
@@ -204,7 +203,7 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
         given:
         def document = Document.parse('{_id: 1, str: "foo"}')
         getCollectionHelper().insertDocuments(document)
-        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(
+        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(),
                 namespace,
                 new BsonJavaScript('function(){ emit( this.str, 1 ); }'),
                 new BsonJavaScript('function(key, values){ return Array.sum(values); }'),
@@ -242,8 +241,8 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
               }''')
         appendReadConcernToCommand(sessionContext, MIN_WIRE_VERSION, commandDocument)
 
-        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(helper.namespace, new BsonJavaScript('function(){ }'),
-                new BsonJavaScript('function(key, values){ }'), bsonDocumentCodec)
+        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.namespace,
+                new BsonJavaScript('function(){ }'), new BsonJavaScript('function(key, values){ }'), bsonDocumentCodec)
 
         when:
         operation.execute(binding)
@@ -291,8 +290,8 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
               }''')
         appendReadConcernToCommand(sessionContext, MIN_WIRE_VERSION, commandDocument)
 
-        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(helper.namespace, new BsonJavaScript('function(){ }'),
-                new BsonJavaScript('function(key, values){ }'), bsonDocumentCodec)
+        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), helper.namespace,
+                new BsonJavaScript('function(){ }'), new BsonJavaScript('function(key, values){ }'), bsonDocumentCodec)
 
         when:
         executeAsync(operation, binding)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
@@ -48,6 +48,7 @@ import org.bson.types.ObjectId
 import spock.lang.IgnoreIf
 import util.spock.annotations.Slow
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.configureFailPoint
 import static com.mongodb.ClusterFixture.disableFailPoint
 import static com.mongodb.ClusterFixture.disableOnPrimaryTransactionalWriteFailPoint
@@ -72,7 +73,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'should throw IllegalArgumentException for empty list of requests'() {
         when:
-        new MixedBulkWriteOperation(getNamespace(), [], true, ACKNOWLEDGED, false)
+        new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), [], true, ACKNOWLEDGED, false)
 
         then:
         thrown(IllegalArgumentException)
@@ -80,7 +81,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'should have the expected passed values'() {
         when:
-        def operation = new MixedBulkWriteOperation(getNamespace(), requests, ordered, writeConcern, retryWrites)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), requests, ordered, writeConcern, retryWrites)
                 .bypassDocumentValidation(bypassValidation)
 
         then:
@@ -100,8 +101,8 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'when no document with the same id exists, should insert the document'() {
         given:
-        def operation = new MixedBulkWriteOperation(getNamespace(), [new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))],
-                ordered, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                [new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))], ordered, ACKNOWLEDGED, false)
 
         when:
         BulkWriteResult result = execute(operation, async)
@@ -120,7 +121,8 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         def document = new BsonDocument('_id', new BsonInt32(1))
         getCollectionHelper().insertDocuments(document)
-        def operation = new MixedBulkWriteOperation(getNamespace(), [new InsertRequest(document)], ordered, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), [new InsertRequest(document)], ordered,
+                ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -135,8 +137,8 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'RawBsonDocument should not generate an _id'() {
         given:
-        def operation = new MixedBulkWriteOperation(getNamespace(), [new InsertRequest(RawBsonDocument.parse('{_id: 1}'))],
-                ordered, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                [new InsertRequest(RawBsonDocument.parse('{_id: 1}'))], ordered, ACKNOWLEDGED, false)
 
         when:
         BulkWriteResult result = execute(operation, async)
@@ -154,7 +156,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when documents match the query, a remove of one should remove one of them'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true))
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                                              [new DeleteRequest(new BsonDocument('x', BsonBoolean.TRUE)).multi(false)],
                                              ordered, ACKNOWLEDGED, false)
 
@@ -173,7 +175,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true),
                                               new Document('x', false))
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                                              [new DeleteRequest(new BsonDocument('x', BsonBoolean.TRUE))],
                                              ordered, ACKNOWLEDGED, false)
 
@@ -191,7 +193,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when multiple document match the query, update of one should update only one of them'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true))
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                                              [new UpdateRequest(new BsonDocument('x', BsonBoolean.TRUE),
                                                                 new BsonDocument('$set', new BsonDocument('y', new BsonInt32(1))),
                                                                 UPDATE).multi(false)],
@@ -211,7 +213,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when documents match the query, update multi should update all of them'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true))
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [new UpdateRequest(new BsonDocument('x', BsonBoolean.TRUE),
                         new BsonDocument('$set', new BsonDocument('y', new BsonInt32(1))),
                         UPDATE).multi(true)], ordered, ACKNOWLEDGED, false)
@@ -231,7 +233,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         def id = new ObjectId()
         def query = new BsonDocument('_id', new BsonObjectId(id))
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [new UpdateRequest(query, new BsonDocument('$set', new BsonDocument('x', new BsonInt32(2))),
                         UPDATE).upsert(true)], ordered, ACKNOWLEDGED, false)
 
@@ -250,7 +252,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         def id = new ObjectId()
         def query = new BsonDocument('_id', new BsonObjectId(id))
         given:
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                                              [new UpdateRequest(query, new BsonDocument('$set', new BsonDocument('x', new BsonInt32(2))),
                                                                 UPDATE).upsert(true).multi(true)],
                                              ordered, ACKNOWLEDGED, false)
@@ -270,7 +272,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when documents matches the query, update one with upsert should update only one of them'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true))
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                                              [new UpdateRequest(new BsonDocument('x', BsonBoolean.TRUE),
                                                                 new BsonDocument('$set', new BsonDocument('y', new BsonInt32(1))),
                                                                 UPDATE).multi(false).upsert(true)],
@@ -290,7 +292,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when documents match the query, update multi with upsert should update all of them'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true))
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                                              [new UpdateRequest(new BsonDocument('x', BsonBoolean.TRUE),
                                                                 new BsonDocument('$set', new BsonDocument('y', new BsonInt32(1))),
                                                                 UPDATE).upsert(true).multi(true)],
@@ -310,7 +312,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when updating with an empty document, update should throw IllegalArgumentException'() {
         given:
         def id = new ObjectId()
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)), new BsonDocument(), UPDATE)],
                 true, ACKNOWLEDGED, false)
 
@@ -327,7 +329,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when replacing with an empty document, update should not throw IllegalArgumentException'() {
         given:
         def id = new ObjectId()
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)), new BsonDocument(), REPLACE)],
                 true, ACKNOWLEDGED, false)
 
@@ -344,7 +346,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when updating with an invalid document, update should throw IllegalArgumentException'() {
         given:
         def id = new ObjectId()
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)), new BsonDocument('a', new BsonInt32(1)), UPDATE)],
                 true, ACKNOWLEDGED, false)
 
@@ -362,7 +364,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when replacing an invalid document, replace should throw IllegalArgumentException'() {
         given:
         def id = new ObjectId()
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)),
                         new BsonDocument('$set', new BsonDocument('x', new BsonInt32(1))), REPLACE)],
                 true, ACKNOWLEDGED, false)
@@ -381,7 +383,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     @IgnoreIf({ serverVersionLessThan(5, 0) })
     def 'when inserting a document with a field starting with a dollar sign, insert should not throw'() {
         given:
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [new InsertRequest(new BsonDocument('$inc', new BsonDocument('x', new BsonInt32(1))))],
                 true, ACKNOWLEDGED, false)
 
@@ -398,12 +400,12 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when a document contains a key with an illegal character, replacing a document with it should throw IllegalArgumentException'() {
         given:
         def id = new ObjectId()
-        def operation = new MixedBulkWriteOperation(getNamespace(),
-                                             [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)),
-                                                                new BsonDocument('$set', new BsonDocument('x', new BsonInt32(1))),
-                                                                REPLACE)
-                                                      .upsert(true)],
-                                             true, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)),
+                        new BsonDocument('$set', new BsonDocument('x', new BsonInt32(1))),
+                        REPLACE)
+                         .upsert(true)],
+                true, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -418,7 +420,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when no document matches the query, a replace with upsert should insert a document'() {
         given:
         def id = new ObjectId()
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                                              [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)),
                                                                 new BsonDocument('_id', new BsonObjectId(id))
                                                                         .append('x', new BsonInt32(2)),
@@ -439,7 +441,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'when a custom _id is upserted it should be in the write result'() {
         given:
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                                              [new UpdateRequest(new BsonDocument('_id', new BsonInt32(0)),
                                                                 new BsonDocument('$set', new BsonDocument('a', new BsonInt32(0))),
                                                                 UPDATE)
@@ -471,7 +473,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'unacknowledged upserts with custom _id should not error'() {
         given:
         def binding = async ? getAsyncSingleConnectionBinding() : getSingleConnectionBinding()
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                                              [new UpdateRequest(new BsonDocument('_id', new BsonInt32(0)),
                                                                 new BsonDocument('$set', new BsonDocument('a', new BsonInt32(0))),
                                                                 UPDATE)
@@ -503,7 +505,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true))
 
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                                              [new UpdateRequest(new BsonDocument('x', BsonBoolean.TRUE),
                                                                 new BsonDocument('y', new BsonInt32(1)).append('x', BsonBoolean.FALSE),
                                                                 REPLACE).upsert(true)],
@@ -524,7 +526,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when a replacement document is 16MB, the document is still replaced'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('_id', 1))
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
                         new BsonDocument('_id', new BsonInt32(1))
                                 .append('x', new BsonBinary(new byte[1024 * 1024 * 16 - 30])),
@@ -545,16 +547,16 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when two update documents together exceed 16MB, the documents are still updated'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('_id', 1), new Document('_id', 2))
-        def operation = new MixedBulkWriteOperation(getNamespace(),
-                                             [new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
-                                                                new BsonDocument('_id', new BsonInt32(1))
-                                                                        .append('x', new BsonBinary(new byte[1024 * 1024 * 16 - 30])),
-                                                                REPLACE),
-                                              new UpdateRequest(new BsonDocument('_id', new BsonInt32(2)),
-                                                                new BsonDocument('_id', new BsonInt32(2))
-                                                                        .append('x', new BsonBinary(new byte[1024 * 1024 * 16 - 30])),
-                                                                REPLACE)],
-                                             true, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                [new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
+                        new BsonDocument('_id', new BsonInt32(1))
+                                .append('x', new BsonBinary(new byte[1024 * 1024 * 16 - 30])),
+                        REPLACE),
+                 new UpdateRequest(new BsonDocument('_id', new BsonInt32(2)),
+                         new BsonDocument('_id', new BsonInt32(2))
+                                 .append('x', new BsonBinary(new byte[1024 * 1024 * 16 - 30])),
+                         REPLACE)],
+                true, ACKNOWLEDGED, false)
 
         when:
         BulkWriteResult result = execute(operation, async)
@@ -571,7 +573,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when documents together are just below the max message size, the documents are still inserted'() {
         given:
         def bsonBinary = new BsonBinary(new byte[16 * 1000 * 1000 - (getCollectionName().length() + 33)])
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [
                         new InsertRequest(new BsonDocument('_id', new BsonObjectId()).append('b', bsonBinary)),
                         new InsertRequest(new BsonDocument('_id', new BsonObjectId()).append('b', bsonBinary)),
@@ -592,7 +594,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when documents together are just above the max message size, the documents are still inserted'() {
         given:
         def bsonBinary = new BsonBinary(new byte[16 * 1000 * 1000 - (getCollectionName().length() + 32)])
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [
                         new InsertRequest(new BsonDocument('_id', new BsonObjectId()).append('b', bsonBinary)),
                         new InsertRequest(new BsonDocument('_id', new BsonObjectId()).append('b', bsonBinary)),
@@ -613,7 +615,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'should handle multi-length runs of ordered insert, update, replace, and remove'() {
         given:
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(getNamespace(), getTestWrites(), ordered, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), getTestWrites(), ordered, ACKNOWLEDGED, false)
 
         when:
         BulkWriteResult result = execute(operation, async)
@@ -636,13 +638,13 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'should handle multi-length runs of UNACKNOWLEDGED insert, update, replace, and remove'() {
         given:
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(getNamespace(),  getTestWrites(), ordered, UNACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),  getTestWrites(), ordered, UNACKNOWLEDGED, false)
         def binding = async ? getAsyncSingleConnectionBinding() : getSingleConnectionBinding()
 
         when:
         def result = execute(operation, binding)
-        execute(new MixedBulkWriteOperation(namespace, [new InsertRequest(new BsonDocument('_id', new BsonInt32(9)))], true, ACKNOWLEDGED,
-                false,), binding)
+        execute(new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), namespace,
+                [new InsertRequest(new BsonDocument('_id', new BsonInt32(9)))], true, ACKNOWLEDGED, false,), binding)
 
         then:
         !result.wasAcknowledged()
@@ -671,7 +673,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         (1..numberOfWrites).each {
             writes.add(new InsertRequest(new BsonDocument()))
         }
-        def operation = new MixedBulkWriteOperation(getNamespace(), writes, ordered, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), writes, ordered, ACKNOWLEDGED, false)
 
         when:
         execute(operation, binding)
@@ -694,7 +696,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
             writeOperations.add(upsert)
             writeOperations.add(new DeleteRequest(new BsonDocument('key', new BsonInt32(it))))
         }
-        def operation = new MixedBulkWriteOperation(getNamespace(), writeOperations, ordered, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), writeOperations, ordered, ACKNOWLEDGED, false)
 
         when:
         BulkWriteResult result = execute(operation, async)
@@ -709,13 +711,13 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'error details should have correct index on ordered write failure'() {
         given:
-        def operation = new MixedBulkWriteOperation(getNamespace(),
-                                             [new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
-                                              new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
-                                                                new BsonDocument('$set', new BsonDocument('x', new BsonInt32(3))),
-                                                                UPDATE),
-                                              new InsertRequest(new BsonDocument('_id', new BsonInt32(1))) // this should fail with index 2
-                                             ], true, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                [new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
+                 new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
+                         new BsonDocument('$set', new BsonDocument('x', new BsonInt32(3))),
+                         UPDATE),
+                 new InsertRequest(new BsonDocument('_id', new BsonInt32(1))) // this should fail with index 2
+                ], true, ACKNOWLEDGED, false)
         when:
         execute(operation, async)
 
@@ -732,13 +734,13 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'error details should have correct index on unordered write failure'() {
         given:
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(getNamespace(),
-                                             [new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
-                                              new UpdateRequest(new BsonDocument('_id', new BsonInt32(2)),
-                                                                new BsonDocument('$set', new BsonDocument('x', new BsonInt32(3))),
-                                                                UPDATE),
-                                              new InsertRequest(new BsonDocument('_id', new BsonInt32(3))) // this should fail with index 2
-                                             ], false, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                [new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
+                 new UpdateRequest(new BsonDocument('_id', new BsonInt32(2)),
+                         new BsonDocument('$set', new BsonDocument('x', new BsonInt32(3))),
+                         UPDATE),
+                 new InsertRequest(new BsonDocument('_id', new BsonInt32(3))) // this should fail with index 2
+                ], false, ACKNOWLEDGED, false)
         when:
         execute(operation, async)
 
@@ -761,7 +763,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         for (int i = 0; i < 2000; i++) {
             inserts.add(new InsertRequest(new BsonDocument('_id', new BsonInt32(i))))
         }
-        def operation = new MixedBulkWriteOperation(getNamespace(), inserts, false, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), inserts, false, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -783,7 +785,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         for (int i = 0; i < 2000; i++) {
             inserts.add(new InsertRequest(new BsonDocument('_id', new BsonInt32(i))))
         }
-        def operation = new MixedBulkWriteOperation(getNamespace(), inserts, true, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), inserts, true, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -803,9 +805,9 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     @IgnoreIf({ !isDiscoverableReplicaSet() })
     def 'should throw bulk write exception with a write concern error when wtimeout is exceeded'() {
         given:
-        def operation = new MixedBulkWriteOperation(getNamespace(),
-                                             [new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))],
-                                             false, new WriteConcern(5, 1), false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                [new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))],
+                false, new WriteConcern(5, 1), false)
         when:
         execute(operation, async)
 
@@ -822,10 +824,10 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when there is a duplicate key error and a write concern error, both should be reported'() {
         given:
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(getNamespace(),
-                                             [new InsertRequest(new BsonDocument('_id', new BsonInt32(7))),
-                                              new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))   // duplicate key
-                                             ], false, new WriteConcern(4, 1), false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                [new InsertRequest(new BsonDocument('_id', new BsonInt32(7))),
+                 new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))   // duplicate key
+                ], false, new WriteConcern(4, 1), false)
 
         when:
         execute(operation, async)  // This is assuming that it won't be able to replicate to 4 servers in 1 ms
@@ -845,7 +847,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'should throw on write concern error on multiple failpoint'() {
         given:
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [new DeleteRequest(new BsonDocument('_id', new BsonInt32(2))), // existing key
                  new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))  // existing (duplicate) key
                 ], true, ACKNOWLEDGED, true)
@@ -877,7 +879,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'should throw IllegalArgumentException when passed an empty bulk operation'() {
         when:
-        new MixedBulkWriteOperation(getNamespace(), [], ordered, UNACKNOWLEDGED, false)
+        new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), [], ordered, UNACKNOWLEDGED, false)
 
         then:
         thrown(IllegalArgumentException)
@@ -889,7 +891,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should throw if bypassDocumentValidation is set and writeConcern is UNACKNOWLEDGED'() {
         given:
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [new InsertRequest(BsonDocument.parse('{ level: 9 }'))], true, UNACKNOWLEDGED, false)
                 .bypassDocumentValidation(bypassDocumentValidation)
 
@@ -906,7 +908,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should throw if collation is set and write is UNACKNOWLEDGED'() {
         given:
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [new DeleteRequest(BsonDocument.parse('{ level: 9 }')).collation(defaultCollation)], true, UNACKNOWLEDGED, false)
 
         when:
@@ -926,8 +928,8 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         def collectionHelper = getCollectionHelper(namespace)
         collectionHelper.create(namespace.getCollectionName(), new CreateCollectionOptions().validationOptions(
                 new ValidationOptions().validator(gte('level', 10))))
-        def operation = new MixedBulkWriteOperation(namespace, [new InsertRequest(BsonDocument.parse('{ level: 9 }'))], ordered,
-                ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), namespace,
+                [new InsertRequest(BsonDocument.parse('{ level: 9 }'))], ordered, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -962,7 +964,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
                 new ValidationOptions().validator(gte('level', 10))))
 
         collectionHelper.insertDocuments(BsonDocument.parse('{ x: true, level: 10}'))
-        def operation = new MixedBulkWriteOperation(namespace,
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), namespace,
                 [new UpdateRequest(BsonDocument.parse('{x: true}'), BsonDocument.parse('{$inc: {level: -1}}'), UPDATE).multi(false)],
                 ordered, ACKNOWLEDGED, false)
 
@@ -990,7 +992,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', 1), new Document('y', 1),
                 new Document('z', 1))
-        def operation = new MixedBulkWriteOperation(namespace, requests, false, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), namespace, requests, false, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -1021,7 +1023,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         def requests = [new DeleteRequest(BsonDocument.parse('{str: "FOO"}}')).collation(caseInsensitiveCollation),
                         new UpdateRequest(BsonDocument.parse('{str: "BAR"}}'), BsonDocument.parse('{str: "bar"}}'), REPLACE)
                                 .collation(caseInsensitiveCollation)]
-        def operation = new MixedBulkWriteOperation(namespace, requests, false, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), namespace, requests, false, ACKNOWLEDGED, false)
 
         when:
         BulkWriteResult result = execute(operation, async)
@@ -1039,7 +1041,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         def testWrites = getTestWrites()
         Collections.shuffle(testWrites)
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(getNamespace(), testWrites, true, ACKNOWLEDGED, true)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), testWrites, true, ACKNOWLEDGED, true)
 
         when:
         if (serverVersionAtLeast(3, 6) && isDiscoverableReplicaSet()) {
@@ -1082,7 +1084,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         def testWrites = getTestWrites()
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(getNamespace(), testWrites, true, ACKNOWLEDGED, true)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), testWrites, true, ACKNOWLEDGED, true)
 
         when:
         enableOnPrimaryTransactionalWriteFailPoint(BsonDocument.parse(failPoint))
@@ -1107,7 +1109,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         def testWrites = getTestWrites()
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(getNamespace(), testWrites, true, UNACKNOWLEDGED, true)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), testWrites, true, UNACKNOWLEDGED, true)
 
         when:
         enableOnPrimaryTransactionalWriteFailPoint(BsonDocument.parse(failPoint))
@@ -1131,7 +1133,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'should retry if the connection initially fails'() {
         when:
         def cannedResult = BsonDocument.parse('{ok: 1.0, n: 1}')
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [new InsertRequest(BsonDocument.parse('{ level: 9 }'))], true, ACKNOWLEDGED, true)
         def expectedCommand = new BsonDocument('insert', new BsonString(getNamespace().getCollectionName()))
                 .append('ordered', BsonBoolean.TRUE)
@@ -1146,7 +1148,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'should throw original error when retrying and failing'() {
         given:
-        def operation = new MixedBulkWriteOperation(getNamespace(),
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
                 [new InsertRequest(BsonDocument.parse('{ level: 9 }'))], true, ACKNOWLEDGED, true)
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
@@ -1173,7 +1175,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should not request retryable write for multi updates or deletes'() {
         given:
-        def operation = new MixedBulkWriteOperation(getNamespace(), writes, true, ACKNOWLEDGED, true)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), writes, true, ACKNOWLEDGED, true)
 
         when:
         executeWithSession(operation, async)
@@ -1221,7 +1223,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
                         .multi(true)
                         .arrayFilters([BsonDocument.parse('{"i.b": 1}')]),
         ]
-        def operation = new MixedBulkWriteOperation(namespace, requests, true, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), namespace, requests, true, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -1243,7 +1245,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
                 new UpdateRequest(new BsonDocument(), BsonDocument.parse('{ $set: {"y.$[i].b": 2}}'), UPDATE)
                         .arrayFilters([BsonDocument.parse('{"i.b": 3}')])
         ]
-        def operation = new MixedBulkWriteOperation(namespace, requests, true, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), namespace, requests, true, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -1262,7 +1264,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
                 new UpdateRequest(new BsonDocument(), BsonDocument.parse('{ $set: {"y.$[i].b": 2}}'), UPDATE)
                         .arrayFilters([BsonDocument.parse('{"i.b": 3}')])
         ]
-        def operation = new MixedBulkWriteOperation(namespace, requests, true, UNACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), namespace, requests, true, UNACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -1281,7 +1283,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
                 new UpdateRequest(new BsonDocument(), BsonDocument.parse('{ $set: {"y.$[i].b": 2}}'), UPDATE)
                         .hint(BsonDocument.parse('{ _id: 1 }'))
         ]
-        def operation = new MixedBulkWriteOperation(namespace, requests, true, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), namespace, requests, true, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -1300,7 +1302,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
                 new UpdateRequest(new BsonDocument(), BsonDocument.parse('{ $set: {"y.$[i].b": 2}}'), UPDATE)
                         .hintString('_id')
         ]
-        def operation = new MixedBulkWriteOperation(namespace, requests, true, UNACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), namespace, requests, true, UNACKNOWLEDGED, false)
 
         when:
         execute(operation, async)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/RenameCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/RenameCollectionOperationSpecification.groovy
@@ -25,6 +25,8 @@ import org.bson.Document
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
+import static com.mongodb.ClusterFixture.CSOT_TIMEOUT
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
@@ -35,61 +37,43 @@ import static com.mongodb.ClusterFixture.serverVersionLessThan
 class RenameCollectionOperationSpecification extends OperationFunctionalSpecification {
 
     def cleanup() {
-        new DropCollectionOperation(new MongoNamespace(getDatabaseName(), 'newCollection')).execute(getBinding())
+        new DropCollectionOperation(CSOT_TIMEOUT.get(), new MongoNamespace(getDatabaseName(), 'newCollection'),
+                WriteConcern.ACKNOWLEDGED).execute(getBinding())
     }
 
     def 'should return rename a collection'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentThat', 'forces creation of the Collection'))
         assert collectionNameExists(getCollectionName())
+        def operation = new RenameCollectionOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                new MongoNamespace(getDatabaseName(), 'newCollection'), null)
 
         when:
-        new RenameCollectionOperation(getNamespace(), new MongoNamespace(getDatabaseName(), 'newCollection')).execute(getBinding())
+        execute(operation, async)
 
         then:
         !collectionNameExists(getCollectionName())
         collectionNameExists('newCollection')
-    }
 
-
-    def 'should return rename a collection asynchronously'() {
-        given:
-        getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentThat', 'forces creation of the Collection'))
-        assert collectionNameExists(getCollectionName())
-
-        when:
-        executeAsync(new RenameCollectionOperation(getNamespace(), new MongoNamespace(getDatabaseName(), 'newCollection')))
-
-        then:
-        !collectionNameExists(getCollectionName())
-        collectionNameExists('newCollection')
+        where:
+        async << [true, false]
     }
 
     def 'should throw if not drop and collection exists'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentThat', 'forces creation of the Collection'))
         assert collectionNameExists(getCollectionName())
+        def operation = new RenameCollectionOperation(CSOT_NO_TIMEOUT.get(), getNamespace(), getNamespace(), null)
 
         when:
-        new RenameCollectionOperation(getNamespace(), getNamespace()).execute(getBinding())
+        execute(operation, async)
 
         then:
         thrown(MongoServerException)
         collectionNameExists(getCollectionName())
-    }
 
-
-    def 'should throw if not drop and collection exists asynchronously'() {
-        given:
-        getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentThat', 'forces creation of the Collection'))
-        assert collectionNameExists(getCollectionName())
-
-        when:
-        executeAsync(new RenameCollectionOperation(getNamespace(), getNamespace()))
-
-        then:
-        thrown(MongoServerException)
-        collectionNameExists(getCollectionName())
+        where:
+        async << [true, false]
     }
 
     @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
@@ -97,8 +81,8 @@ class RenameCollectionOperationSpecification extends OperationFunctionalSpecific
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentThat', 'forces creation of the Collection'))
         assert collectionNameExists(getCollectionName())
-        def operation = new RenameCollectionOperation(getNamespace(), new MongoNamespace(getDatabaseName(), 'newCollection'),
-                new WriteConcern(5))
+        def operation = new RenameCollectionOperation(CSOT_NO_TIMEOUT.get(), getNamespace(),
+                new MongoNamespace(getDatabaseName(), 'newCollection'), new WriteConcern(5))
 
         when:
         async ? executeAsync(operation) : operation.execute(getBinding())
@@ -112,9 +96,8 @@ class RenameCollectionOperationSpecification extends OperationFunctionalSpecific
         async << [true, false]
     }
 
-
     def collectionNameExists(String collectionName) {
-        def cursor = new ListCollectionsOperation(databaseName, new DocumentCodec()).execute(getBinding())
+        def cursor = new ListCollectionsOperation(CSOT_NO_TIMEOUT.get(), databaseName, new DocumentCodec()).execute(getBinding())
         if (!cursor.hasNext()) {
             return false
         }

--- a/driver-core/src/test/unit/com/mongodb/internal/ClientSideOperationTimeoutsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/ClientSideOperationTimeoutsTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.Collection;
+
+import static com.mongodb.ClusterFixture.sleep;
+import static com.mongodb.internal.ClientSideOperationTimeouts.NO_TIMEOUT;
+import static com.mongodb.internal.ClientSideOperationTimeouts.create;
+import static com.mongodb.internal.ClientSideOperationTimeouts.withMaxCommitMS;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+final class ClientSideOperationTimeoutsTest {
+
+
+    @TestFactory
+    Collection<DynamicTest> clientSideOperationTimeoutsTest() {
+        return asList(
+                dynamicTest("test defaults", () -> {
+                    ClientSideOperationTimeout clientSideOperationTimeout = NO_TIMEOUT;
+                    assertAll(
+                            () -> assertFalse(clientSideOperationTimeout.hasTimeoutMS()),
+                            () -> assertEquals(0, clientSideOperationTimeout.getMaxTimeMS()),
+                            () -> assertEquals(0, clientSideOperationTimeout.getMaxAwaitTimeMS()),
+                            () -> assertEquals(0, clientSideOperationTimeout.getMaxCommitTimeMS())
+                    );
+                }),
+                dynamicTest("Uses timeoutMS if set", () -> {
+                    long altTimeout = 9;
+                    ClientSideOperationTimeout clientSideOperationTimeout = create(99999999L, altTimeout, altTimeout, altTimeout);
+                    assertAll(
+                            () -> assertTrue(clientSideOperationTimeout.hasTimeoutMS()),
+                            () -> assertTrue(clientSideOperationTimeout.getMaxTimeMS() > 0),
+                            () -> assertTrue(clientSideOperationTimeout.getMaxAwaitTimeMS() > 0),
+                            () -> assertTrue(clientSideOperationTimeout.getMaxCommitTimeMS() > 0)
+                    );
+                }),
+                dynamicTest("MaxTimeMS set", () -> {
+                    ClientSideOperationTimeout clientSideOperationTimeout = create(null, 9);
+                    assertAll(
+                            () -> assertEquals(9, clientSideOperationTimeout.getMaxTimeMS()),
+                            () -> assertEquals(0, clientSideOperationTimeout.getMaxAwaitTimeMS()),
+                            () -> assertEquals(0, clientSideOperationTimeout.getMaxCommitTimeMS())
+                    );
+                }),
+                dynamicTest("MaxTimeMS and MaxAwaitTimeMS set", () -> {
+                    ClientSideOperationTimeout clientSideOperationTimeout = create(null, 9, 99);
+                    assertAll(
+                            () -> assertEquals(9, clientSideOperationTimeout.getMaxTimeMS()),
+                            () -> assertEquals(99, clientSideOperationTimeout.getMaxAwaitTimeMS()),
+                            () -> assertEquals(0, clientSideOperationTimeout.getMaxCommitTimeMS())
+                    );
+                }),
+                dynamicTest("MaxCommitTimeMS set", () -> {
+                    ClientSideOperationTimeout clientSideOperationTimeout = withMaxCommitMS(null, 9L);
+                    assertAll(
+                            () -> assertEquals(0, clientSideOperationTimeout.getMaxTimeMS()),
+                            () -> assertEquals(0, clientSideOperationTimeout.getMaxAwaitTimeMS()),
+                            () -> assertEquals(9L, clientSideOperationTimeout.getMaxCommitTimeMS())
+                    );
+                }),
+                dynamicTest("All deprecated options set", () -> {
+                    ClientSideOperationTimeout clientSideOperationTimeout = create(null, 99, 9L, 999);
+                    assertAll(
+                            () -> assertEquals(9, clientSideOperationTimeout.getMaxAwaitTimeMS()),
+                            () -> assertEquals(99, clientSideOperationTimeout.getMaxTimeMS()),
+                            () -> assertEquals(999, clientSideOperationTimeout.getMaxCommitTimeMS())
+                    );
+                }),
+                dynamicTest("Use timeout if available or the alternative", () -> assertAll(
+                        () -> assertEquals(99L, NO_TIMEOUT.timeoutOrAlternative(99)),
+                        () -> assertEquals(0L, ClientSideOperationTimeouts.create(0L).timeoutOrAlternative(99)),
+                        () -> assertTrue(ClientSideOperationTimeouts.create(999L).timeoutOrAlternative(0) <= 999),
+                        () -> assertTrue(ClientSideOperationTimeouts.create(999L).timeoutOrAlternative(999999) <= 999)
+                )),
+                dynamicTest("Calculate min works as expected", () -> assertAll(
+                        () -> assertEquals(99L, NO_TIMEOUT.calculateMin(99)),
+                        () -> assertEquals(99L, ClientSideOperationTimeouts.create(0L).calculateMin(99)),
+                        () -> assertTrue(ClientSideOperationTimeouts.create(999L).calculateMin(0) <= 999),
+                        () -> assertTrue(ClientSideOperationTimeouts.create(999L).calculateMin(999999) <= 999)
+                )),
+                dynamicTest("Expired works as expected", () -> {
+                    ClientSideOperationTimeout smallTimeout = ClientSideOperationTimeouts.create(1L);
+                    ClientSideOperationTimeout longTimeout = ClientSideOperationTimeouts.create(999999999L);
+                    ClientSideOperationTimeout noTimeout = NO_TIMEOUT;
+                    sleep(100);
+                    assertAll(
+                            () -> assertFalse(noTimeout.expired()),
+                            () -> assertFalse(longTimeout.expired()),
+                            () -> assertTrue(smallTimeout.expired())
+                    );
+                })
+        );
+    }
+
+    private ClientSideOperationTimeoutsTest() {
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
@@ -81,6 +81,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT;
 import static com.mongodb.assertions.Assertions.assertFalse;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
@@ -474,7 +475,8 @@ public abstract class AbstractConnectionPoolTest {
     }
 
     private static void executeAdminCommand(final BsonDocument command) {
-        new CommandReadOperation<>("admin", command, new BsonDocumentCodec()).execute(ClusterFixture.getBinding());
+        new CommandReadOperation<>(CSOT_NO_TIMEOUT.get(), "admin", command, new BsonDocumentCodec())
+                .execute(ClusterFixture.getBinding());
     }
 
     private void setFailPoint() {

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncOperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncOperationHelperSpecification.groovy
@@ -36,6 +36,7 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.Decoder
 import spock.lang.Specification
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ReadPreference.primary
 import static com.mongodb.internal.operation.AsyncOperationHelper.CommandReadTransformerAsync
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync
@@ -54,7 +55,7 @@ class AsyncOperationHelperSpecification extends Specification {
             getMaxWireVersion() >> getMaxWireVersionForServerVersion([4, 0, 0])
             getServerType() >> ServerType.REPLICA_SET_PRIMARY
         }
-        def commandCreator = { serverDesc, connectionDesc -> command }
+        def commandCreator = { csot, serverDesc, connectionDesc -> command }
         def callback = new SingleResultCallback() {
             def result
             def throwable
@@ -89,7 +90,7 @@ class AsyncOperationHelperSpecification extends Specification {
         }
 
         when:
-        executeRetryableWriteAsync(asyncWriteBinding, dbName, primary(), new NoOpFieldNameValidator(), decoder,
+        executeRetryableWriteAsync(CSOT_NO_TIMEOUT.get(), asyncWriteBinding, dbName, primary(), new NoOpFieldNameValidator(), decoder,
                 commandCreator, FindAndModifyHelper.asyncTransformer(), { cmd -> cmd }, callback)
 
         then:
@@ -129,7 +130,7 @@ class AsyncOperationHelperSpecification extends Specification {
         given:
         def dbName = 'db'
         def command = new BsonDocument('fakeCommandName', BsonNull.VALUE)
-        def commandCreator = { serverDescription, connectionDescription -> command }
+        def commandCreator = { csot, serverDescription, connectionDescription -> command }
         def decoder = Stub(Decoder)
         def callback = Stub(SingleResultCallback)
         def function = Stub(CommandReadTransformerAsync)
@@ -146,7 +147,7 @@ class AsyncOperationHelperSpecification extends Specification {
         def connectionDescription = Stub(ConnectionDescription)
 
         when:
-        executeRetryableReadAsync(asyncReadBinding, dbName, commandCreator, decoder, function, false, callback)
+        executeRetryableReadAsync(CSOT_NO_TIMEOUT.get(), asyncReadBinding, dbName, commandCreator, decoder, function, false, callback)
 
         then:
         _ * connection.getDescription() >> connectionDescription

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/CommitTransactionOperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/CommitTransactionOperationUnitSpecification.groovy
@@ -24,6 +24,8 @@ import com.mongodb.internal.binding.AsyncWriteBinding
 import com.mongodb.internal.binding.WriteBinding
 import com.mongodb.internal.session.SessionContext
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
+
 class CommitTransactionOperationUnitSpecification extends OperationUnitSpecification {
     def 'should add UnknownTransactionCommitResult error label to MongoTimeoutException'() {
         given:
@@ -33,7 +35,7 @@ class CommitTransactionOperationUnitSpecification extends OperationUnitSpecifica
                 hasActiveTransaction() >> true
             }
         }
-        def operation = new CommitTransactionOperation(WriteConcern.ACKNOWLEDGED)
+        def operation = new CommitTransactionOperation(CSOT_NO_TIMEOUT.get(), WriteConcern.ACKNOWLEDGED)
 
         when:
         operation.execute(writeBinding)
@@ -53,7 +55,7 @@ class CommitTransactionOperationUnitSpecification extends OperationUnitSpecifica
                 hasActiveTransaction() >> true
             }
         }
-        def operation = new CommitTransactionOperation(WriteConcern.ACKNOWLEDGED)
+        def operation = new CommitTransactionOperation(CSOT_NO_TIMEOUT.get(), WriteConcern.ACKNOWLEDGED)
         def callback = new FutureResultCallback()
 
         when:

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/FindOperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/FindOperationUnitSpecification.groovy
@@ -27,21 +27,23 @@ import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.CursorType.TailableAwait
-import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME
 
 class FindOperationUnitSpecification extends OperationUnitSpecification {
 
     def 'should find with correct command'() {
         when:
-        def operation = new FindOperation<BsonDocument>(namespace, new BsonDocumentCodec())
+        def operation = new FindOperation<BsonDocument>(CSOT_NO_TIMEOUT.get(), namespace, new BsonDocumentCodec())
         def expectedCommand = new BsonDocument('find', new BsonString(namespace.getCollectionName()))
 
         then:
         testOperation(operation, [3, 2, 0], expectedCommand, async, commandResult)
         // Overrides
         when:
-        operation.filter(new BsonDocument('a', BsonBoolean.TRUE))
+        operation = new FindOperation<BsonDocument>(CSOT_MAX_TIME.get(), namespace, new BsonDocumentCodec())
+                .filter(new BsonDocument('a', BsonBoolean.TRUE))
                 .projection(new BsonDocument('x', new BsonInt32(1)))
                 .skip(2)
                 .limit(limit)
@@ -51,7 +53,6 @@ class FindOperationUnitSpecification extends OperationUnitSpecification {
                 .noCursorTimeout(true)
                 .partial(true)
                 .oplogReplay(true)
-                .maxTime(10, MILLISECONDS)
                 .comment(new BsonString('my comment'))
                 .hint(BsonDocument.parse('{ hint : 1}'))
                 .min(BsonDocument.parse('{ abc: 99 }'))
@@ -71,7 +72,7 @@ class FindOperationUnitSpecification extends OperationUnitSpecification {
                 .append('allowPartialResults', BsonBoolean.TRUE)
                 .append('noCursorTimeout', BsonBoolean.TRUE)
                 .append('oplogReplay', BsonBoolean.TRUE)
-                .append('maxTimeMS', new BsonInt64(operation.getMaxTime(MILLISECONDS)))
+                .append('maxTimeMS', new BsonInt64(100))
                 .append('comment', operation.getComment())
                 .append('hint', operation.getHint())
                 .append('min', operation.getMin())
@@ -108,7 +109,7 @@ class FindOperationUnitSpecification extends OperationUnitSpecification {
 
     def 'should use the readPreference to set secondaryOk for commands'() {
         when:
-        def operation = new FindOperation<Document>(namespace, new DocumentCodec())
+        def operation = new FindOperation<Document>(CSOT_NO_TIMEOUT.get(), namespace, new DocumentCodec())
 
         then:
         testOperationSecondaryOk(operation, [3, 2, 0], readPreference, async, commandResult)

--- a/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/syncadapter/SyncMongoCollection.kt
+++ b/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/syncadapter/SyncMongoCollection.kt
@@ -55,6 +55,7 @@ import com.mongodb.client.result.InsertManyResult
 import com.mongodb.client.result.InsertOneResult
 import com.mongodb.client.result.UpdateResult
 import com.mongodb.kotlin.client.coroutine.MongoCollection
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.toCollection
 import kotlinx.coroutines.runBlocking
 import org.bson.Document
@@ -74,6 +75,7 @@ data class SyncMongoCollection<T : Any>(val wrapped: MongoCollection<T>) : JMong
     override fun getWriteConcern(): WriteConcern = wrapped.writeConcern
 
     override fun getReadConcern(): ReadConcern = wrapped.readConcern
+    override fun getTimeout(timeUnit: TimeUnit): Long? = wrapped.timeout(timeUnit)
 
     override fun <R : Any> withDocumentClass(clazz: Class<R>): SyncMongoCollection<R> =
         SyncMongoCollection(wrapped.withDocumentClass(clazz))
@@ -89,6 +91,9 @@ data class SyncMongoCollection<T : Any>(val wrapped: MongoCollection<T>) : JMong
 
     override fun withReadConcern(readConcern: ReadConcern): SyncMongoCollection<T> =
         SyncMongoCollection(wrapped.withReadConcern(readConcern))
+
+    override fun withTimeout(timeout: Long, timeUnit: TimeUnit): com.mongodb.client.MongoCollection<T> =
+        SyncMongoCollection(wrapped.withTimeout(timeout, timeUnit))
 
     override fun countDocuments(): Long = runBlocking { wrapped.countDocuments() }
 

--- a/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/syncadapter/SyncMongoDatabase.kt
+++ b/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/syncadapter/SyncMongoDatabase.kt
@@ -28,6 +28,7 @@ import com.mongodb.client.MongoIterable
 import com.mongodb.client.model.CreateCollectionOptions
 import com.mongodb.client.model.CreateViewOptions
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.runBlocking
 import org.bson.Document
 import org.bson.codecs.configuration.CodecRegistry
@@ -44,6 +45,8 @@ data class SyncMongoDatabase(val wrapped: MongoDatabase) : JMongoDatabase {
 
     override fun getReadConcern(): ReadConcern = wrapped.readConcern
 
+    override fun getTimeout(timeUnit: TimeUnit): Long? = wrapped.timeout(timeUnit)
+
     override fun withCodecRegistry(codecRegistry: CodecRegistry): SyncMongoDatabase =
         SyncMongoDatabase(wrapped.withCodecRegistry(codecRegistry))
 
@@ -55,6 +58,9 @@ data class SyncMongoDatabase(val wrapped: MongoDatabase) : JMongoDatabase {
 
     override fun withReadConcern(readConcern: ReadConcern): SyncMongoDatabase =
         SyncMongoDatabase(wrapped.withReadConcern(readConcern))
+
+    override fun withTimeout(timeout: Long, timeUnit: TimeUnit): SyncMongoDatabase =
+        SyncMongoDatabase(wrapped.withTimeout(timeout, timeUnit))
 
     override fun getCollection(collectionName: String): MongoCollection<Document> =
         SyncMongoCollection(wrapped.getCollection(collectionName, Document::class.java))

--- a/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/MongoCollection.kt
+++ b/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/MongoCollection.kt
@@ -87,20 +87,21 @@ public class MongoCollection<T : Any>(private val wrapped: JMongoCollection<T>) 
     public val writeConcern: WriteConcern
         get() = wrapped.writeConcern
 
-    /** The time limit for the full execution of an operation. */
     /**
      * The time limit for the full execution of an operation.
      *
      * If not null the following deprecated options will be ignored: `waitQueueTimeoutMS`, `socketTimeoutMS`,
-     * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`
+     * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`.
      *
-     * -`null` means that the timeout mechanism for operations will defer to using: -`waitQueueTimeoutMS`: The maximum
-     * wait time in milliseconds that a thread may wait for a connection to become available -`socketTimeoutMS`: How
-     * long a send or receive on a socket can take before timing out. -`wTimeoutMS`: How long the server will wait for
-     * the write concern to be fulfilled before timing out. -`maxTimeMS`: The time limit for processing operations on a
-     * cursor. See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.
-     * -`maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute. -`0`
-     * means infinite timeout. -`> 0` The time limit to use for the full execution of an operation.
+     *   - `null` means that the timeout mechanism for operations will defer to using:
+     *      - `waitQueueTimeoutMS`: The maximum wait time in milliseconds that a thread may wait for a connection to become available
+     *      - `socketTimeoutMS`: How long a send or receive on a socket can take before timing out.
+     *      - `wTimeoutMS`: How long the server will wait for  the write concern to be fulfilled before timing out.
+     *      - `maxTimeMS`: The time limit for processing operations on a cursor.
+     *        See: [cursor.maxTimeMS](https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS").
+     *      - `maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute.
+     *   - `0` means infinite timeout.
+     *   - `> 0` The time limit to use for the full execution of an operation.
      *
      * @return the optional timeout duration
      * @since 4.x
@@ -172,6 +173,7 @@ public class MongoCollection<T : Any>(private val wrapped: JMongoCollection<T>) 
 
     /**
      * Create a new MongoCollection instance with the set time limit for the full execution of an operation.
+     *
      * - `0` means an infinite timeout
      * - `> 0` The time limit to use for the full execution of an operation.
      *

--- a/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/MongoCollection.kt
+++ b/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/MongoCollection.kt
@@ -87,6 +87,26 @@ public class MongoCollection<T : Any>(private val wrapped: JMongoCollection<T>) 
     public val writeConcern: WriteConcern
         get() = wrapped.writeConcern
 
+    /** The time limit for the full execution of an operation. */
+    /**
+     * The time limit for the full execution of an operation.
+     *
+     * If not null the following deprecated options will be ignored: `waitQueueTimeoutMS`, `socketTimeoutMS`,
+     * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`
+     *
+     * -`null` means that the timeout mechanism for operations will defer to using: -`waitQueueTimeoutMS`: The maximum
+     * wait time in milliseconds that a thread may wait for a connection to become available -`socketTimeoutMS`: How
+     * long a send or receive on a socket can take before timing out. -`wTimeoutMS`: How long the server will wait for
+     * the write concern to be fulfilled before timing out. -`maxTimeMS`: The time limit for processing operations on a
+     * cursor. See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.
+     * -`maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute. -`0`
+     * means infinite timeout. -`> 0` The time limit to use for the full execution of an operation.
+     *
+     * @return the optional timeout duration
+     * @since 4.x
+     */
+    public fun timeout(timeUnit: TimeUnit = TimeUnit.MILLISECONDS): Long? = wrapped.getTimeout(timeUnit)
+
     /**
      * Create a new collection instance with a different default class to cast any documents returned from the database
      * into.
@@ -149,6 +169,20 @@ public class MongoCollection<T : Any>(private val wrapped: JMongoCollection<T>) 
      */
     public fun withWriteConcern(newWriteConcern: WriteConcern): MongoCollection<T> =
         MongoCollection(wrapped.withWriteConcern(newWriteConcern))
+
+    /**
+     * Create a new MongoCollection instance with the set time limit for the full execution of an operation.
+     * - `0` means an infinite timeout
+     * - `> 0` The time limit to use for the full execution of an operation.
+     *
+     * @param timeout the timeout, which must be greater than or equal to 0
+     * @param timeUnit the time unit, defaults to Milliseconds
+     * @return a new MongoCollection instance with the set time limit for operations
+     * @see [MongoCollection.timeout]
+     * @since 4.x
+     */
+    public fun withTimeout(timeout: Long, timeUnit: TimeUnit = TimeUnit.MILLISECONDS): MongoCollection<T> =
+        MongoCollection(wrapped.withTimeout(timeout, timeUnit))
 
     /**
      * Counts the number of documents in the collection.

--- a/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/MongoDatabase.kt
+++ b/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/MongoDatabase.kt
@@ -58,6 +58,25 @@ public class MongoDatabase(private val wrapped: JMongoDatabase) {
         get() = wrapped.writeConcern
 
     /**
+     * The time limit for the full execution of an operation.
+     *
+     * If not null the following deprecated options will be ignored: `waitQueueTimeoutMS`, `socketTimeoutMS`,
+     * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`
+     *
+     * -`null` means that the timeout mechanism for operations will defer to using: -`waitQueueTimeoutMS`: The maximum
+     * wait time in milliseconds that a thread may wait for a connection to become available -`socketTimeoutMS`: How
+     * long a send or receive on a socket can take before timing out. -`wTimeoutMS`: How long the server will wait for
+     * the write concern to be fulfilled before timing out. -`maxTimeMS`: The time limit for processing operations on a
+     * cursor. See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.
+     * -`maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute. -`0`
+     * means infinite timeout. -`> 0` The time limit to use for the full execution of an operation.
+     *
+     * @return the optional timeout duration
+     * @since 4.x
+     */
+    public fun timeout(timeUnit: TimeUnit = TimeUnit.MILLISECONDS): Long? = wrapped.getTimeout(timeUnit)
+
+    /**
      * Create a new MongoDatabase instance with a different codec registry.
      *
      * The [CodecRegistry] configured by this method is effectively treated by the driver as an instance of
@@ -99,6 +118,20 @@ public class MongoDatabase(private val wrapped: JMongoDatabase) {
      */
     public fun withWriteConcern(newWriteConcern: WriteConcern): MongoDatabase =
         MongoDatabase(wrapped.withWriteConcern(newWriteConcern))
+
+    /**
+     * Create a new MongoDatabase instance with the set time limit for the full execution of an operation.
+     * - `0` means an infinite timeout
+     * - `> 0` The time limit to use for the full execution of an operation.
+     *
+     * @param timeout the timeout, which must be greater than or equal to 0
+     * @param timeUnit the time unit, defaults to Milliseconds
+     * @return a new MongoDatabase instance with the set time limit for operations
+     * @see [MongoDatabase.timeout]
+     * @since 4.x
+     */
+    public fun withTimeout(timeout: Long, timeUnit: TimeUnit = TimeUnit.MILLISECONDS): MongoDatabase =
+        MongoDatabase(wrapped.withTimeout(timeout, timeUnit))
 
     /**
      * Gets a collection.

--- a/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/MongoDatabase.kt
+++ b/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/MongoDatabase.kt
@@ -61,15 +61,17 @@ public class MongoDatabase(private val wrapped: JMongoDatabase) {
      * The time limit for the full execution of an operation.
      *
      * If not null the following deprecated options will be ignored: `waitQueueTimeoutMS`, `socketTimeoutMS`,
-     * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`
+     * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`.
      *
-     * -`null` means that the timeout mechanism for operations will defer to using: -`waitQueueTimeoutMS`: The maximum
-     * wait time in milliseconds that a thread may wait for a connection to become available -`socketTimeoutMS`: How
-     * long a send or receive on a socket can take before timing out. -`wTimeoutMS`: How long the server will wait for
-     * the write concern to be fulfilled before timing out. -`maxTimeMS`: The time limit for processing operations on a
-     * cursor. See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.
-     * -`maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute. -`0`
-     * means infinite timeout. -`> 0` The time limit to use for the full execution of an operation.
+     *   - `null` means that the timeout mechanism for operations will defer to using:
+     *      - `waitQueueTimeoutMS`: The maximum wait time in milliseconds that a thread may wait for a connection to become available
+     *      - `socketTimeoutMS`: How long a send or receive on a socket can take before timing out.
+     *      - `wTimeoutMS`: How long the server will wait for  the write concern to be fulfilled before timing out.
+     *      - `maxTimeMS`: The time limit for processing operations on a cursor.
+     *        See: [cursor.maxTimeMS](https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS").
+     *      - `maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute.
+     *   - `0` means infinite timeout.
+     *   - `> 0` The time limit to use for the full execution of an operation.
      *
      * @return the optional timeout duration
      * @since 4.x
@@ -121,6 +123,7 @@ public class MongoDatabase(private val wrapped: JMongoDatabase) {
 
     /**
      * Create a new MongoDatabase instance with the set time limit for the full execution of an operation.
+     *
      * - `0` means an infinite timeout
      * - `> 0` The time limit to use for the full execution of an operation.
      *

--- a/driver-kotlin-coroutine/src/test/kotlin/com/mongodb/kotlin/client/coroutine/MongoCollectionTest.kt
+++ b/driver-kotlin-coroutine/src/test/kotlin/com/mongodb/kotlin/client/coroutine/MongoCollectionTest.kt
@@ -72,7 +72,16 @@ class MongoCollectionTest {
     fun shouldHaveTheSameMethods() {
         val jMongoCollectionFunctions = JMongoCollection::class.declaredFunctions.map { it.name }.toSet()
         val kMongoCollectionFunctions =
-            MongoCollection::class.declaredFunctions.map { it.name }.toSet() +
+            MongoCollection::class
+                .declaredFunctions
+                .map {
+                    if (it.name == "timeout") {
+                        "getTimeout"
+                    } else {
+                        it.name
+                    }
+                }
+                .toSet() +
                 MongoCollection::class
                     .declaredMemberProperties
                     .filterNot { it.name == "wrapped" }

--- a/driver-kotlin-coroutine/src/test/kotlin/com/mongodb/kotlin/client/coroutine/MongoDatabaseTest.kt
+++ b/driver-kotlin-coroutine/src/test/kotlin/com/mongodb/kotlin/client/coroutine/MongoDatabaseTest.kt
@@ -54,7 +54,16 @@ class MongoDatabaseTest {
     fun shouldHaveTheSameMethods() {
         val jMongoDatabaseFunctions = JMongoDatabase::class.declaredFunctions.map { it.name }.toSet()
         val kMongoDatabaseFunctions =
-            MongoDatabase::class.declaredFunctions.map { it.name }.toSet() +
+            MongoDatabase::class
+                .declaredFunctions
+                .map {
+                    if (it.name == "timeout") {
+                        "getTimeout"
+                    } else {
+                        it.name
+                    }
+                }
+                .toSet() +
                 MongoDatabase::class
                     .declaredMemberProperties
                     .filterNot { it.name == "wrapped" }

--- a/driver-kotlin-sync/src/integration/kotlin/com/mongodb/kotlin/client/syncadapter/SyncMongoCollection.kt
+++ b/driver-kotlin-sync/src/integration/kotlin/com/mongodb/kotlin/client/syncadapter/SyncMongoCollection.kt
@@ -56,6 +56,7 @@ import com.mongodb.client.result.InsertOneResult
 import com.mongodb.client.result.UpdateResult
 import com.mongodb.kotlin.client.MongoCollection
 import java.lang.UnsupportedOperationException
+import java.util.concurrent.TimeUnit
 import org.bson.Document
 import org.bson.codecs.configuration.CodecRegistry
 import org.bson.conversions.Bson
@@ -73,6 +74,7 @@ internal class SyncMongoCollection<T : Any>(val wrapped: MongoCollection<T>) : J
     override fun getWriteConcern(): WriteConcern = wrapped.writeConcern
 
     override fun getReadConcern(): ReadConcern = wrapped.readConcern
+    override fun getTimeout(timeUnit: TimeUnit): Long? = wrapped.timeout(timeUnit)
 
     override fun <R : Any> withDocumentClass(clazz: Class<R>): SyncMongoCollection<R> =
         SyncMongoCollection(wrapped.withDocumentClass(clazz))
@@ -88,6 +90,9 @@ internal class SyncMongoCollection<T : Any>(val wrapped: MongoCollection<T>) : J
 
     override fun withReadConcern(readConcern: ReadConcern): SyncMongoCollection<T> =
         SyncMongoCollection(wrapped.withReadConcern(readConcern))
+
+    override fun withTimeout(timeout: Long, timeUnit: TimeUnit): com.mongodb.client.MongoCollection<T> =
+        SyncMongoCollection(wrapped.withTimeout(timeout, timeUnit))
 
     override fun countDocuments(): Long = wrapped.countDocuments()
 

--- a/driver-kotlin-sync/src/integration/kotlin/com/mongodb/kotlin/client/syncadapter/SyncMongoDatabase.kt
+++ b/driver-kotlin-sync/src/integration/kotlin/com/mongodb/kotlin/client/syncadapter/SyncMongoDatabase.kt
@@ -28,6 +28,7 @@ import com.mongodb.client.MongoIterable
 import com.mongodb.client.model.CreateCollectionOptions
 import com.mongodb.client.model.CreateViewOptions
 import com.mongodb.kotlin.client.MongoDatabase
+import java.util.concurrent.TimeUnit
 import org.bson.Document
 import org.bson.codecs.configuration.CodecRegistry
 import org.bson.conversions.Bson
@@ -43,6 +44,8 @@ internal class SyncMongoDatabase(val wrapped: MongoDatabase) : JMongoDatabase {
 
     override fun getReadConcern(): ReadConcern = wrapped.readConcern
 
+    override fun getTimeout(timeUnit: TimeUnit): Long? = wrapped.timeout(timeUnit)
+
     override fun withCodecRegistry(codecRegistry: CodecRegistry): SyncMongoDatabase =
         SyncMongoDatabase(wrapped.withCodecRegistry(codecRegistry))
 
@@ -54,6 +57,9 @@ internal class SyncMongoDatabase(val wrapped: MongoDatabase) : JMongoDatabase {
 
     override fun withReadConcern(readConcern: ReadConcern): SyncMongoDatabase =
         SyncMongoDatabase(wrapped.withReadConcern(readConcern))
+
+    override fun withTimeout(timeout: Long, timeUnit: TimeUnit): SyncMongoDatabase =
+        SyncMongoDatabase(wrapped.withTimeout(timeout, timeUnit))
 
     override fun getCollection(collectionName: String): MongoCollection<Document> =
         SyncMongoCollection(wrapped.getCollection(collectionName, Document::class.java))

--- a/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoCollection.kt
+++ b/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoCollection.kt
@@ -85,6 +85,25 @@ public class MongoCollection<T : Any>(private val wrapped: JMongoCollection<T>) 
         get() = wrapped.writeConcern
 
     /**
+     * The time limit for the full execution of an operation.
+     *
+     * If not null the following deprecated options will be ignored: `waitQueueTimeoutMS`, `socketTimeoutMS`,
+     * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`
+     *
+     * -`null` means that the timeout mechanism for operations will defer to using: -`waitQueueTimeoutMS`: The maximum
+     * wait time in milliseconds that a thread may wait for a connection to become available -`socketTimeoutMS`: How
+     * long a send or receive on a socket can take before timing out. -`wTimeoutMS`: How long the server will wait for
+     * the write concern to be fulfilled before timing out. -`maxTimeMS`: The time limit for processing operations on a
+     * cursor. See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.
+     * -`maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute. -`0`
+     * means infinite timeout. -`> 0` The time limit to use for the full execution of an operation.
+     *
+     * @return the optional timeout duration
+     * @since 4.x
+     */
+    public fun timeout(timeUnit: TimeUnit = TimeUnit.MILLISECONDS): Long? = wrapped.getTimeout(timeUnit)
+
+    /**
      * Create a new collection instance with a different default class to cast any documents returned from the database
      * into.
      *
@@ -146,6 +165,20 @@ public class MongoCollection<T : Any>(private val wrapped: JMongoCollection<T>) 
      */
     public fun withWriteConcern(newWriteConcern: WriteConcern): MongoCollection<T> =
         MongoCollection(wrapped.withWriteConcern(newWriteConcern))
+
+    /**
+     * Create a new MongoCollection instance with the set time limit for the full execution of an operation.
+     * - `0` means an infinite timeout
+     * - `> 0` The time limit to use for the full execution of an operation.
+     *
+     * @param timeout the timeout, which must be greater than or equal to 0
+     * @param timeUnit the time unit, defaults to Milliseconds
+     * @return a new MongoCollection instance with the set time limit for operations
+     * @see [MongoCollection.timeout]
+     * @since 4.x
+     */
+    public fun withTimeout(timeout: Long, timeUnit: TimeUnit = TimeUnit.MILLISECONDS): MongoCollection<T> =
+        MongoCollection(wrapped.withTimeout(timeout, timeUnit))
 
     /**
      * Counts the number of documents in the collection.

--- a/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoCollection.kt
+++ b/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoCollection.kt
@@ -88,15 +88,17 @@ public class MongoCollection<T : Any>(private val wrapped: JMongoCollection<T>) 
      * The time limit for the full execution of an operation.
      *
      * If not null the following deprecated options will be ignored: `waitQueueTimeoutMS`, `socketTimeoutMS`,
-     * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`
+     * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`.
      *
-     * -`null` means that the timeout mechanism for operations will defer to using: -`waitQueueTimeoutMS`: The maximum
-     * wait time in milliseconds that a thread may wait for a connection to become available -`socketTimeoutMS`: How
-     * long a send or receive on a socket can take before timing out. -`wTimeoutMS`: How long the server will wait for
-     * the write concern to be fulfilled before timing out. -`maxTimeMS`: The time limit for processing operations on a
-     * cursor. See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.
-     * -`maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute. -`0`
-     * means infinite timeout. -`> 0` The time limit to use for the full execution of an operation.
+     *   - `null` means that the timeout mechanism for operations will defer to using:
+     *      - `waitQueueTimeoutMS`: The maximum wait time in milliseconds that a thread may wait for a connection to become available
+     *      - `socketTimeoutMS`: How long a send or receive on a socket can take before timing out.
+     *      - `wTimeoutMS`: How long the server will wait for  the write concern to be fulfilled before timing out.
+     *      - `maxTimeMS`: The time limit for processing operations on a cursor.
+     *        See: [cursor.maxTimeMS](https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS").
+     *      - `maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute.
+     *   - `0` means infinite timeout.
+     *   - `> 0` The time limit to use for the full execution of an operation.
      *
      * @return the optional timeout duration
      * @since 4.x
@@ -168,6 +170,7 @@ public class MongoCollection<T : Any>(private val wrapped: JMongoCollection<T>) 
 
     /**
      * Create a new MongoCollection instance with the set time limit for the full execution of an operation.
+     *
      * - `0` means an infinite timeout
      * - `> 0` The time limit to use for the full execution of an operation.
      *

--- a/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoDatabase.kt
+++ b/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoDatabase.kt
@@ -54,6 +54,25 @@ public class MongoDatabase(private val wrapped: JMongoDatabase) {
         get() = wrapped.writeConcern
 
     /**
+     * The time limit for the full execution of an operation.
+     *
+     * If not null the following deprecated options will be ignored: `waitQueueTimeoutMS`, `socketTimeoutMS`,
+     * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`
+     *
+     * -`null` means that the timeout mechanism for operations will defer to using: -`waitQueueTimeoutMS`: The maximum
+     * wait time in milliseconds that a thread may wait for a connection to become available -`socketTimeoutMS`: How
+     * long a send or receive on a socket can take before timing out. -`wTimeoutMS`: How long the server will wait for
+     * the write concern to be fulfilled before timing out. -`maxTimeMS`: The time limit for processing operations on a
+     * cursor. See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.
+     * -`maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute. -`0`
+     * means infinite timeout. -`> 0` The time limit to use for the full execution of an operation.
+     *
+     * @return the optional timeout duration
+     * @since 4.x
+     */
+    public fun timeout(timeUnit: TimeUnit = TimeUnit.MILLISECONDS): Long? = wrapped.getTimeout(timeUnit)
+
+    /**
      * Create a new MongoDatabase instance with a different codec registry.
      *
      * The [CodecRegistry] configured by this method is effectively treated by the driver as an instance of
@@ -95,6 +114,20 @@ public class MongoDatabase(private val wrapped: JMongoDatabase) {
      */
     public fun withWriteConcern(newWriteConcern: WriteConcern): MongoDatabase =
         MongoDatabase(wrapped.withWriteConcern(newWriteConcern))
+
+    /**
+     * Create a new MongoDatabase instance with the set time limit for the full execution of an operation.
+     * - `0` means an infinite timeout
+     * - `> 0` The time limit to use for the full execution of an operation.
+     *
+     * @param timeout the timeout, which must be greater than or equal to 0
+     * @param timeUnit the time unit, defaults to Milliseconds
+     * @return a new MongoDatabase instance with the set time limit for operations
+     * @see [MongoDatabase.timeout]
+     * @since 4.x
+     */
+    public fun withTimeout(timeout: Long, timeUnit: TimeUnit = TimeUnit.MILLISECONDS): MongoDatabase =
+        MongoDatabase(wrapped.withTimeout(timeout, timeUnit))
 
     /**
      * Gets a collection.

--- a/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoDatabase.kt
+++ b/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoDatabase.kt
@@ -57,15 +57,17 @@ public class MongoDatabase(private val wrapped: JMongoDatabase) {
      * The time limit for the full execution of an operation.
      *
      * If not null the following deprecated options will be ignored: `waitQueueTimeoutMS`, `socketTimeoutMS`,
-     * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`
+     * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`.
      *
-     * -`null` means that the timeout mechanism for operations will defer to using: -`waitQueueTimeoutMS`: The maximum
-     * wait time in milliseconds that a thread may wait for a connection to become available -`socketTimeoutMS`: How
-     * long a send or receive on a socket can take before timing out. -`wTimeoutMS`: How long the server will wait for
-     * the write concern to be fulfilled before timing out. -`maxTimeMS`: The time limit for processing operations on a
-     * cursor. See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.
-     * -`maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute. -`0`
-     * means infinite timeout. -`> 0` The time limit to use for the full execution of an operation.
+     *   - `null` means that the timeout mechanism for operations will defer to using:
+     *      - `waitQueueTimeoutMS`: The maximum wait time in milliseconds that a thread may wait for a connection to become available
+     *      - `socketTimeoutMS`: How long a send or receive on a socket can take before timing out.
+     *      - `wTimeoutMS`: How long the server will wait for  the write concern to be fulfilled before timing out.
+     *      - `maxTimeMS`: The time limit for processing operations on a cursor.
+     *        See: [cursor.maxTimeMS](https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS").
+     *      - `maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute.
+     *   - `0` means infinite timeout.
+     *   - `> 0` The time limit to use for the full execution of an operation.
      *
      * @return the optional timeout duration
      * @since 4.x

--- a/driver-kotlin-sync/src/test/kotlin/com/mongodb/kotlin/client/MongoCollectionTest.kt
+++ b/driver-kotlin-sync/src/test/kotlin/com/mongodb/kotlin/client/MongoCollectionTest.kt
@@ -71,7 +71,16 @@ class MongoCollectionTest {
     fun shouldHaveTheSameMethods() {
         val jMongoCollectionFunctions = JMongoCollection::class.declaredFunctions.map { it.name }.toSet() - "mapReduce"
         val kMongoCollectionFunctions =
-            MongoCollection::class.declaredFunctions.map { it.name }.toSet() +
+            MongoCollection::class
+                .declaredFunctions
+                .map {
+                    if (it.name == "timeout") {
+                        "getTimeout"
+                    } else {
+                        it.name
+                    }
+                }
+                .toSet() +
                 MongoCollection::class
                     .declaredMemberProperties
                     .filterNot { it.name == "wrapped" }

--- a/driver-kotlin-sync/src/test/kotlin/com/mongodb/kotlin/client/MongoDatabaseTest.kt
+++ b/driver-kotlin-sync/src/test/kotlin/com/mongodb/kotlin/client/MongoDatabaseTest.kt
@@ -52,7 +52,16 @@ class MongoDatabaseTest {
     fun shouldHaveTheSameMethods() {
         val jMongoDatabaseFunctions = JMongoDatabase::class.declaredFunctions.map { it.name }.toSet()
         val kMongoDatabaseFunctions =
-            MongoDatabase::class.declaredFunctions.map { it.name }.toSet() +
+            MongoDatabase::class
+                .declaredFunctions
+                .map {
+                    if (it.name == "timeout") {
+                        "getTimeout"
+                    } else {
+                        it.name
+                    }
+                }
+                .toSet() +
                 MongoDatabase::class
                     .declaredMemberProperties
                     .filterNot { it.name == "wrapped" }

--- a/driver-legacy/src/main/com/mongodb/DB.java
+++ b/driver-legacy/src/main/com/mongodb/DB.java
@@ -23,6 +23,7 @@ import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.DBCreateViewOptions;
 import com.mongodb.client.model.ValidationAction;
 import com.mongodb.client.model.ValidationLevel;
+import com.mongodb.internal.ClientSideOperationTimeouts;
 import com.mongodb.internal.operation.BatchCursor;
 import com.mongodb.internal.operation.CommandReadOperation;
 import com.mongodb.internal.operation.CreateCollectionOperation;
@@ -195,7 +196,8 @@ public class DB {
      */
     public void dropDatabase() {
         try {
-            getExecutor().execute(new DropDatabaseOperation(getName(), getWriteConcern()), getReadConcern());
+            getExecutor().execute(new DropDatabaseOperation(ClientSideOperationTimeouts.create(getTimeoutMS()),
+                            getName(), getWriteConcern()), getReadConcern());
         } catch (MongoWriteConcernException e) {
             throw createWriteConcernException(e);
         }
@@ -220,11 +222,11 @@ public class DB {
     public Set<String> getCollectionNames() {
         List<String> collectionNames =
                 new MongoIterableImpl<DBObject>(null, executor, ReadConcern.DEFAULT, primary(),
-                        mongo.getMongoClientOptions().getRetryReads()) {
+                                                mongo.getMongoClientOptions().getRetryReads(), null) {
                     @Override
                     public ReadOperation<BatchCursor<DBObject>> asReadOperation() {
-                        return new ListCollectionsOperation<>(name, commandCodec)
-                                .nameOnly(true);
+                        return new ListCollectionsOperation<>(ClientSideOperationTimeouts.create(DB.this.getTimeoutMS()),
+                                name, commandCodec).nameOnly(true);
                     }
                 }.map(result -> (String) result.get("name")).into(new ArrayList<>());
         Collections.sort(collectionNames);
@@ -304,8 +306,9 @@ public class DB {
         try {
             notNull("options", options);
             DBCollection view = getCollection(viewName);
-            executor.execute(new CreateViewOperation(name, viewName, viewOn, view.preparePipeline(pipeline), writeConcern)
-                                     .collation(options.getCollation()), getReadConcern());
+            executor.execute(new CreateViewOperation(ClientSideOperationTimeouts.create(getTimeoutMS()), name, viewName, viewOn,
+                    view.preparePipeline(pipeline), writeConcern)
+                    .collation(options.getCollation()), getReadConcern());
             return view;
         } catch (MongoWriteConcernException e) {
             throw createWriteConcernException(e);
@@ -380,7 +383,8 @@ public class DB {
             validationAction = ValidationAction.fromString((String) options.get("validationAction"));
         }
         Collation collation = DBObjectCollationHelper.createCollationFromOptions(options);
-        return new CreateCollectionOperation(getName(), collectionName, getWriteConcern())
+        return new CreateCollectionOperation(ClientSideOperationTimeouts.create(getTimeoutMS()), getName(), collectionName,
+                getWriteConcern())
                    .capped(capped)
                    .collation(collation)
                    .sizeInBytes(sizeInBytes)
@@ -513,7 +517,8 @@ public class DB {
     }
 
     CommandResult executeCommand(final BsonDocument commandDocument, final ReadPreference readPreference) {
-        return new CommandResult(executor.execute(new CommandReadOperation<>(getName(), commandDocument,
+        return new CommandResult(executor.execute(
+                new CommandReadOperation<>(ClientSideOperationTimeouts.create(getTimeoutMS()), getName(), commandDocument,
                         new BsonDocumentCodec()), readPreference, getReadConcern()), getDefaultDBObjectCodec());
     }
 
@@ -559,6 +564,11 @@ public class DB {
                 DBObjectCodec.getDefaultBsonTypeClassMap(),
                 new DBCollectionObjectFactory())
                 .withUuidRepresentation(getMongoClient().getMongoClientOptions().getUuidRepresentation());
+    }
+
+    @Nullable
+    Long getTimeoutMS() {
+        return null; // TODO - JAVA-4064
     }
 
     private static final Set<String> OBEDIENT_COMMANDS = new HashSet<>();

--- a/driver-legacy/src/main/com/mongodb/DB.java
+++ b/driver-legacy/src/main/com/mongodb/DB.java
@@ -568,7 +568,7 @@ public class DB {
 
     @Nullable
     Long getTimeoutMS() {
-        return null; // TODO - JAVA-4064
+        return null; // TODO (CSOT) - JAVA-4064
     }
 
     private static final Set<String> OBEDIENT_COMMANDS = new HashSet<>();

--- a/driver-legacy/src/main/com/mongodb/DBCollection.java
+++ b/driver-legacy/src/main/com/mongodb/DBCollection.java
@@ -26,6 +26,8 @@ import com.mongodb.client.model.DBCollectionFindAndModifyOptions;
 import com.mongodb.client.model.DBCollectionFindOptions;
 import com.mongodb.client.model.DBCollectionRemoveOptions;
 import com.mongodb.client.model.DBCollectionUpdateOptions;
+import com.mongodb.internal.ClientSideOperationTimeout;
+import com.mongodb.internal.ClientSideOperationTimeouts;
 import com.mongodb.internal.bulk.DeleteRequest;
 import com.mongodb.internal.bulk.IndexRequest;
 import com.mongodb.internal.bulk.InsertRequest;
@@ -341,8 +343,8 @@ public class DBCollection {
 
     private WriteResult insert(final List<InsertRequest> insertRequestList, final WriteConcern writeConcern,
                                final boolean continueOnError, @Nullable final Boolean bypassDocumentValidation) {
-        return executeWriteOperation(createBulkWriteOperationForInsert(getNamespace(), !continueOnError, writeConcern,
-                retryWrites, insertRequestList).bypassDocumentValidation(bypassDocumentValidation));
+        return executeWriteOperation(createBulkWriteOperationForInsert(getClientSideOperationTimeout(), getNamespace(),
+                !continueOnError, writeConcern, retryWrites, insertRequestList).bypassDocumentValidation(bypassDocumentValidation));
     }
 
     WriteResult executeWriteOperation(final LegacyMixedBulkWriteOperation operation) {
@@ -425,8 +427,8 @@ public class DBCollection {
         UpdateRequest replaceRequest = new UpdateRequest(wrap(filter), wrap(obj, objectCodec),
                                                          Type.REPLACE).upsert(true);
 
-        return executeWriteOperation(createBulkWriteOperationForReplace(getNamespace(), false, writeConcern, retryWrites,
-                singletonList(replaceRequest)));
+        return executeWriteOperation(createBulkWriteOperationForReplace(getClientSideOperationTimeout(), getNamespace(), false,
+                writeConcern, retryWrites, singletonList(replaceRequest)));
     }
 
     /**
@@ -578,8 +580,10 @@ public class DBCollection {
                                               .collation(options.getCollation())
                                               .arrayFilters(wrapAllowNull(options.getArrayFilters(), options.getEncoder()));
         LegacyMixedBulkWriteOperation operation = (updateType == UPDATE
-                ? createBulkWriteOperationForUpdate(getNamespace(), true, writeConcern, retryWrites, singletonList(updateRequest))
-                : createBulkWriteOperationForReplace(getNamespace(), true, writeConcern, retryWrites, singletonList(updateRequest)))
+                ? createBulkWriteOperationForUpdate(getClientSideOperationTimeout(), getNamespace(), true, writeConcern, retryWrites,
+                singletonList(updateRequest))
+                : createBulkWriteOperationForReplace(getClientSideOperationTimeout(), getNamespace(), true, writeConcern, retryWrites,
+                singletonList(updateRequest)))
                 .bypassDocumentValidation(options.getBypassDocumentValidation());
         return executeWriteOperation(operation);
     }
@@ -651,8 +655,8 @@ public class DBCollection {
         WriteConcern optionsWriteConcern = options.getWriteConcern();
         WriteConcern writeConcern = optionsWriteConcern != null ? optionsWriteConcern : getWriteConcern();
         DeleteRequest deleteRequest = new DeleteRequest(wrap(query, options.getEncoder())).collation(options.getCollation());
-        return executeWriteOperation(createBulkWriteOperationForDelete(getNamespace(), false, writeConcern, retryWrites,
-                singletonList(deleteRequest)));
+        return executeWriteOperation(createBulkWriteOperationForDelete(getClientSideOperationTimeout(), getNamespace(), false,
+                writeConcern, retryWrites, singletonList(deleteRequest)));
     }
 
     /**
@@ -909,12 +913,12 @@ public class DBCollection {
      */
     public long getCount(@Nullable final DBObject query, final DBCollectionCountOptions options) {
         notNull("countOptions", options);
-        CountOperation operation = new CountOperation(getNamespace())
-                                       .skip(options.getSkip())
-                                       .limit(options.getLimit())
-                                       .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                                       .collation(options.getCollation())
-                                       .retryReads(retryReads);
+        CountOperation operation = new CountOperation(
+                getClientSideOperationTimeout(options.getMaxTime(MILLISECONDS)), getNamespace())
+                .skip(options.getSkip())
+                .limit(options.getLimit())
+                .collation(options.getCollation())
+                .retryReads(retryReads);
         if (query != null) {
             operation.filter(wrap(query));
         }
@@ -956,9 +960,9 @@ public class DBCollection {
      */
     public DBCollection rename(final String newName, final boolean dropTarget) {
         try {
-            executor.execute(new RenameCollectionOperation(getNamespace(),
-                                                           new MongoNamespace(getNamespace().getDatabaseName(), newName), getWriteConcern())
-                                     .dropTarget(dropTarget), getReadConcern());
+            executor.execute(new RenameCollectionOperation(getClientSideOperationTimeout(), getNamespace(),
+                    new MongoNamespace(getNamespace().getDatabaseName(), newName), getWriteConcern())
+                    .dropTarget(dropTarget), getReadConcern());
             return getDB().getCollection(newName);
         } catch (MongoWriteConcernException e) {
             throw createWriteConcernException(e);
@@ -1025,12 +1029,12 @@ public class DBCollection {
     public List distinct(final String fieldName, final DBCollectionDistinctOptions options) {
         notNull("fieldName", fieldName);
         return new MongoIterableImpl<BsonValue>(null, executor,
-                                                  options.getReadConcern() != null ? options.getReadConcern() : getReadConcern(),
-                                                  options.getReadPreference() != null ? options.getReadPreference() : getReadPreference(),
-                                                  retryReads) {
+                                                options.getReadConcern() != null ? options.getReadConcern() : getReadConcern(),
+                                                options.getReadPreference() != null ? options.getReadPreference() : getReadPreference(),
+                                                retryReads, null) {
             @Override
             public ReadOperation<BatchCursor<BsonValue>> asReadOperation() {
-                return new DistinctOperation<>(getNamespace(), fieldName, new BsonValueCodec())
+                return new DistinctOperation<>(getClientSideOperationTimeout(), getNamespace(), fieldName, new BsonValueCodec())
                                .filter(wrapAllowNull(options.getFilter()))
                                .collation(options.getCollation())
                                .retryReads(retryReads);
@@ -1112,16 +1116,15 @@ public class DBCollection {
         Boolean jsMode = command.getJsMode();
         if (command.getOutputType() == MapReduceCommand.OutputType.INLINE) {
 
-            MapReduceWithInlineResultsOperation<DBObject> operation =
-                    new MapReduceWithInlineResultsOperation<>(getNamespace(), new BsonJavaScript(command.getMap()),
-                            new BsonJavaScript(command.getReduce()), getDefaultDBObjectCodec())
-                            .filter(wrapAllowNull(command.getQuery()))
-                            .limit(command.getLimit())
-                            .maxTime(command.getMaxTime(MILLISECONDS), MILLISECONDS)
-                            .jsMode(jsMode != null && jsMode)
-                            .sort(wrapAllowNull(command.getSort()))
-                            .verbose(command.isVerbose())
-                            .collation(command.getCollation());
+            MapReduceWithInlineResultsOperation<DBObject> operation = new MapReduceWithInlineResultsOperation<>(
+                    getClientSideOperationTimeout(command.getMaxTime(MILLISECONDS)), getNamespace(), new BsonJavaScript(command.getMap()),
+                    new BsonJavaScript(command.getReduce()), getDefaultDBObjectCodec())
+                    .filter(wrapAllowNull(command.getQuery()))
+                    .limit(command.getLimit())
+                    .jsMode(jsMode != null && jsMode)
+                    .sort(wrapAllowNull(command.getSort()))
+                    .verbose(command.isVerbose())
+                    .collation(command.getCollation());
 
             if (scope != null) {
                 operation.scope(wrap(new BasicDBObject(scope)));
@@ -1148,14 +1151,12 @@ public class DBCollection {
             }
 
             MapReduceToCollectionOperation operation =
-                new MapReduceToCollectionOperation(getNamespace(),
-                                                   new BsonJavaScript(command.getMap()),
-                                                   new BsonJavaScript(command.getReduce()),
-                                                   command.getOutputTarget(),
-                                                   getWriteConcern())
+                new MapReduceToCollectionOperation(
+                        getClientSideOperationTimeout(command.getMaxTime(MILLISECONDS)),
+                        getNamespace(), new BsonJavaScript(command.getMap()), new BsonJavaScript(command.getReduce()),
+                        command.getOutputTarget(), getWriteConcern())
                     .filter(wrapAllowNull(command.getQuery()))
                     .limit(command.getLimit())
-                    .maxTime(command.getMaxTime(MILLISECONDS), MILLISECONDS)
                     .jsMode(jsMode != null && jsMode)
                     .sort(wrapAllowNull(command.getSort()))
                     .verbose(command.isVerbose())
@@ -1221,12 +1222,13 @@ public class DBCollection {
         BsonValue outCollection = stages.get(stages.size() - 1).get("$out");
 
         if (outCollection != null) {
-            AggregateToCollectionOperation operation = new AggregateToCollectionOperation(getNamespace(), stages,
-                    getReadConcern(), getWriteConcern())
-                                                       .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                                                       .allowDiskUse(options.getAllowDiskUse())
-                                                       .bypassDocumentValidation(options.getBypassDocumentValidation())
-                                                       .collation(options.getCollation());
+            AggregateToCollectionOperation operation =
+                    new AggregateToCollectionOperation(
+                            getClientSideOperationTimeout(options.getMaxTime(MILLISECONDS)),
+                            getNamespace(), stages, getReadConcern(), getWriteConcern())
+                            .allowDiskUse(options.getAllowDiskUse())
+                            .bypassDocumentValidation(options.getBypassDocumentValidation())
+                            .collation(options.getCollation());
             try {
                 executor.execute(operation, getReadPreference(), getReadConcern());
                 result = new DBCursor(database.getCollection(outCollection.asString().getValue()), new BasicDBObject(),
@@ -1235,8 +1237,9 @@ public class DBCollection {
                 throw createWriteConcernException(e);
             }
         } else {
-            AggregateOperation<DBObject> operation = new AggregateOperation<>(getNamespace(), stages, getDefaultDBObjectCodec())
-                    .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+            AggregateOperation<DBObject> operation = new AggregateOperation<>(
+                    getClientSideOperationTimeout(options.getMaxTime(MILLISECONDS)), getNamespace(), stages,
+                    getDefaultDBObjectCodec())
                     .allowDiskUse(options.getAllowDiskUse())
                     .batchSize(options.getBatchSize())
                     .collation(options.getCollation())
@@ -1258,12 +1261,12 @@ public class DBCollection {
      * @mongodb.server.release 3.6
      */
     public CommandResult explainAggregate(final List<? extends DBObject> pipeline, final AggregationOptions options) {
-        AggregateOperation<BsonDocument> operation = new AggregateOperation<>(getNamespace(), preparePipeline(pipeline),
-                new BsonDocumentCodec())
-                                                         .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                                                         .allowDiskUse(options.getAllowDiskUse())
-                                                         .collation(options.getCollation())
-                                                         .retryReads(retryReads);
+        AggregateOperation<BsonDocument> operation = new AggregateOperation<>(
+                getClientSideOperationTimeout(options.getMaxTime(MILLISECONDS)), getNamespace(),
+                preparePipeline(pipeline), new BsonDocumentCodec())
+                .allowDiskUse(options.getAllowDiskUse())
+                .collation(options.getCollation())
+                .retryReads(retryReads);
         return new CommandResult(executor.execute(operation.asExplainableOperation(ExplainVerbosity.QUERY_PLANNER, new BsonDocumentCodec()),
                 primaryPreferred(), getReadConcern()), getDefaultDBObjectCodec());
     }
@@ -1648,12 +1651,12 @@ public class DBCollection {
         WriteConcern optionsWriteConcern = options.getWriteConcern();
         WriteConcern writeConcern = optionsWriteConcern != null ? optionsWriteConcern : getWriteConcern();
         WriteOperation<DBObject> operation;
+        ClientSideOperationTimeout clientSideOperationTimeout = getClientSideOperationTimeout(options.getMaxTime(MILLISECONDS));
         if (options.isRemove()) {
-            operation = new FindAndDeleteOperation<>(getNamespace(), writeConcern, retryWrites, objectCodec)
+            operation = new FindAndDeleteOperation<>(clientSideOperationTimeout, getNamespace(), writeConcern, retryWrites, objectCodec)
                         .filter(wrapAllowNull(query))
                         .projection(wrapAllowNull(options.getProjection()))
                         .sort(wrapAllowNull(options.getSort()))
-                        .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                         .collation(options.getCollation());
         } else {
             DBObject update = options.getUpdate();
@@ -1661,26 +1664,24 @@ public class DBCollection {
                 throw new IllegalArgumentException("update can not be null unless it's a remove");
             }
             if (!update.keySet().isEmpty() && update.keySet().iterator().next().charAt(0) == '$') {
-                operation = new FindAndUpdateOperation<>(getNamespace(), writeConcern, retryWrites, objectCodec,
-                        wrap(update))
+                operation = new FindAndUpdateOperation<>(clientSideOperationTimeout,  getNamespace(), writeConcern, retryWrites,
+                        objectCodec, wrap(update))
                         .filter(wrap(query))
                         .projection(wrapAllowNull(options.getProjection()))
                         .sort(wrapAllowNull(options.getSort()))
                         .returnOriginal(!options.returnNew())
                         .upsert(options.isUpsert())
-                        .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                         .bypassDocumentValidation(options.getBypassDocumentValidation())
                         .collation(options.getCollation())
                         .arrayFilters(wrapAllowNull(options.getArrayFilters(), (Encoder<DBObject>) null));
             } else {
-                operation = new FindAndReplaceOperation<>(getNamespace(), writeConcern, retryWrites, objectCodec,
-                        wrap(update))
+                operation = new FindAndReplaceOperation<>(clientSideOperationTimeout, getNamespace(), writeConcern, retryWrites,
+                        objectCodec, wrap(update))
                         .filter(wrap(query))
                         .projection(wrapAllowNull(options.getProjection()))
                         .sort(wrapAllowNull(options.getSort()))
                         .returnOriginal(!options.returnNew())
                         .upsert(options.isUpsert())
-                        .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                         .bypassDocumentValidation(options.getBypassDocumentValidation())
                         .collation(options.getCollation());
             }
@@ -1787,7 +1788,8 @@ public class DBCollection {
      */
     public void drop() {
         try {
-            executor.execute(new DropCollectionOperation(getNamespace(), getWriteConcern()), getReadConcern());
+            executor.execute(new DropCollectionOperation(getClientSideOperationTimeout(), getNamespace(),
+                            getWriteConcern()), getReadConcern());
         } catch (MongoWriteConcernException e) {
             throw createWriteConcernException(e);
         }
@@ -1851,10 +1853,12 @@ public class DBCollection {
      * @mongodb.driver.manual core/indexes/ Indexes
      */
     public List<DBObject> getIndexInfo() {
-        return new MongoIterableImpl<DBObject>(null, executor, ReadConcern.DEFAULT, primary(), retryReads) {
+        return new MongoIterableImpl<DBObject>(null, executor, ReadConcern.DEFAULT,
+                                               primary(), retryReads, null) {
             @Override
             public ReadOperation<BatchCursor<DBObject>> asReadOperation() {
-                return new ListIndexesOperation<>(getNamespace(), getDefaultDBObjectCodec()).retryReads(retryReads);
+                return new ListIndexesOperation<>(getClientSideOperationTimeout(), getNamespace(),
+                        getDefaultDBObjectCodec()).retryReads(retryReads);
             }
         }.into(new ArrayList<>());
     }
@@ -1869,7 +1873,8 @@ public class DBCollection {
      */
     public void dropIndex(final DBObject index) {
         try {
-            executor.execute(new DropIndexOperation(getNamespace(), wrap(index), getWriteConcern()), getReadConcern());
+            executor.execute(new DropIndexOperation(getClientSideOperationTimeout(), getNamespace(), wrap(index),
+                    getWriteConcern()), getReadConcern());
         } catch (MongoWriteConcernException e) {
             throw createWriteConcernException(e);
         }
@@ -1884,7 +1889,8 @@ public class DBCollection {
      */
     public void dropIndex(final String indexName) {
         try {
-            executor.execute(new DropIndexOperation(getNamespace(), indexName, getWriteConcern()), getReadConcern());
+            executor.execute(new DropIndexOperation(getClientSideOperationTimeout(), getNamespace(), indexName,
+                    getWriteConcern()), getReadConcern());
         } catch (MongoWriteConcernException e) {
             throw createWriteConcernException(e);
         }
@@ -2018,9 +2024,9 @@ public class DBCollection {
                                               final List<WriteRequest> writeRequests,
                                               final WriteConcern writeConcern) {
         try {
-            return translateBulkWriteResult(executor.execute(new MixedBulkWriteOperation(getNamespace(),
-                            translateWriteRequestsToNew(writeRequests), ordered, writeConcern, false)
-                            .bypassDocumentValidation(bypassDocumentValidation), getReadConcern()), getObjectCodec());
+            return translateBulkWriteResult(executor.execute(new MixedBulkWriteOperation(getClientSideOperationTimeout(),
+                    getNamespace(), translateWriteRequestsToNew(writeRequests), ordered, writeConcern, false)
+                    .bypassDocumentValidation(bypassDocumentValidation), getReadConcern()), getObjectCodec());
         } catch (MongoBulkWriteException e) {
             throw BulkWriteHelper.translateBulkWriteException(e, MongoClient.getDefaultCodecRegistry().get(DBObject.class));
         }
@@ -2134,7 +2140,7 @@ public class DBCollection {
         if (options.containsField("collation")) {
             request.collation(DBObjectCollationHelper.createCollationFromOptions(options));
         }
-        return new CreateIndexesOperation(getNamespace(), singletonList(request), writeConcern);
+        return new CreateIndexesOperation(getClientSideOperationTimeout(), getNamespace(), singletonList(request), writeConcern);
     }
 
     Codec<DBObject> getObjectCodec() {
@@ -2194,6 +2200,19 @@ public class DBCollection {
             return new BsonDocumentWrapper<>(document, encoder);
         }
     }
+
+    private ClientSideOperationTimeout getClientSideOperationTimeout(){
+       return ClientSideOperationTimeouts.create(database.getTimeoutMS());
+    }
+
+    private ClientSideOperationTimeout getClientSideOperationTimeout(final long maxTimeMS){
+        return ClientSideOperationTimeouts.create(database.getTimeoutMS(), maxTimeMS);
+    }
+
+    ClientSideOperationTimeout getClientSideOperationTimeout(final long maxTimeMS, final long maxAwaitTimeMS){
+        return ClientSideOperationTimeouts.create(database.getTimeoutMS(), maxTimeMS, maxAwaitTimeMS);
+    }
+
 
     static WriteConcernException createWriteConcernException(final MongoWriteConcernException e) {
         return new WriteConcernException(new BsonDocument("code", new BsonInt32(e.getWriteConcernError().getCode()))

--- a/driver-legacy/src/main/com/mongodb/DBCursor.java
+++ b/driver-legacy/src/main/com/mongodb/DBCursor.java
@@ -429,32 +429,31 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
 
     @SuppressWarnings("deprecation")
     private FindOperation<DBObject> getQueryOperation(final Decoder<DBObject> decoder) {
-
-        return new FindOperation<>(collection.getNamespace(), decoder)
-                                                .filter(collection.wrapAllowNull(filter))
-                                                .batchSize(findOptions.getBatchSize())
-                                                .skip(findOptions.getSkip())
-                                                .limit(findOptions.getLimit())
-                                                .maxAwaitTime(findOptions.getMaxAwaitTime(MILLISECONDS), MILLISECONDS)
-                                                .maxTime(findOptions.getMaxTime(MILLISECONDS), MILLISECONDS)
-                                                .projection(collection.wrapAllowNull(findOptions.getProjection()))
-                                                .sort(collection.wrapAllowNull(findOptions.getSort()))
-                                                .collation(findOptions.getCollation())
-                                                .comment(findOptions.getComment() != null
-                                                        ? new BsonString(findOptions.getComment()) : null)
-                                                .hint(findOptions.getHint() != null
-                                                        ? collection.wrapAllowNull(findOptions.getHint())
-                                                        : (findOptions.getHintString() != null
-                                                        ? new BsonString(findOptions.getHintString()) : null))
-                                                .min(collection.wrapAllowNull(findOptions.getMin()))
-                                                .max(collection.wrapAllowNull(findOptions.getMax()))
-                                                .cursorType(findOptions.getCursorType())
-                                                .noCursorTimeout(findOptions.isNoCursorTimeout())
-                                                .oplogReplay(findOptions.isOplogReplay())
-                                                .partial(findOptions.isPartial())
-                                                .returnKey(findOptions.isReturnKey())
-                                                .showRecordId(findOptions.isShowRecordId())
-                                                .retryReads(retryReads);
+        return new FindOperation<>(
+                collection.getClientSideOperationTimeout(findOptions.getMaxTime(MILLISECONDS), findOptions.getMaxAwaitTime(MILLISECONDS)),
+                collection.getNamespace(), decoder)
+                .filter(collection.wrapAllowNull(filter))
+                .batchSize(findOptions.getBatchSize())
+                .skip(findOptions.getSkip())
+                .limit(findOptions.getLimit())
+                .projection(collection.wrapAllowNull(findOptions.getProjection()))
+                .sort(collection.wrapAllowNull(findOptions.getSort()))
+                .collation(findOptions.getCollation())
+                .comment(findOptions.getComment() != null
+                        ? new BsonString(findOptions.getComment()) : null)
+                .hint(findOptions.getHint() != null
+                        ? collection.wrapAllowNull(findOptions.getHint())
+                        : (findOptions.getHintString() != null
+                        ? new BsonString(findOptions.getHintString()) : null))
+                .min(collection.wrapAllowNull(findOptions.getMin()))
+                .max(collection.wrapAllowNull(findOptions.getMax()))
+                .cursorType(findOptions.getCursorType())
+                .noCursorTimeout(findOptions.isNoCursorTimeout())
+                .oplogReplay(findOptions.isOplogReplay())
+                .partial(findOptions.isPartial())
+                .returnKey(findOptions.isReturnKey())
+                .showRecordId(findOptions.isShowRecordId())
+                .retryReads(retryReads);
     }
 
     /**

--- a/driver-legacy/src/main/com/mongodb/LegacyMixedBulkWriteOperation.java
+++ b/driver-legacy/src/main/com/mongodb/LegacyMixedBulkWriteOperation.java
@@ -19,6 +19,7 @@ package com.mongodb;
 import com.mongodb.bulk.BulkWriteError;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.bulk.WriteConcernError;
+import com.mongodb.internal.ClientSideOperationTimeout;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.internal.bulk.DeleteRequest;
 import com.mongodb.internal.bulk.InsertRequest;
@@ -47,6 +48,7 @@ import static com.mongodb.internal.bulk.WriteRequest.Type.UPDATE;
  * Operation for bulk writes for the legacy API.
  */
 final class LegacyMixedBulkWriteOperation implements WriteOperation<WriteConcernResult> {
+    private final ClientSideOperationTimeout clientSideOperationTimeout;
     private final WriteConcern writeConcern;
     private final MongoNamespace namespace;
     private final List<? extends WriteRequest> writeRequests;
@@ -55,31 +57,41 @@ final class LegacyMixedBulkWriteOperation implements WriteOperation<WriteConcern
     private final boolean retryWrites;
     private Boolean bypassDocumentValidation;
 
-    static LegacyMixedBulkWriteOperation createBulkWriteOperationForInsert(final MongoNamespace namespace, final boolean ordered,
-            final WriteConcern writeConcern, final boolean retryWrites, final List<InsertRequest> insertRequests) {
-        return new LegacyMixedBulkWriteOperation(namespace, ordered, writeConcern, retryWrites, insertRequests, INSERT);
+    static LegacyMixedBulkWriteOperation createBulkWriteOperationForInsert(final ClientSideOperationTimeout clientSideOperationTimeout,
+            final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern, final boolean retryWrites,
+            final List<InsertRequest> insertRequests) {
+        return new LegacyMixedBulkWriteOperation(clientSideOperationTimeout, namespace, ordered, writeConcern, retryWrites, insertRequests,
+                INSERT);
     }
 
-    static LegacyMixedBulkWriteOperation createBulkWriteOperationForUpdate(final MongoNamespace namespace, final boolean ordered,
-            final WriteConcern writeConcern, final boolean retryWrites, final List<UpdateRequest> updateRequests) {
+    static LegacyMixedBulkWriteOperation createBulkWriteOperationForUpdate(final ClientSideOperationTimeout clientSideOperationTimeout,
+            final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern, final boolean retryWrites,
+            final List<UpdateRequest> updateRequests) {
         assertTrue(updateRequests.stream().allMatch(updateRequest -> updateRequest.getType() == UPDATE));
-        return new LegacyMixedBulkWriteOperation(namespace, ordered, writeConcern, retryWrites, updateRequests, UPDATE);
+        return new LegacyMixedBulkWriteOperation(clientSideOperationTimeout, namespace, ordered, writeConcern, retryWrites, updateRequests,
+                UPDATE);
     }
 
-    static LegacyMixedBulkWriteOperation createBulkWriteOperationForReplace(final MongoNamespace namespace, final boolean ordered,
-            final WriteConcern writeConcern, final boolean retryWrites, final List<UpdateRequest> replaceRequests) {
+    static LegacyMixedBulkWriteOperation createBulkWriteOperationForReplace(final ClientSideOperationTimeout clientSideOperationTimeout,
+            final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern, final boolean retryWrites,
+            final List<UpdateRequest> replaceRequests) {
         assertTrue(replaceRequests.stream().allMatch(updateRequest -> updateRequest.getType() == REPLACE));
-        return new LegacyMixedBulkWriteOperation(namespace, ordered, writeConcern, retryWrites, replaceRequests, REPLACE);
+        return new LegacyMixedBulkWriteOperation(clientSideOperationTimeout, namespace, ordered, writeConcern, retryWrites, replaceRequests,
+                REPLACE);
     }
 
-    static LegacyMixedBulkWriteOperation createBulkWriteOperationForDelete(final MongoNamespace namespace, final boolean ordered,
-            final WriteConcern writeConcern, final boolean retryWrites, final List<DeleteRequest> deleteRequests) {
-        return new LegacyMixedBulkWriteOperation(namespace, ordered, writeConcern, retryWrites, deleteRequests, DELETE);
+    static LegacyMixedBulkWriteOperation createBulkWriteOperationForDelete(final ClientSideOperationTimeout clientSideOperationTimeout,
+            final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern, final boolean retryWrites,
+            final List<DeleteRequest> deleteRequests) {
+        return new LegacyMixedBulkWriteOperation(clientSideOperationTimeout, namespace, ordered, writeConcern, retryWrites, deleteRequests,
+                DELETE);
     }
 
-    private LegacyMixedBulkWriteOperation(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
+    private LegacyMixedBulkWriteOperation(final ClientSideOperationTimeout clientSideOperationTimeout, final MongoNamespace namespace,
+            final boolean ordered, final WriteConcern writeConcern,
             final boolean retryWrites, final List<? extends WriteRequest> writeRequests, final WriteRequest.Type type) {
         isTrueArgument("writeRequests not empty", !writeRequests.isEmpty());
+        this.clientSideOperationTimeout = notNull("clientSideOperationTimeout", clientSideOperationTimeout);
         this.writeRequests = notNull("writeRequests", writeRequests);
         this.type = type;
         this.ordered = ordered;
@@ -100,8 +112,8 @@ final class LegacyMixedBulkWriteOperation implements WriteOperation<WriteConcern
     @Override
     public WriteConcernResult execute(final WriteBinding binding) {
         try {
-            BulkWriteResult result = new MixedBulkWriteOperation(namespace, writeRequests, ordered, writeConcern, retryWrites)
-                    .bypassDocumentValidation(bypassDocumentValidation).execute(binding);
+            BulkWriteResult result = new MixedBulkWriteOperation(clientSideOperationTimeout, namespace, writeRequests,
+                    ordered, writeConcern, retryWrites).bypassDocumentValidation(bypassDocumentValidation).execute(binding);
             if (result.wasAcknowledged()) {
                 return translateBulkWriteResult(result);
             } else {

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
@@ -63,6 +63,7 @@ import spock.lang.Specification
 import java.util.concurrent.TimeUnit
 
 import static Fixture.getMongoClient
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.LegacyMixedBulkWriteOperation.createBulkWriteOperationForDelete
 import static com.mongodb.LegacyMixedBulkWriteOperation.createBulkWriteOperationForUpdate
@@ -270,9 +271,9 @@ class DBCollectionSpecification extends Specification {
         collection.getStats()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new CommandReadOperation('myDatabase',
-                                                                                 new BsonDocument('collStats', new BsonString('test')),
-                                                                new BsonDocumentCodec()))
+        expect executor.getReadOperation(), isTheSameAs(new CommandReadOperation(CSOT_NO_TIMEOUT.get(), 'myDatabase',
+                new BsonDocument('collStats', new BsonString('test')),
+                new BsonDocumentCodec()))
         executor.getReadPreference() == collection.getReadPreference()
     }
 
@@ -290,7 +291,8 @@ class DBCollectionSpecification extends Specification {
         collection.find().iterator().hasNext()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(), collection.getObjectCodec())
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                collection.getObjectCodec())
                 .filter(new BsonDocument())
                 .retryReads(true))
 
@@ -299,7 +301,8 @@ class DBCollectionSpecification extends Specification {
         collection.find().iterator().hasNext()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(), collection.getObjectCodec())
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                collection.getObjectCodec())
                 .filter(new BsonDocument())
                 .retryReads(true))
 
@@ -308,7 +311,8 @@ class DBCollectionSpecification extends Specification {
         collection.find(new BasicDBObject(), new DBCollectionFindOptions().collation(collation)).iterator().hasNext()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(), collection.getObjectCodec())
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                collection.getObjectCodec())
                 .filter(new BsonDocument())
                 .collation(collation)
                 .retryReads(true))
@@ -330,7 +334,8 @@ class DBCollectionSpecification extends Specification {
         collection.findOne()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(), collection.getObjectCodec())
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                collection.getObjectCodec())
                 .filter(new BsonDocument())
                 .limit(-1)
                 .retryReads(true))
@@ -340,7 +345,8 @@ class DBCollectionSpecification extends Specification {
         collection.findOne()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(), collection.getObjectCodec())
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                collection.getObjectCodec())
                 .filter(new BsonDocument())
                 .limit(-1)
                 .retryReads(true))
@@ -350,7 +356,8 @@ class DBCollectionSpecification extends Specification {
         collection.findOne(new BasicDBObject(), new DBCollectionFindOptions().collation(collation))
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(), collection.getObjectCodec())
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                collection.getObjectCodec())
                 .filter(new BsonDocument())
                 .limit(-1)
                 .collation(collation)
@@ -370,8 +377,8 @@ class DBCollectionSpecification extends Specification {
         collection.findAndRemove(query)
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new FindAndDeleteOperation<DBObject>(collection.getNamespace(),
-                WriteConcern.ACKNOWLEDGED, retryWrites, collection.getObjectCodec()).filter(new BsonDocument()))
+        expect executor.getWriteOperation(), isTheSameAs(new FindAndDeleteOperation<DBObject>(CSOT_NO_TIMEOUT.get(), collection.
+                getNamespace(), WriteConcern.ACKNOWLEDGED, retryWrites, collection.getObjectCodec()).filter(new BsonDocument()))
     }
 
     def 'findAndModify should create the correct FindAndUpdateOperation'() {
@@ -390,8 +397,8 @@ class DBCollectionSpecification extends Specification {
         collection.findAndModify(query, update)
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new FindAndUpdateOperation<DBObject>(collection.getNamespace(),
-                WriteConcern.ACKNOWLEDGED, retryWrites, collection.getObjectCodec(), bsonUpdate)
+        expect executor.getWriteOperation(), isTheSameAs(new FindAndUpdateOperation<DBObject>(CSOT_NO_TIMEOUT.get(),
+                collection.getNamespace(), WriteConcern.ACKNOWLEDGED, retryWrites, collection.getObjectCodec(), bsonUpdate)
                 .filter(new BsonDocument()))
 
         when: // With options
@@ -399,10 +406,11 @@ class DBCollectionSpecification extends Specification {
                 .arrayFilters(dbObjectArrayFilters).writeConcern(WriteConcern.W3))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new FindAndUpdateOperation<DBObject>(collection.getNamespace(), WriteConcern.W3,
-                retryWrites, collection.getObjectCodec(), bsonUpdate)
+        expect executor.getWriteOperation(), isTheSameAs(new FindAndUpdateOperation<DBObject>(CSOT_NO_TIMEOUT.get(),
+                collection.getNamespace(), WriteConcern.W3, retryWrites, collection.getObjectCodec(), bsonUpdate)
                 .filter(new BsonDocument())
-                .collation(collation).arrayFilters(bsonDocumentWrapperArrayFilters))
+                .collation(collation)
+                .arrayFilters(bsonDocumentWrapperArrayFilters))
 
         where:
         dbObjectArrayFilters <<            [null, [], [new BasicDBObject('i.b', 1)]]
@@ -426,8 +434,8 @@ class DBCollectionSpecification extends Specification {
         collection.findAndModify(query, replace)
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new FindAndReplaceOperation<DBObject>(collection.getNamespace(),
-                WriteConcern.ACKNOWLEDGED, retryWrites, collection.getObjectCodec(), bsonReplace)
+        expect executor.getWriteOperation(), isTheSameAs(new FindAndReplaceOperation<DBObject>(CSOT_NO_TIMEOUT.get(), collection.
+                getNamespace(), WriteConcern.ACKNOWLEDGED, retryWrites, collection.getObjectCodec(), bsonReplace)
                 .filter(new BsonDocument()))
 
         when: // With options
@@ -435,8 +443,8 @@ class DBCollectionSpecification extends Specification {
                 .writeConcern(WriteConcern.W3))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new FindAndReplaceOperation<DBObject>(collection.getNamespace(), WriteConcern.W3,
-                retryWrites, collection.getObjectCodec(), bsonReplace)
+        expect executor.getWriteOperation(), isTheSameAs(new FindAndReplaceOperation<DBObject>(CSOT_NO_TIMEOUT.get(),
+                collection.getNamespace(), WriteConcern.W3, retryWrites, collection.getObjectCodec(), bsonReplace)
                 .filter(new BsonDocument())
                 .collation(collation))
     }
@@ -451,7 +459,7 @@ class DBCollectionSpecification extends Specification {
         collection.count()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new CountOperation(collection.getNamespace())
+        expect executor.getReadOperation(), isTheSameAs(new CountOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace())
                 .filter(new BsonDocument()).retryReads(true))
 
         when: // Inherits from DB
@@ -460,7 +468,7 @@ class DBCollectionSpecification extends Specification {
         executor.getReadConcern() == ReadConcern.MAJORITY
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new CountOperation(collection.getNamespace())
+        expect executor.getReadOperation(), isTheSameAs(new CountOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace())
                 .filter(new BsonDocument()).retryReads(true))
         executor.getReadConcern() == ReadConcern.MAJORITY
 
@@ -469,7 +477,7 @@ class DBCollectionSpecification extends Specification {
         collection.count(new BasicDBObject(), new DBCollectionCountOptions().collation(collation))
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new CountOperation(collection.getNamespace())
+        expect executor.getReadOperation(), isTheSameAs(new CountOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace())
                 .filter(new BsonDocument()).retryReads(true)
                 .collation(collation))
         executor.getReadConcern() == ReadConcern.LOCAL
@@ -496,8 +504,8 @@ class DBCollectionSpecification extends Specification {
 
         then:
         distinctFieldValues == [1, 2]
-        expect executor.getReadOperation(), isTheSameAs(new DistinctOperation(collection.getNamespace(), 'field1', new BsonValueCodec())
-                                                                .filter(new BsonDocument()).retryReads(true))
+        expect executor.getReadOperation(), isTheSameAs(new DistinctOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(), 'field1',
+                new BsonValueCodec()).filter(new BsonDocument()).retryReads(true))
         executor.getReadConcern() == ReadConcern.DEFAULT
 
         when: // Inherits from DB
@@ -505,7 +513,8 @@ class DBCollectionSpecification extends Specification {
         collection.distinct('field1')
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new DistinctOperation(collection.getNamespace(), 'field1', new BsonValueCodec())
+        expect executor.getReadOperation(), isTheSameAs(new DistinctOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(), 'field1',
+                new BsonValueCodec())
                 .filter(new BsonDocument()).retryReads(true))
         executor.getReadConcern() == ReadConcern.MAJORITY
 
@@ -514,8 +523,8 @@ class DBCollectionSpecification extends Specification {
         collection.distinct('field1', new DBCollectionDistinctOptions().collation(collation))
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new DistinctOperation(collection.getNamespace(), 'field1', new BsonValueCodec())
-                .collation(collation).retryReads(true))
+        expect executor.getReadOperation(), isTheSameAs(new DistinctOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(), 'field1',
+                new BsonValueCodec()).collation(collation).retryReads(true))
         executor.getReadConcern() == ReadConcern.LOCAL
     }
 
@@ -534,8 +543,8 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getReadOperation(), isTheSameAs(
-                new MapReduceWithInlineResultsOperation(collection.getNamespace(), new BsonJavaScript('map'), new BsonJavaScript('reduce'),
-                        collection.getDefaultDBObjectCodec())
+                new MapReduceWithInlineResultsOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(), new BsonJavaScript('map'),
+                        new BsonJavaScript('reduce'), collection.getDefaultDBObjectCodec())
                         .verbose(true)
                         .filter(new BsonDocument()))
         executor.getReadConcern() == ReadConcern.DEFAULT
@@ -546,8 +555,8 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getReadOperation(), isTheSameAs(
-                new MapReduceWithInlineResultsOperation(collection.getNamespace(), new BsonJavaScript('map'), new BsonJavaScript('reduce'),
-                        collection.getDefaultDBObjectCodec())
+                new MapReduceWithInlineResultsOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(), new BsonJavaScript('map'),
+                        new BsonJavaScript('reduce'), collection.getDefaultDBObjectCodec())
                         .verbose(true)
                         .filter(new BsonDocument()))
         executor.getReadConcern() == ReadConcern.LOCAL
@@ -561,8 +570,8 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getReadOperation(), isTheSameAs(
-                new MapReduceWithInlineResultsOperation(collection.getNamespace(), new BsonJavaScript('map'), new BsonJavaScript('reduce'),
-                        collection.getDefaultDBObjectCodec())
+                new MapReduceWithInlineResultsOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(), new BsonJavaScript('map'),
+                        new BsonJavaScript('reduce'), collection.getDefaultDBObjectCodec())
                         .verbose(true)
                         .filter(new BsonDocument())
                         .collation(collation))
@@ -581,8 +590,8 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getWriteOperation(), isTheSameAs(
-                new MapReduceToCollectionOperation(collection.getNamespace(), new BsonJavaScript('map'), new BsonJavaScript('reduce'),
-                        'myColl', collection.getWriteConcern())
+                new MapReduceToCollectionOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(), new BsonJavaScript('map'),
+                        new BsonJavaScript('reduce'), 'myColl', collection.getWriteConcern())
                         .verbose(true)
                         .filter(new BsonDocument())
         )
@@ -592,8 +601,8 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getWriteOperation(), isTheSameAs(
-                new MapReduceToCollectionOperation(collection.getNamespace(), new BsonJavaScript('map'), new BsonJavaScript('reduce'),
-                        'myColl', collection.getWriteConcern())
+                new MapReduceToCollectionOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(), new BsonJavaScript('map'),
+                        new BsonJavaScript('reduce'), 'myColl', collection.getWriteConcern())
                         .verbose(true)
                         .filter(new BsonDocument())
         )
@@ -606,8 +615,8 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getWriteOperation(), isTheSameAs(
-                new MapReduceToCollectionOperation(collection.getNamespace(), new BsonJavaScript('map'), new BsonJavaScript('reduce'),
-                        'myColl', collection.getWriteConcern())
+                new MapReduceToCollectionOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(), new BsonJavaScript('map'),
+                        new BsonJavaScript('reduce'), 'myColl', collection.getWriteConcern())
                         .verbose(true)
                         .filter(new BsonDocument())
                         .collation(collation)
@@ -630,8 +639,8 @@ class DBCollectionSpecification extends Specification {
         collection.aggregate(pipeline, AggregationOptions.builder().build())
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(collection.getNamespace(), bsonPipeline,
-                collection.getDefaultDBObjectCodec()).retryReads(true))
+        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                bsonPipeline, collection.getDefaultDBObjectCodec()).retryReads(true))
         executor.getReadConcern() == ReadConcern.DEFAULT
 
         when: // Inherits from DB
@@ -639,8 +648,8 @@ class DBCollectionSpecification extends Specification {
         collection.aggregate(pipeline, AggregationOptions.builder().build())
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(collection.getNamespace(), bsonPipeline,
-                collection.getDefaultDBObjectCodec()).retryReads(true))
+        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                bsonPipeline, collection.getDefaultDBObjectCodec()).retryReads(true))
         executor.getReadConcern() == ReadConcern.MAJORITY
 
         when:
@@ -648,8 +657,8 @@ class DBCollectionSpecification extends Specification {
         collection.aggregate(pipeline, AggregationOptions.builder().collation(collation).build())
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(collection.getNamespace(), bsonPipeline,
-                collection.getDefaultDBObjectCodec()).collation(collation).retryReads(true))
+        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                bsonPipeline, collection.getDefaultDBObjectCodec()).collation(collation).retryReads(true))
         executor.getReadConcern() == ReadConcern.LOCAL
     }
 
@@ -665,21 +674,21 @@ class DBCollectionSpecification extends Specification {
         collection.aggregate(pipeline, AggregationOptions.builder().build())
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
                 bsonPipeline, collection.getReadConcern(), collection.getWriteConcern()))
 
         when: // Inherits from DB
         collection.aggregate(pipeline, AggregationOptions.builder().build())
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
                 bsonPipeline, collection.getReadConcern(), collection.getWriteConcern()))
 
         when:
         collection.aggregate(pipeline, AggregationOptions.builder().collation(collation).build())
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
                 bsonPipeline, collection.getReadConcern(), collection.getWriteConcern()).collation(collation))
     }
 
@@ -697,8 +706,8 @@ class DBCollectionSpecification extends Specification {
         collection.explainAggregate(pipeline, options)
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(collection.getNamespace(), bsonPipeline,
-                collection.getDefaultDBObjectCodec()).retryReads(true).collation(collation)
+        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                bsonPipeline, collection.getDefaultDBObjectCodec()).retryReads(true).collation(collation)
                 .asExplainableOperation(ExplainVerbosity.QUERY_PLANNER, new BsonDocumentCodec()))
 
         when: // Inherits from DB
@@ -706,8 +715,8 @@ class DBCollectionSpecification extends Specification {
         collection.explainAggregate(pipeline, options)
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(collection.getNamespace(), bsonPipeline,
-                collection.getDefaultDBObjectCodec()).retryReads(true).collation(collation)
+        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                bsonPipeline, collection.getDefaultDBObjectCodec()).retryReads(true).collation(collation)
                 .asExplainableOperation(ExplainVerbosity.QUERY_PLANNER, new BsonDocumentCodec()))
 
         when:
@@ -715,8 +724,8 @@ class DBCollectionSpecification extends Specification {
         collection.explainAggregate(pipeline, options)
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(collection.getNamespace(), bsonPipeline,
-                collection.getDefaultDBObjectCodec()).retryReads(true).collation(collation)
+        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                bsonPipeline, collection.getDefaultDBObjectCodec()).retryReads(true).collation(collation)
                 .asExplainableOperation(ExplainVerbosity.QUERY_PLANNER, new BsonDocumentCodec()))
     }
 
@@ -736,8 +745,8 @@ class DBCollectionSpecification extends Specification {
         collection.update(BasicDBObject.parse(query), BasicDBObject.parse(update))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForUpdate(collection.getNamespace(), true,
-                WriteConcern.ACKNOWLEDGED, retryWrites, asList(updateRequest)))
+        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForUpdate(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                true, WriteConcern.ACKNOWLEDGED, retryWrites, asList(updateRequest)))
 
         when: // Inherits from DB
         db.setWriteConcern(WriteConcern.W3)
@@ -745,8 +754,8 @@ class DBCollectionSpecification extends Specification {
 
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForUpdate(collection.getNamespace(), true,
-                WriteConcern.W3, retryWrites, asList(updateRequest)))
+        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForUpdate(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                true, WriteConcern.W3, retryWrites, asList(updateRequest)))
 
         when:
         collection.setWriteConcern(WriteConcern.W1)
@@ -755,8 +764,8 @@ class DBCollectionSpecification extends Specification {
                 new DBCollectionUpdateOptions().collation(collation).arrayFilters(dbObjectArrayFilters))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForUpdate(collection.getNamespace(), true,
-                WriteConcern.W1, retryWrites, asList(updateRequest.arrayFilters(bsonDocumentWrapperArrayFilters))))
+        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForUpdate(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                true, WriteConcern.W1, retryWrites, asList(updateRequest.arrayFilters(bsonDocumentWrapperArrayFilters))))
 
         where:
         dbObjectArrayFilters <<            [null, [], [new BasicDBObject('i.b', 1)]]
@@ -778,16 +787,16 @@ class DBCollectionSpecification extends Specification {
         collection.remove(BasicDBObject.parse(query))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForDelete(collection.getNamespace(), false,
-                WriteConcern.ACKNOWLEDGED, retryWrites, asList(deleteRequest)))
+        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForDelete(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                false, WriteConcern.ACKNOWLEDGED, retryWrites, asList(deleteRequest)))
 
         when: // Inherits from DB
         db.setWriteConcern(WriteConcern.W3)
         collection.remove(BasicDBObject.parse(query))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForDelete(collection.getNamespace(), false,
-                WriteConcern.W3, retryWrites, asList(deleteRequest)))
+        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForDelete(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                false, WriteConcern.W3, retryWrites, asList(deleteRequest)))
 
         when:
         collection.setWriteConcern(WriteConcern.W1)
@@ -795,8 +804,8 @@ class DBCollectionSpecification extends Specification {
         collection.remove(BasicDBObject.parse(query), new DBCollectionRemoveOptions().collation(collation))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForDelete(collection.getNamespace(), false,
-                WriteConcern.W1, retryWrites, asList(deleteRequest)))
+        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForDelete(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                false, WriteConcern.W1, retryWrites, asList(deleteRequest)))
     }
 
     def 'should create the correct MixedBulkWriteOperation'() {
@@ -827,7 +836,8 @@ class DBCollectionSpecification extends Specification {
         bulk().execute()
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new MixedBulkWriteOperation(collection.getNamespace(), writeRequests, ordered,
+        expect executor.getWriteOperation(), isTheSameAs(new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                writeRequests, ordered,
                 WriteConcern.ACKNOWLEDGED, false))
 
         when: // Inherits from DB
@@ -835,16 +845,16 @@ class DBCollectionSpecification extends Specification {
         bulk().execute()
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new MixedBulkWriteOperation(collection.getNamespace(), writeRequests, ordered,
-                WriteConcern.W3, false))
+        expect executor.getWriteOperation(), isTheSameAs(new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                writeRequests, ordered, WriteConcern.W3, false))
 
         when:
         collection.setWriteConcern(WriteConcern.W1)
         bulk().execute()
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new MixedBulkWriteOperation(collection.getNamespace(), writeRequests, ordered,
-                WriteConcern.W1, false))
+        expect executor.getWriteOperation(), isTheSameAs(new MixedBulkWriteOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                writeRequests, ordered, WriteConcern.W1, false))
 
         where:
         ordered << [true, false, true]

--- a/driver-legacy/src/test/functional/com/mongodb/DBTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import java.util.Locale;
 import java.util.UUID;
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT;
 import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.getBinding;
@@ -344,7 +345,7 @@ public class DBTest extends DatabaseTestCase {
     }
 
     BsonDocument getCollectionInfo(final String collectionName) {
-        return new ListCollectionsOperation<>(getDefaultDatabaseName(), new BsonDocumentCodec())
+        return new ListCollectionsOperation<>(CSOT_NO_TIMEOUT.get(), getDefaultDatabaseName(), new BsonDocumentCodec())
                 .filter(new BsonDocument("name", new BsonString(collectionName))).execute(getBinding()).next().get(0);
     }
 }

--- a/driver-legacy/src/test/functional/com/mongodb/LegacyMixedBulkWriteOperationSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/LegacyMixedBulkWriteOperationSpecification.groovy
@@ -28,6 +28,7 @@ import org.bson.codecs.DocumentCodec
 import org.bson.types.ObjectId
 import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.getSingleConnectionBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
@@ -46,7 +47,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
 
     def 'should throw IllegalArgumentException for empty list of requests'() {
         when:
-        createBulkWriteOperationForInsert(getNamespace(), true, ACKNOWLEDGED, true, [])
+        createBulkWriteOperationForInsert(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED, true, [])
 
         then:
         thrown(IllegalArgumentException)
@@ -56,7 +57,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
         given:
         def inserts = [new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
                        new InsertRequest(new BsonDocument('_id', new BsonInt32(2)))]
-        def operation = createBulkWriteOperationForInsert(getNamespace(), true, ACKNOWLEDGED, false, inserts)
+        def operation = createBulkWriteOperationForInsert(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED, false, inserts)
 
         when:
         def result = execute(operation)
@@ -73,7 +74,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should insert a single document'() {
         given:
         def insert = new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))
-        def operation = createBulkWriteOperationForInsert(getNamespace(), true, ACKNOWLEDGED, false, asList(insert))
+        def operation = createBulkWriteOperationForInsert(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED, false, asList(insert))
 
         when:
         execute(operation)
@@ -85,7 +86,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should execute unacknowledged write'() {
         given:
         def binding = getSingleConnectionBinding()
-        def operation = createBulkWriteOperationForInsert(getNamespace(), true, UNACKNOWLEDGED, false,
+        def operation = createBulkWriteOperationForInsert(CSOT_NO_TIMEOUT.get(), getNamespace(), true, UNACKNOWLEDGED, false,
                 [new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
                  new InsertRequest(new BsonDocument('_id', new BsonInt32(2)))])
 
@@ -107,7 +108,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
                 new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
                 new InsertRequest(new BsonDocument('_id', new BsonInt32(2))),
         ]
-        def operation = createBulkWriteOperationForInsert(getNamespace(), false, ACKNOWLEDGED, false, documents)
+        def operation = createBulkWriteOperationForInsert(CSOT_NO_TIMEOUT.get(), getNamespace(), false, ACKNOWLEDGED, false, documents)
 
         when:
         execute(operation)
@@ -124,7 +125,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
                 new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
                 new InsertRequest(new BsonDocument('_id', new BsonInt32(2))),
         ]
-        def operation = createBulkWriteOperationForInsert(getNamespace(), true, ACKNOWLEDGED, false, documents)
+        def operation = createBulkWriteOperationForInsert(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED, false, documents)
 
         when:
         execute(operation)
@@ -138,7 +139,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should support retryable writes'() {
         given:
         def insert = new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))
-        def operation = createBulkWriteOperationForInsert(getNamespace(), true, ACKNOWLEDGED, true, asList(insert))
+        def operation = createBulkWriteOperationForInsert(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED, true, asList(insert))
 
         when:
         executeWithSession(operation, false)
@@ -150,7 +151,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should remove a document'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('_id', 1))
-        def operation = createBulkWriteOperationForDelete(getNamespace(), true, ACKNOWLEDGED, false,
+        def operation = createBulkWriteOperationForDelete(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED, false,
                 [new DeleteRequest(new BsonDocument('_id', new BsonInt32(1)))])
 
         when:
@@ -167,7 +168,8 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should return correct result for replace'() {
         given:
         def replacement = new UpdateRequest(new BsonDocument(), new BsonDocument('_id', new BsonInt32(1)), REPLACE)
-        def operation = createBulkWriteOperationForReplace(getNamespace(), true, ACKNOWLEDGED, false, asList(replacement))
+        def operation = createBulkWriteOperationForReplace(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED,
+                false, asList(replacement))
 
         when:
         def result = execute(operation)
@@ -182,11 +184,13 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should replace a single document'() {
         given:
         def insert = new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))
-        createBulkWriteOperationForInsert(getNamespace(), true, ACKNOWLEDGED, false, asList(insert)).execute(getBinding())
+        createBulkWriteOperationForInsert(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED, false, asList(insert))
+                .execute(getBinding())
 
         def replacement = new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
                 new BsonDocument('_id', new BsonInt32(1)).append('x', new BsonInt32(1)), REPLACE)
-        def operation = createBulkWriteOperationForReplace(getNamespace(), true, ACKNOWLEDGED, false, asList(replacement))
+        def operation = createBulkWriteOperationForReplace(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED,
+                false, asList(replacement))
 
         when:
         def result = execute(operation)
@@ -205,7 +209,8 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
         def replacement = new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
                 new BsonDocument('_id', new BsonInt32(1)).append('x', new BsonInt32(1)), REPLACE)
                 .upsert(true)
-        def operation = createBulkWriteOperationForReplace(getNamespace(), true, ACKNOWLEDGED, false, asList(replacement))
+        def operation = createBulkWriteOperationForReplace(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED,
+                false, asList(replacement))
 
         when:
         execute(operation)
@@ -216,9 +221,9 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
 
     def 'should update nothing if no documents match'() {
         given:
-        def operation = createBulkWriteOperationForUpdate(getNamespace(), true, ACKNOWLEDGED, false,
-                asList(new UpdateRequest(new BsonDocument('x', new BsonInt32(1)),
-                        new BsonDocument('$set', new BsonDocument('y', new BsonInt32(2))), UPDATE).multi(false)))
+        def operation = createBulkWriteOperationForUpdate(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED,
+                false, asList(new UpdateRequest(new BsonDocument('x', new BsonInt32(1)),
+                new BsonDocument('$set', new BsonDocument('y', new BsonInt32(2))), UPDATE).multi(false)))
 
         when:
         WriteConcernResult result = execute(operation)
@@ -236,7 +241,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
         getCollectionHelper().insertDocuments(new DocumentCodec(),
                 new Document('x', 1),
                 new Document('x', 1))
-        def operation = createBulkWriteOperationForUpdate(getNamespace(), true, ACKNOWLEDGED, false,
+        def operation = createBulkWriteOperationForUpdate(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED, false,
                 asList(new UpdateRequest(new BsonDocument('x', new BsonInt32(1)),
                         new BsonDocument('$set', new BsonDocument('y', new BsonInt32(2))), UPDATE).multi(false)))
 
@@ -256,7 +261,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
         getCollectionHelper().insertDocuments(new DocumentCodec(),
                 new Document('x', 1),
                 new Document('x', 1))
-        def operation = createBulkWriteOperationForUpdate(getNamespace(), true, ACKNOWLEDGED, false,
+        def operation = createBulkWriteOperationForUpdate(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED, false,
                 asList(new UpdateRequest(new BsonDocument('x', new BsonInt32(1)),
                         new BsonDocument('$set', new BsonDocument('y', new BsonInt32(2))), UPDATE).multi(true)))
 
@@ -273,7 +278,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
 
     def 'when upsert is true should insert a document if there are no matching documents'() {
         given:
-        def operation = createBulkWriteOperationForUpdate(getNamespace(), true, ACKNOWLEDGED, false,
+        def operation = createBulkWriteOperationForUpdate(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED, false,
                 asList(new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
                         new BsonDocument('$set', new BsonDocument('y', new BsonInt32(2))), UPDATE).upsert(true)))
 
@@ -291,7 +296,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should return correct result for upsert'() {
         given:
         def id = new ObjectId()
-        def operation = createBulkWriteOperationForUpdate(getNamespace(), true, ACKNOWLEDGED, false,
+        def operation = createBulkWriteOperationForUpdate(CSOT_NO_TIMEOUT.get(), getNamespace(), true, ACKNOWLEDGED, false,
                 asList(new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)),
                         new BsonDocument('$set', new BsonDocument('x', new BsonInt32(1))), UPDATE).upsert(true)))
 

--- a/driver-legacy/src/test/unit/com/mongodb/DBCursorSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/DBCursorSpecification.groovy
@@ -28,7 +28,10 @@ import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME
 import static Fixture.getMongoClient
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME_AND_MAX_AWAIT_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static spock.util.matcher.HamcrestSupport.expect
 
@@ -122,10 +125,11 @@ class DBCursorSpecification extends Specification {
         cursor.toArray()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(), collection.getObjectCodec())
-                                                                .filter(new BsonDocument())
-                                                                .projection(new BsonDocument())
-                                                                .retryReads(true))
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(),
+                collection.getObjectCodec())
+                .filter(new BsonDocument())
+                .projection(new BsonDocument())
+                .retryReads(true))
     }
 
 
@@ -140,11 +144,13 @@ class DBCursorSpecification extends Specification {
         cursor.one()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(), collection.getObjectCodec())
-                                                                .limit(-1)
-                                                                .filter(new BsonDocument())
-                                                                .projection(new BsonDocument())
-                                                                .retryReads(true))
+        expect executor.getReadOperation(), isTheSameAs(
+                new FindOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace(), collection.getObjectCodec())
+                        .limit(-1)
+                        .filter(new BsonDocument())
+                        .projection(new BsonDocument())
+                        .retryReads(true)
+        )
     }
 
     def 'DBCursor methods should be used to create the expected operation'() {
@@ -167,7 +173,7 @@ class DBCursorSpecification extends Specification {
                 .batchSize(1)
                 .cursorType(cursorType)
                 .limit(1)
-                .maxTime(1, TimeUnit.MILLISECONDS)
+                .maxTime(100, TimeUnit.MILLISECONDS)
                 .noCursorTimeout(true)
                 .oplogReplay(true)
                 .partial(true)
@@ -178,13 +184,13 @@ class DBCursorSpecification extends Specification {
         cursor.toArray()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(), collection.getObjectCodec())
+        expect executor.getReadOperation(), isTheSameAs(
+                new FindOperation(CSOT_MAX_TIME.get(), collection.getNamespace(), collection.getObjectCodec())
                 .batchSize(1)
                 .collation(collation)
                 .cursorType(cursorType)
                 .filter(bsonFilter)
                 .limit(1)
-                .maxTime(1, TimeUnit.MILLISECONDS)
                 .noCursorTimeout(true)
                 .oplogReplay(true)
                 .partial(true)
@@ -223,8 +229,8 @@ class DBCursorSpecification extends Specification {
                 .collation(collation)
                 .cursorType(cursorType)
                 .limit(1)
-                .maxAwaitTime(1, TimeUnit.MILLISECONDS)
-                .maxTime(1, TimeUnit.MILLISECONDS)
+                .maxAwaitTime(1001, TimeUnit.MILLISECONDS)
+                .maxTime(101, TimeUnit.MILLISECONDS)
                 .noCursorTimeout(true)
                 .oplogReplay(true)
                 .partial(true)
@@ -246,14 +252,13 @@ class DBCursorSpecification extends Specification {
         cursor.toArray()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(), collection.getObjectCodec())
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(CSOT_MAX_TIME_AND_MAX_AWAIT_TIME.get(),
+                collection.getNamespace(), collection.getObjectCodec())
                 .batchSize(1)
                 .collation(collation)
                 .cursorType(cursorType)
                 .filter(bsonFilter)
                 .limit(1)
-                .maxAwaitTime(1, TimeUnit.MILLISECONDS)
-                .maxTime(1, TimeUnit.MILLISECONDS)
                 .noCursorTimeout(true)
                 .oplogReplay(true)
                 .partial(true)
@@ -283,7 +288,7 @@ class DBCursorSpecification extends Specification {
 
         then:
         result == 42
-        expect executor.getReadOperation(), isTheSameAs(new CountOperation(collection.getNamespace())
+        expect executor.getReadOperation(), isTheSameAs(new CountOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace())
                                                                 .filter(new BsonDocument()).retryReads(true))
         executor.getReadConcern() == ReadConcern.MAJORITY
     }
@@ -299,7 +304,7 @@ class DBCursorSpecification extends Specification {
 
         then:
         result == 42
-        expect executor.getReadOperation(), isTheSameAs(new CountOperation(collection.getNamespace())
+        expect executor.getReadOperation(), isTheSameAs(new CountOperation(CSOT_NO_TIMEOUT.get(), collection.getNamespace())
                                                                 .filter(new BsonDocument()).retryReads(true))
         executor.getReadConcern() == ReadConcern.MAJORITY
     }

--- a/driver-legacy/src/test/unit/com/mongodb/DBSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/DBSpecification.groovy
@@ -35,6 +35,7 @@ import org.bson.BsonDouble
 import spock.lang.Specification
 
 import static Fixture.getMongoClient
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.MongoClientSettings.getDefaultCodecRegistry
 import static spock.util.matcher.HamcrestSupport.expect
@@ -84,7 +85,7 @@ class DBSpecification extends Specification {
 
         then:
         def operation = executor.getWriteOperation() as CreateCollectionOperation
-        expect operation, isTheSameAs(new CreateCollectionOperation('test', 'ctest', db.getWriteConcern()))
+        expect operation, isTheSameAs(new CreateCollectionOperation(CSOT_NO_TIMEOUT.get(), 'test', 'ctest', db.getWriteConcern()))
         executor.getReadConcern() == ReadConcern.MAJORITY
 
         when:
@@ -104,7 +105,7 @@ class DBSpecification extends Specification {
         operation = executor.getWriteOperation() as CreateCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new CreateCollectionOperation('test', 'ctest', db.getWriteConcern())
+        expect operation, isTheSameAs(new CreateCollectionOperation(CSOT_NO_TIMEOUT.get(), 'test', 'ctest', db.getWriteConcern())
                 .sizeInBytes(100000)
                 .maxDocuments(2000)
                 .capped(true)
@@ -132,7 +133,8 @@ class DBSpecification extends Specification {
         operation = executor.getWriteOperation() as CreateCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new CreateCollectionOperation('test', 'ctest', db.getWriteConcern()).collation(collation))
+        expect operation, isTheSameAs(new CreateCollectionOperation(CSOT_NO_TIMEOUT.get(), 'test', 'ctest', db.getWriteConcern())
+                .collation(collation))
         executor.getReadConcern() == ReadConcern.MAJORITY
     }
 
@@ -160,7 +162,7 @@ class DBSpecification extends Specification {
 
         then:
         def operation = executor.getWriteOperation() as CreateViewOperation
-        expect operation, isTheSameAs(new CreateViewOperation(databaseName, viewName, viewOn,
+        expect operation, isTheSameAs(new CreateViewOperation(CSOT_NO_TIMEOUT.get(), databaseName, viewName, viewOn,
                 [new BsonDocument('$match', new BsonDocument('x', BsonBoolean.TRUE))], writeConcern))
         executor.getReadConcern() == ReadConcern.MAJORITY
 
@@ -169,7 +171,7 @@ class DBSpecification extends Specification {
         operation = executor.getWriteOperation() as CreateViewOperation
 
         then:
-        expect operation, isTheSameAs(new CreateViewOperation(databaseName, viewName, viewOn,
+        expect operation, isTheSameAs(new CreateViewOperation(CSOT_NO_TIMEOUT.get(), databaseName, viewName, viewOn,
                 [new BsonDocument('$match', new BsonDocument('x', BsonBoolean.TRUE))], writeConcern).collation(collation))
         executor.getReadConcern() == ReadConcern.MAJORITY
     }
@@ -189,7 +191,8 @@ class DBSpecification extends Specification {
         def operation = executor.getReadOperation() as ListCollectionsOperation
 
         then:
-        expect operation, isTheSameAs(new ListCollectionsOperation(databaseName, new DBObjectCodec(getDefaultCodecRegistry()))
+        expect operation, isTheSameAs(new ListCollectionsOperation(CSOT_NO_TIMEOUT.get(), databaseName,
+                new DBObjectCodec(getDefaultCodecRegistry()))
                 .nameOnly(true))
 
         when:
@@ -197,7 +200,8 @@ class DBSpecification extends Specification {
         operation = executor.getReadOperation() as ListCollectionsOperation
 
         then:
-        expect operation, isTheSameAs(new ListCollectionsOperation(databaseName, new DBObjectCodec(getDefaultCodecRegistry()))
+        expect operation, isTheSameAs(new ListCollectionsOperation(CSOT_NO_TIMEOUT.get(), databaseName,
+                new DBObjectCodec(getDefaultCodecRegistry()))
                 .nameOnly(true))
     }
 

--- a/driver-legacy/src/test/unit/com/mongodb/MongoClientSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoClientSpecification.groovy
@@ -339,7 +339,7 @@ class MongoClientSpecification extends Specification {
 
         then:
         expect database, isTheSameAs(new MongoDatabaseImpl('name', client.getCodecRegistry(), secondary(),
-                WriteConcern.MAJORITY, true, true, ReadConcern.MAJORITY, STANDARD, null,
+                WriteConcern.MAJORITY, true, true, ReadConcern.MAJORITY, STANDARD, null, null,
                 client.getOperationExecutor()))
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoCollection.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoCollection.java
@@ -45,12 +45,14 @@ import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.InsertManyResult;
 import com.mongodb.client.result.InsertOneResult;
 import com.mongodb.client.result.UpdateResult;
+import com.mongodb.lang.Nullable;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 import org.reactivestreams.Publisher;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The MongoCollection interface.
@@ -108,6 +110,36 @@ public interface MongoCollection<TDocument> {
     ReadConcern getReadConcern();
 
     /**
+     * The time limit for the full execution of an operation.
+     *
+     * <p>If not null the following deprecated options will be ignored:
+     * {@code waitQueueTimeoutMS}, {@code socketTimeoutMS}, {@code wTimeoutMS}, {@code maxTimeMS} and {@code maxCommitTimeMS}</p>
+     *
+     * <ul>
+     *   <li>{@code null} means that the timeout mechanism for operations will defer to using:
+     *    <ul>
+     *        <li>{@code waitQueueTimeoutMS}: The maximum wait time in milliseconds that a thread may wait for a connection to become
+     *        available</li>
+     *        <li>{@code socketTimeoutMS}: How long a send or receive on a socket can take before timing out.</li>
+     *        <li>{@code wTimeoutMS}: How long the server will wait for the write concern to be fulfilled before timing out.</li>
+     *        <li>{@code maxTimeMS}: The cumulative time limit for processing operations on a cursor.
+     *        See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.</li>
+     *        <li>{@code maxCommitTimeMS}: The maximum amount of time to allow a single {@code commitTransaction} command to execute.
+     *        See: {@link com.mongodb.TransactionOptions#getMaxCommitTime}.</li>
+     *   </ul>
+     *   </li>
+     *   <li>{@code 0} means infinite timeout.</li>
+     *    <li>{@code > 0} The time limit to use for the full execution of an operation.</li>
+     * </ul>
+     *
+     * @param timeUnit the time unit
+     * @return the timeout in the given time unit
+     * @since 4.x
+     */
+    @Nullable
+    Long getTimeout(TimeUnit timeUnit);
+
+    /**
      * Create a new MongoCollection instance with a different default class to cast any documents returned from the database into..
      *
      * @param clazz          the default class to cast any documents returned from the database into.
@@ -155,6 +187,22 @@ public interface MongoCollection<TDocument> {
      * @since 1.2
      */
     MongoCollection<TDocument> withReadConcern(ReadConcern readConcern);
+
+    /**
+     * Create a new MongoCollection instance with the set time limit for the full execution of an operation.
+     *
+     * <ul>
+     *   <li>{@code 0} means infinite timeout.</li>
+     *    <li>{@code > 0} The time limit to use for the full execution of an operation.</li>
+     * </ul>
+     *
+     * @param timeout the timeout, which must be greater than or equal to 0
+     * @param timeUnit the time unit
+     * @return a new MongoCollection instance with the set time limit for the full execution of an operation
+     * @since 4.x
+     * @see #getTimeout
+     */
+    MongoCollection<TDocument> withTimeout(long timeout, TimeUnit timeUnit);
 
     /**
      * Gets an estimate of the count of documents in a collection using collection metadata.

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoDatabase.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoDatabase.java
@@ -22,12 +22,14 @@ import com.mongodb.WriteConcern;
 import com.mongodb.annotations.ThreadSafe;
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.CreateViewOptions;
+import com.mongodb.lang.Nullable;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 import org.reactivestreams.Publisher;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The MongoDatabase interface.
@@ -75,6 +77,36 @@ public interface MongoDatabase {
     ReadConcern getReadConcern();
 
     /**
+     * The time limit for the full execution of an operation.
+     *
+     * <p>If not null the following deprecated options will be ignored:
+     * {@code waitQueueTimeoutMS}, {@code socketTimeoutMS}, {@code wTimeoutMS}, {@code maxTimeMS} and {@code maxCommitTimeMS}</p>
+     *
+     * <ul>
+     *   <li>{@code null} means that the timeout mechanism for operations will defer to using:
+     *    <ul>
+     *        <li>{@code waitQueueTimeoutMS}: The maximum wait time in milliseconds that a thread may wait for a connection to become
+     *        available</li>
+     *        <li>{@code socketTimeoutMS}: How long a send or receive on a socket can take before timing out.</li>
+     *        <li>{@code wTimeoutMS}: How long the server will wait for the write concern to be fulfilled before timing out.</li>
+     *        <li>{@code maxTimeMS}: The cumulative time limit for processing operations on a cursor.
+     *        See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.</li>
+     *        <li>{@code maxCommitTimeMS}: The maximum amount of time to allow a single {@code commitTransaction} command to execute.
+     *        See: {@link com.mongodb.TransactionOptions#getMaxCommitTime}.</li>
+     *   </ul>
+     *   </li>
+     *   <li>{@code 0} means infinite timeout.</li>
+     *    <li>{@code > 0} The time limit to use for the full execution of an operation.</li>
+     * </ul>
+     *
+     * @param timeUnit the time unit
+     * @return the timeout in the given time unit
+     * @since 4.x
+     */
+    @Nullable
+    Long getTimeout(TimeUnit timeUnit);
+
+    /**
      * Create a new MongoDatabase instance with a different codec registry.
      *
      * <p>The {@link CodecRegistry} configured by this method is effectively treated by the driver as an instance of
@@ -113,6 +145,22 @@ public interface MongoDatabase {
      * @mongodb.server.release 3.2
      */
     MongoDatabase withReadConcern(ReadConcern readConcern);
+
+    /**
+     * Create a new MongoDatabase instance with the set time limit for the full execution of an operation.
+     *
+     * <ul>
+     *   <li>{@code 0} means infinite timeout.</li>
+     *    <li>{@code > 0} The time limit to use for the full execution of an operation.</li>
+     * </ul>
+     *
+     * @param timeout the timeout, which must be greater than or equal to 0
+     * @param timeUnit the time unit
+     * @return a new MongoDatabase instance with the set time limit for the full execution of an operation.
+     * @since 4.x
+     * @see #getTimeout
+     */
+    MongoDatabase withTimeout(long timeout, TimeUnit timeUnit);
 
     /**
      * Gets a collection.

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionPublisherImpl.java
@@ -146,7 +146,7 @@ final class ClientSessionPublisherImpl extends BaseClientSessionImpl implements 
 
             return executor.execute(
                     new CommitTransactionOperation(
-                            // TODO - JAVA-4067
+                            // TODO (CSOT) - JAVA-4067
                             ClientSideOperationTimeouts.withMaxCommitMS(null, transactionOptions.getMaxCommitTime(MILLISECONDS)),
                             assertNotNull(transactionOptions.getWriteConcern()), alreadyCommitted)
                             .recoveryToken(getRecoveryToken()),
@@ -180,7 +180,7 @@ final class ClientSessionPublisherImpl extends BaseClientSessionImpl implements 
             }
             return executor.execute(
                     new AbortTransactionOperation(
-                            // TODO - JAVA-4067
+                            // TODO (CSOT) - JAVA-4067
                             ClientSideOperationTimeouts.withMaxCommitMS(null, transactionOptions.getMaxCommitTime(MILLISECONDS)),
                             assertNotNull(transactionOptions.getWriteConcern()))
                             .recoveryToken(getRecoveryToken()),

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionPublisherImpl.java
@@ -23,6 +23,7 @@ import com.mongodb.MongoInternalException;
 import com.mongodb.ReadConcern;
 import com.mongodb.TransactionOptions;
 import com.mongodb.WriteConcern;
+import com.mongodb.internal.ClientSideOperationTimeouts;
 import com.mongodb.internal.operation.AbortTransactionOperation;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.internal.operation.AsyncWriteOperation;
@@ -144,9 +145,11 @@ final class ClientSessionPublisherImpl extends BaseClientSessionImpl implements 
             commitInProgress = true;
 
             return executor.execute(
-                    new CommitTransactionOperation(assertNotNull(transactionOptions.getWriteConcern()), alreadyCommitted)
-                            .recoveryToken(getRecoveryToken())
-                            .maxCommitTime(transactionOptions.getMaxCommitTime(MILLISECONDS), MILLISECONDS),
+                    new CommitTransactionOperation(
+                            // TODO - JAVA-4067
+                            ClientSideOperationTimeouts.withMaxCommitMS(null, transactionOptions.getMaxCommitTime(MILLISECONDS)),
+                            assertNotNull(transactionOptions.getWriteConcern()), alreadyCommitted)
+                            .recoveryToken(getRecoveryToken()),
                     readConcern, this)
                     .doOnTerminate(() -> {
                         commitInProgress = false;
@@ -176,7 +179,10 @@ final class ClientSessionPublisherImpl extends BaseClientSessionImpl implements 
                 throw new MongoInternalException("Invariant violated. Transaction options read concern can not be null");
             }
             return executor.execute(
-                    new AbortTransactionOperation(assertNotNull(transactionOptions.getWriteConcern()))
+                    new AbortTransactionOperation(
+                            // TODO - JAVA-4067
+                            ClientSideOperationTimeouts.withMaxCommitMS(null, transactionOptions.getMaxCommitTime(MILLISECONDS)),
+                            assertNotNull(transactionOptions.getWriteConcern()))
                             .recoveryToken(getRecoveryToken()),
                     readConcern, this)
                     .onErrorResume(Throwable.class, (e) -> Mono.empty())

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoClientImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoClientImpl.java
@@ -103,6 +103,7 @@ public final class MongoClientImpl implements MongoClient {
                                                                      settings.getRetryWrites(), settings.getRetryReads(),
                                                                      settings.getUuidRepresentation(),
                                                                      settings.getAutoEncryptionSettings(),
+                                                                     null, // TODO JAVA-4064
                                                                      this.executor);
         this.closed = new AtomicBoolean();
         BsonDocument clientMetadataDocument = createClientMetadataDocument(settings.getApplicationName(), mongoDriverInformation);

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoCollectionImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoCollectionImpl.java
@@ -62,6 +62,7 @@ import org.reactivestreams.Publisher;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.notNull;
@@ -105,6 +106,12 @@ final class MongoCollectionImpl<T> implements MongoCollection<T> {
         return mongoOperationPublisher.getReadConcern();
     }
 
+    @Override
+    public Long getTimeout(final TimeUnit timeUnit) {
+        Long timeoutMS = mongoOperationPublisher.getTimeoutMS();
+        return (timeoutMS != null) ? notNull("timeUnit", timeUnit).convert(timeoutMS, TimeUnit.MILLISECONDS) : null;
+    }
+
     MongoOperationPublisher<T> getPublisherHelper() {
         return mongoOperationPublisher;
     }
@@ -132,6 +139,11 @@ final class MongoCollectionImpl<T> implements MongoCollection<T> {
     @Override
     public MongoCollection<T> withReadConcern(final ReadConcern readConcern) {
         return new MongoCollectionImpl<>(mongoOperationPublisher.withReadConcern(readConcern));
+    }
+
+    @Override
+    public MongoCollection<T> withTimeout(final long timeout, final TimeUnit timeUnit) {
+        return new MongoCollectionImpl<>(mongoOperationPublisher.withTimeout(timeout, timeUnit));
     }
 
     @Override

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoDatabaseImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoDatabaseImpl.java
@@ -38,6 +38,7 @@ import reactor.core.publisher.Flux;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.MongoNamespace.checkDatabaseNameValidity;
 import static com.mongodb.assertions.Assertions.assertNotNull;
@@ -82,6 +83,12 @@ public final class MongoDatabaseImpl implements MongoDatabase {
         return mongoOperationPublisher.getReadConcern();
     }
 
+    @Override
+    public Long getTimeout(final TimeUnit timeUnit) {
+        Long timeoutMS = mongoOperationPublisher.getTimeoutMS();
+        return (timeoutMS != null) ? notNull("timeUnit", timeUnit).convert(timeoutMS, TimeUnit.MILLISECONDS) : null;
+    }
+
     MongoOperationPublisher<Document> getMongoOperationPublisher() {
         return mongoOperationPublisher;
     }
@@ -104,6 +111,11 @@ public final class MongoDatabaseImpl implements MongoDatabase {
     @Override
     public MongoDatabase withReadConcern(final ReadConcern readConcern) {
         return new MongoDatabaseImpl(mongoOperationPublisher.withReadConcern(readConcern));
+    }
+
+    @Override
+    public MongoDatabase withTimeout(final long timeout, final TimeUnit timeUnit) {
+        return new MongoDatabaseImpl(mongoOperationPublisher.withTimeout(timeout, timeUnit));
     }
 
     @Override

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
@@ -229,7 +229,7 @@ public final class MongoOperationPublisher<T> {
         return new MongoOperationPublisher<>(getNamespace(), getDocumentClass(),
                 getCodecRegistry(), getReadPreference(), getReadConcern(),
                 getWriteConcern(), getRetryWrites(), getRetryReads(), uuidRepresentation,
-                autoEncryptionSettings, getTimeoutMS(), executor);
+                autoEncryptionSettings, timeoutMS, executor);
     }
 
     Publisher<Void> dropDatabase(@Nullable final ClientSession clientSession) {

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCollection.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCollection.java
@@ -59,6 +59,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
 import static com.mongodb.reactivestreams.client.syncadapter.ContextHelper.CONTEXT;
@@ -103,6 +104,11 @@ class SyncMongoCollection<T> implements MongoCollection<T> {
     }
 
     @Override
+    public Long getTimeout(final TimeUnit timeUnit) {
+        return wrapped.getTimeout(timeUnit);
+    }
+
+    @Override
     public <NewTDocument> MongoCollection<NewTDocument> withDocumentClass(final Class<NewTDocument> clazz) {
         return new SyncMongoCollection<>(wrapped.withDocumentClass(clazz));
     }
@@ -125,6 +131,11 @@ class SyncMongoCollection<T> implements MongoCollection<T> {
     @Override
     public MongoCollection<T> withReadConcern(final ReadConcern readConcern) {
         return new SyncMongoCollection<>(wrapped.withReadConcern(readConcern));
+    }
+
+    @Override
+    public MongoCollection<T> withTimeout(final long timeout, final TimeUnit timeUnit) {
+        return new SyncMongoCollection<>(wrapped.withTimeout(timeout, timeUnit));
     }
 
     @Override

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoDatabase.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoDatabase.java
@@ -35,6 +35,7 @@ import org.bson.conversions.Bson;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
 import static com.mongodb.reactivestreams.client.syncadapter.ContextHelper.CONTEXT;
@@ -77,6 +78,11 @@ public class SyncMongoDatabase implements MongoDatabase {
     }
 
     @Override
+    public Long getTimeout(final TimeUnit timeUnit) {
+        return wrapped.getTimeout(timeUnit);
+    }
+
+    @Override
     public MongoDatabase withCodecRegistry(final CodecRegistry codecRegistry) {
         return new SyncMongoDatabase(wrapped.withCodecRegistry(codecRegistry));
     }
@@ -94,6 +100,11 @@ public class SyncMongoDatabase implements MongoDatabase {
     @Override
     public MongoDatabase withReadConcern(final ReadConcern readConcern) {
         return new SyncMongoDatabase(wrapped.withReadConcern(readConcern));
+    }
+
+    @Override
+    public MongoDatabase withTimeout(final long timeout, final TimeUnit timeUnit) {
+        return new SyncMongoDatabase(wrapped.withTimeout(timeout, timeUnit));
     }
 
     @Override

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/DistinctPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/DistinctPublisherImplTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,7 +44,7 @@ public class DistinctPublisherImplTest extends TestHelper {
         DistinctPublisher<Document> publisher =
                 new DistinctPublisherImpl<>(null, createMongoOperationPublisher(executor), fieldName, new Document());
 
-        DistinctOperation<Document> expectedOperation = new DistinctOperation<>(NAMESPACE, fieldName,
+        DistinctOperation<Document> expectedOperation = new DistinctOperation<>(CSOT_NO_TIMEOUT.get(), NAMESPACE, fieldName,
                                                                                 getDefaultCodecRegistry().get(Document.class))
                 .retryReads(true).filter(new BsonDocument());
 

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/FindPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/FindPublisherImplTest.java
@@ -31,10 +31,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME_AND_MAX_AWAIT_TIME;
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("deprecation")
@@ -51,7 +52,8 @@ public class FindPublisherImplTest extends TestHelper {
         TestOperationExecutor executor = createOperationExecutor(asList(getBatchCursor(), getBatchCursor()));
         FindPublisher<Document> publisher = new FindPublisherImpl<>(null, createMongoOperationPublisher(executor), new Document());
 
-        FindOperation<Document> expectedOperation = new FindOperation<>(NAMESPACE, getDefaultCodecRegistry().get(Document.class))
+        FindOperation<Document> expectedOperation = new FindOperation<>(CSOT_NO_TIMEOUT.get(), NAMESPACE,
+                getDefaultCodecRegistry().get(Document.class))
                 .batchSize(Integer.MAX_VALUE)
                 .retryReads(true)
                 .filter(new BsonDocument());
@@ -67,8 +69,8 @@ public class FindPublisherImplTest extends TestHelper {
                 .filter(new Document("filter", 1))
                 .sort(Sorts.ascending("sort"))
                 .projection(new Document("projection", 1))
-                .maxTime(10, SECONDS)
-                .maxAwaitTime(20, SECONDS)
+                .maxTime(101, MILLISECONDS)
+                .maxAwaitTime(1001, MILLISECONDS)
                 .batchSize(100)
                 .limit(100)
                 .skip(10)
@@ -85,7 +87,10 @@ public class FindPublisherImplTest extends TestHelper {
                 .showRecordId(false)
                 .allowDiskUse(false);
 
-        expectedOperation
+        expectedOperation = new FindOperation<>(CSOT_MAX_TIME_AND_MAX_AWAIT_TIME.get(), NAMESPACE,
+                getDefaultCodecRegistry().get(Document.class))
+                .retryReads(true)
+                .filter(new BsonDocument())
                 .allowDiskUse(false)
                 .batchSize(100)
                 .collation(COLLATION)
@@ -95,8 +100,6 @@ public class FindPublisherImplTest extends TestHelper {
                 .hint(new BsonString("a_1"))
                 .limit(100)
                 .max(new BsonDocument("max", new BsonInt32(1)))
-                .maxAwaitTime(20000, MILLISECONDS)
-                .maxTime(10000, MILLISECONDS)
                 .min(new BsonDocument("min", new BsonInt32(1)))
                 .projection(new BsonDocument("projection", new BsonInt32(1)))
                 .returnKey(false)

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImplTest.java
@@ -26,9 +26,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME;
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.Arrays.asList;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ListCollectionsPublisherImplTest extends TestHelper {
@@ -42,7 +44,7 @@ public class ListCollectionsPublisherImplTest extends TestHelper {
         ListCollectionsPublisher<String> publisher = new ListCollectionsPublisherImpl<>(null, createMongoOperationPublisher(executor)
                 .withDocumentClass(String.class), true);
 
-        ListCollectionsOperation<String> expectedOperation = new ListCollectionsOperation<>(DATABASE_NAME,
+        ListCollectionsOperation<String> expectedOperation = new ListCollectionsOperation<>(CSOT_NO_TIMEOUT.get(), DATABASE_NAME,
                                                                                             getDefaultCodecRegistry().get(String.class))
                 .batchSize(Integer.MAX_VALUE)
                 .nameOnly(true).retryReads(true);
@@ -56,12 +58,14 @@ public class ListCollectionsPublisherImplTest extends TestHelper {
         // Should apply settings
         publisher
                 .filter(new Document("filter", 1))
-                .maxTime(10, SECONDS)
+                .maxTime(100, MILLISECONDS)
                 .batchSize(100);
 
-        expectedOperation
+        expectedOperation = new ListCollectionsOperation<>(CSOT_MAX_TIME.get(), DATABASE_NAME,
+                getDefaultCodecRegistry().get(String.class))
+                .nameOnly(true)
+                .retryReads(true)
                 .filter(new BsonDocument("filter", new BsonInt32(1)))
-                .maxTime(10, SECONDS)
                 .batchSize(100);
 
         Flux.from(publisher).blockFirst();

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListDatabasesPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListDatabasesPublisherImplTest.java
@@ -26,9 +26,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.Arrays.asList;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ListDatabasesPublisherImplTest extends TestHelper {
@@ -41,7 +42,8 @@ public class ListDatabasesPublisherImplTest extends TestHelper {
         TestOperationExecutor executor = createOperationExecutor(asList(getBatchCursor(), getBatchCursor()));
         ListDatabasesPublisher<Document> publisher = new ListDatabasesPublisherImpl<>(null, createMongoOperationPublisher(executor));
 
-        ListDatabasesOperation<Document> expectedOperation = new ListDatabasesOperation<>(getDefaultCodecRegistry().get(Document.class))
+        ListDatabasesOperation<Document> expectedOperation = new ListDatabasesOperation<>(CSOT_MAX_TIME.get(),
+                getDefaultCodecRegistry().get(Document.class))
                 .retryReads(true);
 
         // default input should be as expected
@@ -54,13 +56,12 @@ public class ListDatabasesPublisherImplTest extends TestHelper {
         publisher
                 .authorizedDatabasesOnly(true)
                 .filter(new Document("filter", 1))
-                .maxTime(10, SECONDS)
+                .maxTime(100, MILLISECONDS)
                 .batchSize(100);
 
         expectedOperation
                 .authorizedDatabasesOnly(true)
-                .filter(new BsonDocument("filter", new BsonInt32(1)))
-                .maxTime(10, SECONDS);
+                .filter(new BsonDocument("filter", new BsonInt32(1)));
 
         configureBatchCursor();
         Flux.from(publisher).blockFirst();

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListIndexesPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListIndexesPublisherImplTest.java
@@ -25,9 +25,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.Arrays.asList;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ListIndexesPublisherImplTest extends TestHelper {
@@ -43,7 +44,7 @@ public class ListIndexesPublisherImplTest extends TestHelper {
         ListIndexesPublisher<Document> publisher = new ListIndexesPublisherImpl<>(null, createMongoOperationPublisher(executor));
 
         ListIndexesOperation<Document> expectedOperation =
-                new ListIndexesOperation<>(NAMESPACE, getDefaultCodecRegistry().get(Document.class))
+                new ListIndexesOperation<>(CSOT_NO_TIMEOUT.get(), NAMESPACE, getDefaultCodecRegistry().get(Document.class))
                         .batchSize(Integer.MAX_VALUE)
                         .retryReads(true);
 
@@ -54,13 +55,13 @@ public class ListIndexesPublisherImplTest extends TestHelper {
         assertEquals(ReadPreference.primary(), executor.getReadPreference());
 
         // Should apply settings
-        publisher
-                .batchSize(100)
-                .maxTime(10, SECONDS);
+        publisher.batchSize(100)
+                .maxTime(100, MILLISECONDS);
 
-        expectedOperation
-                .batchSize(100)
-                .maxTime(10, SECONDS);
+        expectedOperation =
+                new ListIndexesOperation<>(CSOT_NO_TIMEOUT.get(), NAMESPACE, getDefaultCodecRegistry().get(Document.class))
+                        .batchSize(100)
+                        .retryReads(true);
 
         configureBatchCursor();
         Flux.from(publisher).blockFirst();

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MapReducePublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MapReducePublisherImplTest.java
@@ -34,8 +34,11 @@ import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME;
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -57,9 +60,9 @@ public class MapReducePublisherImplTest extends TestHelper {
         com.mongodb.reactivestreams.client.MapReducePublisher<Document> publisher =
                 new MapReducePublisherImpl<>(null, createMongoOperationPublisher(executor), MAP_FUNCTION, REDUCE_FUNCTION);
 
-        MapReduceWithInlineResultsOperation<Document> expectedOperation =
-                new MapReduceWithInlineResultsOperation<>(NAMESPACE, new BsonJavaScript(MAP_FUNCTION), new BsonJavaScript(REDUCE_FUNCTION),
-                                                          getDefaultCodecRegistry().get(Document.class)).verbose(true);
+        MapReduceWithInlineResultsOperation<Document> expectedOperation = new MapReduceWithInlineResultsOperation<>(
+                CSOT_NO_TIMEOUT.get(), NAMESPACE, new BsonJavaScript(MAP_FUNCTION), new BsonJavaScript(REDUCE_FUNCTION),
+                getDefaultCodecRegistry().get(Document.class)).verbose(true);
 
         // default input should be as expected
         Flux.from(publisher).blockFirst();
@@ -78,19 +81,19 @@ public class MapReducePublisherImplTest extends TestHelper {
                 .filter(new Document("filter", 1))
                 .finalizeFunction(FINALIZE_FUNCTION)
                 .limit(999)
-                .maxTime(10, SECONDS)
+                .maxTime(100, SECONDS)
                 .scope(new Document("scope", 1))
                 .sort(Sorts.ascending("sort"))
                 .verbose(false);
 
-        expectedOperation
-                .collation(COLLATION)
+        expectedOperation = new MapReduceWithInlineResultsOperation<>(
+                CSOT_MAX_TIME.get(), NAMESPACE, new BsonJavaScript(MAP_FUNCTION), new BsonJavaScript(REDUCE_FUNCTION),
+                getDefaultCodecRegistry().get(Document.class))
+                .verbose(true)
                 .collation(COLLATION)
                 .filter(BsonDocument.parse("{filter: 1}"))
                 .finalizeFunction(new BsonJavaScript(FINALIZE_FUNCTION))
                 .limit(999)
-                .maxTime(10, SECONDS)
-                .maxTime(10, SECONDS)
                 .scope(new BsonDocument("scope", new BsonInt32(1)))
                 .sort(new BsonDocument("sort", new BsonInt32(1)))
                 .verbose(false);
@@ -113,11 +116,9 @@ public class MapReducePublisherImplTest extends TestHelper {
                 new MapReducePublisherImpl<>(null, createMongoOperationPublisher(executor), MAP_FUNCTION, REDUCE_FUNCTION)
                         .collectionName(NAMESPACE.getCollectionName());
 
-        MapReduceToCollectionOperation expectedOperation = new MapReduceToCollectionOperation(NAMESPACE,
-                                                                                              new BsonJavaScript(MAP_FUNCTION),
-                                                                                              new BsonJavaScript(REDUCE_FUNCTION),
-                                                                                              NAMESPACE.getCollectionName(),
-                                                                                              WriteConcern.ACKNOWLEDGED).verbose(true);
+        MapReduceToCollectionOperation expectedOperation = new MapReduceToCollectionOperation(CSOT_NO_TIMEOUT.get(), NAMESPACE,
+                new BsonJavaScript(MAP_FUNCTION), new BsonJavaScript(REDUCE_FUNCTION), NAMESPACE.getCollectionName(),
+                WriteConcern.ACKNOWLEDGED).verbose(true);
 
         // default input should be as expected
         Flux.from(publisher.toCollection()).blockFirst();
@@ -131,19 +132,19 @@ public class MapReducePublisherImplTest extends TestHelper {
                 .filter(new Document("filter", 1))
                 .finalizeFunction(FINALIZE_FUNCTION)
                 .limit(999)
-                .maxTime(10, SECONDS)
+                .maxTime(100, MILLISECONDS)
                 .scope(new Document("scope", 1))
                 .sort(Sorts.ascending("sort"))
                 .verbose(false);
 
-        expectedOperation
+        expectedOperation = new MapReduceToCollectionOperation(CSOT_MAX_TIME.get(), NAMESPACE, new BsonJavaScript(MAP_FUNCTION),
+                new BsonJavaScript(REDUCE_FUNCTION), NAMESPACE.getCollectionName(), WriteConcern.ACKNOWLEDGED)
+                .verbose(true)
                 .collation(COLLATION)
                 .bypassDocumentValidation(true)
                 .filter(BsonDocument.parse("{filter: 1}"))
                 .finalizeFunction(new BsonJavaScript(FINALIZE_FUNCTION))
                 .limit(999)
-                .maxTime(10, SECONDS)
-                .maxTime(10, SECONDS)
                 .scope(new BsonDocument("scope", new BsonInt32(1)))
                 .sort(new BsonDocument("sort", new BsonInt32(1)))
                 .verbose(false);

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoOperationPublisherTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoOperationPublisherTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.reactivestreams.client.internal;
+
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import org.bson.BsonDocument;
+import org.bson.BsonReader;
+import org.bson.BsonWriter;
+import org.bson.Document;
+import org.bson.UuidRepresentation;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecRegistries;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+
+public class MongoOperationPublisherTest {
+    private static final OperationExecutor OPERATION_EXECUTOR = mock(OperationExecutor.class);
+    private static final MongoNamespace MONGO_NAMESPACE = new MongoNamespace("a.b");
+
+    private static final MongoOperationPublisher<Document> DEFAULT_MOP = new MongoOperationPublisher<>(
+            MONGO_NAMESPACE, Document.class, MongoClientSettings.getDefaultCodecRegistry(), ReadPreference.primary(),
+            ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED, true, true, UuidRepresentation.STANDARD,
+            null, 100L, OPERATION_EXECUTOR);
+
+    @Test
+    public void withCodecRegistry() {
+        // Cannot do equality test as registries are wrapped
+        CodecRegistry codecRegistry = DEFAULT_MOP.withCodecRegistry(CodecRegistries.fromCodecs(new MyLongCodec())).getCodecRegistry();
+        assertTrue(codecRegistry.get(Long.class) instanceof MyLongCodec);
+    }
+
+    @Test
+    public void withDatabase() {
+        assertEquals(new MongoNamespace("c.ignored"), DEFAULT_MOP.withDatabase("c").getNamespace());
+    }
+
+    @Test
+    public void withDocumentClass() {
+        assertEquals(DEFAULT_MOP, DEFAULT_MOP.withDocumentClass(Document.class));
+        assertEquals(BsonDocument.class, DEFAULT_MOP.withDocumentClass(BsonDocument.class).getDocumentClass());
+    }
+
+    @Test
+    public void withDatabaseAndDocumentClass() {
+        MongoOperationPublisher<BsonDocument> alternative = DEFAULT_MOP.withDatabaseAndDocumentClass("c", BsonDocument.class);
+        assertEquals(BsonDocument.class, alternative.getDocumentClass());
+        assertEquals(new MongoNamespace("c.ignored"), alternative.getNamespace());
+    }
+
+    @Test
+    public void withNamespaceAndDocumentClass() {
+        assertEquals(DEFAULT_MOP, DEFAULT_MOP.withNamespaceAndDocumentClass(new MongoNamespace("a.b"), Document.class));
+
+        MongoOperationPublisher<BsonDocument> alternative = DEFAULT_MOP.withNamespaceAndDocumentClass(new MongoNamespace("c.d"),
+                BsonDocument.class);
+        assertEquals(BsonDocument.class, alternative.getDocumentClass());
+        assertEquals(new MongoNamespace("c.d"), alternative.getNamespace());
+    }
+
+
+    @Test
+    public void withNamespace() {
+        assertEquals(DEFAULT_MOP, DEFAULT_MOP.withNamespaceAndDocumentClass(new MongoNamespace("a.b"), Document.class));
+        assertEquals(new MongoNamespace("c.d"), DEFAULT_MOP.withNamespace(new MongoNamespace("c.d")).getNamespace());
+    }
+
+    @Test
+    public void withReadConcern() {
+        assertEquals(DEFAULT_MOP, DEFAULT_MOP.withReadConcern(ReadConcern.DEFAULT));
+        assertEquals(ReadConcern.AVAILABLE, DEFAULT_MOP.withReadConcern(ReadConcern.AVAILABLE).getReadConcern());
+    }
+
+    @Test
+    public void withReadPreference() {
+        assertEquals(DEFAULT_MOP, DEFAULT_MOP.withReadPreference(ReadPreference.primary()));
+        assertEquals(ReadPreference.secondaryPreferred(), DEFAULT_MOP.withReadPreference(ReadPreference.secondaryPreferred())
+                .getReadPreference());
+    }
+
+    @Test
+    public void withTimeout() {
+        assertEquals(DEFAULT_MOP, DEFAULT_MOP.withTimeout(100, TimeUnit.MILLISECONDS));
+        assertEquals(1000, DEFAULT_MOP.withTimeout(1000, TimeUnit.MILLISECONDS).getTimeoutMS());
+    }
+
+    @Test
+    public void withWriteConcern() {
+        assertEquals(DEFAULT_MOP, DEFAULT_MOP.withWriteConcern(WriteConcern.ACKNOWLEDGED));
+        assertEquals(WriteConcern.MAJORITY, DEFAULT_MOP.withWriteConcern(WriteConcern.MAJORITY).getWriteConcern());
+    }
+
+    private static class MyLongCodec implements Codec<Long> {
+
+        @Override
+        public Long decode(final BsonReader reader, final DecoderContext decoderContext) {
+            return 42L;
+        }
+
+        @Override
+        public void encode(final BsonWriter writer, final Long value, final EncoderContext encoderContext) {
+        }
+
+        @Override
+        public Class<Long> getEncoderClass() {
+            return Long.class;
+        }
+    }
+}

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/TestHelper.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/TestHelper.java
@@ -96,7 +96,7 @@ public class TestHelper {
         return new MongoOperationPublisher<>(NAMESPACE, Document.class,
                                              getDefaultCodecRegistry(), ReadPreference.primary(), ReadConcern.DEFAULT,
                                              WriteConcern.ACKNOWLEDGED, true, true,
-                                             UuidRepresentation.STANDARD, null, executor);
+                                             UuidRepresentation.STANDARD, null, null, executor);
     }
 
 

--- a/driver-scala/src/integration/scala/org/mongodb/scala/syncadapter/SyncMongoDatabase.scala
+++ b/driver-scala/src/integration/scala/org/mongodb/scala/syncadapter/SyncMongoDatabase.scala
@@ -24,7 +24,10 @@ import org.bson.conversions.Bson
 import org.mongodb.scala.MongoDatabase
 import org.mongodb.scala.bson.DefaultHelper.DefaultsTo
 
+import java.lang
+import java.util.concurrent.TimeUnit
 import scala.collection.JavaConverters._
+import scala.concurrent.duration.MILLISECONDS
 import scala.reflect.ClassTag
 
 case class SyncMongoDatabase(wrapped: MongoDatabase) extends JMongoDatabase {
@@ -39,6 +42,13 @@ case class SyncMongoDatabase(wrapped: MongoDatabase) extends JMongoDatabase {
 
   override def getReadConcern: ReadConcern = wrapped.readConcern
 
+  override def getTimeout(timeUnit: TimeUnit): java.lang.Long = {
+    wrapped.timeout match {
+      case Some(value) => timeUnit.convert(value.toMillis, MILLISECONDS)
+      case None        => null
+    }
+  }
+
   override def withCodecRegistry(codecRegistry: CodecRegistry) =
     SyncMongoDatabase(wrapped.withCodecRegistry(codecRegistry))
 
@@ -47,6 +57,8 @@ case class SyncMongoDatabase(wrapped: MongoDatabase) extends JMongoDatabase {
   override def withWriteConcern(writeConcern: WriteConcern) = throw new UnsupportedOperationException
 
   override def withReadConcern(readConcern: ReadConcern) = throw new UnsupportedOperationException
+
+  override def withTimeout(timeout: Long, timeUnit: TimeUnit) = throw new UnsupportedOperationException
 
   override def getCollection(collectionName: String) =
     SyncMongoCollection[Document](wrapped.getCollection(collectionName))

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoCollection.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoCollection.scala
@@ -87,18 +87,18 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
   /**
    * The time limit for the full execution of an operation.
    *
-   * If not null the following deprecated options will be ignored:
-   * `waitQueueTimeoutMS`, `socketTimeoutMS`, `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`
+   * If not null the following deprecated options will be ignored: `waitQueueTimeoutMS`, `socketTimeoutMS`,
+   * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`.
    *
-   *   -`null` means that the timeout mechanism for operations will defer to using:
-   *   -`waitQueueTimeoutMS`: The maximum wait time in milliseconds that a thread may wait for a connection to become available
-   *   -`socketTimeoutMS`: How long a send or receive on a socket can take before timing out.
-   *   -`wTimeoutMS`: How long the server will wait for the write concern to be fulfilled before timing out.
-   *   -`maxTimeMS`: The time limit for processing operations on a cursor.
-   *                 See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.
-   *   -`maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute.
-   *   -`0` means infinite timeout.
-   *   -`> 0` The time limit to use for the full execution of an operation.
+   *   - `null` means that the timeout mechanism for operations will defer to using:
+   *      - `waitQueueTimeoutMS`: The maximum wait time in milliseconds that a thread may wait for a connection to become available
+   *      - `socketTimeoutMS`: How long a send or receive on a socket can take before timing out.
+   *      - `wTimeoutMS`: How long the server will wait for  the write concern to be fulfilled before timing out.
+   *      - `maxTimeMS`: The time limit for processing operations on a cursor.
+   *        See: [cursor.maxTimeMS](https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS").
+   *      - `maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute.
+   *   - `0` means infinite timeout.
+   *   - `> 0` The time limit to use for the full execution of an operation.
    *
    * @return the optional timeout duration
    * @since 4.x

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoCollection.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoCollection.scala
@@ -27,6 +27,7 @@ import org.mongodb.scala.model._
 import org.mongodb.scala.result._
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration.{ Duration, MILLISECONDS, TimeUnit }
 import scala.reflect.ClassTag
 
 // scalastyle:off number.of.methods file.size.limit
@@ -84,6 +85,28 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
   lazy val readConcern: ReadConcern = wrapped.getReadConcern
 
   /**
+   * The time limit for the full execution of an operation.
+   *
+   * If not null the following deprecated options will be ignored:
+   * `waitQueueTimeoutMS`, `socketTimeoutMS`, `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`
+   *
+   *   -`null` means that the timeout mechanism for operations will defer to using:
+   *   -`waitQueueTimeoutMS`: The maximum wait time in milliseconds that a thread may wait for a connection to become available
+   *   -`socketTimeoutMS`: How long a send or receive on a socket can take before timing out.
+   *   -`wTimeoutMS`: How long the server will wait for the write concern to be fulfilled before timing out.
+   *   -`maxTimeMS`: The time limit for processing operations on a cursor.
+   *                 See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.
+   *   -`maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute.
+   *   -`0` means infinite timeout.
+   *   -`> 0` The time limit to use for the full execution of an operation.
+   *
+   * @return the optional timeout duration
+   * @since 4.x
+   */
+  lazy val timeout: Option[Duration] =
+    Option.apply(wrapped.getTimeout(MILLISECONDS)).map(t => Duration(t, MILLISECONDS))
+
+  /**
    * Create a new MongoCollection instance with a different default class to cast any documents returned from the database into..
    *
    * @tparam C   The type that the new collection will encode documents from and decode documents to
@@ -135,6 +158,19 @@ case class MongoCollection[TResult](private val wrapped: JMongoCollection[TResul
    */
   def withReadConcern(readConcern: ReadConcern): MongoCollection[TResult] =
     MongoCollection(wrapped.withReadConcern(readConcern))
+
+  /**
+   * Sets the time limit for the full execution of an operation.
+   *
+   * - `0` means infinite timeout.
+   * - `> 0` The time limit to use for the full execution of an operation.
+   *
+   * @param timeout the timeout, which must be greater than or equal to 0
+   * @return a new MongoCollection instance with the set time limit for operations
+   * @since 4.x
+   */
+  def withTimeout(timeout: Duration): MongoCollection[TResult] =
+    MongoCollection(wrapped.withTimeout(timeout.toMillis, MILLISECONDS))
 
   /**
    * Gets an estimate of the count of documents in a collection using collection metadata.

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoDatabase.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoDatabase.scala
@@ -23,6 +23,7 @@ import org.mongodb.scala.bson.DefaultHelper.DefaultsTo
 import org.mongodb.scala.bson.conversions.Bson
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration.{ Duration, MILLISECONDS }
 import scala.reflect.ClassTag
 
 /**
@@ -70,6 +71,28 @@ case class MongoDatabase(private[scala] val wrapped: JMongoDatabase) {
   lazy val readConcern: ReadConcern = wrapped.getReadConcern
 
   /**
+   * The time limit for the full execution of an operation.
+   *
+   * If not null the following deprecated options will be ignored:
+   * `waitQueueTimeoutMS`, `socketTimeoutMS`, `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`
+   *
+   * -`null` means that the timeout mechanism for operations will defer to using:
+   * -`waitQueueTimeoutMS`: The maximum wait time in milliseconds that a thread may wait for a connection to become available
+   * -`socketTimeoutMS`: How long a send or receive on a socket can take before timing out.
+   * -`wTimeoutMS`: How long the server will wait for the write concern to be fulfilled before timing out.
+   * -`maxTimeMS`: The time limit for processing operations on a cursor.
+   * See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.
+   * -`maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute.
+   * -`0` means infinite timeout.
+   * -`> 0` The time limit to use for the full execution of an operation.
+   *
+   * @return the optional timeout duration
+   * @since 4.x
+   */
+  lazy val timeout: Option[Duration] =
+    Option.apply(wrapped.getTimeout(MILLISECONDS)).map(t => Duration(t, MILLISECONDS))
+
+  /**
    * Create a new MongoDatabase instance with a different codec registry.
    *
    * The { @link CodecRegistry} configured by this method is effectively treated by the driver as an
@@ -112,6 +135,19 @@ case class MongoDatabase(private[scala] val wrapped: JMongoDatabase) {
    */
   def withReadConcern(readConcern: ReadConcern): MongoDatabase =
     MongoDatabase(wrapped.withReadConcern(readConcern))
+
+  /**
+   * Sets the time limit for the full execution of an operation.
+   *
+   * - `0` means infinite timeout.
+   * - `> 0` The time limit to use for the full execution of an operation.
+   *
+   * @param timeout the timeout, which must be greater than or equal to 0
+   * @return a new MongoCollection instance with the set time limit for operations
+   * @since 4.x
+   */
+  def withTimeout(timeout: Duration): MongoDatabase =
+    MongoDatabase(wrapped.withTimeout(timeout.toMillis, MILLISECONDS))
 
   /**
    * Gets a collection, with a specific default document class.

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoDatabase.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoDatabase.scala
@@ -73,18 +73,18 @@ case class MongoDatabase(private[scala] val wrapped: JMongoDatabase) {
   /**
    * The time limit for the full execution of an operation.
    *
-   * If not null the following deprecated options will be ignored:
-   * `waitQueueTimeoutMS`, `socketTimeoutMS`, `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`
+   * If not null the following deprecated options will be ignored: `waitQueueTimeoutMS`, `socketTimeoutMS`,
+   * `wTimeoutMS`, `maxTimeMS` and `maxCommitTimeMS`.
    *
-   * -`null` means that the timeout mechanism for operations will defer to using:
-   * -`waitQueueTimeoutMS`: The maximum wait time in milliseconds that a thread may wait for a connection to become available
-   * -`socketTimeoutMS`: How long a send or receive on a socket can take before timing out.
-   * -`wTimeoutMS`: How long the server will wait for the write concern to be fulfilled before timing out.
-   * -`maxTimeMS`: The time limit for processing operations on a cursor.
-   * See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.
-   * -`maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute.
-   * -`0` means infinite timeout.
-   * -`> 0` The time limit to use for the full execution of an operation.
+   *   - `null` means that the timeout mechanism for operations will defer to using:
+   *      - `waitQueueTimeoutMS`: The maximum wait time in milliseconds that a thread may wait for a connection to become available
+   *      - `socketTimeoutMS`: How long a send or receive on a socket can take before timing out.
+   *      - `wTimeoutMS`: How long the server will wait for  the write concern to be fulfilled before timing out.
+   *      - `maxTimeMS`: The time limit for processing operations on a cursor.
+   *        See: [cursor.maxTimeMS](https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS").
+   *      - `maxCommitTimeMS`: The maximum amount of time to allow a single `commitTransaction` command to execute.
+   *   - `0` means infinite timeout.
+   *   - `> 0` The time limit to use for the full execution of an operation.
    *
    * @return the optional timeout duration
    * @since 4.x

--- a/driver-sync/src/main/com/mongodb/client/MongoCollection.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoCollection.java
@@ -51,6 +51,7 @@ import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The MongoCollection interface.
@@ -113,6 +114,36 @@ public interface MongoCollection<TDocument> {
     ReadConcern getReadConcern();
 
     /**
+     * The time limit for the full execution of an operation.
+     *
+     * <p>If not null the following deprecated options will be ignored:
+     * {@code waitQueueTimeoutMS}, {@code socketTimeoutMS}, {@code wTimeoutMS}, {@code maxTimeMS} and {@code maxCommitTimeMS}</p>
+     *
+     * <ul>
+     *   <li>{@code null} means that the timeout mechanism for operations will defer to using:
+     *    <ul>
+     *        <li>{@code waitQueueTimeoutMS}: The maximum wait time in milliseconds that a thread may wait for a connection to become
+     *        available</li>
+     *        <li>{@code socketTimeoutMS}: How long a send or receive on a socket can take before timing out.</li>
+     *        <li>{@code wTimeoutMS}: How long the server will wait for the write concern to be fulfilled before timing out.</li>
+     *        <li>{@code maxTimeMS}: The cumulative time limit for processing operations on a cursor.
+     *        See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.</li>
+     *        <li>{@code maxCommitTimeMS}: The maximum amount of time to allow a single {@code commitTransaction} command to execute.
+     *        See: {@link com.mongodb.TransactionOptions#getMaxCommitTime}.</li>
+     *   </ul>
+     *   </li>
+     *   <li>{@code 0} means infinite timeout.</li>
+     *    <li>{@code > 0} The time limit to use for the full execution of an operation.</li>
+     * </ul>
+     *
+     * @param timeUnit the time unit
+     * @return the timeout in the given time unit
+     * @since 4.x
+     */
+    @Nullable
+    Long getTimeout(TimeUnit timeUnit);
+
+    /**
      * Create a new MongoCollection instance with a different default class to cast any documents returned from the database into..
      *
      * @param clazz the default class to cast any documents returned from the database into.
@@ -161,6 +192,22 @@ public interface MongoCollection<TDocument> {
      * @mongodb.driver.manual reference/readConcern/ Read Concern
      */
     MongoCollection<TDocument> withReadConcern(ReadConcern readConcern);
+
+    /**
+     * Create a new MongoCollection instance with the set time limit for the full execution of an operation.
+     *
+     * <ul>
+     *   <li>{@code 0} means infinite timeout.</li>
+     *    <li>{@code > 0} The time limit to use for the full execution of an operation.</li>
+     * </ul>
+     *
+     * @param timeout the timeout, which must be greater than or equal to 0
+     * @param timeUnit the time unit
+     * @return a new MongoCollection instance with the set time limit for the full execution of an operation
+     * @since 4.x
+     * @see #getTimeout
+     */
+    MongoCollection<TDocument> withTimeout(long timeout, TimeUnit timeUnit);
 
     /**
      * Counts the number of documents in the collection.

--- a/driver-sync/src/main/com/mongodb/client/MongoDatabase.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoDatabase.java
@@ -22,11 +22,13 @@ import com.mongodb.WriteConcern;
 import com.mongodb.annotations.ThreadSafe;
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.CreateViewOptions;
+import com.mongodb.lang.Nullable;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The MongoDatabase interface.
@@ -77,6 +79,36 @@ public interface MongoDatabase {
     ReadConcern getReadConcern();
 
     /**
+     * The time limit for the full execution of an operation.
+     *
+     * <p>If not null the following deprecated options will be ignored:
+     * {@code waitQueueTimeoutMS}, {@code socketTimeoutMS}, {@code wTimeoutMS}, {@code maxTimeMS} and {@code maxCommitTimeMS}</p>
+     *
+     * <ul>
+     *   <li>{@code null} means that the timeout mechanism for operations will defer to using:
+     *    <ul>
+     *        <li>{@code waitQueueTimeoutMS}: The maximum wait time in milliseconds that a thread may wait for a connection to become
+     *        available</li>
+     *        <li>{@code socketTimeoutMS}: How long a send or receive on a socket can take before timing out.</li>
+     *        <li>{@code wTimeoutMS}: How long the server will wait for the write concern to be fulfilled before timing out.</li>
+     *        <li>{@code maxTimeMS}: The cumulative time limit for processing operations on a cursor.
+     *        See: <a href="https://docs.mongodb.com/manual/reference/method/cursor.maxTimeMS">cursor.maxTimeMS</a>.</li>
+     *        <li>{@code maxCommitTimeMS}: The maximum amount of time to allow a single {@code commitTransaction} command to execute.
+     *        See: {@link com.mongodb.TransactionOptions#getMaxCommitTime}.</li>
+     *   </ul>
+     *   </li>
+     *   <li>{@code 0} means infinite timeout.</li>
+     *    <li>{@code > 0} The time limit to use for the full execution of an operation.</li>
+     * </ul>
+     *
+     * @param timeUnit the time unit
+     * @return the timeout in the given time unit
+     * @since 4.x
+     */
+    @Nullable
+    Long getTimeout(TimeUnit timeUnit);
+
+    /**
      * Create a new MongoDatabase instance with a different codec registry.
      *
      * <p>The {@link CodecRegistry} configured by this method is effectively treated by the driver as an instance of
@@ -118,6 +150,22 @@ public interface MongoDatabase {
     MongoDatabase withReadConcern(ReadConcern readConcern);
 
     /**
+     * Create a new MongoDatabase instance with the set time limit for the full execution of an operation.
+     *
+     * <ul>
+     *   <li>{@code 0} means infinite timeout.</li>
+     *    <li>{@code > 0} The time limit to use for the full execution of an operation.</li>
+     * </ul>
+     *
+     * @param timeout the timeout, which must be greater than or equal to 0
+     * @param timeUnit the time unit
+     * @return a new MongoDatabase instance with the set time limit for the full execution of an operation.
+     * @since 4.x
+     * @see #getTimeout
+     */
+    MongoDatabase withTimeout(long timeout, TimeUnit timeUnit);
+
+    /**
      * Gets a collection.
      *
      * @param collectionName the name of the collection to return
@@ -140,6 +188,8 @@ public interface MongoDatabase {
     /**
      * Executes the given command in the context of the current database with a read preference of {@link ReadPreference#primary()}.
      *
+     * <p>Note: If set the {@link #getTimeout} value will overwrite any {@code maxTimeMS} value in the command.</p>
+     *
      * @param command the command to be run
      * @return the command result
      */
@@ -147,6 +197,8 @@ public interface MongoDatabase {
 
     /**
      * Executes the given command in the context of the current database with the given read preference.
+     *
+     * <p>Note: If set the {@link #getTimeout} value will overwrite any {@code maxTimeMS} value in the command.</p>
      *
      * @param command        the command to be run
      * @param readPreference the {@link ReadPreference} to be used when executing the command
@@ -157,6 +209,8 @@ public interface MongoDatabase {
     /**
      * Executes the given command in the context of the current database with a read preference of {@link ReadPreference#primary()}.
      *
+     * <p>Note: If set the {@link #getTimeout} value will overwrite any {@code maxTimeMS} value in the command.</p>
+     *
      * @param command     the command to be run
      * @param resultClass the class to decode each document into
      * @param <TResult> the type of the class to use instead of {@code Document}.
@@ -166,6 +220,8 @@ public interface MongoDatabase {
 
     /**
      * Executes the given command in the context of the current database with the given read preference.
+     *
+     * <p>Note: If set the {@link #getTimeout} value will overwrite any {@code maxTimeMS} value in the command.</p>
      *
      * @param command        the command to be run
      * @param readPreference the {@link ReadPreference} to be used when executing the command
@@ -178,6 +234,8 @@ public interface MongoDatabase {
     /**
      * Executes the given command in the context of the current database with a read preference of {@link ReadPreference#primary()}.
      *
+     * <p>Note: If set the {@link #getTimeout} value will overwrite any {@code maxTimeMS} value in the command.</p>
+     *
      * @param clientSession the client session with which to associate this operation
      * @param command the command to be run
      * @return the command result
@@ -188,6 +246,8 @@ public interface MongoDatabase {
 
     /**
      * Executes the given command in the context of the current database with the given read preference.
+     *
+     * <p>Note: If set the {@link #getTimeout} value will overwrite any {@code maxTimeMS} value in the command.</p>
      *
      * @param clientSession the client session with which to associate this operation
      * @param command        the command to be run
@@ -201,6 +261,8 @@ public interface MongoDatabase {
     /**
      * Executes the given command in the context of the current database with a read preference of {@link ReadPreference#primary()}.
      *
+     * <p>Note: If set the {@link #getTimeout} value will overwrite any {@code maxTimeMS} value in the command.</p>
+     *
      * @param clientSession the client session with which to associate this operation
      * @param command     the command to be run
      * @param resultClass the class to decode each document into
@@ -213,6 +275,8 @@ public interface MongoDatabase {
 
     /**
      * Executes the given command in the context of the current database with the given read preference.
+     *
+     * <p>Note: If set the {@link #getTimeout} value will overwrite any {@code maxTimeMS} value in the command.</p>
      *
      * @param clientSession  the client session with which to associate this operation
      * @param command        the command to be run

--- a/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
@@ -63,28 +63,22 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     private Bson variables;
 
     AggregateIterableImpl(@Nullable final ClientSession clientSession, final String databaseName, final Class<TDocument> documentClass,
-                          final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                          final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
-                          final List<? extends Bson> pipeline, final AggregationLevel aggregationLevel) {
+            final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
+            final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
+            final List<? extends Bson> pipeline, final AggregationLevel aggregationLevel, final boolean retryReads,
+            @Nullable final Long timeoutMS) {
         this(clientSession, new MongoNamespace(databaseName, "ignored"), documentClass, resultClass, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, pipeline, aggregationLevel, true);
-    }
-
-    AggregateIterableImpl(@Nullable final ClientSession clientSession, final String databaseName, final Class<TDocument> documentClass,
-                          final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                          final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
-                          final List<? extends Bson> pipeline, final AggregationLevel aggregationLevel, final boolean retryReads) {
-        this(clientSession, new MongoNamespace(databaseName, "ignored"), documentClass, resultClass, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, pipeline, aggregationLevel, retryReads);
+                readConcern, writeConcern, executor, pipeline, aggregationLevel, retryReads, timeoutMS);
     }
 
     AggregateIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace, final Class<TDocument> documentClass,
-                          final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                          final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
-                          final List<? extends Bson> pipeline, final AggregationLevel aggregationLevel, final boolean retryReads) {
-        super(clientSession, executor, readConcern, readPreference, retryReads);
+            final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
+            final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
+            final List<? extends Bson> pipeline, final AggregationLevel aggregationLevel, final boolean retryReads,
+            @Nullable final Long timeoutMS) {
+        super(clientSession, executor, readConcern, readPreference, retryReads, timeoutMS);
         this.operations = new SyncOperations<>(namespace, documentClass, readPreference, codecRegistry, readConcern, writeConcern,
-                true, retryReads);
+                true, retryReads, timeoutMS);
         this.namespace = notNull("namespace", namespace);
         this.documentClass = notNull("documentClass", documentClass);
         this.resultClass = notNull("resultClass", resultClass);

--- a/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
@@ -62,6 +62,7 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     private String hintString;
     private Bson variables;
 
+    @SuppressWarnings("checkstyle:ParameterNumber")
     AggregateIterableImpl(@Nullable final ClientSession clientSession, final String databaseName, final Class<TDocument> documentClass,
             final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
             final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
@@ -71,6 +72,7 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
                 readConcern, writeConcern, executor, pipeline, aggregationLevel, retryReads, timeoutMS);
     }
 
+    @SuppressWarnings("checkstyle:ParameterNumber")
     AggregateIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace, final Class<TDocument> documentClass,
             final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
             final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,

--- a/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
@@ -70,23 +70,23 @@ public class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeS
     private boolean showExpandedEvents;
 
     public ChangeStreamIterableImpl(@Nullable final ClientSession clientSession, final String databaseName,
-                                    final CodecRegistry codecRegistry, final ReadPreference readPreference, final ReadConcern readConcern,
-                                    final OperationExecutor executor, final List<? extends Bson> pipeline, final Class<TResult> resultClass,
-                                    final ChangeStreamLevel changeStreamLevel, final boolean retryReads) {
+            final CodecRegistry codecRegistry, final ReadPreference readPreference, final ReadConcern readConcern,
+            final OperationExecutor executor, final List<? extends Bson> pipeline, final Class<TResult> resultClass,
+            final ChangeStreamLevel changeStreamLevel, final boolean retryReads, @Nullable final Long timeoutMS) {
         this(clientSession, new MongoNamespace(databaseName, "ignored"), codecRegistry, readPreference, readConcern, executor, pipeline,
-                resultClass, changeStreamLevel, retryReads);
+                resultClass, changeStreamLevel, retryReads, timeoutMS);
     }
 
     public ChangeStreamIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace,
                                     final CodecRegistry codecRegistry, final ReadPreference readPreference, final ReadConcern readConcern,
                                     final OperationExecutor executor, final List<? extends Bson> pipeline, final Class<TResult> resultClass,
-                                    final ChangeStreamLevel changeStreamLevel, final boolean retryReads) {
-        super(clientSession, executor, readConcern, readPreference, retryReads);
+                                    final ChangeStreamLevel changeStreamLevel, final boolean retryReads, @Nullable final Long timeoutMS) {
+        super(clientSession, executor, readConcern, readPreference, retryReads, null);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.pipeline = notNull("pipeline", pipeline);
         this.codec = ChangeStreamDocument.createCodec(notNull("resultClass", resultClass), codecRegistry);
         this.changeStreamLevel = notNull("changeStreamLevel", changeStreamLevel);
-        this.operations = new SyncOperations<>(namespace, resultClass, readPreference, codecRegistry, retryReads);
+        this.operations = new SyncOperations<>(namespace, resultClass, readPreference, codecRegistry, retryReads, timeoutMS);
     }
 
     @Override
@@ -128,7 +128,7 @@ public class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeS
 
     @Override
     public <TDocument> MongoIterable<TDocument> withDocumentClass(final Class<TDocument> clazz) {
-        return new MongoIterableImpl<TDocument>(getClientSession(), getExecutor(), getReadConcern(), getReadPreference(), getRetryReads()) {
+        return new MongoIterableImpl<TDocument>(getClientSession(), getExecutor(), getReadConcern(), getReadPreference(), getRetryReads(), getTimeoutMS()) {
             @Override
             public MongoCursor<TDocument> iterator() {
                 return cursor();

--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
@@ -148,7 +148,7 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
                 commitInProgress = true;
                 delegate.getOperationExecutor().execute(
                         new CommitTransactionOperation(
-                                // TODO - JAVA-4067
+                                // TODO (CSOT) - JAVA-4067
                                 ClientSideOperationTimeouts.withMaxCommitMS(null, transactionOptions.getMaxCommitTime(MILLISECONDS)),
                                 assertNotNull(transactionOptions.getWriteConcern()),
                         transactionState == TransactionState.COMMITTED)
@@ -182,7 +182,7 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
                     throw new MongoInternalException("Invariant violated.  Transaction options read concern can not be null");
                 }
                 delegate.getOperationExecutor().execute(new AbortTransactionOperation(
-                        // TODO - JAVA-4067
+                        // TODO (CSOT) - JAVA-4067
                         ClientSideOperationTimeouts.withMaxCommitMS(null, transactionOptions.getMaxCommitTime(MILLISECONDS)),
                         assertNotNull(transactionOptions.getWriteConcern()))
                         .recoveryToken(getRecoveryToken()), readConcern, this);

--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
@@ -26,6 +26,7 @@ import com.mongodb.TransactionOptions;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.TransactionBody;
+import com.mongodb.internal.ClientSideOperationTimeouts;
 import com.mongodb.internal.operation.AbortTransactionOperation;
 import com.mongodb.internal.operation.CommitTransactionOperation;
 import com.mongodb.internal.operation.ReadOperation;
@@ -145,10 +146,13 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
                     throw new MongoInternalException("Invariant violated.  Transaction options read concern can not be null");
                 }
                 commitInProgress = true;
-                delegate.getOperationExecutor().execute(new CommitTransactionOperation(assertNotNull(transactionOptions.getWriteConcern()),
+                delegate.getOperationExecutor().execute(
+                        new CommitTransactionOperation(
+                                // TODO - JAVA-4067
+                                ClientSideOperationTimeouts.withMaxCommitMS(null, transactionOptions.getMaxCommitTime(MILLISECONDS)),
+                                assertNotNull(transactionOptions.getWriteConcern()),
                         transactionState == TransactionState.COMMITTED)
-                                .recoveryToken(getRecoveryToken())
-                                .maxCommitTime(transactionOptions.getMaxCommitTime(MILLISECONDS), MILLISECONDS),
+                                .recoveryToken(getRecoveryToken()),
                         readConcern, this);
             }
         } catch (MongoException e) {
@@ -177,9 +181,11 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
                 if (readConcern == null) {
                     throw new MongoInternalException("Invariant violated.  Transaction options read concern can not be null");
                 }
-                delegate.getOperationExecutor().execute(new AbortTransactionOperation(assertNotNull(transactionOptions.getWriteConcern()))
-                                .recoveryToken(getRecoveryToken()),
-                        readConcern, this);
+                delegate.getOperationExecutor().execute(new AbortTransactionOperation(
+                        // TODO - JAVA-4067
+                        ClientSideOperationTimeouts.withMaxCommitMS(null, transactionOptions.getMaxCommitTime(MILLISECONDS)),
+                        assertNotNull(transactionOptions.getWriteConcern()))
+                        .recoveryToken(getRecoveryToken()), readConcern, this);
             }
         } catch (RuntimeException e) {
             // ignore exceptions from abort

--- a/driver-sync/src/main/com/mongodb/client/internal/DistinctIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/DistinctIterableImpl.java
@@ -48,17 +48,10 @@ class DistinctIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult
 
     DistinctIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace, final Class<TDocument> documentClass,
                          final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                         final ReadConcern readConcern, final OperationExecutor executor, final String fieldName, final Bson filter) {
-        this(clientSession, namespace, documentClass, resultClass, codecRegistry, readPreference, readConcern, executor, fieldName,
-                filter, true);
-    }
-
-    DistinctIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace, final Class<TDocument> documentClass,
-                         final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
                          final ReadConcern readConcern, final OperationExecutor executor, final String fieldName, final Bson filter,
-                         final boolean retryReads) {
-        super(clientSession, executor, readConcern, readPreference, retryReads);
-        this.operations = new SyncOperations<>(namespace, documentClass, readPreference, codecRegistry, retryReads);
+                         final boolean retryReads, @Nullable final Long timeoutMS) {
+        super(clientSession, executor, readConcern, readPreference, retryReads, null);
+        this.operations = new SyncOperations<>(namespace, documentClass, readPreference, codecRegistry, retryReads, timeoutMS);
         this.resultClass = notNull("resultClass", resultClass);
         this.fieldName = notNull("mapFunction", fieldName);
         this.filter = filter;

--- a/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
@@ -49,16 +49,11 @@ class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> im
     private Bson filter;
 
     FindIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace, final Class<TDocument> documentClass,
-                     final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                     final ReadConcern readConcern, final OperationExecutor executor, final Bson filter) {
-        this(clientSession, namespace, documentClass, resultClass, codecRegistry, readPreference, readConcern, executor, filter, true);
-    }
-
-    FindIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace, final Class<TDocument> documentClass,
-                     final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                     final ReadConcern readConcern, final OperationExecutor executor, final Bson filter, final boolean retryReads) {
-        super(clientSession, executor, readConcern, readPreference, retryReads);
-        this.operations = new SyncOperations<>(namespace, documentClass, readPreference, codecRegistry, retryReads);
+            final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
+            final ReadConcern readConcern, final OperationExecutor executor, final Bson filter, final boolean retryReads,
+            @Nullable final Long timeoutMS) {
+        super(clientSession, executor, readConcern, readPreference, retryReads, timeoutMS);
+        this.operations = new SyncOperations<>(namespace, documentClass, readPreference, codecRegistry, retryReads, timeoutMS);
         this.resultClass = notNull("resultClass", resultClass);
         this.filter = notNull("filter", filter);
         this.findOptions = new FindOptions();

--- a/driver-sync/src/main/com/mongodb/client/internal/ListCollectionsIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ListCollectionsIterableImpl.java
@@ -46,17 +46,11 @@ class ListCollectionsIterableImpl<TResult> extends MongoIterableImpl<TResult> im
     private BsonValue comment;
 
     ListCollectionsIterableImpl(@Nullable final ClientSession clientSession, final String databaseName, final boolean collectionNamesOnly,
-                                final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                                final OperationExecutor executor) {
-        this(clientSession, databaseName, collectionNamesOnly, resultClass, codecRegistry, readPreference, executor, true);
-    }
-
-    ListCollectionsIterableImpl(@Nullable final ClientSession clientSession, final String databaseName, final boolean collectionNamesOnly,
-                                final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                                final OperationExecutor executor, final boolean retryReads) {
-        super(clientSession, executor, ReadConcern.DEFAULT, readPreference, retryReads); // TODO: read concern?
+            final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
+            final OperationExecutor executor, final boolean retryReads, @Nullable final Long timeoutMS) {
+        super(clientSession, executor, ReadConcern.DEFAULT, readPreference, retryReads, timeoutMS); // TODO: read concern?
         this.collectionNamesOnly = collectionNamesOnly;
-        this.operations = new SyncOperations<>(BsonDocument.class, readPreference, codecRegistry, retryReads);
+        this.operations = new SyncOperations<>(BsonDocument.class, readPreference, codecRegistry, retryReads, timeoutMS);
         this.databaseName = notNull("databaseName", databaseName);
         this.resultClass = notNull("resultClass", resultClass);
     }

--- a/driver-sync/src/main/com/mongodb/client/internal/ListDatabasesIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ListDatabasesIterableImpl.java
@@ -48,17 +48,11 @@ public class ListDatabasesIterableImpl<TResult> extends MongoIterableImpl<TResul
     private Boolean authorizedDatabasesOnly;
     private BsonValue comment;
 
-    ListDatabasesIterableImpl(@Nullable final ClientSession clientSession, final Class<TResult> resultClass,
-                              final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                              final OperationExecutor executor) {
-        this(clientSession, resultClass, codecRegistry, readPreference, executor, true);
-    }
-
     public ListDatabasesIterableImpl(@Nullable final ClientSession clientSession, final Class<TResult> resultClass,
-                                     final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                                     final OperationExecutor executor, final boolean retryReads) {
-        super(clientSession, executor, ReadConcern.DEFAULT, readPreference, retryReads); // TODO: read concern?
-        this.operations = new SyncOperations<>(BsonDocument.class, readPreference, codecRegistry, retryReads);
+            final CodecRegistry codecRegistry, final ReadPreference readPreference, final OperationExecutor executor,
+            final boolean retryReads, @Nullable final Long timeoutMS) {
+        super(clientSession, executor, ReadConcern.DEFAULT, readPreference, retryReads, timeoutMS); // TODO: read concern?
+        this.operations = new SyncOperations<>(BsonDocument.class, readPreference, codecRegistry, retryReads, timeoutMS);
         this.resultClass = notNull("clazz", resultClass);
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/ListIndexesIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ListIndexesIterableImpl.java
@@ -42,15 +42,10 @@ class ListIndexesIterableImpl<TResult> extends MongoIterableImpl<TResult> implem
     private BsonValue comment;
 
     ListIndexesIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace, final Class<TResult> resultClass,
-                            final CodecRegistry codecRegistry, final ReadPreference readPreference, final OperationExecutor executor) {
-        this(clientSession, namespace, resultClass, codecRegistry, readPreference, executor, true);
-    }
-
-    ListIndexesIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace, final Class<TResult> resultClass,
-                            final CodecRegistry codecRegistry, final ReadPreference readPreference, final OperationExecutor executor,
-                            final boolean retryReads) {
-        super(clientSession, executor, ReadConcern.DEFAULT, readPreference, retryReads);
-        this.operations = new SyncOperations<>(namespace, BsonDocument.class, readPreference, codecRegistry, retryReads);
+            final CodecRegistry codecRegistry, final ReadPreference readPreference, final OperationExecutor executor,
+            final boolean retryReads, @Nullable final Long timeoutMS) {
+        super(clientSession, executor, ReadConcern.DEFAULT, readPreference, retryReads, timeoutMS);
+        this.operations = new SyncOperations<>(namespace, BsonDocument.class, readPreference, codecRegistry, retryReads, timeoutMS);
         this.resultClass = notNull("resultClass", resultClass);
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/ListSearchIndexesIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ListSearchIndexesIterableImpl.java
@@ -55,11 +55,11 @@ final class ListSearchIndexesIterableImpl<TResult> extends MongoIterableImpl<TRe
     ListSearchIndexesIterableImpl(final MongoNamespace namespace, final OperationExecutor executor,
                                          final ReadConcern readConcern, final Class<TResult> resultClass,
                                          final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                                         final boolean retryReads) {
-        super(null, executor, readConcern, readPreference, retryReads);
+                                         final boolean retryReads, @Nullable final Long timeoutMS) {
+        super(null, executor, readConcern, readPreference, retryReads, timeoutMS);
 
         this.resultClass = resultClass;
-        this.operations = new SyncOperations<>(namespace, BsonDocument.class, readPreference, codecRegistry, retryReads);
+        this.operations = new SyncOperations<>(namespace, BsonDocument.class, readPreference, codecRegistry, retryReads, timeoutMS);
         this.codecRegistry = codecRegistry;
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/MapReduceIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MapReduceIterableImpl.java
@@ -69,10 +69,10 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     MapReduceIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace, final Class<TDocument> documentClass,
                           final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
                           final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
-                          final String mapFunction, final String reduceFunction) {
-        super(clientSession, executor, readConcern, readPreference, false);
+                          final String mapFunction, final String reduceFunction, @Nullable final Long timeoutMS) {
+        super(clientSession, executor, readConcern, readPreference, false, timeoutMS);
         this.operations = new SyncOperations<>(namespace, documentClass, readPreference, codecRegistry, readConcern, writeConcern,
-                false, false);
+                false, false, timeoutMS);
         this.namespace = notNull("namespace", namespace);
         this.resultClass = notNull("resultClass", resultClass);
         this.mapFunction = notNull("mapFunction", mapFunction);

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoClientImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoClientImpl.java
@@ -93,8 +93,8 @@ public final class MongoClientImpl implements MongoClient {
     @Override
     public MongoDatabase getDatabase(final String databaseName) {
         return new MongoDatabaseImpl(databaseName, delegate.getCodecRegistry(), settings.getReadPreference(), settings.getWriteConcern(),
-                settings.getRetryWrites(), settings.getRetryReads(), settings.getReadConcern(),
-                settings.getUuidRepresentation(), settings.getAutoEncryptionSettings(), delegate.getOperationExecutor());
+                settings.getRetryWrites(), settings.getRetryReads(), settings.getReadConcern(), settings.getUuidRepresentation(),
+                settings.getAutoEncryptionSettings(), getTimeoutMS(), delegate.getOperationExecutor());
     }
 
     @Override
@@ -206,8 +206,8 @@ public final class MongoClientImpl implements MongoClient {
                                                                                final List<? extends Bson> pipeline,
                                                                                final Class<TResult> resultClass) {
         return new ChangeStreamIterableImpl<>(clientSession, "admin", delegate.getCodecRegistry(), settings.getReadPreference(),
-                settings.getReadConcern(), delegate.getOperationExecutor(),
-                pipeline, resultClass, ChangeStreamLevel.CLIENT, settings.getRetryReads());
+                settings.getReadConcern(), delegate.getOperationExecutor(), pipeline, resultClass, ChangeStreamLevel.CLIENT,
+                settings.getRetryReads(), getTimeoutMS());
     }
 
     public Cluster getCluster() {
@@ -241,7 +241,7 @@ public final class MongoClientImpl implements MongoClient {
 
     private <T> ListDatabasesIterable<T> createListDatabasesIterable(@Nullable final ClientSession clientSession, final Class<T> clazz) {
         return new ListDatabasesIterableImpl<>(clientSession, clazz, delegate.getCodecRegistry(), ReadPreference.primary(),
-                delegate.getOperationExecutor(), settings.getRetryReads());
+                delegate.getOperationExecutor(), settings.getRetryReads(), getTimeoutMS());
     }
 
     private MongoIterable<String> createListDatabaseNamesIterable(@Nullable final ClientSession clientSession) {
@@ -262,5 +262,9 @@ public final class MongoClientImpl implements MongoClient {
 
     public MongoDriverInformation getMongoDriverInformation() {
         return mongoDriverInformation;
+    }
+
+    private @Nullable Long getTimeoutMS() {
+        return null; // TODO - JAVA-4064
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoClientImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoClientImpl.java
@@ -265,6 +265,6 @@ public final class MongoClientImpl implements MongoClient {
     }
 
     private @Nullable Long getTimeoutMS() {
-        return null; // TODO - JAVA-4064
+        return null; // TODO (CSOT) - JAVA-4064
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoIterableImpl.java
@@ -40,15 +40,17 @@ public abstract class MongoIterableImpl<TResult> implements MongoIterable<TResul
     private final OperationExecutor executor;
     private final ReadPreference readPreference;
     private final boolean retryReads;
+    private final Long timeoutMS;
     private Integer batchSize;
 
     public MongoIterableImpl(@Nullable final ClientSession clientSession, final OperationExecutor executor, final ReadConcern readConcern,
-                             final ReadPreference readPreference, final boolean retryReads) {
+                             final ReadPreference readPreference, final boolean retryReads, @Nullable final Long timeoutMS) {
         this.clientSession = clientSession;
         this.executor = notNull("executor", executor);
         this.readConcern = notNull("readConcern", readConcern);
         this.readPreference = notNull("readPreference", readPreference);
         this.retryReads = notNull("retryReads", retryReads);
+        this.timeoutMS = timeoutMS;
     }
 
     public abstract ReadOperation<BatchCursor<TResult>> asReadOperation();
@@ -72,6 +74,11 @@ public abstract class MongoIterableImpl<TResult> implements MongoIterable<TResul
 
     protected boolean getRetryReads() {
         return retryReads;
+    }
+
+    @Nullable
+    protected Long getTimeoutMS() {
+        return timeoutMS;
     }
 
     @Nullable

--- a/driver-sync/src/test/unit/com/mongodb/client/MongoClientSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/MongoClientSpecification.groovy
@@ -75,7 +75,7 @@ class MongoClientSpecification extends Specification {
 
         where:
         expectedDatabase << new MongoDatabaseImpl('name', withUuidRepresentation(codecRegistry, UNSPECIFIED), secondary(),
-                WriteConcern.MAJORITY, true, true, ReadConcern.MAJORITY, UNSPECIFIED, null, new TestOperationExecutor([]))
+                WriteConcern.MAJORITY, true, true, ReadConcern.MAJORITY, UNSPECIFIED, null, null, new TestOperationExecutor([]))
     }
 
     def 'should use ListDatabasesIterableImpl correctly'() {
@@ -90,14 +90,14 @@ class MongoClientSpecification extends Specification {
 
         then:
         expect listDatabasesIterable, isTheSameAs(new ListDatabasesIterableImpl<>(session, Document,
-                withUuidRepresentation(getDefaultCodecRegistry(), UNSPECIFIED), primary(), executor, true))
+                withUuidRepresentation(getDefaultCodecRegistry(), UNSPECIFIED), primary(), executor, true, null))
 
         when:
         listDatabasesIterable = execute(listDatabasesMethod, session, BsonDocument)
 
         then:
         expect listDatabasesIterable, isTheSameAs(new ListDatabasesIterableImpl<>(session, BsonDocument,
-                withUuidRepresentation(getDefaultCodecRegistry(), UNSPECIFIED), primary(), executor, true))
+                withUuidRepresentation(getDefaultCodecRegistry(), UNSPECIFIED), primary(), executor, true, null))
 
         when:
         def listDatabaseNamesIterable = execute(listDatabasesNamesMethod, session) as MongoIterable<String>
@@ -105,7 +105,7 @@ class MongoClientSpecification extends Specification {
         then:
         // listDatabaseNamesIterable is an instance of a MappingIterable, so have to get the mapped iterable inside it
         expect listDatabaseNamesIterable.getMapped(), isTheSameAs(new ListDatabasesIterableImpl<>(session, BsonDocument,
-                withUuidRepresentation(getDefaultCodecRegistry(), UNSPECIFIED), primary(), executor, true).nameOnly(true))
+                withUuidRepresentation(getDefaultCodecRegistry(), UNSPECIFIED), primary(), executor, true, null).nameOnly(true))
 
         cleanup:
         client?.close()
@@ -134,7 +134,7 @@ class MongoClientSpecification extends Specification {
         then:
         expect changeStreamIterable, isTheSameAs(new ChangeStreamIterableImpl<>(session, namespace,
                 withUuidRepresentation(getDefaultCodecRegistry(), UNSPECIFIED),
-                readPreference, readConcern, executor, [], Document, ChangeStreamLevel.CLIENT, true),
+                readPreference, readConcern, executor, [], Document, ChangeStreamLevel.CLIENT, true, null),
                 ['codec'])
 
         when:
@@ -144,7 +144,7 @@ class MongoClientSpecification extends Specification {
         expect changeStreamIterable, isTheSameAs(new ChangeStreamIterableImpl<>(session, namespace,
                 withUuidRepresentation(getDefaultCodecRegistry(), UNSPECIFIED),
                 readPreference, readConcern, executor, [new Document('$match', 1)], Document, ChangeStreamLevel.CLIENT,
-                true), ['codec'])
+                true, null), ['codec'])
 
         when:
         changeStreamIterable = execute(watchMethod, session, [new Document('$match', 1)], BsonDocument)
@@ -153,7 +153,7 @@ class MongoClientSpecification extends Specification {
         expect changeStreamIterable, isTheSameAs(new ChangeStreamIterableImpl<>(session, namespace,
                 withUuidRepresentation(getDefaultCodecRegistry(), UNSPECIFIED),
                 readPreference, readConcern, executor, [new Document('$match', 1)], BsonDocument,
-                ChangeStreamLevel.CLIENT, true), ['codec'])
+                ChangeStreamLevel.CLIENT, true, null), ['codec'])
 
         where:
         session << [null, Stub(ClientSession)]

--- a/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSBucketsSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSBucketsSpecification.groovy
@@ -35,7 +35,7 @@ class GridFSBucketsSpecification extends Specification {
     def 'should create a GridFSBucket with default bucket name'() {
         given:
         def database = new MongoDatabaseImpl('db', Stub(CodecRegistry), Stub(ReadPreference), Stub(WriteConcern), false, true, readConcern,
-                JAVA_LEGACY, null, Stub(OperationExecutor))
+                JAVA_LEGACY, null, null, Stub(OperationExecutor))
 
         when:
         def gridFSBucket = GridFSBuckets.create(database)
@@ -48,7 +48,7 @@ class GridFSBucketsSpecification extends Specification {
     def 'should create a GridFSBucket with custom bucket name'() {
         given:
         def database = new MongoDatabaseImpl('db', Stub(CodecRegistry), Stub(ReadPreference), Stub(WriteConcern), false, true, readConcern,
-                JAVA_LEGACY, null, Stub(OperationExecutor))
+                JAVA_LEGACY, null, null, Stub(OperationExecutor))
         def customName = 'custom'
 
         when:

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ChangeStreamIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ChangeStreamIterableSpecification.groovy
@@ -20,7 +20,6 @@ import com.mongodb.Function
 import com.mongodb.MongoException
 import com.mongodb.MongoNamespace
 import com.mongodb.ReadConcern
-import com.mongodb.WriteConcern
 import com.mongodb.client.ClientSession
 import com.mongodb.client.model.Collation
 import com.mongodb.client.model.changestream.ChangeStreamDocument
@@ -43,6 +42,8 @@ import spock.lang.Specification
 
 import java.util.function.Consumer
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_AWAIT_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -54,7 +55,6 @@ class ChangeStreamIterableSpecification extends Specification {
     def codecRegistry = fromProviders([new ValueCodecProvider(), new DocumentCodecProvider(), new BsonValueCodecProvider()])
     def readPreference = secondary()
     def readConcern = ReadConcern.MAJORITY
-    def writeConcern = WriteConcern.MAJORITY
     def collation = Collation.builder().locale('en').build()
 
     def 'should build the expected ChangeStreamOperation'() {
@@ -62,7 +62,7 @@ class ChangeStreamIterableSpecification extends Specification {
         def executor = new TestOperationExecutor([null, null, null, null, null])
         def pipeline = [new Document('$match', 1)]
         def changeStreamIterable = new ChangeStreamIterableImpl(null, namespace, codecRegistry, readPreference, readConcern,
-                executor, pipeline, Document, ChangeStreamLevel.COLLECTION, true)
+                executor, pipeline, Document, ChangeStreamLevel.COLLECTION, true, null)
 
         when: 'default input should be as expected'
         changeStreamIterable.iterator()
@@ -72,14 +72,17 @@ class ChangeStreamIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new ChangeStreamOperation<Document>(namespace, FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT,
-                [BsonDocument.parse('{$match: 1}')], codec, ChangeStreamLevel.COLLECTION).retryReads(true))
+        expect operation, isTheSameAs(new ChangeStreamOperation<Document>(CSOT_NO_TIMEOUT.get(), namespace,
+                FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [BsonDocument.parse('{$match: 1}')], codec,
+                ChangeStreamLevel.COLLECTION)
+                .retryReads(true))
         readPreference == secondary()
 
         when: 'overriding initial options'
         def resumeToken = RawBsonDocument.parse('{_id: {a: 1}}')
         def startAtOperationTime = new BsonTimestamp(99)
-        changeStreamIterable.collation(collation).maxAwaitTime(99, MILLISECONDS)
+        changeStreamIterable.collation(collation)
+                .maxAwaitTime(101, MILLISECONDS)
                 .fullDocument(FullDocument.UPDATE_LOOKUP)
                 .fullDocumentBeforeChange(FullDocumentBeforeChange.WHEN_AVAILABLE)
                 .resumeAfter(resumeToken).startAtOperationTime(startAtOperationTime)
@@ -88,12 +91,14 @@ class ChangeStreamIterableSpecification extends Specification {
         operation = executor.getReadOperation() as ChangeStreamOperation<Document>
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new ChangeStreamOperation<Document>(namespace, FullDocument.UPDATE_LOOKUP,
-                FullDocumentBeforeChange.WHEN_AVAILABLE,
-                [BsonDocument.parse('{$match: 1}')], codec, ChangeStreamLevel.COLLECTION)
+        expect operation, isTheSameAs(new ChangeStreamOperation<Document>(CSOT_MAX_AWAIT_TIME.get(), namespace,
+                FullDocument.UPDATE_LOOKUP, FullDocumentBeforeChange.WHEN_AVAILABLE, [BsonDocument.parse('{$match: 1}')], codec,
+                ChangeStreamLevel.COLLECTION)
                 .retryReads(true)
-                .collation(collation).maxAwaitTime(99, MILLISECONDS)
-                .resumeAfter(resumeToken).startAtOperationTime(startAtOperationTime).startAfter(resumeToken))
+                .collation(collation)
+                .resumeAfter(resumeToken)
+                .startAtOperationTime(startAtOperationTime)
+                .startAfter(resumeToken))
     }
 
     def 'should use ClientSession'() {
@@ -103,7 +108,7 @@ class ChangeStreamIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([batchCursor, batchCursor])
         def changeStreamIterable = new ChangeStreamIterableImpl(clientSession, namespace, codecRegistry, readPreference, readConcern,
-                executor, [], Document, ChangeStreamLevel.COLLECTION, true)
+                executor, [], Document, ChangeStreamLevel.COLLECTION, true, null)
 
         when:
         changeStreamIterable.first()
@@ -127,7 +132,7 @@ class ChangeStreamIterableSpecification extends Specification {
         def executor = new TestOperationExecutor([new MongoException('failure')])
         def pipeline = [new BsonDocument('$match', new BsonInt32(1))]
         def changeStreamIterable = new ChangeStreamIterableImpl(null, namespace, codecRegistry, readPreference, readConcern,
-                executor, pipeline, BsonDocument, ChangeStreamLevel.COLLECTION, true)
+                executor, pipeline, BsonDocument, ChangeStreamLevel.COLLECTION, true, null)
 
         when: 'The operation fails with an exception'
         changeStreamIterable.iterator()
@@ -137,14 +142,14 @@ class ChangeStreamIterableSpecification extends Specification {
 
         when: 'a codec is missing'
         new ChangeStreamIterableImpl(null, namespace, altRegistry, readPreference, readConcern, executor, pipeline, Document,
-                ChangeStreamLevel.COLLECTION, true).iterator()
+                ChangeStreamLevel.COLLECTION, true, null).iterator()
 
         then:
         thrown(CodecConfigurationException)
 
         when: 'pipeline contains null'
         new ChangeStreamIterableImpl(null, namespace, codecRegistry, readPreference, readConcern, executor, [null], Document,
-                ChangeStreamLevel.COLLECTION, true).iterator()
+                ChangeStreamLevel.COLLECTION, true, null).iterator()
 
         then:
         thrown(IllegalArgumentException)
@@ -159,7 +164,7 @@ class ChangeStreamIterableSpecification extends Specification {
         def executor = new TestOperationExecutor([cursor(cannedResults), cursor(cannedResults), cursor(cannedResults),
                                                   cursor(cannedResults)])
         def mongoIterable = new ChangeStreamIterableImpl(null, namespace, codecRegistry, readPreference, readConcern, executor, [],
-                Document, ChangeStreamLevel.COLLECTION, true)
+                Document, ChangeStreamLevel.COLLECTION, true, null)
 
         when:
         def results = mongoIterable.first()
@@ -207,7 +212,7 @@ class ChangeStreamIterableSpecification extends Specification {
         def executor = new TestOperationExecutor([cursor(cannedResults), cursor(cannedResults), cursor(cannedResults),
                                                   cursor(cannedResults)])
         def mongoIterable = new ChangeStreamIterableImpl(null, namespace, codecRegistry, readPreference, readConcern, executor, [],
-                Document, ChangeStreamLevel.COLLECTION, true).withDocumentClass(RawBsonDocument)
+                Document, ChangeStreamLevel.COLLECTION, true, null).withDocumentClass(RawBsonDocument)
 
         when:
         def results = mongoIterable.first()
@@ -251,7 +256,7 @@ class ChangeStreamIterableSpecification extends Specification {
         when:
         def batchSize = 5
         def mongoIterable = new ChangeStreamIterableImpl(null, namespace, codecRegistry, readPreference, readConcern,
-                Stub(OperationExecutor), [BsonDocument.parse('{$match: 1}')], BsonDocument, ChangeStreamLevel.COLLECTION, true)
+                Stub(OperationExecutor), [BsonDocument.parse('{$match: 1}')], BsonDocument, ChangeStreamLevel.COLLECTION, true, null)
 
         then:
         mongoIterable.getBatchSize() == null

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/FindIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/FindIterableSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.client.internal
 
-
 import com.mongodb.CursorType
 import com.mongodb.Function
 import com.mongodb.MongoException
@@ -39,10 +38,11 @@ import spock.lang.Specification
 
 import java.util.function.Consumer
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME_AND_MAX_AWAIT_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
 import static java.util.concurrent.TimeUnit.MILLISECONDS
-import static java.util.concurrent.TimeUnit.SECONDS
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders
 import static spock.util.matcher.HamcrestSupport.expect
 
@@ -59,11 +59,9 @@ class FindIterableSpecification extends Specification {
         given:
         def executor = new TestOperationExecutor([null, null, null])
         def findIterable = new FindIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern,
-                executor, new Document('filter', 1), true)
+                executor, new Document('filter', 1), true, null)
                 .sort(new Document('sort', 1))
                 .projection(new Document('projection', 1))
-                .maxTime(10, SECONDS)
-                .maxAwaitTime(20, SECONDS)
                 .batchSize(100)
                 .limit(100)
                 .skip(10)
@@ -87,12 +85,10 @@ class FindIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new FindOperation<Document>(namespace, new DocumentCodec())
+        expect operation, isTheSameAs(new FindOperation<Document>(CSOT_NO_TIMEOUT.get(), namespace, new DocumentCodec())
                 .filter(new BsonDocument('filter', new BsonInt32(1)))
                 .sort(new BsonDocument('sort', new BsonInt32(1)))
                 .projection(new BsonDocument('projection', new BsonInt32(1)))
-                .maxTime(10000, MILLISECONDS)
-                .maxAwaitTime(20000, MILLISECONDS)
                 .batchSize(100)
                 .limit(100)
                 .skip(10)
@@ -112,8 +108,8 @@ class FindIterableSpecification extends Specification {
         findIterable.filter(new Document('filter', 2))
                 .sort(new Document('sort', 2))
                 .projection(new Document('projection', 2))
-                .maxTime(9, SECONDS)
-                .maxAwaitTime(18, SECONDS)
+                .maxTime(101, MILLISECONDS)
+                .maxAwaitTime(1001, MILLISECONDS)
                 .batchSize(99)
                 .limit(99)
                 .skip(9)
@@ -134,12 +130,10 @@ class FindIterableSpecification extends Specification {
         operation = executor.getReadOperation() as FindOperation<Document>
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new FindOperation<Document>(namespace, new DocumentCodec())
+        expect operation, isTheSameAs(new FindOperation<Document>(CSOT_MAX_TIME_AND_MAX_AWAIT_TIME.get(), namespace, new DocumentCodec())
                 .filter(new BsonDocument('filter', new BsonInt32(2)))
                 .sort(new BsonDocument('sort', new BsonInt32(2)))
                 .projection(new BsonDocument('projection', new BsonInt32(2)))
-                .maxTime(9000, MILLISECONDS)
-                .maxAwaitTime(18000, MILLISECONDS)
                 .batchSize(99)
                 .limit(99)
                 .skip(9)
@@ -160,7 +154,7 @@ class FindIterableSpecification extends Specification {
 
         when: 'passing nulls to nullable methods'
         new FindIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern,
-                executor, new Document('filter', 1), true)
+                executor, new Document('filter', 1), true, null)
                 .filter(null as Bson)
                 .collation(null)
                 .projection(null)
@@ -174,7 +168,7 @@ class FindIterableSpecification extends Specification {
         operation = executor.getReadOperation() as FindOperation<Document>
 
         then: 'should set an empty doc for the filter'
-        expect operation, isTheSameAs(new FindOperation<Document>(namespace, new DocumentCodec())
+        expect operation, isTheSameAs(new FindOperation<Document>(CSOT_NO_TIMEOUT.get(), namespace, new DocumentCodec())
                 .filter(new BsonDocument()).retryReads(true))
     }
 
@@ -185,7 +179,7 @@ class FindIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([batchCursor, batchCursor])
         def findIterable = new FindIterableImpl(clientSession, namespace, Document, Document, codecRegistry, readPreference, readConcern,
-                executor, new Document('filter', 1))
+                executor, new Document('filter', 1), true, null)
 
         when:
         findIterable.first()
@@ -207,7 +201,7 @@ class FindIterableSpecification extends Specification {
         given:
         def executor = new TestOperationExecutor([null, null])
         def findIterable = new FindIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern,
-                executor, new Document('filter', 1), true)
+                executor, new Document('filter', 1), true, null)
 
         when:
         findIterable.filter(new Document('filter', 1))
@@ -217,7 +211,7 @@ class FindIterableSpecification extends Specification {
         def operation = executor.getReadOperation() as FindOperation<Document>
 
         then:
-        expect operation, isTheSameAs(new FindOperation<Document>(namespace, new DocumentCodec())
+        expect operation, isTheSameAs(new FindOperation<Document>(CSOT_NO_TIMEOUT.get(), namespace, new DocumentCodec())
                 .filter(new BsonDocument('filter', new BsonInt32(1)))
                 .sort(new BsonDocument('sort', new BsonInt32(1)))
                 .cursorType(CursorType.NonTailable)
@@ -247,7 +241,7 @@ class FindIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()])
         def mongoIterable = new FindIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern,
-                executor, new Document())
+                executor, new Document(), true, null)
 
         when:
         def results = mongoIterable.first()
@@ -291,7 +285,7 @@ class FindIterableSpecification extends Specification {
         when:
         def batchSize = 5
         def mongoIterable = new FindIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
-                readConcern, Stub(OperationExecutor), new Document())
+                readConcern, Stub(OperationExecutor), new Document(), true, null)
 
         then:
         mongoIterable.getBatchSize() == null
@@ -313,7 +307,7 @@ class FindIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([cursor])
         def mongoIterable = new FindIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern,
-                executor, new Document())
+                executor, new Document(), true, null)
 
         when:
         mongoIterable.forEach(new Consumer<Document>() {

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ListCollectionsIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ListCollectionsIterableSpecification.groovy
@@ -30,11 +30,13 @@ import org.bson.codecs.DocumentCodecProvider
 import org.bson.codecs.ValueCodecProvider
 import spock.lang.Specification
 
+import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
-import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders
 import static spock.util.matcher.HamcrestSupport.expect
 
@@ -48,12 +50,11 @@ class ListCollectionsIterableSpecification extends Specification {
         given:
         def executor = new TestOperationExecutor([null, null, null])
         def listCollectionIterable = new ListCollectionsIterableImpl<Document>(null, 'db', false, Document, codecRegistry,
-                readPreference, executor)
+                readPreference, executor, true, null)
                 .filter(new Document('filter', 1))
                 .batchSize(100)
-                .maxTime(1000, MILLISECONDS)
         def listCollectionNamesIterable = new ListCollectionsIterableImpl<Document>(null, 'db', true, Document, codecRegistry,
-                readPreference, executor)
+                readPreference, executor, true, null)
 
         when: 'default input should be as expected'
         listCollectionIterable.iterator()
@@ -62,19 +63,19 @@ class ListCollectionsIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new ListCollectionsOperation<Document>('db', new DocumentCodec())
-                .filter(new BsonDocument('filter', new BsonInt32(1))).batchSize(100).maxTime(1000, MILLISECONDS)
+        expect operation, isTheSameAs(new ListCollectionsOperation<Document>(CSOT_NO_TIMEOUT.get(), 'db', new DocumentCodec())
+                .filter(new BsonDocument('filter', new BsonInt32(1))).batchSize(100)
                 .retryReads(true))
         readPreference == secondary()
 
         when: 'overriding initial options'
-        listCollectionIterable.filter(new Document('filter', 2)).batchSize(99).maxTime(999, MILLISECONDS).iterator()
+        listCollectionIterable.filter(new Document('filter', 2)).batchSize(99).maxTime(100, TimeUnit.MILLISECONDS).iterator()
 
         operation = executor.getReadOperation() as ListCollectionsOperation<Document>
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new ListCollectionsOperation<Document>('db', new DocumentCodec())
-                .filter(new BsonDocument('filter', new BsonInt32(2))).batchSize(99).maxTime(999, MILLISECONDS)
+        expect operation, isTheSameAs(new ListCollectionsOperation<Document>(CSOT_MAX_TIME.get(), 'db', new DocumentCodec())
+                .filter(new BsonDocument('filter', new BsonInt32(2))).batchSize(99)
                 .retryReads(true))
 
         when: 'requesting collection names only'
@@ -83,8 +84,8 @@ class ListCollectionsIterableSpecification extends Specification {
         operation = executor.getReadOperation() as ListCollectionsOperation<Document>
 
         then: 'should create operation with nameOnly'
-        expect operation, isTheSameAs(new ListCollectionsOperation<Document>('db', new DocumentCodec()).nameOnly(true)
-                .retryReads(true))
+        expect operation, isTheSameAs(new ListCollectionsOperation<Document>(CSOT_NO_TIMEOUT.get(), 'db', new DocumentCodec())
+                .nameOnly(true).retryReads(true))
     }
 
     def 'should use ClientSession'() {
@@ -94,7 +95,7 @@ class ListCollectionsIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([batchCursor, batchCursor])
         def listCollectionIterable = new ListCollectionsIterableImpl<Document>(clientSession, 'db', false, Document, codecRegistry,
-                readPreference, executor)
+                readPreference, executor, true, null)
 
         when:
         listCollectionIterable.first()
@@ -134,7 +135,7 @@ class ListCollectionsIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()])
         def mongoIterable = new ListCollectionsIterableImpl<Document>(null, 'db', false, Document, codecRegistry, readPreference,
-                executor)
+                executor, true, null)
 
         when:
         def results = mongoIterable.first()
@@ -178,7 +179,7 @@ class ListCollectionsIterableSpecification extends Specification {
         when:
         def batchSize = 5
         def mongoIterable = new ListCollectionsIterableImpl<Document>(null, 'db', false, Document, codecRegistry, readPreference,
-                Stub(OperationExecutor))
+                Stub(OperationExecutor), true, null)
 
         then:
         mongoIterable.getBatchSize() == null

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ListIndexesIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ListIndexesIterableSpecification.groovy
@@ -31,6 +31,8 @@ import spock.lang.Specification
 
 import java.util.function.Consumer
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -47,8 +49,8 @@ class ListIndexesIterableSpecification extends Specification {
     def 'should build the expected listIndexesOperation'() {
         given:
         def executor = new TestOperationExecutor([null, null])
-        def listIndexesIterable = new ListIndexesIterableImpl<Document>(null, namespace, Document, codecRegistry, readPreference, executor)
-                .batchSize(100).maxTime(1000, MILLISECONDS)
+        def listIndexesIterable = new ListIndexesIterableImpl<Document>(null, namespace, Document, codecRegistry, readPreference,
+                executor, true, null).batchSize(100)
 
         when: 'default input should be as expected'
         listIndexesIterable.iterator()
@@ -57,20 +59,20 @@ class ListIndexesIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new ListIndexesOperation<Document>(namespace, new DocumentCodec())
-                .batchSize(100).maxTime(1000, MILLISECONDS).retryReads(true))
+        expect operation, isTheSameAs(new ListIndexesOperation<Document>(CSOT_NO_TIMEOUT.get(), namespace, new DocumentCodec())
+                .batchSize(100).retryReads(true))
         readPreference == secondary()
 
         when: 'overriding initial options'
         listIndexesIterable.batchSize(99)
-                .maxTime(999, MILLISECONDS)
+                .maxTime(100, MILLISECONDS)
                 .iterator()
 
         operation = executor.getReadOperation() as ListIndexesOperation<Document>
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new ListIndexesOperation<Document>(namespace, new DocumentCodec())
-                .batchSize(99).maxTime(999, MILLISECONDS).retryReads(true))
+        expect operation, isTheSameAs(new ListIndexesOperation<Document>(CSOT_MAX_TIME.get(), namespace, new DocumentCodec())
+                .batchSize(99).retryReads(true))
     }
 
     def 'should use ClientSession'() {
@@ -80,7 +82,7 @@ class ListIndexesIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([batchCursor, batchCursor])
         def listIndexesIterable = new ListIndexesIterableImpl<Document>(clientSession, namespace, Document, codecRegistry, readPreference,
-                executor)
+                executor, true, null)
 
         when:
         listIndexesIterable.first()
@@ -120,7 +122,8 @@ class ListIndexesIterableSpecification extends Specification {
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()])
-        def mongoIterable = new ListIndexesIterableImpl<Document>(null, namespace, Document, codecRegistry, readPreference, executor)
+        def mongoIterable = new ListIndexesIterableImpl<Document>(null, namespace, Document, codecRegistry, readPreference,
+                executor, true, null)
 
         when:
         def results = mongoIterable.first()
@@ -164,7 +167,7 @@ class ListIndexesIterableSpecification extends Specification {
         when:
         def batchSize = 5
         def mongoIterable = new ListIndexesIterableImpl<Document>(null, namespace, Document, codecRegistry, readPreference,
-                Stub(OperationExecutor))
+                Stub(OperationExecutor), true, null)
 
         then:
         mongoIterable.getBatchSize() == null

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MapReduceIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MapReduceIterableSpecification.groovy
@@ -42,6 +42,8 @@ import spock.lang.Specification
 
 import java.util.function.Consumer
 
+import static com.mongodb.ClusterFixture.CSOT_MAX_TIME
+import static com.mongodb.ClusterFixture.CSOT_NO_TIMEOUT
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -62,7 +64,7 @@ class MapReduceIterableSpecification extends Specification {
         given:
         def executor = new TestOperationExecutor([null, null])
         def mapReduceIterable = new MapReduceIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, 'map', 'reduce')
+                readConcern, writeConcern, executor, 'map', 'reduce', null)
 
         when: 'default input should be as expected'
         mapReduceIterable.iterator()
@@ -71,8 +73,8 @@ class MapReduceIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new MapReduceWithInlineResultsOperation<Document>(namespace, new BsonJavaScript('map'),
-                new BsonJavaScript('reduce'), new DocumentCodec())
+        expect operation, isTheSameAs(new MapReduceWithInlineResultsOperation<Document>(CSOT_NO_TIMEOUT.get(), namespace,
+                new BsonJavaScript('map'), new BsonJavaScript('reduce'), new DocumentCodec())
                 .verbose(true))
         readPreference == secondary()
 
@@ -80,7 +82,7 @@ class MapReduceIterableSpecification extends Specification {
         mapReduceIterable.filter(new Document('filter', 1))
                 .finalizeFunction('finalize')
                 .limit(999)
-                .maxTime(999, MILLISECONDS)
+                .maxTime(100, MILLISECONDS)
                 .scope(new Document('scope', 1))
                 .sort(new Document('sort', 1))
                 .verbose(false)
@@ -90,12 +92,11 @@ class MapReduceIterableSpecification extends Specification {
         operation = (executor.getReadOperation() as MapReduceIterableImpl.WrappedMapReduceReadOperation<Document>).getOperation()
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new MapReduceWithInlineResultsOperation<Document>(namespace, new BsonJavaScript('map'),
-                new BsonJavaScript('reduce'), new DocumentCodec())
+        expect operation, isTheSameAs(new MapReduceWithInlineResultsOperation<Document>(CSOT_MAX_TIME.get(), namespace,
+                new BsonJavaScript('map'), new BsonJavaScript('reduce'), new DocumentCodec())
                 .filter(new BsonDocument('filter', new BsonInt32(1)))
                 .finalizeFunction(new BsonJavaScript('finalize'))
                 .limit(999)
-                .maxTime(999, MILLISECONDS)
                 .scope(new BsonDocument('scope', new BsonInt32(1)))
                 .sort(new BsonDocument('sort', new BsonInt32(1)))
                 .verbose(false)
@@ -109,14 +110,14 @@ class MapReduceIterableSpecification extends Specification {
 
         when: 'mapReduce to a collection'
         def collectionNamespace = new MongoNamespace('dbName', 'collName')
-        def mapReduceIterable = new MapReduceIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern,
-                writeConcern, executor, 'map', 'reduce')
+        def mapReduceIterable = new MapReduceIterableImpl(null, namespace, Document, Document, codecRegistry,
+                readPreference, readConcern, writeConcern, executor, 'map', 'reduce', null)
                 .collectionName(collectionNamespace.getCollectionName())
                 .databaseName(collectionNamespace.getDatabaseName())
                 .filter(new Document('filter', 1))
                 .finalizeFunction('finalize')
                 .limit(999)
-                .maxTime(999, MILLISECONDS)
+                .maxTime(100, MILLISECONDS)
                 .scope(new Document('scope', 1))
                 .sort(new Document('sort', 1))
                 .verbose(false)
@@ -130,13 +131,12 @@ class MapReduceIterableSpecification extends Specification {
         mapReduceIterable.iterator()
 
         def operation = executor.getWriteOperation() as MapReduceToCollectionOperation
-        def expectedOperation = new MapReduceToCollectionOperation(namespace, new BsonJavaScript('map'),
-                new BsonJavaScript('reduce'), 'collName', writeConcern)
+        def expectedOperation = new MapReduceToCollectionOperation(CSOT_MAX_TIME.get(), namespace,
+                new BsonJavaScript('map'), new BsonJavaScript('reduce'), 'collName', writeConcern)
                 .databaseName(collectionNamespace.getDatabaseName())
                 .filter(new BsonDocument('filter', new BsonInt32(1)))
                 .finalizeFunction(new BsonJavaScript('finalize'))
                 .limit(999)
-                .maxTime(999, MILLISECONDS)
                 .scope(new BsonDocument('scope', new BsonInt32(1)))
                 .sort(new BsonDocument('sort', new BsonInt32(1)))
                 .verbose(false)
@@ -174,7 +174,7 @@ class MapReduceIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([batchCursor, batchCursor])
         def mapReduceIterable = new MapReduceIterableImpl(clientSession, namespace, Document, Document, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, 'map', 'reduce')
+                readConcern, writeConcern, executor, 'map', 'reduce', null)
 
         when:
         mapReduceIterable.first()
@@ -199,7 +199,7 @@ class MapReduceIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([null, batchCursor, null, batchCursor, null])
         def mapReduceIterable = new MapReduceIterableImpl(clientSession, namespace, Document, Document, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, 'map', 'reduce')
+                readConcern, writeConcern, executor, 'map', 'reduce', null)
                 .collectionName('collName')
 
         when:
@@ -232,7 +232,7 @@ class MapReduceIterableSpecification extends Specification {
         def codecRegistry = fromProviders([new ValueCodecProvider(), new BsonValueCodecProvider()])
         def executor = new TestOperationExecutor([new MongoException('failure')])
         def mapReduceIterable = new MapReduceIterableImpl(null, namespace, BsonDocument, BsonDocument, codecRegistry,
-                readPreference, readConcern, writeConcern, executor, 'map', 'reduce')
+                readPreference, readConcern, writeConcern, executor, 'map', 'reduce', null)
 
 
         when: 'The operation fails with an exception'
@@ -249,7 +249,7 @@ class MapReduceIterableSpecification extends Specification {
 
         when: 'a codec is missing'
         new MapReduceIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,
-                'map', 'reduce').iterator()
+                'map', 'reduce', null).iterator()
 
         then:
         thrown(CodecConfigurationException)
@@ -278,7 +278,7 @@ class MapReduceIterableSpecification extends Specification {
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()])
         def mongoIterable = new MapReduceIterableImpl(null, namespace, BsonDocument, BsonDocument, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, 'map', 'reduce')
+                readConcern, writeConcern, executor, 'map', 'reduce', null)
 
         when:
         def results = mongoIterable.first()
@@ -322,7 +322,7 @@ class MapReduceIterableSpecification extends Specification {
         when:
         def batchSize = 5
         def mongoIterable = new MapReduceIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference,
-                readConcern, writeConcern, Stub(OperationExecutor), 'map', 'reduce')
+                readConcern, writeConcern, Stub(OperationExecutor), 'map', 'reduce', null)
 
         then:
         mongoIterable.getBatchSize() == null


### PR DESCRIPTION
Initial client side operation timeout (CSOT) work. The CSOT class is passed to all operations and currently encapsulate the following timeouts:

  - `timeoutMS` the new optional client side operation timeout
  - `maxTimeMS` the legacy maxTimeMS operation value. Ignored if CSOT is set.
  - `maxCommitTimeMS` the legacy commit timeout. Ignored if CSOT is set.
  - `maxAwaitTimeMS` the getMore await timeout.

This initial work allows for the CSOT to be available to all operations and later work will pass / apply this timeout where required by the Spec.

JAVA-4086