### PR TITLE
Evergreen: Updated static checks

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -901,7 +901,7 @@ tasks:
       commands:
         - func: "exec script"
           vars:
-            file: ".evergreen/compile.sh"
+            file: ".evergreen/static-checks.sh"
 
     - name: "test"
       commands:

--- a/.evergreen/run-kotlin-tests.sh
+++ b/.evergreen/run-kotlin-tests.sh
@@ -34,4 +34,4 @@ fi
 echo "Running Kotlin tests"
 
 ./gradlew -version
-./gradlew kCheck -Dorg.mongodb.test.uri=${MONGODB_URI} ${MULTI_MONGOS_URI_SYSTEM_PROPERTY}
+./gradlew kotlinCheck -Dorg.mongodb.test.uri=${MONGODB_URI} ${MULTI_MONGOS_URI_SYSTEM_PROPERTY}

--- a/.evergreen/run-scala-tests.sh
+++ b/.evergreen/run-scala-tests.sh
@@ -34,4 +34,4 @@ fi
 echo "Running scala tests with Scala $SCALA"
 
 ./gradlew -version
-./gradlew -PscalaVersion=$SCALA --stacktrace --info :bson-scala:test :driver-scala:test :driver-scala:integrationTest -Dorg.mongodb.test.uri=${MONGODB_URI} ${MULTI_MONGOS_URI_SYSTEM_PROPERTY}
+./gradlew -PscalaVersion=$SCALA --stacktrace --info scalaCheck -Dorg.mongodb.test.uri=${MONGODB_URI} ${MULTI_MONGOS_URI_SYSTEM_PROPERTY}

--- a/.evergreen/static-checks.sh
+++ b/.evergreen/static-checks.sh
@@ -9,7 +9,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 RELATIVE_DIR_PATH="$(dirname "${BASH_SOURCE[0]:-$0}")"
 . "${RELATIVE_DIR_PATH}/javaConfig.bash"
 
-echo "Compiling java driver"
+echo "Compiling JVM drivers"
 
 ./gradlew -version
-./gradlew -PxmlReports.enabled=true --info -x test -x integrationTest -x spotlessApply clean check jar testClasses docs
+./gradlew -PxmlReports.enabled=true --info -x test -x integrationTest -x spotlessApply clean check scalaCheck kotlinCheck jar testClasses docs

--- a/bson-kotlin/build.gradle.kts
+++ b/bson-kotlin/build.gradle.kts
@@ -111,7 +111,7 @@ spotbugs { showProgress.set(true) }
 // ===========================
 //     Test Configuration
 // ===========================
-tasks.create("kCheck") {
+tasks.create("kotlinCheck") {
     description = "Runs all the kotlin checks"
     group = "verification"
 

--- a/bson-kotlinx/build.gradle.kts
+++ b/bson-kotlinx/build.gradle.kts
@@ -115,7 +115,7 @@ spotbugs { showProgress.set(true) }
 // ===========================
 //     Test Configuration
 // ===========================
-tasks.create("kCheck") {
+tasks.create("kotlinCheck") {
     description = "Runs all the kotlin checks"
     group = "verification"
 

--- a/bson-scala/build.gradle
+++ b/bson-scala/build.gradle
@@ -39,6 +39,17 @@ tasks.withType(Test) {
     }
 }
 
+// ===================
+//     Scala checks
+// ===================
+tasks.register("scalaCheck") {
+    description = "Runs all the Scala checks"
+    group = "verification"
+
+    dependsOn("clean", "compileTestScala", "check")
+    tasks.findByName("check").mustRunAfter("clean")
+}
+
 ext {
     pomName = 'Mongo Scala Bson Library'
 }

--- a/driver-kotlin-coroutine/build.gradle.kts
+++ b/driver-kotlin-coroutine/build.gradle.kts
@@ -155,7 +155,7 @@ val integrationTest =
         classpath = sourceSets["integrationTest"].runtimeClasspath
     }
 
-tasks.create("kCheck") {
+tasks.create("kotlinCheck") {
     description = "Runs all the kotlin checks"
     group = "verification"
 

--- a/driver-kotlin-sync/build.gradle.kts
+++ b/driver-kotlin-sync/build.gradle.kts
@@ -150,7 +150,7 @@ val integrationTest =
         classpath = sourceSets["integrationTest"].runtimeClasspath
     }
 
-tasks.create("kCheck") {
+tasks.create("kotlinCheck") {
     description = "Runs all the kotlin checks"
     group = "verification"
 

--- a/driver-scala/build.gradle
+++ b/driver-scala/build.gradle
@@ -69,6 +69,18 @@ task integrationTest(type: Test) {
 
 check.dependsOn integrationTest
 
+// ===================
+//     Scala checks
+// ===================
+tasks.register("scalaCheck") {
+    description = "Runs all the Scala checks"
+    group = "verification"
+
+    dependsOn("clean", "compileTestScala", "compileIntegrationTestScala", "check")
+    tasks.findByName("check").mustRunAfter("clean")
+}
+
+
 task aggregatedScalaDoc(type: ScalaDoc) {
     description('Unified Scaladoc for bson-scala and driver-scala')
     group('documentation')


### PR DESCRIPTION
Ensures that Kotlin and Scala checks are also run.

* Renamed compile.sh to static-checks.sh so its discoverable
* Added compileIntegrationTest to Kotlin/Scala checks
* Updated the evergreen static-checks.sh to run the Kotlin & Scala checks

JAVA-5095