### PR TITLE
Make NettyStreamFactoryFactory implement AutoCloseable

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/NettyTransportSettings.java
+++ b/driver-core/src/main/com/mongodb/connection/NettyTransportSettings.java
@@ -87,8 +87,7 @@ public final class NettyTransportSettings extends TransportSettings {
         /**
          * Sets the event loop group.
          *
-         * <p>It is highly recommended to supply your own event loop group and manage its shutdown.  Otherwise, the event
-         * loop group created by default will not be shutdown properly.</p>
+         * <p>The application is responsible for shutting down the provided {@code eventLoopGroup}</p>
          *
          * @param eventLoopGroup the event loop group that all channels created by this factory will be a part of
          * @return this

--- a/driver-core/src/main/com/mongodb/internal/connection/AsynchronousSocketChannelStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsynchronousSocketChannelStreamFactoryFactory.java
@@ -36,4 +36,8 @@ public final class AsynchronousSocketChannelStreamFactoryFactory implements Stre
     public StreamFactory create(final SocketSettings socketSettings, final SslSettings sslSettings) {
         return new AsynchronousSocketChannelStreamFactory(inetAddressResolver, socketSettings, sslSettings);
     }
+
+    @Override
+    public void close() {
+    }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/StreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/StreamFactoryFactory.java
@@ -22,7 +22,7 @@ import com.mongodb.connection.SslSettings;
 /**
  * A factory of {@code StreamFactory} instances.
  */
-public interface StreamFactoryFactory {
+public interface StreamFactoryFactory extends AutoCloseable {
 
     /**
      * Create a {@code StreamFactory} with the given settings.
@@ -32,4 +32,7 @@ public interface StreamFactoryFactory {
      * @return a stream factory that will apply the given settins
      */
     StreamFactory create(SocketSettings socketSettings, SslSettings sslSettings);
+
+    @Override
+    void close();
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/TlsChannelStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/TlsChannelStreamFactoryFactory.java
@@ -59,7 +59,7 @@ import static java.util.Optional.ofNullable;
 /**
  * A {@code StreamFactoryFactory} that supports TLS/SSL.  The implementation supports asynchronous usage.
  */
-public class TlsChannelStreamFactoryFactory implements StreamFactoryFactory, Closeable {
+public class TlsChannelStreamFactoryFactory implements StreamFactoryFactory {
 
     private static final Logger LOGGER = Loggers.getLogger("connection.tls");
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoClients.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoClients.java
@@ -127,10 +127,9 @@ public final class MongoClients {
         }
         StreamFactory streamFactory = getStreamFactory(streamFactoryFactory, settings, false);
         StreamFactory heartbeatStreamFactory = getStreamFactory(streamFactoryFactory, settings, true);
-        AutoCloseable externalResourceCloser = streamFactoryFactory instanceof AutoCloseable ? (AutoCloseable) streamFactoryFactory : null;
         MongoDriverInformation wrappedMongoDriverInformation = wrapMongoDriverInformation(mongoDriverInformation);
         Cluster cluster = createCluster(settings, wrappedMongoDriverInformation, streamFactory, heartbeatStreamFactory);
-        return new MongoClientImpl(settings, wrappedMongoDriverInformation, cluster, externalResourceCloser);
+        return new MongoClientImpl(settings, wrappedMongoDriverInformation, cluster, streamFactoryFactory);
     }
 
     /**


### PR DESCRIPTION
Since StreamFactoryFactory is now internal, just made that interface extend AutoCloseable in order to simplify MongoClients code

JAVA-5158

Note: If TransportSettings are used with the synchronous MongoClient, it currently won't close the StreamFactoryFactory.  That will require a bit more refactoring than I wanted to do in this PR, and is not likely to be encountered by actual users, as there's no good reason that I know of to use Netty with the synchronous MongoClient.