### PR TITLE
Improve BsonNumber support for Decimal128

### DIFF
--- a/bson/src/main/org/bson/BsonDecimal128.java
+++ b/bson/src/main/org/bson/BsonDecimal128.java
@@ -84,17 +84,17 @@ public final class BsonDecimal128 extends BsonNumber {
 
     @Override
     public int intValue() {
-        return value.bigDecimalValue().intValue();
+        return value.intValue();
     }
 
     @Override
     public long longValue() {
-        return value.bigDecimalValue().longValue();
+        return value.longValue();
     }
 
     @Override
     public double doubleValue() {
-        return value.bigDecimalValue().doubleValue();
+        return value.doubleValue();
     }
 
     @Override

--- a/bson/src/main/org/bson/BsonValue.java
+++ b/bson/src/main/org/bson/BsonValue.java
@@ -77,7 +77,7 @@ public abstract class BsonValue {
      * @throws org.bson.BsonInvalidOperationException if this value is not of the expected type
      */
     public BsonNumber asNumber() {
-        if (getBsonType() != BsonType.INT32 && getBsonType() != BsonType.INT64 && getBsonType() != BsonType.DOUBLE) {
+        if (!(this instanceof BsonNumber)) {
             throw new BsonInvalidOperationException(format("Value expected to be of a numerical BSON type is of unexpected type %s",
                                                            getBsonType()));
         }
@@ -282,7 +282,7 @@ public abstract class BsonValue {
      * @return true if this is a BsonNumber, false otherwise
      */
     public boolean isNumber() {
-        return isInt32() || isInt64() || isDouble();
+        return this instanceof BsonNumber;
     }
 
     /**

--- a/bson/src/main/org/bson/BsonValue.java
+++ b/bson/src/main/org/bson/BsonValue.java
@@ -77,7 +77,7 @@ public abstract class BsonValue {
      * @throws org.bson.BsonInvalidOperationException if this value is not of the expected type
      */
     public BsonNumber asNumber() {
-        if (!(this instanceof BsonNumber)) {
+        if (!isNumber()) {
             throw new BsonInvalidOperationException(format("Value expected to be of a numerical BSON type is of unexpected type %s",
                                                            getBsonType()));
         }

--- a/bson/src/test/unit/org/bson/BsonValueSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BsonValueSpecification.groovy
@@ -29,6 +29,7 @@ class BsonValueSpecification extends Specification {
         new BsonInt64(52L).isInt64()
         new BsonInt64(52L).isNumber()
         new BsonDecimal128(Decimal128.parse('1')).isDecimal128()
+        new BsonDecimal128(Decimal128.parse('1')).isNumber()
         new BsonDouble(62.0).isDouble()
         new BsonDouble(62.0).isNumber()
         new BsonBoolean(true).isBoolean()
@@ -71,7 +72,26 @@ class BsonValueSpecification extends Specification {
         !new BsonNull().isDocument()
     }
 
-    def 'as methods should return false for the incorrect type'() {
+    def 'support BsonNumber interface for all number types'() {
+        expect:
+        bsonValue.asNumber() == bsonValue
+        bsonValue.asNumber().intValue()== intValue
+        bsonValue.asNumber().longValue() == longValue
+        bsonValue.asNumber().doubleValue() == doubleValue
+        bsonValue.asNumber().decimal128Value() == decimal128Value
+
+        where:
+        bsonValue                                         | intValue           | longValue      | doubleValue              | decimal128Value
+        new BsonInt32(42)                                 | 42                 | 42L            | 42.0                     | Decimal128.parse('42')
+        new BsonInt64(42)                                 | 42                 | 42L            | 42.0                     | Decimal128.parse('42')
+        new BsonDouble(42)                                | 42                 | 42L            | 42.0                     | Decimal128.parse('42')
+        new BsonDecimal128(Decimal128.parse('42'))        | 42                 | 42L            | 42.0                     | Decimal128.parse('42')
+        new BsonDecimal128(Decimal128.POSITIVE_INFINITY)  | Integer.MAX_VALUE  | Long.MAX_VALUE | Double.POSITIVE_INFINITY | Decimal128.POSITIVE_INFINITY
+        new BsonDecimal128(Decimal128.NEGATIVE_INFINITY)  | Integer.MIN_VALUE  | Long.MIN_VALUE | Double.NEGATIVE_INFINITY | Decimal128.NEGATIVE_INFINITY
+        new BsonDecimal128(Decimal128.NaN)                | 0                  | 0L             | Double.NaN               | Decimal128.NaN
+    }
+
+    def 'as methods should return throw for the incorrect type'() {
         when:
         new BsonNull().asInt32()
 

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -82,6 +82,7 @@
         <rule-config name='LineLength'>
             <property name='length' value='140'/>
             <property name='doNotApplyToFileNames' value='ClientSideEncryptionProseTestSpecification.groovy'/>
+            <property name='doNotApplyToFileNames' value='BsonValueSpecification.groovy'/>
         </rule-config>
         <!-- this check is failing '})' when it shouldn't -->
         <exclude name='SpaceAfterClosingBrace'/>


### PR DESCRIPTION
* Change implementation of BsonDecimal128#intValue/longValue/doubleValue to just call the corresponding methods in Decimal128, which handle infinity and NaN similarly to JDK classes
* Change BsonValue#isNumber/asNumber to treat BsonDecimal128 as a number

JAVA-5265