### PR TITLE
Don't gossip cluster time from monitoring connections

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
@@ -82,7 +82,7 @@ public class DefaultClusterableServerFactory implements ClusterableServerFactory
         ServerId serverId = new ServerId(cluster.getClusterId(), serverAddress);
         ClusterConnectionMode clusterMode = cluster.getSettings().getMode();
         SameObjectProvider<SdamServerDescriptionManager> sdamProvider = SameObjectProvider.uninitialized();
-        ServerMonitor serverMonitor = new DefaultServerMonitor(serverId, serverSettings, cluster.getClock(),
+        ServerMonitor serverMonitor = new DefaultServerMonitor(serverId, serverSettings,
                 // no credentials, compressor list, or command listener for the server monitor factory
                 new InternalStreamConnectionFactory(clusterMode, true, heartbeatStreamFactory, null, applicationName,
                         mongoDriverInformation, emptyList(), loggerSettings, null, serverApi),

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
@@ -71,7 +71,6 @@ class DefaultServerMonitor implements ServerMonitor {
 
     private final ServerId serverId;
     private final ServerMonitorListener serverMonitorListener;
-    private final ClusterClock clusterClock;
     private final Provider<SdamServerDescriptionManager> sdamProvider;
     private final InternalConnectionFactory internalConnectionFactory;
     private final ClusterConnectionMode clusterConnectionMode;
@@ -88,15 +87,13 @@ class DefaultServerMonitor implements ServerMonitor {
     private volatile boolean isClosed;
 
     DefaultServerMonitor(final ServerId serverId, final ServerSettings serverSettings,
-                         final ClusterClock clusterClock,
-                         final InternalConnectionFactory internalConnectionFactory,
+            final InternalConnectionFactory internalConnectionFactory,
                          final ClusterConnectionMode clusterConnectionMode,
                          @Nullable final ServerApi serverApi,
                          final Provider<SdamServerDescriptionManager> sdamProvider) {
         this.serverSettings = notNull("serverSettings", serverSettings);
         this.serverId = notNull("serverId", serverId);
         this.serverMonitorListener = singleServerMonitorListener(serverSettings);
-        this.clusterClock = notNull("clusterClock", clusterClock);
         this.internalConnectionFactory = notNull("internalConnectionFactory", internalConnectionFactory);
         this.clusterConnectionMode = notNull("clusterConnectionMode", clusterConnectionMode);
         this.serverApi = serverApi;
@@ -206,7 +203,7 @@ class DefaultServerMonitor implements ServerMonitor {
 
                 long start = System.nanoTime();
                 try {
-                    SessionContext sessionContext = new ClusterClockAdvancingSessionContext(NoOpSessionContext.INSTANCE, clusterClock);
+                    SessionContext sessionContext = NoOpSessionContext.INSTANCE;
                     if (!connection.hasMoreToCome()) {
                         BsonDocument helloDocument = new BsonDocument(getHandshakeCommandName(currentServerDescription), new BsonInt32(1))
                                 .append("helloOk", BsonBoolean.TRUE);
@@ -432,7 +429,7 @@ class DefaultServerMonitor implements ServerMonitor {
             long start = System.nanoTime();
             executeCommand("admin",
                     new BsonDocument(getHandshakeCommandName(connection.getInitialServerDescription()), new BsonInt32(1)),
-                    clusterClock, clusterConnectionMode, serverApi, connection);
+                    clusterConnectionMode, serverApi, connection);
             long elapsedTimeNanos = System.nanoTime() - start;
             averageRoundTripTime.addSample(elapsedTimeNanos);
         }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/CommandHelperSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/CommandHelperSpecification.groovy
@@ -18,18 +18,13 @@ package com.mongodb.internal.connection
 
 import com.mongodb.LoggerSettings
 import com.mongodb.MongoCommandException
-import com.mongodb.ServerAddress
 import com.mongodb.connection.ClusterConnectionMode
 import com.mongodb.connection.ClusterId
-import com.mongodb.connection.ConnectionDescription
-import com.mongodb.connection.ConnectionId
 import com.mongodb.connection.ServerId
-import com.mongodb.connection.ServerType
 import com.mongodb.connection.SocketSettings
 import com.mongodb.internal.connection.netty.NettyStreamFactory
 import org.bson.BsonDocument
 import org.bson.BsonInt32
-import org.bson.BsonTimestamp
 import spock.lang.Specification
 
 import java.util.concurrent.CountDownLatch
@@ -40,7 +35,6 @@ import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getServerApi
 import static com.mongodb.ClusterFixture.getSslSettings
-import static com.mongodb.internal.connection.CommandHelper.executeCommand
 import static com.mongodb.internal.connection.CommandHelper.executeCommandAsync
 
 class CommandHelperSpecification extends Specification {
@@ -57,24 +51,6 @@ class CommandHelperSpecification extends Specification {
     def cleanup() {
         connection?.close()
     }
-
-    def 'should gossip cluster time'() {
-        given:
-        def connection = Mock(InternalStreamConnection) {
-            getDescription() >> new ConnectionDescription(new ConnectionId(new ServerId(new ClusterId(), new ServerAddress())),
-                    6, ServerType.REPLICA_SET_PRIMARY, 1000, 1000, 1000, [])
-        }
-        def clusterClock = new ClusterClock()
-        clusterClock.advance(new BsonDocument('clusterTime', new BsonTimestamp(42L)))
-
-        when:
-        executeCommand('admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)), clusterClock, getClusterConnectionMode(),
-                getServerApi(), connection)
-
-        then:
-        1 * connection.sendAndReceive(_, _, _ as ClusterClockAdvancingSessionContext, _, _) >> new BsonDocument()
-    }
-
 
     def 'should execute command asynchronously'() {
         when:

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/ServerMonitorSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/ServerMonitorSpecification.groovy
@@ -220,7 +220,6 @@ class ServerMonitorSpecification extends OperationFunctionalSpecification {
             }
         }
         serverMonitor = new DefaultServerMonitor(new ServerId(new ClusterId(), address), ServerSettings.builder().build(),
-                new ClusterClock(),
                 new InternalStreamConnectionFactory(SINGLE, new SocketStreamFactory(new DefaultInetAddressResolver(),
                         SocketSettings.builder().connectTimeout(500, TimeUnit.MILLISECONDS).build(), getSslSettings()),
                         getCredentialWithCache(), null, null, [], LoggerSettings.builder().build(), null,

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerMonitorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerMonitorSpecification.groovy
@@ -84,7 +84,7 @@ class DefaultServerMonitorSpecification extends Specification {
             }
         }
         monitor = new DefaultServerMonitor(new ServerId(new ClusterId(), new ServerAddress()), ServerSettings.builder().build(),
-                new ClusterClock(), internalConnectionFactory, ClusterConnectionMode.SINGLE, null, SameObjectProvider.initialized(sdam))
+                internalConnectionFactory, ClusterConnectionMode.SINGLE, null, SameObjectProvider.initialized(sdam))
         monitor.start()
 
         when:
@@ -167,7 +167,7 @@ class DefaultServerMonitorSpecification extends Specification {
         }
         monitor = new DefaultServerMonitor(new ServerId(new ClusterId(), new ServerAddress()),
                 ServerSettings.builder().heartbeatFrequency(1, TimeUnit.SECONDS).addServerMonitorListener(serverMonitorListener).build(),
-                new ClusterClock(), internalConnectionFactory, ClusterConnectionMode.SINGLE, null, mockSdamProvider())
+                internalConnectionFactory, ClusterConnectionMode.SINGLE, null, mockSdamProvider())
 
         when:
         monitor.start()
@@ -246,7 +246,7 @@ class DefaultServerMonitorSpecification extends Specification {
         }
         monitor = new DefaultServerMonitor(new ServerId(new ClusterId(), new ServerAddress()),
                 ServerSettings.builder().heartbeatFrequency(1, TimeUnit.SECONDS).addServerMonitorListener(serverMonitorListener).build(),
-                new ClusterClock(), internalConnectionFactory, ClusterConnectionMode.SINGLE, null, mockSdamProvider())
+                internalConnectionFactory, ClusterConnectionMode.SINGLE, null, mockSdamProvider())
 
         when:
         monitor.start()


### PR DESCRIPTION
JAVA-5256

The driver is compliant with https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst#gossipping-the-cluster-time, but in the case reported, the driver connects to a member of a different replica set and by the time it realizes that the server should be discarded it's too late.  We can address this by not gossiping cluster time from monitoring connections.