### PR TITLE
Make `ConnectionId.serverValue`/`localValue` of the `Long`/`long` type

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/ConnectionId.java
+++ b/driver-core/src/main/com/mongodb/connection/ConnectionId.java
@@ -20,7 +20,7 @@ import com.mongodb.annotations.Immutable;
 import com.mongodb.lang.Nullable;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.assertions.Assertions.notNull;
@@ -35,7 +35,7 @@ import static java.lang.String.format;
  */
 @Immutable
 public final class ConnectionId {
-    private static final AtomicInteger INCREMENTING_ID = new AtomicInteger();
+    private static final AtomicLong INCREMENTING_ID = new AtomicLong();
 
     private final ServerId serverId;
     private final long localValue;

--- a/driver-core/src/main/com/mongodb/connection/ConnectionId.java
+++ b/driver-core/src/main/com/mongodb/connection/ConnectionId.java
@@ -38,8 +38,9 @@ public final class ConnectionId {
     private static final AtomicInteger INCREMENTING_ID = new AtomicInteger();
 
     private final ServerId serverId;
-    private final int localValue;
-    private final Integer serverValue;
+    private final long localValue;
+    @Nullable
+    private final Long serverValue;
     private final String stringValue;
 
     /**
@@ -56,16 +57,16 @@ public final class ConnectionId {
      * Construct an instance with the given serverId, localValue, and serverValue.
      *
      * <p>
-     *     Useful for testing, but generally prefer {@link #withServerValue(int)}
+     *     Useful for testing, but generally prefer {@link #withServerValue(long)}
      * </p>
      *
      * @param serverId the server id
      * @param localValue the local value
      * @param serverValue the server value, which may be null
-     * @see #withServerValue(int)
+     * @see #withServerValue(long)
      * @since 3.11
      */
-    public ConnectionId(final ServerId serverId, final int localValue, @Nullable final Integer serverValue) {
+    public ConnectionId(final ServerId serverId, final long localValue, @Nullable final Long serverValue) {
         this.serverId = notNull("serverId", serverId);
         this.localValue = localValue;
         this.serverValue = serverValue;
@@ -83,7 +84,7 @@ public final class ConnectionId {
      * @return the new connection id
      * @since 3.8
      */
-    public ConnectionId withServerValue(final int serverValue) {
+    public ConnectionId withServerValue(final long serverValue) {
         isTrue("server value is null", this.serverValue == null);
         return new ConnectionId(serverId, localValue, serverValue);
     }
@@ -102,7 +103,7 @@ public final class ConnectionId {
      *
      * @return the locally created id value for the connection
      */
-    public int getLocalValue() {
+    public long getLocalValue() {
         return localValue;
     }
 
@@ -112,7 +113,7 @@ public final class ConnectionId {
      * @return the server generated id value for the connection or null if not set.
      */
     @Nullable
-    public Integer getServerValue() {
+    public Long getServerValue() {
         return serverValue;
     }
 
@@ -142,10 +143,7 @@ public final class ConnectionId {
 
     @Override
     public int hashCode() {
-        int result = serverId.hashCode();
-        result = 31 * result + localValue;
-        result = 31 * result + (serverValue != null ? serverValue.hashCode() : 0);
-        return result;
+        return Objects.hash(serverId, localValue, serverValue);
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -1587,7 +1587,7 @@ final class DefaultConnectionPool implements ConnectionPool {
         }
 
     }
-    private void logEventMessage(final String messageId, final String format, final int driverConnectionId) {
+    private void logEventMessage(final String messageId, final String format, final long driverConnectionId) {
         ClusterId clusterId = serverId.getClusterId();
         if (requiresLogging(clusterId)) {
             List<LogMessage.Entry> entries = createBasicEntries();

--- a/driver-core/src/main/com/mongodb/internal/connection/DescriptionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DescriptionHelper.java
@@ -71,7 +71,7 @@ public final class DescriptionHelper {
                 helloResult.getArray("saslSupportedMechs", null), getLogicalSessionTimeoutMinutes(helloResult));
         if (helloResult.containsKey("connectionId")) {
             ConnectionId newConnectionId =
-                    connectionDescription.getConnectionId().withServerValue(helloResult.getNumber("connectionId").intValue());
+                    connectionDescription.getConnectionId().withServerValue(helloResult.getNumber("connectionId").longValue());
             connectionDescription = connectionDescription.withConnectionId(newConnectionId);
         }
         if (clusterConnectionMode == ClusterConnectionMode.LOAD_BALANCED) {

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
@@ -244,7 +244,7 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
 
         if (getLastErrorResult.containsKey("connectionId")) {
             connectionId = connectionDescription.getConnectionId()
-                    .withServerValue(getLastErrorResult.getNumber("connectionId").intValue());
+                    .withServerValue(getLastErrorResult.getNumber("connectionId").longValue());
         } else {
             connectionId = connectionDescription.getConnectionId();
         }

--- a/driver-core/src/test/unit/com/mongodb/connection/ConnectionIdSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ConnectionIdSpecification.groovy
@@ -26,7 +26,7 @@ class ConnectionIdSpecification extends Specification {
     def 'should set all properties'() {
         given:
         def id1 = new ConnectionId(serverId)
-        def id2 = new ConnectionId(serverId, 11, 32)
+        def id2 = new ConnectionId(serverId, Long.MAX_VALUE - 1, Long.MAX_VALUE)
 
         expect:
         id1.serverId == serverId
@@ -34,8 +34,8 @@ class ConnectionIdSpecification extends Specification {
         !id1.serverValue
 
         id2.serverId == serverId
-        id2.localValue == 11
-        id2.serverValue == 32
+        id2.localValue == Long.MAX_VALUE - 1
+        id2.serverValue == Long.MAX_VALUE
     }
 
     def 'should increment local value'() {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
@@ -77,7 +77,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.mongodb.assertions.Assertions.assertFalse;
 import static com.mongodb.internal.thread.InterruptionUtil.interruptAndCreateMongoInterruptedException;
@@ -386,8 +386,8 @@ public abstract class AbstractConnectionPoolTest {
     }
 
     private void assertConnectionIdMatch(final BsonDocument expectedEvent, final ConnectionId actualConnectionId) {
-        int actualConnectionIdLocalValue = actualConnectionId.getLocalValue();
-        int adjustedConnectionIdLocalValue = adjustedConnectionIdLocalValue(actualConnectionIdLocalValue);
+        long actualConnectionIdLocalValue = actualConnectionId.getLocalValue();
+        long adjustedConnectionIdLocalValue = adjustedConnectionIdLocalValue(actualConnectionIdLocalValue);
         String connectionIdKey = "connectionId";
         if (expectedEvent.containsKey(connectionIdKey)) {
             int expectedConnectionId = expectedEvent.getInt32(connectionIdKey).intValue();
@@ -400,7 +400,7 @@ public abstract class AbstractConnectionPoolTest {
         }
     }
 
-    private int adjustedConnectionIdLocalValue(final int connectionIdLocalValue) {
+    private long adjustedConnectionIdLocalValue(final long connectionIdLocalValue) {
         if (pool instanceof ConnectionIdAdjustingConnectionPool) {
             return ((ConnectionIdAdjustingConnectionPool) pool).adjustedConnectionIdLocalValue(connectionIdLocalValue);
         } else {
@@ -541,21 +541,21 @@ public abstract class AbstractConnectionPoolTest {
     }
 
     private static final class ConnectionIdAdjustingConnectionPool implements ConnectionPool {
-        private static final int UNINITIALIZED = Integer.MAX_VALUE;
+        private static final long UNINITIALIZED = Long.MAX_VALUE;
 
         private final DefaultConnectionPool pool;
-        private final AtomicInteger connectionIdLocalValueAdjustment;
+        private final AtomicLong connectionIdLocalValueAdjustment;
 
         private ConnectionIdAdjustingConnectionPool(final DefaultConnectionPool pool) {
             this.pool = pool;
-            connectionIdLocalValueAdjustment = new AtomicInteger(UNINITIALIZED);
+            connectionIdLocalValueAdjustment = new AtomicLong(UNINITIALIZED);
         }
 
         private void updateConnectionIdLocalValueAdjustment(final InternalConnection conn) {
             connectionIdLocalValueAdjustment.accumulateAndGet(conn.getDescription().getConnectionId().getLocalValue() - 1, Math::min);
         }
 
-        int adjustedConnectionIdLocalValue(final int connectionIdLocalValue) {
+        long adjustedConnectionIdLocalValue(final long connectionIdLocalValue) {
             return connectionIdLocalValue - connectionIdLocalValueAdjustment.get();
         }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionInitializerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionInitializerSpecification.groovy
@@ -435,7 +435,7 @@ class InternalStreamConnectionInitializerSpecification extends Specification {
         async << [true, false]
     }
 
-    private ConnectionDescription getExpectedConnectionDescription(final Integer localValue, final Integer serverValue) {
+    private ConnectionDescription getExpectedConnectionDescription(final Long localValue, final Long serverValue) {
         new ConnectionDescription(new ConnectionId(serverId, localValue, serverValue),
                 3, ServerType.STANDALONE, 512, 16777216, 33554432, [])
     }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/Entities.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/Entities.java
@@ -819,7 +819,7 @@ public final class Entities {
 
         private BsonDocument createEventDocument(final String name, final ConnectionId connectionId) {
             return createEventDocument(name, connectionId.getServerId())
-                    .append("connectionId", new BsonString(Integer.toString(connectionId.getLocalValue())));
+                    .append("connectionId", new BsonString(Long.toString(connectionId.getLocalValue())));
         }
 
         private BsonDocument createEventDocument(final String name, final ServerId serverId) {

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/EventMatcher.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/EventMatcher.java
@@ -99,7 +99,7 @@ final class EventMatcher {
 
             if (expected.containsKey("hasServerConnectionId")) {
                 boolean hasServerConnectionId = expected.getBoolean("hasServerConnectionId").getValue();
-                Integer serverConnectionId = actual.getConnectionDescription().getConnectionId().getServerValue();
+                Long serverConnectionId = actual.getConnectionDescription().getConnectionId().getServerValue();
                 if (hasServerConnectionId) {
                     assertNotNull(context.getMessage("Expected serverConnectionId"), serverConnectionId);
                 } else {


### PR DESCRIPTION
The corresponding spec change: https://github.com/mongodb/specifications/commit/1f272b30a2e9714578b71a02b2836d5a0bd853f8.

JAVA-4846