### PR TITLE
Handle kotlin / JVM erasure of types

### DIFF
--- a/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/DataClassCodec.kt
+++ b/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/DataClassCodec.kt
@@ -23,12 +23,14 @@ import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
+import kotlin.reflect.KTypeProjection
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.findAnnotations
 import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.javaType
+import kotlin.reflect.jvm.jvmErasure
 import org.bson.BsonReader
 import org.bson.BsonType
 import org.bson.BsonWriter
@@ -199,7 +201,7 @@ internal data class DataClassCodec<T : Any>(
                     codecRegistry.getCodec(
                         kParameter,
                         (kParameter.type.classifier as KClass<Any>).javaObjectType,
-                        kParameter.type.arguments.mapNotNull { typeMap[it.type] ?: it.type?.javaType }.toList())
+                        kParameter.type.arguments.mapNotNull { typeMap[it.type] ?: computeJavaType(it) }.toList())
                 }
                 is KTypeParameter -> {
                     when (val pType = typeMap[kParameter.type] ?: kParameter.type.javaType) {
@@ -217,6 +219,13 @@ internal data class DataClassCodec<T : Any>(
             }
                 ?: throw CodecConfigurationException(
                     "Could not find codec for ${kParameter.name} with type ${kParameter.type}")
+        }
+
+        private fun computeJavaType(kTypeProjection: KTypeProjection): Type? {
+            val javaType: Type = kTypeProjection.type?.javaType!!
+            return if (javaType == Any().javaClass) {
+                kTypeProjection.type?.jvmErasure?.javaObjectType
+            } else javaType
         }
 
         @Suppress("UNCHECKED_CAST")

--- a/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/DataClassCodec.kt
+++ b/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/DataClassCodec.kt
@@ -223,7 +223,7 @@ internal data class DataClassCodec<T : Any>(
 
         private fun computeJavaType(kTypeProjection: KTypeProjection): Type? {
             val javaType: Type = kTypeProjection.type?.javaType!!
-            return if (javaType == Any().javaClass) {
+            return if (javaType == Any::class.java) {
                 kTypeProjection.type?.jvmErasure?.javaObjectType
             } else javaType
         }

--- a/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/samples/DataClasses.kt
+++ b/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/samples/DataClasses.kt
@@ -15,6 +15,7 @@
  */
 package org.bson.codecs.kotlin.samples
 
+import kotlin.time.Duration
 import org.bson.BsonDocument
 import org.bson.BsonMaxKey
 import org.bson.BsonType
@@ -159,3 +160,5 @@ data class DataClassWithFailingInit(val id: String) {
 }
 
 data class DataClassWithSequence(val value: Sequence<String>)
+
+data class DataClassWithJVMErasure(val duration: Duration, val ints: List<Int>)


### PR DESCRIPTION
It has been observed that the Kotlin can behave
differently during reflection and return Type<Object> where normally it would report the correct type.

Checking for erasure allows the bson-kotlin library to handle these cases and return the expected type.

JAVA-5292