### PR TITLE
Remove dead code in ReplyHeader

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -546,7 +546,7 @@ public class InternalStreamConnection implements InternalConnection {
     }
 
     private <T> T getCommandResult(final Decoder<T> decoder, final ResponseBuffers responseBuffers, final int messageId) {
-        T result = new ReplyMessage<>(responseBuffers, decoder, messageId).getDocuments().get(0);
+        T result = new ReplyMessage<>(responseBuffers, decoder, messageId).getDocument();
         MongoException writeConcernBasedError = createSpecialWriteConcernException(responseBuffers, description.getServerAddress());
         if (writeConcernBasedError != null) {
             throw new MongoWriteConcernWithResponseException(writeConcernBasedError, result);

--- a/driver-core/src/main/com/mongodb/internal/connection/ResponseBuffers.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ResponseBuffers.java
@@ -49,7 +49,7 @@ public class ResponseBuffers implements Closeable {
     <T extends BsonDocument> T getResponseDocument(final int messageId, final Decoder<T> decoder) {
         ReplyMessage<T> replyMessage = new ReplyMessage<>(this, decoder, messageId);
         reset();
-        return replyMessage.getDocuments().get(0);
+        return replyMessage.getDocument();
     }
 
     /**

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/ReplyHeaderSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/ReplyHeaderSpecification.groovy
@@ -35,7 +35,7 @@ class ReplyHeaderSpecification extends Specification {
             writeInt(responseFlags)
             writeLong(9000)
             writeInt(4)
-            writeInt(30)
+            writeInt(1)
         }
         def byteBuf = outputBuffer.byteBuffers.get(0)
 
@@ -46,12 +46,6 @@ class ReplyHeaderSpecification extends Specification {
         replyHeader.messageLength == 186
         replyHeader.requestId == 45
         replyHeader.responseTo == 23
-        replyHeader.responseFlags == responseFlags
-        replyHeader.cursorId == 9000
-        replyHeader.startingFrom == 4
-        replyHeader.numberReturned == 30
-        replyHeader.cursorNotFound == cursorNotFound
-        replyHeader.queryFailure == queryFailure
 
         where:
         responseFlags << [0, 1, 2, 3]
@@ -72,7 +66,7 @@ class ReplyHeaderSpecification extends Specification {
             writeInt(responseFlags)
             writeLong(9000)
             writeInt(4)
-            writeInt(30)
+            writeInt(1)
         }
         def byteBuf = outputBuffer.byteBuffers.get(0)
         def compressedHeader = new CompressedHeader(byteBuf, new MessageHeader(byteBuf, getDefaultMaxMessageSize()))
@@ -84,12 +78,6 @@ class ReplyHeaderSpecification extends Specification {
         replyHeader.messageLength == 274
         replyHeader.requestId == 45
         replyHeader.responseTo == 23
-        replyHeader.responseFlags == responseFlags
-        replyHeader.cursorId == 9000
-        replyHeader.startingFrom == 4
-        replyHeader.numberReturned == 30
-        replyHeader.cursorNotFound == cursorNotFound
-        replyHeader.queryFailure == queryFailure
 
         where:
         responseFlags << [0, 1, 2, 3]
@@ -138,7 +126,7 @@ class ReplyHeaderSpecification extends Specification {
 
         then:
         def ex = thrown(MongoInternalException)
-        ex.getMessage() == 'The reply message length 35 is less than the mimimum message length 36'
+        ex.getMessage() == 'The reply message length 35 is less than the minimum message length 36'
     }
 
     def 'should throw MongoInternalException on message size > max message size'() {
@@ -182,7 +170,7 @@ class ReplyHeaderSpecification extends Specification {
 
         then:
         def ex = thrown(MongoInternalException)
-        ex.getMessage() == 'The reply message number of returned documents, -1, is less than 0'
+        ex.getMessage() == 'The reply message number of returned documents, -1, is expected to be 1'
     }
 
     def 'should throw MongoInternalException on num documents < 0 with compressed header'() {
@@ -208,6 +196,6 @@ class ReplyHeaderSpecification extends Specification {
 
         then:
         def ex = thrown(MongoInternalException)
-        ex.getMessage() == 'The reply message number of returned documents, -1, is less than 0'
+        ex.getMessage() == 'The reply message number of returned documents, -1, is expected to be 1'
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/MessageHelper.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/MessageHelper.java
@@ -55,24 +55,15 @@ final class MessageHelper {
         return buildReply(responseTo, json, 0);
     }
 
-    public static ResponseBuffers buildFailedReply(final String json) {
-        return buildFailedReply(0, json);
-    }
-
-    public static ResponseBuffers buildFailedReply(final int responseTo, final String json) {
-        return buildReply(responseTo, json, 2);
-    }
-
     public static ResponseBuffers buildReply(final int responseTo, final String json, final int responseFlags) {
         ByteBuf body = encodeJson(json);
         body.flip();
 
-        ReplyHeader header = buildReplyHeader(responseTo, 1, body.remaining(), responseFlags);
+        ReplyHeader header = buildReplyHeader(responseTo, body.remaining(), responseFlags);
         return new ResponseBuffers(header, body);
     }
 
-    private static ReplyHeader buildReplyHeader(final int responseTo, final int numDocuments, final int documentsSize,
-                                                final int responseFlags) {
+    private static ReplyHeader buildReplyHeader(final int responseTo, final int documentsSize, final int responseFlags) {
         ByteBuffer headerByteBuffer = ByteBuffer.allocate(36);
         headerByteBuffer.order(ByteOrder.LITTLE_ENDIAN);
         headerByteBuffer.putInt(36 + documentsSize); // length
@@ -82,7 +73,7 @@ final class MessageHelper {
         headerByteBuffer.putInt(responseFlags); // responseFlags
         headerByteBuffer.putLong(0); // cursorId
         headerByteBuffer.putInt(0); // startingFrom
-        headerByteBuffer.putInt(numDocuments); //numberReturned
+        headerByteBuffer.putInt(1); //numberReturned
         ((Buffer) headerByteBuffer).flip();
 
         ByteBufNIO buffer = new ByteBufNIO(headerByteBuffer);

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestInternalConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestInternalConnection.java
@@ -177,7 +177,7 @@ class TestInternalConnection implements InternalConnection {
                 throw getCommandFailureException(getResponseDocument(responseBuffers, message, new BsonDocumentCodec()),
                         description.getServerAddress());
             }
-            return new ReplyMessage<>(responseBuffers, decoder, message.getId()).getDocuments().get(0);
+            return new ReplyMessage<>(responseBuffers, decoder, message.getId()).getDocument();
         }
     }
 
@@ -200,7 +200,7 @@ class TestInternalConnection implements InternalConnection {
                                                            final CommandMessage commandMessage, final Decoder<T> decoder) {
         ReplyMessage<T> replyMessage = new ReplyMessage<>(responseBuffers, decoder, commandMessage.getId());
         responseBuffers.reset();
-        return replyMessage.getDocuments().get(0);
+        return replyMessage.getDocument();
     }
 
     @Override
@@ -222,10 +222,10 @@ class TestInternalConnection implements InternalConnection {
         headerByteBuffer.putInt(header.getRequestId());
         headerByteBuffer.putInt(responseTo);
         headerByteBuffer.putInt(1);
-        headerByteBuffer.putInt(header.getResponseFlags());
-        headerByteBuffer.putLong(header.getCursorId());
-        headerByteBuffer.putInt(header.getStartingFrom());
-        headerByteBuffer.putInt(header.getNumberReturned());
+        headerByteBuffer.putInt(0);
+        headerByteBuffer.putLong(0);
+        headerByteBuffer.putInt(0);
+        headerByteBuffer.putInt(1);
         ((Buffer) headerByteBuffer).flip();
 
         ByteBufNIO buffer = new ByteBufNIO(headerByteBuffer);


### PR DESCRIPTION
The dead code is a remnant of when the driver supported the full range of OP_REPLY wire protocol message usage.  Since the driver now only runs against MongoDB releases that support OP_MSG, OP_REPLY is only used for the response to the `hello` command in the handshake, and therefore most of the OP_REPLY-handling code is no longer on any execution paths.

JAVA-5204