### PR TITLE
Remove deprecated methods in WriteConcernError class 

### DIFF
--- a/driver-core/src/main/com/mongodb/MongoBulkWriteException.java
+++ b/driver-core/src/main/com/mongodb/MongoBulkWriteException.java
@@ -50,7 +50,6 @@ public class MongoBulkWriteException extends MongoServerException {
      * @param errorLabels              any server errorLabels
      * @since 4.1
      */
-    @SuppressWarnings("deprecation")
     public MongoBulkWriteException(final BulkWriteResult writeResult, final List<BulkWriteError> writeErrors,
                                    @Nullable final WriteConcernError writeConcernError, final ServerAddress serverAddress,
                                    final Set<String> errorLabels) {
@@ -63,10 +62,6 @@ public class MongoBulkWriteException extends MongoServerException {
         this.serverAddress = serverAddress;
 
         addLabels(errorLabels);
-
-        if (writeConcernError != null) {
-            addLabels(writeConcernError.getErrorLabels());
-        }
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/MongoWriteConcernException.java
+++ b/driver-core/src/main/com/mongodb/MongoWriteConcernException.java
@@ -19,6 +19,9 @@ package com.mongodb;
 import com.mongodb.bulk.WriteConcernError;
 import com.mongodb.lang.Nullable;
 
+import java.util.Collection;
+import java.util.Collections;
+
 import static com.mongodb.assertions.Assertions.notNull;
 
 /**
@@ -40,9 +43,11 @@ public class MongoWriteConcernException extends MongoServerException {
      *
      * @param writeConcernError the non-null write concern error
      * @param serverAddress the non-null server address
+     * @deprecated Prefer {@link MongoWriteConcernException(WriteConcernError, WriteConcernResult, ServerAddress, Collection)}
      */
+    @Deprecated
     public MongoWriteConcernException(final WriteConcernError writeConcernError, final ServerAddress serverAddress) {
-        this(writeConcernError, null, serverAddress);
+        this(writeConcernError, null, serverAddress, Collections.emptySet());
     }
 
     /**
@@ -52,24 +57,31 @@ public class MongoWriteConcernException extends MongoServerException {
      * @param writeConcernResult the write result
      * @param serverAddress     the non-null server address
      * @since 3.2
+     * @deprecated Prefer {@link MongoWriteConcernException(WriteConcernError, WriteConcernResult, ServerAddress, Collection)}
      */
-    @SuppressWarnings("deprecation")
+    @Deprecated
     public MongoWriteConcernException(final WriteConcernError writeConcernError, @Nullable final WriteConcernResult writeConcernResult,
                                       final ServerAddress serverAddress) {
+        this(writeConcernError, writeConcernResult, serverAddress, Collections.emptySet());
+    }
+
+    /**
+     * Construct an instance.
+     *
+     * @param writeConcernError the non-null write concern error
+     * @param writeConcernResult the write result
+     * @param serverAddress     the non-null server address
+     * @param errorLabels       the server errorLabels
+     * @since 5.0
+     */
+    public MongoWriteConcernException(final WriteConcernError writeConcernError, @Nullable final WriteConcernResult writeConcernResult,
+            final ServerAddress serverAddress, final Collection<String> errorLabels) {
         super(writeConcernError.getCode(), writeConcernError.getMessage(), serverAddress);
         this.writeConcernResult = writeConcernResult;
         this.writeConcernError = notNull("writeConcernError", writeConcernError);
-        for (final String errorLabel : writeConcernError.getErrorLabels()) {
-            super.addLabel(errorLabel);
-        }
+        addLabels(errorLabels);
     }
 
-    @Override
-    @SuppressWarnings("deprecation")
-    public void addLabel(final String errorLabel) {
-        writeConcernError.addLabel(errorLabel);
-        super.addLabel(errorLabel);
-    }
 
     /**
      * Gets the write concern error.

--- a/driver-core/src/main/com/mongodb/MongoWriteException.java
+++ b/driver-core/src/main/com/mongodb/MongoWriteException.java
@@ -16,6 +16,9 @@
 
 package com.mongodb;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * An exception indicating the failure of a write operation.
  *
@@ -32,10 +35,24 @@ public class MongoWriteException extends MongoServerException {
      * Construct an instance
      * @param error the error
      * @param serverAddress the server address
+     * @deprecated Prefer {@link MongoWriteException(WriteError, ServerAddress, Collection)}
      */
+    @Deprecated
     public MongoWriteException(final WriteError error, final ServerAddress serverAddress) {
+        this(error, serverAddress, Collections.emptySet());
+    }
+
+    /**
+     * Construct an instance
+     * @param error the error
+     * @param serverAddress the server address
+     * @param errorLabels the server errorLabels
+     * @since 5.0
+     */
+    public MongoWriteException(final WriteError error, final ServerAddress serverAddress, final Collection<String> errorLabels) {
         super(error.getCode(), "Write operation error on server " + serverAddress + ". Write error: " + error + ".", serverAddress);
         this.error = error;
+        addLabels(errorLabels);
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/bulk/WriteConcernError.java
+++ b/driver-core/src/main/com/mongodb/bulk/WriteConcernError.java
@@ -16,11 +16,7 @@
 
 package com.mongodb.bulk;
 
-import com.mongodb.lang.NonNull;
 import org.bson.BsonDocument;
-
-import java.util.Collections;
-import java.util.Set;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -35,8 +31,6 @@ public class WriteConcernError {
     private final String codeName;
     private final String message;
     private final BsonDocument details;
-    private final Set<String> errorLabels;
-
 
     /**
      * Constructs a new instance.
@@ -47,28 +41,10 @@ public class WriteConcernError {
      * @param details any details
      */
     public WriteConcernError(final int code, final String codeName, final String message, final BsonDocument details) {
-        this(code, codeName, message, details, Collections.emptySet());
-    }
-
-    /**
-     * Constructs a new instance.
-     *
-     * @param code    the error code
-     * @param codeName the error code name
-     * @param message the error message
-     * @param details any details
-     * @param errorLabels any error labels
-     * @since 4.1
-     * @deprecated Prefer using error labels included in the top level response document
-     */
-    @Deprecated
-    public WriteConcernError(final int code, final String codeName, final String message, final BsonDocument details,
-                             final Set<String> errorLabels) {
         this.code = code;
         this.codeName = notNull("codeName", codeName);
         this.message = notNull("message", message);
         this.details = notNull("details", details);
-        this.errorLabels = notNull("errorLabels", errorLabels);
     }
 
     /**
@@ -109,33 +85,6 @@ public class WriteConcernError {
         return details;
     }
 
-    /**
-     * Adds the given error label to the exception.
-     *
-     * @param errorLabel the non-null error label to add to the exception
-     *
-     * @since 4.1
-     * @deprecated Prefer using error labels included in the top level response document
-     */
-    @Deprecated
-    public void addLabel(final String errorLabel) {
-        notNull("errorLabel", errorLabel);
-        errorLabels.add(errorLabel);
-    }
-
-    /**
-     * Gets the set of error labels associated with this exception.
-     *
-     * @return the error labels, which may not be null but may be empty
-     * @since 4.1
-     * @deprecated Prefer using error labels included in the top level response document
-     */
-    @NonNull
-    @Deprecated
-    public Set<String> getErrorLabels() {
-        return Collections.unmodifiableSet(errorLabels);
-    }
-
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -159,9 +108,6 @@ public class WriteConcernError {
         if (!message.equals(that.message)) {
             return false;
         }
-        if (!errorLabels.equals(that.errorLabels)) {
-            return false;
-        }
 
         return true;
     }
@@ -172,7 +118,6 @@ public class WriteConcernError {
         result = 31 * result + codeName.hashCode();
         result = 31 * result + message.hashCode();
         result = 31 * result + details.hashCode();
-        result = 31 * result + errorLabels.hashCode();
         return result;
     }
 
@@ -183,7 +128,6 @@ public class WriteConcernError {
                + ", codeName='" + codeName + '\''
                + ", message='" + message + '\''
                + ", details=" + details
-               + ", errorLabels=" + errorLabels
                + '}';
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/BulkWriteBatchCombiner.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BulkWriteBatchCombiner.java
@@ -179,10 +179,8 @@ public class BulkWriteBatchCombiner {
         if (writeConcernError != null) {
             if (writeConcernErrors.isEmpty()) {
                 writeConcernErrors.add(writeConcernError);
-                errorLabels.addAll(writeConcernError.getErrorLabels());
             } else if (!writeConcernError.equals(writeConcernErrors.get(writeConcernErrors.size() - 1))) {
                 writeConcernErrors.add(writeConcernError);
-                errorLabels.addAll(writeConcernError.getErrorLabels());
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/WriteConcernHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/WriteConcernHelper.java
@@ -58,22 +58,18 @@ public final class WriteConcernHelper {
     }
 
     public static MongoWriteConcernException createWriteConcernException(final BsonDocument result, final ServerAddress serverAddress) {
-        MongoWriteConcernException writeConcernException = new MongoWriteConcernException(
+        return new MongoWriteConcernException(
                 createWriteConcernError(result.getDocument("writeConcernError")),
-                WriteConcernResult.acknowledged(0, false, null), serverAddress);
-        result.getArray("errorLabels", new BsonArray()).stream().map(i -> i.asString().getValue())
-                .forEach(writeConcernException::addLabel);
-        return writeConcernException;
+                WriteConcernResult.acknowledged(0, false, null), serverAddress,
+                result.getArray("errorLabels", new BsonArray()).stream().map(i -> i.asString().getValue())
+                        .collect(Collectors.toSet()));
     }
 
-    @SuppressWarnings("deprecation")
     public static WriteConcernError createWriteConcernError(final BsonDocument writeConcernErrorDocument) {
         return new WriteConcernError(writeConcernErrorDocument.getNumber("code").intValue(),
                 writeConcernErrorDocument.getString("codeName", new BsonString("")).getValue(),
                 writeConcernErrorDocument.getString("errmsg").getValue(),
-                writeConcernErrorDocument.getDocument("errInfo", new BsonDocument()),
-                writeConcernErrorDocument.getArray("errorLabels", new BsonArray()).stream().map(i -> i.asString().getValue())
-                        .collect(Collectors.toSet()));
+                writeConcernErrorDocument.getDocument("errInfo", new BsonDocument()));
     }
 
     private WriteConcernHelper() {

--- a/driver-core/src/test/unit/com/mongodb/MongoWriteExceptionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/MongoWriteExceptionTest.java
@@ -21,6 +21,8 @@ import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MongoWriteExceptionTest {
@@ -28,7 +30,7 @@ public class MongoWriteExceptionTest {
     @Test
     public void testExceptionProperties() {
         WriteError writeError = new WriteError(11000, "Duplicate key", new BsonDocument("x", new BsonInt32(1)));
-        MongoWriteException e = new MongoWriteException(writeError, new ServerAddress("host1"));
+        MongoWriteException e = new MongoWriteException(writeError, new ServerAddress("host1"), Collections.emptySet());
 
         assertEquals("Write operation error on server host1:27017. Write error: WriteError{code=11000, message='Duplicate key', "
                 + "details={\"x\": 1}}.",

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
@@ -468,17 +468,16 @@ public final class MongoOperationPublisher<T> {
                                                   e.getWriteResult().getUpserts().isEmpty()
                                                           ? null : e.getWriteResult().getUpserts().get(0).getId());
                         }
-                        exception = new MongoWriteConcernException(writeConcernError, writeConcernResult, e.getServerAddress());
+                        exception = new MongoWriteConcernException(writeConcernError, writeConcernResult, e.getServerAddress(),
+                                e.getErrorLabels());
                     } else if (!e.getWriteErrors().isEmpty()) {
-                        exception = new MongoWriteException(new WriteError(e.getWriteErrors().get(0)), e.getServerAddress());
+                        exception = new MongoWriteException(new WriteError(e.getWriteErrors().get(0)), e.getServerAddress(),
+                                e.getErrorLabels());
                     } else {
                         exception = new MongoWriteException(new WriteError(-1, "Unknown write error", new BsonDocument()),
-                                                            e.getServerAddress());
+                                                            e.getServerAddress(), e.getErrorLabels());
                     }
 
-                    for (final String errorLabel : e.getErrorLabels()) {
-                        exception.addLabel(errorLabel);
-                    }
                     return exception;
                 });
     }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
@@ -18,7 +18,6 @@ package com.mongodb.client.internal;
 
 import com.mongodb.AutoEncryptionSettings;
 import com.mongodb.MongoBulkWriteException;
-import com.mongodb.MongoException;
 import com.mongodb.MongoInternalException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.MongoWriteConcernException;
@@ -49,11 +48,11 @@ import com.mongodb.client.model.FindOneAndReplaceOptions;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
 import com.mongodb.client.model.IndexModel;
 import com.mongodb.client.model.IndexOptions;
-import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.InsertManyOptions;
 import com.mongodb.client.model.InsertOneOptions;
 import com.mongodb.client.model.RenameCollectionOptions;
 import com.mongodb.client.model.ReplaceOptions;
+import com.mongodb.client.model.SearchIndexModel;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.DeleteResult;
@@ -1084,18 +1083,14 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
         try {
             return executor.execute(writeOperation, readConcern, clientSession);
         } catch (MongoBulkWriteException e) {
-            MongoException exception;
             if (e.getWriteErrors().isEmpty()) {
-                exception = new MongoWriteConcernException(e.getWriteConcernError(),
+                throw new MongoWriteConcernException(e.getWriteConcernError(),
                         translateBulkWriteResult(type, e.getWriteResult()),
-                        e.getServerAddress());
+                        e.getServerAddress(), e.getErrorLabels());
             } else {
-                exception = new MongoWriteException(new WriteError(e.getWriteErrors().get(0)), e.getServerAddress());
+                throw new MongoWriteException(new WriteError(e.getWriteErrors().get(0)), e.getServerAddress(), e.getErrorLabels());
             }
-            for (final String errorLabel : e.getErrorLabels()) {
-                exception.addLabel(errorLabel);
-            }
-            throw exception;
+
         }
     }
 

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableWritesTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableWritesTest.java
@@ -71,7 +71,10 @@ public abstract class AbstractRetryableWritesTest {
     private JsonPoweredCrudTestHelper helper;
 
     public AbstractRetryableWritesTest(final String filename, final String description, final String databaseName, final BsonArray data,
-                                       final BsonDocument definition, final boolean skipTest) {
+            final BsonDocument definition, final boolean skipTest) {
+        assumeFalse("MongoDB releases prior to 4.4 incorrectly add errorLabels as a field within the writeConcernError document "
+                        + "instead of as a top-level field.  Rather than handle that in code, we skip the test on older server versions.",
+                description.equals("InsertOne fails after multiple retryable writeConcernErrors") && serverVersionLessThan(4, 4));
         this.filename = filename;
         this.description = description;
         this.databaseName = databaseName;
@@ -166,7 +169,7 @@ public abstract class AbstractRetryableWritesTest {
                 MongoException mongoException = (MongoException) e;
                 for (String curErrorLabel : getErrorLabelsContainField(expectedResult)) {
                     assertTrue(String.format("Expected error label '%s but found labels '%s' for operation %s",
-                            curErrorLabel, mongoException.getErrorLabels(), operationName),
+                                    curErrorLabel, mongoException.getErrorLabels(), operationName),
                             mongoException.hasErrorLabel(curErrorLabel));
                 }
             }
@@ -176,7 +179,7 @@ public abstract class AbstractRetryableWritesTest {
                 MongoException mongoException = (MongoException) e;
                 for (String curErrorLabel : getErrorLabelsOmitField(expectedResult)) {
                     assertFalse(String.format("Expected error label '%s omitted but found labels '%s' for operation %s",
-                            curErrorLabel, mongoException.getErrorLabels(), operationName),
+                                    curErrorLabel, mongoException.getErrorLabels(), operationName),
                             mongoException.hasErrorLabel(curErrorLabel));
                 }
             }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestValidator.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestValidator.java
@@ -26,12 +26,18 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
+import static com.mongodb.ClusterFixture.serverVersionLessThan;
+import static org.junit.Assume.assumeFalse;
+
 public class UnifiedTestValidator extends UnifiedSyncTest {
     public UnifiedTestValidator(@SuppressWarnings("unused") final String fileDescription,
                                 @SuppressWarnings("unused") final String testDescription,
                                 final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
                                 final BsonArray initialData, final BsonDocument definition) {
         super(schemaVersion, runOnRequirements, entities, initialData, definition);
+        assumeFalse("MongoDB releases prior to 4.4 incorrectly add errorLabels as a field within the writeConcernError document "
+                        + "instead of as a top-level field.  Rather than handle that in code, we skip the test on older server versions.",
+                testDescription.equals("InsertOne fails after multiple retryable writeConcernErrors") && serverVersionLessThan(4, 4));
     }
 
     @Before


### PR DESCRIPTION
JAVA-5153

This has already been reviewed in https://github.com/mongodb/mongo-java-driver/pull/1257 and https://github.com/mongodb/mongo-java-driver/pull/1269.  This PR is just to merge it into master.