### PR TITLE
fix: include Kotlin sources into the sources jar

### DIFF
--- a/bson-kotlin/build.gradle.kts
+++ b/bson-kotlin/build.gradle.kts
@@ -143,3 +143,10 @@ tasks.javadocJar.configure {
     archiveClassifier.set("javadoc")
     from(dokkaOutputDir)
 }
+
+// ===========================
+//     Sources publishing configuration
+// ===========================
+tasks.sourcesJar {
+    from(project.sourceSets.main.map { it.kotlin })
+}

--- a/bson-kotlinx/build.gradle.kts
+++ b/bson-kotlinx/build.gradle.kts
@@ -147,3 +147,10 @@ tasks.javadocJar.configure {
     archiveClassifier.set("javadoc")
     from(dokkaOutputDir)
 }
+
+// ===========================
+//     Sources publishing configuration
+// ===========================
+tasks.sourcesJar {
+    from(project.sourceSets.main.map { it.kotlin })
+}

--- a/driver-kotlin-coroutine/build.gradle.kts
+++ b/driver-kotlin-coroutine/build.gradle.kts
@@ -188,3 +188,10 @@ tasks.javadocJar.configure {
     archiveClassifier.set("javadoc")
     from(dokkaOutputDir)
 }
+
+// ===========================
+//     Sources publishing configuration
+// ===========================
+tasks.sourcesJar {
+    from(project.sourceSets.main.map { it.kotlin })
+}

--- a/driver-kotlin-sync/build.gradle.kts
+++ b/driver-kotlin-sync/build.gradle.kts
@@ -183,3 +183,10 @@ tasks.javadocJar.configure {
     archiveClassifier.set("javadoc")
     from(dokkaOutputDir)
 }
+
+// ===========================
+//     Sources publishing configuration
+// ===========================
+tasks.sourcesJar {
+    from(project.sourceSets.main.map { it.kotlin })
+}


### PR DESCRIPTION
Configures `sourcesJar` task for Kotlin projects to actually include Kotlin sources, otherwise jar files are empty.

See [mongodb-driver-kotlin-sync-4.10.2-sources.jar](https://repo1.maven.org/maven2/org/mongodb/mongodb-driver-kotlin-sync/4.10.2/mongodb-driver-kotlin-sync-4.10.2-sources.jar) for example.

Also see this for context: https://youtrack.jetbrains.com/issue/KT-54207