### PR TITLE
Add async API

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/AsyncCompletionHandler.java
+++ b/driver-core/src/main/com/mongodb/connection/AsyncCompletionHandler.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.connection;
 
+import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.lang.Nullable;
 
 /**
@@ -38,4 +39,14 @@ public interface AsyncCompletionHandler<T> {
      * @param t the exception that describes the failure
      */
     void failed(Throwable t);
+
+    default SingleResultCallback<T> asCallback() {
+        return (r, t) -> {
+            if (t != null) {
+                failed(t);
+            } else {
+                completed(r);
+            }
+        };
+    }
 }

--- a/driver-core/src/main/com/mongodb/connection/AsyncCompletionHandler.java
+++ b/driver-core/src/main/com/mongodb/connection/AsyncCompletionHandler.java
@@ -40,6 +40,9 @@ public interface AsyncCompletionHandler<T> {
      */
     void failed(Throwable t);
 
+    /**
+     * @return this handler as a callback
+     */
     default SingleResultCallback<T> asCallback() {
         return (r, t) -> {
             if (t != null) {

--- a/driver-core/src/main/com/mongodb/connection/Stream.java
+++ b/driver-core/src/main/com/mongodb/connection/Stream.java
@@ -17,6 +17,7 @@
 package com.mongodb.connection;
 
 import com.mongodb.ServerAddress;
+import com.mongodb.internal.async.SingleResultCallback;
 import org.bson.ByteBuf;
 
 import java.io.IOException;
@@ -43,7 +44,7 @@ public interface Stream extends BufferProvider{
      *
      * @param handler the completion handler for opening the stream
      */
-    void openAsync(AsyncCompletionHandler<Void> handler);
+    void openAsync(SingleResultCallback<Void> handler);
 
     /**
      * Write each buffer in the list to the stream in order, blocking until all are completely written.

--- a/driver-core/src/main/com/mongodb/connection/TlsChannelStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/TlsChannelStreamFactoryFactory.java
@@ -203,7 +203,7 @@ public class TlsChannelStreamFactoryFactory implements StreamFactoryFactory, Clo
         @SuppressWarnings("deprecation")
         @Override
         public void openAsync(final SingleResultCallback<Void> callback) {
-            AsyncCompletionHandler<Void> handler = callback.toHandler();
+            AsyncCompletionHandler<Void> handler = callback.asHandler();
             isTrue("unopened", getChannel() == null);
             try {
                 SocketChannel socketChannel = SocketChannel.open();

--- a/driver-core/src/main/com/mongodb/connection/TlsChannelStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/TlsChannelStreamFactoryFactory.java
@@ -19,6 +19,7 @@ package com.mongodb.connection;
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoSocketOpenException;
 import com.mongodb.ServerAddress;
+import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.connection.AsynchronousChannelStream;
 import com.mongodb.internal.connection.ExtendedAsynchronousByteChannel;
 import com.mongodb.internal.connection.PowerOfTwoBufferPool;
@@ -201,7 +202,8 @@ public class TlsChannelStreamFactoryFactory implements StreamFactoryFactory, Clo
 
         @SuppressWarnings("deprecation")
         @Override
-        public void openAsync(final AsyncCompletionHandler<Void> handler) {
+        public void openAsync(final SingleResultCallback<Void> callback) {
+            AsyncCompletionHandler<Void> handler = callback.toHandler();
             isTrue("unopened", getChannel() == null);
             try {
                 SocketChannel socketChannel = SocketChannel.open();

--- a/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
@@ -28,6 +28,7 @@ import com.mongodb.connection.AsyncCompletionHandler;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.SslSettings;
 import com.mongodb.connection.Stream;
+import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.connection.netty.NettyByteBuf;
 import com.mongodb.lang.Nullable;
 import io.netty.bootstrap.Bootstrap;
@@ -158,13 +159,14 @@ final class NettyStream implements Stream {
     @Override
     public void open() throws IOException {
         FutureAsyncCompletionHandler<Void> handler = new FutureAsyncCompletionHandler<>();
-        openAsync(handler);
+        openAsync(handler.asCallback());
         handler.get();
     }
 
     @SuppressWarnings("deprecation")
     @Override
-    public void openAsync(final AsyncCompletionHandler<Void> handler) {
+    public void openAsync(final SingleResultCallback<Void> callback) {
+        AsyncCompletionHandler<Void> handler = callback.toHandler();
         Queue<SocketAddress> socketAddressQueue;
 
         try {

--- a/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyStream.java
@@ -166,7 +166,7 @@ final class NettyStream implements Stream {
     @SuppressWarnings("deprecation")
     @Override
     public void openAsync(final SingleResultCallback<Void> callback) {
-        AsyncCompletionHandler<Void> handler = callback.toHandler();
+        AsyncCompletionHandler<Void> handler = callback.asHandler();
         Queue<SocketAddress> socketAddressQueue;
 
         try {

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncConsumer.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncConsumer.java
@@ -13,23 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mongodb.internal.async.function;
 
-import com.mongodb.internal.async.SingleResultCallback;
+package com.mongodb.internal.async;
 
 /**
- * An {@linkplain AsyncCallbackFunction asynchronous callback-based function} of no parameters and no successful result.
- * This class is a callback-based counterpart of {@link Runnable}.
- *
- * <p>This class is not part of the public API and may be removed or changed at any time</p>
- *
- * @see AsyncCallbackFunction
+ * See tests for usage (AsyncFunctionsTest).
+ * <p>
+ * This class is not part of the public API and may be removed or changed at any time
  */
 @FunctionalInterface
-public interface AsyncCallbackRunnable {
-    /**
-     * @see AsyncCallbackFunction#apply(Object, SingleResultCallback)
-     */
-    void run(SingleResultCallback<Void> callback);
-
+public interface AsyncConsumer<T> extends AsyncFunction<T, Void> {
 }

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncFunction.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncFunction.java
@@ -13,23 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mongodb.internal.async.function;
 
-import com.mongodb.internal.async.SingleResultCallback;
+package com.mongodb.internal.async;
+
+import com.mongodb.lang.Nullable;
 
 /**
- * An {@linkplain AsyncCallbackFunction asynchronous callback-based function} of no parameters and no successful result.
- * This class is a callback-based counterpart of {@link Runnable}.
- *
- * <p>This class is not part of the public API and may be removed or changed at any time</p>
- *
- * @see AsyncCallbackFunction
+ * See tests for usage (AsyncFunctionsTest).
+ * <p>
+ * This class is not part of the public API and may be removed or changed at any time
  */
 @FunctionalInterface
-public interface AsyncCallbackRunnable {
+public interface AsyncFunction<T, R> {
     /**
-     * @see AsyncCallbackFunction#apply(Object, SingleResultCallback)
+     * This should not be called externally, but should be implemented as a
+     * lambda. To "finish" an async chain, use one of the "finish" methods.
      */
-    void run(SingleResultCallback<Void> callback);
-
+    void unsafeFinish(@Nullable T value, SingleResultCallback<R> callback);
 }

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncFunction.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncFunction.java
@@ -16,8 +16,6 @@
 
 package com.mongodb.internal.async;
 
-import com.mongodb.lang.Nullable;
-
 /**
  * See tests for usage (AsyncFunctionsTest).
  * <p>
@@ -29,5 +27,5 @@ public interface AsyncFunction<T, R> {
      * This should not be called externally, but should be implemented as a
      * lambda. To "finish" an async chain, use one of the "finish" methods.
      */
-    void unsafeFinish(@Nullable T value, SingleResultCallback<R> callback);
+    void unsafeFinish(T value, SingleResultCallback<R> callback);
 }

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncRunnable.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncRunnable.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.async;
+
+import com.mongodb.internal.async.function.RetryState;
+import com.mongodb.internal.async.function.RetryingAsyncCallbackSupplier;
+
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * See tests for usage (AsyncFunctionsTest).
+ * <p>
+ * This class is not part of the public API and may be removed or changed at any time
+ */
+@FunctionalInterface
+public interface AsyncRunnable extends AsyncSupplier<Void>, AsyncConsumer<Void> {
+
+    static AsyncRunnable beginAsync() {
+        return (c) -> c.onResult(null, null);
+    }
+
+    /**
+     * Must be invoked at end of async chain
+     * @param runnable the sync code to invoke (under non-exceptional flow)
+     *                 prior to the callback
+     * @param callback the callback provided by the method the chain is used in
+     */
+    default void thenRunAndFinish(final Runnable runnable, final SingleResultCallback<Void> callback) {
+        this.finish((r, e) -> {
+            if (e != null) {
+                callback.onResult(null, e);
+                return;
+            }
+            try {
+                runnable.run();
+            } catch (Throwable t) {
+                callback.onResult(null, t);
+                return;
+            }
+            callback.onResult(null, null);
+        });
+    }
+
+    /**
+     * See {@link #thenRunAndFinish(Runnable, SingleResultCallback)}, but the runnable
+     * will always be executed, including on the exceptional path.
+     * @param runnable the runnable
+     * @param callback the callback
+     */
+    default void thenAlwaysRunAndFinish(final Runnable runnable, final SingleResultCallback<Void> callback) {
+        this.finish((r, e) -> {
+            try {
+                runnable.run();
+            } catch (Throwable t) {
+                if (e != null) {
+                    t.addSuppressed(e);
+                }
+                callback.onResult(null, t);
+                return;
+            }
+            callback.onResult(null, e);
+        });
+    }
+
+    /**
+     * @param runnable The async runnable to run after this runnable
+     * @return the composition of this runnable and the runnable, a runnable
+     */
+    default AsyncRunnable thenRun(final AsyncRunnable runnable) {
+        return (c) -> {
+            this.unsafeFinish((r, e) -> {
+                if (e == null) {
+                    runnable.unsafeFinish(c);
+                } else {
+                    c.onResult(null, e);
+                }
+            });
+        };
+    }
+
+    /**
+     * @param condition the condition to check
+     * @param runnable The async runnable to run after this runnable,
+     *                 if and only if the condition is met
+     * @return the composition of this runnable and the runnable, a runnable
+     */
+    default AsyncRunnable thenRunIf(final Supplier<Boolean> condition, final AsyncRunnable runnable) {
+        return (callback) -> {
+            this.unsafeFinish((r, e) -> {
+                if (e != null) {
+                    callback.onResult(null, e);
+                    return;
+                }
+                boolean matched;
+                try {
+                    matched = condition.get();
+                } catch (Throwable t) {
+                    callback.onResult(null, t);
+                    return;
+                }
+                if (matched) {
+                    runnable.unsafeFinish(callback);
+                } else {
+                    callback.onResult(null, null);
+                }
+            });
+        };
+    }
+
+    /**
+     * @param supplier The supplier to supply using after this runnable
+     * @return the composition of this runnable and the supplier, a supplier
+     * @param <R> The return type of the resulting supplier
+     */
+    default <R> AsyncSupplier<R> thenSupply(final AsyncSupplier<R> supplier) {
+        return (c) -> {
+            this.unsafeFinish((r, e) -> {
+                if (e == null) {
+                    supplier.unsafeFinish(c);
+                } else {
+                    c.onResult(null, e);
+                }
+            });
+        };
+    }
+
+    /**
+     * @param runnable    the runnable to loop
+     * @param shouldRetry condition under which to retry
+     * @return the composition of this, and the looping branch
+     * @see RetryingAsyncCallbackSupplier
+     */
+    default AsyncRunnable thenRunRetryingWhile(
+            final AsyncRunnable runnable, final Predicate<Throwable> shouldRetry) {
+        return thenRun(callback -> {
+            new RetryingAsyncCallbackSupplier<Void>(
+                    new RetryState(),
+                    (rs, lastAttemptFailure) -> shouldRetry.test(lastAttemptFailure),
+                    cb -> runnable.finish(cb) // finish is required here, to handle exceptions
+            ).get(callback);
+        });
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncSupplier.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.async;
+
+import com.mongodb.lang.Nullable;
+
+import java.util.function.Predicate;
+
+
+/**
+ * See tests for usage (AsyncFunctionsTest).
+ * <p>
+ * This class is not part of the public API and may be removed or changed at any time
+ */
+@FunctionalInterface
+public interface AsyncSupplier<T> extends AsyncFunction<Void, T> {
+    /**
+     * This should not be called externally to this API. It should be
+     * implemented as a lambda. To "finish" an async chain, use one of
+     * the "finish" methods.
+     *
+     * @see #finish(SingleResultCallback)
+     */
+    void unsafeFinish(SingleResultCallback<T> callback);
+
+    /**
+     * This method must only be used when this AsyncSupplier corresponds
+     * to a {@link java.util.function.Supplier} (and is therefore being
+     * used within an async chain method lambda).
+     * @param callback the callback
+     */
+    default void getAsync(final SingleResultCallback<T> callback) {
+        unsafeFinish(callback);
+    }
+
+    @Override
+    default void unsafeFinish(@Nullable final Void value, final SingleResultCallback<T> callback) {
+        unsafeFinish(callback);
+    }
+
+    /**
+     * Must be invoked at end of async chain.
+     * @param callback the callback provided by the method the chain is used in
+     */
+    default void finish(final SingleResultCallback<T> callback) {
+        final boolean[] callbackInvoked = {false};
+        try {
+            this.unsafeFinish((v, e) -> {
+                callbackInvoked[0] = true;
+                callback.onResult(v, e);
+            });
+        } catch (Throwable t) {
+            if (callbackInvoked[0]) {
+                throw t;
+            } else {
+                callback.onResult(null, t);
+            }
+        }
+    }
+
+    /**
+     * @param function The async function to run after this supplier
+     * @return the composition of this supplier and the function, a supplier
+     * @param <R> The return type of the resulting supplier
+     */
+    default <R> AsyncSupplier<R> thenApply(final AsyncFunction<T, R> function) {
+        return (c) -> {
+            this.unsafeFinish((v, e) -> {
+                if (e == null) {
+                    function.unsafeFinish(v, c);
+                } else {
+                    c.onResult(null, e);
+                }
+            });
+        };
+    }
+
+
+    /**
+     * @param consumer The async consumer to run after this supplier
+     * @return the composition of this supplier and the consumer, a runnable
+     */
+    default AsyncRunnable thenConsume(final AsyncConsumer<T> consumer) {
+        return (c) -> {
+            this.unsafeFinish((v, e) -> {
+                if (e == null) {
+                    consumer.unsafeFinish(v, c);
+                } else {
+                    c.onResult(null, e);
+                }
+            });
+        };
+    }
+
+    /**
+     * @param errorCheck A check, comparable to a catch-if/otherwise-rethrow
+     * @param supplier   The branch to execute if the error matches
+     * @return The composition of this, and the conditional branch
+     */
+    default AsyncSupplier<T> onErrorIf(
+            final Predicate<Throwable> errorCheck,
+            final AsyncSupplier<T> supplier) {
+        return (callback) -> this.unsafeFinish((r, e) -> {
+            if (e == null) {
+                callback.onResult(r, null);
+                return;
+            }
+            boolean errorMatched;
+            try {
+                errorMatched = errorCheck.test(e);
+            } catch (Throwable t) {
+                t.addSuppressed(e);
+                callback.onResult(null, t);
+                return;
+            }
+            if (errorMatched) {
+                supplier.unsafeFinish(callback);
+            } else {
+                callback.onResult(null, e);
+            }
+        });
+    }
+
+}

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncSupplier.java
@@ -38,6 +38,7 @@ public interface AsyncSupplier<T> extends AsyncFunction<Void, T> {
     void unsafeFinish(SingleResultCallback<T> callback);
 
     /**
+     * This is the async variant of a supplier's get method.
      * This method must only be used when this AsyncSupplier corresponds
      * to a {@link java.util.function.Supplier} (and is therefore being
      * used within an async chain method lambda).
@@ -108,13 +109,13 @@ public interface AsyncSupplier<T> extends AsyncFunction<Void, T> {
 
     /**
      * @param errorCheck A check, comparable to a catch-if/otherwise-rethrow
-     * @param supplier   The branch to execute if the error matches
+     * @param errorFunction   The branch to execute if the error matches
      * @return The composition of this, and the conditional branch
      */
     default AsyncSupplier<T> onErrorIf(
             final Predicate<Throwable> errorCheck,
-            final AsyncSupplier<T> supplier) {
-        return (callback) -> this.unsafeFinish((r, e) -> {
+            final AsyncFunction<Throwable, T> errorFunction) {
+        return (callback) -> this.finish((r, e) -> {
             if (e == null) {
                 callback.onResult(r, null);
                 return;
@@ -128,7 +129,7 @@ public interface AsyncSupplier<T> extends AsyncFunction<Void, T> {
                 return;
             }
             if (errorMatched) {
-                supplier.unsafeFinish(callback);
+                errorFunction.unsafeFinish(e, callback);
             } else {
                 callback.onResult(null, e);
             }

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncSupplier.java
@@ -16,8 +16,6 @@
 
 package com.mongodb.internal.async;
 
-import com.mongodb.lang.Nullable;
-
 import java.util.function.Predicate;
 
 
@@ -49,7 +47,7 @@ public interface AsyncSupplier<T> extends AsyncFunction<Void, T> {
     }
 
     @Override
-    default void unsafeFinish(@Nullable final Void value, final SingleResultCallback<T> callback) {
+    default void unsafeFinish(final Void value, final SingleResultCallback<T> callback) {
         unsafeFinish(callback);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/async/SingleResultCallback.java
+++ b/driver-core/src/main/com/mongodb/internal/async/SingleResultCallback.java
@@ -37,7 +37,10 @@ public interface SingleResultCallback<T> {
      */
     void onResult(@Nullable T result, @Nullable Throwable t);
 
-    default AsyncCompletionHandler<T> toHandler() {
+    /**
+     * @return this callback as a handler
+     */
+    default AsyncCompletionHandler<T> asHandler() {
         return new AsyncCompletionHandler<T>() {
             @Override
             public void completed(@Nullable final T result) {

--- a/driver-core/src/main/com/mongodb/internal/async/SingleResultCallback.java
+++ b/driver-core/src/main/com/mongodb/internal/async/SingleResultCallback.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.async;
 
+import com.mongodb.connection.AsyncCompletionHandler;
 import com.mongodb.internal.async.function.AsyncCallbackFunction;
 import com.mongodb.lang.Nullable;
 
@@ -34,4 +35,25 @@ public interface SingleResultCallback<T> {
      * @throws Error Never, on the best effort basis.
      */
     void onResult(@Nullable T result, @Nullable Throwable t);
+
+    default AsyncCompletionHandler<T> toHandler() {
+        return new AsyncCompletionHandler<T>() {
+            @Override
+            public void completed(@Nullable final T result) {
+                onResult(result, null);
+            }
+            @Override
+            public void failed(final Throwable t) {
+                onResult(null, t);
+            }
+        };
+    }
+
+    default void complete() {
+        this.onResult(null, null);
+    }
+
+    default void complete(final T result) {
+        this.onResult(result, null);
+    }
 }

--- a/driver-core/src/main/com/mongodb/internal/async/SingleResultCallback.java
+++ b/driver-core/src/main/com/mongodb/internal/async/SingleResultCallback.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.async;
 
+import com.mongodb.assertions.Assertions;
 import com.mongodb.connection.AsyncCompletionHandler;
 import com.mongodb.internal.async.function.AsyncCallbackFunction;
 import com.mongodb.lang.Nullable;
@@ -49,7 +50,11 @@ public interface SingleResultCallback<T> {
         };
     }
 
-    default void complete() {
+    default void complete(final SingleResultCallback<Void> callback) {
+        // takes a void callback (itself) to help ensure that this method
+        // is not accidentally used when "complete(T)" should have been used
+        // instead, since results are not marked nullable.
+        Assertions.assertTrue(callback == this);
         this.onResult(null, null);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryingAsyncCallbackSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryingAsyncCallbackSupplier.java
@@ -84,6 +84,13 @@ public final class RetryingAsyncCallbackSupplier<R> implements AsyncCallbackSupp
         this.asyncFunction = asyncFunction;
     }
 
+    public RetryingAsyncCallbackSupplier(
+            final RetryState state,
+            final BiPredicate<RetryState, Throwable> retryPredicate,
+            final AsyncCallbackSupplier<R> asyncFunction) {
+        this(state, (previouslyChosenFailure, lastAttemptFailure) -> lastAttemptFailure, retryPredicate, asyncFunction);
+    }
+
     @Override
     public void get(final SingleResultCallback<R> callback) {
         /* `asyncFunction` and `callback` are the only externally provided pieces of code for which we do not need to care about

--- a/driver-core/src/main/com/mongodb/internal/connection/AsynchronousChannelStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsynchronousChannelStream.java
@@ -127,7 +127,7 @@ public abstract class AsynchronousChannelStream implements Stream {
     @Override
     public void open() throws IOException {
         FutureAsyncCompletionHandler<Void> handler = new FutureAsyncCompletionHandler<>();
-        openAsync(handler);
+        openAsync(handler.asCallback());
         handler.getOpen();
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/AsynchronousSocketChannelStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsynchronousSocketChannelStream.java
@@ -21,6 +21,7 @@ import com.mongodb.MongoSocketOpenException;
 import com.mongodb.ServerAddress;
 import com.mongodb.connection.AsyncCompletionHandler;
 import com.mongodb.connection.SocketSettings;
+import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.lang.Nullable;
 
 import java.io.IOException;
@@ -56,7 +57,9 @@ public final class AsynchronousSocketChannelStream extends AsynchronousChannelSt
 
     @SuppressWarnings("deprecation")
     @Override
-    public void openAsync(final AsyncCompletionHandler<Void> handler) {
+    public void openAsync(final SingleResultCallback<Void> callback) {
+        AsyncCompletionHandler<Void> handler = callback.toHandler();
+
         isTrue("unopened", getChannel() == null);
         Queue<SocketAddress> socketAddressQueue;
 

--- a/driver-core/src/main/com/mongodb/internal/connection/AsynchronousSocketChannelStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsynchronousSocketChannelStream.java
@@ -58,7 +58,7 @@ public final class AsynchronousSocketChannelStream extends AsynchronousChannelSt
     @SuppressWarnings("deprecation")
     @Override
     public void openAsync(final SingleResultCallback<Void> callback) {
-        AsyncCompletionHandler<Void> handler = callback.toHandler();
+        AsyncCompletionHandler<Void> handler = callback.asHandler();
 
         isTrue("unopened", getChannel() == null);
         Queue<SocketAddress> socketAddressQueue;

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -245,7 +245,7 @@ public class InternalStreamConnection implements InternalConnection {
             if (t instanceof MongoException) {
                 throw (MongoException) t;
             } else {
-                throw new MongoException(assertNotNull(t).toString(), t);
+                throw new MongoException(t.toString(), t);
             }
         }).finish(callback);
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
@@ -36,7 +36,6 @@ import org.bson.BsonString;
 
 import java.util.List;
 
-import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.AsyncRunnable.beginAsync;
 import static com.mongodb.internal.connection.CommandHelper.HELLO;
@@ -109,9 +108,9 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
             beginAsync().<BsonDocument>thenSupply(c2 -> {
                 executeCommandAsync("admin", helloCommandDocument, clusterConnectionMode, serverApi, internalConnection, c2);
             }).onErrorIf(e -> e instanceof MongoException, (t, c2) -> {
-                throw mapHelloException((MongoException) assertNotNull(t));
+                throw mapHelloException((MongoException) t);
             }).thenApply((helloResult, c2) -> {
-                setSpeculativeAuthenticateResponse(assertNotNull(helloResult));
+                setSpeculativeAuthenticateResponse(helloResult);
                 c2.complete(createInitializationDescription(helloResult, internalConnection, startTime));
             });
         }).finish(callback);

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
@@ -109,10 +109,10 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
                 executeCommandAsync("admin", helloCommandDocument, clusterConnectionMode, serverApi, internalConnection, c2);
             }).onErrorIf(e -> e instanceof MongoException, (t, c2) -> {
                 throw mapHelloException((MongoException) t);
-            }).thenApply((helloResult, c2) -> {
+            }).<InternalConnectionInitializationDescription>thenApply((helloResult, c2) -> {
                 setSpeculativeAuthenticateResponse(helloResult);
                 c2.complete(createInitializationDescription(helloResult, internalConnection, startTime));
-            });
+            }).finish(c);
         }).finish(callback);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
@@ -112,7 +112,7 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
                 throw mapHelloException((MongoException) assertNotNull(t));
             }).thenApply((helloResult, c2) -> {
                 setSpeculativeAuthenticateResponse(assertNotNull(helloResult));
-                callback.complete(createInitializationDescription(helloResult, internalConnection, startTime));
+                c2.complete(createInitializationDescription(helloResult, internalConnection, startTime));
             });
         }).finish(callback);
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
@@ -26,6 +26,7 @@ import com.mongodb.connection.ProxySettings;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.SslSettings;
 import com.mongodb.connection.Stream;
+import com.mongodb.internal.async.SingleResultCallback;
 import org.bson.ByteBuf;
 
 import javax.net.SocketFactory;
@@ -207,7 +208,7 @@ public class SocketStream implements Stream {
     }
 
     @Override
-    public void openAsync(final AsyncCompletionHandler<Void> handler) {
+    public void openAsync(final SingleResultCallback<Void> callback) {
         throw new UnsupportedOperationException(getClass() + " does not support asynchronous operations.");
     }
 

--- a/driver-core/src/test/functional/com/mongodb/client/TestListener.java
+++ b/driver-core/src/test/functional/com/mongodb/client/TestListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.annotations.ThreadSafe;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A simple listener that consumes string events, which can be checked in tests.
+ */
+@ThreadSafe
+public final class TestListener {
+    private final List<String> events = Collections.synchronizedList(new ArrayList<>());
+
+    public void add(final String s) {
+        events.add(s);
+    }
+
+    public List<String> getEventStrings() {
+        return new ArrayList<>(events);
+    }
+
+    public void clear() {
+        events.clear();
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/connection/netty/NettyStreamSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/netty/NettyStreamSpecification.groovy
@@ -76,7 +76,7 @@ class NettyStreamSpecification extends Specification {
 
         def stream = new NettyStreamFactory(SocketSettings.builder().connectTimeout(1000, TimeUnit.MILLISECONDS).build(),
                 SslSettings.builder().build()).create(serverAddress)
-        def callback = new CallbackErrorHolder()
+        def callback = new CallbackErrorHolder().asCallback()
 
         when:
         stream.openAsync(callback)

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncSocketChannelStreamSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncSocketChannelStreamSpecification.groovy
@@ -83,7 +83,7 @@ class AsyncSocketChannelStreamSpecification extends Specification {
         def stream = new AsynchronousSocketChannelStream(serverAddress,
                 SocketSettings.builder().connectTimeout(100, MILLISECONDS).build(),
                 new PowerOfTwoBufferPool(), null)
-        def callback = new CallbackErrorHolder()
+        def callback = new CallbackErrorHolder().asCallback()
 
         when:
         stream.openAsync(callback)

--- a/driver-core/src/test/unit/com/mongodb/internal/async/AsyncFunctionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/AsyncFunctionsTest.java
@@ -1,0 +1,657 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.async;
+
+import com.mongodb.client.TestListener;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static com.mongodb.internal.async.AsyncRunnable.beginAsync;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+final class AsyncFunctionsTest {
+    private final TestListener listener = new TestListener();
+    private final InvocationTracker invocationTracker = new InvocationTracker();
+
+    @Test
+    void testVariations1() {
+        /*
+        In our async code:
+        1. a callback is provided as a method parameter
+        2. at least one sync method must be converted to async
+
+        To use this API:
+        1. start an async chain using the "beginAsync" static method
+        2. use an appropriate chaining method (then...), which will provide "c"
+        3. copy all sync code to that method
+        4. at the async method, pass in "c" and start a new chaining method
+        5. provide the original "callback" at the end of the chain via "finish"
+
+        Async methods MUST be preceded by unaffected "plain" sync code (sync
+        code with no async counterpart), and this code MUST reside above the
+        affected method, as it appears in the sync code. Plain code after
+        the sync method should be supplied via one of the "finally" variants.
+        Safe "shared" plain code (variable and lambda declarations) which cannot
+        throw, may remain outside the chained invocations, for convenience.
+
+        Plain sync code MAY throw exceptions, and SHOULD NOT attempt to handle
+        them asynchronously. The exceptions will be caught and handled by the
+        chaining methods that contain this sync code.
+
+        Each async lambda MUST invoke its async method with "c", and MUST return
+        immediately after invoking that method. It MUST NOT, for example, have
+        a catch or finally (including close on try-with-resources) after the
+        invocation of the sync method.
+
+        A braced lambda body (with no linebreak before "."), as shown below,
+        should be used, as this will be consistent with other usages, and allows
+        the async code to be more easily compared to the sync code.
+        */
+
+        // the number of expected variations is often: 1 + N methods invoked
+        // 1 variation with no exceptions, and N per an exception in each method
+        assertBehavesSameVariations(2,
+                () -> {
+                    // single sync method invocations...
+                    sync(1);
+                },
+                (callback) -> {
+                    // ...become a single async invocation, wrapped in begin-thenRun/finish:
+                    beginAsync().thenRun(c -> {
+                        async(1, c);
+                    }).finish(callback);
+                });
+    }
+
+    @Test
+    void testVariations2() {
+        // tests pairs
+        // converting: plain-sync, sync-plain, sync-sync
+        // (plain-plain does not need an async chain)
+
+        assertBehavesSameVariations(3,
+                () -> {
+                    // plain (unaffected) invocations...
+                    plain(1);
+                    sync(2);
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        // ...are preserved above affected methods
+                        plain(1);
+                        async(2, c);
+                    }).finish(callback);
+                });
+
+        assertBehavesSameVariations(3,
+                () -> {
+                    // when a plain invocation follows an affected method...
+                    sync(1);
+                    plain(2);
+                },
+                (callback) -> {
+                    // ...it is moved to its own block
+                    beginAsync().thenRun(c -> {
+                        async(1, c);
+                    }).thenRunAndFinish(() -> {
+                        plain(2);
+                    }, callback);
+                });
+
+        assertBehavesSameVariations(3,
+                () -> {
+                    // when an affected method follows an affected method
+                    sync(1);
+                    sync(2);
+                },
+                (callback) -> {
+                    // ...it is moved to its own block
+                    beginAsync().thenRun(c -> {
+                        async(1, c);
+                    }).thenRun(c -> {
+                        async(2, c);
+                    }).finish(callback);
+                });
+    }
+
+    @Test
+    void testVariations4() {
+        // tests the sync-sync pair with preceding and ensuing plain methods:
+        assertBehavesSameVariations(5,
+                () -> {
+                    plain(11);
+                    sync(1);
+                    plain(22);
+                    sync(2);
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        plain(11);
+                        async(1, c);
+                    }).thenRun(c -> {
+                        plain(22);
+                        async(2, c);
+                    }).finish(callback);
+                });
+
+        assertBehavesSameVariations(5,
+                () -> {
+                    sync(1);
+                    plain(11);
+                    sync(2);
+                    plain(22);
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        async(1, c);
+                    }).thenRun(c -> {
+                        plain(11);
+                        async(2, c);
+                    }).thenRunAndFinish(() ->{
+                        plain(22);
+                    }, callback);
+                });
+    }
+
+    @Test
+    void testSupply() {
+        assertBehavesSameVariations(4,
+                () -> {
+                    sync(0);
+                    plain(1);
+                    return syncReturns(2);
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        async(0, c);
+                    }).<Integer>thenSupply(c -> {
+                        plain(1);
+                        asyncReturns(2, c);
+                    }).finish(callback);
+                });
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    void testFullChain() {
+        // tests a chain: runnable, producer, function, function, consumer
+
+        assertBehavesSameVariations(14,
+                () -> {
+                    plain(90);
+                    sync(0);
+                    plain(91);
+                    sync(1);
+                    plain(92);
+                    int v = syncReturns(2);
+                    plain(93);
+                    v = syncReturns(v + 1);
+                    plain(94);
+                    v = syncReturns(v + 10);
+                    plain(95);
+                    sync(v + 100);
+                    plain(96);
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        plain(90);
+                        async(0, c);
+                    }).thenRun(c -> {
+                        plain(91);
+                        async(1, c);
+                    }).<Integer>thenSupply(c -> {
+                        plain(92);
+                        asyncReturns(2, c);
+                    }).<Integer>thenApply((v, c) -> {
+                        plain(93);
+                        asyncReturns(v + 1, c);
+                    }).<Integer>thenApply((v, c) -> {
+                        plain(94);
+                        asyncReturns(v + 10, c);
+                    }).thenConsume((v, c) -> {
+                        plain(95);
+                        async(v + 100, c);
+                    }).thenRunAndFinish(() -> {
+                        plain(96);
+                    }, callback);
+                });
+    }
+
+    @Test
+    void testVariationsBranching() {
+        assertBehavesSameVariations(5,
+                () -> {
+                    if (plainTest(1)) {
+                        sync(2);
+                    } else {
+                        sync(3);
+                    }
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        if (plainTest(1)) {
+                            async(2, c);
+                        } else {
+                            async(3, c);
+                        }
+                    }).finish(callback);
+                });
+
+        // 2 : fail on first sync, fail on test
+        // 3 : true test, sync2, sync3
+        // 2 : false test, sync3
+        // 7 total
+        assertBehavesSameVariations(7,
+                () -> {
+                    sync(0);
+                    if (plainTest(1)) {
+                        sync(2);
+                    }
+                    sync(3);
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        async(0, c);
+                    }).thenRunIf(() -> plainTest(1), c -> {
+                        async(2, c);
+                    }).thenRun(c -> {
+                        async(3, c);
+                    }).finish(callback);
+                });
+
+        // an additional affected method within the "if" branch
+        assertBehavesSameVariations(8,
+                () -> {
+                    sync(0);
+                    if (plainTest(1)) {
+                        sync(21);
+                        sync(22);
+                    }
+                    sync(3);
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        async(0, c);
+                    }).thenRunIf(() -> plainTest(1),
+                            beginAsync().thenRun(c -> {
+                                async(21, c);
+                            }).thenRun((c) -> {
+                                async(22, c);
+                            })
+                    ).thenRun(c -> {
+                        async(3, c);
+                    }).finish(callback);
+                });
+    }
+
+    @Test
+    void testErrorIf() {
+        // thenSupply:
+        assertBehavesSameVariations(5,
+                () -> {
+                    try {
+                        return syncReturns(1);
+                    } catch (Exception e) {
+                        if (e.getMessage().equals(plainTest(1) ? "unexpected" : "exception-1")) {
+                            return syncReturns(2);
+                        } else {
+                            throw e;
+                        }
+                    }
+                },
+                (callback) -> {
+                    beginAsync().<Integer>thenSupply(c -> {
+                        asyncReturns(1, c);
+                    }).onErrorIf(e -> e.getMessage().equals(plainTest(1) ? "unexpected" : "exception-1"), c -> {
+                        asyncReturns(2, c);
+                    }).finish(callback);
+                });
+
+        // thenRun:
+        assertBehavesSameVariations(5,
+                () -> {
+                    try {
+                        sync(1);
+                    } catch (Exception e) {
+                        if (e.getMessage().equals(plainTest(1) ? "unexpected" : "exception-1")) {
+                            sync(2);
+                        } else {
+                            throw e;
+                        }
+                    }
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        async(1, c);
+                    }).onErrorIf(e -> e.getMessage().equals(plainTest(1) ? "unexpected" : "exception-1"), c -> {
+                        async(2, c);
+                    }).finish(callback);
+                });
+    }
+
+    @Test
+    void testLoop() {
+        assertBehavesSameVariations(InvocationTracker.DEPTH_LIMIT * 2 + 1,
+                () -> {
+                    while (true) {
+                        try {
+                            sync(plainTest(0) ? 1 : 2);
+                            break;
+                        } catch (RuntimeException e) {
+                            if (e.getMessage().equals("exception-1")) {
+                                continue;
+                            }
+                            throw e;
+                        }
+                    }
+                },
+                (callback) -> {
+                    beginAsync().thenRunRetryingWhile(
+                            c -> sync(plainTest(0) ? 1 : 2),
+                            e -> e.getMessage().equals("exception-1")
+                    ).finish(callback);
+                });
+    }
+
+    @Test
+    void testFinally() {
+        // (in try: normal flow + exception + exception) * (in finally: normal + exception) = 6
+        assertBehavesSameVariations(6,
+                () -> {
+                    try {
+                        plain(1);
+                        sync(2);
+                    } finally {
+                        plain(3);
+                    }
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        plain(1);
+                        async(2, c);
+                    }).thenAlwaysRunAndFinish(() -> {
+                        plain(3);
+                    }, callback);
+                });
+    }
+
+    @Test
+    void testUsedAsLambda() {
+        assertBehavesSameVariations(4,
+                () -> {
+                    Supplier<Integer> s = () -> syncReturns(9);
+                    sync(0);
+                    plain(1);
+                    return s.get();
+                },
+                (callback) -> {
+                    AsyncSupplier<Integer> s = (c) -> asyncReturns(9, c);
+                    beginAsync().thenRun(c -> {
+                        async(0, c);
+                    }).<Integer>thenSupply((c) -> {
+                        plain(1);
+                        s.getAsync(c);
+                    }).finish(callback);
+                });
+    }
+
+    @Test
+    void testVariables() {
+        assertBehavesSameVariations(3,
+                () -> {
+                    int something;
+                    something = 90;
+                    sync(something);
+                    something = something + 10;
+                    sync(something);
+                },
+                (callback) -> {
+                    // Certain variables may need to be shared; these can be
+                    // declared (but not initialized) outside the async chain.
+                    // Any container works (atomic allowed but not needed)
+                    final int[] something = new int[1];
+                    beginAsync().thenRun(c -> {
+                        something[0] = 90;
+                        async(something[0], c);
+                    }).thenRun((c) -> {
+                        something[0] = something[0] + 10;
+                        async(something[0], c);
+                    }).finish(callback);
+                });
+    }
+
+    @Test
+    void testInvalid() {
+        assertThrows(IllegalStateException.class, () -> {
+            beginAsync().thenRun(c -> {
+                async(3, c);
+                throw new IllegalStateException("must not cause second callback invocation");
+            }).finish((v, e) -> {});
+        });
+        assertThrows(IllegalStateException.class, () -> {
+            beginAsync().thenRun(c -> {
+                async(3, c);
+            }).finish((v, e) -> {
+                throw new IllegalStateException("must not cause second callback invocation");
+            });
+        });
+    }
+
+    // invoked methods:
+
+    private void plain(final int i) {
+        int cur = invocationTracker.getNextOption(2);
+        if (cur == 0) {
+            listener.add("plain-exception-" + i);
+            throw new RuntimeException("affected method exception-" + i);
+        } else {
+            listener.add("plain-success-" + i);
+        }
+    }
+
+    private boolean plainTest(final int i) {
+        int cur = invocationTracker.getNextOption(3);
+        if (cur == 0) {
+            listener.add("plain-exception-" + i);
+            throw new RuntimeException("affected method exception-" + i);
+        } else if (cur == 1) {
+            listener.add("plain-false-" + i);
+            return false;
+        } else {
+            listener.add("plain-true-" + i);
+            return true;
+        }
+    }
+
+    private void sync(final int i) {
+        int cur = invocationTracker.getNextOption(2);
+        if (cur == 0) {
+            listener.add("affected-exception-" + i);
+            throw new RuntimeException("exception-" + i);
+        } else {
+            listener.add("affected-success-" + i);
+        }
+    }
+
+    private Integer syncReturns(final int i) {
+        int cur = invocationTracker.getNextOption(2);
+        if (cur == 0) {
+            listener.add("affected-exception-" + i);
+            throw new RuntimeException("exception-" + i);
+        } else {
+            listener.add("affected-success-" + i);
+            return i;
+        }
+    }
+
+    private void async(final int i, final SingleResultCallback<Void> callback) {
+        try {
+            sync(i);
+            callback.onResult(null, null);
+        } catch (Throwable t) {
+            callback.onResult(null, t);
+        }
+    }
+
+    private void asyncReturns(final int i, final SingleResultCallback<Integer> callback) {
+        try {
+            callback.onResult(syncReturns(i), null);
+        } catch (Throwable t) {
+            callback.onResult(null, t);
+        }
+    }
+
+    // assert methods:
+
+    private void assertBehavesSameVariations(final int expectedVariations, final Runnable sync,
+            final Consumer<SingleResultCallback<Void>> async) {
+        assertBehavesSameVariations(
+                expectedVariations,
+                () -> {
+                    sync.run();
+                    return null;
+                },
+                (c) -> {
+                    async.accept((v, e) -> c.onResult(v, e));
+                });
+    }
+
+    private <T> void assertBehavesSameVariations(final int expectedVariations, final Supplier<T> sync,
+            final Consumer<SingleResultCallback<T>> async) {
+        invocationTracker.reset();
+        do {
+            invocationTracker.startInitialStep();
+            assertBehavesSame(
+                    sync,
+                    () -> invocationTracker.startMatchStep(),
+                    async);
+
+        } while (invocationTracker.countDown());
+        assertEquals(expectedVariations, invocationTracker.getVariationCount());
+    }
+
+    private <T> void assertBehavesSame(final Supplier<T> sync, final Runnable between, final Consumer<SingleResultCallback<T>> async) {
+        T expectedValue = null;
+        Throwable expectedException = null;
+        try {
+            expectedValue = sync.get();
+        } catch (Throwable e) {
+            expectedException = e;
+        }
+        List<String> expectedEvents = listener.getEventStrings();
+
+        listener.clear();
+        between.run();
+
+        AtomicReference<T> actualValue = new AtomicReference<>();
+        AtomicReference<Throwable> actualException = new AtomicReference<>();
+        try {
+            async.accept((v, e) -> {
+                actualValue.set(v);
+                actualException.set(e);
+            });
+        } catch (Throwable e) {
+            fail("async threw instead of using callback");
+        }
+
+        // The following code can be used to debug variations:
+        // System.out.println("===");
+        // System.out.println(listener.getEventStrings());
+        // System.out.println("===");
+
+        assertEquals(expectedEvents, listener.getEventStrings(), "steps did not match");
+        assertEquals(expectedValue, actualValue.get());
+        assertEquals(expectedException == null, actualException.get() == null);
+        if (expectedException != null) {
+            assertEquals(expectedException.getMessage(), actualException.get().getMessage());
+            assertEquals(expectedException.getClass(), actualException.get().getClass());
+        }
+
+        listener.clear();
+    }
+
+    /**
+     * Tracks invocations: allows testing of all variations of a method calls
+     */
+    private static class InvocationTracker {
+        public static final int DEPTH_LIMIT = 50;
+        private final List<Integer> invocationResults = new ArrayList<>();
+        private boolean isMatchStep = false; // vs initial step
+        private int item = 0;
+        private int variationCount = 0;
+
+        public void reset() {
+            variationCount = 0;
+        }
+
+        public void startInitialStep() {
+            variationCount++;
+            isMatchStep = false;
+            item = -1;
+        }
+
+        public int getNextOption(final int myOptionsSize) {
+            item++;
+            if (item >= invocationResults.size()) {
+                if (isMatchStep) {
+                    fail("result should have been pre-initialized: steps may not match");
+                }
+                if (isWithinDepthLimit()) {
+                    invocationResults.add(myOptionsSize - 1);
+                } else {
+                    invocationResults.add(0); // choose "0" option, usually an exception
+                }
+            }
+            return invocationResults.get(item);
+        }
+
+        public void startMatchStep() {
+            isMatchStep = true;
+            item = -1;
+        }
+
+        private boolean countDown() {
+            while (!invocationResults.isEmpty()) {
+                int lastItemIndex = invocationResults.size() - 1;
+                int lastItem = invocationResults.get(lastItemIndex);
+                if (lastItem > 0) {
+                    // count current digit down by 1, until 0
+                    invocationResults.set(lastItemIndex, lastItem - 1);
+                    return true;
+                } else {
+                    // current digit completed, remove (move left)
+                    invocationResults.remove(lastItemIndex);
+                }
+            }
+            return false;
+        }
+
+        public int getVariationCount() {
+            return variationCount;
+        }
+
+        public boolean isWithinDepthLimit() {
+            return invocationResults.size() < DEPTH_LIMIT;
+        }
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/async/AsyncFunctionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/AsyncFunctionsTest.java
@@ -20,52 +20,86 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.internal.async.AsyncRunnable.beginAsync;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 final class AsyncFunctionsTest {
     private final TestListener listener = new TestListener();
     private final InvocationTracker invocationTracker = new InvocationTracker();
+    private boolean throwExceptionsFromAsync = false;
 
     @Test
-    void testVariations1() {
+    void testBasicVariations1() {
         /*
-        In our async code:
-        1. a callback is provided as a method parameter
-        2. at least one sync method must be converted to async
+        Some of our methods have "Async" counterparts. These "Async" methods
+        must implement the same behaviour asynchronously. In these "Async"
+        methods, a SingleResultCallback is provided as a parameter, and the
+        method calls at least one other "Async" method (or it invokes a
+        non-driver async API).
 
-        To use this API:
-        1. start an async chain using the "beginAsync" static method
-        2. use an appropriate chaining method (then...), which will provide "c"
-        3. copy all sync code to that method
-        4. at the async method, pass in "c" and start a new chaining method
+        The API tested here facilitates the writing of such methods using
+        standardized, tested, and non-nested boilerplate. For example, given
+        the following "sync" method:
+
+            public T myMethod()
+                sync(1);
+            }
+
+        The async counterpart would be:
+
+            public void myMethodAsync(SingleResultCallback<T> callback)
+                beginAsync().thenRun(c -> { // 1, 2
+                    async(1, c);            // 3, 4
+                }).finish(callback);        // 5
+            }
+
+        Usage:
+        1. Start an async chain using the "beginAsync" static method.
+        2. Use an appropriate chaining method (then...), which will provide "c"
+        3. copy all sync code into that method; convert sync methods to async
+        4. at any async method, pass in "c", and end that "block"
         5. provide the original "callback" at the end of the chain via "finish"
 
-        Async methods MUST be preceded by unaffected "plain" sync code (sync
-        code with no async counterpart), and this code MUST reside above the
-        affected method, as it appears in the sync code. Plain code after
-        the sync method should be supplied via one of the "finally" variants.
-        Safe "shared" plain code (variable and lambda declarations) which cannot
-        throw, may remain outside the chained invocations, for convenience.
+        (The above example is tested at the end of this method, and other tests
+        will provide additional examples.)
 
-        Plain sync code MAY throw exceptions, and SHOULD NOT attempt to handle
-        them asynchronously. The exceptions will be caught and handled by the
-        chaining methods that contain this sync code.
+        Requirements and conventions:
 
         Each async lambda MUST invoke its async method with "c", and MUST return
         immediately after invoking that method. It MUST NOT, for example, have
         a catch or finally (including close on try-with-resources) after the
-        invocation of the sync method.
+        invocation of the async method.
 
-        A braced lambda body (with no linebreak before "."), as shown below,
-        should be used, as this will be consistent with other usages, and allows
-        the async code to be more easily compared to the sync code.
+        In cases where the async method has "mixed" returns (some of which are
+        plain sync, some async), the "c" callback MUST be completed on the
+        plain sync path, `c.complete()`, followed by a return or end of method.
+
+        Chains starting with "beginAsync" correspond roughly to code blocks.
+        This includes the method body, blocks used in if/try/catch/while/etc.
+        statements, and places where anonymous code blocks might be used. For
+        clarity, such nested/indented chains might be omitted (where possible,
+        as demonstrated in the tests/examples below).
+
+        Plain sync code MAY throw exceptions, and SHOULD NOT attempt to handle
+        them asynchronously. The exceptions will be caught and handled by the
+        code blocks that contain this sync code.
+
+        All code, including "plain" code (parameter checks) SHOULD be placed
+        within the "boilerplate". This ensures that exceptions are handled,
+        and facilitates comparison/review. This excludes code that must be
+        "shared", such as lambda and variable declarations.
+
+        A curly-braced lambda body (with no linebreak before "."), as shown
+        below, SHOULD be used (for consistency, and ease of comparison/review).
         */
 
         // the number of expected variations is often: 1 + N methods invoked
@@ -84,7 +118,7 @@ final class AsyncFunctionsTest {
     }
 
     @Test
-    void testVariations2() {
+    void testBasicVariations2() {
         // tests pairs
         // converting: plain-sync, sync-plain, sync-sync
         // (plain-plain does not need an async chain)
@@ -110,12 +144,13 @@ final class AsyncFunctionsTest {
                     plain(2);
                 },
                 (callback) -> {
-                    // ...it is moved to its own block
+                    // ...it is moved to its own block, and must be completed:
                     beginAsync().thenRun(c -> {
                         async(1, c);
-                    }).thenRunAndFinish(() -> {
+                    }).thenRun(c -> {
                         plain(2);
-                    }, callback);
+                        c.complete();
+                    }).finish(callback);
                 });
 
         assertBehavesSameVariations(3,
@@ -135,7 +170,7 @@ final class AsyncFunctionsTest {
     }
 
     @Test
-    void testVariations4() {
+    void testBasicVariations4() {
         // tests the sync-sync pair with preceding and ensuing plain methods:
         assertBehavesSameVariations(5,
                 () -> {
@@ -191,11 +226,33 @@ final class AsyncFunctionsTest {
                 });
     }
 
+    @Test
+    void testSupplyMixed() {
+        assertBehavesSameVariations(5,
+                () -> {
+                    if (plainTest(1)) {
+                        return syncReturns(11);
+                    } else {
+                        return plainReturns(22);
+                    }
+                },
+                (callback) -> {
+                    beginAsync().<Integer>thenSupply(c -> {
+                        if (plainTest(1)) {
+                            asyncReturns(11, c);
+                        } else {
+                            int r = plainReturns(22);
+                            c.complete(r); // corresponds to a return, and
+                            // must be followed by a return or end of method
+                        }
+                    }).finish(callback);
+                });
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void testFullChain() {
-        // tests a chain: runnable, producer, function, function, consumer
-
+        // tests a chain with: runnable, producer, function, function, consumer
         assertBehavesSameVariations(14,
                 () -> {
                     plain(90);
@@ -238,7 +295,7 @@ final class AsyncFunctionsTest {
     }
 
     @Test
-    void testVariationsBranching() {
+    void testConditionalVariations() {
         assertBehavesSameVariations(5,
                 () -> {
                     if (plainTest(1)) {
@@ -293,11 +350,11 @@ final class AsyncFunctionsTest {
                     beginAsync().thenRun(c -> {
                         async(0, c);
                     }).thenRunIf(() -> plainTest(1),
-                            beginAsync().thenRun(c -> {
-                                async(21, c);
-                            }).thenRun((c) -> {
-                                async(22, c);
-                            })
+                        beginAsync().thenRun(c -> {
+                            async(21, c);
+                        }).thenRun((c) -> {
+                            async(22, c);
+                        })
                     ).thenRun(c -> {
                         async(3, c);
                     }).finish(callback);
@@ -305,7 +362,286 @@ final class AsyncFunctionsTest {
     }
 
     @Test
-    void testErrorIf() {
+    void testMixedConditionalCascade() {
+        assertBehavesSameVariations(9,
+                () -> {
+                    boolean test1 = plainTest(1);
+                    if (test1) {
+                        return syncReturns(11);
+                    }
+                    boolean test2 = plainTest(2);
+                    if (test2) {
+                        return 22;
+                    }
+                    int x = syncReturns(33);
+                    plain(x + 100);
+                    return syncReturns(44);
+                },
+                (callback) -> {
+                    beginAsync().<Integer>thenSupply(c -> {
+                        boolean test1 = plainTest(1);
+                        if (test1) {
+                            asyncReturns(11, c);
+                            return;
+                        }
+                        boolean test2 = plainTest(2);
+                        if (test2) {
+                            c.complete(22);
+                            return;
+                        }
+                        beginAsync().<Integer>thenSupply(c2 -> {
+                            asyncReturns(33, c2);
+                        }).<Integer>thenApply((x, c2) -> {
+                            plain(assertNotNull(x) + 100);
+                            asyncReturns(44, c2);
+                        }).finish(c);
+                    }).finish(callback);
+                });
+    }
+
+    @Test
+    void testPlain() {
+        // for completeness; should not be used, since there is no async
+        assertBehavesSameVariations(2,
+                () -> {
+                    plain(1);
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        plain(1);
+                        c.complete();
+                    }).finish(callback);
+                });
+    }
+
+    @Test
+    void testTryCatch() {
+        // single method in both try and catch
+        assertBehavesSameVariations(3,
+                () -> {
+                    try {
+                        sync(1);
+                    } catch (Throwable t) {
+                        sync(2);
+                    }
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        async(1, c);
+                    }).onErrorIf(t -> true, (t, c) -> {
+                        async(2, c);
+                    }).finish(callback);
+                });
+
+        // mixed sync/plain
+        assertBehavesSameVariations(3,
+                () -> {
+                    try {
+                        sync(1);
+                    } catch (Throwable t) {
+                        plain(2);
+                    }
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        async(1, c);
+                    }).onErrorIf(t -> true, (t, c) -> {
+                        plain(2);
+                        c.complete();
+                    }).finish(callback);
+                });
+
+        // chain of 2 in try
+        // "onErrorIf" will consider everything in
+        // the preceding chain to be part of the try
+        assertBehavesSameVariations(5,
+                () -> {
+                    try {
+                        sync(1);
+                        sync(2);
+                    } catch (Throwable t) {
+                        sync(9);
+                    }
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        async(1, c);
+                    }).thenRun(c -> {
+                        async(2, c);
+                    }).onErrorIf(t -> true, (t, c) -> {
+                        async(9, c);
+                    }).finish(callback);
+                });
+
+        // chain of 2 in catch
+        assertBehavesSameVariations(4,
+                () -> {
+                    try {
+                        sync(1);
+                    } catch (Throwable t) {
+                        sync(8);
+                        sync(9);
+                    }
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        async(1, c);
+                    }).onErrorIf(t -> true, (t, callback2) -> {
+                        beginAsync().thenRun(c -> {
+                            async(8, c);
+                        }).thenRun(c -> {
+                            async(9, c);
+                        }).finish(callback2);
+                    }).finish(callback);
+                });
+
+        // method after the try-catch block
+        // here, the try-catch must be nested (as a code block)
+        assertBehavesSameVariations(5,
+                () -> {
+                    try {
+                        sync(1);
+                    } catch (Throwable t) {
+                        sync(2);
+                    }
+                    sync(3);
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c2 -> {
+                        beginAsync().thenRun(c -> {
+                            async(1, c);
+                        }).onErrorIf(t -> true, (t, c) -> {
+                            async(2, c);
+                        }).finish(c2);
+                    }).thenRun(c -> {
+                        async(3, c);
+                    }).finish(callback);
+                });
+
+        // multiple catch blocks
+        // WARNING: these are not exclusive; if multiple "onErrorIf" blocks
+        // match, they will all be executed.
+        assertBehavesSameVariations(5,
+                () -> {
+                    try {
+                        if (plainTest(1)) {
+                            throw new UnsupportedOperationException("A");
+                        } else {
+                            throw new IllegalStateException("B");
+                        }
+                    } catch (UnsupportedOperationException t) {
+                        sync(8);
+                    } catch (IllegalStateException t) {
+                        sync(9);
+                    }
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        if (plainTest(1)) {
+                            throw new UnsupportedOperationException("A");
+                        } else {
+                            throw new IllegalStateException("B");
+                        }
+                    }).onErrorIf(t -> t instanceof UnsupportedOperationException, (t, c) -> {
+                        async(8, c);
+                    }).onErrorIf(t -> t instanceof IllegalStateException, (t, c) -> {
+                        async(9, c);
+                    }).finish(callback);
+                });
+    }
+
+    @Test
+    void testTryCatchWithVariables() {
+        // using supply etc.
+        assertBehavesSameVariations(12,
+                () -> {
+                    try {
+                        int i = plainTest(0) ? 1 : 2;
+                        i = syncReturns(i + 10);
+                        sync(i + 100);
+                    } catch (Throwable t) {
+                        sync(3);
+                    }
+                },
+                (callback) -> {
+                    beginAsync().thenRun(
+                            beginAsync().<Integer>thenSupply(c -> {
+                                int i = plainTest(0) ? 1 : 2;
+                                asyncReturns(i + 10, c);
+                            }).thenConsume((i, c) -> {
+                                async(assertNotNull(i) + 100, c);
+                            })
+                    ).onErrorIf(t -> true, (t, c) -> {
+                        async(3, c);
+                    }).finish(callback);
+                });
+
+        // using an externally-declared variable
+        assertBehavesSameVariations(17,
+                () -> {
+                    int i = plainTest(0) ? 1 : 2;
+                    try {
+                        i = syncReturns(i + 10);
+                        sync(i + 100);
+                    } catch (Throwable t) {
+                        sync(3);
+                    }
+                    sync(i + 1000);
+                },
+                (callback) -> {
+                    final int[] i = new int[1];
+                    beginAsync().thenRun(c -> {
+                        i[0] = plainTest(0) ? 1 : 2;
+                        c.complete();
+                    }).thenRun(c -> {
+                        beginAsync().<Integer>thenSupply(c2 -> {
+                            asyncReturns(i[0] + 10, c2);
+                        }).thenConsume((i2, c2) -> {
+                            i[0] = assertNotNull(i2);
+                            async(i2 + 100, c2);
+                        }).onErrorIf(t -> true, (t, c2) -> {
+                            async(3, c2);
+                        }).finish(c);
+                    }).thenRun(c -> {
+                        async(i[0] + 1000, c);
+                    }).finish(callback);
+                });
+    }
+
+    @Test
+    void testTryCatchWithConditionInCatch() {
+        assertBehavesSameVariations(8,
+                () -> {
+                    try {
+                        sync(plainTest(0) ? 1 : 2);
+                    } catch (Throwable t) {
+                        sync(5);
+                        if (t.getMessage().equals("exception-1")) {
+                            throw t;
+                        } else {
+                            throw new RuntimeException("wrapped-" + t.getMessage(), t);
+                        }
+                    }
+                },
+                (callback) -> {
+                    beginAsync().thenRun(c -> {
+                        async(plainTest(0) ? 1 : 2, c);
+                    }).onErrorIf(t -> true, (t, c) -> {
+                        beginAsync().thenRun(c2 -> {
+                            async(5, c2);
+                        }).thenRun(c2 -> {
+                            if (assertNotNull(t).getMessage().equals("exception-1")) {
+                                throw (RuntimeException) t;
+                            } else {
+                                throw new RuntimeException("wrapped-" + t.getMessage(), t);
+                            }
+                        }).finish(c);
+                    }).finish(callback);
+                });
+    }
+
+    @Test
+    void testTryCatchTestAndRethrow() {
         // thenSupply:
         assertBehavesSameVariations(5,
                 () -> {
@@ -322,7 +658,7 @@ final class AsyncFunctionsTest {
                 (callback) -> {
                     beginAsync().<Integer>thenSupply(c -> {
                         asyncReturns(1, c);
-                    }).onErrorIf(e -> e.getMessage().equals(plainTest(1) ? "unexpected" : "exception-1"), c -> {
+                    }).onErrorIf(e -> e.getMessage().equals(plainTest(1) ? "unexpected" : "exception-1"), (t, c) -> {
                         asyncReturns(2, c);
                     }).finish(callback);
                 });
@@ -343,7 +679,7 @@ final class AsyncFunctionsTest {
                 (callback) -> {
                     beginAsync().thenRun(c -> {
                         async(1, c);
-                    }).onErrorIf(e -> e.getMessage().equals(plainTest(1) ? "unexpected" : "exception-1"), c -> {
+                    }).onErrorIf(e -> e.getMessage().equals(plainTest(1) ? "unexpected" : "exception-1"), (t, c) -> {
                         async(2, c);
                     }).finish(callback);
                 });
@@ -356,13 +692,13 @@ final class AsyncFunctionsTest {
                     while (true) {
                         try {
                             sync(plainTest(0) ? 1 : 2);
-                            break;
                         } catch (RuntimeException e) {
                             if (e.getMessage().equals("exception-1")) {
                                 continue;
                             }
                             throw e;
                         }
+                        break;
                     }
                 },
                 (callback) -> {
@@ -469,6 +805,17 @@ final class AsyncFunctionsTest {
         }
     }
 
+    private int plainReturns(final int i) {
+        int cur = invocationTracker.getNextOption(2);
+        if (cur == 0) {
+            listener.add("plain-exception-" + i);
+            throw new RuntimeException("affected method exception-" + i);
+        } else {
+            listener.add("plain-success-" + i);
+            return i;
+        }
+    }
+
     private boolean plainTest(final int i) {
         int cur = invocationTracker.getNextOption(3);
         if (cur == 0) {
@@ -505,19 +852,29 @@ final class AsyncFunctionsTest {
     }
 
     private void async(final int i, final SingleResultCallback<Void> callback) {
-        try {
+        if (throwExceptionsFromAsync) {
             sync(i);
-            callback.onResult(null, null);
-        } catch (Throwable t) {
-            callback.onResult(null, t);
+            callback.complete();
+
+        } else {
+            try {
+                sync(i);
+                callback.complete();
+            } catch (Throwable t) {
+                callback.onResult(null, t);
+            }
         }
     }
 
     private void asyncReturns(final int i, final SingleResultCallback<Integer> callback) {
-        try {
-            callback.onResult(syncReturns(i), null);
-        } catch (Throwable t) {
-            callback.onResult(null, t);
+        if (throwExceptionsFromAsync) {
+            callback.complete(syncReturns(i));
+        } else {
+            try {
+                callback.complete(syncReturns(i));
+            } catch (Throwable t) {
+                callback.onResult(null, t);
+            }
         }
     }
 
@@ -525,8 +882,7 @@ final class AsyncFunctionsTest {
 
     private void assertBehavesSameVariations(final int expectedVariations, final Runnable sync,
             final Consumer<SingleResultCallback<Void>> async) {
-        assertBehavesSameVariations(
-                expectedVariations,
+        assertBehavesSameVariations(expectedVariations,
                 () -> {
                     sync.run();
                     return null;
@@ -538,19 +894,27 @@ final class AsyncFunctionsTest {
 
     private <T> void assertBehavesSameVariations(final int expectedVariations, final Supplier<T> sync,
             final Consumer<SingleResultCallback<T>> async) {
-        invocationTracker.reset();
-        do {
-            invocationTracker.startInitialStep();
-            assertBehavesSame(
-                    sync,
-                    () -> invocationTracker.startMatchStep(),
-                    async);
+        // run the variation-trying code twice, with direct/indirect exceptions
+        for (int i = 0; i < 2; i++) {
+            throwExceptionsFromAsync = i == 0;
 
-        } while (invocationTracker.countDown());
-        assertEquals(expectedVariations, invocationTracker.getVariationCount());
+            // the variation-trying code:
+            invocationTracker.reset();
+            do {
+                invocationTracker.startInitialStep();
+                assertBehavesSame(
+                        sync,
+                        () -> invocationTracker.startMatchStep(),
+                        async);
+            } while (invocationTracker.countDown());
+            assertEquals(expectedVariations, invocationTracker.getVariationCount(),
+                    "number of variations did not match");
+        }
+
     }
 
     private <T> void assertBehavesSame(final Supplier<T> sync, final Runnable between, final Consumer<SingleResultCallback<T>> async) {
+
         T expectedValue = null;
         Throwable expectedException = null;
         try {
@@ -565,23 +929,32 @@ final class AsyncFunctionsTest {
 
         AtomicReference<T> actualValue = new AtomicReference<>();
         AtomicReference<Throwable> actualException = new AtomicReference<>();
+        AtomicBoolean wasCalled = new AtomicBoolean(false);
         try {
             async.accept((v, e) -> {
                 actualValue.set(v);
                 actualException.set(e);
+                wasCalled.set(true);
             });
         } catch (Throwable e) {
             fail("async threw instead of using callback");
         }
 
         // The following code can be used to debug variations:
-        // System.out.println("===");
-        // System.out.println(listener.getEventStrings());
-        // System.out.println("===");
+//        System.out.println("===START");
+//        System.out.println("sync: " + expectedEvents);
+//        System.out.println("callback called?: " + wasCalled.get());
+//        System.out.println("value -- sync: " + expectedValue + " -- async: " + actualValue.get());
+//        System.out.println("excep -- sync: " + expectedException + " -- async: " + actualException.get());
+//        System.out.println("variant: " + (throwExceptionsFromAsync
+//             ? "exceptions thrown directly" : "exceptions into callbacks"));
+//        System.out.println("===END");
 
-        assertEquals(expectedEvents, listener.getEventStrings(), "steps did not match");
+        assertTrue(wasCalled.get(), "callback should have been called");
+        assertEquals(expectedEvents, listener.getEventStrings(), "steps should have matched");
         assertEquals(expectedValue, actualValue.get());
-        assertEquals(expectedException == null, actualException.get() == null);
+        assertEquals(expectedException == null, actualException.get() == null,
+                "both or neither should have produced an exception");
         if (expectedException != null) {
             assertEquals(expectedException.getMessage(), actualException.get().getMessage());
             assertEquals(expectedException.getClass(), actualException.get().getClass());

--- a/driver-core/src/test/unit/com/mongodb/internal/async/AsyncFunctionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/AsyncFunctionsTest.java
@@ -122,8 +122,8 @@ final class AsyncFunctionsTest {
         1. Is everything inside the boilerplate?
         2. Is "callback" supplied to "finish"?
         3. In each block and nested block, is that same block's "c" always passed/completed at the end of execution?
-        4. Is any c.complete followed by a return, to end execution?
-        5. Do any sync methods still need to be converted to async?
+        4. Is every c.complete followed by a return, to end execution?
+        5. Have all sync method calls been converted to async, where needed?
         */
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/async/AsyncFunctionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/AsyncFunctionsTest.java
@@ -159,7 +159,7 @@ final class AsyncFunctionsTest {
                         async(1, c);
                     }).thenRun(c -> {
                         plain(2);
-                        c.complete();
+                        c.complete(c);
                     }).finish(callback);
                 });
 
@@ -419,7 +419,7 @@ final class AsyncFunctionsTest {
                 (callback) -> {
                     beginAsync().thenRun(c -> {
                         plain(1);
-                        c.complete();
+                        c.complete(c);
                     }).finish(callback);
                 });
     }
@@ -457,7 +457,7 @@ final class AsyncFunctionsTest {
                         async(1, c);
                     }).onErrorIf(t -> true, (t, c) -> {
                         plain(2);
-                        c.complete();
+                        c.complete(c);
                     }).finish(callback);
                 });
 
@@ -602,7 +602,7 @@ final class AsyncFunctionsTest {
                     final int[] i = new int[1];
                     beginAsync().thenRun(c -> {
                         i[0] = plainTest(0) ? 1 : 2;
-                        c.complete();
+                        c.complete(c);
                     }).thenRun(c -> {
                         beginAsync().<Integer>thenSupply(c2 -> {
                             asyncReturns(i[0] + 10, c2);
@@ -818,7 +818,7 @@ final class AsyncFunctionsTest {
         };
         BiConsumer<Integer, SingleResultCallback<Void>> happyAsync = (i, c) -> {
             happySync.accept(i);
-            c.complete();
+            c.complete(c);
         };
 
         // Standard nested async, no error handling:
@@ -955,12 +955,12 @@ final class AsyncFunctionsTest {
     private void async(final int i, final SingleResultCallback<Void> callback) {
         if (throwExceptionsFromAsync) {
             sync(i);
-            callback.complete();
+            callback.complete(callback);
 
         } else {
             try {
                 sync(i);
-                callback.complete();
+                callback.complete(callback);
             } catch (Throwable t) {
                 callback.onResult(null, t);
             }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionBinding.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionBinding.java
@@ -30,7 +30,6 @@ import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.binding.AsyncReadWriteBinding;
 import com.mongodb.internal.binding.TransactionContext;
 import com.mongodb.internal.connection.AsyncConnection;
-import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.internal.session.ClientSessionContext;
 import com.mongodb.internal.session.SessionContext;
@@ -127,7 +126,7 @@ public class ClientSessionBinding extends AbstractReferenceCounted implements As
                 c2.complete(source);
             }).finish(c);
         }).<AsyncConnectionSource>thenApply((source, c) -> {
-            c.complete(new SessionBindingAsyncConnectionSource(assertNotNull(source)));
+            c.complete(new SessionBindingAsyncConnectionSource(source));
         }).finish(callback);
     }
 
@@ -204,7 +203,7 @@ public class ClientSessionBinding extends AbstractReferenceCounted implements As
                 beginAsync().<AsyncConnection>thenSupply(c2 -> {
                     wrapped.getConnection(c2);
                 }).<AsyncConnection>thenApply((connection, c2) -> {
-                    transactionContext.pinConnection(assertNotNull(connection), AsyncConnection::markAsPinned);
+                    transactionContext.pinConnection(connection, AsyncConnection::markAsPinned);
                     c2.complete(connection);
                 }).finish(c);
             }).finish(callback);

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/KeyManagementService.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/KeyManagementService.java
@@ -85,7 +85,7 @@ class KeyManagementService implements Closeable {
                     stream.close();
                     sink.error(t);
                 }
-            });
+            }.asCallback());
         }).onErrorMap(this::unWrapException);
     }
 


### PR DESCRIPTION
JAVA-5082

The first commit, "Add async functions", extracts the async API and its tests, which were reviewed when that code was merged into https://github.com/mongodb/mongo-java-driver/pull/1134 , though we might want to have further review. Other commits are all new non-reviewed code.
