### PR TITLE
POC WIP

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/ClientWriteModelList.java
+++ b/driver-core/src/main/com/mongodb/client/model/ClientWriteModelList.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model;
+
+import com.mongodb.MongoNamespace;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ClientWriteModelList {
+    private final List<WriteModel<?>> writeModels;
+
+    private final List<NamespaceRange> namespaceRanges;
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public List<WriteModel<?>> getWriteModels() {
+        return writeModels;
+    }
+
+    public List<NamespaceRange> getNamespaceRanges() {
+        return namespaceRanges;
+    }
+
+    public static class NamespaceRange {
+        private final MongoNamespace namespace;
+        private final int startIndex;
+        private final int size;
+
+
+        public MongoNamespace getNamespace() {
+            return namespace;
+        }
+
+        public int getStartIndex() {
+            return startIndex;
+        }
+
+        public int getSize() {
+            return size;
+        }
+
+        public NamespaceRange(MongoNamespace namespace, int startIndex, int size) {
+            this.namespace = namespace;
+            this.startIndex = startIndex;
+            this.size = size;
+        }
+    }
+
+    public static class Builder {
+        private final List<NamespaceRange> namespaceRanges = new ArrayList<>();
+        private final List<WriteModel<?>> writeModels = new ArrayList<>();
+
+        public <TDocument> Builder add(MongoNamespace namespace, WriteModel<TDocument> writeModel) {
+            namespaceRanges.add(new NamespaceRange(namespace, this.writeModels.size(), 1));
+            this.writeModels.add(writeModel);
+            return this;
+        }
+
+        public <TDocument> Builder add(MongoNamespace namespace, List<WriteModel<TDocument>> writeModels) {
+            namespaceRanges.add(new NamespaceRange(namespace, this.writeModels.size(), writeModels.size()));
+            this.writeModels.addAll(writeModels);
+            return this;
+        }
+
+        public ClientWriteModelList build() {
+            return new ClientWriteModelList(this);
+        }
+    }
+
+    public ClientWriteModelList(Builder builder) {
+        this.writeModels = builder.writeModels;
+        this.namespaceRanges = builder.namespaceRanges;
+    }
+}

--- a/driver-sync/src/main/com/mongodb/client/MongoClient.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoClient.java
@@ -19,6 +19,8 @@ package com.mongodb.client;
 import com.mongodb.ClientSessionOptions;
 import com.mongodb.MongoNamespace;
 import com.mongodb.annotations.Immutable;
+import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.client.model.ClientWriteModelList;
 import com.mongodb.connection.ClusterDescription;
 import com.mongodb.connection.ClusterSettings;
 import com.mongodb.event.ClusterListener;
@@ -232,6 +234,8 @@ public interface MongoClient extends Closeable {
      * @mongodb.driver.dochub core/changestreams Change Streams
      */
     <TResult> ChangeStreamIterable<TResult> watch(ClientSession clientSession, List<? extends Bson> pipeline, Class<TResult> resultClass);
+
+    BulkWriteResult bulkWrite(ClientWriteModelList requests);
 
     /**
      * Gets the current cluster description.


### PR DESCRIPTION
WRITING-13533

This is a work in progress of a POC for the new bulk write API.  

In this Draft PR I explore an alternative to an API that takes a list of write models.  The restriction I'm attempting to deal with is that in Java the WriteModel class is generic, and its type parameter can be any "POJO" (Plain Old Java Object), or alternatively, a `BsonDocument`.  Given this, what should the type parameter be for the `WriteModel`.  If one is inserting data into multiple collections, each with its own POJO that maps the documents, the only common base class is likely to be <Object>.  That's not generally considered to be proper use of type parameters in Java.

To deal with that I add a `ClientWriteModelList` class, with an associated Builder, that allows use of different type parameters for different WriteModel instances, using Java's support for method-level type parameters.