### PR TITLE
Make `ServerSelectionLoggingTest` pass when run against a load balanced cluster, or when using Unix domain socket

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/unified/EventMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/EventMatcher.java
@@ -313,10 +313,12 @@ final class EventMatcher {
             return true;
         }
         String newType = expectedEventContents.getDocument("newDescription").getString("type").getValue();
-        //noinspection SwitchStatementWithTooFewBranches
         switch (newType) {
             case "Unknown":
                 return event.getNewDescription().getType() == ServerType.UNKNOWN;
+            case "LoadBalancer": {
+                return event.getNewDescription().getType() == ServerType.LOAD_BALANCER;
+            }
             default:
                 throw new UnsupportedOperationException();
         }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/LogMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/LogMatcher.java
@@ -114,7 +114,7 @@ final class LogMatcher {
     interface Tweak extends Function<BsonDocument, BsonDocument> {
         /**
          * @param expectedMessage May be {@code null}, in which case the method simply returns {@code null}.
-         * @return {@code null} iff matching {@code expectedMessage} if the actual message must be skipped.
+         * @return {@code null} iff matching {@code expectedMessage} with the actual message must be skipped.
          */
         @Nullable
         BsonDocument apply(@Nullable BsonDocument expectedMessage);

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/LogMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/LogMatcher.java
@@ -16,9 +16,11 @@
 
 package com.mongodb.client.unified;
 
+import com.mongodb.Function;
 import com.mongodb.MongoCommandException;
 import com.mongodb.internal.ExceptionUtils.MongoCommandExceptionUtils;
 import com.mongodb.internal.logging.LogMessage;
+import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -44,19 +46,20 @@ final class LogMatcher {
         this.context = context;
     }
 
-    void assertLogMessageEquality(final String client, final BsonArray expectedMessages, final List<LogMessage> actualMessages) {
+    void assertLogMessageEquality(final String client, final BsonArray expectedMessages, final List<LogMessage> actualMessages,
+            final Iterable<Tweak> tweaks) {
         context.push(ContextElement.ofLogMessages(client, expectedMessages, actualMessages));
 
         assertEquals(context.getMessage("Number of log messages must be the same"), expectedMessages.size(), actualMessages.size());
 
         for (int i = 0; i < expectedMessages.size(); i++) {
-            BsonDocument expectedMessageAsDocument = expectedMessages.get(i).asDocument().clone();
-            // `LogMessage.Entry.Name.OPERATION` is not supported, therefore we skip matching its value
-            BsonValue expectedDataDocument = expectedMessageAsDocument.get("data");
-            if (expectedDataDocument != null) {
-                expectedDataDocument.asDocument().remove(LogMessage.Entry.Name.OPERATION.getValue());
+            BsonDocument expectedMessage = expectedMessages.get(i).asDocument().clone();
+            for (Tweak tweak : tweaks) {
+                expectedMessage = tweak.apply(expectedMessage);
             }
-            valueMatcher.assertValuesMatch(expectedMessageAsDocument, asDocument(actualMessages.get(i)));
+            if (expectedMessage != null) {
+                valueMatcher.assertValuesMatch(expectedMessage, asDocument(actualMessages.get(i)));
+            }
         }
 
         context.pop();
@@ -108,4 +111,26 @@ final class LogMatcher {
         }
     }
 
+    interface Tweak extends Function<BsonDocument, BsonDocument> {
+        /**
+         * @param expectedMessage May be {@code null}, in which case the method simply returns {@code null}.
+         * @return {@code null} iff matching {@code expectedMessage} if the actual message must be skipped.
+         */
+        @Nullable
+        BsonDocument apply(@Nullable BsonDocument expectedMessage);
+
+        static Tweak skip(final LogMessage.Entry.Name name) {
+            return expectedMessage -> {
+                if (expectedMessage == null) {
+                    return null;
+                } else {
+                    BsonDocument expectedData = expectedMessage.getDocument("data", null);
+                    if (expectedData != null) {
+                        expectedData.remove(name.getValue());
+                    }
+                    return expectedMessage;
+                }
+            };
+        }
+    }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/LogMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/LogMatcher.java
@@ -114,6 +114,7 @@ final class LogMatcher {
     interface Tweak extends Function<BsonDocument, BsonDocument> {
         /**
          * @param expectedMessage May be {@code null}, in which case the method simply returns {@code null}.
+         * This method may mutate {@code expectedMessage}.
          * @return {@code null} iff matching {@code expectedMessage} with the actual message must be skipped.
          */
         @Nullable


### PR DESCRIPTION
Requested review from the same reviewers who reviewed the original https://github.com/mongodb/mongo-java-driver/pull/1221.

Note that the Evergreen patch for this PR includes the `serverless-test` and `socket-test` Evergreen tasks (they are not normally included, here they are included manually), which [failed in Spruce](https://spruce.mongodb.com/version/mongo_java_driver_d375cd45b2cb60cf4400e8f0ed250ef933af9604/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC). This PR fixes those failures.

JAVA-4754