### PR TITLE
Refactor to obtain timeout from OperationContext for server selection

### DIFF
--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -286,6 +286,11 @@
     <Match>
         <Class name="com.mongodb.internal.time.Timeout"/>
         <Method name="awaitOn"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED"/>
+    </Match>
+    <Match>
+        <Class name="com.mongodb.internal.time.Timeout"/>
+        <Method name="awaitOn"/>
         <Bug pattern="WA_AWAIT_NOT_IN_LOOP"/>
     </Match>
 </FindBugsFilter>

--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -15,6 +15,7 @@
  */
 package com.mongodb.internal;
 
+import com.mongodb.internal.time.StartTime;
 import com.mongodb.internal.time.Timeout;
 import com.mongodb.lang.Nullable;
 
@@ -151,5 +152,10 @@ public class TimeoutContext {
             return timeoutMS == 0 ? Timeout.infinite() : Timeout.expiresIn(timeoutMS, MILLISECONDS);
         }
         return null;
+    }
+
+    public Timeout startServerSelectionTimeout(final StartTime startTime) {
+        long ms = getTimeoutSettings().getServerSelectionTimeoutMS();
+        return startTime.timeoutAfterOrInfiniteIfNegative(ms, MILLISECONDS);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -154,8 +154,8 @@ public class TimeoutContext {
         return null;
     }
 
-    public Timeout startServerSelectionTimeout(final StartTime startTime) {
+    public Timeout startServerSelectionTimeout() {
         long ms = getTimeoutSettings().getServerSelectionTimeoutMS();
-        return startTime.timeoutAfterOrInfiniteIfNegative(ms, MILLISECONDS);
+        return StartTime.now().timeoutAfterOrInfiniteIfNegative(ms, MILLISECONDS);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
@@ -26,6 +26,7 @@ import com.mongodb.connection.ServerDescription;
 import com.mongodb.event.ServerDescriptionChangedEvent;
 import com.mongodb.internal.diagnostics.logging.Logger;
 import com.mongodb.internal.diagnostics.logging.Loggers;
+import com.mongodb.internal.time.Timeout;
 import com.mongodb.lang.Nullable;
 import org.bson.types.ObjectId;
 
@@ -122,7 +123,7 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
     }
 
     @Override
-    public ClusterableServer getServer(final ServerAddress serverAddress, final OperationContext operationContext) {
+    public ClusterableServer getServer(final ServerAddress serverAddress, final Timeout serverSelectionTimeout) {
         isTrue("is open", !isClosed());
 
         ServerTuple serverTuple = addressToServerTupleMap.get(serverAddress);

--- a/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
@@ -122,7 +122,7 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
     }
 
     @Override
-    public ClusterableServer getServer(final ServerAddress serverAddress) {
+    public ClusterableServer getServer(final ServerAddress serverAddress, final OperationContext operationContext) {
         isTrue("is open", !isClosed());
 
         ServerTuple serverTuple = addressToServerTupleMap.get(serverAddress);

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -107,7 +107,7 @@ abstract class BaseCluster implements Cluster {
         ServerSelector compositeServerSelector = getCompositeServerSelector(serverSelector);
         boolean selectionFailureLogged = false;
         StartTime startTime = StartTime.now();
-        Timeout timeout = startServerSelectionTimeout(startTime, operationContext);
+        Timeout timeout = operationContext.getTimeoutContext().startServerSelectionTimeout(startTime);
 
         while (true) {
             CountDownLatch currentPhaseLatch = phase.get();
@@ -141,7 +141,7 @@ abstract class BaseCluster implements Cluster {
             LOGGER.trace(format("Asynchronously selecting server with selector %s", serverSelector));
         }
         StartTime startTime = StartTime.now();
-        Timeout timeout = startServerSelectionTimeout(startTime, operationContext);
+        Timeout timeout = operationContext.getTimeoutContext().startServerSelectionTimeout(startTime);
         ServerSelectionRequest request = new ServerSelectionRequest(
                 serverSelector, getCompositeServerSelector(serverSelector), timeout, startTime, callback);
 
@@ -216,11 +216,6 @@ abstract class BaseCluster implements Cluster {
 
     private void updatePhase() {
         withLock(() -> phase.getAndSet(new CountDownLatch(1)).countDown());
-    }
-
-    private Timeout startServerSelectionTimeout(final StartTime startTime, final OperationContext operationContext) {
-        long ms = operationContext.getTimeoutContext().getTimeoutSettings().getServerSelectionTimeoutMS();
-        return startTime.timeoutAfterOrInfiniteIfNegative(ms, MILLISECONDS);
     }
 
     private Timeout startMinWaitHeartbeatTimeout() {

--- a/driver-core/src/main/com/mongodb/internal/connection/Cluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/Cluster.java
@@ -24,6 +24,7 @@ import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.connection.ClusterDescription;
 import com.mongodb.connection.ClusterSettings;
+import com.mongodb.internal.time.Timeout;
 import com.mongodb.lang.Nullable;
 import com.mongodb.selector.ServerSelector;
 
@@ -45,7 +46,7 @@ public interface Cluster extends Closeable {
 
     @Nullable
     @VisibleForTesting(otherwise = PRIVATE)
-    ClusterableServer getServer(ServerAddress serverAddress, OperationContext operationContext);
+    ClusterableServer getServer(ServerAddress serverAddress, Timeout serverSelectionTimeout);
 
     /**
      * Get the current description of this cluster.

--- a/driver-core/src/main/com/mongodb/internal/connection/Cluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/Cluster.java
@@ -45,7 +45,7 @@ public interface Cluster extends Closeable {
 
     @Nullable
     @VisibleForTesting(otherwise = PRIVATE)
-    ClusterableServer getServer(ServerAddress serverAddress);
+    ClusterableServer getServer(ServerAddress serverAddress, OperationContext operationContext);
 
     /**
      * Get the current description of this cluster.

--- a/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedCluster.java
@@ -180,9 +180,9 @@ final class LoadBalancedCluster implements Cluster {
     }
 
     @Override
-    public ClusterableServer getServer(final ServerAddress serverAddress, final OperationContext operationContext) {
+    public ClusterableServer getServer(final ServerAddress serverAddress, final Timeout serverSelectionTimeout) {
         isTrue("open", !isClosed());
-        waitForSrv(operationContext);
+        waitForSrv(serverSelectionTimeout);
         return assertNotNull(server);
     }
 
@@ -201,29 +201,27 @@ final class LoadBalancedCluster implements Cluster {
     @Override
     public ServerTuple selectServer(final ServerSelector serverSelector, final OperationContext operationContext) {
         isTrue("open", !isClosed());
-        waitForSrv(operationContext);
+        Timeout serverSelectionTimeout = operationContext.getTimeoutContext().startServerSelectionTimeout();
+        waitForSrv(serverSelectionTimeout);
         if (srvRecordResolvedToMultipleHosts) {
             throw createResolvedToMultipleHostsException();
         }
         return new ServerTuple(assertNotNull(server), description.getServerDescriptions().get(0));
     }
 
-
-    private void waitForSrv(final OperationContext operationContext) {
+    private void waitForSrv(final Timeout serverSelectionTimeout) {
         if (initializationCompleted) {
             return;
         }
         Locks.withLock(lock, () -> {
-            StartTime startTime = StartTime.now();
-            Timeout timeout = operationContext.getTimeoutContext().startServerSelectionTimeout(startTime);
             while (!initializationCompleted) {
                 if (isClosed()) {
                     throw createShutdownException();
                 }
-                if (timeout.hasExpired()) {
-                    throw createTimeoutException(startTime);
+                if (serverSelectionTimeout.hasExpired()) {
+                    throw createTimeoutException();
                 }
-                timeout.awaitOn(condition, () -> format("resolving SRV records for %s", settings.getSrvHost()));
+                serverSelectionTimeout.awaitOn(condition, () -> format("resolving SRV records for %s", settings.getSrvHost()));
             }
         });
     }
@@ -235,7 +233,7 @@ final class LoadBalancedCluster implements Cluster {
             callback.onResult(null, createShutdownException());
             return;
         }
-        Timeout timeout = operationContext.getTimeoutContext().startServerSelectionTimeout(StartTime.now());
+        Timeout timeout = operationContext.getTimeoutContext().startServerSelectionTimeout();
         ServerSelectionRequest serverSelectionRequest = new ServerSelectionRequest(timeout, callback);
         if (initializationCompleted) {
             handleServerSelectionRequest(serverSelectionRequest);
@@ -295,15 +293,15 @@ final class LoadBalancedCluster implements Cluster {
                 + "to multiple hosts");
     }
 
-    private MongoTimeoutException createTimeoutException(final StartTime startTime) {
+    private MongoTimeoutException createTimeoutException() {
         MongoException localSrvResolutionException = srvResolutionException;
         if (localSrvResolutionException == null) {
-            return new MongoTimeoutException(format("Timed out after %d ms while waiting to resolve SRV records for %s.",
-                    startTime.elapsed().toMillis(), settings.getSrvHost()));
+            return new MongoTimeoutException(format("Timed out while waiting to resolve SRV records for %s.",
+                    settings.getSrvHost()));
         } else {
-            return new MongoTimeoutException(format("Timed out after %d ms while waiting to resolve SRV records for %s. "
+            return new MongoTimeoutException(format("Timed out while waiting to resolve SRV records for %s. "
                             + "Resolution exception was '%s'",
-                    startTime.elapsed().toMillis(), settings.getSrvHost(), localSrvResolutionException));
+                    settings.getSrvHost(), localSrvResolutionException));
         }
     }
 
@@ -332,7 +330,6 @@ final class LoadBalancedCluster implements Cluster {
 
     private final class WaitQueueHandler implements Runnable {
         public void run() {
-            StartTime startTime = StartTime.now();
             List<ServerSelectionRequest> timeoutList = new ArrayList<>();
             while (!(isClosed() || initializationCompleted)) {
                 lockInterruptibly(lock);
@@ -363,7 +360,7 @@ final class LoadBalancedCluster implements Cluster {
                 } finally {
                     lock.unlock();
                 }
-                timeoutList.forEach(request -> request.onError(createTimeoutException(startTime)));
+                timeoutList.forEach(request -> request.onError(createTimeoutException()));
                 timeoutList.clear();
             }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
@@ -69,7 +69,7 @@ public final class SingleServerCluster extends BaseCluster {
     }
 
     @Override
-    public ClusterableServer getServer(final ServerAddress serverAddress) {
+    public ClusterableServer getServer(final ServerAddress serverAddress, final OperationContext operationContext) {
         isTrue("open", !isClosed());
         return assertNotNull(server.get());
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
@@ -28,6 +28,7 @@ import com.mongodb.connection.ServerType;
 import com.mongodb.internal.diagnostics.logging.Logger;
 import com.mongodb.internal.diagnostics.logging.Loggers;
 import com.mongodb.event.ServerDescriptionChangedEvent;
+import com.mongodb.internal.time.Timeout;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -69,7 +70,7 @@ public final class SingleServerCluster extends BaseCluster {
     }
 
     @Override
-    public ClusterableServer getServer(final ServerAddress serverAddress, final OperationContext operationContext) {
+    public ClusterableServer getServer(final ServerAddress serverAddress, final Timeout serverSelectionTimeout) {
         isTrue("open", !isClosed());
         return assertNotNull(server.get());
     }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
@@ -103,10 +103,10 @@ public class SingleServerClusterTest {
     @Test
     public void shouldSuccessfullyQueryASecondaryWithPrimaryReadPreference() {
         // given
-        ServerAddress secondary = getSecondary();
+        OperationContext operationContext = OPERATION_CONTEXT;
+        ServerAddress secondary = getSecondary(operationContext);
         setUpCluster(secondary);
         String collectionName = getClass().getName();
-        OperationContext operationContext = OPERATION_CONTEXT;
         Connection connection = cluster.selectServer(new ServerAddressSelector(secondary), operationContext).getServer()
                 .getConnection(operationContext);
 

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
@@ -104,7 +104,7 @@ public class SingleServerClusterTest {
     public void shouldSuccessfullyQueryASecondaryWithPrimaryReadPreference() {
         // given
         OperationContext operationContext = OPERATION_CONTEXT;
-        ServerAddress secondary = getSecondary(operationContext);
+        ServerAddress secondary = getSecondary();
         setUpCluster(secondary);
         String collectionName = getClass().getName();
         Connection connection = cluster.selectServer(new ServerAddressSelector(secondary), operationContext).getServer()

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractServerDiscoveryAndMonitoringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractServerDiscoveryAndMonitoringTest.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
 import static com.mongodb.connection.ServerConnectionState.CONNECTING;
 import static com.mongodb.internal.connection.DescriptionHelper.createServerDescription;
 import static com.mongodb.internal.connection.ProtocolHelper.getCommandFailureException;
@@ -81,12 +82,12 @@ public class AbstractServerDiscoveryAndMonitoringTest {
     protected void applyApplicationError(final BsonDocument applicationError) {
         ServerAddress serverAddress = new ServerAddress(applicationError.getString("address").getValue());
         int errorGeneration = applicationError.getNumber("generation",
-                new BsonInt32(((DefaultServer) getCluster().getServer(serverAddress)).getConnectionPool().getGeneration())).intValue();
+                new BsonInt32(((DefaultServer) getCluster().getServer(serverAddress, OPERATION_CONTEXT)).getConnectionPool().getGeneration())).intValue();
         int maxWireVersion = applicationError.getNumber("maxWireVersion").intValue();
         String when = applicationError.getString("when").getValue();
         String type = applicationError.getString("type").getValue();
 
-        DefaultServer server = (DefaultServer) cluster.getServer(serverAddress);
+        DefaultServer server = (DefaultServer) cluster.getServer(serverAddress, OPERATION_CONTEXT);
         RuntimeException exception;
 
         switch (type) {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractServerDiscoveryAndMonitoringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractServerDiscoveryAndMonitoringTest.java
@@ -28,6 +28,7 @@ import com.mongodb.connection.ServerDescription;
 import com.mongodb.connection.ServerType;
 import com.mongodb.event.ClusterListener;
 import com.mongodb.internal.connection.SdamServerDescriptionManager.SdamIssue;
+import com.mongodb.internal.time.Timeout;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
@@ -80,14 +81,15 @@ public class AbstractServerDiscoveryAndMonitoringTest {
     }
 
     protected void applyApplicationError(final BsonDocument applicationError) {
+        Timeout serverSelectionTimeout = OPERATION_CONTEXT.getTimeoutContext().startServerSelectionTimeout();
         ServerAddress serverAddress = new ServerAddress(applicationError.getString("address").getValue());
         int errorGeneration = applicationError.getNumber("generation",
-                new BsonInt32(((DefaultServer) getCluster().getServer(serverAddress, OPERATION_CONTEXT)).getConnectionPool().getGeneration())).intValue();
+                new BsonInt32(((DefaultServer) getCluster().getServer(serverAddress, serverSelectionTimeout)).getConnectionPool().getGeneration())).intValue();
         int maxWireVersion = applicationError.getNumber("maxWireVersion").intValue();
         String when = applicationError.getString("when").getValue();
         String type = applicationError.getString("type").getValue();
 
-        DefaultServer server = (DefaultServer) cluster.getServer(serverAddress, OPERATION_CONTEXT);
+        DefaultServer server = (DefaultServer) cluster.getServer(serverAddress, serverSelectionTimeout);
         RuntimeException exception;
 
         switch (type) {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterSpecification.groovy
@@ -68,7 +68,7 @@ class BaseClusterSpecification extends Specification {
             }
 
             @Override
-            ClusterableServer getServer(final ServerAddress serverAddress) {
+            ClusterableServer getServer(final ServerAddress serverAddress, OperationContext operationContext) {
                 throw new UnsupportedOperationException()
             }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterSpecification.groovy
@@ -188,11 +188,11 @@ class BaseClusterSpecification extends Specification {
                                                                .exception(new MongoInternalException('oops'))
                                                                .build())
 
-        cluster.selectServer(new WritableServerSelector(), new OperationContext())
+        cluster.selectServer(new WritableServerSelector(), OPERATION_CONTEXT)
 
         then:
         def e = thrown(MongoTimeoutException)
-        e.getMessage().startsWith("Timed out after ${serverSelectionTimeoutMS} ms while waiting for a server " +
+        e.getMessage().contains("ms while waiting for a server " +
                 'that matches WritableServerSelector. Client view of cluster state is {type=UNKNOWN')
         e.getMessage().contains('{address=localhost:27017, type=UNKNOWN, state=CONNECTING, ' +
                 'exception={com.mongodb.MongoInternalException: oops}}')

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterSpecification.groovy
@@ -34,6 +34,7 @@ import com.mongodb.event.ServerDescriptionChangedEvent
 import com.mongodb.internal.selector.ReadPreferenceServerSelector
 import com.mongodb.internal.selector.ServerAddressSelector
 import com.mongodb.internal.selector.WritableServerSelector
+import com.mongodb.internal.time.Timeout
 import spock.lang.Specification
 import util.spock.annotations.Slow
 
@@ -68,7 +69,7 @@ class BaseClusterSpecification extends Specification {
             }
 
             @Override
-            ClusterableServer getServer(final ServerAddress serverAddress, OperationContext operationContext) {
+            ClusterableServer getServer(final ServerAddress serverAddress, Timeout serverSelectionTimeout) {
                 throw new UnsupportedOperationException()
             }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
@@ -392,7 +392,7 @@ class DefaultServerSpecification extends Specification {
             }
 
             @Override
-            ClusterableServer getServer(final ServerAddress serverAddress) {
+            ClusterableServer getServer(final ServerAddress serverAddress, OperationContext operationContext) {
                 throw new UnsupportedOperationException()
             }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
@@ -39,6 +39,7 @@ import com.mongodb.event.ServerListener
 import com.mongodb.internal.async.SingleResultCallback
 import com.mongodb.internal.inject.SameObjectProvider
 import com.mongodb.internal.session.SessionContext
+import com.mongodb.internal.time.Timeout
 import com.mongodb.internal.validator.NoOpFieldNameValidator
 import org.bson.BsonDocument
 import org.bson.BsonInt32
@@ -392,7 +393,7 @@ class DefaultServerSpecification extends Specification {
             }
 
             @Override
-            ClusterableServer getServer(final ServerAddress serverAddress, OperationContext operationContext) {
+            ClusterableServer getServer(final ServerAddress serverAddress, Timeout serverSelectionTimeout) {
                 throw new UnsupportedOperationException()
             }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DnsMultiServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DnsMultiServerClusterSpecification.groovy
@@ -25,7 +25,6 @@ import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
 import static com.mongodb.connection.ClusterType.SHARDED
 import static com.mongodb.connection.ServerType.SHARD_ROUTER

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DnsMultiServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DnsMultiServerClusterSpecification.groovy
@@ -25,6 +25,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
 
+import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
 import static com.mongodb.connection.ClusterType.SHARDED
 import static com.mongodb.connection.ServerType.SHARD_ROUTER

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoadBalancedClusterTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoadBalancedClusterTest.java
@@ -234,7 +234,7 @@ public class LoadBalancedClusterTest {
 
         MongoTimeoutException exception = assertThrows(MongoTimeoutException.class, () -> cluster.selectServer(mock(ServerSelector.class),
                 OPERATION_CONTEXT));
-        assertEquals("Timed out after 5 ms while waiting to resolve SRV records for foo.bar.com.", exception.getMessage());
+        assertTrue(exception.getMessage().contains("ms while waiting to resolve SRV records for foo.bar.com"));
     }
 
     @Test
@@ -261,9 +261,9 @@ public class LoadBalancedClusterTest {
 
         MongoTimeoutException exception = assertThrows(MongoTimeoutException.class, () -> cluster.selectServer(mock(ServerSelector.class),
                 OPERATION_CONTEXT));
-        assertEquals("Timed out after 10 ms while waiting to resolve SRV records for foo.bar.com. "
-                        + "Resolution exception was 'com.mongodb.MongoConfigurationException: Unable to resolve SRV record'",
-                exception.getMessage());
+
+        assertTrue(exception.getMessage().contains("ms while waiting to resolve SRV records for foo.bar.com"));
+        assertTrue(exception.getMessage().contains("Resolution exception was 'com.mongodb.MongoConfigurationException: Unable to resolve SRV record'"));
     }
 
     @Test
@@ -292,7 +292,7 @@ public class LoadBalancedClusterTest {
         cluster.selectServerAsync(mock(ServerSelector.class), OPERATION_CONTEXT, callback);
 
         MongoTimeoutException exception = assertThrows(MongoTimeoutException.class, callback::get);
-        assertEquals("Timed out after 5 ms while waiting to resolve SRV records for foo.bar.com.", exception.getMessage());
+        assertTrue(exception.getMessage().contains("ms while waiting to resolve SRV records for foo.bar.com"));
     }
 
     @Test
@@ -321,9 +321,8 @@ public class LoadBalancedClusterTest {
         cluster.selectServerAsync(mock(ServerSelector.class), OPERATION_CONTEXT, callback);
 
         MongoTimeoutException exception = assertThrows(MongoTimeoutException.class, callback::get);
-        assertEquals("Timed out after 10 ms while waiting to resolve SRV records for foo.bar.com. "
-                        + "Resolution exception was 'com.mongodb.MongoConfigurationException: Unable to resolve SRV record'",
-                exception.getMessage());
+        assertTrue(exception.getMessage().contains("ms while waiting to resolve SRV records for foo.bar.com"));
+        assertTrue(exception.getMessage().contains("Resolution exception was 'com.mongodb.MongoConfigurationException: Unable to resolve SRV record'"));
     }
 
     @Test

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoadBalancedClusterTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoadBalancedClusterTest.java
@@ -234,7 +234,7 @@ public class LoadBalancedClusterTest {
 
         MongoTimeoutException exception = assertThrows(MongoTimeoutException.class, () -> cluster.selectServer(mock(ServerSelector.class),
                 OPERATION_CONTEXT));
-        assertTrue(exception.getMessage().contains("ms while waiting to resolve SRV records for foo.bar.com"));
+        assertTrue(exception.getMessage().contains("while waiting to resolve SRV records for foo.bar.com"));
     }
 
     @Test
@@ -262,7 +262,7 @@ public class LoadBalancedClusterTest {
         MongoTimeoutException exception = assertThrows(MongoTimeoutException.class, () -> cluster.selectServer(mock(ServerSelector.class),
                 OPERATION_CONTEXT));
 
-        assertTrue(exception.getMessage().contains("ms while waiting to resolve SRV records for foo.bar.com"));
+        assertTrue(exception.getMessage().contains("while waiting to resolve SRV records for foo.bar.com"));
         assertTrue(exception.getMessage().contains("Resolution exception was 'com.mongodb.MongoConfigurationException: Unable to resolve SRV record'"));
     }
 
@@ -292,7 +292,7 @@ public class LoadBalancedClusterTest {
         cluster.selectServerAsync(mock(ServerSelector.class), OPERATION_CONTEXT, callback);
 
         MongoTimeoutException exception = assertThrows(MongoTimeoutException.class, callback::get);
-        assertTrue(exception.getMessage().contains("ms while waiting to resolve SRV records for foo.bar.com"));
+        assertTrue(exception.getMessage().contains("while waiting to resolve SRV records for foo.bar.com"));
     }
 
     @Test
@@ -321,7 +321,7 @@ public class LoadBalancedClusterTest {
         cluster.selectServerAsync(mock(ServerSelector.class), OPERATION_CONTEXT, callback);
 
         MongoTimeoutException exception = assertThrows(MongoTimeoutException.class, callback::get);
-        assertTrue(exception.getMessage().contains("ms while waiting to resolve SRV records for foo.bar.com"));
+        assertTrue(exception.getMessage().contains("while waiting to resolve SRV records for foo.bar.com"));
         assertTrue(exception.getMessage().contains("Resolution exception was 'com.mongodb.MongoConfigurationException: Unable to resolve SRV record'"));
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/MultiServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/MultiServerClusterSpecification.groovy
@@ -95,7 +95,7 @@ class MultiServerClusterSpecification extends Specification {
         cluster.close()
 
         when:
-        cluster.getServer(firstServer, OPERATION_CONTEXT)
+        cluster.getServer(firstServer, OPERATION_CONTEXT.getTimeoutContext().startServerSelectionTimeout())
 
         then:
         thrown(IllegalStateException)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/MultiServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/MultiServerClusterSpecification.groovy
@@ -95,7 +95,7 @@ class MultiServerClusterSpecification extends Specification {
         cluster.close()
 
         when:
-        cluster.getServer(firstServer)
+        cluster.getServer(firstServer, OPERATION_CONTEXT)
 
         then:
         thrown(IllegalStateException)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringTest.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
+import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
 import static com.mongodb.ClusterFixture.getClusterDescription;
 import static com.mongodb.internal.connection.ClusterDescriptionHelper.getPrimaries;
 import static com.mongodb.internal.event.EventListenerHelper.NO_OP_CLUSTER_LISTENER;
@@ -120,7 +121,7 @@ public class ServerDiscoveryAndMonitoringTest extends AbstractServerDiscoveryAnd
 
         if (expectedServerDescriptionDocument.isDocument("pool")) {
             int expectedGeneration = expectedServerDescriptionDocument.getDocument("pool").getNumber("generation").intValue();
-            DefaultServer server = (DefaultServer) getCluster().getServer(new ServerAddress(serverName));
+            DefaultServer server = (DefaultServer) getCluster().getServer(new ServerAddress(serverName), OPERATION_CONTEXT);
             assertEquals(expectedGeneration, server.getConnectionPool().getGeneration());
         }
     }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringTest.java
@@ -19,6 +19,7 @@ package com.mongodb.internal.connection;
 import com.mongodb.ServerAddress;
 import com.mongodb.connection.ClusterType;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.internal.time.Timeout;
 import org.bson.BsonDocument;
 import org.bson.BsonNull;
 import org.bson.BsonValue;
@@ -121,7 +122,8 @@ public class ServerDiscoveryAndMonitoringTest extends AbstractServerDiscoveryAnd
 
         if (expectedServerDescriptionDocument.isDocument("pool")) {
             int expectedGeneration = expectedServerDescriptionDocument.getDocument("pool").getNumber("generation").intValue();
-            DefaultServer server = (DefaultServer) getCluster().getServer(new ServerAddress(serverName), OPERATION_CONTEXT);
+            Timeout serverSelectionTimeout = OPERATION_CONTEXT.getTimeoutContext().startServerSelectionTimeout();
+            DefaultServer server = (DefaultServer) getCluster().getServer(new ServerAddress(serverName), serverSelectionTimeout);
             assertEquals(expectedGeneration, server.getConnectionPool().getGeneration());
         }
     }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/SingleServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/SingleServerClusterSpecification.groovy
@@ -77,7 +77,7 @@ class SingleServerClusterSpecification extends Specification {
         sendNotification(firstServer, STANDALONE)
 
         then:
-        cluster.getServer(firstServer) == factory.getServer(firstServer)
+        cluster.getServer(firstServer, OPERATION_CONTEXT) == factory.getServer(firstServer)
 
         cleanup:
         cluster?.close()
@@ -91,7 +91,7 @@ class SingleServerClusterSpecification extends Specification {
         cluster.close()
 
         when:
-        cluster.getServer(firstServer)
+        cluster.getServer(firstServer, OPERATION_CONTEXT)
 
         then:
         thrown(IllegalStateException)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/SingleServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/SingleServerClusterSpecification.groovy
@@ -77,7 +77,8 @@ class SingleServerClusterSpecification extends Specification {
         sendNotification(firstServer, STANDALONE)
 
         then:
-        cluster.getServer(firstServer, OPERATION_CONTEXT) == factory.getServer(firstServer)
+        cluster.getServer(firstServer,
+                OPERATION_CONTEXT.getTimeoutContext().startServerSelectionTimeout()) == factory.getServer(firstServer)
 
         cleanup:
         cluster?.close()
@@ -91,7 +92,7 @@ class SingleServerClusterSpecification extends Specification {
         cluster.close()
 
         when:
-        cluster.getServer(firstServer, OPERATION_CONTEXT)
+        cluster.getServer(firstServer, OPERATION_CONTEXT.getTimeoutContext().startServerSelectionTimeout())
 
         then:
         thrown(IllegalStateException)


### PR DESCRIPTION
JAVA-5184

Refactoring in advance of [JAVA-4065](https://jira.mongodb.org/browse/JAVA-4065).

In [JAVA-5175](https://jira.mongodb.org/browse/JAVA-5175), we used a timeout, but obtained from the existing settings. Here, we obtain that timeout from the OperationContext added in [JAVA-5170](https://jira.mongodb.org/browse/JAVA-5170).

Also fixes flaky tests.