### PR TITLE
Remove getCluster method

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/binding/AsyncClusterAwareReadWriteBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/AsyncClusterAwareReadWriteBinding.java
@@ -18,13 +18,11 @@ package com.mongodb.internal.binding;
 
 import com.mongodb.ServerAddress;
 import com.mongodb.internal.async.SingleResultCallback;
-import com.mongodb.internal.connection.Cluster;
 
 /**
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public interface AsyncClusterAwareReadWriteBinding extends AsyncReadWriteBinding {
-    Cluster getCluster();
 
     /**
      * Returns a connection source to the specified server

--- a/driver-core/src/main/com/mongodb/internal/binding/AsyncClusterBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/AsyncClusterBinding.java
@@ -81,11 +81,6 @@ public class AsyncClusterBinding extends AbstractReferenceCounted implements Asy
     }
 
     @Override
-    public Cluster getCluster() {
-        return cluster;
-    }
-
-    @Override
     public ReadPreference getReadPreference() {
         return readPreference;
     }

--- a/driver-core/src/main/com/mongodb/internal/binding/ClusterAwareReadWriteBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/ClusterAwareReadWriteBinding.java
@@ -17,13 +17,11 @@
 package com.mongodb.internal.binding;
 
 import com.mongodb.ServerAddress;
-import com.mongodb.internal.connection.Cluster;
 
 /**
  * This interface is not part of the public API and may be removed or changed at any time.
  */
 public interface ClusterAwareReadWriteBinding extends ReadWriteBinding {
-    Cluster getCluster();
 
     /**
      * Returns a connection source to the specified server address.

--- a/driver-core/src/main/com/mongodb/internal/binding/ClusterBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/ClusterBinding.java
@@ -22,10 +22,10 @@ import com.mongodb.RequestContext;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerApi;
 import com.mongodb.connection.ClusterConnectionMode;
-import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.Connection;
+import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.internal.connection.ReadConcernAwareNoOpSessionContext;
 import com.mongodb.internal.connection.Server;
 import com.mongodb.internal.connection.ServerTuple;
@@ -69,14 +69,6 @@ public class ClusterBinding extends AbstractReferenceCounted implements ClusterA
         this.serverApi = serverApi;
         this.requestContext = notNull("requestContext", requestContext);
         operationContext = new OperationContext();
-    }
-
-    /**
-     * Return the cluster.
-     * @return the cluster
-     */
-    public Cluster getCluster() {
-        return cluster;
     }
 
     @Override

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/CryptBinding.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/CryptBinding.java
@@ -25,7 +25,6 @@ import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncClusterAwareReadWriteBinding;
 import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.connection.AsyncConnection;
-import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.internal.session.SessionContext;
 import com.mongodb.lang.Nullable;
@@ -130,11 +129,6 @@ public class CryptBinding implements AsyncClusterAwareReadWriteBinding {
     @Override
     public int release() {
         return wrapped.release();
-    }
-
-    @Override
-    public Cluster getCluster() {
-        return wrapped.getCluster();
     }
 
     private class CryptConnectionSource implements AsyncConnectionSource {

--- a/driver-sync/src/main/com/mongodb/client/internal/CryptBinding.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/CryptBinding.java
@@ -20,13 +20,12 @@ import com.mongodb.ReadPreference;
 import com.mongodb.RequestContext;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerApi;
-import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.internal.binding.ClusterAwareReadWriteBinding;
 import com.mongodb.internal.binding.ConnectionSource;
 import com.mongodb.internal.binding.ReadWriteBinding;
-import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.Connection;
+import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.internal.session.SessionContext;
 import com.mongodb.lang.Nullable;
 
@@ -99,11 +98,6 @@ class CryptBinding implements ClusterAwareReadWriteBinding {
     @Override
     public int release() {
         return wrapped.release();
-    }
-
-    @Override
-    public Cluster getCluster() {
-        return wrapped.getCluster();
     }
 
     private class CryptConnectionSource implements ConnectionSource {


### PR DESCRIPTION
from the following internal interfaces:

* ClusterAwareReadWriteBinding
* AsyncClusterAwareReadWriteBinding

The interfaces remain, as they have picket up a second method.  The existing interface names arguably still make sense since implementations have to be "cluster-aware" in order to implement the remaining method.

JAVA-5217