### PR TITLE
Proposal: added generic param to CodecProvider.java

### DIFF
--- a/bson/src/main/org/bson/codecs/configuration/CodecProvider.java
+++ b/bson/src/main/org/bson/codecs/configuration/CodecProvider.java
@@ -33,7 +33,7 @@ import java.util.List;
  *
  * @since 3.0
  */
-public interface CodecProvider {
+public interface CodecProvider<T> {
 
     /**
      * Get a {@code Codec} using the given context, which includes, most importantly, the Class for which a {@code Codec} is required.
@@ -46,7 +46,7 @@ public interface CodecProvider {
      * @param <T> the type of the class for which a Codec is required
      * @return the Codec instance, which may be null, if this source is unable to provide one for the requested Class
      */
-    <T> Codec<T> get(Class<T> clazz, CodecRegistry registry);
+     Codec<T> get(Class<T> clazz, CodecRegistry registry);
 
     /**
      * Get a {@code Codec} using the given context, which includes, most importantly, the Class for which a {@code Codec} is required.


### PR DESCRIPTION
as the title pertains this is just a proposal and requires multiple code changes to complete, the reason for this pull request is to ask, why not use the generic parameter at the interface declaration level? Just to avoid unnecessary casts during implementation or multiple warnings.