### PR TITLE
Add explicit automatic module name configuration.

### DIFF
--- a/bson-kotlin/build.gradle.kts
+++ b/bson-kotlin/build.gradle.kts
@@ -149,6 +149,4 @@ tasks.javadocJar.configure {
 // ===========================
 tasks.sourcesJar { from(project.sourceSets.main.map { it.kotlin }) }
 
-afterEvaluate {
-    tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.bson.kotlin" } }
-}
+afterEvaluate { tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.bson.kotlin" } } }

--- a/bson-kotlin/build.gradle.kts
+++ b/bson-kotlin/build.gradle.kts
@@ -148,3 +148,5 @@ tasks.javadocJar.configure {
 //     Sources publishing configuration
 // ===========================
 tasks.sourcesJar { from(project.sourceSets.main.map { it.kotlin }) }
+
+afterEvaluate { tasks.jar { manifest { attributes("Automatic-Module-Name" to "org.mongodb.bson.kotlin") } } }

--- a/bson-kotlin/build.gradle.kts
+++ b/bson-kotlin/build.gradle.kts
@@ -149,4 +149,6 @@ tasks.javadocJar.configure {
 // ===========================
 tasks.sourcesJar { from(project.sourceSets.main.map { it.kotlin }) }
 
-afterEvaluate { tasks.jar { manifest { attributes("Automatic-Module-Name" to "org.mongodb.bson.kotlin") } } }
+afterEvaluate {
+    tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.bson.kotlin" } }
+}

--- a/bson-kotlinx/build.gradle.kts
+++ b/bson-kotlinx/build.gradle.kts
@@ -152,3 +152,5 @@ tasks.javadocJar.configure {
 //     Sources publishing configuration
 // ===========================
 tasks.sourcesJar { from(project.sourceSets.main.map { it.kotlin }) }
+
+afterEvaluate { tasks.jar { manifest { attributes("Automatic-Module-Name" to "org.mongodb.bson.kotlinx") } } }

--- a/bson-kotlinx/build.gradle.kts
+++ b/bson-kotlinx/build.gradle.kts
@@ -153,6 +153,4 @@ tasks.javadocJar.configure {
 // ===========================
 tasks.sourcesJar { from(project.sourceSets.main.map { it.kotlin }) }
 
-afterEvaluate {
-    tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.bson.kotlinx" } }
-}
+afterEvaluate { tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.bson.kotlinx" } } }

--- a/bson-kotlinx/build.gradle.kts
+++ b/bson-kotlinx/build.gradle.kts
@@ -153,4 +153,6 @@ tasks.javadocJar.configure {
 // ===========================
 tasks.sourcesJar { from(project.sourceSets.main.map { it.kotlin }) }
 
-afterEvaluate { tasks.jar { manifest { attributes("Automatic-Module-Name" to "org.mongodb.bson.kotlinx") } } }
+afterEvaluate {
+    tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.bson.kotlinx" } }
+}

--- a/bson-scala/build.gradle
+++ b/bson-scala/build.gradle
@@ -58,7 +58,10 @@ test {
     maxParallelForks = 1
 }
 
-jar.manifest.attributes['Import-Package'] =  [
-        '!scala.*',
-        '*'
-].join(',')
+afterEvaluate {
+    jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.scala.bson'
+    jar.manifest.attributes['Import-Package'] = [
+            '!scala.*',
+            '*'
+    ].join(',')
+}

--- a/bson-scala/build.gradle
+++ b/bson-scala/build.gradle
@@ -59,7 +59,7 @@ test {
 }
 
 afterEvaluate {
-    jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.scala.bson'
+    jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.bson.scala'
     jar.manifest.attributes['Import-Package'] = [
             '!scala.*',
             '*'

--- a/bson/build.gradle
+++ b/bson/build.gradle
@@ -22,4 +22,7 @@ ext {
     pomURL = 'https://bsonspec.org'
 }
 
-jar.manifest.attributes['Import-Package'] = 'org.slf4j.*;resolution:=optional'
+afterEvaluate {
+    jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.bson'
+    jar.manifest.attributes['Import-Package'] = 'org.slf4j.*;resolution:=optional'
+}

--- a/driver-kotlin-coroutine/build.gradle.kts
+++ b/driver-kotlin-coroutine/build.gradle.kts
@@ -194,6 +194,6 @@ tasks.javadocJar.configure {
 // ===========================
 tasks.sourcesJar { from(project.sourceSets.main.map { it.kotlin }) }
 
- afterEvaluate {
-    tasks.jar { manifest { attributes("Automatic-Module-Name" to "org.mongodb.driver.kotlin.coroutine") } }
- }
+afterEvaluate {
+    tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.driver.kotlin.coroutine" } }
+}

--- a/driver-kotlin-coroutine/build.gradle.kts
+++ b/driver-kotlin-coroutine/build.gradle.kts
@@ -194,6 +194,4 @@ tasks.javadocJar.configure {
 // ===========================
 tasks.sourcesJar { from(project.sourceSets.main.map { it.kotlin }) }
 
-afterEvaluate {
-    tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.driver.kotlin.coroutine" } }
-}
+afterEvaluate { tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.driver.kotlin.coroutine" } } }

--- a/driver-kotlin-coroutine/build.gradle.kts
+++ b/driver-kotlin-coroutine/build.gradle.kts
@@ -193,3 +193,7 @@ tasks.javadocJar.configure {
 //     Sources publishing configuration
 // ===========================
 tasks.sourcesJar { from(project.sourceSets.main.map { it.kotlin }) }
+
+ afterEvaluate {
+    tasks.jar { manifest { attributes("Automatic-Module-Name" to "org.mongodb.driver.kotlin.coroutine") } }
+ }

--- a/driver-kotlin-sync/build.gradle.kts
+++ b/driver-kotlin-sync/build.gradle.kts
@@ -189,4 +189,6 @@ tasks.javadocJar.configure {
 // ===========================
 tasks.sourcesJar { from(project.sourceSets.main.map { it.kotlin }) }
 
-afterEvaluate { tasks.jar { manifest { attributes("Automatic-Module-Name" to "org.mongodb.driver.kotlin.sync") } } }
+afterEvaluate {
+    tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.driver.kotlin.sync" } }
+}

--- a/driver-kotlin-sync/build.gradle.kts
+++ b/driver-kotlin-sync/build.gradle.kts
@@ -188,3 +188,5 @@ tasks.javadocJar.configure {
 //     Sources publishing configuration
 // ===========================
 tasks.sourcesJar { from(project.sourceSets.main.map { it.kotlin }) }
+
+afterEvaluate { tasks.jar { manifest { attributes("Automatic-Module-Name" to "org.mongodb.driver.kotlin.sync") } } }

--- a/driver-kotlin-sync/build.gradle.kts
+++ b/driver-kotlin-sync/build.gradle.kts
@@ -189,6 +189,4 @@ tasks.javadocJar.configure {
 // ===========================
 tasks.sourcesJar { from(project.sourceSets.main.map { it.kotlin }) }
 
-afterEvaluate {
-    tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.driver.kotlin.sync" } }
-}
+afterEvaluate { tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.driver.kotlin.sync" } } }

--- a/driver-scala/build.gradle
+++ b/driver-scala/build.gradle
@@ -117,7 +117,7 @@ ext {
 }
 
 afterEvaluate {
-    jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.scala.driver'
+    jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.driver.scala'
     jar.manifest.attributes['Import-Package'] = [
             '!scala.*',
             '*'

--- a/driver-scala/build.gradle
+++ b/driver-scala/build.gradle
@@ -117,7 +117,7 @@ ext {
 }
 
 afterEvaluate {
-    jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.scala.mongo-scala-driver'
+    jar.manifest.attributes['Automatic-Module-Name'] = 'org.mongodb.scala.driver'
     jar.manifest.attributes['Import-Package'] = [
             '!scala.*',
             '*'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -60,7 +60,6 @@ ext {
     configureJarManifestAttributes = { project ->
         { ->
             manifest.attributes['-exportcontents'] =  "*;-noimport:=true"
-            manifest.attributes['Automatic-Module-Name'] =  project.group + '.' + project.archivesBaseName
             manifest.attributes['Build-Version'] =  project.gitVersion
             manifest.attributes['Bundle-Version'] =  project.version
             manifest.attributes['Bundle-Name'] =  project.archivesBaseName


### PR DESCRIPTION
<h2> Description :</h2>

Some modules rely on the `publish.gradle` file to generate the Automatic Module Name in the manifest, based on the `groupName` and `archivesBaseName` of the project. However, the `archivesName` contains hyphens that are not valid according to the [Java Language Specification](https://docs.oracle.com/javase/specs/jls/se13/html/jls-7.html#jls-7.7).

As a result, all Automatic Module Names are now explicitly specified in each build.gradle file:

`org.mongodb.mongodb-driver-kotlin-coroutine` is renamed to `org.mongodb.driver.kotlin.coroutine`
`org.mongodb.mongodb-driver-kotlin-sync` is renamed to `org.mongodb.driver.kotlin.sync`
`org.mongodb.bson-kotlin` is renamed to `org.mongodb.bson.kotlin`
`org.mongodb.bson-kotlinx` is renamed to `org.mongodb.bson.kotlinx`
`org.mongodb.mongo-scala-driver` is renamed to `org.mongodb.driver.scala`


[JAVA-5213](https://jira.mongodb.org/browse/JAVA-5213)
[JAVA-5202](https://jira.mongodb.org/browse/JAVA-5202)