### PR TITLE
Enable container and Kubernetes awareness for improved telemetry.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -257,6 +257,7 @@ configure(javaCodeCheckedProjects) {
         testImplementation 'org.spockframework:spock-core'
         testImplementation 'org.spockframework:spock-junit4'
         testImplementation("org.mockito:mockito-core:3.8.0")
+        testImplementation("org.mockito:mockito-inline:3.8.0")
         testImplementation 'cglib:cglib-nodep:2.2.2'
         testImplementation 'org.objenesis:objenesis:1.3'
         testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -277,9 +277,4 @@
         <Bug pattern="NP_NONNULL_PARAM_VIOLATION"/>
     </Match>
 
-    <Match>
-        <Class name="com.mongodb.internal.connection.ClientMetadataHelper$ContainerRuntime"/>
-        <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
-    </Match>
-
 </FindBugsFilter>

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -277,4 +277,9 @@
         <Bug pattern="NP_NONNULL_PARAM_VIOLATION"/>
     </Match>
 
+    <Match>
+        <Class name="com.mongodb.internal.connection.ClientMetadataHelper$ContainerRuntime"/>
+        <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME"/>
+    </Match>
+
 </FindBugsFilter>

--- a/driver-core/src/main/com/mongodb/internal/connection/ClientMetadataHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ClientMetadataHelper.java
@@ -29,6 +29,7 @@ import org.bson.codecs.BsonDocumentCodec;
 import org.bson.codecs.EncoderContext;
 import org.bson.io.BasicOutputBuffer;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -240,7 +241,7 @@ public final class ClientMetadataHelper {
             @Override
             boolean isCurrentRuntimeContainer() {
                 try {
-                    return Files.exists(get("/.dockerenv"));
+                    return Files.exists(get(File.separator + ".dockerenv"));
                 } catch (Exception e) {
                     return false;
                     // NOOP. This could be a SecurityException.

--- a/driver-core/src/main/com/mongodb/internal/connection/ClientMetadataHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ClientMetadataHelper.java
@@ -31,7 +31,6 @@ import org.bson.io.BasicOutputBuffer;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -40,6 +39,7 @@ import java.util.function.Consumer;
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static java.lang.String.format;
 import static java.lang.System.getProperty;
+import static java.nio.file.Paths.get;
 
 /**
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
@@ -240,7 +240,7 @@ public final class ClientMetadataHelper {
             @Override
             boolean isCurrentRuntimeContainer() {
                 try {
-                    return Files.exists(Paths.get("/.dockerenv"));
+                    return Files.exists(get("/.dockerenv"));
                 } catch (Exception e) {
                     return false;
                     // NOOP. This could be a SecurityException.
@@ -248,7 +248,6 @@ public final class ClientMetadataHelper {
             }
         },
         UNKNOWN(null);
-
         @Nullable
         private final String name;
 

--- a/driver-core/src/main/com/mongodb/internal/connection/ClientMetadataHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ClientMetadataHelper.java
@@ -249,6 +249,7 @@ public final class ClientMetadataHelper {
             }
         },
         UNKNOWN(null);
+
         @Nullable
         private final String name;
 

--- a/driver-core/src/main/com/mongodb/internal/connection/ClientMetadataHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ClientMetadataHelper.java
@@ -30,6 +30,8 @@ import org.bson.codecs.EncoderContext;
 import org.bson.io.BasicOutputBuffer;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -98,17 +100,26 @@ public final class ClientMetadataHelper {
             putAtPath(d, "driver.name", listToString(fullDriverInfo.getDriverNames()));
             putAtPath(d, "driver.version", listToString(fullDriverInfo.getDriverVersions()));
         });
+
         // optional fields:
-        Environment environment = getEnvironment();
+        FaasEnvironment faasEnvironment =  getFaasEnvironment();
+        ContainerRuntime containerRuntime = ContainerRuntime.determineExecutionContainer();
+        Orchestrator orchestrator = Orchestrator.determineExecutionOrchestrator();
+
         tryWithLimit(client, d -> putAtPath(d, "platform", listToString(baseDriverInfor.getDriverPlatforms())));
         tryWithLimit(client, d -> putAtPath(d, "platform", listToString(fullDriverInfo.getDriverPlatforms())));
-        tryWithLimit(client, d -> putAtPath(d, "env.name", environment.getName()));
         tryWithLimit(client, d -> putAtPath(d, "os.name", getOperatingSystemName()));
         tryWithLimit(client, d -> putAtPath(d, "os.architecture", getProperty("os.arch", "unknown")));
         tryWithLimit(client, d -> putAtPath(d, "os.version", getProperty("os.version", "unknown")));
-        tryWithLimit(client, d -> putAtPath(d, "env.timeout_sec", environment.getTimeoutSec()));
-        tryWithLimit(client, d -> putAtPath(d, "env.memory_mb", environment.getMemoryMb()));
-        tryWithLimit(client, d -> putAtPath(d, "env.region", environment.getRegion()));
+
+        tryWithLimit(client, d -> putAtPath(d, "env.name", faasEnvironment.getName()));
+        tryWithLimit(client, d -> putAtPath(d, "env.timeout_sec", faasEnvironment.getTimeoutSec()));
+        tryWithLimit(client, d -> putAtPath(d, "env.memory_mb", faasEnvironment.getMemoryMb()));
+        tryWithLimit(client, d -> putAtPath(d, "env.region", faasEnvironment.getRegion()));
+
+        tryWithLimit(client, d -> putAtPath(d, "env.container.runtime", containerRuntime.getName()));
+        tryWithLimit(client, d -> putAtPath(d, "env.container.orchestrator", orchestrator.getName()));
+
         return client;
     }
 
@@ -168,8 +179,7 @@ public final class ClientMetadataHelper {
         new BsonDocumentCodec().encode(new BsonBinaryWriter(buffer), document, EncoderContext.builder().build());
         return buffer.getPosition() > MAXIMUM_CLIENT_METADATA_ENCODED_SIZE;
     }
-
-    private enum Environment {
+    private enum FaasEnvironment {
         AWS_LAMBDA("aws.lambda"),
         AZURE_FUNC("azure.func"),
         GCP_FUNC("gcp.func"),
@@ -179,7 +189,7 @@ public final class ClientMetadataHelper {
         @Nullable
         private final String name;
 
-        Environment(@Nullable final String name) {
+        FaasEnvironment(@Nullable final String name) {
             this.name = name;
         }
 
@@ -225,6 +235,81 @@ public final class ClientMetadataHelper {
         }
     }
 
+    public enum ContainerRuntime {
+        DOCKER("docker") {
+            @Override
+            boolean isCurrentRuntimeContainer() {
+                try {
+                    return Files.exists(Paths.get("/.dockerenv"));
+                } catch (Exception e) {
+                    return false;
+                    // NOOP. This could be a SecurityException.
+                }
+            }
+        },
+        UNKNOWN(null);
+
+        @Nullable
+        private final String name;
+
+        ContainerRuntime(@Nullable final String name) {
+            this.name = name;
+        }
+
+        @Nullable
+        public String getName() {
+            return name;
+        }
+
+        boolean isCurrentRuntimeContainer() {
+            return false;
+        }
+
+        static ContainerRuntime determineExecutionContainer() {
+            for (ContainerRuntime allegedContainer : ContainerRuntime.values()) {
+                if (allegedContainer.isCurrentRuntimeContainer()) {
+                    return allegedContainer;
+                }
+            }
+            return UNKNOWN;
+        }
+    }
+
+    private enum Orchestrator {
+        K8S("kubernetes") {
+            @Override
+            boolean isCurrentOrchestrator() {
+                return System.getenv("KUBERNETES_SERVICE_HOST") != null;
+            }
+        },
+        UNKNOWN(null);
+
+        @Nullable
+        private final String name;
+
+        Orchestrator(@Nullable final String name) {
+            this.name = name;
+        }
+
+        @Nullable
+        public String getName() {
+            return name;
+        }
+
+        boolean isCurrentOrchestrator() {
+            return false;
+        }
+
+        static Orchestrator determineExecutionOrchestrator() {
+            for (Orchestrator alledgedOrchestrator : Orchestrator.values()) {
+                if (alledgedOrchestrator.isCurrentOrchestrator()) {
+                    return alledgedOrchestrator;
+                }
+            }
+            return UNKNOWN;
+        }
+    }
+
     @Nullable
     private static Integer getEnvInteger(final String name) {
         try {
@@ -235,29 +320,29 @@ public final class ClientMetadataHelper {
         }
     }
 
-    static Environment getEnvironment() {
-        List<Environment> result = new ArrayList<>();
+    static FaasEnvironment getFaasEnvironment() {
+        List<FaasEnvironment> result = new ArrayList<>();
         String awsExecutionEnv = System.getenv("AWS_EXECUTION_ENV");
 
         if (System.getenv("VERCEL") != null) {
-            result.add(Environment.VERCEL);
+            result.add(FaasEnvironment.VERCEL);
         }
         if ((awsExecutionEnv != null && awsExecutionEnv.startsWith("AWS_Lambda_"))
                 || System.getenv("AWS_LAMBDA_RUNTIME_API") != null) {
-            result.add(Environment.AWS_LAMBDA);
+            result.add(FaasEnvironment.AWS_LAMBDA);
         }
         if (System.getenv("FUNCTIONS_WORKER_RUNTIME") != null) {
-            result.add(Environment.AZURE_FUNC);
+            result.add(FaasEnvironment.AZURE_FUNC);
         }
         if (System.getenv("K_SERVICE") != null || System.getenv("FUNCTION_NAME") != null) {
-            result.add(Environment.GCP_FUNC);
+            result.add(FaasEnvironment.GCP_FUNC);
         }
         // vercel takes precedence over aws.lambda
-        if (result.equals(Arrays.asList(Environment.VERCEL, Environment.AWS_LAMBDA))) {
-            return Environment.VERCEL;
+        if (result.equals(Arrays.asList(FaasEnvironment.VERCEL, FaasEnvironment.AWS_LAMBDA))) {
+            return FaasEnvironment.VERCEL;
         }
         if (result.size() != 1) {
-            return Environment.UNKNOWN;
+            return FaasEnvironment.UNKNOWN;
         }
         return result.get(0);
     }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/ClientMetadataHelperProseTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/ClientMetadataHelperProseTest.java
@@ -42,6 +42,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * See <a href="https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst#test-plan">spec</a>
+ *
+ * <p>
+ * NOTE: This class also contains tests which are not specified as Prose ones.
  */
 public class ClientMetadataHelperProseTest {
     private static final String APP_NAME = "app name";
@@ -167,6 +170,21 @@ public class ClientMetadataHelperProseTest {
     }
 
     // Additional tests, not specified as prose tests:
+
+    @Test
+    void testKubernetesMetadataIncluded() {
+        withWrapper()
+                .withEnvironmentVariable("AWS_EXECUTION_ENV", "AWS_Lambda_java8")
+                .withEnvironmentVariable("KUBERNETES_SERVICE_HOST", "kubernetes.default.svc.cluster.local")
+                .run(() -> {
+                    BsonDocument expected = createExpectedClientMetadataDocument(APP_NAME);
+                    expected.put("env", BsonDocument.parse("{'name': 'aws.lambda', 'container': {'orchestrator': 'kubernetes'}}"));
+                    BsonDocument actual = createActualClientMetadataDocument();
+                    assertEquals(expected, actual);
+
+                    performHello();
+                });
+    }
 
     @Test
     public void testLimitForDriverVersion() {

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/ClientMetadataHelperProseTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/ClientMetadataHelperProseTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -194,7 +195,7 @@ public class ClientMetadataHelperProseTest {
     @Test
     void testDockerMetadataIncluded() {
         try (MockedStatic<Files> pathsMockedStatic = Mockito.mockStatic(Files.class)) {
-            Path path = Paths.get("/.dockerenv");
+            Path path = Paths.get(File.separator + ".dockerenv");
             pathsMockedStatic.when(() -> Files.exists(path)).thenReturn(true);
 
             withWrapper()
@@ -213,7 +214,7 @@ public class ClientMetadataHelperProseTest {
     @Test
     void testDockerAndKubernetesMetadataIncluded() {
         try (MockedStatic<Files> pathsMockedStatic = Mockito.mockStatic(Files.class)) {
-            Path path = Paths.get("/.dockerenv");
+            Path path = Paths.get(File.separator + "/.dockerenv");
             pathsMockedStatic.when(() -> Files.exists(path)).thenReturn(true);
 
             withWrapper()


### PR DESCRIPTION
Include container and Kubernetes awareness, as specified in the [MongoDB Handshake Specification](https://github.com/abr-egn/specifications/blob/c4831b426c7eab8749723d7f3cd6bb5c237bcbbe/source/mongodb-handshake/handshake.rst#container)

JAVA-5072