### PR TITLE
Refactor transaction server pinning

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/Cluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/Cluster.java
@@ -40,15 +40,6 @@ public interface Cluster extends Closeable {
 
     ClusterSettings getSettings();
 
-    /**
-     * Get the description of this cluster.  This method will not return normally until the cluster type is known.
-     *
-     * @return a ClusterDescription representing the current state of the cluster
-     * @throws com.mongodb.MongoTimeoutException if the timeout has been reached before the cluster type is known
-     * @throws com.mongodb.MongoInterruptedException if interrupted when getting the cluster description
-     */
-    ClusterDescription getDescription();
-
 
     ClusterId getClusterId();
 

--- a/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedCluster.java
@@ -175,13 +175,6 @@ final class LoadBalancedCluster implements Cluster {
     }
 
     @Override
-    public ClusterDescription getDescription() {
-        isTrue("open", !isClosed());
-        waitForSrv();
-        return description;
-    }
-
-    @Override
     public ClusterId getClusterId() {
         return clusterId;
     }

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -19,6 +19,7 @@ package com.mongodb;
 import com.mongodb.async.FutureResultCallback;
 import com.mongodb.connection.AsynchronousSocketChannelStreamFactory;
 import com.mongodb.connection.ClusterConnectionMode;
+import com.mongodb.connection.ClusterDescription;
 import com.mongodb.connection.ClusterSettings;
 import com.mongodb.connection.ClusterType;
 import com.mongodb.connection.ConnectionPoolSettings;
@@ -85,6 +86,7 @@ import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE;
 import static com.mongodb.connection.ClusterType.REPLICA_SET;
 import static com.mongodb.connection.ClusterType.SHARDED;
 import static com.mongodb.connection.ClusterType.STANDALONE;
+import static com.mongodb.connection.ClusterType.UNKNOWN;
 import static com.mongodb.internal.connection.ClusterDescriptionHelper.getPrimaries;
 import static com.mongodb.internal.connection.ClusterDescriptionHelper.getSecondaries;
 import static com.mongodb.internal.thread.InterruptionUtil.interruptAndCreateMongoInterruptedException;
@@ -140,7 +142,20 @@ public final class ClusterFixture {
     }
 
     public static boolean clusterIsType(final ClusterType clusterType) {
-        return getCluster().getDescription().getType() == clusterType;
+        return getClusterDescription(getCluster()).getType() == clusterType;
+    }
+
+    public static ClusterDescription getClusterDescription(final Cluster cluster) {
+        try {
+            ClusterDescription clusterDescription = cluster.getCurrentDescription();
+            while (clusterDescription.getType() == UNKNOWN) {
+                Thread.sleep(10);
+                clusterDescription = cluster.getCurrentDescription();
+            }
+            return clusterDescription;
+        } catch (InterruptedException e) {
+            throw interruptAndCreateMongoInterruptedException("Interrupted", e);
+        }
     }
 
     public static ServerVersion getServerVersion() {
@@ -449,27 +464,27 @@ public final class ClusterFixture {
     }
 
     public static ServerAddress getPrimary() {
-        List<ServerDescription> serverDescriptions = getPrimaries(getCluster().getDescription());
+        List<ServerDescription> serverDescriptions = getPrimaries(getClusterDescription(getCluster()));
         while (serverDescriptions.isEmpty()) {
             try {
                 sleep(100);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            serverDescriptions = getPrimaries(getCluster().getDescription());
+            serverDescriptions = getPrimaries(getClusterDescription(getCluster()));
         }
         return serverDescriptions.get(0).getAddress();
     }
 
     public static ServerAddress getSecondary() {
-        List<ServerDescription> serverDescriptions = getSecondaries(getCluster().getDescription());
+        List<ServerDescription> serverDescriptions = getSecondaries(getClusterDescription(getCluster()));
         while (serverDescriptions.isEmpty()) {
             try {
                 sleep(100);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            serverDescriptions = getSecondaries(getCluster().getDescription());
+            serverDescriptions = getSecondaries(getClusterDescription(getCluster()));
         }
         return serverDescriptions.get(0).getAddress();
     }
@@ -499,16 +514,16 @@ public final class ClusterFixture {
     }
 
     public static boolean isDiscoverableReplicaSet() {
-        return getCluster().getDescription().getType() == REPLICA_SET
-                && getCluster().getDescription().getConnectionMode() == MULTIPLE;
+        return getClusterDescription(getCluster()).getType() == REPLICA_SET
+                && getClusterDescription(getCluster()).getConnectionMode() == MULTIPLE;
     }
 
     public static boolean isSharded() {
-        return getCluster().getDescription().getType() == SHARDED;
+        return getClusterDescription(getCluster()).getType() == SHARDED;
     }
 
     public static boolean isStandalone() {
-        return getCluster().getDescription().getType() == STANDALONE;
+        return getClusterDescription(getCluster()).getType() == STANDALONE;
     }
 
     public static boolean isLoadBalanced() {

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
@@ -80,22 +80,13 @@ public class SingleServerClusterTest {
     }
 
     @Test
-    public void shouldGetDescription() {
-        // given
-        setUpCluster(getPrimary());
-
-        // expect
-        assertNotNull(cluster.getDescription());
-    }
-
-    @Test
     public void descriptionShouldIncludeSettings() {
         // given
         setUpCluster(getPrimary());
 
         // expect
-        assertNotNull(cluster.getDescription().getClusterSettings());
-        assertNotNull(cluster.getDescription().getServerSettings());
+        assertNotNull(cluster.getCurrentDescription().getClusterSettings());
+        assertNotNull(cluster.getCurrentDescription().getServerSettings());
     }
 
     @Test

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterSpecification.groovy
@@ -80,12 +80,6 @@ class BaseClusterSpecification extends Specification {
         cluster.getCurrentDescription() == new ClusterDescription(clusterSettings.getMode(), ClusterType.UNKNOWN, [], clusterSettings,
                 factory.getSettings())
 
-        when: 'the description is accessed before initialization'
-        cluster.getDescription()
-
-        then: 'a MongoTimeoutException is thrown'
-        thrown(MongoTimeoutException)
-
         when: 'a server is selected before initialization'
         cluster.selectServer({ def clusterDescription -> [] }, new OperationContext())
 
@@ -193,21 +187,10 @@ class BaseClusterSpecification extends Specification {
                                                                .exception(new MongoInternalException('oops'))
                                                                .build())
 
-        cluster.getDescription()
-
-        then:
-        def e = thrown(MongoTimeoutException)
-        e.getMessage().startsWith("Timed out after ${serverSelectionTimeoutMS} ms while waiting to connect. " +
-                'Client view of cluster state is {type=UNKNOWN')
-        e.getMessage().contains('{address=localhost:27017, type=UNKNOWN, state=CONNECTING, ' +
-                'exception={com.mongodb.MongoInternalException: oops}}')
-        e.getMessage().contains('{address=localhost:27018, type=UNKNOWN, state=CONNECTING}')
-
-        when:
         cluster.selectServer(new WritableServerSelector(), new OperationContext())
 
         then:
-        e = thrown(MongoTimeoutException)
+        def e = thrown(MongoTimeoutException)
         e.getMessage().startsWith("Timed out after ${serverSelectionTimeoutMS} ms while waiting for a server " +
                 'that matches WritableServerSelector. Client view of cluster state is {type=UNKNOWN')
         e.getMessage().contains('{address=localhost:27017, type=UNKNOWN, state=CONNECTING, ' +
@@ -256,37 +239,6 @@ class BaseClusterSpecification extends Specification {
         def thread = new Thread({
             try {
                 cluster.selectServer(new ReadPreferenceServerSelector(ReadPreference.primary()), new OperationContext())
-            } catch (MongoInterruptedException e) {
-                latch.countDown()
-            }
-        })
-        thread.start()
-        sleep(1000)
-        thread.interrupt()
-        def interrupted = latch.await(ClusterFixture.TIMEOUT, SECONDS)
-
-        then:
-        interrupted
-
-        cleanup:
-        cluster?.close()
-    }
-
-    @Slow
-    def 'should wait indefinitely for a cluster description until interrupted'() {
-        given:
-        def cluster = new MultiServerCluster(new ClusterId(),
-                builder().mode(MULTIPLE)
-                        .hosts([firstServer, secondServer, thirdServer])
-                        .serverSelectionTimeout(-1, SECONDS)
-                        .build(),
-                factory)
-
-        when:
-        def latch = new CountDownLatch(1)
-        def thread = new Thread({
-            try {
-                cluster.getDescription()
             } catch (MongoInterruptedException e) {
                 latch.countDown()
             }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DnsMultiServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DnsMultiServerClusterSpecification.groovy
@@ -98,7 +98,7 @@ class DnsMultiServerClusterSpecification extends Specification {
         factory.sendNotification(secondServer, SHARD_ROUTER)
         def firstTestServer = factory.getServer(firstServer)
         def secondTestServer = factory.getServer(secondServer)
-        def clusterDescription = cluster.getDescription()
+        def clusterDescription = cluster.getCurrentDescription()
 
         then: 'events are generated, description includes hosts, exception is cleared, and servers are open'
         2 * clusterListener.clusterDescriptionChanged(_)
@@ -112,7 +112,7 @@ class DnsMultiServerClusterSpecification extends Specification {
         initializer.initialize([secondServer, thirdServer])
         factory.sendNotification(secondServer, SHARD_ROUTER)
         def thirdTestServer = factory.getServer(thirdServer)
-        clusterDescription = cluster.getDescription()
+        clusterDescription = cluster.getCurrentDescription()
 
         then: 'events are generated, description is updated, and the removed server is closed'
         1 * clusterListener.clusterDescriptionChanged(_)
@@ -125,7 +125,7 @@ class DnsMultiServerClusterSpecification extends Specification {
 
         when: 'the listener is initialized with another exception'
         initializer.initialize(exception)
-        clusterDescription = cluster.getDescription()
+        clusterDescription = cluster.getCurrentDescription()
 
         then: 'the exception is ignored'
         0 * clusterListener.clusterDescriptionChanged(_)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringTest.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
+import static com.mongodb.ClusterFixture.getClusterDescription;
 import static com.mongodb.internal.connection.ClusterDescriptionHelper.getPrimaries;
 import static com.mongodb.internal.event.EventListenerHelper.NO_OP_CLUSTER_LISTENER;
 import static com.mongodb.internal.event.EventListenerHelper.NO_OP_SERVER_LISTENER;
@@ -140,7 +141,7 @@ public class ServerDiscoveryAndMonitoringTest extends AbstractServerDiscoveryAnd
             case "Single":
                 assertTrue(getCluster().getClass() == SingleServerCluster.class
                         || (getCluster().getClass() == MultiServerCluster.class
-                            && getCluster().getDescription().getType() == ClusterType.STANDALONE));
+                            && getClusterDescription(getCluster()).getType() == ClusterType.STANDALONE));
                 assertEquals(getClusterType(topologyType, getCluster().getCurrentDescription().getServerDescriptions()),
                         getCluster().getCurrentDescription().getType());
                 break;

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/SingleServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/SingleServerClusterSpecification.groovy
@@ -59,9 +59,9 @@ class SingleServerClusterSpecification extends Specification {
         sendNotification(firstServer, STANDALONE)
 
         then:
-        cluster.getDescription().type == ClusterType.STANDALONE
-        cluster.getDescription().connectionMode == SINGLE
-        ClusterDescriptionHelper.getAll(cluster.getDescription()) == getDescriptions()
+        cluster.getCurrentDescription().type == ClusterType.STANDALONE
+        cluster.getCurrentDescription().connectionMode == SINGLE
+        ClusterDescriptionHelper.getAll(cluster.getCurrentDescription()) == getDescriptions()
 
         cleanup:
         cluster?.close()
@@ -109,8 +109,8 @@ class SingleServerClusterSpecification extends Specification {
         sendNotification(firstServer, ServerType.REPLICA_SET_PRIMARY)
 
         then:
-        cluster.getDescription().type == ClusterType.SHARDED
-        ClusterDescriptionHelper.getAll(cluster.getDescription()) == [] as Set
+        cluster.getCurrentDescription().type == ClusterType.SHARDED
+        ClusterDescriptionHelper.getAll(cluster.getCurrentDescription()) == [] as Set
 
         cleanup:
         cluster?.close()
@@ -126,8 +126,8 @@ class SingleServerClusterSpecification extends Specification {
         sendNotification(firstServer, ServerType.REPLICA_SET_PRIMARY, 'test1')
 
         then:
-        cluster.getDescription().type == REPLICA_SET
-        ClusterDescriptionHelper.getAll(cluster.getDescription()) == getDescriptions()
+        cluster.getCurrentDescription().type == REPLICA_SET
+        ClusterDescriptionHelper.getAll(cluster.getCurrentDescription()) == getDescriptions()
 
         cleanup:
         cluster?.close()

--- a/driver-legacy/src/test/functional/com/mongodb/Fixture.java
+++ b/driver-legacy/src/test/functional/com/mongodb/Fixture.java
@@ -21,6 +21,7 @@ import org.bson.UuidRepresentation;
 
 import java.util.List;
 
+import static com.mongodb.ClusterFixture.getClusterDescription;
 import static com.mongodb.ClusterFixture.getServerApi;
 import static com.mongodb.internal.connection.ClusterDescriptionHelper.getPrimaries;
 
@@ -97,10 +98,10 @@ public final class Fixture {
 
     public static ServerAddress getPrimary() throws InterruptedException {
         getMongoClient();
-        List<ServerDescription> serverDescriptions = getPrimaries(mongoClient.getCluster().getDescription());
+        List<ServerDescription> serverDescriptions = getPrimaries(getClusterDescription(mongoClient.getCluster()));
         while (serverDescriptions.isEmpty()) {
             Thread.sleep(100);
-            serverDescriptions = getPrimaries(mongoClient.getCluster().getDescription());
+            serverDescriptions = getPrimaries(getClusterDescription(mongoClient.getCluster()));
         }
         return serverDescriptions.get(0).getAddress();
     }

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ClientSessionBindingSpecification.groovy
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ClientSessionBindingSpecification.groovy
@@ -20,9 +20,6 @@ import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
 import com.mongodb.ServerAddress
 import com.mongodb.async.FutureResultCallback
-import com.mongodb.connection.ClusterConnectionMode
-import com.mongodb.connection.ClusterDescription
-import com.mongodb.connection.ClusterType
 import com.mongodb.connection.ServerConnectionState
 import com.mongodb.connection.ServerDescription
 import com.mongodb.connection.ServerType
@@ -54,15 +51,7 @@ class ClientSessionBindingSpecification extends Specification {
     def 'should return the session context from the connection source'() {
         given:
         def session = Stub(ClientSession)
-        def wrappedBinding = Mock(AsyncClusterAwareReadWriteBinding) {
-            getCluster() >> {
-                Mock(Cluster) {
-                    getDescription() >> {
-                        new ClusterDescription(ClusterConnectionMode.MULTIPLE, ClusterType.REPLICA_SET, [])
-                    }
-                }
-            }
-        }
+        def wrappedBinding = Mock(AsyncClusterAwareReadWriteBinding)
         wrappedBinding.retain() >> wrappedBinding
         def binding = new ClientSessionBinding(session, false, wrappedBinding)
 
@@ -191,9 +180,6 @@ class ClientSessionBindingSpecification extends Specification {
                         .state(ServerConnectionState.CONNECTED)
                         .address(new ServerAddress())
                         .build()), null)
-            }
-            getDescription() >> {
-                new ClusterDescription(ClusterConnectionMode.MULTIPLE, ClusterType.REPLICA_SET, [])
             }
         }
         new AsyncClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, null, IgnorableRequestContext.INSTANCE)

--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionBinding.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionBinding.java
@@ -34,7 +34,10 @@ import com.mongodb.internal.session.ClientSessionContext;
 import com.mongodb.internal.session.SessionContext;
 import com.mongodb.lang.Nullable;
 
+import java.util.function.Supplier;
+
 import static com.mongodb.connection.ClusterType.LOAD_BALANCED;
+import static com.mongodb.connection.ClusterType.SHARDED;
 import static org.bson.assertions.Assertions.assertNotNull;
 import static org.bson.assertions.Assertions.notNull;
 
@@ -86,28 +89,17 @@ public class ClientSessionBinding extends AbstractReferenceCounted implements Re
 
     @Override
     public ConnectionSource getReadConnectionSource() {
-        if (isConnectionSourcePinningRequired()) {
-            return new SessionBindingConnectionSource(getPinnedConnectionSource(true));
-        } else {
-            return new SessionBindingConnectionSource(wrapped.getReadConnectionSource());
-        }
+        return new SessionBindingConnectionSource(getConnectionSource(wrapped::getReadConnectionSource));
     }
 
     @Override
     public ConnectionSource getReadConnectionSource(final int minWireVersion, final ReadPreference fallbackReadPreference) {
-        if (isConnectionSourcePinningRequired()) {
-            return new SessionBindingConnectionSource(getPinnedConnectionSource(true));
-        } else {
-            return new SessionBindingConnectionSource(wrapped.getReadConnectionSource(minWireVersion, fallbackReadPreference));
-        }
+        return new SessionBindingConnectionSource(getConnectionSource(() ->
+                wrapped.getReadConnectionSource(minWireVersion, fallbackReadPreference)));
     }
 
     public ConnectionSource getWriteConnectionSource() {
-        if (isConnectionSourcePinningRequired()) {
-            return new SessionBindingConnectionSource(getPinnedConnectionSource(false));
-        } else {
-            return new SessionBindingConnectionSource(wrapped.getWriteConnectionSource());
-        }
+        return new SessionBindingConnectionSource(getConnectionSource(wrapped::getWriteConnectionSource));
     }
 
     @Override
@@ -131,23 +123,23 @@ public class ClientSessionBinding extends AbstractReferenceCounted implements Re
         return wrapped.getOperationContext();
     }
 
-    private boolean isConnectionSourcePinningRequired() {
-        ClusterType clusterType = wrapped.getCluster().getDescription().getType();
-        return session.hasActiveTransaction() && (clusterType == ClusterType.SHARDED || clusterType == LOAD_BALANCED);
-    }
-
-    private ConnectionSource getPinnedConnectionSource(final boolean isRead) {
-        TransactionContext<Connection> transactionContext = TransactionContext.get(session);
-        ConnectionSource source;
-        if (transactionContext == null) {
-            source = isRead ? wrapped.getReadConnectionSource() : wrapped.getWriteConnectionSource();
-            transactionContext = new TransactionContext<>(wrapped.getCluster().getDescription().getType());
-            session.setTransactionContext(source.getServerDescription().getAddress(), transactionContext);
-            transactionContext.release();  // The session is responsible for retaining a reference to the context
-        } else {
-            source = wrapped.getConnectionSource(assertNotNull(session.getPinnedServerAddress()));
+    private ConnectionSource getConnectionSource(final Supplier<ConnectionSource> wrappedConnectionSourceSupplier) {
+        if (!session.hasActiveTransaction()) {
+            return wrappedConnectionSourceSupplier.get();
         }
-        return source;
+
+        if (TransactionContext.get(session) == null) {
+            ConnectionSource source = wrappedConnectionSourceSupplier.get();
+            ClusterType clusterType = source.getServerDescription().getClusterType();
+            if (clusterType == SHARDED || clusterType == LOAD_BALANCED) {
+                TransactionContext<Connection> transactionContext = new TransactionContext<>(clusterType);
+                session.setTransactionContext(source.getServerDescription().getAddress(), transactionContext);
+                transactionContext.release();  // The session is responsible for retaining a reference to the context
+            }
+            return source;
+        } else {
+            return wrapped.getConnectionSource(assertNotNull(session.getPinnedServerAddress()));
+        }
     }
 
     private class SessionBindingConnectionSource implements ConnectionSource {

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ClientSessionBindingSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ClientSessionBindingSpecification.groovy
@@ -19,9 +19,6 @@ package com.mongodb.client.internal
 import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
 import com.mongodb.client.ClientSession
-import com.mongodb.connection.ClusterConnectionMode
-import com.mongodb.connection.ClusterDescription
-import com.mongodb.connection.ClusterType
 import com.mongodb.internal.IgnorableRequestContext
 import com.mongodb.internal.binding.ClusterBinding
 import com.mongodb.internal.binding.ConnectionSource
@@ -47,15 +44,7 @@ class ClientSessionBindingSpecification extends Specification {
     def 'should return the session context from the connection source'() {
         given:
         def session = Stub(ClientSession)
-        def wrappedBinding = Mock(ClusterBinding) {
-            getCluster() >> {
-                Mock(Cluster) {
-                    getDescription() >> {
-                        new ClusterDescription(ClusterConnectionMode.SINGLE, ClusterType.STANDALONE, [])
-                    }
-                }
-            }
-        }
+        def wrappedBinding = Mock(ClusterBinding)
         def binding = new ClientSessionBinding(session, false, wrappedBinding)
 
         when:


### PR DESCRIPTION
* Determine whether TransactionContext is required based on `ConnectionSource`'s `ServerDescription`
instead of the `ClusterDescription` obtained from  `Cluster#getDescription`.
* After the above is done, `Cluster#getDescription`  is only used by tests, so it can be removed.

JAVA-5186