### PR TITLE
Handle interrupts: synchronous `KeyManagementService` uses Socket IO (open, read, write), which is interruptible in a virtual thread

### DIFF
--- a/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;

--- a/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
@@ -350,7 +350,7 @@ public class Crypt implements Closeable {
             }
             cryptContext.completeKeyDecryptors();
         } catch (Throwable t) {
-            throw translateInterruptedException(t, "Interrupted while reading")
+            throw translateInterruptedException(t, "Interrupted while doing IO")
                     .<MongoException>map(Function.identity())
                     .orElseGet(() -> wrapInMongoException(t));
         }

--- a/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
@@ -351,8 +351,7 @@ public class Crypt implements Closeable {
             cryptContext.completeKeyDecryptors();
         } catch (Throwable t) {
             throw translateInterruptedException(t, "Interrupted while doing IO")
-                    .<MongoException>map(Function.identity())
-                    .orElseGet(() -> wrapInMongoException(t));
+                    .orElseThrow(() -> wrapInMongoException(t));
         }
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/KeyManagementService.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/KeyManagementService.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.client.internal;
 
+import com.mongodb.MongoInterruptedException;
 import com.mongodb.ServerAddress;
 import com.mongodb.internal.diagnostics.logging.Logger;
 import com.mongodb.internal.diagnostics.logging.Loggers;
@@ -34,8 +35,10 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.thread.InterruptionUtil.translateInterruptedException;
 
 class KeyManagementService {
     private static final Logger LOGGER = Loggers.getLogger("client");
@@ -63,7 +66,7 @@ class KeyManagementService {
             socket.connect(new InetSocketAddress(InetAddress.getByName(serverAddress.getHost()), serverAddress.getPort()), timeoutMillis);
         } catch (IOException e) {
             closeSocket(socket);
-            throw e;
+            throw handleInterruptAndThrow(e, "Interrupted while connecting");
         }
 
         try {
@@ -75,7 +78,7 @@ class KeyManagementService {
             outputStream.write(bytes);
         } catch (IOException e) {
             closeSocket(socket);
-            throw e;
+            throw handleInterruptAndThrow(e, "Interrupted while writing");
         }
 
         try {
@@ -98,8 +101,21 @@ class KeyManagementService {
     private void closeSocket(final Socket socket) {
         try {
             socket.close();
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             // ignore
+        }
+    }
+
+    /**
+     * @return Never.
+     */
+    private static RuntimeException handleInterruptAndThrow(final IOException e, final String message) throws IOException,
+            MongoInterruptedException {
+        Optional<MongoInterruptedException> interruptedException = translateInterruptedException(e, message);
+        if (interruptedException.isPresent()) {
+            throw interruptedException.get();
+        } else {
+            throw e;
         }
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/KeyManagementService.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/KeyManagementService.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.client.internal;
 
-import com.mongodb.MongoInterruptedException;
 import com.mongodb.ServerAddress;
 import com.mongodb.internal.diagnostics.logging.Logger;
 import com.mongodb.internal.diagnostics.logging.Loggers;
@@ -35,10 +34,8 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.internal.thread.InterruptionUtil.translateInterruptedException;
 
 class KeyManagementService {
     private static final Logger LOGGER = Loggers.getLogger("client");
@@ -66,7 +63,7 @@ class KeyManagementService {
             socket.connect(new InetSocketAddress(InetAddress.getByName(serverAddress.getHost()), serverAddress.getPort()), timeoutMillis);
         } catch (IOException e) {
             closeSocket(socket);
-            throw translateInterruptedExceptionAndThrow(e, "Interrupted while connecting");
+            throw e;
         }
 
         try {
@@ -78,7 +75,7 @@ class KeyManagementService {
             outputStream.write(bytes);
         } catch (IOException e) {
             closeSocket(socket);
-            throw translateInterruptedExceptionAndThrow(e, "Interrupted while writing");
+            throw e;
         }
 
         try {
@@ -103,19 +100,6 @@ class KeyManagementService {
             socket.close();
         } catch (IOException | RuntimeException e) {
             // ignore
-        }
-    }
-
-    /**
-     * @return Never.
-     */
-    private static RuntimeException translateInterruptedExceptionAndThrow(final IOException e, final String message) throws IOException,
-            MongoInterruptedException {
-        Optional<MongoInterruptedException> interruptedException = translateInterruptedException(e, message);
-        if (interruptedException.isPresent()) {
-            throw interruptedException.get();
-        } else {
-            throw e;
         }
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/KeyManagementService.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/KeyManagementService.java
@@ -66,7 +66,7 @@ class KeyManagementService {
             socket.connect(new InetSocketAddress(InetAddress.getByName(serverAddress.getHost()), serverAddress.getPort()), timeoutMillis);
         } catch (IOException e) {
             closeSocket(socket);
-            throw handleInterruptAndThrow(e, "Interrupted while connecting");
+            throw translateInterruptedExceptionAndThrow(e, "Interrupted while connecting");
         }
 
         try {
@@ -78,7 +78,7 @@ class KeyManagementService {
             outputStream.write(bytes);
         } catch (IOException e) {
             closeSocket(socket);
-            throw handleInterruptAndThrow(e, "Interrupted while writing");
+            throw translateInterruptedExceptionAndThrow(e, "Interrupted while writing");
         }
 
         try {
@@ -109,7 +109,7 @@ class KeyManagementService {
     /**
      * @return Never.
      */
-    private static RuntimeException handleInterruptAndThrow(final IOException e, final String message) throws IOException,
+    private static RuntimeException translateInterruptedExceptionAndThrow(final IOException e, final String message) throws IOException,
             MongoInterruptedException {
         Optional<MongoInterruptedException> interruptedException = translateInterruptedException(e, message);
         if (interruptedException.isPresent()) {


### PR DESCRIPTION
This PR is very similar to https://github.com/mongodb/mongo-java-driver/pull/1203, which is why I assigned the same reviewers.

JAVA-5139