### PR TITLE
Ensures the QueryBatchCursor cleans up resources

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/QueryBatchCursor.java
@@ -292,7 +292,7 @@ class QueryBatchCursor<T> implements AggregateResponseBatchCursor<T> {
                 throw translateCommandException(e, serverCursor);
             }
             resourceManager.setServerCursor(nextServerCursor);
-            if (limitReached()) {
+            if (limitReached() || !resourceManager.operable()) {
                 resourceManager.releaseServerAndClientResources(connection);
             }
         });


### PR DESCRIPTION
The QueryBatchCursor now checks the cursor is operable on result of getMore.

Updated the Async test to ensure connectionB is used.

JAVA-5214