### PR TITLE
Account the time to deliver connection pool events as part of the reported duration

### DIFF
--- a/driver-core/src/main/com/mongodb/event/ConnectionCheckOutFailedEvent.java
+++ b/driver-core/src/main/com/mongodb/event/ConnectionCheckOutFailedEvent.java
@@ -109,15 +109,13 @@ public final class ConnectionCheckOutFailedEvent {
 
     /**
      * The time it took to check out the connection.
-     * More specifically, the time elapsed between the {@link ConnectionCheckOutStartedEvent} emitted by the same checking out and this event.
+     * More specifically, the time elapsed between emitting a {@link ConnectionCheckOutStartedEvent}
+     * and emitting this event as part of the same checking out.
      * <p>
      * Naturally, if a new connection was not {@linkplain ConnectionCreatedEvent created}
      * and {@linkplain ConnectionReadyEvent established} as part of checking out,
      * this duration is usually not greater than {@link ConnectionPoolSettings#getMaxWaitTime(TimeUnit)},
      * but may occasionally be greater than that, because the driver does not provide hard real-time guarantees.</p>
-     * <p>
-     * This duration does not currently include the time to deliver the {@link ConnectionCheckOutStartedEvent}.
-     * Subject to change.</p>
      *
      * @param timeUnit The time unit of the result.
      * {@link TimeUnit#convert(long, TimeUnit)} specifies how the conversion from nanoseconds to {@code timeUnit} is done.

--- a/driver-core/src/main/com/mongodb/event/ConnectionCheckedOutEvent.java
+++ b/driver-core/src/main/com/mongodb/event/ConnectionCheckedOutEvent.java
@@ -71,15 +71,13 @@ public final class ConnectionCheckedOutEvent {
 
     /**
      * The time it took to check out the connection.
-     * More specifically, the time elapsed between the {@link ConnectionCheckOutStartedEvent} emitted by the same checking out and this event.
+     * More specifically, the time elapsed between emitting a {@link ConnectionCheckOutStartedEvent}
+     * and emitting this event as part of the same checking out.
      * <p>
      * Naturally, if a new connection was not {@linkplain ConnectionCreatedEvent created}
      * and {@linkplain ConnectionReadyEvent established} as part of checking out,
      * this duration is usually not greater than {@link ConnectionPoolSettings#getMaxWaitTime(TimeUnit)},
      * but may occasionally be greater than that, because the driver does not provide hard real-time guarantees.</p>
-     * <p>
-     * This duration does not currently include the time to deliver the {@link ConnectionCheckOutStartedEvent}.
-     * Subject to change.</p>
      *
      * @param timeUnit The time unit of the result.
      * {@link TimeUnit#convert(long, TimeUnit)} specifies how the conversion from nanoseconds to {@code timeUnit} is done.

--- a/driver-core/src/main/com/mongodb/event/ConnectionReadyEvent.java
+++ b/driver-core/src/main/com/mongodb/event/ConnectionReadyEvent.java
@@ -58,14 +58,12 @@ public final class ConnectionReadyEvent {
 
     /**
      * The time it took to establish the connection.
-     * More specifically, the time elapsed between the {@link ConnectionCreatedEvent} emitted by the same checking out and this event.
+     * More specifically, the time elapsed between emitting a {@link ConnectionCreatedEvent}
+     * and emitting this event as part of the same checking out.
      * <p>
      * Naturally, when establishing a connection is part of checking out,
      * this duration is not greater than
      * {@link ConnectionCheckedOutEvent#getElapsedTime(TimeUnit)}/{@link ConnectionCheckOutFailedEvent#getElapsedTime(TimeUnit)}.</p>
-     * <p>
-     * This duration does not currently include the time to deliver the {@link ConnectionCreatedEvent}.
-     * Subject to change.</p>
      *
      * @param timeUnit The time unit of the result.
      * {@link TimeUnit#convert(long, TimeUnit)} specifies how the conversion from nanoseconds to {@code timeUnit} is done.


### PR DESCRIPTION
The spec change: https://github.com/mongodb/specifications/commit/c6621d01b37df9c7a9ae2036f10d0b6597047bc3.

JAVA-5121