### PR TITLE
[JAVA-5203] Support stored nulls for non-primitive fields in Java records

### DIFF
--- a/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
@@ -16,6 +16,7 @@
 
 package org.bson.codecs.record;
 
+import org.bson.BsonInvalidOperationException;
 import org.bson.BsonReader;
 import org.bson.BsonType;
 import org.bson.BsonWriter;
@@ -277,7 +278,10 @@ final class RecordCodec<T extends Record> implements Codec<T> {
                 if (LOGGER.isTraceEnabled()) {
                     LOGGER.trace(format("Found property not present in the ClassModel: %s", fieldName));
                 }
-            } else if (reader.getCurrentBsonType() == BsonType.NULL && componentModel.isNullable) {
+            } else if (reader.getCurrentBsonType() == BsonType.NULL) {
+                if (!componentModel.isNullable) {
+                    throw new BsonInvalidOperationException(format("Null value on primitive field: %s", componentModel.fieldName));
+                }
                 reader.readNull();
             } else {
                 constructorArguments[componentModel.index] = decoderContext.decodeWithChildContext(componentModel.codec, reader);

--- a/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
+++ b/bson-record-codec/src/main/org/bson/codecs/record/RecordCodec.java
@@ -71,7 +71,7 @@ final class RecordCodec<T extends Record> implements Codec<T> {
             this.codec = computeCodec(typeParameters, component, codecRegistry);
             this.index = index;
             this.fieldName = computeFieldName(component);
-            this.isNullable = checkFieldIsNullable(component);
+            this.isNullable = !component.getType().isPrimitive();
         }
 
         String getComponentName() {
@@ -156,14 +156,6 @@ final class RecordCodec<T extends Record> implements Codec<T> {
                 return getAnnotationOnField(component, org.bson.codecs.pojo.annotations.BsonProperty.class).value();
             }
             return component.getName();
-        }
-
-        private static boolean checkFieldIsNullable(final RecordComponent component) {
-            try {
-                return component.getDeclaringRecord().getDeclaredField(component.getName()).isAnnotationPresent(Nullable.class);
-            } catch (NoSuchFieldException e) {
-                throw new AssertionError(format("Unexpectedly missing the declared field for recordComponent %s", component), e);
-            }
         }
 
         private static <T extends Annotation> boolean isAnnotationPresentOnField(final RecordComponent component,

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
@@ -22,6 +22,7 @@ import org.bson.BsonDocumentReader;
 import org.bson.BsonDocumentWriter;
 import org.bson.BsonDouble;
 import org.bson.BsonInt32;
+import org.bson.BsonNull;
 import org.bson.BsonObjectId;
 import org.bson.BsonString;
 import org.bson.codecs.DecoderContext;
@@ -49,6 +50,7 @@ import org.bson.codecs.record.samples.TestRecordWithMapOfListOfRecords;
 import org.bson.codecs.record.samples.TestRecordWithMapOfRecords;
 import org.bson.codecs.record.samples.TestRecordWithNestedParameterized;
 import org.bson.codecs.record.samples.TestRecordWithNestedParameterizedRecord;
+import org.bson.codecs.record.samples.TestRecordWithNullableAnnotation;
 import org.bson.codecs.record.samples.TestRecordWithParameterizedRecord;
 import org.bson.codecs.record.samples.TestRecordWithPojoAnnotations;
 import org.bson.codecs.record.samples.TestSelfReferentialHolderRecord;
@@ -317,6 +319,22 @@ public class RecordCodecTest {
                 new BsonDocument("_id", new BsonObjectId(identifier))
                         .append("a", new BsonInt32(14)),
                 document);
+
+        // when
+        var decoded = codec.decode(new BsonDocumentReader(document), DecoderContext.builder().build());
+
+        // then
+        assertEquals(testRecord, decoded);
+    }
+
+    @Test
+    public void testRecordWithStoredNulls() {
+        var codec = createRecordCodec(TestRecordWithNullableAnnotation.class, Bson.DEFAULT_CODEC_REGISTRY);
+        var identifier = new ObjectId();
+        var testRecord = new TestRecordWithNullableAnnotation(identifier, null);
+
+        var document = new BsonDocument("_id", new BsonObjectId(identifier))
+                .append("name", new BsonNull());
 
         // when
         var decoded = codec.decode(new BsonDocumentReader(document), DecoderContext.builder().build());

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/RecordCodecTest.java
@@ -50,7 +50,7 @@ import org.bson.codecs.record.samples.TestRecordWithMapOfListOfRecords;
 import org.bson.codecs.record.samples.TestRecordWithMapOfRecords;
 import org.bson.codecs.record.samples.TestRecordWithNestedParameterized;
 import org.bson.codecs.record.samples.TestRecordWithNestedParameterizedRecord;
-import org.bson.codecs.record.samples.TestRecordWithNullableAnnotation;
+import org.bson.codecs.record.samples.TestRecordWithNullableField;
 import org.bson.codecs.record.samples.TestRecordWithParameterizedRecord;
 import org.bson.codecs.record.samples.TestRecordWithPojoAnnotations;
 import org.bson.codecs.record.samples.TestSelfReferentialHolderRecord;
@@ -329,9 +329,9 @@ public class RecordCodecTest {
 
     @Test
     public void testRecordWithStoredNulls() {
-        var codec = createRecordCodec(TestRecordWithNullableAnnotation.class, Bson.DEFAULT_CODEC_REGISTRY);
+        var codec = createRecordCodec(TestRecordWithNullableField.class, Bson.DEFAULT_CODEC_REGISTRY);
         var identifier = new ObjectId();
-        var testRecord = new TestRecordWithNullableAnnotation(identifier, null);
+        var testRecord = new TestRecordWithNullableField(identifier, null);
 
         var document = new BsonDocument("_id", new BsonObjectId(identifier))
                 .append("name", new BsonNull());

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithNullableAnnotation.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithNullableAnnotation.java
@@ -1,9 +1,0 @@
-package org.bson.codecs.record.samples;
-
-import org.bson.codecs.pojo.annotations.BsonId;
-import org.bson.types.ObjectId;
-
-import javax.annotation.Nullable;
-
-public record TestRecordWithNullableAnnotation (@BsonId ObjectId id, @Nullable String name) {
-}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithNullableAnnotation.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithNullableAnnotation.java
@@ -1,0 +1,9 @@
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.types.ObjectId;
+
+import javax.annotation.Nullable;
+
+public record TestRecordWithNullableAnnotation (@BsonId ObjectId id, @Nullable String name) {
+}

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithNullableField.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithNullableField.java
@@ -19,5 +19,5 @@ package org.bson.codecs.record.samples;
 import org.bson.codecs.pojo.annotations.BsonId;
 import org.bson.types.ObjectId;
 
-public record TestRecordWithNullableField(@BsonId ObjectId id, String name) {
+public record TestRecordWithNullableField(@BsonId ObjectId id, String name, int age) {
 }

--- a/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithNullableField.java
+++ b/bson-record-codec/src/test/unit/org/bson/codecs/record/samples/TestRecordWithNullableField.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.record.samples;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.types.ObjectId;
+
+public record TestRecordWithNullableField(@BsonId ObjectId id, String name) {
+}


### PR DESCRIPTION
## Why
Same as the issue raised in https://jira.mongodb.org/browse/JAVA-5134, this change implements a mechanism to gracefully handle stored nulls for fields that are annotated with JSR305 `@Nullable` annotations.

## Changes
- Introduce a boolean field `isNullable` to `RecordCodec.ComponentModel`, which is set to true when given field is not primitive.
- When decoding stored null for a field that is considered nullable in above step, read null in stead of throwing an `BsonInvalidOperationException`.
- For any other scenarios, previous codec behaviour is preserved.

## Issue ticket
https://jira.mongodb.org/browse/JAVA-5203