### PR TITLE
Fix `onErrorDropped` logged message

### DIFF
--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorFlux.java
@@ -87,29 +87,28 @@ class BatchCursorFlux<T> implements Publisher<T> {
                 batchCursor.setBatchSize(calculateBatchSize(sink.requestedFromDownstream()));
                 Mono.from(batchCursor.next(() -> sink.isCancelled()))
                         .doOnCancel(this::closeCursor)
-                        .doOnError((e) -> {
-                            try {
-                                closeCursor();
-                            } finally {
-                                sink.error(e);
-                            }
-                        })
-                        .doOnSuccess(results -> {
-                            if (!results.isEmpty()) {
-                                results
-                                        .stream()
-                                        .filter(Objects::nonNull)
-                                        .forEach(sink::next);
-                                calculateDemand(-results.size());
-                            }
-                            if (batchCursor.isClosed()) {
-                                sink.complete();
-                            } else {
-                                inProgress.set(false);
-                                recurseCursor();
-                            }
-                        })
-                        .subscribe();
+                        .subscribe(results -> {
+                                    if (!results.isEmpty()) {
+                                        results
+                                                .stream()
+                                                .filter(Objects::nonNull)
+                                                .forEach(sink::next);
+                                        calculateDemand(-results.size());
+                                    }
+                                    if (batchCursor.isClosed()) {
+                                        sink.complete();
+                                    } else {
+                                        inProgress.set(false);
+                                        recurseCursor();
+                                    }
+                                },
+                                e -> {
+                                    try {
+                                        closeCursor();
+                                    } finally {
+                                        sink.error(e);
+                                    }
+                                });
                 }
         }
     }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ClientSideOperationTimeoutTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ClientSideOperationTimeoutTest.java
@@ -28,10 +28,12 @@ import org.bson.BsonDocument;
 import org.junit.After;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import reactor.core.publisher.Hooks;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.mongodb.client.ClientSideOperationTimeoutTest.checkSkipCSOTTest;
 import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.disableSleep;
@@ -42,6 +44,7 @@ import static org.junit.Assume.assumeFalse;
 @RunWith(Parameterized.class)
 public class ClientSideOperationTimeoutTest extends UnifiedReactiveStreamsTest {
     private final String testDescription;
+    private final AtomicReference<Throwable> atomicReferenceThrowable = new AtomicReference<>();
 
     public ClientSideOperationTimeoutTest(final String fileDescription, final String testDescription,
             final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
@@ -58,11 +61,23 @@ public class ClientSideOperationTimeoutTest extends UnifiedReactiveStreamsTest {
         if (testDescription.equals("timeoutMS is refreshed for close")) {
             enableSleepAfterCursorError(256);
         }
+
+        Hooks.onOperatorDebug();
+        Hooks.onErrorDropped(atomicReferenceThrowable::set);
     }
 
     @Parameterized.Parameters(name = "{0}: {1}")
     public static Collection<Object[]> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/client-side-operation-timeout");
+    }
+
+    @Override
+    public void shouldPassAllOutcomes() {
+        super.shouldPassAllOutcomes();
+        Throwable droppedError = atomicReferenceThrowable.get();
+        if (droppedError != null) {
+            throw new AssertionError("Test passed but there was a dropped error; `onError` called with no handler.", droppedError);
+        }
     }
 
     @Override
@@ -77,5 +92,7 @@ public class ClientSideOperationTimeoutTest extends UnifiedReactiveStreamsTest {
     public void cleanUp() {
         super.cleanUp();
         disableSleep();
+        Hooks.resetOnOperatorDebug();
+        Hooks.resetOnErrorDropped();
     }
 }


### PR DESCRIPTION
Caused by using `doOnError` rather than using `subscribe` and passing the handler in there.

JAVA-5266