### PR TITLE
Proposal for deprecating Stream-related API

### DIFF
--- a/bson/src/main/org/bson/ByteBufNIO.java
+++ b/bson/src/main/org/bson/ByteBufNIO.java
@@ -26,6 +26,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @since 3.0
  */
+@Deprecated
+// TODO: Can we?  Can we go even further and deprecate ByteBuf? The main public usage in in RawBsonArray and RawBsonDocument
+// and in org.bson.io package. It would be nice because ByteBuf is not a good abstraction currently and removing it from the API would
+// give us more flexibility to refactor it.
 public class ByteBufNIO implements ByteBuf {
     private ByteBuffer buf;
     private final AtomicInteger referenceCount = new AtomicInteger(1);

--- a/driver-core/src/main/com/mongodb/MongoClientSettings.java
+++ b/driver-core/src/main/com/mongodb/MongoClientSettings.java
@@ -27,6 +27,7 @@ import com.mongodb.connection.ServerSettings;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.SslSettings;
 import com.mongodb.connection.StreamFactoryFactory;
+import com.mongodb.connection.TransportSettings;
 import com.mongodb.event.CommandListener;
 import com.mongodb.lang.Nullable;
 import com.mongodb.spi.dns.DnsClient;
@@ -490,9 +491,25 @@ public final class MongoClientSettings {
          * @param streamFactoryFactory the stream factory factory
          * @return this
          * @see #getStreamFactoryFactory()
+         * @see #transportSettings(TransportSettings)
          */
+        @Deprecated
         public Builder streamFactoryFactory(final StreamFactoryFactory streamFactoryFactory) {
             this.streamFactoryFactory = notNull("streamFactoryFactory", streamFactoryFactory);
+            return this;
+        }
+
+        /**
+         * Enables Netty with the given settings.
+         *
+         * <p>
+         * If Netty is enabled with this method, it is an error to also use {@link #streamFactoryFactory}.
+         * </p>
+         *
+         * @param nettySettings the settings for Netty
+         * @return this
+         */
+        public Builder transportSettings(final TransportSettings nettySettings) {
             return this;
         }
 
@@ -771,10 +788,24 @@ public final class MongoClientSettings {
      *
      * @return the stream factory factory
      * @see Builder#streamFactoryFactory(StreamFactoryFactory)
+     * @see #getTransportSettings() ()
      */
+    @Deprecated
     @Nullable
     public StreamFactoryFactory getStreamFactoryFactory() {
         return streamFactoryFactory;
+    }
+
+    /**
+     * Gets the settings for the underlying transport API
+     *
+     * @return the settings for the underlying transport API
+     *
+     * @since 4.11
+     */
+    @Nullable
+    public TransportSettings getTransportSettings() {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/AsynchronousSocketChannelStreamFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/AsynchronousSocketChannelStreamFactory.java
@@ -30,6 +30,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
+@Deprecated
 public class AsynchronousSocketChannelStreamFactory implements StreamFactory {
     private final PowerOfTwoBufferPool bufferProvider = PowerOfTwoBufferPool.DEFAULT;
     private final SocketSettings settings;

--- a/driver-core/src/main/com/mongodb/connection/AsynchronousSocketChannelStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/AsynchronousSocketChannelStreamFactoryFactory.java
@@ -24,6 +24,7 @@ import java.nio.channels.AsynchronousChannelGroup;
  * @see java.nio.channels.AsynchronousSocketChannel
  * @since 3.1
  */
+@Deprecated
 public final class AsynchronousSocketChannelStreamFactoryFactory implements StreamFactoryFactory {
     private final AsynchronousChannelGroup group;
 

--- a/driver-core/src/main/com/mongodb/connection/SocketStreamFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/SocketStreamFactory.java
@@ -36,6 +36,7 @@ import static java.util.Optional.ofNullable;
  *
  * @since 3.0
  */
+@Deprecated
 public class SocketStreamFactory implements StreamFactory {
     private final SocketSettings settings;
     private final SslSettings sslSettings;

--- a/driver-core/src/main/com/mongodb/connection/Stream.java
+++ b/driver-core/src/main/com/mongodb/connection/Stream.java
@@ -27,6 +27,7 @@ import java.util.List;
  *
  * @since 3.0
  */
+@Deprecated
 public interface Stream extends BufferProvider{
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/StreamFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/StreamFactory.java
@@ -23,6 +23,7 @@ import com.mongodb.ServerAddress;
  *
  * @since 3.0
  */
+@Deprecated
 public interface StreamFactory {
     /**
      * Create a Stream to the given address

--- a/driver-core/src/main/com/mongodb/connection/StreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/StreamFactoryFactory.java
@@ -21,6 +21,7 @@ package com.mongodb.connection;
  *
  * @since 3.1
  */
+@Deprecated
 public interface StreamFactoryFactory {
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/TlsChannelStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/TlsChannelStreamFactoryFactory.java
@@ -58,6 +58,7 @@ import static java.util.Optional.ofNullable;
  *
  * @since 3.10
  */
+@Deprecated
 public class TlsChannelStreamFactoryFactory implements StreamFactoryFactory, Closeable {
 
     private static final Logger LOGGER = Loggers.getLogger("connection.tls");

--- a/driver-core/src/main/com/mongodb/connection/TransportSettings.java
+++ b/driver-core/src/main/com/mongodb/connection/TransportSettings.java
@@ -16,22 +16,20 @@
 
 package com.mongodb.connection;
 
-import com.mongodb.annotations.ThreadSafe;
-import org.bson.ByteBuf;
+import com.mongodb.connection.netty.NettySettings;
 
 /**
- * A provider of instances of ByteBuf.
+ * Transport settings for the driver.
  *
- * @since 3.0
+ * @since 4.11
  */
-@Deprecated
-@ThreadSafe
-public interface BufferProvider {
+public abstract class TransportSettings {
     /**
-     * Gets a buffer with the givens capacity.
+     * A builder for NettySettings.
      *
-     * @param size the size required for the buffer
-     * @return a ByteBuf with the given size, which is now owned by the caller and must be released.
+     * @return a builder for NettySettings
      */
-    ByteBuf getBuffer(int size);
+    public static NettySettings.Builder nettyBuilder() {
+        return NettySettings.builder();
+    }
 }

--- a/driver-core/src/main/com/mongodb/connection/netty/NettySettings.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettySettings.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection.netty;
+
+import com.mongodb.connection.SslSettings;
+import com.mongodb.connection.TransportSettings;
+import com.mongodb.lang.Nullable;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.ssl.ReferenceCountedOpenSslClientContext;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+
+import java.security.Security;
+
+import static com.mongodb.assertions.Assertions.isTrueArgument;
+import static com.mongodb.assertions.Assertions.notNull;
+
+/**
+ * A {@code TransportSettings} implementation for <a href="http://netty.io/">Netty</a>-based streams.
+ *
+ * @since 4.11
+ */
+public final class NettySettings extends TransportSettings {
+
+    private final EventLoopGroup eventLoopGroup;
+    private final Class<? extends SocketChannel> socketChannelClass;
+    private final ByteBufAllocator allocator;
+    @Nullable
+    private final SslContext sslContext;
+
+    /**
+     * Gets a builder for an instance of {@code NettyStreamFactoryFactory}.
+     * @return the builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder for an instance of {@code NettyStreamFactoryFactory}.
+     */
+    public static final class Builder {
+        private ByteBufAllocator allocator;
+        private Class<? extends SocketChannel> socketChannelClass;
+        private EventLoopGroup eventLoopGroup;
+        @Nullable
+        private SslContext sslContext;
+
+        private Builder() {
+            allocator(ByteBufAllocator.DEFAULT);
+            socketChannelClass(NioSocketChannel.class);
+        }
+
+        /**
+         * Sets the allocator.
+         *
+         * @param allocator the allocator to use for ByteBuf instances
+         * @return this
+         */
+        public Builder allocator(final ByteBufAllocator allocator) {
+            this.allocator = notNull("allocator", allocator);
+            return this;
+        }
+
+        /**
+         * Sets the socket channel class
+         *
+         * @param socketChannelClass the socket channel class
+         * @return this
+         */
+        public Builder socketChannelClass(final Class<? extends SocketChannel> socketChannelClass) {
+            this.socketChannelClass = notNull("socketChannelClass", socketChannelClass);
+            return this;
+        }
+
+        /**
+         * Sets the event loop group.
+         *
+         * <p>It is highly recommended to supply your own event loop group and manage its shutdown.  Otherwise, the event
+         * loop group created by default will not be shutdown properly.</p>
+         *
+         * @param eventLoopGroup the event loop group that all channels created by this factory will be a part of
+         * @return this
+         */
+        public Builder eventLoopGroup(final EventLoopGroup eventLoopGroup) {
+            this.eventLoopGroup = notNull("eventLoopGroup", eventLoopGroup);
+            return this;
+        }
+
+        /**
+         * Sets a {@linkplain SslContextBuilder#forClient() client-side} {@link SslContext io.netty.handler.ssl.SslContext},
+         * which overrides the standard {@link SslSettings#getContext()}.
+         * By default it is {@code null} and {@link SslSettings#getContext()} is at play.
+         * <p>
+         * This option may be used as a convenient way to utilize
+         * <a href="https://www.openssl.org/">OpenSSL</a> as an alternative to the TLS/SSL protocol implementation in a JDK.
+         * To achieve this, specify {@link SslProvider#OPENSSL} TLS/SSL protocol provider via
+         * {@link SslContextBuilder#sslProvider(SslProvider)}. Note that doing so adds a runtime dependency on
+         * <a href="https://netty.io/wiki/forked-tomcat-native.html">netty-tcnative</a>, which you must satisfy.
+         * <p>
+         * Notes:
+         * <ul>
+         *    <li>Netty {@link SslContext} may not examine some
+         *    {@linkplain Security security}/{@linkplain System#getProperties() system} properties that are used to
+         *    <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#Customization">
+         *    customize JSSE</a>. Therefore, instead of using them you may have to apply the equivalent configuration programmatically,
+         *    if both the {@link SslContextBuilder} and the TLS/SSL protocol provider of choice support it.
+         *    </li>
+         *    <li>Only {@link SslProvider#JDK} and {@link SslProvider#OPENSSL} TLS/SSL protocol providers are supported.
+         *    </li>
+         * </ul>
+         *
+         * @param sslContext The Netty {@link SslContext}, which must be created via {@linkplain SslContextBuilder#forClient()}.
+         * @return {@code this}.
+         */
+        public Builder sslContext(final SslContext sslContext) {
+            this.sslContext = notNull("sslContext", sslContext);
+            isTrueArgument("sslContext must be client-side", sslContext.isClient());
+            isTrueArgument("sslContext must use either SslProvider.JDK or SslProvider.OPENSSL TLS/SSL protocol provider",
+                    !(sslContext instanceof ReferenceCountedOpenSslClientContext));
+
+            return this;
+        }
+
+        /**
+         * Build an instance of {@code NettyStreamFactoryFactory}.
+         * @return factory of the netty stream factory
+         */
+        public NettySettings build() {
+            return new NettySettings(this);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "NettySettings{"
+                + "eventLoopGroup=" + eventLoopGroup
+                + ", socketChannelClass=" + socketChannelClass
+                + ", allocator=" + allocator
+                + ", sslContext=" + sslContext
+                + '}';
+    }
+
+    private NettySettings(final Builder builder) {
+        allocator = builder.allocator;
+        socketChannelClass = builder.socketChannelClass;
+        if (builder.eventLoopGroup != null) {
+            eventLoopGroup = builder.eventLoopGroup;
+        } else {
+            eventLoopGroup = new NioEventLoopGroup();
+        }
+        sslContext = builder.sslContext;
+    }
+}

--- a/driver-core/src/main/com/mongodb/connection/netty/NettyStreamFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyStreamFactory.java
@@ -37,6 +37,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
+@Deprecated
 public class NettyStreamFactory implements StreamFactory {
     private final SocketSettings settings;
     private final SslSettings sslSettings;


### PR DESCRIPTION
Adds:

* TransportSettings abstract class
* NettySettings subclass of TransportSettings
* A new method on MongoClientSettings to configure TransportSettings

Deprecates:

* MongoClientSettings#streamFactoryFactory
* NettyStreamFactory
* AsynchronousSocketChannelStreamFactory
* AsynchronousSocketChannelStreamFactoryFactory
* BufferProvider
* SocketStreamFactory
* Stream
* StreamFactory
* StreamFactoryFactory
* TlsChannelStreamFactoryFactory

JAVA-5051