### PR TITLE
Deprecate SocketAddress-related methods

### DIFF
--- a/driver-core/src/main/com/mongodb/ServerAddress.java
+++ b/driver-core/src/main/com/mongodb/ServerAddress.java
@@ -188,7 +188,9 @@ public class ServerAddress implements Serializable {
      * Gets the underlying socket address
      *
      * @return socket address
+     * @deprecated Prefer {@link InetAddress#getByName(String)}
      */
+    @Deprecated
     public InetSocketAddress getSocketAddress() {
         try {
             return new InetSocketAddress(InetAddress.getByName(host), port);
@@ -203,7 +205,9 @@ public class ServerAddress implements Serializable {
      * @return array of socket addresses
      *
      * @since 3.9
+     * @deprecated Prefer {@link InetAddress#getAllByName(String)}
      */
+    @Deprecated
     public List<InetSocketAddress> getSocketAddresses() {
         try {
             InetAddress[] inetAddresses = InetAddress.getAllByName(host);

--- a/driver-core/src/main/com/mongodb/UnixServerAddress.java
+++ b/driver-core/src/main/com/mongodb/UnixServerAddress.java
@@ -44,6 +44,8 @@ public final class UnixServerAddress extends ServerAddress {
         isTrueArgument("The path must end in .sock", path.endsWith(".sock"));
     }
 
+    @SuppressWarnings("deprecation")
+    @Deprecated
     @Override
     public InetSocketAddress getSocketAddress() {
         throw new UnsupportedOperationException("Cannot return a InetSocketAddress from a UnixServerAddress");
@@ -51,7 +53,9 @@ public final class UnixServerAddress extends ServerAddress {
 
     /**
      * @return the SocketAddress for the MongoD unix domain socket.
+     * @deprecated Prefer {@link UnixSocketAddress#UnixSocketAddress(String)}
      */
+    @Deprecated
     public SocketAddress getUnixSocketAddress() {
         return new UnixSocketAddress(getHost());
     }

--- a/driver-core/src/main/com/mongodb/connection/TlsChannelStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/TlsChannelStreamFactoryFactory.java
@@ -197,6 +197,7 @@ public class TlsChannelStreamFactoryFactory implements StreamFactoryFactory, Clo
             return true;
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void openAsync(final AsyncCompletionHandler<Void> handler) {
             isTrue("unopened", getChannel() == null);

--- a/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
@@ -160,6 +160,7 @@ final class NettyStream implements Stream {
         handler.get();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void openAsync(final AsyncCompletionHandler<Void> handler) {
         Queue<SocketAddress> socketAddressQueue;

--- a/driver-core/src/main/com/mongodb/internal/connection/AsynchronousSocketChannelStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsynchronousSocketChannelStream.java
@@ -54,6 +54,7 @@ public final class AsynchronousSocketChannelStream extends AsynchronousChannelSt
         this.group = group;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void openAsync(final AsyncCompletionHandler<Void> handler) {
         isTrue("unopened", getChannel() == null);

--- a/driver-core/src/main/com/mongodb/internal/connection/ServerAddressWithResolver.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ServerAddressWithResolver.java
@@ -51,6 +51,7 @@ final class ServerAddressWithResolver extends ServerAddress {
         this.resolver = inetAddressResolver == null ? DEFAULT_INET_ADDRESS_RESOLVER : inetAddressResolver;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public InetSocketAddress getSocketAddress() {
         if (resolver == null) {
@@ -60,6 +61,7 @@ final class ServerAddressWithResolver extends ServerAddress {
         return getSocketAddresses().get(0);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public List<InetSocketAddress> getSocketAddresses() {
         if (resolver == null) {

--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
@@ -74,6 +74,7 @@ public class SocketStream implements Stream {
         }
     }
 
+    @SuppressWarnings("deprecation")
     protected Socket initializeSocket() throws IOException {
         Iterator<InetSocketAddress> inetSocketAddresses = address.getSocketAddresses().iterator();
         while (inetSocketAddresses.hasNext()) {

--- a/driver-core/src/main/com/mongodb/internal/connection/UnixSocketChannelStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/UnixSocketChannelStream.java
@@ -39,6 +39,7 @@ public class UnixSocketChannelStream extends SocketStream {
         this.address = address;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected Socket initializeSocket() throws IOException {
         return UnixSocketChannel.open((UnixSocketAddress) address.getUnixSocketAddress()).socket();


### PR DESCRIPTION
* ServerAddress#getSocketAddress
* ServerAddress#getSocketAddresses
* UnixServerAddress#getUnixSocketAddress

JAVA-4940

When we actually remove these methods and replace with some private helper, and also remove `StreamFactory` from API, we'll be able to remove the `ServerAddressWithResolver` class and just pass the `InetAddressResolver` wherever it needs to be available.