### PR TITLE
CSOT - Command Execution

### DIFF
--- a/driver-core/src/main/com/mongodb/MongoSocketWriteTimeoutException.java
+++ b/driver-core/src/main/com/mongodb/MongoSocketWriteTimeoutException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+/**
+ * This exception is thrown when there is a timeout writing a response from the socket.
+ *
+ * @since 4.x
+ */
+public class MongoSocketWriteTimeoutException extends MongoSocketException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Construct a new instance
+     *
+     * @param message the message
+     * @param address the address
+     * @param cause the cause
+     */
+    public MongoSocketWriteTimeoutException(final String message, final ServerAddress address, final Throwable cause) {
+        super(message, address, cause);
+    }
+
+}

--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -16,7 +16,6 @@
 package com.mongodb.internal;
 
 import com.mongodb.MongoExecutionTimeoutException;
-import com.mongodb.MongoTimeoutException;
 import com.mongodb.internal.time.StartTime;
 import com.mongodb.internal.time.Timeout;
 import com.mongodb.lang.Nullable;

--- a/driver-core/src/main/com/mongodb/internal/binding/AsyncClusterBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/AsyncClusterBinding.java
@@ -33,6 +33,7 @@ import com.mongodb.internal.selector.WritableServerSelector;
 import com.mongodb.selector.ServerSelector;
 
 import static com.mongodb.assertions.Assertions.notNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * A simple ReadWriteBinding implementation that supplies write connection sources bound to a possibly different primary each time, and a
@@ -136,6 +137,7 @@ public class AsyncClusterBinding extends AbstractReferenceCounted implements Asy
             this.server = server;
             this.serverDescription = serverDescription;
             this.appliedReadPreference = appliedReadPreference;
+            operationContext.getTimeoutContext().minRoundTripTimeMS(NANOSECONDS.toMillis(serverDescription.getMinRoundTripTimeNanos()));
             AsyncClusterBinding.this.retain();
         }
 

--- a/driver-core/src/main/com/mongodb/internal/binding/ClusterBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/ClusterBinding.java
@@ -32,6 +32,7 @@ import com.mongodb.internal.selector.ServerAddressSelector;
 import com.mongodb.internal.selector.WritableServerSelector;
 
 import static com.mongodb.assertions.Assertions.notNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * A simple ReadWriteBinding implementation that supplies write connection sources bound to a possibly different primary each time, and a
@@ -113,6 +114,7 @@ public class ClusterBinding extends AbstractReferenceCounted implements ClusterA
             this.server = serverTuple.getServer();
             this.serverDescription = serverTuple.getServerDescription();
             this.appliedReadPreference = appliedReadPreference;
+            operationContext.getTimeoutContext().minRoundTripTimeMS(NANOSECONDS.toMillis(serverDescription.getMinRoundTripTimeNanos()));
             ClusterBinding.this.retain();
         }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/AsynchronousChannelStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsynchronousChannelStream.java
@@ -86,7 +86,8 @@ public abstract class AsynchronousChannelStream implements Stream {
     }
 
     @Override
-    public void writeAsync(final List<ByteBuf> buffers, final AsyncCompletionHandler<Void> handler) {
+    public void writeAsync(final List<ByteBuf> buffers, final OperationContext operationContext,
+            final AsyncCompletionHandler<Void> handler) {
         AsyncWritableByteChannelAdapter byteChannel = new AsyncWritableByteChannelAdapter();
         Iterator<ByteBuf> iter = buffers.iterator();
         pipeOneBuffer(byteChannel, iter.next(), new AsyncCompletionHandler<Void>() {
@@ -107,11 +108,12 @@ public abstract class AsynchronousChannelStream implements Stream {
     }
 
     @Override
-    public void readAsync(final int numBytes, final AsyncCompletionHandler<ByteBuf> handler) {
-        readAsync(numBytes, 0, handler);
+    public void readAsync(final int numBytes, final OperationContext operationContext, final AsyncCompletionHandler<ByteBuf> handler) {
+        readAsync(numBytes, 0, operationContext, handler);
     }
 
-    private void readAsync(final int numBytes, final int additionalTimeout, final AsyncCompletionHandler<ByteBuf> handler) {
+    private void readAsync(final int numBytes, final int additionalTimeout, final OperationContext operationContext,
+            final AsyncCompletionHandler<ByteBuf> handler) {
         ByteBuf buffer = bufferProvider.getBuffer(numBytes);
 
         int timeout = settings.getReadTimeout(MILLISECONDS);
@@ -130,23 +132,23 @@ public abstract class AsynchronousChannelStream implements Stream {
     }
 
     @Override
-    public void write(final List<ByteBuf> buffers) throws IOException {
+    public void write(final List<ByteBuf> buffers, final OperationContext operationContext) throws IOException {
         FutureAsyncCompletionHandler<Void> handler = new FutureAsyncCompletionHandler<>();
-        writeAsync(buffers, handler);
+        writeAsync(buffers, operationContext, handler);
         handler.getWrite();
     }
 
     @Override
-    public ByteBuf read(final int numBytes) throws IOException {
+    public ByteBuf read(final int numBytes, final OperationContext operationContext) throws IOException {
         FutureAsyncCompletionHandler<ByteBuf> handler = new FutureAsyncCompletionHandler<>();
-        readAsync(numBytes, handler);
+        readAsync(numBytes, operationContext, handler);
         return handler.getRead();
     }
 
     @Override
-    public ByteBuf read(final int numBytes, final int additionalTimeout) throws IOException {
+    public ByteBuf read(final int numBytes, final int additionalTimeout, final OperationContext operationContext) throws IOException {
         FutureAsyncCompletionHandler<ByteBuf> handler = new FutureAsyncCompletionHandler<>();
-        readAsync(numBytes, additionalTimeout, handler);
+        readAsync(numBytes, additionalTimeout, operationContext, handler);
         return handler.getRead();
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -723,9 +723,9 @@ final class DefaultConnectionPool implements ConnectionPool {
         }
 
         @Override
-        public void sendMessage(final List<ByteBuf> byteBuffers, final int lastRequestId) {
+        public void sendMessage(final List<ByteBuf> byteBuffers, final int lastRequestId, final OperationContext operationContext) {
             isTrue("open", !isClosed.get());
-            wrapped.sendMessage(byteBuffers, lastRequestId);
+            wrapped.sendMessage(byteBuffers, lastRequestId, operationContext);
         }
 
         @Override
@@ -772,21 +772,23 @@ final class DefaultConnectionPool implements ConnectionPool {
         }
 
         @Override
-        public ResponseBuffers receiveMessage(final int responseTo) {
+        public ResponseBuffers receiveMessage(final int responseTo, final OperationContext operationContext) {
             isTrue("open", !isClosed.get());
-            return wrapped.receiveMessage(responseTo);
+            return wrapped.receiveMessage(responseTo, operationContext);
         }
 
         @Override
-        public void sendMessageAsync(final List<ByteBuf> byteBuffers, final int lastRequestId, final SingleResultCallback<Void> callback) {
+        public void sendMessageAsync(final List<ByteBuf> byteBuffers, final int lastRequestId, final OperationContext operationContext,
+                final SingleResultCallback<Void> callback) {
             isTrue("open", !isClosed.get());
-            wrapped.sendMessageAsync(byteBuffers, lastRequestId, (result, t) -> callback.onResult(null, t));
+            wrapped.sendMessageAsync(byteBuffers, lastRequestId, operationContext, (result, t) -> callback.onResult(null, t));
         }
 
         @Override
-        public void receiveMessageAsync(final int responseTo, final SingleResultCallback<ResponseBuffers> callback) {
+        public void receiveMessageAsync(final int responseTo, final OperationContext operationContext,
+                final SingleResultCallback<ResponseBuffers> callback) {
             isTrue("open", !isClosed.get());
-            wrapped.receiveMessageAsync(responseTo, callback);
+            wrapped.receiveMessageAsync(responseTo, operationContext, callback);
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
@@ -224,6 +224,7 @@ class DefaultServerMonitor implements ServerMonitor {
 
                     BsonDocument helloResult;
                     if (shouldStreamResponses(currentServerDescription)) {
+                        // TODO (CSOT) - JAVA-4063 remove additionalTimeout - just use operationContext
                         helloResult = connection.receive(new BsonDocumentCodec(), operationContext,
                                 Math.toIntExact(serverSettings.getHeartbeatFrequency(MILLISECONDS)));
                     } else {

--- a/driver-core/src/main/com/mongodb/internal/connection/ExtendedAsynchronousByteChannel.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ExtendedAsynchronousByteChannel.java
@@ -171,7 +171,7 @@ public interface ExtendedAsynchronousByteChannel extends AsynchronousByteChannel
     <A> void write(
             ByteBuffer src,
             long timeout, TimeUnit unit,
-            A attach, CompletionHandler<Integer, ? super A> handler);
+            @Nullable A attach, CompletionHandler<Integer, ? super A> handler);
 
     /**
      * Writes a sequence of bytes to this channel from a subsequence of the given
@@ -233,5 +233,5 @@ public interface ExtendedAsynchronousByteChannel extends AsynchronousByteChannel
     <A> void write(
             ByteBuffer[] srcs, int offset, int length,
             long timeout, TimeUnit unit,
-            A attach, CompletionHandler<Long, ? super A> handler);
+            @Nullable A attach, CompletionHandler<Long, ? super A> handler);
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalConnection.java
@@ -48,13 +48,15 @@ public interface InternalConnection extends BufferProvider {
 
     /**
      * Opens the connection so its ready for use
+     *
+     * @param operationContext the operation context
      */
     void open(OperationContext operationContext);
 
     /**
      * Opens the connection so its ready for use
      *
-     * @param operationContext
+     * @param operationContext the operation context
      * @param callback         the callback to be called once the connection has been opened
      */
     void openAsync(OperationContext operationContext, SingleResultCallback<Void> callback);
@@ -121,33 +123,38 @@ public interface InternalConnection extends BufferProvider {
      *
      * @param byteBuffers   the list of byte buffers to send.
      * @param lastRequestId the request id of the last message in byteBuffers
+     * @param operationContext the operation context
      */
-    void sendMessage(List<ByteBuf> byteBuffers, int lastRequestId);
+    void sendMessage(List<ByteBuf> byteBuffers, int lastRequestId, OperationContext operationContext);
 
     /**
      * Receive a response to a sent message from the server.
      *
      * @param responseTo the request id that this message is a response to
+     * @param operationContext the operation context
      * @return the response
      */
-    ResponseBuffers receiveMessage(int responseTo);
+    ResponseBuffers receiveMessage(int responseTo, OperationContext operationContext);
 
     /**
      * Asynchronously send a message to the server. The connection may not make any attempt to validate the integrity of the message.
      *
      * @param byteBuffers   the list of byte buffers to send
      * @param lastRequestId the request id of the last message in byteBuffers
+     * @param operationContext the operation context
      * @param callback      the callback to invoke on completion
      */
-    void sendMessageAsync(List<ByteBuf> byteBuffers, int lastRequestId, SingleResultCallback<Void> callback);
+    void sendMessageAsync(List<ByteBuf> byteBuffers, int lastRequestId, OperationContext operationContext,
+            SingleResultCallback<Void> callback);
 
     /**
      * Asynchronously receive a response to a sent message from the server.
      *
      * @param responseTo the request id that this message is a response to
+     * @param operationContext the operation context
      * @param callback the callback to invoke on completion
      */
-    void receiveMessageAsync(int responseTo, SingleResultCallback<ResponseBuffers> callback);
+    void receiveMessageAsync(int responseTo, OperationContext operationContext, SingleResultCallback<ResponseBuffers> callback);
 
     default void markAsPinned(Connection.PinningMode pinningMode) {
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
@@ -159,14 +159,14 @@ public class SocketStream implements Stream {
     }
 
     @Override
-    public void write(final List<ByteBuf> buffers) throws IOException {
+    public void write(final List<ByteBuf> buffers, final OperationContext operationContext) throws IOException {
         for (final ByteBuf cur : buffers) {
             outputStream.write(cur.array(), 0, cur.limit());
         }
     }
 
     @Override
-    public ByteBuf read(final int numBytes) throws IOException {
+    public ByteBuf read(final int numBytes, final OperationContext operationContext) throws IOException {
         ByteBuf buffer = bufferProvider.getBuffer(numBytes);
         try {
             int totalBytesRead = 0;
@@ -186,13 +186,13 @@ public class SocketStream implements Stream {
     }
 
     @Override
-    public ByteBuf read(final int numBytes, final int additionalTimeout) throws IOException {
+    public ByteBuf read(final int numBytes, final int additionalTimeout, final OperationContext operationContext) throws IOException {
         int curTimeout = socket.getSoTimeout();
         if (curTimeout > 0 && additionalTimeout > 0) {
             socket.setSoTimeout(curTimeout + additionalTimeout);
         }
         try {
-            return read(numBytes);
+            return read(numBytes, operationContext);
         } finally {
             if (!socket.isClosed()) {
                 // `socket` may be closed if the current thread is virtual, and it is interrupted while reading
@@ -207,12 +207,14 @@ public class SocketStream implements Stream {
     }
 
     @Override
-    public void writeAsync(final List<ByteBuf> buffers, final AsyncCompletionHandler<Void> handler) {
+    public void writeAsync(final List<ByteBuf> buffers, final OperationContext operationContext,
+            final AsyncCompletionHandler<Void> handler) {
         throw new UnsupportedOperationException(getClass() + " does not support asynchronous operations.");
     }
 
     @Override
-    public void readAsync(final int numBytes, final AsyncCompletionHandler<ByteBuf> handler) {
+    public void readAsync(final int numBytes, final OperationContext operationContext,
+            final AsyncCompletionHandler<ByteBuf> handler) {
         throw new UnsupportedOperationException(getClass() + " does not support asynchronous operations.");
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/Stream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/Stream.java
@@ -49,18 +49,20 @@ public interface Stream extends BufferProvider {
      *
      * @param buffers the buffers to write. The operation must not {@linkplain ByteBuf#release() release} any buffer from {@code buffers},
      * unless the operation {@linkplain ByteBuf#retain() retains} it, and releasing is meant to compensate for that.
+     * @param operationContext the operation context
      * @throws IOException if there are problems writing to the stream
      */
-    void write(List<ByteBuf> buffers) throws IOException;
+    void write(List<ByteBuf> buffers, OperationContext operationContext) throws IOException;
 
     /**
      * Read from the stream, blocking until the requested number of bytes have been read.
      *
      * @param numBytes The number of bytes to read into the returned byte buffer
+     * @param operationContext the operation context
      * @return a byte buffer filled with number of bytes requested
      * @throws IOException if there are problems reading from the stream
      */
-    ByteBuf read(int numBytes) throws IOException;
+    ByteBuf read(int numBytes, OperationContext operationContext) throws IOException;
 
     /**
      * Read from the stream, blocking until the requested number of bytes have been read.  If supported by the implementation,
@@ -68,10 +70,11 @@ public interface Stream extends BufferProvider {
      *
      * @param numBytes The number of bytes to read into the returned byte buffer
      * @param additionalTimeout additional timeout in milliseconds to add to the configured timeout
+     * @param operationContext the operation context
      * @return a byte buffer filled with number of bytes requested
      * @throws IOException if there are problems reading from the stream
      */
-    ByteBuf read(int numBytes, int additionalTimeout) throws IOException;
+    ByteBuf read(int numBytes, int additionalTimeout, OperationContext operationContext) throws IOException;
 
     /**
      * Write each buffer in the list to the stream in order, asynchronously.  This method should return immediately, and invoke the given
@@ -79,18 +82,20 @@ public interface Stream extends BufferProvider {
      *
      * @param buffers the buffers to write. The operation must not {@linkplain ByteBuf#release() release} any buffer from {@code buffers},
      * unless the operation {@linkplain ByteBuf#retain() retains} it, and releasing is meant to compensate for that.
+     * @param operationContext the operation context
      * @param handler invoked when the write operation has completed
      */
-    void writeAsync(List<ByteBuf> buffers, AsyncCompletionHandler<Void> handler);
+    void writeAsync(List<ByteBuf> buffers, OperationContext operationContext, AsyncCompletionHandler<Void> handler);
 
     /**
      * Read from the stream, asynchronously.  This method should return immediately, and invoke the given callback when the number of
      * requested bytes have been read.
      *
      * @param numBytes the number of bytes
+     * @param operationContext the operation context
      * @param handler invoked when the read operation has completed
      */
-    void readAsync(int numBytes, AsyncCompletionHandler<ByteBuf> handler);
+    void readAsync(int numBytes, OperationContext operationContext, AsyncCompletionHandler<ByteBuf> handler);
 
     /**
      * The address that this stream is connected to.

--- a/driver-core/src/main/com/mongodb/internal/connection/UsageTrackingInternalConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/UsageTrackingInternalConnection.java
@@ -101,8 +101,8 @@ class UsageTrackingInternalConnection implements InternalConnection {
     }
 
     @Override
-    public void sendMessage(final List<ByteBuf> byteBuffers, final int lastRequestId) {
-        wrapped.sendMessage(byteBuffers, lastRequestId);
+    public void sendMessage(final List<ByteBuf> byteBuffers, final int lastRequestId, final OperationContext operationContext) {
+        wrapped.sendMessage(byteBuffers, lastRequestId, operationContext);
         lastUsedAt = System.currentTimeMillis();
     }
 
@@ -149,28 +149,30 @@ class UsageTrackingInternalConnection implements InternalConnection {
     }
 
     @Override
-    public ResponseBuffers receiveMessage(final int responseTo) {
-        ResponseBuffers responseBuffers = wrapped.receiveMessage(responseTo);
+    public ResponseBuffers receiveMessage(final int responseTo, final OperationContext operationContext) {
+        ResponseBuffers responseBuffers = wrapped.receiveMessage(responseTo, operationContext);
         lastUsedAt = System.currentTimeMillis();
         return responseBuffers;
     }
 
     @Override
-    public void sendMessageAsync(final List<ByteBuf> byteBuffers, final int lastRequestId, final SingleResultCallback<Void> callback) {
+    public void sendMessageAsync(final List<ByteBuf> byteBuffers, final int lastRequestId, final OperationContext operationContext,
+            final SingleResultCallback<Void> callback) {
         SingleResultCallback<Void> errHandlingCallback = errorHandlingCallback((result, t) -> {
             lastUsedAt = System.currentTimeMillis();
             callback.onResult(result, t);
         }, LOGGER);
-        wrapped.sendMessageAsync(byteBuffers, lastRequestId, errHandlingCallback);
+        wrapped.sendMessageAsync(byteBuffers, lastRequestId, operationContext, errHandlingCallback);
     }
 
     @Override
-    public void receiveMessageAsync(final int responseTo, final SingleResultCallback<ResponseBuffers> callback) {
+    public void receiveMessageAsync(final int responseTo, final OperationContext operationContext,
+            final SingleResultCallback<ResponseBuffers> callback) {
         SingleResultCallback<ResponseBuffers> errHandlingCallback = errorHandlingCallback((result, t) -> {
             lastUsedAt = System.currentTimeMillis();
             callback.onResult(result, t);
         }, LOGGER);
-        wrapped.receiveMessageAsync(responseTo, errHandlingCallback);
+        wrapped.receiveMessageAsync(responseTo, operationContext, errHandlingCallback);
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandBatchCursor.java
@@ -314,7 +314,8 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
         private void killServerCursor(final MongoNamespace namespace, final ServerCursor localServerCursor,
                 final AsyncConnection localConnection, final SingleResultCallback<Void> callback) {
             OperationContext operationContext = assertNotNull(getConnectionSource()).getOperationContext();
-            localConnection.commandAsync(namespace.getDatabaseName(), getKillCursorsCommand(namespace, localServerCursor),
+            localConnection.commandAsync(namespace.getDatabaseName(), getKillCursorsCommand(namespace, localServerCursor,
+                            operationContext.getTimeoutContext().getMaxTimeMS()),
                     NO_OP_FIELD_NAME_VALIDATOR, ReadPreference.primary(), new BsonDocumentCodec(),
                     operationContext, (r, t) -> callback.onResult(null, null));
         }

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursor.java
@@ -354,7 +354,8 @@ class CommandBatchCursor<T> implements AggregateResponseBatchCursor<T> {
         private void killServerCursor(final MongoNamespace namespace, final ServerCursor localServerCursor,
                 final Connection localConnection) {
             OperationContext operationContext = assertNotNull(getConnectionSource()).getOperationContext();
-            localConnection.command(namespace.getDatabaseName(), getKillCursorsCommand(namespace, localServerCursor),
+            localConnection.command(namespace.getDatabaseName(), getKillCursorsCommand(namespace, localServerCursor,
+                            operationContext.getTimeoutContext().getMaxTimeMS()),
                     NO_OP_FIELD_NAME_VALIDATOR, ReadPreference.primary(), new BsonDocumentCodec(), operationContext);
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursorHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursorHelper.java
@@ -33,6 +33,7 @@ import org.bson.BsonValue;
 import org.bson.FieldNameValidator;
 
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
+import static com.mongodb.internal.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionFourDotFour;
 import static java.lang.String.format;
@@ -75,9 +76,11 @@ final class CommandBatchCursorHelper {
         return commandCursorResult;
     }
 
-    static BsonDocument getKillCursorsCommand(final MongoNamespace namespace, final ServerCursor serverCursor) {
-        return new BsonDocument("killCursors", new BsonString(namespace.getCollectionName()))
+    static BsonDocument getKillCursorsCommand(final MongoNamespace namespace, final ServerCursor serverCursor, final long maxTimeMS) {
+        BsonDocument command = new BsonDocument("killCursors", new BsonString(namespace.getCollectionName()))
                 .append("cursors", new BsonArray(singletonList(new BsonInt64(serverCursor.getId()))));
+        putIfNotZero(command, "maxTimeMS", maxTimeMS);
+        return command;
     }
 
 

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -129,6 +129,7 @@ public final class ClusterFixture {
 
     public static final TimeoutSettings TIMEOUT_SETTINGS = new TimeoutSettings(30_000, 10_000, 0, null, SECONDS.toMillis(5));
     public static final TimeoutSettings TIMEOUT_SETTINGS_WITH_TIMEOUT = TIMEOUT_SETTINGS.withTimeoutMS(TIMEOUT_DURATION.toMillis());
+    public static final TimeoutSettings TIMEOUT_SETTINGS_WITH_INFINITE_TIMEOUT = TIMEOUT_SETTINGS.withTimeoutMS(0);
     public static final TimeoutSettings TIMEOUT_SETTINGS_WITH_MAX_TIME = TIMEOUT_SETTINGS.withMaxTimeMS(100);
     public static final TimeoutSettings TIMEOUT_SETTINGS_WITH_MAX_AWAIT_TIME = TIMEOUT_SETTINGS.withMaxAwaitTimeMS(101);
     public static final TimeoutSettings TIMEOUT_SETTINGS_WITH_MAX_TIME_AND_AWAIT_TIME =

--- a/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/change-streams.json
+++ b/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/change-streams.json
@@ -1,5 +1,6 @@
 {
   "description": "timeoutMS behaves correctly for change streams",
+  "comment": "Manually updated some of the timeoutMS and blockTimeMS to remove race conditions",
   "schemaVersion": "1.9",
   "runOnRequirements": [
     {
@@ -242,7 +243,7 @@
                   "getMore"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 15
+                "blockTimeMS": 150
               }
             }
           }
@@ -252,7 +253,7 @@
           "object": "collection",
           "arguments": {
             "pipeline": [],
-            "timeoutMS": 20,
+            "timeoutMS": 200,
             "batchSize": 2,
             "maxAwaitTimeMS": 1
           },

--- a/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/close-cursors.json
+++ b/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/close-cursors.json
@@ -1,5 +1,6 @@
 {
   "description": "timeoutMS behaves correctly when closing cursors",
+  "comment": "Manually updated some of the timeoutMS and blockTimeMS to remove race conditions",
   "schemaVersion": "1.9",
   "runOnRequirements": [
     {
@@ -75,7 +76,7 @@
                   "getMore"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 50
+                "blockTimeMS": 100
               }
             }
           }
@@ -86,7 +87,7 @@
           "arguments": {
             "filter": {},
             "batchSize": 2,
-            "timeoutMS": 20
+            "timeoutMS": 100
           },
           "saveResultAsEntity": "cursor"
         },

--- a/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/non-tailable-cursors.json
+++ b/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/non-tailable-cursors.json
@@ -1,5 +1,6 @@
 {
   "description": "timeoutMS behaves correctly for non-tailable cursors",
+  "comment": "Manually updated some of the timeoutMS and blockTimeMS to remove race conditions",
   "schemaVersion": "1.9",
   "runOnRequirements": [
     {
@@ -84,7 +85,7 @@
                   "find"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 15
+                "blockTimeMS": 150
               }
             }
           }
@@ -94,6 +95,7 @@
           "object": "collection",
           "arguments": {
             "filter": {},
+            "timeoutMS": 100,
             "timeoutMode": "cursorLifetime"
           },
           "expectError": {
@@ -143,7 +145,7 @@
                   "getMore"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 15
+                "blockTimeMS": 150
               }
             }
           }
@@ -153,7 +155,7 @@
           "object": "collection",
           "arguments": {
             "filter": {},
-            "timeoutMS": 20,
+            "timeoutMS": 200,
             "batchSize": 2
           },
           "expectError": {
@@ -221,7 +223,7 @@
                   "getMore"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 15
+                "blockTimeMS": 150
               }
             }
           }
@@ -232,7 +234,7 @@
           "arguments": {
             "filter": {},
             "timeoutMode": "cursorLifetime",
-            "timeoutMS": 20,
+            "timeoutMS": 200,
             "batchSize": 2
           },
           "expectError": {
@@ -427,7 +429,7 @@
                   "getMore"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 15
+                "blockTimeMS": 101
               }
             }
           }
@@ -438,6 +440,7 @@
           "arguments": {
             "filter": {},
             "timeoutMode": "iteration",
+            "timeoutMS": 100,
             "batchSize": 2
           },
           "expectError": {

--- a/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/tailable-awaitData.json
+++ b/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/tailable-awaitData.json
@@ -1,5 +1,6 @@
 {
   "description": "timeoutMS behaves correctly for tailable awaitData cursors",
+  "comment": "Manually updated some of the timeoutMS and blockTimeMS to remove race conditions",
   "schemaVersion": "1.9",
   "runOnRequirements": [
     {
@@ -188,7 +189,7 @@
                   "getMore"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 15
+                "blockTimeMS": 150
               }
             }
           }
@@ -199,7 +200,7 @@
           "arguments": {
             "filter": {},
             "cursorType": "tailableAwait",
-            "timeoutMS": 20,
+            "timeoutMS": 200,
             "batchSize": 1
           },
           "saveResultAsEntity": "tailableCursor"
@@ -272,7 +273,7 @@
                   "getMore"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 15
+                "blockTimeMS": 150
               }
             }
           }
@@ -283,7 +284,7 @@
           "arguments": {
             "filter": {},
             "cursorType": "tailableAwait",
-            "timeoutMS": 20,
+            "timeoutMS": 200,
             "batchSize": 1,
             "maxAwaitTimeMS": 1
           },

--- a/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/tailable-non-awaitData.json
+++ b/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/tailable-non-awaitData.json
@@ -154,7 +154,7 @@
                   "getMore"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 15
+                "blockTimeMS": 150
               }
             }
           }
@@ -165,7 +165,7 @@
           "arguments": {
             "filter": {},
             "cursorType": "tailable",
-            "timeoutMS": 20,
+            "timeoutMS": 200,
             "batchSize": 1
           },
           "saveResultAsEntity": "tailableCursor"

--- a/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
@@ -15,7 +15,7 @@
  */
 package com.mongodb.internal;
 
-import com.mongodb.MongoTimeoutException;
+import com.mongodb.MongoExecutionTimeoutException;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 
@@ -176,8 +176,8 @@ final class TimeoutContextTest {
                     assertAll(
                             () -> assertTrue(supplier.get().getMaxTimeMS() <= 100),
                             () -> assertTrue(supplier.get().minRoundTripTimeMS(10).getMaxTimeMS() <= 90),
-                            () -> assertThrows(MongoTimeoutException.class, () -> supplier.get().minRoundTripTimeMS(101).getMaxTimeMS()),
-                            () -> assertThrows(MongoTimeoutException.class, () -> supplier.get().minRoundTripTimeMS(100).getMaxTimeMS())
+                            () -> assertThrows(MongoExecutionTimeoutException.class, () -> supplier.get().minRoundTripTimeMS(101).getMaxTimeMS()),
+                            () -> assertThrows(MongoExecutionTimeoutException.class, () -> supplier.get().minRoundTripTimeMS(100).getMaxTimeMS())
                     );
                 })
         );

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestConnectionPool.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestConnectionPool.java
@@ -45,7 +45,7 @@ public class TestConnectionPool implements ConnectionPool {
             }
 
             @Override
-            public void sendMessage(final List<ByteBuf> byteBuffers, final int lastRequestId) {
+            public void sendMessage(final List<ByteBuf> byteBuffers, final int lastRequestId, final OperationContext operationContext) {
                 throw new UnsupportedOperationException("Not implemented yet!");
             }
 
@@ -76,18 +76,19 @@ public class TestConnectionPool implements ConnectionPool {
             }
 
             @Override
-            public ResponseBuffers receiveMessage(final int responseTo) {
+            public ResponseBuffers receiveMessage(final int responseTo, final OperationContext operationContext) {
                 throw new UnsupportedOperationException("Not implemented yet!");
             }
 
             @Override
-            public void sendMessageAsync(final List<ByteBuf> byteBuffers, final int lastRequestId,
+            public void sendMessageAsync(final List<ByteBuf> byteBuffers, final int lastRequestId, final OperationContext operationContext,
                                          final SingleResultCallback<Void> callback) {
                 throw new UnsupportedOperationException("Not implemented yet!");
             }
 
             @Override
-            public void receiveMessageAsync(final int responseTo, final SingleResultCallback<ResponseBuffers> callback) {
+            public void receiveMessageAsync(final int responseTo, final OperationContext operationContext,
+                    final SingleResultCallback<ResponseBuffers> callback) {
                 throw new UnsupportedOperationException("Not implemented yet!");
             }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestInternalConnectionFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestInternalConnectionFactory.java
@@ -98,7 +98,7 @@ class TestInternalConnectionFactory implements InternalConnectionFactory {
         }
 
         @Override
-        public void sendMessage(final List<ByteBuf> byteBuffers, final int lastRequestId) {
+        public void sendMessage(final List<ByteBuf> byteBuffers, final int lastRequestId, final OperationContext operationContext) {
         }
 
         @Override
@@ -127,17 +127,19 @@ class TestInternalConnectionFactory implements InternalConnectionFactory {
         }
 
         @Override
-        public ResponseBuffers receiveMessage(final int responseTo) {
+        public ResponseBuffers receiveMessage(final int responseTo, final OperationContext operationContext) {
             return null;
         }
 
         @Override
-        public void sendMessageAsync(final List<ByteBuf> byteBuffers, final int lastRequestId, final SingleResultCallback<Void> callback) {
+        public void sendMessageAsync(final List<ByteBuf> byteBuffers, final int lastRequestId, final OperationContext operationContext,
+                final SingleResultCallback<Void> callback) {
             callback.onResult(null, null);
         }
 
         @Override
-        public void receiveMessageAsync(final int responseTo, final SingleResultCallback<ResponseBuffers> callback) {
+        public void receiveMessageAsync(final int responseTo, final OperationContext operationContext,
+                final SingleResultCallback<ResponseBuffers> callback) {
             callback.onResult(null, null);
         }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/UsageTrackingConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/UsageTrackingConnectionSpecification.groovy
@@ -111,7 +111,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         def openedLastUsedAt = connection.lastUsedAt
 
         when:
-        connection.sendMessage(Arrays.asList(), 1)
+        connection.sendMessage([], 1, OPERATION_CONTEXT)
 
         then:
         connection.lastUsedAt >= openedLastUsedAt
@@ -127,7 +127,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         def futureResultCallback = new FutureResultCallback<Void>()
 
         when:
-        connection.sendMessageAsync(Arrays.asList(), 1, futureResultCallback)
+        connection.sendMessageAsync([], 1, OPERATION_CONTEXT, futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -141,7 +141,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         connection.open(OPERATION_CONTEXT)
         def openedLastUsedAt = connection.lastUsedAt
         when:
-        connection.receiveMessage(1)
+        connection.receiveMessage(1, OPERATION_CONTEXT)
 
         then:
         connection.lastUsedAt >= openedLastUsedAt
@@ -156,7 +156,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         def futureResultCallback = new FutureResultCallback<Void>()
 
         when:
-        connection.receiveMessageAsync(1, futureResultCallback)
+        connection.receiveMessageAsync(1, OPERATION_CONTEXT, futureResultCallback)
         futureResultCallback.get()
 
         then:

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/KeyManagementService.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/KeyManagementService.java
@@ -93,7 +93,8 @@ class KeyManagementService implements Closeable {
 
     private void streamWrite(final Stream stream, final MongoKeyDecryptor keyDecryptor, final MonoSink<Void> sink) {
         List<ByteBuf> byteBufs = singletonList(new ByteBufNIO(keyDecryptor.getMessage()));
-        stream.writeAsync(byteBufs, new AsyncCompletionHandler<Void>() {
+        // TODO (CSOT) - JAVA-4055
+        stream.writeAsync(byteBufs, OperationContext.todoOperationContext(), new AsyncCompletionHandler<Void>() {
             @Override
             public void completed(@Nullable final Void aVoid) {
                 streamRead(stream, keyDecryptor, sink);

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCursor.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCursor.java
@@ -36,6 +36,7 @@ import static com.mongodb.ClusterFixture.TIMEOUT;
 import static com.mongodb.internal.thread.InterruptionUtil.interruptAndCreateMongoInterruptedException;
 import static com.mongodb.reactivestreams.client.syncadapter.ContextHelper.CONTEXT;
 import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.getSleepAfterCursorClose;
+import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.getSleepAfterCursorError;
 import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.getSleepAfterCursorOpen;
 
 class SyncMongoCursor<T> implements MongoCursor<T> {
@@ -72,6 +73,7 @@ class SyncMongoCursor<T> implements MongoCursor<T> {
             @Override
             public void onError(final Throwable t) {
                 results.addLast(t);
+                sleep(getSleepAfterCursorError());
             }
 
             @Override
@@ -126,6 +128,7 @@ class SyncMongoCursor<T> implements MongoCursor<T> {
                 throw new MongoTimeoutException("Time out waiting for result from cursor");
             } else if (next instanceof Throwable) {
                 error = translateError((Throwable) next);
+                sleep(getSleepAfterCursorError());
                 throw error;
             } else if (next == COMPLETED) {
                 completed = true;

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedServerDiscoveryAndMonitoringTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedServerDiscoveryAndMonitoringTest.java
@@ -25,13 +25,20 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
+import static org.junit.Assume.assumeFalse;
+
 public class UnifiedServerDiscoveryAndMonitoringTest extends UnifiedReactiveStreamsTest {
     public UnifiedServerDiscoveryAndMonitoringTest(@SuppressWarnings("unused") final String fileDescription,
-            @SuppressWarnings("unused") final String testDescription,
-            final String schemaVersion,
+            final String testDescription, final String schemaVersion,
             @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
             final BsonDocument definition) {
         super(schemaVersion, runOnRequirements, entities, initialData, definition);
+
+        assumeFalse("TODO (CSOT) - JAVA-4063 - apply settings to the operation context",
+                (fileDescription.equals("hello-timeout") && testDescription.startsWith("Network timeout on Monitor"))
+                        || (fileDescription.equals("find-network-timeout-error")
+                        && testDescription.startsWith("Ignore network timeout error on find"))
+                        || fileDescription.equals("auth-network-timeout-error"));
     }
 
     @Parameterized.Parameters(name = "{0}: {1}")

--- a/driver-scala/src/main/scala/org/mongodb/scala/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/package.scala
@@ -334,6 +334,11 @@ package object scala extends ClientSessionImplicits with ObservableImplicits wit
   type MongoSocketReadTimeoutException = com.mongodb.MongoSocketReadTimeoutException
 
   /**
+   * This exception is thrown when there is a timeout writing to a socket.
+   */
+  type MongoSocketWriteTimeoutException = com.mongodb.MongoSocketWriteTimeoutException
+
+  /**
    * This exception is thrown when there is an exception writing a response to a Socket.
    */
   type MongoSocketWriteException = com.mongodb.MongoSocketWriteException

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideOperationTimeoutTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideOperationTimeoutTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
 
 // See https://github.com/mongodb/specifications/tree/master/source/client-side-operation-timeout/tests
 @RunWith(Parameterized.class)

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedServerDiscoveryAndMonitoringTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedServerDiscoveryAndMonitoringTest.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
+import static org.junit.Assume.assumeFalse;
+
 public class UnifiedServerDiscoveryAndMonitoringTest extends UnifiedSyncTest {
 
     public UnifiedServerDiscoveryAndMonitoringTest(@SuppressWarnings("unused") final String fileDescription,
@@ -32,6 +34,12 @@ public class UnifiedServerDiscoveryAndMonitoringTest extends UnifiedSyncTest {
             final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
             final BsonArray initialData, final BsonDocument definition) {
         super(schemaVersion, runOnRequirements, entities, initialData, definition);
+
+        assumeFalse("TODO (CSOT) - JAVA-4063 - apply settings to the operation context",
+                (fileDescription.equals("hello-timeout") && testDescription.startsWith("Network timeout on Monitor check"))
+                || (fileDescription.equals("find-network-timeout-error")
+                        && testDescription.startsWith("Ignore network timeout error on find"))
+                || fileDescription.equals("auth-network-timeout-error"));
     }
 
     @Parameterized.Parameters(name = "{0}: {1}")


### PR DESCRIPTION
4 separate commits, incremently adding CSOT command execution support.

~I have noticed some async CSOT tests dropping an error (https://projectreactor.io/docs/core/release/reference/index.html#hooks-dropping) that maybe related to the sync adapter. Added JAVA-5266 to investigate and ensure tests catch them silently failing.~

Some tests have been shown to be prone to race conditions, especially in async. Often the timeoutMS is too small to allow time for a getMore to be called (especially if minRTT latency is greater than 0). I have added catches those that locally regularly fail locally but evergreen may find some more.