### PR TITLE
JAVA-5311

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -227,24 +227,29 @@ functions:
       type: test
       params:
         working_dir: "src"
+        env:
+          AWS_ACCESS_KEY_ID: ${aws_access_key_id}
+          AWS_SECRET_ACCESS_KEY: ${aws_secret_access_key}
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: ${aws_access_key_id}
+          AZURE_TENANT_ID: ${azure_tenant_id}
+          AZURE_CLIENT_ID: ${azure_client_id}
+          AZURE_CLIENT_SECRET: ${azure_client_secret}
+          GCP_EMAIL: ${gcp_email}
+          GCP_PRIVATE_KEY: ${gcp_private_key}
+          AZUREKMS_KEY_VAULT_ENDPOINT: ${testazurekms_keyvaultendpoint}
+          AZUREKMS_KEY_NAME: ${testazurekms_keyname}
         script: |
           ${PREPARE_SHELL}
-          export AWS_ACCESS_KEY_ID=${aws_access_key_id}
-          export AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}
-          export AWS_DEFAULT_REGION=us-east-1
+          
           . ${DRIVERS_TOOLS}/.evergreen/csfle/set-temp-creds.sh
+          
           AUTH="${AUTH}" SSL="${SSL}" MONGODB_URI="${MONGODB_URI}" SAFE_FOR_MULTI_MONGOS="${SAFE_FOR_MULTI_MONGOS}" TOPOLOGY="${TOPOLOGY}" \
-          COMPRESSOR="${COMPRESSOR}" JAVA_VERSION="${JAVA_VERSION}" \
-          AWS_ACCESS_KEY_ID=${aws_access_key_id} AWS_SECRET_ACCESS_KEY=${aws_secret_access_key} \
+          COMPRESSOR="${COMPRESSOR}" JAVA_VERSION="${JAVA_VERSION}" REQUIRE_API_VERSION=${REQUIRE_API_VERSION} \
           AWS_TEMP_ACCESS_KEY_ID=$CSFLE_AWS_TEMP_ACCESS_KEY_ID \
           AWS_TEMP_SECRET_ACCESS_KEY=$CSFLE_AWS_TEMP_SECRET_ACCESS_KEY \
           AWS_TEMP_SESSION_TOKEN=$CSFLE_AWS_TEMP_SESSION_TOKEN \
-          AZURE_TENANT_ID=${azure_tenant_id} AZURE_CLIENT_ID=${azure_client_id} AZURE_CLIENT_SECRET=${azure_client_secret} \
-          GCP_EMAIL=${gcp_email} GCP_PRIVATE_KEY=${gcp_private_key} \
-          AZUREKMS_KEY_VAULT_ENDPOINT=${testazurekms_keyvaultendpoint} \
-          AZUREKMS_KEY_NAME=${testazurekms_keyname} \
-          REQUIRE_API_VERSION=${REQUIRE_API_VERSION} \
-          CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}" \
+          CRYPT_SHARED_LIB_PATH=${CRYPT_SHARED_LIB_PATH} \
           .evergreen/run-tests.sh
 
   "run load-balancer tests":
@@ -795,22 +800,25 @@ functions:
       type: test
       params:
         working_dir: "src"
+        env:
+          AWS_ACCESS_KEY_ID: ${aws_access_key_id}
+          AWS_SECRET_ACCESS_KEY: ${aws_secret_access_key}
+          AWS_DEFAULT_REGION: us-east-1
+          AZURE_TENANT_ID: ${azure_tenant_id}
+          AZURE_CLIENT_ID: ${azure_client_id}
+          AZURE_CLIENT_SECRET: ${azure_client_secret}
+          GCP_EMAIL: ${gcp_email}
+          GCP_PRIVATE_KEY: ${gcp_private_key}
+          AZUREKMS_KEY_VAULT_ENDPOINT: ${testazurekms_keyvaultendpoint}
+          AZUREKMS_KEY_NAME: ${testazurekms_keyname}
         script: |
           ${PREPARE_SHELL}
-          export AWS_ACCESS_KEY_ID=${aws_access_key_id}
-          export AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}
-          export AWS_DEFAULT_REGION=us-east-1
           . ${DRIVERS_TOOLS}/.evergreen/csfle/set-temp-creds.sh
-          MONGODB_URI="${MONGODB_URI}" \
-          JAVA_VERSION="${JAVA_VERSION}" \
-          AWS_ACCESS_KEY_ID=${aws_access_key_id} AWS_SECRET_ACCESS_KEY=${aws_secret_access_key} \
+          
+          MONGODB_URI="${MONGODB_URI}" JAVA_VERSION="${JAVA_VERSION}" \
           AWS_TEMP_ACCESS_KEY_ID=$CSFLE_AWS_TEMP_ACCESS_KEY_ID \
           AWS_TEMP_SECRET_ACCESS_KEY=$CSFLE_AWS_TEMP_SECRET_ACCESS_KEY \
           AWS_TEMP_SESSION_TOKEN=$CSFLE_AWS_TEMP_SESSION_TOKEN \
-          AZURE_TENANT_ID=${azure_tenant_id} AZURE_CLIENT_ID=${azure_client_id} AZURE_CLIENT_SECRET=${azure_client_secret} \
-          GCP_EMAIL=${gcp_email} GCP_PRIVATE_KEY=${gcp_private_key} \
-          AZUREKMS_KEY_VAULT_ENDPOINT=${testazurekms_keyvaultendpoint} \
-          AZUREKMS_KEY_NAME=${testazurekms_keyname} \
           .evergreen/run-csfle-tests-with-mongocryptd.sh
 
   "publish snapshot":
@@ -818,18 +826,26 @@ functions:
       type: test
       params:
         working_dir: "src"
+        env:
+          NEXUS_USERNAME: ${nexus_username}
+          NEXUS_PASSWORD: ${nexus_password}
+          SIGNING_PASSWORD: ${signing_password}
+          SIGNING_KEY: ${gpg_ascii_armored}
         script: |
-          # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
-          RELEASE=false PROJECT_DIRECTORY=${PROJECT_DIRECTORY} NEXUS_USERNAME=${nexus_username} NEXUS_PASSWORD=${nexus_password} SIGNING_PASSWORD=${signing_password} SIGNING_KEY="${gpg_ascii_armored}" .evergreen/publish.sh
+          RELEASE=false PROJECT_DIRECTORY=${PROJECT_DIRECTORY} .evergreen/publish.sh
 
   "publish release":
     - command: shell.exec
       type: test
       params:
         working_dir: "src"
+        env:
+          NEXUS_USERNAME: ${nexus_username}
+          NEXUS_PASSWORD: ${nexus_password}
+          SIGNING_PASSWORD: ${signing_password}
+          SIGNING_KEY: ${gpg_ascii_armored}
         script: |
-          # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
-          RELEASE=true PROJECT_DIRECTORY=${PROJECT_DIRECTORY} NEXUS_USERNAME=${nexus_username} NEXUS_PASSWORD=${nexus_password} SIGNING_PASSWORD=${signing_password} SIGNING_KEY="${gpg_ascii_armored}" .evergreen/publish.sh
+          RELEASE=true PROJECT_DIRECTORY=${PROJECT_DIRECTORY} .evergreen/publish.sh
 
   "cleanup":
     - command: shell.exec

--- a/.evergreen/run-csfle-tests-with-mongocryptd.sh
+++ b/.evergreen/run-csfle-tests-with-mongocryptd.sh
@@ -49,18 +49,30 @@ provision_ssl () {
 provision_ssl
 
 echo "Running tests with Java ${JAVA_VERSION}"
+
+# Append to gradle.properties so that they are not echoed below on the gradlew  command line
+cat <<EOF >> ./gradle.properties
+systemProp.org.mongodb.test.fle.on.demand.credential.test.failure.enabled=true
+systemProp.org.mongodb.test.fle.on.demand.credential.test.azure.keyVaultEndpoint=${AZUREKMS_KEY_VAULT_ENDPOINT}
+systemProp.org.mongodb.test.fle.on.demand.credential.test.azure.keyName=${AZUREKMS_KEY_NAME}
+systemProp.org.mongodb.test.awsAccessKeyId=${AWS_ACCESS_KEY_ID}
+systemProp.org.mongodb.test.awsSecretAccessKey=${AWS_SECRET_ACCESS_KEY}
+systemProp.org.mongodb.test.tmpAwsAccessKeyId=${AWS_TEMP_ACCESS_KEY_ID}
+systemProp.org.mongodb.test.tmpAwsSecretAccessKey=${AWS_TEMP_SECRET_ACCESS_KEY}
+systemProp.org.mongodb.test.tmpAwsSessionToken=${AWS_TEMP_SESSION_TOKEN}
+systemProp.org.mongodb.test.azureTenantId=${AZURE_TENANT_ID}
+systemProp.org.mongodb.test.azureClientId=${AZURE_CLIENT_ID}
+systemProp.org.mongodb.test.azureClientSecret=${AZURE_CLIENT_SECRET}
+systemProp.org.mongodb.test.gcpEmail=${GCP_EMAIL}
+systemProp.org.mongodb.test.gcpPrivateKey=${GCP_PRIVATE_KEY}
+systemProp.org.mongodb.test.crypt.shared.lib.path=${CRYPT_SHARED_LIB_PATH}
+EOF
+
 ./gradlew -version
 
 # By not specifying the path to the `crypt_shared` via the `org.mongodb.test.crypt.shared.lib.path` Java system property,
 # we force the driver to start `mongocryptd` instead of loading and using `crypt_shared`.
 ./gradlew -PjavaVersion=${JAVA_VERSION} -Dorg.mongodb.test.uri=${MONGODB_URI} \
-      -Dorg.mongodb.test.fle.on.demand.credential.test.failure.enabled="true" \
-      -Dorg.mongodb.test.fle.on.demand.credential.test.azure.keyVaultEndpoint="${AZUREKMS_KEY_VAULT_ENDPOINT}" \
-      -Dorg.mongodb.test.fle.on.demand.credential.test.azure.keyName="${AZUREKMS_KEY_NAME}" \
-      -Dorg.mongodb.test.awsAccessKeyId=${AWS_ACCESS_KEY_ID} -Dorg.mongodb.test.awsSecretAccessKey=${AWS_SECRET_ACCESS_KEY} \
-      -Dorg.mongodb.test.tmpAwsAccessKeyId=${AWS_TEMP_ACCESS_KEY_ID} -Dorg.mongodb.test.tmpAwsSecretAccessKey=${AWS_TEMP_SECRET_ACCESS_KEY} -Dorg.mongodb.test.tmpAwsSessionToken=${AWS_TEMP_SESSION_TOKEN} \
-      -Dorg.mongodb.test.azureTenantId=${AZURE_TENANT_ID} -Dorg.mongodb.test.azureClientId=${AZURE_CLIENT_ID} -Dorg.mongodb.test.azureClientSecret=${AZURE_CLIENT_SECRET} \
-      -Dorg.mongodb.test.gcpEmail=${GCP_EMAIL} -Dorg.mongodb.test.gcpPrivateKey=${GCP_PRIVATE_KEY} \
       ${GRADLE_EXTRA_VARS} \
       --stacktrace --info --continue \
       driver-legacy:test \

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -134,6 +134,24 @@ echo "Running $AUTH tests over $SSL for $TOPOLOGY and connecting to $MONGODB_URI
 echo "Running tests with Java ${JAVA_VERSION}"
 ./gradlew -version
 
+# Append to gradle.properties so that they are not echoed below on the gradlew  command line
+cat <<EOF >> ./gradle.properties
+systemProp.org.mongodb.test.fle.on.demand.credential.test.failure.enabled=true
+systemProp.org.mongodb.test.fle.on.demand.credential.test.azure.keyVaultEndpoint=${AZUREKMS_KEY_VAULT_ENDPOINT}
+systemProp.org.mongodb.test.fle.on.demand.credential.test.azure.keyName=${AZUREKMS_KEY_NAME}
+systemProp.org.mongodb.test.awsAccessKeyId=${AWS_ACCESS_KEY_ID}
+systemProp.org.mongodb.test.awsSecretAccessKey=${AWS_SECRET_ACCESS_KEY}
+systemProp.org.mongodb.test.tmpAwsAccessKeyId=${AWS_TEMP_ACCESS_KEY_ID}
+systemProp.org.mongodb.test.tmpAwsSecretAccessKey=${AWS_TEMP_SECRET_ACCESS_KEY}
+systemProp.org.mongodb.test.tmpAwsSessionToken=${AWS_TEMP_SESSION_TOKEN}
+systemProp.org.mongodb.test.azureTenantId=${AZURE_TENANT_ID}
+systemProp.org.mongodb.test.azureClientId=${AZURE_CLIENT_ID}
+systemProp.org.mongodb.test.azureClientSecret=${AZURE_CLIENT_SECRET}
+systemProp.org.mongodb.test.gcpEmail=${GCP_EMAIL}
+systemProp.org.mongodb.test.gcpPrivateKey=${GCP_PRIVATE_KEY}
+systemProp.org.mongodb.test.crypt.shared.lib.path=${CRYPT_SHARED_LIB_PATH}
+EOF
+
 if [ "$SLOW_TESTS_ONLY" == "true" ]; then
     ./gradlew -PjavaVersion=${JAVA_VERSION} -Dorg.mongodb.test.uri=${MONGODB_URI} \
               ${MULTI_MONGOS_URI_SYSTEM_PROPERTY} ${GRADLE_EXTRA_VARS} ${ASYNC_TYPE} \
@@ -141,15 +159,7 @@ if [ "$SLOW_TESTS_ONLY" == "true" ]; then
               --stacktrace --info testSlowOnly
 else
     ./gradlew -PjavaVersion=${JAVA_VERSION} -Dorg.mongodb.test.uri=${MONGODB_URI} \
-              -Dorg.mongodb.test.fle.on.demand.credential.test.failure.enabled="true" \
-              -Dorg.mongodb.test.fle.on.demand.credential.test.azure.keyVaultEndpoint="${AZUREKMS_KEY_VAULT_ENDPOINT}" \
-              -Dorg.mongodb.test.fle.on.demand.credential.test.azure.keyName="${AZUREKMS_KEY_NAME}" \
-              -Dorg.mongodb.test.awsAccessKeyId=${AWS_ACCESS_KEY_ID} -Dorg.mongodb.test.awsSecretAccessKey=${AWS_SECRET_ACCESS_KEY} \
-              -Dorg.mongodb.test.tmpAwsAccessKeyId=${AWS_TEMP_ACCESS_KEY_ID} -Dorg.mongodb.test.tmpAwsSecretAccessKey=${AWS_TEMP_SECRET_ACCESS_KEY} -Dorg.mongodb.test.tmpAwsSessionToken=${AWS_TEMP_SESSION_TOKEN} \
-              -Dorg.mongodb.test.azureTenantId=${AZURE_TENANT_ID} -Dorg.mongodb.test.azureClientId=${AZURE_CLIENT_ID} -Dorg.mongodb.test.azureClientSecret=${AZURE_CLIENT_SECRET} \
-              -Dorg.mongodb.test.gcpEmail=${GCP_EMAIL} -Dorg.mongodb.test.gcpPrivateKey=${GCP_PRIVATE_KEY} \
               ${MULTI_MONGOS_URI_SYSTEM_PROPERTY} ${API_VERSION} ${GRADLE_EXTRA_VARS} ${ASYNC_TYPE} \
-              -Dorg.mongodb.test.crypt.shared.lib.path=${CRYPT_SHARED_LIB_PATH} \
               ${JAVA_SYSPROP_NETTY_SSL_PROVIDER} \
               --stacktrace --info --continue test
 fi


### PR DESCRIPTION
This is generating a new evergreen validation warning, not sure why:

```
WARNING: strict unmarshalling YAML: load project error(s): error unmarshalling yaml strict: input fields may not match the command fields: yaml: unmarshal errors:
  line 226: cannot unmarshal !!seq into struct { Function string "yaml:\"func,omitempty\" bson:\"func,omitempty\""; Type string "yaml:\"type,omitempty\" bson:\"type,omitempty\""; DisplayName string "yaml:\"display_name,omitempty\" bson:\"display_name,omitempty\""; Command string "yaml:\"command,omitempty\" bson:\"command,omitempty\""; Variants []string "yaml:\"variants,omitempty\" bson:\"variants,omitempty\""; TimeoutSecs int "yaml:\"timeout_secs,omitempty\" bson:\"timeout_secs,omitempty\""; Params map[string]interface {} "yaml:\"params,omitempty\" bson:\"params,omitempty\""; ParamsYAML string "yaml:\"params_yaml,omitempty\" bson:\"params_yaml,omitempty\""; Vars map[string]string "yaml:\"vars,omitempty\" bson:\"vars,omitempty\""; RetryOnFailure bool "yaml:\"retry_on_failure,omitempty\" bson:\"retry_on_failure,omitempty\""; Loggers *model.LoggerConfig "yaml:\"loggers,omitempty\" bson:\"loggers,omitempty\"" }
```