### PR TITLE
Reclaim native memory quicker when using ZlibCompressor

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/ZlibCompressor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ZlibCompressor.java
@@ -49,7 +49,7 @@ class ZlibCompressor extends Compressor {
 
     @Override
     OutputStream getOutputStream(final OutputStream source) {
-        return new DeflaterOutputStream(source, new Deflater(level)){
+        return new DeflaterOutputStream(source, new Deflater(level)) {
             @Override
             public void close() throws IOException {
                 try {

--- a/driver-core/src/main/com/mongodb/internal/connection/ZlibCompressor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ZlibCompressor.java
@@ -18,6 +18,7 @@ package com.mongodb.internal.connection;
 
 import com.mongodb.MongoCompressor;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.zip.Deflater;
@@ -48,6 +49,15 @@ class ZlibCompressor extends Compressor {
 
     @Override
     OutputStream getOutputStream(final OutputStream source) {
-        return new DeflaterOutputStream(source, new Deflater(level));
+        return new DeflaterOutputStream(source, new Deflater(level)){
+            @Override
+            public void close() throws IOException {
+                try {
+                    super.close();
+                } finally {
+                    def.end();
+                }
+            }
+        };
     }
 }


### PR DESCRIPTION
Reclaim native memory quicker by overriding `close()` to invoke `end()` on the deflater, since by supplying a deflater to the constructor of `DeflaterOutputStream` `usesDefaultDeflater` is set to `false` and therefore `end()` is not invoked in [DeflaterOutputStream#close](https://github.com/openjdk/jdk/blob/2a59243cbaf3e7d5d1bfc9f247d28bc648687ea5/src/java.base/share/classes/java/util/zip/DeflaterOutputStream.java#L241).

This is related to [JDK-4797189]( https://bugs.openjdk.org/browse/JDK-4797189) bug/feature (marked as Won't Fix)

See the following blog post for more information: https://medium.com/swlh/native-memory-the-silent-jvm-killer-595913cba8e7

JAVA-5280