### PR TITLE
Improve performance monitoring

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -2060,15 +2060,10 @@ buildvariants:
 
 - name: "perf"
   display_name: Performance Tests
+  tags: ["perf-variant"]
   run_on: rhel90-dbx-perf-large
   tasks:
     - name: "perf"
-      vars:
-        VERSION: "v6.0-perf"
-        TOPOLOGY: "server"
-        SSL: "nossl"
-        AUTH: "noauth"
-        SKIP_LEGACY_SHELL: "true"
 
 - name: plain-auth-test
   display_name: "PLAIN (LDAP) Auth test"

--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -148,7 +148,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          REQUIRE_API_VERSION=${REQUIRE_API_VERSION} LOAD_BALANCER=${LOAD_BALANCER} MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          REQUIRE_API_VERSION=${REQUIRE_API_VERSION} LOAD_BALANCER=${LOAD_BALANCER} MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} SKIP_LEGACY_SHELL=${SKIP_LEGACY_SHELL} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with the MONGODB_URI for the cluster
     - command: expansions.update
       params:
@@ -1491,6 +1491,12 @@ tasks:
       tags: ["perf"]
       commands:
         - func: "bootstrap mongo-orchestration"
+          vars:
+            VERSION: "v6.0-perf"
+            TOPOLOGY: "server"
+            SSL: "nossl"
+            AUTH: "noauth"
+            SKIP_LEGACY_SHELL: "true"
         - func: "run perf tests"
         - func: "send dashboard data"
 
@@ -2052,13 +2058,18 @@ buildvariants:
   tasks:
      - name: "gssapi-auth-test"
 
-- matrix_name: "perf"
-  matrix_spec:  { auth: "noauth", ssl: "nossl", jdk: "jdk17", version: ["latest"], topology: "standalone", os: "linux" }
-  batchtime: 1440 # run once a day
-  display_name: "Perf Tests ${version} "
-  tags: ["perf-variant"]
+- name: "perf"
+  display_name: Performance Tests
+  run_on: rhel90-dbx-perf-large
   tasks:
-     - name: "perf"
+    - name: "perf"
+      batchtime: 1440 # run once a day
+      vars:
+        VERSION: "v6.0-perf"
+        TOPOLOGY: "server"
+        SSL: "nossl"
+        AUTH: "noauth"
+        SKIP_LEGACY_SHELL: "true"
 
 - name: plain-auth-test
   display_name: "PLAIN (LDAP) Auth test"

--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -2063,7 +2063,6 @@ buildvariants:
   run_on: rhel90-dbx-perf-large
   tasks:
     - name: "perf"
-      batchtime: 1440 # run once a day
       vars:
         VERSION: "v6.0-perf"
         TOPOLOGY: "server"


### PR DESCRIPTION
This PR introduces enhancements to performance monitoring:

-  Adds dedicated distro rhel90-dbx-perf-large for performance testing.
- Uses patch-pinned v6 server (6.0.6) as v6.0-perf alias.

JAVA-5065