### PR TITLE
Remove Stream#shouldSupportAdditionalTimeout method

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/AsynchronousChannelStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsynchronousChannelStream.java
@@ -144,11 +144,6 @@ public abstract class AsynchronousChannelStream implements Stream {
     }
 
     @Override
-    public boolean supportsAdditionalTimeout() {
-        return true;
-    }
-
-    @Override
     public ByteBuf read(final int numBytes, final int additionalTimeout) throws IOException {
         FutureAsyncCompletionHandler<ByteBuf> handler = new FutureAsyncCompletionHandler<>();
         readAsync(numBytes, additionalTimeout, handler);

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -43,8 +43,6 @@ import com.mongodb.event.ConnectionPoolCreatedEvent;
 import com.mongodb.event.ConnectionPoolListener;
 import com.mongodb.event.ConnectionPoolReadyEvent;
 import com.mongodb.event.ConnectionReadyEvent;
-import com.mongodb.internal.time.TimePoint;
-import com.mongodb.internal.time.Timeout;
 import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.connection.SdamServerDescriptionManager.SdamIssue;
@@ -56,6 +54,8 @@ import com.mongodb.internal.logging.LogMessage;
 import com.mongodb.internal.logging.StructuredLogger;
 import com.mongodb.internal.session.SessionContext;
 import com.mongodb.internal.thread.DaemonThreadFactory;
+import com.mongodb.internal.time.TimePoint;
+import com.mongodb.internal.time.Timeout;
 import com.mongodb.lang.NonNull;
 import com.mongodb.lang.Nullable;
 import org.bson.ByteBuf;
@@ -775,12 +775,6 @@ final class DefaultConnectionPool implements ConnectionPool {
         public <T> T receive(final Decoder<T> decoder, final SessionContext sessionContext) {
             isTrue("open", !isClosed.get());
             return wrapped.receive(decoder, sessionContext);
-        }
-
-        @Override
-        public boolean supportsAdditionalTimeout() {
-            isTrue("open", !isClosed.get());
-            return wrapped.supportsAdditionalTimeout();
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
@@ -254,7 +254,7 @@ class DefaultServerMonitor implements ServerMonitor {
         }
 
         private boolean shouldStreamResponses(final ServerDescription currentServerDescription) {
-            return currentServerDescription.getTopologyVersion() != null && connection.supportsAdditionalTimeout();
+            return currentServerDescription.getTopologyVersion() != null;
         }
 
         private CommandMessage createCommandMessage(final BsonDocument command, final InternalConnection connection,

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalConnection.java
@@ -103,10 +103,6 @@ public interface InternalConnection extends BufferProvider {
     <T> T receive(Decoder<T> decoder, SessionContext sessionContext);
 
 
-    default boolean supportsAdditionalTimeout() {
-        return false;
-    }
-
     default <T> T receive(Decoder<T> decoder, SessionContext sessionContext, int additionalTimeout) {
         throw new UnsupportedOperationException();
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -376,11 +376,6 @@ public class InternalStreamConnection implements InternalConnection {
     }
 
     @Override
-    public boolean supportsAdditionalTimeout() {
-        return stream.supportsAdditionalTimeout();
-    }
-
-    @Override
     public <T> T receive(final Decoder<T> decoder, final SessionContext sessionContext, final int additionalTimeout) {
         isTrue("Response is expected", hasMoreToCome);
         return receiveCommandMessageResponse(decoder, new NoOpCommandEventSender(), sessionContext, additionalTimeout);

--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
@@ -187,11 +187,6 @@ public class SocketStream implements Stream {
     }
 
     @Override
-    public boolean supportsAdditionalTimeout() {
-        return true;
-    }
-
-    @Override
     public ByteBuf read(final int numBytes, final int additionalTimeout) throws IOException {
         int curTimeout = socket.getSoTimeout();
         if (curTimeout > 0 && additionalTimeout > 0) {

--- a/driver-core/src/main/com/mongodb/internal/connection/Stream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/Stream.java
@@ -61,38 +61,15 @@ public interface Stream extends BufferProvider {
     ByteBuf read(int numBytes) throws IOException;
 
     /**
-     * Gets whether this implementation supports specifying an additional timeout for read operations
-     * <p>
-     * The default is to not support specifying an additional timeout
-     * </p>
-     *
-     * @return true if this implementation supports specifying an additional timeouts for reads operations
-     * @see #read(int, int)
-     */
-    default boolean supportsAdditionalTimeout() {
-        return false;
-    }
-
-    /**
      * Read from the stream, blocking until the requested number of bytes have been read.  If supported by the implementation,
      * adds the given additional timeout to the configured timeout for the stream.
-     * <p>
-     * This method should not be called unless {@link #supportsAdditionalTimeout()} returns true.
-     * </p>
-     * <p>
-     * The default behavior is to throw an {@link UnsupportedOperationException}
-     * </p>
      *
      * @param numBytes The number of bytes to read into the returned byte buffer
      * @param additionalTimeout additional timeout in milliseconds to add to the configured timeout
      * @return a byte buffer filled with number of bytes requested
      * @throws IOException if there are problems reading from the stream
-     * @throws UnsupportedOperationException if this implementation does not support additional timeouts
-     * @see #supportsAdditionalTimeout()
      */
-    default ByteBuf read(int numBytes, int additionalTimeout) throws IOException {
-        throw new UnsupportedOperationException();
-    }
+    ByteBuf read(int numBytes, int additionalTimeout) throws IOException;
 
     /**
      * Write each buffer in the list to the stream in order, asynchronously.  This method should return immediately, and invoke the given

--- a/driver-core/src/main/com/mongodb/internal/connection/TlsChannelStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/TlsChannelStreamFactoryFactory.java
@@ -180,11 +180,6 @@ public class TlsChannelStreamFactoryFactory implements StreamFactoryFactory, Clo
         }
 
         @Override
-        public boolean supportsAdditionalTimeout() {
-            return true;
-        }
-
-        @Override
         public void openAsync(final AsyncCompletionHandler<Void> handler) {
             isTrue("unopened", getChannel() == null);
             try {

--- a/driver-core/src/main/com/mongodb/internal/connection/UsageTrackingInternalConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/UsageTrackingInternalConnection.java
@@ -130,11 +130,6 @@ class UsageTrackingInternalConnection implements InternalConnection {
     }
 
     @Override
-    public boolean supportsAdditionalTimeout() {
-        return wrapped.supportsAdditionalTimeout();
-    }
-
-    @Override
     public <T> T receive(final Decoder<T> decoder, final SessionContext sessionContext, final int additionalTimeout) {
         T result = wrapped.receive(decoder, sessionContext, additionalTimeout);
         lastUsedAt = System.currentTimeMillis();

--- a/driver-core/src/main/com/mongodb/internal/connection/netty/NettyStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/netty/NettyStream.java
@@ -241,11 +241,6 @@ final class NettyStream implements Stream {
     }
 
     @Override
-    public boolean supportsAdditionalTimeout() {
-        return true;
-    }
-
-    @Override
     public ByteBuf read(final int numBytes, final int additionalTimeoutMillis) throws IOException {
         isTrueArgument("additionalTimeoutMillis must not be negative", additionalTimeoutMillis >= 0);
         FutureAsyncCompletionHandler<ByteBuf> future = new FutureAsyncCompletionHandler<>();

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerMonitorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerMonitorSpecification.groovy
@@ -157,8 +157,6 @@ class DefaultServerMonitorSpecification extends Specification {
                         initialServerDescription
                     }
 
-                    supportsAdditionalTimeout() >> true
-
                     send(_, _, _) >> { }
 
                     receive(_, _) >> {
@@ -237,8 +235,6 @@ class DefaultServerMonitorSpecification extends Specification {
                     getInitialServerDescription() >> {
                         initialServerDescription
                     }
-
-                    supportsAdditionalTimeout() >> true
 
                     send(_, _, _) >> { }
 


### PR DESCRIPTION
Now that Stream is not part of the API, this method can be removed.  It only existed due to the possibility that an application creates its own Stream implementation.

JAVA-5180