### PR TITLE
Handle interrupts: `Socket.connect` is interruptible in a virtual thread

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
@@ -83,8 +83,7 @@ public class SocketStream implements Stream {
         } catch (IOException e) {
             close();
             throw translateInterruptedException(e, "Interrupted while connecting")
-                    .<MongoException>map(Function.identity())
-                    .orElseGet(() -> new MongoSocketOpenException("Exception opening socket", getAddress(), e));
+                    .orElseThrow(() -> new MongoSocketOpenException("Exception opening socket", getAddress(), e));
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.connection;
 
-import com.mongodb.MongoException;
 import com.mongodb.MongoSocketException;
 import com.mongodb.MongoSocketOpenException;
 import com.mongodb.MongoSocketReadException;
@@ -41,7 +40,6 @@ import java.net.SocketTimeoutException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.assertions.Assertions.notNull;

--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
@@ -81,11 +81,7 @@ public class SocketStream implements Stream {
             outputStream = socket.getOutputStream();
             inputStream = socket.getInputStream();
         } catch (IOException e) {
-            try {
-                close();
-            } catch (Exception closeException) {
-                e.addSuppressed(closeException);
-            }
+            close();
             throw translateInterruptedException(e, "Interrupted while connecting")
                     .<MongoException>map(Function.identity())
                     .orElseGet(() -> new MongoSocketOpenException("Exception opening socket", getAddress(), e));
@@ -249,7 +245,7 @@ public class SocketStream implements Stream {
             if (socket != null) {
                 socket.close();
             }
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             // ignore
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/SocksSocket.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocksSocket.java
@@ -105,7 +105,11 @@ public final class SocksSocket extends Socket {
              * 1. Enforces self-closing under RFC 1928 if METHOD is X'FF'.
              * 2. Handles all other errors during connection, distinct from external closures.
              */
-            close();
+            try {
+                close();
+            } catch (Exception closeException) {
+                socketException.addSuppressed(closeException);
+            }
             throw socketException;
         }
     }


### PR DESCRIPTION
Notably, `Socket.close` may also block if one enables `SO_LINGER` by calling `Socket.setSoLinger`, yet there is not a word on interruptibility of `Socket.close` in the docs. Fortunately, we don't enable `SO_LINGER`, so we don't have to care about the behavior of `Socket.close`.

JAVA-5138