### PR TITLE
Operation Context Server Monitoring and discovery updates

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.assertNull;
+import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.assertions.Assertions.isTrue;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -178,6 +179,7 @@ public class TimeoutContext {
     public TimeoutContext withAdditionalReadTimeout(final int additionalReadTimeout) {
         // Only used outside timeoutMS usage
         assertNull(timeout);
+        assertTrue(additionalReadTimeout >= 0);
 
         // Check existing read timeout is infinite
         if (timeoutSettings.getReadTimeoutMS() == 0) {

--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -174,11 +174,23 @@ public class TimeoutContext {
         timeout = calculateTimeout(timeoutSettings.getTimeoutMS());
     }
 
+    public TimeoutContext withAdditionalReadTimeout(final int additionalReadTimeout) {
+        long newReadTimeout = getReadTimeoutMS() + additionalReadTimeout;
+        newReadTimeout = newReadTimeout > 0 ? newReadTimeout : Long.MAX_VALUE;
+        if (timeout != null) {
+            if (timeout.isInfinite()) {
+                return this;
+            }
+            return new TimeoutContext(timeoutSettings.withTimeoutMS(newReadTimeout));
+        } else {
+            return new TimeoutContext(timeoutSettings.withReadTimeoutMS(newReadTimeout));
+        }
+    }
+
     private long timeoutRemainingMS() {
         assertNotNull(timeout);
         return timeout.isInfinite() ? 0 : timeout.remaining(MILLISECONDS);
     }
-
 
     @Override
     public String toString() {

--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -175,12 +175,14 @@ public class TimeoutContext {
     }
 
     public TimeoutContext withAdditionalReadTimeout(final int additionalReadTimeout) {
+        // Check existing read timeout is infinite
+        if (getReadTimeoutMS() == 0) {
+            return this;
+        }
+
         long newReadTimeout = getReadTimeoutMS() + additionalReadTimeout;
         newReadTimeout = newReadTimeout > 0 ? newReadTimeout : Long.MAX_VALUE;
         if (timeout != null) {
-            if (timeout.isInfinite()) {
-                return this;
-            }
             return new TimeoutContext(timeoutSettings.withTimeoutMS(newReadTimeout));
         } else {
             return new TimeoutContext(timeoutSettings.withReadTimeoutMS(newReadTimeout));

--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -23,6 +23,7 @@ import com.mongodb.lang.Nullable;
 import java.util.Objects;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
+import static com.mongodb.assertions.Assertions.assertNull;
 import static com.mongodb.assertions.Assertions.isTrue;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -175,18 +176,16 @@ public class TimeoutContext {
     }
 
     public TimeoutContext withAdditionalReadTimeout(final int additionalReadTimeout) {
+        // Only used outside timeoutMS usage
+        assertNull(timeout);
+
         // Check existing read timeout is infinite
-        if (getReadTimeoutMS() == 0) {
+        if (timeoutSettings.getReadTimeoutMS() == 0) {
             return this;
         }
 
         long newReadTimeout = getReadTimeoutMS() + additionalReadTimeout;
-        newReadTimeout = newReadTimeout > 0 ? newReadTimeout : Long.MAX_VALUE;
-        if (timeout != null) {
-            return new TimeoutContext(timeoutSettings.withTimeoutMS(newReadTimeout));
-        } else {
-            return new TimeoutContext(timeoutSettings.withReadTimeoutMS(newReadTimeout));
-        }
+        return new TimeoutContext(timeoutSettings.withReadTimeoutMS(newReadTimeout > 0 ? newReadTimeout : Long.MAX_VALUE));
     }
 
     private long timeoutRemainingMS() {

--- a/driver-core/src/main/com/mongodb/internal/TimeoutSettings.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutSettings.java
@@ -132,6 +132,11 @@ public class TimeoutSettings {
                 maxTimeMS, maxCommitTimeMS, wTimeoutMS, maxWaitTimeMS);
     }
 
+    public TimeoutSettings withReadTimeoutMS(final long readTimeoutMS) {
+        return new TimeoutSettings(timeoutMS, defaultTimeoutMS, serverSelectionTimeoutMS, connectTimeoutMS, readTimeoutMS, maxAwaitTimeMS,
+                maxTimeMS, maxCommitTimeMS, wTimeoutMS, maxWaitTimeMS);
+    }
+
     public TimeoutSettings withMaxWaitTimeMS(final long maxWaitTimeMS) {
         return new TimeoutSettings(timeoutMS, defaultTimeoutMS, serverSelectionTimeoutMS, connectTimeoutMS, readTimeoutMS, maxAwaitTimeMS,
                 maxTimeMS, maxCommitTimeMS, wTimeoutMS, maxWaitTimeMS);

--- a/driver-core/src/main/com/mongodb/internal/connection/AsynchronousChannelStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsynchronousChannelStream.java
@@ -110,17 +110,9 @@ public abstract class AsynchronousChannelStream implements Stream {
 
     @Override
     public void readAsync(final int numBytes, final OperationContext operationContext, final AsyncCompletionHandler<ByteBuf> handler) {
-        readAsync(numBytes, 0, operationContext, handler);
-    }
-
-    private void readAsync(final int numBytes, final int additionalTimeout, final OperationContext operationContext,
-            final AsyncCompletionHandler<ByteBuf> handler) {
         ByteBuf buffer = bufferProvider.getBuffer(numBytes);
 
         long timeout = operationContext.getTimeoutContext().getReadTimeoutMS();
-        if (timeout > 0 && additionalTimeout > 0) {
-            timeout += additionalTimeout;
-        }
         getChannel().read(buffer.asNIO(), timeout, MILLISECONDS, null, new BasicCompletionHandler(buffer, operationContext, handler));
     }
 
@@ -142,13 +134,6 @@ public abstract class AsynchronousChannelStream implements Stream {
     public ByteBuf read(final int numBytes, final OperationContext operationContext) throws IOException {
         FutureAsyncCompletionHandler<ByteBuf> handler = new FutureAsyncCompletionHandler<>();
         readAsync(numBytes, operationContext, handler);
-        return handler.getRead();
-    }
-
-    @Override
-    public ByteBuf read(final int numBytes, final int additionalTimeout, final OperationContext operationContext) throws IOException {
-        FutureAsyncCompletionHandler<ByteBuf> handler = new FutureAsyncCompletionHandler<>();
-        readAsync(numBytes, additionalTimeout, operationContext, handler);
         return handler.getRead();
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -755,18 +755,6 @@ final class DefaultConnectionPool implements ConnectionPool {
         }
 
         @Override
-        public boolean supportsAdditionalTimeout() {
-            isTrue("open", !isClosed.get());
-            return wrapped.supportsAdditionalTimeout();
-        }
-
-        @Override
-        public <T> T receive(final Decoder<T> decoder, final OperationContext operationContext, final int additionalTimeout) {
-            isTrue("open", !isClosed.get());
-            return wrapped.receive(decoder, operationContext, additionalTimeout);
-        }
-
-        @Override
         public boolean hasMoreToCome() {
             isTrue("open", !isClosed.get());
             return wrapped.hasMoreToCome();

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -128,6 +128,7 @@ final class DefaultConnectionPool implements ConnectionPool {
     private static final StructuredLogger STRUCTURED_LOGGER = new StructuredLogger("connection");
     private final ConcurrentPool<UsageTrackingInternalConnection> pool;
     private final ConnectionPoolSettings settings;
+    private final Supplier<OperationContext> connectionOperationContextSupplier;
     private final BackgroundMaintenanceManager backgroundMaintenance;
     private final AsyncWorkManager asyncWorkManager;
     private final ConnectionPoolListener connectionPoolListener;
@@ -141,8 +142,10 @@ final class DefaultConnectionPool implements ConnectionPool {
 
     @VisibleForTesting(otherwise = PRIVATE)
     DefaultConnectionPool(final ServerId serverId, final InternalConnectionFactory internalConnectionFactory,
-            final ConnectionPoolSettings settings, final OptionalProvider<SdamServerDescriptionManager> sdamProvider) {
-        this(serverId, internalConnectionFactory, settings, InternalConnectionPoolSettings.builder().build(), sdamProvider);
+            final ConnectionPoolSettings settings, final OptionalProvider<SdamServerDescriptionManager> sdamProvider,
+            final Supplier<OperationContext> connectionOperationContextSupplier) {
+        this(serverId, internalConnectionFactory, settings, InternalConnectionPoolSettings.builder().build(), sdamProvider,
+                connectionOperationContextSupplier);
     }
 
     /**
@@ -156,13 +159,15 @@ final class DefaultConnectionPool implements ConnectionPool {
      */
     DefaultConnectionPool(final ServerId serverId, final InternalConnectionFactory internalConnectionFactory,
             final ConnectionPoolSettings settings, final InternalConnectionPoolSettings internalSettings,
-            final OptionalProvider<SdamServerDescriptionManager> sdamProvider) {
+            final OptionalProvider<SdamServerDescriptionManager> sdamProvider,
+            final Supplier<OperationContext> connectionOperationContextSupplier) {
         this.serverId = notNull("serverId", serverId);
         this.settings = notNull("settings", settings);
         UsageTrackingInternalConnectionItemFactory connectionItemFactory =
                 new UsageTrackingInternalConnectionItemFactory(internalConnectionFactory);
         pool = new ConcurrentPool<>(maxSize(settings), connectionItemFactory, format("The server at %s is no longer available",
                 serverId.getAddress()));
+        this.connectionOperationContextSupplier = assertNotNull(connectionOperationContextSupplier);
         this.sdamProvider = assertNotNull(sdamProvider);
         this.connectionPoolListener = getConnectionPoolListener(settings);
         backgroundMaintenance = new BackgroundMaintenanceManager();
@@ -411,8 +416,7 @@ final class DefaultConnectionPool implements ConnectionPool {
             if (shouldEnsureMinSize()) {
                 pool.ensureMinSize(settings.getMinSize(), newConnection -> {
                     try {
-                        // TODO (CSOT) create OC from ConnectionPoolSettings
-                        OperationContext operationContext = OperationContext.todoOperationContext();
+                        OperationContext operationContext = connectionOperationContextSupplier.get();
                         openConcurrencyLimiter.openImmediatelyAndTryHandOverOrRelease(operationContext, new PooledConnection(newConnection));
                     } catch (MongoException | MongoOpenConnectionInternalException e) {
                         RuntimeException actualException = e instanceof MongoOpenConnectionInternalException

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
@@ -256,13 +256,8 @@ class DefaultServerMonitor implements ServerMonitor {
         }
 
         private OperationContext operationContextWithAdditionalTimeout(final OperationContext originalOperationContext) {
-            TimeoutContext timeoutContext = originalOperationContext.getTimeoutContext();
-            if (timeoutContext.getReadTimeoutMS() == 0) {
-                return originalOperationContext;
-            }
-
-            TimeoutContext newTimeoutContext =
-                    timeoutContext.withAdditionalReadTimeout(Math.toIntExact(serverSettings.getHeartbeatFrequency(MILLISECONDS)));
+            TimeoutContext newTimeoutContext = originalOperationContext.getTimeoutContext()
+                            .withAdditionalReadTimeout(Math.toIntExact(serverSettings.getHeartbeatFrequency(MILLISECONDS)));
             return originalOperationContext.withTimeoutContext(newTimeoutContext);
         }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalConnection.java
@@ -100,14 +100,6 @@ public interface InternalConnection extends BufferProvider {
 
     <T> T receive(Decoder<T> decoder, OperationContext operationContext);
 
-    default boolean supportsAdditionalTimeout() {
-        return false;
-    }
-
-    default <T> T receive(Decoder<T> decoder, OperationContext operationContext, int additionalTimeout) {
-        throw new UnsupportedOperationException();
-    }
-
     boolean hasMoreToCome();
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedClusterableServerFactory.java
@@ -32,6 +32,7 @@ import com.mongodb.internal.inject.EmptyProvider;
 import com.mongodb.lang.Nullable;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import static com.mongodb.internal.event.EventListenerHelper.singleServerListener;
 
@@ -51,6 +52,7 @@ public class LoadBalancedClusterableServerFactory implements ClusterableServerFa
     private final MongoDriverInformation mongoDriverInformation;
     private final List<MongoCompressor> compressorList;
     private final ServerApi serverApi;
+    private final Supplier<OperationContext> connectionOperationContextSupplier;
 
     public LoadBalancedClusterableServerFactory(final ServerSettings serverSettings,
             final ConnectionPoolSettings connectionPoolSettings,
@@ -59,7 +61,8 @@ public class LoadBalancedClusterableServerFactory implements ClusterableServerFa
             final LoggerSettings loggerSettings,
             @Nullable final CommandListener commandListener,
             @Nullable final String applicationName, final MongoDriverInformation mongoDriverInformation,
-            final List<MongoCompressor> compressorList, @Nullable final ServerApi serverApi) {
+            final List<MongoCompressor> compressorList, @Nullable final ServerApi serverApi,
+            final Supplier<OperationContext> connectionOperationContextSupplier) {
         this.serverSettings = serverSettings;
         this.connectionPoolSettings = connectionPoolSettings;
         this.internalConnectionPoolSettings = internalConnectionPoolSettings;
@@ -71,6 +74,7 @@ public class LoadBalancedClusterableServerFactory implements ClusterableServerFa
         this.mongoDriverInformation = mongoDriverInformation;
         this.compressorList = compressorList;
         this.serverApi = serverApi;
+        this.connectionOperationContextSupplier = connectionOperationContextSupplier;
     }
 
     @Override
@@ -78,7 +82,7 @@ public class LoadBalancedClusterableServerFactory implements ClusterableServerFa
         ConnectionPool connectionPool = new DefaultConnectionPool(new ServerId(cluster.getClusterId(), serverAddress),
                 new InternalStreamConnectionFactory(ClusterConnectionMode.LOAD_BALANCED, streamFactory, credential, applicationName,
                         mongoDriverInformation, compressorList, loggerSettings, commandListener, serverApi),
-                connectionPoolSettings, internalConnectionPoolSettings, EmptyProvider.instance());
+                connectionPoolSettings, internalConnectionPoolSettings, EmptyProvider.instance(), connectionOperationContextSupplier);
         connectionPool.ready();
 
         return new LoadBalancedServer(new ServerId(cluster.getClusterId(), serverAddress), connectionPool, new DefaultConnectionFactory(),

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -15,7 +15,6 @@
  */
 package com.mongodb.internal.connection;
 
-import com.mongodb.MongoClientSettings;
 import com.mongodb.RequestContext;
 import com.mongodb.ServerApi;
 import com.mongodb.internal.IgnorableRequestContext;
@@ -44,17 +43,13 @@ public class OperationContext {
         this(NEXT_ID.incrementAndGet(), requestContext, sessionContext, timeoutContext, serverApi);
     }
 
-
     public static OperationContext todoOperationContext() {
-        // TODO (CSOT) should be removed; used at locations that require an OC, but which do not yet have one available
-        return nonUserOperationContext(MongoClientSettings.builder().build());
+        // TODO (CSOT) - JAVA-4055 : should be removed during crypt work
+        return nonUserOperationContext(TimeoutSettings.DEFAULT, null);
     }
 
-    public static OperationContext nonUserOperationContext(final MongoClientSettings settings) {
-        // TODO (CSOT) below is placeholder, validate correctness (serverApi/timeoutSettings might
-        // TODO (CSOT) need to be passed in instead)
-        TimeoutSettings timeoutSettings = TimeoutSettings.create(settings);
-        ServerApi serverApi = settings.getServerApi();
+    public static OperationContext nonUserOperationContext(
+            final TimeoutSettings timeoutSettings, @Nullable final ServerApi serverApi) {
         return new OperationContext(
                 IgnorableRequestContext.INSTANCE,
                 NoOpSessionContext.INSTANCE,

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -61,6 +61,10 @@ public class OperationContext {
         return new OperationContext(id, requestContext, sessionContext, timeoutContext, serverApi);
     }
 
+    public OperationContext withTimeoutContext(final TimeoutContext timeoutContext) {
+        return new OperationContext(id, requestContext, sessionContext, timeoutContext, serverApi);
+    }
+
     public long getId() {
         return id;
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
@@ -171,14 +171,9 @@ public class SocketStream implements Stream {
 
     @Override
     public ByteBuf read(final int numBytes, final OperationContext operationContext) throws IOException {
-        return read(numBytes, 0, operationContext);
-    }
-
-    @Override
-    public ByteBuf read(final int numBytes, final int additionalTimeout, final OperationContext operationContext) throws IOException {
         int readTimeoutMS = (int) operationContext.getTimeoutContext().getReadTimeoutMS();
         if (readTimeoutMS > 0) {
-            socket.setSoTimeout(readTimeoutMS + additionalTimeout);
+            socket.setSoTimeout(readTimeoutMS);
         }
         try {
             ByteBuf buffer = bufferProvider.getBuffer(numBytes);

--- a/driver-core/src/main/com/mongodb/internal/connection/Stream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/Stream.java
@@ -65,18 +65,6 @@ public interface Stream extends BufferProvider {
     ByteBuf read(int numBytes, OperationContext operationContext) throws IOException;
 
     /**
-     * Read from the stream, blocking until the requested number of bytes have been read.  If supported by the implementation,
-     * adds the given additional timeout to the configured timeout for the stream.
-     *
-     * @param numBytes The number of bytes to read into the returned byte buffer
-     * @param additionalTimeout additional timeout in milliseconds to add to the configured timeout
-     * @param operationContext the operation context
-     * @return a byte buffer filled with number of bytes requested
-     * @throws IOException if there are problems reading from the stream
-     */
-    ByteBuf read(int numBytes, int additionalTimeout, OperationContext operationContext) throws IOException;
-
-    /**
      * Write each buffer in the list to the stream in order, asynchronously.  This method should return immediately, and invoke the given
      * callback on completion.
      *

--- a/driver-core/src/main/com/mongodb/internal/connection/UsageTrackingInternalConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/UsageTrackingInternalConnection.java
@@ -127,13 +127,6 @@ class UsageTrackingInternalConnection implements InternalConnection {
     }
 
     @Override
-    public <T> T receive(final Decoder<T> decoder, final OperationContext operationContext, final int additionalTimeout) {
-        T result = wrapped.receive(decoder, operationContext, additionalTimeout);
-        lastUsedAt = System.currentTimeMillis();
-        return result;
-    }
-
-    @Override
     public boolean hasMoreToCome() {
         return wrapped.hasMoreToCome();
     }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
@@ -60,6 +60,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
 
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_SUPPLIER;
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.ClusterFixture.createOperationContext;
 import static java.lang.Long.MAX_VALUE;
@@ -115,7 +116,7 @@ public class DefaultConnectionPoolTest {
                 ConnectionPoolSettings.builder()
                         .maxSize(1)
                         .build(),
-                mockSdamProvider());
+                mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
         provider.ready();
         TimeoutSettings timeoutSettings = TIMEOUT_SETTINGS.withMaxWaitTimeMS(50);
         provider.get(createOperationContext(timeoutSettings));
@@ -136,7 +137,7 @@ public class DefaultConnectionPoolTest {
                 ConnectionPoolSettings.builder()
                         .maxSize(1)
                         .build(),
-                mockSdamProvider());
+                mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
         provider.close();
 
         String expectedExceptionMessage = "The server at 127.0.0.1:27017 is no longer available";
@@ -158,7 +159,7 @@ public class DefaultConnectionPoolTest {
                         .maintenanceInitialDelay(5, MINUTES)
                         .maxConnectionLifeTime(50, MILLISECONDS)
                         .build(),
-                mockSdamProvider());
+                mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
         provider.ready();
 
         // when
@@ -179,7 +180,7 @@ public class DefaultConnectionPoolTest {
                 ConnectionPoolSettings.builder()
                         .maxSize(1)
                         .maxConnectionLifeTime(20, MILLISECONDS).build(),
-                mockSdamProvider());
+                mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
         provider.ready();
 
         // when
@@ -200,7 +201,7 @@ public class DefaultConnectionPoolTest {
                         .maxSize(1)
                         .maintenanceInitialDelay(5, MINUTES)
                         .maxConnectionIdleTime(50, MILLISECONDS).build(),
-                mockSdamProvider());
+                mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
         provider.ready();
 
         // when
@@ -222,7 +223,7 @@ public class DefaultConnectionPoolTest {
                         .maxSize(1)
                         .maintenanceInitialDelay(5, MINUTES)
                         .maxConnectionLifeTime(20, MILLISECONDS).build(),
-                mockSdamProvider());
+                mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
         provider.ready();
 
         // when
@@ -244,7 +245,7 @@ public class DefaultConnectionPoolTest {
                         .maxSize(1)
                         .maintenanceInitialDelay(5, MINUTES)
                         .maxConnectionLifeTime(20, MILLISECONDS).build(),
-                mockSdamProvider());
+                mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
         provider.ready();
 
         // when
@@ -268,7 +269,7 @@ public class DefaultConnectionPoolTest {
                         .maxConnectionLifeTime(1, MILLISECONDS)
                         .maintenanceInitialDelay(5, MINUTES)
                         .build(),
-                mockSdamProvider());
+                mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
         provider.ready();
         provider.get(OPERATION_CONTEXT).close();
 
@@ -285,7 +286,7 @@ public class DefaultConnectionPoolTest {
     void infiniteMaxSize() {
         int defaultMaxSize = ConnectionPoolSettings.builder().build().getMaxSize();
         provider = new DefaultConnectionPool(SERVER_ID, connectionFactory,
-                ConnectionPoolSettings.builder().maxSize(0).build(), EmptyProvider.instance());
+                ConnectionPoolSettings.builder().maxSize(0).build(), EmptyProvider.instance(), OPERATION_CONTEXT_SUPPLIER);
         provider.ready();
         List<InternalConnection> connections = new ArrayList<>();
         try {
@@ -321,7 +322,7 @@ public class DefaultConnectionPoolTest {
                     .maxConnectionLifeTime(limitConnectionLifeIdleTime ? 350 : 0, MILLISECONDS)
                     .maxConnectionIdleTime(limitConnectionLifeIdleTime ? 50 : 0, MILLISECONDS)
                     .build(),
-                mockSdamProvider());
+                mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
         provider.ready();
         assertUseConcurrently(provider, concurrentUsersCount,
                 checkoutSync, checkoutAsync,
@@ -356,7 +357,7 @@ public class DefaultConnectionPoolTest {
                     .addConnectionPoolListener(listener)
                     .maintenanceInitialDelay(MAX_VALUE, NANOSECONDS)
                     .build(),
-                mockSdamProvider());
+                mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
         provider.ready();
         TimeoutSettings timeoutSettings = TIMEOUT_SETTINGS.withMaxWaitTimeMS(TEST_WAIT_TIMEOUT_MILLIS);
         acquireOpenPermits(provider, DEFAULT_MAX_CONNECTING, InfiniteCheckoutEmulation.INFINITE_CALLBACK,
@@ -395,7 +396,7 @@ public class DefaultConnectionPoolTest {
                     .addConnectionPoolListener(listener)
                     .maintenanceInitialDelay(MAX_VALUE, NANOSECONDS)
                     .build(),
-                mockSdamProvider());
+                mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
         provider.ready();
         List<InternalConnection> connections = new ArrayList<>();
         for (int i = 0; i < openConnectionsCount; i++) {
@@ -453,7 +454,7 @@ public class DefaultConnectionPoolTest {
                 SERVER_ID,
                 connectionFactory,
                 ConnectionPoolSettings.builder().maxSize(1).build(),
-                mockSdamProvider());
+                mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
         provider.close();
         provider.ready();
     }
@@ -464,7 +465,7 @@ public class DefaultConnectionPoolTest {
                 SERVER_ID,
                 connectionFactory,
                 ConnectionPoolSettings.builder().maxSize(1).build(),
-                mockSdamProvider());
+                mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
         provider.ready();
         provider.close();
         provider.invalidate(null);
@@ -478,7 +479,7 @@ public class DefaultConnectionPoolTest {
                     SERVER_ID,
                     connectionFactory,
                     ConnectionPoolSettings.builder().maxSize(1).build(),
-                    mockSdamProvider());
+                    mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER);
             try {
                 readyAndInvalidateResult = cachedExecutor.submit(() -> {
                     provider.ready();

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/ServerMonitorSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/ServerMonitorSpecification.groovy
@@ -34,6 +34,7 @@ import org.bson.types.ObjectId
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_SUPPLIER
 import static com.mongodb.ClusterFixture.getClusterConnectionMode
 import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getPrimary
@@ -220,11 +221,11 @@ class ServerMonitorSpecification extends OperationFunctionalSpecification {
             }
         }
         serverMonitor = new DefaultServerMonitor(new ServerId(new ClusterId(), address), ServerSettings.builder().build(),
-                new InternalStreamConnectionFactory(SINGLE, new SocketStreamFactory(new DefaultInetAddressResolver(),
+                        new InternalStreamConnectionFactory(SINGLE, new SocketStreamFactory(new DefaultInetAddressResolver(),
                         SocketSettings.builder().connectTimeout(500, TimeUnit.MILLISECONDS).build(), getSslSettings()),
                         getCredentialWithCache(), null, null, [], LoggerSettings.builder().build(), null,
                         getServerApi()),
-                getClusterConnectionMode(), getServerApi(), SameObjectProvider.initialized(sdam))
+                getClusterConnectionMode(), getServerApi(), SameObjectProvider.initialized(sdam), OPERATION_CONTEXT_SUPPLIER)
         serverMonitor.start()
         serverMonitor
     }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_SUPPLIER;
 import static com.mongodb.ClusterFixture.getCredential;
 import static com.mongodb.ClusterFixture.getDefaultDatabaseName;
 import static com.mongodb.ClusterFixture.getPrimary;
@@ -66,9 +67,8 @@ public class SingleServerClusterTest {
                 new DefaultClusterableServerFactory(ServerSettings.builder().build(),
                         ConnectionPoolSettings.builder().maxSize(1).build(), InternalConnectionPoolSettings.builder().build(),
                         streamFactory, streamFactory, getCredential(),
-
                         LoggerSettings.builder().build(), null, null, null,
-                        Collections.emptyList(), getServerApi()));
+                        Collections.emptyList(), getServerApi(), OPERATION_CONTEXT_SUPPLIER));
     }
 
     @After

--- a/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
@@ -38,8 +38,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
+
 final class TimeoutContextTest {
 
+    @SuppressWarnings("checkstyle:methodLength")
     @TestFactory
     Collection<DynamicTest> timeoutContextTest() {
         return asList(

--- a/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
@@ -164,6 +164,10 @@ final class TimeoutContextTest {
                 )),
                 dynamicTest("withAdditionalReadTimeout works as expected", () -> assertAll(
                         () -> {
+                            TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS.withReadTimeoutMS(0));
+                            assertEquals(0L, timeoutContext.withAdditionalReadTimeout(101).getReadTimeoutMS());
+                        },
+                        () -> {
                             TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS.withReadTimeoutMS(10_000L));
                             assertEquals(10_101L, timeoutContext.withAdditionalReadTimeout(101).getReadTimeoutMS());
                         },
@@ -173,17 +177,12 @@ final class TimeoutContextTest {
                             assertEquals(Long.MAX_VALUE, timeoutContext.withAdditionalReadTimeout(101).getReadTimeoutMS());
                         },
                         () -> {
+                            TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS.withTimeoutMS(0L));
+                            assertThrows(AssertionError.class, () -> timeoutContext.withAdditionalReadTimeout(1));
+                        },
+                        () -> {
                             TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS.withTimeoutMS(10_000L));
-                            long readTimeoutMS = timeoutContext.withAdditionalReadTimeout(101).getReadTimeoutMS();
-                            assertTrue(10_101L >= readTimeoutMS && readTimeoutMS > 10_000L);
-                        },
-                        () -> {
-                            TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS.withReadTimeoutMS(0));
-                            assertEquals(0L, timeoutContext.withAdditionalReadTimeout(101).getReadTimeoutMS());
-                        },
-                        () -> {
-                            TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS.withTimeoutMS(0));
-                            assertEquals(0L, timeoutContext.withAdditionalReadTimeout(101).getReadTimeoutMS());
+                            assertThrows(AssertionError.class, () -> timeoutContext.withAdditionalReadTimeout(1));
                         }
                 )),
                 dynamicTest("Expired works as expected", () -> {

--- a/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
@@ -164,10 +164,6 @@ final class TimeoutContextTest {
                 )),
                 dynamicTest("withAdditionalReadTimeout works as expected", () -> assertAll(
                         () -> {
-                            TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS);
-                            assertEquals(101L, timeoutContext.withAdditionalReadTimeout(101).getReadTimeoutMS());
-                        },
-                        () -> {
                             TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS.withReadTimeoutMS(10_000L));
                             assertEquals(10_101L, timeoutContext.withAdditionalReadTimeout(101).getReadTimeoutMS());
                         },
@@ -180,6 +176,14 @@ final class TimeoutContextTest {
                             TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS.withTimeoutMS(10_000L));
                             long readTimeoutMS = timeoutContext.withAdditionalReadTimeout(101).getReadTimeoutMS();
                             assertTrue(10_101L >= readTimeoutMS && readTimeoutMS > 10_000L);
+                        },
+                        () -> {
+                            TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS.withReadTimeoutMS(0));
+                            assertEquals(0L, timeoutContext.withAdditionalReadTimeout(101).getReadTimeoutMS());
+                        },
+                        () -> {
+                            TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS.withTimeoutMS(0));
+                            assertEquals(0L, timeoutContext.withAdditionalReadTimeout(101).getReadTimeoutMS());
                         }
                 )),
                 dynamicTest("Expired works as expected", () -> {

--- a/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
@@ -183,6 +183,10 @@ final class TimeoutContextTest {
                         () -> {
                             TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS.withTimeoutMS(10_000L));
                             assertThrows(AssertionError.class, () -> timeoutContext.withAdditionalReadTimeout(1));
+                        },
+                        () -> {
+                            TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS);
+                            assertThrows(AssertionError.class, () -> timeoutContext.withAdditionalReadTimeout(-101));
                         }
                 )),
                 dynamicTest("Expired works as expected", () -> {

--- a/driver-core/src/test/unit/com/mongodb/internal/TimeoutSettingsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/TimeoutSettingsTest.java
@@ -55,11 +55,12 @@ final class TimeoutSettingsTest {
                             .withMaxTimeMS(111)
                             .withMaxAwaitTimeMS(11)
                             .withMaxCommitMS(999L)
+                            .withReadTimeoutMS(11_000)
                             .withWTimeoutMS(222L);
                     assertAll(
                             () -> assertEquals(30_000, timeoutSettings.getServerSelectionTimeoutMS()),
                             () -> assertEquals(10_000, timeoutSettings.getConnectTimeoutMS()),
-                            () -> assertEquals(0, timeoutSettings.getReadTimeoutMS()),
+                            () -> assertEquals(11_000, timeoutSettings.getReadTimeoutMS()),
                             () -> assertEquals(100, timeoutSettings.getTimeoutMS()),
                             () -> assertEquals(1000, timeoutSettings.getDefaultTimeoutMS()),
                             () -> assertEquals(111, timeoutSettings.getMaxTimeMS()),

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
@@ -79,6 +79,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_SUPPLIER;
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.assertions.Assertions.assertFalse;
 import static com.mongodb.internal.thread.InterruptionUtil.interruptAndCreateMongoInterruptedException;
@@ -170,7 +171,7 @@ public abstract class AbstractConnectionPoolTest {
             case UNIT: {
                 ServerId serverId = new ServerId(new ClusterId(), new ServerAddress("host1"));
                 pool = new DefaultConnectionPool(serverId, new TestInternalConnectionFactory(), settings, internalSettings,
-                        SameObjectProvider.initialized(mock(SdamServerDescriptionManager.class)));
+                        SameObjectProvider.initialized(mock(SdamServerDescriptionManager.class)), OPERATION_CONTEXT_SUPPLIER);
                 break;
             }
             case INTEGRATION: {
@@ -189,7 +190,7 @@ public abstract class AbstractConnectionPoolTest {
                                 new TestCommandListener(),
                                 ClusterFixture.getServerApi()
                         ),
-                        settings, internalSettings, sdamProvider));
+                        settings, internalSettings, sdamProvider, OPERATION_CONTEXT_SUPPLIER));
                 sdamProvider.initialize(new DefaultSdamServerDescriptionManager(mockedCluster(), serverId, mock(ServerListener.class),
                         mock(ServerMonitor.class), pool, connectionMode));
                 setFailPoint();

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerMonitorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerMonitorSpecification.groovy
@@ -39,6 +39,7 @@ import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_SUPPLIER
 import static com.mongodb.internal.connection.MessageHelper.LEGACY_HELLO_LOWER
 
 @SuppressWarnings('BusyWait')
@@ -84,7 +85,8 @@ class DefaultServerMonitorSpecification extends Specification {
             }
         }
         monitor = new DefaultServerMonitor(new ServerId(new ClusterId(), new ServerAddress()), ServerSettings.builder().build(),
-                internalConnectionFactory, ClusterConnectionMode.SINGLE, null, SameObjectProvider.initialized(sdam))
+                internalConnectionFactory, ClusterConnectionMode.SINGLE, null, SameObjectProvider.initialized(sdam),
+                OPERATION_CONTEXT_SUPPLIER)
         monitor.start()
 
         when:
@@ -167,7 +169,7 @@ class DefaultServerMonitorSpecification extends Specification {
         }
         monitor = new DefaultServerMonitor(new ServerId(new ClusterId(), new ServerAddress()),
                 ServerSettings.builder().heartbeatFrequency(1, TimeUnit.SECONDS).addServerMonitorListener(serverMonitorListener).build(),
-                internalConnectionFactory, ClusterConnectionMode.SINGLE, null, mockSdamProvider())
+                internalConnectionFactory, ClusterConnectionMode.SINGLE, null, mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER)
 
         when:
         monitor.start()
@@ -246,7 +248,7 @@ class DefaultServerMonitorSpecification extends Specification {
         }
         monitor = new DefaultServerMonitor(new ServerId(new ClusterId(), new ServerAddress()),
                 ServerSettings.builder().heartbeatFrequency(1, TimeUnit.SECONDS).addServerMonitorListener(serverMonitorListener).build(),
-                internalConnectionFactory, ClusterConnectionMode.SINGLE, null, mockSdamProvider())
+                internalConnectionFactory, ClusterConnectionMode.SINGLE, null, mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER)
 
         when:
         monitor.start()

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
@@ -257,7 +257,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
     def 'should close the stream when reading the message header throws an exception'() {
         given:
-        stream.read(16, 0, _) >> { throw new IOException('Something went wrong') }
+        stream.read(16, _) >> { throw new IOException('Something went wrong') }
 
         def connection = getOpenedConnection()
         def (buffers1, messageId1) = helper.hello()
@@ -281,7 +281,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
     def 'should throw MongoInternalException when reply header message length > max message length'() {
         given:
-        stream.read(36, 0, _) >> { helper.headerWithMessageSizeGreaterThanMax(1) }
+        stream.read(36, _) >> { helper.headerWithMessageSizeGreaterThanMax(1) }
 
         def connection = getOpenedConnection()
 
@@ -385,7 +385,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
     def 'should throw MongoInterruptedException and leave the interrupt status set when Stream.read throws InterruptedIOException'() {
         given:
-        stream.read(_, _, _) >> { throw new InterruptedIOException() }
+        stream.read(_, _) >> { throw new InterruptedIOException() }
         def connection = getOpenedConnection()
         Thread.currentThread().interrupt()
 
@@ -400,7 +400,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
     def 'should throw MongoInterruptedException and leave the interrupt status unset when Stream.read throws InterruptedIOException'() {
         given:
-        stream.read(_, _, _) >> { throw new InterruptedIOException() }
+        stream.read(_, _) >> { throw new InterruptedIOException() }
         def connection = getOpenedConnection()
 
         when:
@@ -414,7 +414,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
     def 'should throw MongoInterruptedException and leave the interrupt status set when Stream.read throws ClosedByInterruptException'() {
         given:
-        stream.read(_, _, _) >> { throw new ClosedByInterruptException() }
+        stream.read(_, _) >> { throw new ClosedByInterruptException() }
         def connection = getOpenedConnection()
         Thread.currentThread().interrupt()
 
@@ -429,7 +429,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
     def 'should throw MongoInterruptedException when Stream.read throws SocketException and the thread is interrupted'() {
         given:
-        stream.read(_, _, _) >> { throw new SocketException() }
+        stream.read(_, _) >> { throw new SocketException() }
         def connection = getOpenedConnection()
         Thread.currentThread().interrupt()
 
@@ -444,7 +444,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
     def 'should throw MongoSocketReadException when Stream.read throws SocketException and the thread is not interrupted'() {
         given:
-        stream.read(_, _, _) >> { throw new SocketException() }
+        stream.read(_, _) >> { throw new SocketException() }
         def connection = getOpenedConnection()
 
         when:
@@ -497,8 +497,8 @@ class InternalStreamConnectionSpecification extends Specification {
 
     def 'should close the stream when reading the message body throws an exception'() {
         given:
-        stream.read(16, 0, _) >> helper.defaultMessageHeader(1)
-        stream.read(90, 0, _) >> { throw new IOException('Something went wrong') }
+        stream.read(16, _) >> helper.defaultMessageHeader(1)
+        stream.read(90, _) >> { throw new IOException('Something went wrong') }
 
         def connection = getOpenedConnection()
 
@@ -560,8 +560,8 @@ class InternalStreamConnectionSpecification extends Specification {
                 null)
         def response = '{ok : 0, errmsg : "failed"}'
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
-        stream.read(16, 0, _) >> helper.messageHeader(commandMessage.getId(), response)
-        stream.read(_, 0, _) >> helper.reply(response)
+        stream.read(16, _) >> helper.messageHeader(commandMessage.getId(), response)
+        stream.read(_, _) >> helper.reply(response)
 
         when:
         connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
@@ -641,8 +641,8 @@ class InternalStreamConnectionSpecification extends Specification {
         def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
-        stream.read(16, 0, _) >> helper.defaultMessageHeader(commandMessage.getId())
-        stream.read(90, 0, _) >> helper.defaultReply()
+        stream.read(16, _) >> helper.defaultMessageHeader(commandMessage.getId())
+        stream.read(90, _) >> helper.defaultReply()
 
         when:
         connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
@@ -662,8 +662,8 @@ class InternalStreamConnectionSpecification extends Specification {
         def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
-        stream.read(16, 0, _) >> helper.defaultMessageHeader(commandMessage.getId())
-        stream.read(90, 0, _) >> helper.defaultReply()
+        stream.read(16, _) >> helper.defaultMessageHeader(commandMessage.getId())
+        stream.read(90, _) >> helper.defaultReply()
 
         when:
         connection.sendAndReceive(commandMessage, {
@@ -691,8 +691,8 @@ class InternalStreamConnectionSpecification extends Specification {
                             $clusterTime :  { clusterTime : { $timestamp : { "t" : 42, "i" : 21 } } }
                           }'''
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
-        stream.read(16, 0, _) >> helper.defaultMessageHeader(commandMessage.getId())
-        stream.read(_, 0, _) >> helper.reply(response)
+        stream.read(16, _) >> helper.defaultMessageHeader(commandMessage.getId())
+        stream.read(_, _) >> helper.reply(response)
         def sessionContext = Mock(SessionContext) {
             1 * advanceOperationTime(BsonDocument.parse(response).getTimestamp('operationTime'))
             1 * advanceClusterTime(BsonDocument.parse(response).getDocument('$clusterTime'))
@@ -771,7 +771,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
-        stream.read(16, 0, _) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
+        stream.read(16, _) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
 
         when:
         connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
@@ -791,8 +791,8 @@ class InternalStreamConnectionSpecification extends Specification {
         def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
-        stream.read(16, 0, _) >> helper.defaultMessageHeader(commandMessage.getId())
-        stream.read(90, 0, _) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
+        stream.read(16, _) >> helper.defaultMessageHeader(commandMessage.getId())
+        stream.read(90, _) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
 
         when:
         connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
@@ -813,8 +813,8 @@ class InternalStreamConnectionSpecification extends Specification {
                 null)
         def response = '{ok : 0, errmsg : "failed"}'
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
-        stream.read(16, 0, _) >> helper.messageHeader(commandMessage.getId(), response)
-        stream.read(_, 0, _) >> helper.reply(response)
+        stream.read(16, _) >> helper.messageHeader(commandMessage.getId(), response)
+        stream.read(_, _) >> helper.reply(response)
 
         when:
         connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
@@ -834,8 +834,8 @@ class InternalStreamConnectionSpecification extends Specification {
         def commandMessage = new CommandMessage(cmdNamespace, securitySensitiveCommand, fieldNameValidator, primary(), messageSettings,
                 MULTIPLE, null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
-        stream.read(16, 0, _) >> helper.defaultMessageHeader(commandMessage.getId())
-        stream.read(90, 0, _) >> helper.defaultReply()
+        stream.read(16, _) >> helper.defaultMessageHeader(commandMessage.getId())
+        stream.read(90, _) >> helper.defaultReply()
 
         when:
         connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
@@ -870,8 +870,8 @@ class InternalStreamConnectionSpecification extends Specification {
         def commandMessage = new CommandMessage(cmdNamespace, securitySensitiveCommand, fieldNameValidator, primary(), messageSettings,
                 MULTIPLE, null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
-        stream.read(16, 0, _) >> helper.defaultMessageHeader(commandMessage.getId())
-        stream.read(_, 0, _) >> helper.reply('{ok : 0, errmsg : "failed"}')
+        stream.read(16, _) >> helper.defaultMessageHeader(commandMessage.getId())
+        stream.read(_, _) >> helper.reply('{ok : 0, errmsg : "failed"}')
 
         when:
         connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/JMXConnectionPoolListenerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/JMXConnectionPoolListenerSpecification.groovy
@@ -30,6 +30,7 @@ import javax.management.ObjectName
 import java.lang.management.ManagementFactory
 
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_SUPPLIER
 
 class JMXConnectionPoolListenerSpecification extends Specification {
     private static final ServerId SERVER_ID = new ServerId(new ClusterId(), new ServerAddress('host1', 27018))
@@ -45,7 +46,7 @@ class JMXConnectionPoolListenerSpecification extends Specification {
         given:
         provider = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                 ConnectionPoolSettings.builder().minSize(0).maxSize(5)
-                        .addConnectionPoolListener(jmxListener).build(), mockSdamProvider())
+                        .addConnectionPoolListener(jmxListener).build(), mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER)
         provider.ready()
 
         when:
@@ -70,7 +71,7 @@ class JMXConnectionPoolListenerSpecification extends Specification {
         when:
         provider = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                 ConnectionPoolSettings.builder().minSize(0).maxSize(5)
-                        .addConnectionPoolListener(jmxListener).build(), mockSdamProvider())
+                        .addConnectionPoolListener(jmxListener).build(), mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER)
 
         then:
         ManagementFactory.getPlatformMBeanServer().isRegistered(
@@ -84,7 +85,7 @@ class JMXConnectionPoolListenerSpecification extends Specification {
         given:
         provider = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                 ConnectionPoolSettings.builder().minSize(0).maxSize(5)
-                        .addConnectionPoolListener(jmxListener).build(), mockSdamProvider())
+                        .addConnectionPoolListener(jmxListener).build(), mockSdamProvider(), OPERATION_CONTEXT_SUPPLIER)
 
         when:
         provider.close()

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoClients.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoClients.java
@@ -21,6 +21,7 @@ import com.mongodb.MongoClientException;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoDriverInformation;
 import com.mongodb.connection.TransportSettings;
+import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.connection.AsynchronousSocketChannelStreamFactoryFactory;
 import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.DefaultClusterFactory;
@@ -148,11 +149,10 @@ public final class MongoClients {
                                          final StreamFactory streamFactory, final StreamFactory heartbeatStreamFactory) {
         notNull("settings", settings);
         return new DefaultClusterFactory().createCluster(settings.getClusterSettings(), settings.getServerSettings(),
-                settings.getConnectionPoolSettings(),
-                InternalConnectionPoolSettings.builder().prestartAsyncWorkManager(true).build(),
-                streamFactory, heartbeatStreamFactory, settings.getCredential(), settings.getLoggerSettings(),
-                getCommandListener(settings.getCommandListeners()), settings.getApplicationName(), mongoDriverInformation,
-                settings.getCompressorList(), settings.getServerApi(), settings.getDnsClient());
+                settings.getConnectionPoolSettings(), InternalConnectionPoolSettings.builder().prestartAsyncWorkManager(true).build(),
+                TimeoutSettings.create(settings).connectionOnly(), streamFactory, heartbeatStreamFactory, settings.getCredential(),
+                settings.getLoggerSettings(), getCommandListener(settings.getCommandListeners()), settings.getApplicationName(),
+                mongoDriverInformation, settings.getCompressorList(), settings.getServerApi(), settings.getDnsClient());
     }
 
     private static MongoDriverInformation wrapMongoDriverInformation(@Nullable final MongoDriverInformation mongoDriverInformation) {

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoClientImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoClientImpl.java
@@ -223,7 +223,7 @@ public final class MongoClientImpl implements MongoClient {
         notNull("settings", settings);
         return new DefaultClusterFactory().createCluster(settings.getClusterSettings(), settings.getServerSettings(),
                 settings.getConnectionPoolSettings(), InternalConnectionPoolSettings.builder().build(),
-                getStreamFactory(settings, false), getStreamFactory(settings, true),
+                TimeoutSettings.create(settings).connectionOnly(), getStreamFactory(settings, false), getStreamFactory(settings, true),
                 settings.getCredential(), settings.getLoggerSettings(), getCommandListener(settings.getCommandListeners()),
                 settings.getApplicationName(), mongoDriverInformation, settings.getCompressorList(), settings.getServerApi(),
                 settings.getDnsClient());


### PR DESCRIPTION
Added Operation Context to DefaultClusterFactory. So that the DefaultServerMonitor and DefaultConnectionPool have access to an OperationContext.

Removed additionalTimeout from API use OperationContext instead.

JAVA-4063 JAVA-4056