### PR TITLE
Migrate bson tests from JUnit 4 to 5

### DIFF
--- a/bson/src/test/unit/org/bson/BsonBinaryReaderTest.java
+++ b/bson/src/test/unit/org/bson/BsonBinaryReaderTest.java
@@ -18,14 +18,14 @@ package org.bson;
 
 import org.bson.io.ByteBufferBsonInput;
 import org.bson.types.ObjectId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BsonBinaryReaderTest {
 
@@ -53,8 +53,7 @@ public class BsonBinaryReaderTest {
             reader.readBsonType();
             fail("Should have thrown BsonSerializationException");
         } catch (BsonSerializationException e) {
-            assertEquals("Detected unknown BSON type \"\\x16\" for fieldname \"a\". Are you using the latest driver version?",
-                    e.getMessage());
+            assertEquals("Detected unknown BSON type \"\\x16\" for fieldname \"a\". Are you using the latest driver version?", e.getMessage());
         }
     }
 

--- a/bson/src/test/unit/org/bson/BsonBinaryWriterTest.java
+++ b/bson/src/test/unit/org/bson/BsonBinaryWriterTest.java
@@ -19,9 +19,9 @@ package org.bson;
 import org.bson.io.BasicOutputBuffer;
 import org.bson.io.ByteBufferBsonInput;
 import org.bson.types.ObjectId;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -31,25 +31,25 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class BsonBinaryWriterTest {
 
     private BsonBinaryWriter writer;
     private BasicOutputBuffer buffer;
 
-    @Before
+    @BeforeEach
     public void setup() {
         buffer = new BasicOutputBuffer();
         writer = new BsonBinaryWriter(new BsonWriterSettings(100), new BsonBinaryWriterSettings(1024), buffer);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         writer.close();
     }

--- a/bson/src/test/unit/org/bson/BsonDocumentTest.java
+++ b/bson/src/test/unit/org/bson/BsonDocumentTest.java
@@ -23,13 +23,13 @@ import org.bson.json.JsonMode;
 import org.bson.json.JsonReader;
 import org.bson.json.JsonWriter;
 import org.bson.json.JsonWriterSettings;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 // Don't convert to Spock, as Groovy intercepts equals/hashCode methods that we are trying to test
 public class BsonDocumentTest {
@@ -78,8 +78,7 @@ public class BsonDocumentTest {
 
     @Test
     public void toJsonShouldReturnEquivalent() {
-        assertEquals(new BsonDocumentCodec().decode(new JsonReader(document.toJson()), DecoderContext.builder().build()),
-                     document);
+        assertEquals(new BsonDocumentCodec().decode(new JsonReader(document.toJson()), DecoderContext.builder().build()), document);
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/DocumentTest.java
+++ b/bson/src/test/unit/org/bson/DocumentTest.java
@@ -28,7 +28,7 @@ import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 import org.bson.json.JsonReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -38,9 +38,9 @@ import static java.util.Arrays.asList;
 import static org.bson.codecs.configuration.CodecRegistries.fromCodecs;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 // Don't convert to Spock, as Groovy intercepts equals/hashCode methods that we are trying to test
 public class DocumentTest {
@@ -75,8 +75,7 @@ public class DocumentTest {
 
     @Test
     public void toJsonShouldReturnEquivalent() {
-        assertEquals(new DocumentCodec().decode(new JsonReader(document.toJson()), DecoderContext.builder().build()),
-                     document);
+        assertEquals(new DocumentCodec().decode(new JsonReader(document.toJson()), DecoderContext.builder().build()), document);
     }
 
     // Test to ensure that toJson does not reorder _id field

--- a/bson/src/test/unit/org/bson/GenericBsonTest.java
+++ b/bson/src/test/unit/org/bson/GenericBsonTest.java
@@ -24,10 +24,9 @@ import org.bson.json.JsonMode;
 import org.bson.json.JsonParseException;
 import org.bson.json.JsonWriterSettings;
 import org.bson.types.Decimal128;
-import org.junit.Assume;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import util.Hex;
 import util.JsonPoweredTestHelper;
 
@@ -40,17 +39,17 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static org.bson.BsonDocument.parse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 // BSON tests powered by language-agnostic JSON-based tests included in test resources
-@RunWith(Parameterized.class)
 public class GenericBsonTest {
 
     private static final List<String> IGNORED_PARSE_ERRORS = Arrays.asList(
@@ -65,35 +64,26 @@ public class GenericBsonTest {
         PARSE_ERROR
     }
 
-    private final BsonDocument testDefinition;
-    private final BsonDocument testCase;
-    private final TestCaseType testCaseType;
-
-    public GenericBsonTest(@SuppressWarnings("unused") final String description,
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("data")
+    public void shouldPassAllOutcomes(@SuppressWarnings("unused") final String description,
             final BsonDocument testDefinition, final BsonDocument testCase, final TestCaseType testCaseType) {
-        this.testDefinition = testDefinition;
-        this.testCase = testCase;
-        this.testCaseType = testCaseType;
-    }
-
-    @Test
-    public void shouldPassAllOutcomes() {
         switch (testCaseType) {
             case VALID:
-                runValid();
+                runValid(testCase);
                 break;
             case DECODE_ERROR:
-                runDecodeError();
+                runDecodeError(testCase);
                 break;
             case PARSE_ERROR:
-                runParseError();
+                runParseError(testDefinition, testCase);
                 break;
             default:
                 throw new IllegalArgumentException(format("Unsupported test case type %s", testCaseType));
         }
     }
 
-    private void runValid() {
+    private void runValid(final BsonDocument testCase) {
         String description = testCase.getString("description").getValue();
         String canonicalBsonHex = testCase.getString("canonical_bson").getValue().toUpperCase();
         String degenerateBsonHex = testCase.getString("degenerate_bson", new BsonString("")).getValue().toUpperCase();
@@ -105,50 +95,51 @@ public class GenericBsonTest {
         BsonDocument decodedDocument = decodeToDocument(canonicalBsonHex, description);
 
         // native_to_bson( bson_to_native(cB) ) = cB
-        assertEquals(format("Failed to create expected BSON for document with description '%s'", description),
-                canonicalBsonHex, encodeToHex(decodedDocument));
+        assertEquals(canonicalBsonHex, encodeToHex(decodedDocument),
+                format("Failed to create expected BSON for document with description '%s'", description));
 
         JsonWriterSettings canonicalJsonWriterSettings = JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
         JsonWriterSettings relaxedJsonWriterSettings = JsonWriterSettings.builder().outputMode(JsonMode.RELAXED).build();
 
         if (!canonicalJson.isEmpty()) {
             // native_to_canonical_extended_json( bson_to_native(cB) ) = cEJ
-            assertEquals(format("Failed to create expected canonical JSON for document with description '%s'", description),
-                    stripWhiteSpace(canonicalJson), stripWhiteSpace(decodedDocument.toJson(canonicalJsonWriterSettings)));
+            assertEquals(stripWhiteSpace(canonicalJson), stripWhiteSpace(decodedDocument.toJson(canonicalJsonWriterSettings)),
+                    format("Failed to create expected canonical JSON for document with description '%s'", description));
 
             // native_to_canonical_extended_json( json_to_native(cEJ) ) = cEJ
             BsonDocument parsedCanonicalJsonDocument = parse(canonicalJson);
-            assertEquals("Failed to create expected canonical JSON from parsing canonical JSON",
-                    stripWhiteSpace(canonicalJson), stripWhiteSpace(parsedCanonicalJsonDocument.toJson(canonicalJsonWriterSettings)));
+            assertEquals(stripWhiteSpace(canonicalJson), stripWhiteSpace(parsedCanonicalJsonDocument.toJson(canonicalJsonWriterSettings)),
+                    "Failed to create expected canonical JSON from parsing canonical JSON");
 
             if (!lossy) {
                 // native_to_bson( json_to_native(cEJ) ) = cB
-                assertEquals("Failed to create expected canonical BSON from parsing canonical JSON",
-                        canonicalBsonHex, encodeToHex(parsedCanonicalJsonDocument));
+                assertEquals(canonicalBsonHex, encodeToHex(parsedCanonicalJsonDocument),
+                        "Failed to create expected canonical BSON from parsing canonical JSON");
             }
         }
 
         if (!relaxedJson.isEmpty()) {
             // native_to_relaxed_extended_json( bson_to_native(cB) ) = rEJ
-            assertEquals(format("Failed to create expected relaxed JSON for document with description '%s'", description),
-                    stripWhiteSpace(relaxedJson), stripWhiteSpace(decodedDocument.toJson(relaxedJsonWriterSettings)));
+            assertEquals(stripWhiteSpace(relaxedJson), stripWhiteSpace(decodedDocument.toJson(relaxedJsonWriterSettings)),
+                    format("Failed to create expected relaxed JSON for document with description '%s'", description));
 
             // native_to_relaxed_extended_json( json_to_native(rEJ) ) = rEJ
-            assertEquals("Failed to create expected relaxed JSON from parsing relaxed JSON", stripWhiteSpace(relaxedJson),
-                    stripWhiteSpace(parse(relaxedJson).toJson(relaxedJsonWriterSettings)));
+            assertEquals(stripWhiteSpace(relaxedJson), stripWhiteSpace(parse(relaxedJson).toJson(relaxedJsonWriterSettings)),
+                    "Failed to create expected relaxed JSON from parsing relaxed JSON");
         }
 
         if (!degenerateJson.isEmpty()) {
             // native_to_bson( json_to_native(dEJ) ) = cB
-            assertEquals("Failed to create expected canonical BSON from parsing canonical JSON",
-                    canonicalBsonHex, encodeToHex(parse(degenerateJson)));
+            assertEquals(canonicalBsonHex, encodeToHex(parse(degenerateJson)),
+                    "Failed to create expected canonical BSON from parsing canonical JSON");
         }
 
         if (!degenerateBsonHex.isEmpty()) {
             BsonDocument decodedDegenerateDocument = decodeToDocument(degenerateBsonHex, description);
             // native_to_bson( bson_to_native(dB) ) = cB
-            assertEquals(format("Failed to create expected canonical BSON from degenerate BSON for document with description "
-                                        + "'%s'", description), canonicalBsonHex, encodeToHex(decodedDegenerateDocument));
+            assertEquals(canonicalBsonHex, encodeToHex(decodedDegenerateDocument),
+                    format("Failed to create expected canonical BSON from degenerate BSON for document with description '%s'",
+                            description));
         }
     }
 
@@ -223,7 +214,7 @@ public class GenericBsonTest {
 
         if (byteBuffer.hasRemaining()) {
             throw new BsonSerializationException(format("Should have consumed all bytes, but " + byteBuffer.remaining()
-                                                                + " still remain in the buffer for document with description ",
+                            + " still remain in the buffer for document with description ",
                     description));
         }
         return actualDecodedDocument;
@@ -235,20 +226,20 @@ public class GenericBsonTest {
         return Hex.encode(outputBuffer.toByteArray());
     }
 
-    private void runDecodeError() {
+    private void runDecodeError(final BsonDocument testCase) {
         try {
             String description = testCase.getString("description").getValue();
-            throwIfValueIsStringContainingReplacementCharacter(description);
+            throwIfValueIsStringContainingReplacementCharacter(testCase, description);
             fail(format("Should have failed parsing for subject with description '%s'", description));
         } catch (BsonSerializationException e) {
             // all good
         }
     }
 
-    private void runParseError() {
+    private void runParseError(final BsonDocument testDefinition, final BsonDocument testCase) {
         String description = testCase.getString("description").getValue();
 
-        Assume.assumeFalse(IGNORED_PARSE_ERRORS.contains(description));
+        assumeFalse(IGNORED_PARSE_ERRORS.contains(description));
 
         String str = testCase.getString("string").getValue();
 
@@ -290,7 +281,7 @@ public class GenericBsonTest {
 
     // Working around the fact that the Java driver doesn't report an error for invalid UTF-8, but rather replaces the invalid
     // sequence with the replacement character
-    private void throwIfValueIsStringContainingReplacementCharacter(final String description) {
+    private void throwIfValueIsStringContainingReplacementCharacter(final BsonDocument testCase, final String description) {
         BsonDocument decodedDocument = decodeToDocument(testCase.getString("bson").getValue(), description);
         BsonValue value = decodedDocument.get(decodedDocument.getFirstKey());
 
@@ -312,39 +303,40 @@ public class GenericBsonTest {
         if (decodedString.contains(StandardCharsets.UTF_8.newDecoder().replacement())) {
             throw new BsonSerializationException("String contains replacement character");
         }
-   }
+    }
 
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
-        List<Object[]> data = new ArrayList<>();
+    private static Stream<Arguments> data() throws URISyntaxException, IOException {
+        List<Arguments> data = new ArrayList<>();
         for (File file : JsonPoweredTestHelper.getTestFiles("/bson")) {
             BsonDocument testDocument = JsonPoweredTestHelper.getTestDocument(file);
             for (BsonValue curValue : testDocument.getArray("valid", new BsonArray())) {
                 BsonDocument testCaseDocument = curValue.asDocument();
-                data.add(new Object[]{createTestCaseDescription(testDocument, testCaseDocument, "valid"), testDocument, testCaseDocument,
-                        TestCaseType.VALID});
+                data.add(Arguments.of(
+                        createTestCaseDescription(testDocument, testCaseDocument, "valid"), testDocument, testCaseDocument,
+                        TestCaseType.VALID));
             }
 
             for (BsonValue curValue : testDocument.getArray("decodeErrors", new BsonArray())) {
                 BsonDocument testCaseDocument = curValue.asDocument();
-                data.add(new Object[]{createTestCaseDescription(testDocument, testCaseDocument, "decodeError"), testDocument,
-                        testCaseDocument, TestCaseType.DECODE_ERROR});
+                data.add(Arguments.of(
+                        createTestCaseDescription(testDocument, testCaseDocument, "decodeError"), testDocument, testCaseDocument,
+                        TestCaseType.DECODE_ERROR));
             }
             for (BsonValue curValue : testDocument.getArray("parseErrors", new BsonArray())) {
                 BsonDocument testCaseDocument = curValue.asDocument();
-                data.add(new Object[]{createTestCaseDescription(testDocument, testCaseDocument, "parseError"), testDocument,
-                        testCaseDocument, TestCaseType.PARSE_ERROR});
+                data.add(Arguments.of(createTestCaseDescription(testDocument, testCaseDocument, "parseError"), testDocument,
+                        testCaseDocument, TestCaseType.PARSE_ERROR));
             }
         }
-        return data;
+        return data.stream();
     }
 
     private static String createTestCaseDescription(final BsonDocument testDocument, final BsonDocument testCaseDocument,
-                                                    final String testCaseType) {
+            final String testCaseType) {
         return testDocument.getString("description").getValue()
-                       + "[" + testCaseType + "]"
-                       + ": " + testCaseDocument.getString("description").getValue();
+                + "[" + testCaseType + "]"
+                + ": " + testCaseDocument.getString("description").getValue();
     }
 
     private String stripWhiteSpace(final String json) {

--- a/bson/src/test/unit/org/bson/LazyBSONDecoderTest.java
+++ b/bson/src/test/unit/org/bson/LazyBSONDecoderTest.java
@@ -16,8 +16,8 @@
 
 package org.bson;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -26,13 +26,14 @@ import java.io.InputStream;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LazyBSONDecoderTest {
     private BSONDecoder bsonDecoder;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         bsonDecoder = new LazyBSONDecoder();
     }
@@ -59,10 +60,10 @@ public class LazyBSONDecoderTest {
         assertEquals(1, document.get("a"));
     }
 
-    @Test(expected = BSONException.class)
+    @Test
     public void testDecodingFromInvalidInput() {
         byte[] bytes = {16, 0, 0, 0, 16, 97, 0, 1, 0, 0, 0, 0};
-        bsonDecoder.readObject(bytes);
+        assertThrows(BSONException.class, () -> bsonDecoder.readObject(bytes));
     }
 
 }

--- a/bson/src/test/unit/org/bson/LazyBSONListTest.java
+++ b/bson/src/test/unit/org/bson/LazyBSONListTest.java
@@ -16,16 +16,17 @@
 
 package org.bson;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings({"rawtypes"})
 public class LazyBSONListTest {
@@ -86,12 +87,14 @@ public class LazyBSONListTest {
         assertFalse(it.hasNext());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testIteratorNextWhileNothingLeft() {
-        LazyBSONList list = encodeAndExtractList(asList());
-        Iterator it = list.iterator();
-        assertFalse(it.hasNext());
-        it.next();
+        assertThrows(NoSuchElementException.class, () -> {
+            LazyBSONList list = encodeAndExtractList(asList());
+            Iterator it = list.iterator();
+            assertFalse(it.hasNext());
+            it.next();
+        });
     }
 
 }

--- a/bson/src/test/unit/org/bson/codecs/AtomicIntegerCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/AtomicIntegerCodecTest.java
@@ -18,11 +18,12 @@ package org.bson.codecs;
 
 import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class AtomicIntegerCodecTest extends CodecTestCase {
 
@@ -44,20 +45,20 @@ public final class AtomicIntegerCodecTest extends CodecTestCase {
         roundTrip(new Document("a", 9.9999999999999992), new AtomicIntegerComparator(expected));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowWhenHandlingLossyDoubleValues() {
         Document original = new Document("a", 9.9999999999999991);
-        roundTrip(original, new AtomicIntegerComparator(original));
+        assertThrows(BsonInvalidOperationException.class, () ->roundTrip(original, new AtomicIntegerComparator(original)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldErrorDecodingOutsideMinRange() {
-        roundTrip(new Document("a", Long.MIN_VALUE));
+        assertThrows(BsonInvalidOperationException.class, () ->roundTrip(new Document("a", Long.MIN_VALUE)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldErrorDecodingOutsideMaxRange() {
-        roundTrip(new Document("a", Long.MAX_VALUE));
+        assertThrows(BsonInvalidOperationException.class, () ->roundTrip(new Document("a", Long.MAX_VALUE)));
     }
 
     @Override
@@ -74,7 +75,7 @@ public final class AtomicIntegerCodecTest extends CodecTestCase {
 
         @Override
         public void apply(final Document result) {
-            assertEquals("Codec Round Trip",
+            assertEquals(
                     expected.get("a", AtomicInteger.class).get(),
                     result.get("a", AtomicInteger.class).get());
         }

--- a/bson/src/test/unit/org/bson/codecs/AtomicLongCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/AtomicLongCodecTest.java
@@ -18,11 +18,12 @@ package org.bson.codecs;
 
 import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class AtomicLongCodecTest extends CodecTestCase {
 
@@ -44,20 +45,20 @@ public final class AtomicLongCodecTest extends CodecTestCase {
         roundTrip(new Document("a", 9.9999999999999992), new AtomicLongComparator(expected));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowWhenHandlingLossyDoubleValues() {
         Document original = new Document("a", 9.9999999999999991);
-        roundTrip(original, new AtomicLongComparator(original));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(original, new AtomicLongComparator(original)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldErrorDecodingOutsideMinRange() {
-        roundTrip(new Document("a", -Double.MAX_VALUE));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", -Double.MAX_VALUE)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldErrorDecodingOutsideMaxRange() {
-        roundTrip(new Document("a", Double.MAX_VALUE));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", Double.MAX_VALUE)));
     }
 
     @Override
@@ -74,9 +75,7 @@ public final class AtomicLongCodecTest extends CodecTestCase {
 
         @Override
         public void apply(final Document result) {
-            assertEquals("Codec Round Trip",
-                    expected.get("a", AtomicLong.class).get(),
-                    result.get("a", AtomicLong.class).get());
+            assertEquals(expected.get("a", AtomicLong.class).get(), result.get("a", AtomicLong.class).get());
         }
     }
 

--- a/bson/src/test/unit/org/bson/codecs/ByteCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/ByteCodecTest.java
@@ -18,7 +18,9 @@ package org.bson.codecs;
 
 import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ByteCodecTest extends CodecTestCase {
 
@@ -36,19 +38,22 @@ public final class ByteCodecTest extends CodecTestCase {
         roundTrip(new Document("a", 9.9999999999999992), expected);
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldErrorDecodingOutsideMinRange() {
-        roundTrip(new Document("a", Integer.MIN_VALUE));
+        assertThrows(BsonInvalidOperationException.class, () ->
+                roundTrip(new Document("a", Integer.MIN_VALUE)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldErrorDecodingOutsideMaxRange() {
-        roundTrip(new Document("a", Integer.MAX_VALUE));
+        assertThrows(BsonInvalidOperationException.class, () ->
+                roundTrip(new Document("a", Integer.MAX_VALUE)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowWhenHandlingLossyDoubleValues() {
-        roundTrip(new Document("a", 9.9999999999999991));
+        assertThrows(BsonInvalidOperationException.class, () ->
+                roundTrip(new Document("a", 9.9999999999999991)));
     }
 
     @Override

--- a/bson/src/test/unit/org/bson/codecs/CodecTestCase.java
+++ b/bson/src/test/unit/org/bson/codecs/CodecTestCase.java
@@ -36,7 +36,7 @@ import java.util.HashMap;
 
 import static java.util.Arrays.asList;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 abstract class CodecTestCase {
 
@@ -82,7 +82,7 @@ abstract class CodecTestCase {
     }
 
     public void roundTrip(final Document input, final Document expected) {
-        roundTrip(input, result -> assertEquals("Codec Round Trip", expected, result));
+        roundTrip(input, result -> assertEquals(expected, result));
     }
 
     <T> OutputBuffer encode(final Codec<T> codec, final T value) {
@@ -119,7 +119,7 @@ abstract class CodecTestCase {
 
         @Override
         public void apply(final T result) {
-            assertEquals("Codec Round Trip", original, result);
+            assertEquals(original, result);
         }
     }
 

--- a/bson/src/test/unit/org/bson/codecs/DocumentCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/DocumentCodecTest.java
@@ -33,9 +33,9 @@ import org.bson.types.Decimal128;
 import org.bson.types.MaxKey;
 import org.bson.types.MinKey;
 import org.bson.types.ObjectId;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -45,21 +45,21 @@ import java.util.HashSet;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DocumentCodecTest {
     private BasicOutputBuffer buffer;
     private BsonBinaryWriter writer;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         buffer = new BasicOutputBuffer();
         writer = new BsonBinaryWriter(buffer);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         writer.close();
     }
@@ -103,8 +103,7 @@ public class DocumentCodecTest {
         Document decodedDocument = documentCodec.decode(new BsonBinaryReader(bsonInput), DecoderContext.builder().build());
         assertEquals(new Document()
                      .append("list", asList(1, 2, 3, 4, 5))
-                     .append("set", asList(1, 2, 3, 4)),
-                     decodedDocument);
+                     .append("set", asList(1, 2, 3, 4)), decodedDocument);
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/codecs/DoubleCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/DoubleCodecTest.java
@@ -19,7 +19,9 @@ package org.bson.codecs;
 import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
 import org.bson.types.Decimal128;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class DoubleCodecTest extends CodecTestCase {
 
@@ -37,24 +39,24 @@ public final class DoubleCodecTest extends CodecTestCase {
         roundTrip(new Document("a", Decimal128.parse("10")), expected);
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowWhenHandlingLossyLongValues() {
-        roundTrip(new Document("a", Long.MAX_VALUE - 1));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", Long.MAX_VALUE - 1)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowWhenHandlingLossyLongValues2() {
-        roundTrip(new Document("a", Long.MIN_VALUE + 1));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", Long.MIN_VALUE + 1)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowWhenHandlingLossyDecimal128Values() {
-        roundTrip(new Document("a", Decimal128.parse("10.0")));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", Decimal128.parse("10.0"))));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowWhenHandlingNonExpressibleDecimal128Values() {
-        roundTrip(new Document("a", Decimal128.parse("NaN")));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", Decimal128.parse("NaN"))));
     }
 
     @Override

--- a/bson/src/test/unit/org/bson/codecs/FloatCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/FloatCodecTest.java
@@ -19,7 +19,9 @@ package org.bson.codecs;
 import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
 import org.bson.types.Decimal128;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class FloatCodecTest extends CodecTestCase {
 
@@ -43,19 +45,19 @@ public final class FloatCodecTest extends CodecTestCase {
         roundTrip(new Document("a", Decimal128.parse("10")), expected);
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldErrorDecodingOutsideMinRange() {
-        roundTrip(new Document("a", -Double.MAX_VALUE));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", -Double.MAX_VALUE)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldErrorDecodingOutsideMaxRange() {
-        roundTrip(new Document("a", Double.MAX_VALUE));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", Double.MAX_VALUE)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowWhenHandlingLossyDecimal128Values() {
-        roundTrip(new Document("a", Decimal128.parse("10.0")));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", Decimal128.parse("10.0"))));
     }
 
     @Override

--- a/bson/src/test/unit/org/bson/codecs/IntegerCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/IntegerCodecTest.java
@@ -19,7 +19,9 @@ package org.bson.codecs;
 import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
 import org.bson.types.Decimal128;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class IntegerCodecTest extends CodecTestCase {
 
@@ -38,24 +40,24 @@ public final class IntegerCodecTest extends CodecTestCase {
         roundTrip(new Document("a", Decimal128.parse("10")), expected);
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldErrorDecodingOutsideMinRange() {
-        roundTrip(new Document("a", Long.MIN_VALUE));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", Long.MIN_VALUE)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldErrorDecodingOutsideMaxRange() {
-        roundTrip(new Document("a", Long.MAX_VALUE));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", Long.MAX_VALUE)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowWhenHandlingLossyDoubleValues() {
-        roundTrip(new Document("a", 9.9999999999999991));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", 9.9999999999999991)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowWhenHandlingLossyDecimal128Values() {
-        roundTrip(new Document("a", Decimal128.parse("10.0")));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", Decimal128.parse("10.0"))));
     }
 
     @Override

--- a/bson/src/test/unit/org/bson/codecs/JsonObjectCodecProviderTest.java
+++ b/bson/src/test/unit/org/bson/codecs/JsonObjectCodecProviderTest.java
@@ -19,7 +19,7 @@ package org.bson.codecs;
 import org.bson.codecs.configuration.CodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.json.JsonObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/bson/src/test/unit/org/bson/codecs/LongCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/LongCodecTest.java
@@ -19,7 +19,9 @@ package org.bson.codecs;
 import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
 import org.bson.types.Decimal128;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class LongCodecTest extends CodecTestCase {
 
@@ -38,19 +40,19 @@ public final class LongCodecTest extends CodecTestCase {
         roundTrip(new Document("a", Decimal128.parse("10")), expected);
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowWhenHandlingLossyValues() {
-        roundTrip(new Document("a", Double.MAX_VALUE));
+        assertThrows(BsonInvalidOperationException.class, () ->roundTrip(new Document("a", Double.MAX_VALUE)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowWhenHandlingLossyDoubleValues() {
-        roundTrip(new Document("a", 9.9999999999999991));
+        assertThrows(BsonInvalidOperationException.class, () ->roundTrip(new Document("a", 9.9999999999999991)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowWhenHandlingLossyDecimal128Values() {
-        roundTrip(new Document("a", Decimal128.parse("10.0")));
+        assertThrows(BsonInvalidOperationException.class, () ->roundTrip(new Document("a", Decimal128.parse("10.0"))));
     }
 
     @Override

--- a/bson/src/test/unit/org/bson/codecs/ShortCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/ShortCodecTest.java
@@ -18,7 +18,9 @@ package org.bson.codecs;
 
 import org.bson.BsonInvalidOperationException;
 import org.bson.Document;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class ShortCodecTest extends CodecTestCase {
 
@@ -37,14 +39,14 @@ public final class ShortCodecTest extends CodecTestCase {
         roundTrip(new Document("a", 9.9999999999999992), expected);
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldErrorDecodingOutsideMinRange() {
-        roundTrip(new Document("a", Integer.MIN_VALUE));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", Integer.MIN_VALUE)));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldErrorDecodingOutsideMaxRange() {
-        roundTrip(new Document("a", Integer.MAX_VALUE));
+        assertThrows(BsonInvalidOperationException.class, () -> roundTrip(new Document("a", Integer.MAX_VALUE)));
     }
 
     @Override

--- a/bson/src/test/unit/org/bson/codecs/StringCodecTest.java
+++ b/bson/src/test/unit/org/bson/codecs/StringCodecTest.java
@@ -23,17 +23,18 @@ import org.bson.BsonWriter;
 import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.json.JsonReader;
 import org.bson.json.JsonWriter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class StringCodecTest {
 
     private final DecoderContext decoderContext = DecoderContext.builder().build();
     private final EncoderContext encoderContext = EncoderContext.builder().build();
-    private final Codec<String> parent =  new StringCodec();
+    private final Codec<String> parent = new StringCodec();
     @SuppressWarnings("unchecked")
     private final Codec<String> child = ((RepresentationConfigurable<String>) parent).withRepresentation(BsonType.OBJECT_ID);
 
@@ -50,9 +51,9 @@ public class StringCodecTest {
         assertEquals(((RepresentationConfigurable) child).getRepresentation(), BsonType.STRING);
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testInvalidRepresentation() {
-        ((RepresentationConfigurable) parent).withRepresentation(BsonType.INT32);
+        assertThrows(CodecConfigurationException.class, () -> ((RepresentationConfigurable) parent).withRepresentation(BsonType.INT32));
     }
 
 
@@ -66,20 +67,24 @@ public class StringCodecTest {
         assertEquals(stringId, "5f5a6cc03237b5e06d6b887b");
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void testDecodeOnObjectIdWithStringRep() {
-        BsonReader reader = new JsonReader("{'_id':  ObjectId('5f5a6cc03237b5e06d6b887b'), 'name': 'Brian'}");
-        reader.readStartDocument();
-        reader.readName();
-        parent.decode(reader, decoderContext);
+        assertThrows(BsonInvalidOperationException.class, () -> {
+            BsonReader reader = new JsonReader("{'_id':  ObjectId('5f5a6cc03237b5e06d6b887b'), 'name': 'Brian'}");
+            reader.readStartDocument();
+            reader.readName();
+            parent.decode(reader, decoderContext);
+        });
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void testDecodeOnStringWithObjectIdRep() {
-        BsonReader reader = new JsonReader("{'name': 'Brian'");
-        reader.readStartDocument();
-        reader.readName();
-        child.decode(reader, decoderContext);
+        assertThrows(BsonInvalidOperationException.class, () -> {
+            BsonReader reader = new JsonReader("{'name': 'Brian'");
+            reader.readStartDocument();
+            reader.readName();
+            child.decode(reader, decoderContext);
+        });
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/codecs/pojo/ClassModelBuilderTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/ClassModelBuilderTest.java
@@ -25,7 +25,7 @@ import org.bson.codecs.pojo.entities.SimpleGenericsModel;
 import org.bson.codecs.pojo.entities.SimpleIdModel;
 import org.bson.codecs.pojo.entities.UpperBoundsConcreteModel;
 import org.bson.codecs.pojo.entities.UpperBoundsModel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -37,10 +37,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("rawtypes")
 public final class ClassModelBuilderTest {
@@ -148,32 +149,36 @@ public final class ClassModelBuilderTest {
         assertEquals(3, builder.getPropertyModelBuilders().size());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test()
     public void testValidationIdProperty() {
-        ClassModel.builder(SimpleGenericsModel.class).idPropertyName("ID").build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(SimpleGenericsModel.class).idPropertyName("ID").build());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test()
     public void testValidationDuplicateDocumentFieldName() {
-        ClassModelBuilder<SimpleGenericsModel> builder = ClassModel.builder(SimpleGenericsModel.class);
-        builder.getProperty("myIntegerField").writeName("myGenericField");
-        builder.build();
+        assertThrows(CodecConfigurationException.class, () -> {
+            ClassModelBuilder<SimpleGenericsModel> builder = ClassModel.builder(SimpleGenericsModel.class);
+            builder.getProperty("myIntegerField").writeName("myGenericField");
+            builder.build();
+        });
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test()
     public void testDifferentTypeIdGenerator() {
-        ClassModel.builder(SimpleIdModel.class)
-                .idGenerator(new IdGenerator<String>() {
-                    @Override
-                    public String generate() {
-                        return "id";
-                    }
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(SimpleIdModel.class)
+                        .idGenerator(new IdGenerator<String>() {
+                            @Override
+                            public String generate() {
+                                return "id";
+                            }
 
-                    @Override
-                    public Class<String> getType() {
-                        return String.class;
-                    }
-                }).build();
+                            @Override
+                            public Class<String> getType() {
+                                return String.class;
+                            }
+                        }).build());
     }
 
     private static final List<Annotation> TEST_ANNOTATIONS = Collections.singletonList(

--- a/bson/src/test/unit/org/bson/codecs/pojo/ClassModelTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/ClassModelTest.java
@@ -38,17 +38,17 @@ import org.bson.codecs.pojo.entities.SimpleModel;
 import org.bson.codecs.pojo.entities.SimpleWithStaticModel;
 import org.bson.codecs.pojo.entities.conventions.AnnotationInheritedModel;
 import org.bson.codecs.pojo.entities.conventions.AnnotationModel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ClassModelTest {
 
@@ -200,8 +200,7 @@ public final class ClassModelTest {
         ClassModel<?> classModel = ClassModel.builder(ListListGenericExtendedModel.class).build();
 
         assertEquals(1, classModel.getPropertyModels().size());
-        assertEquals(createBuilder(List.class).addTypeParameter(createTypeData(List.class, Integer.class)).build(),
-                classModel.getPropertyModel("values").getTypeData());
+        assertEquals(createBuilder(List.class).addTypeParameter(createTypeData(List.class, Integer.class)).build(), classModel.getPropertyModel("values").getTypeData());
     }
 
     @Test
@@ -218,8 +217,7 @@ public final class ClassModelTest {
 
         assertEquals(1, classModel.getPropertyModels().size());
         assertEquals(createBuilder(Map.class).addTypeParameter(createTypeData(String.class))
-                        .addTypeParameter(createTypeData(Map.class, String.class, Integer.class)).build(),
-                classModel.getPropertyModel("values").getTypeData());
+                        .addTypeParameter(createTypeData(Map.class, String.class, Integer.class)).build(), classModel.getPropertyModel("values").getTypeData());
     }
 
     @Test
@@ -227,8 +225,7 @@ public final class ClassModelTest {
         ClassModel<?> classModel = ClassModel.builder(ListMapGenericExtendedModel.class).build();
 
         assertEquals(1, classModel.getPropertyModels().size());
-        assertEquals(createBuilder(List.class).addTypeParameter(createTypeData(Map.class, String.class, Integer.class)).build(),
-                classModel.getPropertyModel("values").getTypeData());
+        assertEquals(createBuilder(List.class).addTypeParameter(createTypeData(Map.class, String.class, Integer.class)).build(), classModel.getPropertyModel("values").getTypeData());
     }
 
 
@@ -239,8 +236,7 @@ public final class ClassModelTest {
         assertEquals(1, classModel.getPropertyModels().size());
         assertEquals(createBuilder(Map.class)
                         .addTypeParameter(createTypeData(String.class))
-                        .addTypeParameter(createTypeData(List.class, Integer.class)).build(),
-                classModel.getPropertyModel("values").getTypeData());
+                        .addTypeParameter(createTypeData(List.class, Integer.class)).build(), classModel.getPropertyModel("values").getTypeData());
     }
 
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/ConventionsTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/ConventionsTest.java
@@ -38,18 +38,19 @@ import org.bson.codecs.pojo.entities.conventions.CreatorInvalidMultipleCreatorsM
 import org.bson.codecs.pojo.entities.conventions.CreatorInvalidMultipleStaticCreatorsModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorInvalidTypeConstructorModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorInvalidTypeMethodModel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.singletonList;
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
 import static org.bson.codecs.pojo.Conventions.ANNOTATION_CONVENTION;
 import static org.bson.codecs.pojo.Conventions.CLASS_AND_PROPERTY_CONVENTION;
 import static org.bson.codecs.pojo.Conventions.DEFAULT_CONVENTIONS;
 import static org.bson.codecs.pojo.Conventions.NO_CONVENTIONS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ConventionsTest {
 
@@ -122,7 +123,7 @@ public final class ConventionsTest {
         ClassModel<AnnotationBsonRepresentation> stringIdObjectRep = ClassModel.builder(AnnotationBsonRepresentation.class).build();
         assertEquals(stringIdObjectRep.getIdPropertyModelHolder().getIdGenerator(), IdGenerators.STRING_ID_GENERATOR);
 
-        ClassModel<ConventionModel>  stringIdStringRep = ClassModel.builder(ConventionModel.class).build();
+        ClassModel<ConventionModel> stringIdStringRep = ClassModel.builder(ConventionModel.class).build();
         assertNull(stringIdStringRep.getIdPropertyModelHolder().getIdGenerator());
 
         ClassModel<BsonIdModel> bsonId = ClassModel.builder(BsonIdModel.class).build();
@@ -150,7 +151,7 @@ public final class ConventionsTest {
                 .propertySerialization(new PropertyModelSerializationImpl<>())
                 .propertyAccessor(new PropertyAccessorTest<>());
 
-        ClassModel<SimpleModel> classModel  = builder.idPropertyName("stringField").build();
+        ClassModel<SimpleModel> classModel = builder.idPropertyName("stringField").build();
 
         assertTrue(classModel.useDiscriminator());
         assertEquals("_cls", classModel.getDiscriminatorKey());
@@ -163,80 +164,93 @@ public final class ConventionsTest {
         assertNull(idPropertyModel.useDiscriminator());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testAnnotationCollision() {
-        ClassModel.builder(AnnotationCollision.class).conventions(DEFAULT_CONVENTIONS).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(AnnotationCollision.class).conventions(DEFAULT_CONVENTIONS).build());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testAnnotationWriteCollision() {
-        ClassModel.builder(AnnotationWriteCollision.class).conventions(DEFAULT_CONVENTIONS).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(AnnotationWriteCollision.class).conventions(DEFAULT_CONVENTIONS).build());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testAnnotationNameCollision() {
-        ClassModel.builder(AnnotationNameCollision.class)
-                .conventions(singletonList(ANNOTATION_CONVENTION)).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(AnnotationNameCollision.class)
+                        .conventions(singletonList(ANNOTATION_CONVENTION)).build());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testCreatorInvalidConstructorModel() {
-        ClassModel.builder(CreatorInvalidConstructorModel.class)
-                .conventions(singletonList(ANNOTATION_CONVENTION)).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(CreatorInvalidConstructorModel.class)
+                        .conventions(singletonList(ANNOTATION_CONVENTION)).build());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testCreatorInvalidMethodModel() {
-        ClassModel.builder(CreatorInvalidMethodModel.class)
-                .conventions(singletonList(ANNOTATION_CONVENTION)).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(CreatorInvalidMethodModel.class)
+                        .conventions(singletonList(ANNOTATION_CONVENTION)).build());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testCreatorInvalidMultipleConstructorsModel() {
-        ClassModel.builder(CreatorInvalidMultipleConstructorsModel.class)
-                .conventions(singletonList(ANNOTATION_CONVENTION)).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(CreatorInvalidMultipleConstructorsModel.class)
+                        .conventions(singletonList(ANNOTATION_CONVENTION)).build());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testCreatorInvalidMultipleCreatorsModel() {
-        ClassModel.builder(CreatorInvalidMultipleCreatorsModel.class)
-                .conventions(singletonList(ANNOTATION_CONVENTION)).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(CreatorInvalidMultipleCreatorsModel.class)
+                        .conventions(singletonList(ANNOTATION_CONVENTION)).build());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testCreatorInvalidMultipleStaticCreatorsModel() {
-        ClassModel.builder(CreatorInvalidMultipleStaticCreatorsModel.class)
-                .conventions(singletonList(ANNOTATION_CONVENTION)).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(CreatorInvalidMultipleStaticCreatorsModel.class)
+                        .conventions(singletonList(ANNOTATION_CONVENTION)).build());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testCreatorInvalidMethodReturnTypeModel() {
-        ClassModel.builder(CreatorInvalidMethodReturnTypeModel.class)
-                .conventions(singletonList(ANNOTATION_CONVENTION)).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(CreatorInvalidMethodReturnTypeModel.class)
+                        .conventions(singletonList(ANNOTATION_CONVENTION)).build());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testCreatorInvalidTypeConstructorModel() {
-        ClassModel.builder(CreatorInvalidTypeConstructorModel.class)
-                .conventions(singletonList(ANNOTATION_CONVENTION)).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(CreatorInvalidTypeConstructorModel.class)
+                        .conventions(singletonList(ANNOTATION_CONVENTION)).build());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testCreatorInvalidTypeMethodModel() {
-        ClassModel.builder(CreatorInvalidTypeMethodModel.class)
-                .conventions(singletonList(ANNOTATION_CONVENTION)).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(CreatorInvalidTypeMethodModel.class)
+                        .conventions(singletonList(ANNOTATION_CONVENTION)).build());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testCreatorConstructorNoKnownIdModel() {
-        ClassModel.builder(CreatorConstructorNoKnownIdModel.class)
-                .conventions(singletonList(ANNOTATION_CONVENTION)).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(CreatorConstructorNoKnownIdModel.class)
+                        .conventions(singletonList(ANNOTATION_CONVENTION)).build());
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testBsonIgnoreDuplicatePropertyMultipleTypesModel() {
-        ClassModel.builder(BsonIgnoreDuplicatePropertyMultipleTypes.class)
-                .conventions(NO_CONVENTIONS).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                ClassModel.builder(BsonIgnoreDuplicatePropertyMultipleTypes.class)
+                        .conventions(NO_CONVENTIONS).build());
     }
 
     private class PropertyAccessorTest<T> implements PropertyAccessor<T> {

--- a/bson/src/test/unit/org/bson/codecs/pojo/IdGeneratorsTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/IdGeneratorsTest.java
@@ -18,9 +18,9 @@ package org.bson.codecs.pojo;
 
 import org.bson.BsonObjectId;
 import org.bson.types.ObjectId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class IdGeneratorsTest {
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCodecCyclicalLookupTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCodecCyclicalLookupTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PojoCodecCyclicalLookupTest extends PojoTestCase {
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCodecProviderTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCodecProviderTest.java
@@ -21,11 +21,11 @@ import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.entities.SimpleModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorInvalidMethodModel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public final class PojoCodecProviderTest extends PojoTestCase {
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -79,7 +79,7 @@ import org.bson.codecs.pojo.entities.conventions.MapGetterMutableModel;
 import org.bson.codecs.pojo.entities.conventions.MapGetterNonEmptyModel;
 import org.bson.codecs.pojo.entities.conventions.MapGetterNullModel;
 import org.bson.types.ObjectId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -99,9 +99,10 @@ import static org.bson.codecs.pojo.Conventions.DEFAULT_CONVENTIONS;
 import static org.bson.codecs.pojo.Conventions.NO_CONVENTIONS;
 import static org.bson.codecs.pojo.Conventions.SET_PRIVATE_FIELDS_CONVENTION;
 import static org.bson.codecs.pojo.Conventions.USE_GETTERS_FOR_SETTERS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("deprecation")
 public final class PojoCustomTest extends PojoTestCase {
@@ -283,68 +284,68 @@ public final class PojoCustomTest extends PojoTestCase {
                         + "'name': 'B'}]}");
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testUseGettersForSettersConventionInvalidTypeForCollection() {
         PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(CollectionsGetterMutableModel.class)
                 .conventions(getDefaultAndUseGettersConvention());
-
-        decodingShouldFail(getCodec(builder, CollectionsGetterMutableModel.class), "{listField: ['1', '2']}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(builder, CollectionsGetterMutableModel.class), "{listField: ['1', '2']}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testUseGettersForSettersConventionInvalidTypeForMap() {
         PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(MapGetterMutableModel.class)
                 .conventions(getDefaultAndUseGettersConvention());
-
-        decodingShouldFail(getCodec(builder, MapGetterMutableModel.class), "{mapField: {a: '1'}}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(builder, MapGetterMutableModel.class), "{mapField: {a: '1'}}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testUseGettersForSettersConventionImmutableCollection() {
         PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(CollectionsGetterImmutableModel.class)
                 .conventions(getDefaultAndUseGettersConvention());
-
-        roundTrip(builder, new CollectionsGetterImmutableModel(asList(1, 2)), "{listField: [1, 2]}");
+        assertThrows(CodecConfigurationException.class, () ->
+                roundTrip(builder, new CollectionsGetterImmutableModel(asList(1, 2)), "{listField: [1, 2]}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testUseGettersForSettersConventionImmutableMap() {
         PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(MapGetterImmutableModel.class)
                 .conventions(getDefaultAndUseGettersConvention());
-
-        roundTrip(builder, new MapGetterImmutableModel(Collections.singletonMap("a", 3)), "{mapField: {a: 3}}");
+        assertThrows(CodecConfigurationException.class, () ->
+                roundTrip(builder, new MapGetterImmutableModel(Collections.singletonMap("a", 3)), "{mapField: {a: 3}}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testUseGettersForSettersConventionNullCollection() {
         PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(CollectionsGetterNullModel.class)
                 .conventions(getDefaultAndUseGettersConvention());
-
-        roundTrip(builder, new CollectionsGetterNullModel(asList(1, 2)), "{listField: [1, 2]}");
+        assertThrows(CodecConfigurationException.class, () ->
+                roundTrip(builder, new CollectionsGetterNullModel(asList(1, 2)), "{listField: [1, 2]}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testUseGettersForSettersConventionNullMap() {
         PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(MapGetterNullModel.class)
                 .conventions(getDefaultAndUseGettersConvention());
-
-        roundTrip(builder, new MapGetterNullModel(Collections.singletonMap("a", 3)), "{mapField: {a: 3}}");
+        assertThrows(CodecConfigurationException.class, () ->
+                roundTrip(builder, new MapGetterNullModel(Collections.singletonMap("a", 3)), "{mapField: {a: 3}}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testUseGettersForSettersConventionNotEmptyCollection() {
         PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(CollectionsGetterNonEmptyModel.class)
                 .conventions(getDefaultAndUseGettersConvention());
-
-        roundTrip(builder, new CollectionsGetterNonEmptyModel(asList(1, 2)), "{listField: [1, 2]}");
+        assertThrows(CodecConfigurationException.class, () ->
+                roundTrip(builder, new CollectionsGetterNonEmptyModel(asList(1, 2)), "{listField: [1, 2]}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testUseGettersForSettersConventionNotEmptyMap() {
         PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(MapGetterNonEmptyModel.class)
                 .conventions(getDefaultAndUseGettersConvention());
-
-        roundTrip(builder, new MapGetterNonEmptyModel(Collections.singletonMap("a", 3)), "{mapField: {a: 3}}");
+        assertThrows(CodecConfigurationException.class, () ->
+                roundTrip(builder, new MapGetterNonEmptyModel(Collections.singletonMap("a", 3)), "{mapField: {a: 3}}"));
     }
 
     @Test
@@ -468,38 +469,34 @@ public final class PojoCustomTest extends PojoTestCase {
         roundTrip(registry, model, "{ map: {a : 1, b: 'b', c: [1, 2, 3]}}");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testMapStringObjectModelWithObjectCodec() {
         MapStringObjectModel model = new MapStringObjectModel(new HashMap<>(Document.parse("{a : 1, b: 'b', c: [1, 2, 3]}")));
         CodecRegistry registry = fromRegistries(fromCodecs(new org.bson.codecs.MapCodec()), fromCodecs(new ObjectCodec()),
                 fromProviders(getPojoCodecProviderBuilder(MapStringObjectModel.class).build()));
-        roundTrip(registry, model, "{ map: {a : 1, b: 'b', c: [1, 2, 3]}}");
+        assertThrows(UnsupportedOperationException.class, () ->
+                roundTrip(registry, model, "{ map: {a : 1, b: 'b', c: [1, 2, 3]}}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testEncodingInvalidMapModel() {
-        encodesTo(getPojoCodecProviderBuilder(InvalidMapModel.class), getInvalidMapModel(), "{'invalidMap': {'1': 1, '2': 2}}");
+        assertThrows(CodecConfigurationException.class, () ->
+                encodesTo(getPojoCodecProviderBuilder(InvalidMapModel.class), getInvalidMapModel(), "{'invalidMap': {'1': 1, '2': 2}}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testDecodingInvalidMapModel() {
-        try {
-            decodingShouldFail(getCodec(InvalidMapModel.class), "{'invalidMap': {'1': 1, '2': 2}}");
-        } catch (CodecConfigurationException e) {
-            assertTrue(e.getMessage().startsWith("Failed to decode 'InvalidMapModel'. Decoding 'invalidMap' errored with:"));
-            throw e;
-        }
+        CodecConfigurationException e = assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(InvalidMapModel.class), "{'invalidMap': {'1': 1, '2': 2}}"));
+        assertTrue(e.getMessage().startsWith("Failed to decode 'InvalidMapModel'. Decoding 'invalidMap' errored with:"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testEncodingInvalidCollectionModel() {
-        try {
-            encodesTo(getPojoCodecProviderBuilder(InvalidCollectionModel.class), new InvalidCollectionModel(asList(1, 2, 3)),
-                "{collectionField: [1, 2, 3]}");
-        } catch (CodecConfigurationException e) {
-            assertTrue(e.getMessage().startsWith("Failed to encode 'InvalidCollectionModel'. Encoding 'collectionField' errored with:"));
-            throw e;
-        }
+        CodecConfigurationException e = assertThrows(CodecConfigurationException.class, () ->
+                encodesTo(getPojoCodecProviderBuilder(InvalidCollectionModel.class), new InvalidCollectionModel(asList(1, 2, 3)),
+                        "{collectionField: [1, 2, 3]}"));
+        assertTrue(e.getMessage().startsWith("Failed to encode 'InvalidCollectionModel'. Encoding 'collectionField' errored with:"));
     }
 
     @Test
@@ -508,108 +505,122 @@ public final class PojoCustomTest extends PojoTestCase {
                 "{'invalidMap': {'1': 1, '2': 2}}");
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testConstructorNotPublicModel() {
-        decodingShouldFail(getCodec(ConstructorNotPublicModel.class), "{'integerField': 99}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(ConstructorNotPublicModel.class), "{'integerField': 99}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testDataUnknownClass() {
         ClassModel<SimpleModel> classModel = ClassModel.builder(SimpleModel.class).enableDiscriminator(true).build();
-        try {
-            decodingShouldFail(getCodec(PojoCodecProvider.builder().register(classModel), SimpleModel.class), "{'_t': 'FakeModel'}");
-        } catch (CodecConfigurationException e) {
-            assertTrue(e.getMessage().startsWith("Failed to decode 'SimpleModel'. Decoding errored with:"));
-            throw e;
-        }
+        CodecConfigurationException e = assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(PojoCodecProvider.builder().register(classModel), SimpleModel.class), "{'_t': 'FakeModel'}"));
+        assertTrue(e.getMessage().startsWith("Failed to decode 'SimpleModel'. Decoding errored with:"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testInvalidTypeForField() {
-        decodingShouldFail(getCodec(SimpleModel.class), "{'_t': 'SimpleModel', 'stringField': 123}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(SimpleModel.class), "{'_t': 'SimpleModel', 'stringField': 123}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testInvalidTypeForPrimitiveField() {
-        decodingShouldFail(getCodec(PrimitivesModel.class), "{ '_t': 'PrimitivesModel', 'myBoolean': null}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(PrimitivesModel.class), "{ '_t': 'PrimitivesModel', 'myBoolean': null}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testInvalidTypeForModelField() {
-        decodingShouldFail(getCodec(SimpleNestedPojoModel.class), "{ '_t': 'SimpleNestedPojoModel', 'simple': 123}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(SimpleNestedPojoModel.class), "{ '_t': 'SimpleNestedPojoModel', 'simple': 123}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testInvalidDiscriminatorInNestedModel() {
-        decodingShouldFail(getCodec(SimpleNestedPojoModel.class), "{ '_t': 'SimpleNestedPojoModel',"
-                + "'simple': {'_t': 'FakeModel', 'integerField': 42, 'stringField': 'myString'}}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(SimpleNestedPojoModel.class), "{ '_t': 'SimpleNestedPojoModel',"
+                        + "'simple': {'_t': 'FakeModel', 'integerField': 42, 'stringField': 'myString'}}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testCannotEncodeUnspecializedClasses() {
         CodecRegistry registry = fromProviders(getPojoCodecProviderBuilder(GenericTreeModel.class).build());
-        encode(registry.get(GenericTreeModel.class), getGenericTreeModel(), false);
+        assertThrows(CodecConfigurationException.class, () ->
+                encode(registry.get(GenericTreeModel.class), getGenericTreeModel(), false));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testCannotDecodeUnspecializedClasses() {
-        decodingShouldFail(getCodec(GenericTreeModel.class),
-                "{'field1': 'top', 'field2': 1, "
-                        + "'left': {'field1': 'left', 'field2': 2, 'left': {'field1': 'left', 'field2': 3}}, "
-                        + "'right': {'field1': 'right', 'field2': 4, 'left': {'field1': 'left', 'field2': 5}}}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(GenericTreeModel.class),
+                        "{'field1': 'top', 'field2': 1, "
+                                + "'left': {'field1': 'left', 'field2': 2, 'left': {'field1': 'left', 'field2': 3}}, "
+                                + "'right': {'field1': 'right', 'field2': 4, 'left': {'field1': 'left', 'field2': 5}}}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testBsonCreatorPrimitivesAndNullValues() {
-        decodingShouldFail(getCodec(CreatorConstructorPrimitivesModel.class), "{intField: 100,  stringField: 'test'}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(CreatorConstructorPrimitivesModel.class), "{intField: 100,  stringField: 'test'}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testCreatorMethodThrowsExceptionModel() {
-        decodingShouldFail(getCodec(CreatorMethodThrowsExceptionModel.class),
-                "{'integerField': 10, 'stringField': 'eleven', 'longField': {$numberLong: '12'}}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(CreatorMethodThrowsExceptionModel.class),
+                        "{'integerField': 10, 'stringField': 'eleven', 'longField': {$numberLong: '12'}}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testCreatorConstructorThrowsExceptionModel() {
-        decodingShouldFail(getCodec(CreatorConstructorThrowsExceptionModel.class), "{}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(CreatorConstructorThrowsExceptionModel.class), "{}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testInvalidSetterModel() {
-        decodingShouldFail(getCodec(InvalidSetterArgsModel.class), "{'integerField': 42, 'stringField': 'myString'}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(InvalidSetterArgsModel.class), "{'integerField': 42, 'stringField': 'myString'}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testInvalidGetterAndSetterModelEncoding() {
         InvalidGetterAndSetterModel model = new InvalidGetterAndSetterModel(42, "myString");
-        roundTrip(getPojoCodecProviderBuilder(InvalidGetterAndSetterModel.class), model, "{'integerField': 42, 'stringField': 'myString'}");
+        assertThrows(CodecConfigurationException.class, () ->
+                roundTrip(getPojoCodecProviderBuilder(InvalidGetterAndSetterModel.class), model, "{'integerField': 42, 'stringField': 'myString'}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testInvalidGetterAndSetterModelDecoding() {
-        decodingShouldFail(getCodec(InvalidGetterAndSetterModel.class), "{'integerField': 42, 'stringField': 'myString'}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(InvalidGetterAndSetterModel.class), "{'integerField': 42, 'stringField': 'myString'}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testInvalidBsonRepresentationStringDecoding() {
-        decodingShouldFail(getCodec(BsonRepresentationUnsupportedString.class), "{'id': 'hello', s: 3}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(BsonRepresentationUnsupportedString.class), "{'id': 'hello', s: 3}"));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testInvalidBsonRepresentationStringEncoding() {
-        encodesTo(getPojoCodecProviderBuilder(BsonRepresentationUnsupportedString.class),
-                new BsonRepresentationUnsupportedString("1"), "");
+        assertThrows(CodecConfigurationException.class, () ->
+                encodesTo(getPojoCodecProviderBuilder(BsonRepresentationUnsupportedString.class),
+                        new BsonRepresentationUnsupportedString("1"), ""));
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testInvalidBsonRepresentationIntDecoding() {
-        decodingShouldFail(getCodec(BsonRepresentationUnsupportedInt.class), "{'id': 'hello', age: '3'}");
+        assertThrows(CodecConfigurationException.class, () ->
+                decodingShouldFail(getCodec(BsonRepresentationUnsupportedInt.class), "{'id': 'hello', age: '3'}"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testStringIdIsNotObjectId() {
-        encodesTo(getCodec(BsonRepresentationModel.class), new BsonRepresentationModel("notanobjectid", 1), null);
+        assertThrows(IllegalArgumentException.class, () ->
+                encodesTo(getCodec(BsonRepresentationModel.class), new BsonRepresentationModel("notanobjectid", 1), null));
     }
 
     @Test
@@ -638,9 +649,10 @@ public final class PojoCustomTest extends PojoTestCase {
         roundTrip(actualRegistry, model, json);
     }
 
-    @Test(expected = CodecConfigurationException.class)
+    @Test
     public void testBsonExtraElementsInvalidModel() {
-        getPojoCodecProviderBuilder(BsonExtraElementsInvalidModel.class).build();
+        assertThrows(CodecConfigurationException.class, () ->
+                getPojoCodecProviderBuilder(BsonExtraElementsInvalidModel.class).build());
     }
 
     private List<Convention> getDefaultAndUseGettersConvention() {

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoRoundTripTest.java
@@ -102,37 +102,25 @@ import org.bson.codecs.pojo.entities.conventions.Subclass1Model;
 import org.bson.codecs.pojo.entities.conventions.Subclass2Model;
 import org.bson.codecs.pojo.entities.conventions.SuperClassModel;
 import org.bson.types.ObjectId;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
-@RunWith(Parameterized.class)
 public final class PojoRoundTripTest extends PojoTestCase {
 
-    private final String name;
-    private final Object model;
-    private final PojoCodecProvider.Builder builder;
-    private final String json;
-
-    public PojoRoundTripTest(final String name, final Object model, final String json, final PojoCodecProvider.Builder builder) {
-        this.name = name;
-        this.model = model;
-        this.json = json;
-        this.builder = builder;
-    }
-
-    @Test
-    public void test() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("data")
+    public void test(final String name, final Object model, final String json, final PojoCodecProvider.Builder builder) {
         roundTrip(builder, model, json);
         threadedRoundTrip(builder, model, json);
     }
@@ -540,16 +528,15 @@ public final class PojoRoundTripTest extends PojoTestCase {
         return data;
     }
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        List<Object[]> data = new ArrayList<>();
+    public static Stream<Arguments> data() {
+        List<Arguments> data = new ArrayList<>();
 
         for (TestData testData : testCases()) {
-            data.add(new Object[]{format("%s", testData.getName()), testData.getModel(), testData.getJson(), testData.getBuilder()});
-            data.add(new Object[]{format("%s [Auto]", testData.getName()), testData.getModel(), testData.getJson(), AUTOMATIC_BUILDER});
-            data.add(new Object[]{format("%s [Package]", testData.getName()), testData.getModel(), testData.getJson(), PACKAGE_BUILDER});
+            data.add(Arguments.of(format("%s", testData.getName()), testData.getModel(), testData.getJson(), testData.getBuilder()));
+            data.add(Arguments.of(format("%s [Auto]", testData.getName()), testData.getModel(), testData.getJson(), AUTOMATIC_BUILDER));
+            data.add(Arguments.of(format("%s [Package]", testData.getName()), testData.getModel(), testData.getJson(), PACKAGE_BUILDER));
         }
-        return data;
+        return data.stream();
     }
 
     private static final PojoCodecProvider.Builder AUTOMATIC_BUILDER = PojoCodecProvider.builder().automatic(true);

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoTestCase.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoTestCase.java
@@ -75,7 +75,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.pojo.Conventions.DEFAULT_CONVENTIONS;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static util.ThreadTestHelpers.executeAll;
 
 abstract class PojoTestCase {
@@ -132,7 +132,7 @@ abstract class PojoTestCase {
         OutputBuffer encoded = encode(codec, value, collectible);
 
         BsonDocument asBsonDocument = decode(DOCUMENT_CODEC, encoded);
-        assertEquals("Encoded value", BsonDocument.parse(json), asBsonDocument);
+        assertEquals(BsonDocument.parse(json), asBsonDocument);
     }
 
     <T> void decodesTo(final PojoCodecProvider.Builder builder, final String json, final T expected) {
@@ -148,7 +148,7 @@ abstract class PojoTestCase {
     <T> void decodesTo(final Codec<T> codec, final String json, final T expected) {
         OutputBuffer encoded = encode(DOCUMENT_CODEC, BsonDocument.parse(json), false);
         T result = decode(codec, encoded);
-        assertEquals("Decoded value", expected, result);
+        assertEquals(expected, result);
     }
 
     <T> void decodingShouldFail(final Codec<T> codec, final String json) {

--- a/bson/src/test/unit/org/bson/codecs/pojo/PropertyModelBuilderTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PropertyModelBuilderTest.java
@@ -18,17 +18,18 @@ package org.bson.codecs.pojo;
 
 import org.bson.codecs.IntegerCodec;
 import org.bson.codecs.pojo.annotations.BsonProperty;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.List;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.bson.codecs.pojo.PojoBuilderHelper.createPropertyModelBuilder;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class PropertyModelBuilderTest {
 
@@ -67,12 +68,13 @@ public final class PropertyModelBuilderTest {
         assertFalse(propertyModelBuilder.isDiscriminatorEnabled());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testMustBeReadableOrWritable() {
-        createPropertyModelBuilder(PROPERTY_METADATA)
+        assertThrows(IllegalStateException.class, () ->
+                createPropertyModelBuilder(PROPERTY_METADATA)
                 .readName(null)
                 .writeName(null)
-                .build();
+                .build());
     }
 
     private static final List<Annotation> ANNOTATIONS = Collections.singletonList(

--- a/bson/src/test/unit/org/bson/codecs/pojo/PropertyModelTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PropertyModelTest.java
@@ -18,16 +18,16 @@ package org.bson.codecs.pojo;
 
 import org.bson.codecs.IntegerCodec;
 import org.bson.codecs.pojo.annotations.BsonProperty;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.List;
 
-import static junit.framework.TestCase.assertFalse;
 import static org.bson.codecs.pojo.PojoBuilderHelper.createPropertyModelBuilder;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public final class PropertyModelTest {
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/TypeDataTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/TypeDataTest.java
@@ -17,15 +17,15 @@
 package org.bson.codecs.pojo;
 
 import org.bson.codecs.pojo.entities.GenericHolderModel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("rawtypes")
 public final class TypeDataTest {

--- a/bson/src/test/unit/org/bson/codecs/pojo/TypeParameterMapTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/TypeParameterMapTest.java
@@ -16,13 +16,14 @@
 
 package org.bson.codecs.pojo;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class TypeParameterMapTest {
 
@@ -49,8 +50,9 @@ public final class TypeParameterMapTest {
         assertEquals(expected, typeParameterMap.getPropertyToClassParamIndexMap());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testFieldCannotBeGenericAndContainTypeParameters() {
-        TypeParameterMap.builder().addIndex(1).addIndex(2, 2).build();
+        assertThrows(IllegalStateException.class, () ->
+                TypeParameterMap.builder().addIndex(1).addIndex(2, 2).build());
     }
 }

--- a/bson/src/test/unit/org/bson/internal/BsonUtilTest.java
+++ b/bson/src/test/unit/org/bson/internal/BsonUtilTest.java
@@ -32,6 +32,7 @@ import java.util.Map.Entry;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.bson.assertions.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
@@ -122,7 +123,7 @@ final class BsonUtilTest {
         } else if (expected instanceof BsonJavaScriptWithScope) {
             assertEquals(BsonJavaScriptWithScope.class, actualClass);
         } else {
-            org.bson.assertions.Assertions.fail("Unexpected " + expected.getClass().toString());
+            fail("Unexpected " + expected.getClass().toString());
         }
     }
 

--- a/bson/src/test/unit/org/bson/io/BasicOutputBufferTest.java
+++ b/bson/src/test/unit/org/bson/io/BasicOutputBufferTest.java
@@ -16,14 +16,14 @@
 
 package org.bson.io;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 // for tests that are too slow to run in Groovy
 public class BasicOutputBufferTest {
@@ -43,7 +43,7 @@ public class BasicOutputBufferTest {
 
             // then
             byte[] bytes = getBytes(bsonOutput);
-            assertArrayEquals("failed with code point " + codePoint, str.getBytes(StandardCharsets.UTF_8), Arrays.copyOfRange(bytes, 0, bytes.length - 1));
+            assertArrayEquals(str.getBytes(StandardCharsets.UTF_8), Arrays.copyOfRange(bytes, 0, bytes.length - 1), "failed with code point " + codePoint);
         }
     }
 

--- a/bson/src/test/unit/org/bson/json/JsonObjectTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonObjectTest.java
@@ -20,47 +20,48 @@ import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.codecs.BsonCodecProvider;
 import org.bson.codecs.JsonObjectCodecProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JsonObjectTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNull() {
-        new JsonObject(null);
+        assertThrows(IllegalArgumentException.class, () -> new JsonObject(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testArray() {
-        new JsonObject("['A', 'B', 'C']");
+        assertThrows(IllegalArgumentException.class, () ->new JsonObject("['A', 'B', 'C']"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSpaceInvalidObject() {
-        new JsonObject(" ['A']");
+        assertThrows(IllegalArgumentException.class, () ->new JsonObject(" ['A']"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLineFeedInvalidObject() {
-        new JsonObject("\nvalue");
+        assertThrows(IllegalArgumentException.class, () ->new JsonObject("\nvalue"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCarriageReturnInvalidObject() {
-        new JsonObject("\r123");
+        assertThrows(IllegalArgumentException.class, () ->new JsonObject("\r123"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testHorizontalTabInvalidObject() {
-        new JsonObject("\t123");
+        assertThrows(IllegalArgumentException.class, () ->new JsonObject("\t123"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testOnlyWhitespace() {
-        new JsonObject("    \t\n  \r  ");
+        assertThrows(IllegalArgumentException.class, () ->new JsonObject("    \t\n  \r  "));
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -26,7 +26,7 @@ import org.bson.BsonTimestamp;
 import org.bson.BsonType;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -41,11 +41,12 @@ import java.util.Locale;
 import java.util.function.Function;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class JsonReaderTest {
@@ -872,11 +873,11 @@ public class JsonReaderTest {
         });
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testClosedState() {
         AbstractBsonReader bsonReader = new JsonReader("");
         bsonReader.close();
-        bsonReader.readBinaryData();
+        assertThrows(IllegalStateException.class, () -> bsonReader.readBinaryData());
     }
 
     @Test
@@ -1015,14 +1016,15 @@ public class JsonReaderTest {
     }
 
     // testing that JsonReader uses internal UuidStringValidator, as UUID.fromString accepts this UUID
-    @Test(expected = JsonParseException.class)
+    @Test
     public void testInvalidUuid() {
         // first hyphen out of place
         String json = "{ \"$uuid\" : \"73ff-d26444b-34c6-990e8e-7d1dfc035d4\"}}";
-        testStringAndStream(json, bsonReader -> {
-            bsonReader.readBinaryData();
-            return null;
-        });
+        assertThrows(JsonParseException.class, () ->
+                testStringAndStream(json, bsonReader -> {
+                    bsonReader.readBinaryData();
+                    return null;
+                }));
     }
 
     @Test
@@ -1305,7 +1307,7 @@ public class JsonReaderTest {
     }
 
     private void testStringAndStream(final String json, final Function<AbstractBsonReader, Void> testFunc,
-                                     final Class<? extends RuntimeException> exClass) {
+            final Class<? extends RuntimeException> exClass) {
         try {
             testFunc.apply(new JsonReader(json));
         } catch (Exception e) {

--- a/bson/src/test/unit/org/bson/json/JsonScannerTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonScannerTest.java
@@ -17,9 +17,10 @@
 package org.bson.json;
 
 import org.bson.BsonRegularExpression;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JsonScannerTest {
 
@@ -497,41 +498,41 @@ public class JsonScannerTest {
         assertEquals(',', buffer.read());
     }
 
-    @Test(expected = JsonParseException.class)
+    @Test
     public void testInvalidRegularExpression() {
         String json = "\t /pattern/nsk,";
         JsonBuffer buffer = new JsonStringBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
-        scanner.nextToken();
+        assertThrows(JsonParseException.class, () -> scanner.nextToken());
     }
 
-    @Test(expected = JsonParseException.class)
+    @Test
     public void testInvalidRegularExpressionNoEnd() {
         String json = "/b";
         JsonBuffer buffer = new JsonStringBuffer(json);
         JsonScanner scanner = new JsonScanner(buffer);
-        scanner.nextToken();
+        assertThrows(JsonParseException.class, () ->scanner.nextToken());
     }
 
-    @Test(expected = JsonParseException.class)
+    @Test
     public void testInvalidInput() {
         String json = "\t &&";
         JsonScanner scanner = new JsonScanner(json);
-        scanner.nextToken();
+        assertThrows(JsonParseException.class, () -> scanner.nextToken());
     }
 
-    @Test(expected = JsonParseException.class)
+    @Test
     public void testInvalidNumber() {
         String json = "\t 123a]";
         JsonScanner scanner = new JsonScanner(json);
-        scanner.nextToken();
+        assertThrows(JsonParseException.class, () -> scanner.nextToken());
     }
 
-    @Test(expected = JsonParseException.class)
+    @Test
     public void testInvalidInfinity() {
         String json = "\t -Infinnity]";
         JsonScanner scanner = new JsonScanner(json);
-        scanner.nextToken();
+        assertThrows(JsonParseException.class, () -> scanner.nextToken());
     }
 }
 

--- a/bson/src/test/unit/org/bson/json/JsonStreamBufferTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonStreamBufferTest.java
@@ -16,12 +16,13 @@
 
 package org.bson.json;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JsonStreamBufferTest {
 
@@ -51,12 +52,12 @@ public class JsonStreamBufferTest {
         assertEquals(2, buffer.getPosition());
     }
 
-    @Test(expected = JsonParseException.class)
+    @Test
     public void testEOFCheck() {
         JsonStreamBuffer buffer = new JsonStreamBuffer(new InputStreamReader(new ByteArrayInputStream("".getBytes())));
 
         buffer.read();
-        buffer.read();
+        assertThrows(JsonParseException.class, () -> buffer.read());
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/json/JsonStringBufferTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonStringBufferTest.java
@@ -16,9 +16,10 @@
 
 package org.bson.json;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JsonStringBufferTest {
 
@@ -48,11 +49,11 @@ public class JsonStringBufferTest {
         assertEquals(2, buffer.getPosition());
     }
 
-    @Test(expected = JsonParseException.class)
+    @Test
     public void testEOFCheck() {
         JsonStringBuffer buffer = new JsonStringBuffer("");
 
         buffer.read();
-        buffer.read();
+        assertThrows(JsonParseException.class, () -> buffer.read());
     }
 }

--- a/bson/src/test/unit/org/bson/json/JsonWriterTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonWriterTest.java
@@ -23,21 +23,22 @@ import org.bson.BsonRegularExpression;
 import org.bson.BsonTimestamp;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
 import java.util.Date;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JsonWriterTest {
     private StringWriter stringWriter;
     private JsonWriter writer;
 
-    @Before
+    @BeforeEach
     public void before() {
         stringWriter = new StringWriter();
         writer = new JsonWriter(stringWriter, JsonWriterSettings.builder().build());
@@ -53,123 +54,140 @@ public class JsonWriterTest {
         }
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowExceptionForBooleanWhenWritingBeforeStartingDocument() {
-        writer.writeBoolean("b1", true);
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeBoolean("b1", true));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowExceptionForNameWhenWritingBeforeStartingDocument() {
-        writer.writeName("name");
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeName("name"));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowExceptionForStringWhenStateIsValue() {
         writer.writeStartDocument();
-        writer.writeString("SomeString");
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeString("SomeString"));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowExceptionWhenEndingAnArrayWhenStateIsValue() {
         writer.writeStartDocument();
-        writer.writeEndArray();
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeEndArray());
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowExceptionWhenWritingASecondName() {
         writer.writeStartDocument();
         writer.writeName("f1");
-        writer.writeName("i2");
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeName("i2"));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowExceptionWhenEndingADocumentBeforeValueIsWritten() {
         writer.writeStartDocument();
         writer.writeName("f1");
-        writer.writeEndDocument();
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeEndDocument());
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowAnExceptionWhenTryingToWriteASecondValue() {
+        writer.writeStartDocument();
+        writer.writeName("f1");
         writer.writeDouble(100);
-        writer.writeString("i2");
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeString("i2"));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowAnExceptionWhenTryingToWriteJavaScript() {
+        writer.writeStartDocument();
+        writer.writeName("f1");
         writer.writeDouble(100);
-        writer.writeJavaScript("var i");
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeJavaScript("var i"));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowAnExceptionWhenWritingANameInAnArray() {
         writer.writeStartDocument();
         writer.writeStartArray("f2");
-        writer.writeName("i3");
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeName("i3"));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowAnExceptionWhenEndingDocumentInTheMiddleOfWritingAnArray() {
         writer.writeStartDocument();
         writer.writeStartArray("f2");
-        writer.writeEndDocument();
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeEndDocument());
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowAnExceptionWhenEndingAnArrayInASubDocument() {
         writer.writeStartDocument();
         writer.writeStartArray("f2");
         writer.writeStartDocument();
-        writer.writeEndArray();
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeEndArray());
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowAnExceptionWhenWritingANameInAnArrayEvenWhenSubDocumentExistsInArray() {
         writer.writeStartDocument();
         writer.writeStartArray("f2");
         writer.writeStartDocument();
         writer.writeEndDocument();
-        writer.writeName("i3");
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeName("i3"));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowAnExceptionWhenAttemptingToEndAnArrayThatWasNotStarted() {
         writer.writeStartDocument();
         writer.writeStartArray("f2");
         writer.writeEndArray();
-        writer.writeEndArray();
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeEndArray());
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowAnErrorIfTryingToWriteNameIntoAJavascriptScope() {
         writer.writeStartDocument();
         writer.writeJavaScriptWithScope("js1", "var i = 1");
-
-        writer.writeName("b1");
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeName("b1"));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowAnErrorIfTryingToWriteValueIntoAJavascriptScope() {
         writer.writeStartDocument();
         writer.writeJavaScriptWithScope("js1", "var i = 1");
-
-        writer.writeBinaryData(new BsonBinary(new byte[]{0, 0, 1, 0}));
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeBinaryData(new BsonBinary(new byte[]{0, 0, 1, 0})));
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowAnErrorIfTryingToWriteArrayIntoAJavascriptScope() {
         writer.writeStartDocument();
         writer.writeJavaScriptWithScope("js1", "var i = 1");
-
-        writer.writeStartArray();
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeStartArray());
     }
 
-    @Test(expected = BsonInvalidOperationException.class)
+    @Test
     public void shouldThrowAnErrorIfTryingToWriteEndDocumentIntoAJavascriptScope() {
         writer.writeStartDocument();
         writer.writeJavaScriptWithScope("js1", "var i = 1");
-
-        writer.writeEndDocument();
+        assertThrows(BsonInvalidOperationException.class, () ->
+                writer.writeEndDocument());
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/types/BSONBsonTimestampTest.java
+++ b/bson/src/test/unit/org/bson/types/BSONBsonTimestampTest.java
@@ -16,10 +16,10 @@
 
 package org.bson.types;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BSONBsonTimestampTest {
 

--- a/bson/src/test/unit/org/bson/types/Decimal128Test.java
+++ b/bson/src/test/unit/org/bson/types/Decimal128Test.java
@@ -16,7 +16,7 @@
 
 package org.bson.types;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
@@ -28,11 +28,12 @@ import static org.bson.types.Decimal128.POSITIVE_INFINITY;
 import static org.bson.types.Decimal128.POSITIVE_ZERO;
 import static org.bson.types.Decimal128.fromIEEE754BIDEncoding;
 import static org.bson.types.Decimal128.parse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class Decimal128Test {
 
@@ -221,10 +222,11 @@ public class Decimal128Test {
         assertEquals(NEGATIVE_NaN, parse("-nAn"));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void shouldNotConvertNaNToBigDecimal() {
-        // when
-        NaN.bigDecimalValue();
+        assertThrows(ArithmeticException.class, () ->
+                // when
+                NaN.bigDecimalValue());
     }
 
     @Test
@@ -316,14 +318,14 @@ public class Decimal128Test {
         assertEquals(809500703, fromIEEE754BIDEncoding(0x3040000000000000L, 0x0000000000000001L).hashCode());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void shouldNotConvertPositiveInfinityToBigDecimal() {
-        POSITIVE_INFINITY.bigDecimalValue();
+        assertThrows(ArithmeticException.class, () -> POSITIVE_INFINITY.bigDecimalValue());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void shouldNotConvertNegativeInfinityToBigDecimal() {
-        NEGATIVE_INFINITY.bigDecimalValue();
+        assertThrows(ArithmeticException.class, () ->NEGATIVE_INFINITY.bigDecimalValue());
     }
 
     @Test
@@ -506,9 +508,9 @@ public class Decimal128Test {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowIllegalArgumentExceptionIfBigDecimalIsTooLarge() {
-        new Decimal128(new BigDecimal("12345678901234567890123456789012345"));
+        assertThrows(IllegalArgumentException.class, () -> new Decimal128(new BigDecimal("12345678901234567890123456789012345")));
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/types/ObjectIdTest.java
+++ b/bson/src/test/unit/org/bson/types/ObjectIdTest.java
@@ -16,7 +16,7 @@
 
 package org.bson.types;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -30,11 +30,11 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.Random;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ObjectIdTest {
     @Test
@@ -167,8 +167,7 @@ public class ObjectIdTest {
     @Test
     public void testToHexString() {
         assertEquals("000000000000000000000000", new ObjectId(new byte[12]).toHexString());
-        assertEquals("7fffffff007fff7fff007fff",
-                new ObjectId(new byte[]{127, -1, -1, -1, 0, 127, -1, 127, -1, 0, 127, -1}).toHexString());
+        assertEquals("7fffffff007fff7fff007fff", new ObjectId(new byte[]{127, -1, -1, -1, 0, 127, -1, 127, -1, 0, 127, -1}).toHexString());
     }
 
     private Date getDate(final String s) throws ParseException {
@@ -211,8 +210,7 @@ public class ObjectIdTest {
                         46, 79, 98, 106, 101, 99, 116, 73, 100, 36, 83, 101, 114, 105, 97, 108, 105, 122, 97, 116, 105, 111, 110, 80, 114,
                         111, 120, 121, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 1, 91, 0, 5, 98, 121, 116, 101, 115, 116, 0, 2, 91, 66, 120, 112, 117,
                         114, 0, 2, 91, 66, -84, -13, 23, -8, 6, 8, 84, -32, 2, 0, 0, 120, 112, 0, 0, 0, 12, 95, -113, 79, -49, 39, 81, 111,
-                        5, -25, -22, -27, -66},
-                baos.toByteArray());
+                        5, -25, -22, -27, -66}, baos.toByteArray());
 
         // when
         ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());


### PR DESCRIPTION
JAVA-5215

I tried to use the IntelliJ inspection to do this automatically.  It got me part of the way there, but there were a bunch of tests that it either didn't pick up or didn't know how to translate (e.g. the parameterized test), so I went ahead and finished the job manually.  It's tedious but low risk.