### PR TITLE
Handle new explain output in tests

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateOperationSpecification.groovy
@@ -320,7 +320,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         def result = execute(operation, async)
 
         then:
-        result.containsKey('stages') || result.containsKey('queryPlanner')
+        result.containsKey('stages') || result.containsKey('queryPlanner') || result.containsKey('shards')
 
         where:
         async << [true, false]

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractExplainTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractExplainTest.java
@@ -119,6 +119,8 @@ public abstract class AbstractExplainTest {
         assertFalse(explainBsonDocument.containsKey("executionStats"));
     }
 
+    // Post-MongoDB 7.0, sharded cluster responses move the explain plan document into a "shards" document, which a plan for each shard.
+    // This method grabs the explain plan document from the first shard when this new structure is present.
     private static Document getAggregateExplainDocument(final Document rootAggregateExplainDocument) {
         assertNotNull(rootAggregateExplainDocument);
         Document aggregateExplainDocument = rootAggregateExplainDocument;


### PR DESCRIPTION
The response document for the explain command has changed in 7.2 sharded clusters. It introduces a top-level "shards" document that contains the explain output for each shard. This patch supports this new field in tests of explain API in the driver.

JAVA-5137