### PR TITLE
Remove TimeoutSettings from Operations

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/AbortTransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AbortTransactionOperation.java
@@ -18,7 +18,6 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.Function;
 import com.mongodb.WriteConcern;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 
@@ -32,8 +31,8 @@ import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreat
 public class AbortTransactionOperation extends TransactionOperation {
     private BsonDocument recoveryToken;
 
-    public AbortTransactionOperation(final TimeoutSettings timeoutSettings, final WriteConcern writeConcern) {
-        super(timeoutSettings, writeConcern);
+    public AbortTransactionOperation(final WriteConcern writeConcern) {
+        super(writeConcern);
     }
 
     public AbortTransactionOperation recoveryToken(@Nullable final BsonDocument recoveryToken) {

--- a/driver-core/src/main/com/mongodb/internal/operation/AbstractWriteSearchIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AbstractWriteSearchIndexOperation.java
@@ -19,7 +19,6 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -39,17 +38,10 @@ import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErr
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 abstract class AbstractWriteSearchIndexOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
 
-    AbstractWriteSearchIndexOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace) {
-        this.timeoutSettings = timeoutSettings;
+    AbstractWriteSearchIndexOperation(final MongoNamespace namespace) {
         this.namespace = namespace;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateOperation.java
@@ -20,7 +20,6 @@ import com.mongodb.ExplainVerbosity;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.cursor.TimeoutMode;
 import com.mongodb.client.model.Collation;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
@@ -44,14 +43,13 @@ import static com.mongodb.internal.operation.ServerVersionHelper.MIN_WIRE_VERSIO
 public class AggregateOperation<T> implements AsyncExplainableReadOperation<AsyncBatchCursor<T>>, ExplainableReadOperation<BatchCursor<T>> {
     private final AggregateOperationImpl<T> wrapped;
 
-    public AggregateOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final List<BsonDocument> pipeline, final Decoder<T> decoder) {
-        this(timeoutSettings, namespace, pipeline, decoder, AggregationLevel.COLLECTION);
+    public AggregateOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline, final Decoder<T> decoder) {
+        this(namespace, pipeline, decoder, AggregationLevel.COLLECTION);
     }
 
-    public AggregateOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final List<BsonDocument> pipeline, final Decoder<T> decoder, final AggregationLevel aggregationLevel) {
-        this.wrapped = new AggregateOperationImpl<>(timeoutSettings, namespace, pipeline, decoder, aggregationLevel);
+    public AggregateOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline, final Decoder<T> decoder,
+            final AggregationLevel aggregationLevel) {
+        this.wrapped = new AggregateOperationImpl<>(namespace, pipeline, decoder, aggregationLevel);
     }
 
     public List<BsonDocument> getPipeline() {
@@ -131,11 +129,6 @@ public class AggregateOperation<T> implements AsyncExplainableReadOperation<Asyn
         return this;
     }
 
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return wrapped.getTimeoutSettings();
-    }
-
     public AggregateOperation<T> timeoutMode(@Nullable final TimeoutMode timeoutMode) {
         wrapped.timeoutMode(timeoutMode);
         return this;
@@ -161,7 +154,7 @@ public class AggregateOperation<T> implements AsyncExplainableReadOperation<Asyn
     }
 
     <R> CommandReadOperation<R> createExplainableOperation(@Nullable final ExplainVerbosity verbosity, final Decoder<R> resultDecoder) {
-        return new CommandReadOperation<>(wrapped.getTimeoutSettings(), getNamespace().getDatabaseName(),
+        return new CommandReadOperation<>(getNamespace().getDatabaseName(),
                 (operationContext, serverDescription, connectionDescription) ->
                         asExplainCommand(wrapped.getCommand(operationContext, MIN_WIRE_VERSION), verbosity), resultDecoder);
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
@@ -45,7 +45,6 @@ import static com.mongodb.internal.operation.AsyncOperationHelper.executeRetryab
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.OperationHelper.addMaxTimeMSToNonTailableCursor;
-import static com.mongodb.internal.operation.OperationHelper.validateTimeoutMode;
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.CommandReadTransformer;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeRetryableRead;
@@ -191,7 +190,6 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
     }
 
     BsonDocument getCommand(final OperationContext operationContext, final int maxWireVersion) {
-        validateTimeoutMode(operationContext, timeoutMode);
         BsonDocument commandDocument = new BsonDocument("aggregate", aggregateTarget.create());
         appendReadConcernToCommand(operationContext.getSessionContext(), maxWireVersion, commandDocument);
         commandDocument.put("pipeline", pipelineCreator.create());

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
@@ -19,7 +19,6 @@ package com.mongodb.internal.operation;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.cursor.TimeoutMode;
 import com.mongodb.client.model.Collation;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
@@ -46,6 +45,7 @@ import static com.mongodb.internal.operation.AsyncOperationHelper.executeRetryab
 import static com.mongodb.internal.operation.CommandOperationHelper.CommandCreator;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.OperationHelper.addMaxTimeMSToNonTailableCursor;
+import static com.mongodb.internal.operation.OperationHelper.validateTimeoutMode;
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand;
 import static com.mongodb.internal.operation.SyncOperationHelper.CommandReadTransformer;
 import static com.mongodb.internal.operation.SyncOperationHelper.executeRetryableRead;
@@ -55,7 +55,6 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
     private static final String CURSOR = "cursor";
     private static final String FIRST_BATCH = "firstBatch";
     private static final List<String> FIELD_NAMES_WITH_RESULT = Arrays.asList(RESULT, FIRST_BATCH);
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private final List<BsonDocument> pipeline;
     private final Decoder<T> decoder;
@@ -71,18 +70,17 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
     private BsonDocument variables;
     private TimeoutMode timeoutMode;
 
-    AggregateOperationImpl(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
+    AggregateOperationImpl(final MongoNamespace namespace,
             final List<BsonDocument> pipeline, final Decoder<T> decoder, final AggregationLevel aggregationLevel) {
-        this(timeoutSettings, namespace, pipeline, decoder,
+        this(namespace, pipeline, decoder,
                 defaultAggregateTarget(notNull("aggregationLevel", aggregationLevel),
                         notNull("namespace", namespace).getCollectionName()),
                 defaultPipelineCreator(pipeline));
     }
 
-    AggregateOperationImpl(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
+    AggregateOperationImpl(final MongoNamespace namespace,
             final List<BsonDocument> pipeline, final Decoder<T> decoder, final AggregateTarget aggregateTarget,
             final PipelineCreator pipelineCreator) {
-        this.timeoutSettings = timeoutSettings;
         this.namespace = notNull("namespace", namespace);
         this.pipeline = notNull("pipeline", pipeline);
         this.decoder = notNull("decoder", decoder);
@@ -158,13 +156,7 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
         return hint;
     }
 
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
-    }
-
     public AggregateOperationImpl<T> timeoutMode(@Nullable final TimeoutMode timeoutMode) {
-        isTrueArgument("timeoutMode requires timeoutMS.", timeoutMode == null || timeoutSettings.getTimeoutMS() != null);
         if (timeoutMode != null) {
             this.timeoutMode = timeoutMode;
         }
@@ -199,6 +191,7 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
     }
 
     BsonDocument getCommand(final OperationContext operationContext, final int maxWireVersion) {
+        validateTimeoutMode(operationContext, timeoutMode);
         BsonDocument commandDocument = new BsonDocument("aggregate", aggregateTarget.create());
         appendReadConcernToCommand(operationContext.getSessionContext(), maxWireVersion, commandDocument);
         commandDocument.put("pipeline", pipelineCreator.create());
@@ -229,14 +222,14 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
 
     private CommandReadTransformer<BsonDocument, CommandBatchCursor<T>> transformer() {
         return (result, source, connection) ->
-                new CommandBatchCursor<>(getTimeoutMode(), result, batchSize != null ? batchSize : 0, getMaxTimeForCursor(), decoder,
-                        comment, source, connection);
+                new CommandBatchCursor<>(getTimeoutMode(), result, batchSize != null ? batchSize : 0,
+                        getMaxTimeForCursor(source.getOperationContext()), decoder, comment, source, connection);
     }
 
     private CommandReadTransformerAsync<BsonDocument, AsyncBatchCursor<T>> asyncTransformer() {
         return (result, source, connection) ->
-            new AsyncCommandBatchCursor<>(getTimeoutMode(), result, batchSize != null ? batchSize : 0, getMaxTimeForCursor(), decoder,
-                    comment, source, connection);
+            new AsyncCommandBatchCursor<>(getTimeoutMode(), result, batchSize != null ? batchSize : 0,
+                    getMaxTimeForCursor(source.getOperationContext()), decoder, comment, source, connection);
     }
 
     private TimeoutMode getTimeoutMode() {
@@ -247,8 +240,8 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
         return localTimeoutMode;
     }
 
-    private long getMaxTimeForCursor() {
-        return timeoutSettings.getMaxAwaitTimeMS();
+    private long getMaxTimeForCursor(final OperationContext operationContext) {
+        return operationContext.getTimeoutContext().getMaxAwaitTimeMS();
     }
 
     interface AggregateTarget {

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateToCollectionOperation.java
@@ -22,7 +22,6 @@ import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.cursor.TimeoutMode;
 import com.mongodb.client.model.Collation;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
 import com.mongodb.internal.binding.ReadBinding;
@@ -57,7 +56,6 @@ import static com.mongodb.internal.operation.WriteConcernHelper.throwOnWriteConc
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class AggregateToCollectionOperation implements AsyncReadOperation<Void>, ReadOperation<Void> {
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private final List<BsonDocument> pipeline;
     private final WriteConcern writeConcern;
@@ -71,15 +69,13 @@ public class AggregateToCollectionOperation implements AsyncReadOperation<Void>,
     private BsonValue hint;
     private BsonDocument variables;
 
-    public AggregateToCollectionOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final List<BsonDocument> pipeline, final ReadConcern readConcern, final WriteConcern writeConcern) {
-        this(timeoutSettings, namespace, pipeline, readConcern, writeConcern, AggregationLevel.COLLECTION);
+    public AggregateToCollectionOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline, final ReadConcern readConcern,
+            final WriteConcern writeConcern) {
+        this(namespace, pipeline, readConcern, writeConcern, AggregationLevel.COLLECTION);
     }
 
-    public AggregateToCollectionOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final List<BsonDocument> pipeline, @Nullable final ReadConcern readConcern, @Nullable final WriteConcern writeConcern,
-            final AggregationLevel aggregationLevel) {
-        this.timeoutSettings = timeoutSettings;
+    public AggregateToCollectionOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline,
+            @Nullable final ReadConcern readConcern, @Nullable final WriteConcern writeConcern, final AggregationLevel aggregationLevel) {
         this.namespace = notNull("namespace", namespace);
         this.pipeline = notNull("pipeline", pipeline);
         this.writeConcern = writeConcern;
@@ -154,11 +150,6 @@ public class AggregateToCollectionOperation implements AsyncReadOperation<Void>,
     public AggregateToCollectionOperation timeoutMode(@Nullable final TimeoutMode timeoutMode) {
         isTrueArgument("timeoutMode cannot be ITERATION.", timeoutMode == null || timeoutMode.equals(TimeoutMode.CURSOR_LIFETIME));
         return this;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
@@ -62,18 +62,21 @@ import org.bson.conversions.Bson;
 import java.util.List;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public final class AsyncOperations<TDocument> {
     private final Operations<TDocument> operations;
+    private final TimeoutSettings timeoutSettings;
 
     public AsyncOperations(final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
             final CodecRegistry codecRegistry, final ReadConcern readConcern, final WriteConcern writeConcern,
             final boolean retryWrites, final boolean retryReads, final TimeoutSettings timeoutSettings) {
         this.operations = new Operations<>(namespace, documentClass, readPreference, codecRegistry, readConcern, writeConcern,
-                retryWrites, retryReads, timeoutSettings);
+                retryWrites, retryReads);
+        this.timeoutSettings = timeoutSettings;
     }
 
     public MongoNamespace getNamespace() {
@@ -100,6 +103,10 @@ public final class AsyncOperations<TDocument> {
         return operations.getWriteConcern();
     }
 
+    public TimeoutSettings getTimeoutSettings() {
+        return timeoutSettings;
+    }
+
     public boolean isRetryWrites() {
         return operations.isRetryWrites();
     }
@@ -108,8 +115,42 @@ public final class AsyncOperations<TDocument> {
         return operations.isRetryReads();
     }
 
-    public TimeoutSettings getTimeoutSettings() {
-        return operations.getTimeoutSettings();
+    public TimeoutSettings createTimeoutSettings(final long maxTimeMS) {
+        return timeoutSettings.withMaxTimeMS(maxTimeMS);
+    }
+
+    public TimeoutSettings createTimeoutSettings(final long maxTimeMS, final long maxAwaitTimeMS) {
+        return timeoutSettings.withMaxTimeAndMaxAwaitTimeMS(maxTimeMS, maxAwaitTimeMS);
+    }
+
+    @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final CountOptions options) {
+        return createTimeoutSettings(options.getMaxTime(MILLISECONDS));
+    }
+
+    @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final EstimatedDocumentCountOptions options) {
+        return createTimeoutSettings(options.getMaxTime(MILLISECONDS));
+    }
+
+    @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final FindOptions options) {
+        return timeoutSettings.withMaxTimeAndMaxAwaitTimeMS(options.getMaxTime(MILLISECONDS), options.getMaxAwaitTime(MILLISECONDS));
+    }
+
+    @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final FindOneAndDeleteOptions options) {
+        return createTimeoutSettings(options.getMaxTime(MILLISECONDS));
+    }
+
+    @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final FindOneAndReplaceOptions options) {
+        return createTimeoutSettings(options.getMaxTime(MILLISECONDS));
+    }
+
+    @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final FindOneAndUpdateOptions options) {
+        return timeoutSettings.withMaxTimeMS(options.getMaxTime(MILLISECONDS));
     }
 
     public AsyncReadOperation<Long> countDocuments(final Bson filter, final CountOptions options) {
@@ -136,14 +177,13 @@ public final class AsyncOperations<TDocument> {
     }
 
     public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> distinct(final String fieldName, final Bson filter,
-            final Class<TResult> resultClass, final long maxTimeMS,
-            final Collation collation, final BsonValue comment) {
-        return operations.distinct(fieldName, filter, resultClass, maxTimeMS, collation, comment);
+            final Class<TResult> resultClass, final Collation collation, final BsonValue comment) {
+        return operations.distinct(fieldName, filter, resultClass, collation, comment);
     }
 
-    public <TResult> AsyncExplainableReadOperation<AsyncBatchCursor<TResult>> aggregate(final List<? extends Bson> pipeline,
+    public <TResult> AsyncExplainableReadOperation<AsyncBatchCursor<TResult>> aggregate(
+            final List<? extends Bson> pipeline,
             final Class<TResult> resultClass,
-            final long maxTimeMS, final long maxAwaitTimeMS,
             @Nullable final TimeoutMode timeoutMode,
             @Nullable final Integer batchSize,
             final Collation collation, final Bson hint,
@@ -152,15 +192,15 @@ public final class AsyncOperations<TDocument> {
             final Bson variables,
             final Boolean allowDiskUse,
             final AggregationLevel aggregationLevel) {
-        return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, timeoutMode, batchSize, collation, hint, hintString,
+        return operations.aggregate(pipeline, resultClass, timeoutMode, batchSize, collation, hint, hintString,
                 comment, variables, allowDiskUse, aggregationLevel);
     }
 
-    public AsyncReadOperation<Void> aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
+    public AsyncReadOperation<Void> aggregateToCollection(final List<? extends Bson> pipeline,
             @Nullable final TimeoutMode timeoutMode, final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
             final Collation collation, final Bson hint, final String hintString, final BsonValue comment,
             final Bson variables, final AggregationLevel aggregationLevel) {
-        return operations.aggregateToCollection(pipeline, maxTimeMS, timeoutMode, allowDiskUse, bypassDocumentValidation, collation, hint,
+        return operations.aggregateToCollection(pipeline, timeoutMode, allowDiskUse, bypassDocumentValidation, collation, hint,
                 hintString, comment, variables, aggregationLevel);
     }
 
@@ -168,21 +208,21 @@ public final class AsyncOperations<TDocument> {
     public AsyncWriteOperation<MapReduceStatistics> mapReduceToCollection(final String databaseName, final String collectionName,
             final String mapFunction, final String reduceFunction,
             final String finalizeFunction, final Bson filter, final int limit,
-            final long maxTimeMS, final boolean jsMode, final Bson scope,
+             final boolean jsMode, final Bson scope,
             final Bson sort, final boolean verbose,
             final com.mongodb.client.model.MapReduceAction action,
             final Boolean bypassDocumentValidation, final Collation collation) {
         return operations.mapReduceToCollection(databaseName, collectionName, mapFunction, reduceFunction, finalizeFunction, filter, limit,
-                maxTimeMS, jsMode, scope, sort, verbose, action, bypassDocumentValidation, collation);
+                jsMode, scope, sort, verbose, action, bypassDocumentValidation, collation);
     }
 
     public <TResult> AsyncReadOperation<MapReduceAsyncBatchCursor<TResult>> mapReduce(final String mapFunction, final String reduceFunction,
             final String finalizeFunction, final Class<TResult> resultClass,
             final Bson filter, final int limit,
-            final long maxTimeMS, final boolean jsMode, final Bson scope,
+             final boolean jsMode, final Bson scope,
             final Bson sort, final boolean verbose,
             final Collation collation) {
-        return operations.mapReduce(mapFunction, reduceFunction, finalizeFunction, resultClass, filter, limit, maxTimeMS, jsMode, scope,
+        return operations.mapReduce(mapFunction, reduceFunction, finalizeFunction, resultClass, filter, limit, jsMode, scope,
                 sort, verbose, collation);
     }
 
@@ -295,14 +335,9 @@ public final class AsyncOperations<TDocument> {
     }
 
     public <TResult> AsyncExplainableReadOperation<AsyncBatchCursor<TResult>> listSearchIndexes(final Class<TResult> resultClass,
-                                                                                      final long maxTimeMS,
-                                                                                      @Nullable final String indexName,
-                                                                                      @Nullable final Integer batchSize,
-                                                                                      @Nullable final Collation collation,
-                                                                                      @Nullable final BsonValue comment,
-                                                                                      @Nullable final Boolean allowDiskUse) {
-        return operations.listSearchIndexes(resultClass, maxTimeMS, indexName, batchSize, collation,
-                comment, allowDiskUse);
+            @Nullable final String indexName, @Nullable final Integer batchSize, @Nullable final Collation collation,
+            @Nullable final BsonValue comment, @Nullable final Boolean allowDiskUse) {
+        return operations.listSearchIndexes(resultClass, indexName, batchSize, collation, comment, allowDiskUse);
     }
 
     public AsyncWriteOperation<Void> dropIndex(final String indexName, final DropIndexOptions options) {
@@ -315,27 +350,27 @@ public final class AsyncOperations<TDocument> {
 
     public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> listCollections(final String databaseName,
             final Class<TResult> resultClass, final Bson filter, final boolean collectionNamesOnly, final boolean authorizedCollections,
-            @Nullable final Integer batchSize, final long maxTimeMS, final BsonValue comment,  @Nullable final TimeoutMode timeoutMode) {
+            @Nullable final Integer batchSize,  final BsonValue comment,  @Nullable final TimeoutMode timeoutMode) {
         return operations.listCollections(databaseName, resultClass, filter, collectionNamesOnly, authorizedCollections,
-                batchSize, maxTimeMS, comment, timeoutMode);
+                batchSize, comment, timeoutMode);
     }
 
     public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> listDatabases(final Class<TResult> resultClass, final Bson filter,
-            final Boolean nameOnly, final long maxTimeMS, final Boolean authorizedDatabases, final BsonValue comment) {
-        return operations.listDatabases(resultClass, filter, nameOnly, maxTimeMS, authorizedDatabases, comment);
+            final Boolean nameOnly,  final Boolean authorizedDatabases, final BsonValue comment) {
+        return operations.listDatabases(resultClass, filter, nameOnly, authorizedDatabases, comment);
     }
 
     public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> listIndexes(final Class<TResult> resultClass,
-            @Nullable final Integer batchSize, final long maxTimeMS, final BsonValue comment, @Nullable final TimeoutMode timeoutMode) {
-        return operations.listIndexes(resultClass, batchSize, maxTimeMS, comment, timeoutMode);
+            @Nullable final Integer batchSize,  final BsonValue comment, @Nullable final TimeoutMode timeoutMode) {
+        return operations.listIndexes(resultClass, batchSize, comment, timeoutMode);
     }
 
     public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> changeStream(final FullDocument fullDocument,
             final FullDocumentBeforeChange fullDocumentBeforeChange, final List<? extends Bson> pipeline,
             final Decoder<TResult> decoder, final ChangeStreamLevel changeStreamLevel, final Integer batchSize, final Collation collation,
-            final BsonValue comment, final long maxAwaitTimeMS, final BsonDocument resumeToken, final BsonTimestamp startAtOperationTime,
+            final BsonValue comment, final BsonDocument resumeToken, final BsonTimestamp startAtOperationTime,
             final BsonDocument startAfter, final boolean showExpandedEvents) {
         return operations.changeStream(fullDocument, fullDocumentBeforeChange, pipeline, decoder, changeStreamLevel, batchSize,
-                collation, comment, maxAwaitTimeMS, resumeToken, startAtOperationTime, startAfter, showExpandedEvents);
+                collation, comment, resumeToken, startAtOperationTime, startAfter, showExpandedEvents);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncReadOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncReadOperation.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation;
 
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
 
@@ -28,11 +27,6 @@ import com.mongodb.internal.binding.AsyncReadBinding;
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public interface AsyncReadOperation<T> {
-
-    /**
-     * @return the timeout settings for this operation
-     */
-    TimeoutSettings getTimeoutSettings();
 
     /**
      * General execute which can return anything of type T

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncWriteOperation.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation;
 
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 
@@ -28,11 +27,6 @@ import com.mongodb.internal.binding.AsyncWriteBinding;
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public interface AsyncWriteOperation<T> {
-
-    /**
-     * @return the timeout settings for this operation
-     */
-    TimeoutSettings getTimeoutSettings();
 
     /**
      * General execute which can return anything of type T

--- a/driver-core/src/main/com/mongodb/internal/operation/BaseFindAndModifyOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/BaseFindAndModifyOperation.java
@@ -20,7 +20,6 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
 import com.mongodb.connection.ConnectionDescription;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -49,7 +48,6 @@ import static com.mongodb.internal.operation.SyncOperationHelper.executeRetryabl
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public abstract class BaseFindAndModifyOperation<T> implements AsyncWriteOperation<T>, WriteOperation<T> {
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private final WriteConcern writeConcern;
     private final boolean retryWrites;
@@ -64,9 +62,8 @@ public abstract class BaseFindAndModifyOperation<T> implements AsyncWriteOperati
     private BsonValue comment;
     private BsonDocument variables;
 
-    protected BaseFindAndModifyOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final WriteConcern writeConcern, final boolean retryWrites, final Decoder<T> decoder) {
-        this.timeoutSettings = timeoutSettings;
+    protected BaseFindAndModifyOperation(final MongoNamespace namespace, final WriteConcern writeConcern, final boolean retryWrites,
+            final Decoder<T> decoder) {
         this.namespace = notNull("namespace", namespace);
         this.writeConcern = notNull("writeConcern", writeConcern);
         this.retryWrites = retryWrites;
@@ -179,11 +176,6 @@ public abstract class BaseFindAndModifyOperation<T> implements AsyncWriteOperati
     public BaseFindAndModifyOperation<T> let(@Nullable final BsonDocument variables) {
         this.variables = variables;
         return this;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     protected abstract FieldNameValidator getFieldNameValidator();

--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
@@ -20,7 +20,6 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
@@ -63,17 +62,16 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
     private boolean showExpandedEvents;
 
 
-    public ChangeStreamOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final FullDocument fullDocument, final FullDocumentBeforeChange fullDocumentBeforeChange,
-            final List<BsonDocument> pipeline, final Decoder<T> decoder) {
-        this(timeoutSettings, namespace, fullDocument, fullDocumentBeforeChange, pipeline, decoder, ChangeStreamLevel.COLLECTION);
+    public ChangeStreamOperation(final MongoNamespace namespace, final FullDocument fullDocument,
+            final FullDocumentBeforeChange fullDocumentBeforeChange, final List<BsonDocument> pipeline, final Decoder<T> decoder) {
+        this(namespace, fullDocument, fullDocumentBeforeChange, pipeline, decoder, ChangeStreamLevel.COLLECTION);
     }
 
-    public ChangeStreamOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final FullDocument fullDocument, final FullDocumentBeforeChange fullDocumentBeforeChange, final List<BsonDocument> pipeline,
-            final Decoder<T> decoder, final ChangeStreamLevel changeStreamLevel) {
-        this.wrapped = new AggregateOperationImpl<>(timeoutSettings, namespace, pipeline, RAW_BSON_DOCUMENT_CODEC,
-                getAggregateTarget(), getPipelineCreator());
+    public ChangeStreamOperation(final MongoNamespace namespace, final FullDocument fullDocument,
+            final FullDocumentBeforeChange fullDocumentBeforeChange, final List<BsonDocument> pipeline, final Decoder<T> decoder,
+            final ChangeStreamLevel changeStreamLevel) {
+        this.wrapped = new AggregateOperationImpl<>(namespace, pipeline, RAW_BSON_DOCUMENT_CODEC, getAggregateTarget(),
+                getPipelineCreator());
         this.fullDocument = notNull("fullDocument", fullDocument);
         this.fullDocumentBeforeChange = notNull("fullDocumentBeforeChange", fullDocumentBeforeChange);
         this.decoder = notNull("decoder", decoder);
@@ -167,11 +165,6 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
     public ChangeStreamOperation<T> showExpandedEvents(final boolean showExpandedEvents) {
         this.showExpandedEvents = showExpandedEvents;
         return this;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return wrapped.getTimeoutSettings();
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
@@ -17,6 +17,7 @@
 package com.mongodb.internal.operation;
 
 import com.mongodb.MongoNamespace;
+import com.mongodb.client.cursor.TimeoutMode;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
@@ -71,7 +72,7 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
             final FullDocumentBeforeChange fullDocumentBeforeChange, final List<BsonDocument> pipeline, final Decoder<T> decoder,
             final ChangeStreamLevel changeStreamLevel) {
         this.wrapped = new AggregateOperationImpl<>(namespace, pipeline, RAW_BSON_DOCUMENT_CODEC, getAggregateTarget(),
-                getPipelineCreator());
+                getPipelineCreator()).timeoutMode(TimeoutMode.ITERATION);
         this.fullDocument = notNull("fullDocument", fullDocument);
         this.fullDocumentBeforeChange = notNull("fullDocumentBeforeChange", fullDocumentBeforeChange);
         this.decoder = notNull("decoder", decoder);

--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
@@ -17,7 +17,6 @@
 package com.mongodb.internal.operation;
 
 import com.mongodb.MongoNamespace;
-import com.mongodb.client.cursor.TimeoutMode;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
@@ -72,7 +71,7 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
             final FullDocumentBeforeChange fullDocumentBeforeChange, final List<BsonDocument> pipeline, final Decoder<T> decoder,
             final ChangeStreamLevel changeStreamLevel) {
         this.wrapped = new AggregateOperationImpl<>(namespace, pipeline, RAW_BSON_DOCUMENT_CODEC, getAggregateTarget(),
-                getPipelineCreator()).timeoutMode(TimeoutMode.ITERATION);
+                getPipelineCreator());
         this.fullDocument = notNull("fullDocument", fullDocument);
         this.fullDocumentBeforeChange = notNull("fullDocumentBeforeChange", fullDocumentBeforeChange);
         this.decoder = notNull("decoder", decoder);

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandReadOperation.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation;
 
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
 import com.mongodb.internal.binding.ReadBinding;
@@ -34,27 +33,18 @@ import static com.mongodb.internal.operation.SyncOperationHelper.executeRetryabl
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class CommandReadOperation<T> implements AsyncReadOperation<T>, ReadOperation<T> {
-    private final TimeoutSettings timeoutSettings;
     private final String databaseName;
     private final CommandCreator commandCreator;
     private final Decoder<T> decoder;
 
-    public CommandReadOperation(final TimeoutSettings timeoutSettings, final String databaseName,
-            final BsonDocument command, final Decoder<T> decoder) {
-        this(timeoutSettings, databaseName, (operationContext, serverDescription, connectionDescription) -> command, decoder);
+    public CommandReadOperation(final String databaseName, final BsonDocument command, final Decoder<T> decoder) {
+        this(databaseName, (operationContext, serverDescription, connectionDescription) -> command, decoder);
     }
 
-    public CommandReadOperation(final TimeoutSettings timeoutSettings, final String databaseName,
-            final CommandCreator commandCreator, final Decoder<T> decoder) {
-        this.timeoutSettings = timeoutSettings;
+    public CommandReadOperation(final String databaseName, final CommandCreator commandCreator, final Decoder<T> decoder) {
         this.databaseName = notNull("databaseName", databaseName);
         this.commandCreator = notNull("commandCreator", commandCreator);
         this.decoder = notNull("decoder", decoder);
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/CommitTransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommitTransactionOperation.java
@@ -25,7 +25,6 @@ import com.mongodb.MongoSocketException;
 import com.mongodb.MongoTimeoutException;
 import com.mongodb.MongoWriteConcernException;
 import com.mongodb.WriteConcern;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -50,13 +49,12 @@ public class CommitTransactionOperation extends TransactionOperation {
     private final boolean alreadyCommitted;
     private BsonDocument recoveryToken;
 
-    public CommitTransactionOperation(final TimeoutSettings timeoutSettings, final WriteConcern writeConcern) {
-        this(timeoutSettings, writeConcern, false);
+    public CommitTransactionOperation(final WriteConcern writeConcern) {
+        this(writeConcern, false);
     }
 
-    public CommitTransactionOperation(final TimeoutSettings timeoutSettings, final WriteConcern writeConcern,
-            final boolean alreadyCommitted) {
-        super(timeoutSettings, writeConcern);
+    public CommitTransactionOperation(final WriteConcern writeConcern, final boolean alreadyCommitted) {
+        super(writeConcern);
         this.alreadyCommitted = alreadyCommitted;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/CountOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CountOperation.java
@@ -18,7 +18,6 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.model.Collation;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
 import com.mongodb.internal.binding.ReadBinding;
@@ -44,7 +43,6 @@ import static com.mongodb.internal.operation.SyncOperationHelper.executeRetryabl
  */
 public class CountOperation implements AsyncReadOperation<Long>, ReadOperation<Long> {
     private static final Decoder<BsonDocument> DECODER = new BsonDocumentCodec();
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private boolean retryReads;
     private BsonDocument filter;
@@ -53,8 +51,7 @@ public class CountOperation implements AsyncReadOperation<Long>, ReadOperation<L
     private long limit;
     private Collation collation;
 
-    public CountOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace) {
-        this.timeoutSettings = timeoutSettings;
+    public CountOperation(final MongoNamespace namespace) {
         this.namespace = notNull("namespace", namespace);
     }
 
@@ -110,11 +107,6 @@ public class CountOperation implements AsyncReadOperation<Long>, ReadOperation<L
     public CountOperation collation(@Nullable final Collation collation) {
         this.collation = collation;
         return this;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateCollectionOperation.java
@@ -26,7 +26,6 @@ import com.mongodb.client.model.TimeSeriesOptions;
 import com.mongodb.client.model.ValidationAction;
 import com.mongodb.client.model.ValidationLevel;
 import com.mongodb.connection.ConnectionDescription;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -72,7 +71,6 @@ public class CreateCollectionOperation implements AsyncWriteOperation<Void>, Wri
     private static final BsonDocument ENCRYPT_CLUSTERED_INDEX = BsonDocument.parse("{key: {_id: 1}, unique: true}");
     private static final BsonArray SAFE_CONTENT_ARRAY = new BsonArray(
             singletonList(BsonDocument.parse("{key: {__safeContent__: 1}, name: '__safeContent___1'}")));
-    private final TimeoutSettings timeoutSettings;
     private final String databaseName;
     private final String collectionName;
     private final WriteConcern writeConcern;
@@ -94,9 +92,7 @@ public class CreateCollectionOperation implements AsyncWriteOperation<Void>, Wri
     private String clusteredIndexName;
     private BsonDocument encryptedFields;
 
-    public CreateCollectionOperation(final TimeoutSettings timeoutSettings, final String databaseName,
-            final String collectionName, @Nullable final WriteConcern writeConcern) {
-        this.timeoutSettings = timeoutSettings;
+    public CreateCollectionOperation(final String databaseName, final String collectionName, @Nullable final WriteConcern writeConcern) {
         this.databaseName = notNull("databaseName", databaseName);
         this.collectionName = notNull("collectionName", collectionName);
         this.writeConcern = writeConcern;
@@ -233,11 +229,6 @@ public class CreateCollectionOperation implements AsyncWriteOperation<Void>, Wri
     public CreateCollectionOperation encryptedFields(@Nullable final BsonDocument encryptedFields) {
         this.encryptedFields = encryptedFields;
         return this;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateIndexesOperation.java
@@ -25,7 +25,6 @@ import com.mongodb.MongoException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteConcernResult;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -60,15 +59,13 @@ import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConce
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class CreateIndexesOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private final List<IndexRequest> requests;
     private final WriteConcern writeConcern;
     private CreateIndexCommitQuorum commitQuorum;
 
-    public CreateIndexesOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final List<IndexRequest> requests, @Nullable final WriteConcern writeConcern) {
-        this.timeoutSettings = timeoutSettings;
+    public CreateIndexesOperation(final MongoNamespace namespace, final List<IndexRequest> requests,
+            @Nullable final WriteConcern writeConcern) {
         this.namespace = notNull("namespace", namespace);
         this.requests = notNull("indexRequests", requests);
         this.writeConcern = writeConcern;
@@ -101,11 +98,6 @@ public class CreateIndexesOperation implements AsyncWriteOperation<Void>, WriteO
     public CreateIndexesOperation commitQuorum(@Nullable final CreateIndexCommitQuorum commitQuorum) {
         this.commitQuorum = commitQuorum;
         return this;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateSearchIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateSearchIndexesOperation.java
@@ -17,7 +17,6 @@
 package com.mongodb.internal.operation;
 
 import com.mongodb.MongoNamespace;
-import com.mongodb.internal.TimeoutSettings;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
@@ -36,9 +35,8 @@ final class CreateSearchIndexesOperation extends AbstractWriteSearchIndexOperati
     private static final String COMMAND_NAME = "createSearchIndexes";
     private final List<SearchIndexRequest> indexRequests;
 
-    CreateSearchIndexesOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final List<SearchIndexRequest> indexRequests) {
-        super(timeoutSettings, namespace);
+    CreateSearchIndexesOperation(final MongoNamespace namespace, final List<SearchIndexRequest> indexRequests) {
+        super(namespace);
         this.indexRequests = assertNotNull(indexRequests);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CreateViewOperation.java
@@ -18,7 +18,6 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -48,7 +47,6 @@ import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConce
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class CreateViewOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
-    private final TimeoutSettings timeoutSettings;
     private final String databaseName;
     private final String viewName;
     private final String viewOn;
@@ -56,9 +54,8 @@ public class CreateViewOperation implements AsyncWriteOperation<Void>, WriteOper
     private final WriteConcern writeConcern;
     private Collation collation;
 
-    public CreateViewOperation(final TimeoutSettings timeoutSettings, final String databaseName,
-            final String viewName, final String viewOn, final List<BsonDocument> pipeline, final WriteConcern writeConcern) {
-        this.timeoutSettings = timeoutSettings;
+    public CreateViewOperation(final String databaseName, final String viewName, final String viewOn, final List<BsonDocument> pipeline,
+            final WriteConcern writeConcern) {
         this.databaseName = notNull("databaseName", databaseName);
         this.viewName = notNull("viewName", viewName);
         this.viewOn = notNull("viewOn", viewOn);
@@ -124,11 +121,6 @@ public class CreateViewOperation implements AsyncWriteOperation<Void>, WriteOper
     public CreateViewOperation collation(@Nullable final Collation collation) {
         this.collation = collation;
         return this;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/DistinctOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DistinctOperation.java
@@ -18,7 +18,6 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.model.Collation;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
@@ -49,8 +48,6 @@ import static com.mongodb.internal.operation.SyncOperationHelper.singleBatchCurs
  */
 public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
     private static final String VALUES = "values";
-
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private final String fieldName;
     private final Decoder<T> decoder;
@@ -59,9 +56,7 @@ public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor
     private Collation collation;
     private BsonValue comment;
 
-    public DistinctOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final String fieldName, final Decoder<T> decoder) {
-        this.timeoutSettings = timeoutSettings;
+    public DistinctOperation(final MongoNamespace namespace, final String fieldName, final Decoder<T> decoder) {
         this.namespace = notNull("namespace", namespace);
         this.fieldName = notNull("fieldName", fieldName);
         this.decoder = notNull("decoder", decoder);
@@ -101,11 +96,6 @@ public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor
     public DistinctOperation<T> comment(final BsonValue comment) {
         this.comment = comment;
         return this;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropCollectionOperation.java
@@ -21,7 +21,6 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.MongoOperationTimeoutException;
 import com.mongodb.WriteConcern;
 import com.mongodb.internal.TimeoutContext;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadWriteBinding;
 import com.mongodb.internal.binding.AsyncWriteBinding;
@@ -66,15 +65,12 @@ import static java.util.Collections.singletonList;
 public class DropCollectionOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
     private static final String ENCRYPT_PREFIX = "enxcol_.";
     private static final BsonValueCodec BSON_VALUE_CODEC = new BsonValueCodec();
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private final WriteConcern writeConcern;
     private BsonDocument encryptedFields;
     private boolean autoEncryptedFields;
 
-    public DropCollectionOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            @Nullable final WriteConcern writeConcern) {
-        this.timeoutSettings = timeoutSettings;
+    public DropCollectionOperation(final MongoNamespace namespace, @Nullable final WriteConcern writeConcern) {
         this.namespace = notNull("namespace", namespace);
         this.writeConcern = writeConcern;
     }
@@ -91,11 +87,6 @@ public class DropCollectionOperation implements AsyncWriteOperation<Void>, Write
     public DropCollectionOperation autoEncryptedFields(final boolean autoEncryptedFields) {
         this.autoEncryptedFields = autoEncryptedFields;
         return this;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override
@@ -229,7 +220,7 @@ public class DropCollectionOperation implements AsyncWriteOperation<Void>, Write
     }
 
     private ListCollectionsOperation<BsonValue> listCollectionOperation() {
-        return new ListCollectionsOperation<>(timeoutSettings, namespace.getDatabaseName(), BSON_VALUE_CODEC)
+        return new ListCollectionsOperation<>(namespace.getDatabaseName(), BSON_VALUE_CODEC)
                 .filter(new BsonDocument("name", new BsonString(namespace.getCollectionName())))
                 .batchSize(1);
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/DropDatabaseOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropDatabaseOperation.java
@@ -17,7 +17,6 @@
 package com.mongodb.internal.operation;
 
 import com.mongodb.WriteConcern;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -44,24 +43,16 @@ import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConce
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class DropDatabaseOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
-    private final TimeoutSettings timeoutSettings;
     private final String databaseName;
     private final WriteConcern writeConcern;
 
-    public DropDatabaseOperation(final TimeoutSettings timeoutSettings,
-            final String databaseName, @Nullable final WriteConcern writeConcern) {
-        this.timeoutSettings = timeoutSettings;
+    public DropDatabaseOperation(final String databaseName, @Nullable final WriteConcern writeConcern) {
         this.databaseName = notNull("databaseName", databaseName);
         this.writeConcern = writeConcern;
     }
 
     public WriteConcern getWriteConcern() {
         return writeConcern;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/DropIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropIndexOperation.java
@@ -19,7 +19,6 @@ package com.mongodb.internal.operation;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -43,24 +42,19 @@ import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConce
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class DropIndexOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private final String indexName;
     private final BsonDocument indexKeys;
     private final WriteConcern writeConcern;
 
-    public DropIndexOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final String indexName, @Nullable final WriteConcern writeConcern) {
-        this.timeoutSettings = timeoutSettings;
+    public DropIndexOperation(final MongoNamespace namespace, final String indexName, @Nullable final WriteConcern writeConcern) {
         this.namespace = notNull("namespace", namespace);
         this.indexName = notNull("indexName", indexName);
         this.indexKeys = null;
         this.writeConcern = writeConcern;
     }
 
-    public DropIndexOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final BsonDocument indexKeys, @Nullable final WriteConcern writeConcern) {
-        this.timeoutSettings = timeoutSettings;
+    public DropIndexOperation(final MongoNamespace namespace, final BsonDocument indexKeys, @Nullable final WriteConcern writeConcern) {
         this.namespace = notNull("namespace", namespace);
         this.indexKeys = notNull("indexKeys", indexKeys);
         this.indexName = null;
@@ -69,11 +63,6 @@ public class DropIndexOperation implements AsyncWriteOperation<Void>, WriteOpera
 
     public WriteConcern getWriteConcern() {
         return writeConcern;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/DropSearchIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DropSearchIndexOperation.java
@@ -17,7 +17,6 @@
 package com.mongodb.internal.operation;
 
 import com.mongodb.MongoNamespace;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
@@ -33,8 +32,8 @@ final class DropSearchIndexOperation extends AbstractWriteSearchIndexOperation {
     private static final String COMMAND_NAME = "dropSearchIndex";
     private final String indexName;
 
-    DropSearchIndexOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace, final String indexName) {
-        super(timeoutSettings, namespace);
+    DropSearchIndexOperation(final MongoNamespace namespace, final String indexName) {
+        super(namespace);
         this.indexName = indexName;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/EstimatedDocumentCountOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/EstimatedDocumentCountOperation.java
@@ -19,7 +19,6 @@ package com.mongodb.internal.operation;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.connection.ConnectionDescription;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
 import com.mongodb.internal.binding.ReadBinding;
@@ -48,13 +47,11 @@ import static java.util.Collections.singletonList;
  */
 public class EstimatedDocumentCountOperation implements AsyncReadOperation<Long>, ReadOperation<Long> {
     private static final Decoder<BsonDocument> DECODER = new BsonDocumentCodec();
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private boolean retryReads;
     private BsonValue comment;
 
-    public EstimatedDocumentCountOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace) {
-        this.timeoutSettings = timeoutSettings;
+    public EstimatedDocumentCountOperation(final MongoNamespace namespace) {
         this.namespace = notNull("namespace", namespace);
     }
 
@@ -71,11 +68,6 @@ public class EstimatedDocumentCountOperation implements AsyncReadOperation<Long>
     public EstimatedDocumentCountOperation comment(@Nullable final BsonValue comment) {
         this.comment = comment;
         return this;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndDeleteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndDeleteOperation.java
@@ -20,7 +20,6 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
 import com.mongodb.connection.ConnectionDescription;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonBoolean;
@@ -37,9 +36,9 @@ import org.bson.conversions.Bson;
  */
 public class FindAndDeleteOperation<T> extends BaseFindAndModifyOperation<T> {
 
-    public FindAndDeleteOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final WriteConcern writeConcern, final boolean retryWrites, final Decoder<T> decoder) {
-        super(timeoutSettings, namespace, writeConcern, retryWrites, decoder);
+    public FindAndDeleteOperation(final MongoNamespace namespace, final WriteConcern writeConcern, final boolean retryWrites,
+            final Decoder<T> decoder) {
+        super(namespace, writeConcern, retryWrites, decoder);
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
@@ -20,7 +20,6 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
 import com.mongodb.connection.ConnectionDescription;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.validator.MappedFieldNameValidator;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.internal.validator.ReplacingDocumentFieldNameValidator;
@@ -49,9 +48,9 @@ public class FindAndReplaceOperation<T> extends BaseFindAndModifyOperation<T> {
     private boolean upsert;
     private Boolean bypassDocumentValidation;
 
-    public FindAndReplaceOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final WriteConcern writeConcern, final boolean retryWrites, final Decoder<T> decoder, final BsonDocument replacement) {
-        super(timeoutSettings, namespace, writeConcern, retryWrites, decoder);
+    public FindAndReplaceOperation(final MongoNamespace namespace, final WriteConcern writeConcern, final boolean retryWrites,
+            final Decoder<T> decoder, final BsonDocument replacement) {
+        super(namespace, writeConcern, retryWrites, decoder);
         this.replacement = notNull("replacement", replacement);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndUpdateOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndUpdateOperation.java
@@ -20,7 +20,6 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
 import com.mongodb.connection.ConnectionDescription;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.validator.MappedFieldNameValidator;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.internal.validator.UpdateFieldNameValidator;
@@ -54,16 +53,16 @@ public class FindAndUpdateOperation<T> extends BaseFindAndModifyOperation<T> {
     private Boolean bypassDocumentValidation;
     private List<BsonDocument> arrayFilters;
 
-    public FindAndUpdateOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
+    public FindAndUpdateOperation(final MongoNamespace namespace,
             final WriteConcern writeConcern, final boolean retryWrites, final Decoder<T> decoder, final BsonDocument update) {
-        super(timeoutSettings, namespace, writeConcern, retryWrites, decoder);
+        super(namespace, writeConcern, retryWrites, decoder);
         this.update = notNull("update", update);
         this.updatePipeline = null;
     }
 
-    public FindAndUpdateOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final WriteConcern writeConcern, final boolean retryWrites, final Decoder<T> decoder, final List<BsonDocument> update) {
-        super(timeoutSettings, namespace, writeConcern, retryWrites, decoder);
+    public FindAndUpdateOperation(final MongoNamespace namespace, final WriteConcern writeConcern, final boolean retryWrites,
+            final Decoder<T> decoder, final List<BsonDocument> update) {
+        super(namespace, writeConcern, retryWrites, decoder);
         this.updatePipeline = update;
         this.update = null;
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
@@ -54,7 +54,6 @@ import static com.mongodb.internal.operation.ExplainHelper.asExplainCommand;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.OperationHelper.addMaxTimeMSToNonTailableCursor;
 import static com.mongodb.internal.operation.OperationHelper.canRetryRead;
-import static com.mongodb.internal.operation.OperationHelper.validateTimeoutMode;
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand;
 import static com.mongodb.internal.operation.ServerVersionHelper.MIN_WIRE_VERSION;
 import static com.mongodb.internal.operation.SyncOperationHelper.CommandReadTransformer;
@@ -370,7 +369,6 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
     }
 
     private BsonDocument getCommand(final OperationContext operationContext, final int maxWireVersion) {
-        validateTimeoutMode(operationContext, timeoutMode);
         BsonDocument commandDocument = new BsonDocument("find", new BsonString(namespace.getCollectionName()));
 
         appendReadConcernToCommand(operationContext.getSessionContext(), maxWireVersion, commandDocument);

--- a/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
@@ -23,7 +23,6 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.MongoQueryException;
 import com.mongodb.client.cursor.TimeoutMode;
 import com.mongodb.client.model.Collation;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackSupplier;
@@ -41,7 +40,6 @@ import org.bson.codecs.Decoder;
 
 import java.util.function.Supplier;
 
-import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.internal.operation.AsyncOperationHelper.CommandReadTransformerAsync;
@@ -56,6 +54,7 @@ import static com.mongodb.internal.operation.ExplainHelper.asExplainCommand;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.OperationHelper.addMaxTimeMSToNonTailableCursor;
 import static com.mongodb.internal.operation.OperationHelper.canRetryRead;
+import static com.mongodb.internal.operation.OperationHelper.validateTimeoutMode;
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand;
 import static com.mongodb.internal.operation.ServerVersionHelper.MIN_WIRE_VERSION;
 import static com.mongodb.internal.operation.SyncOperationHelper.CommandReadTransformer;
@@ -71,7 +70,6 @@ import static com.mongodb.internal.operation.SyncOperationHelper.withSourceAndCo
 public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatchCursor<T>>, ExplainableReadOperation<BatchCursor<T>> {
     private static final String FIRST_BATCH = "firstBatch";
 
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private final Decoder<T> decoder;
     private boolean retryReads;
@@ -95,9 +93,7 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
     private Boolean allowDiskUse;
     private TimeoutMode timeoutMode;
 
-    public FindOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final Decoder<T> decoder) {
-        this.timeoutSettings = timeoutSettings;
+    public FindOperation(final MongoNamespace namespace, final Decoder<T> decoder) {
         this.namespace = notNull("namespace", namespace);
         this.decoder = notNull("decoder", decoder);
     }
@@ -174,7 +170,6 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
     }
 
     public FindOperation<T> timeoutMode(@Nullable final TimeoutMode timeoutMode) {
-        isTrueArgument("timeoutMode requires timeoutMS.", timeoutMode == null || timeoutSettings.getTimeoutMS() != null);
         if (timeoutMode != null) {
             this.timeoutMode = timeoutMode;
         }
@@ -290,11 +285,6 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
     }
 
     @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
-    }
-
-    @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
         IllegalStateException invalidTimeoutModeException = invalidTimeoutModeException();
         if (invalidTimeoutModeException != null) {
@@ -374,12 +364,13 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
     }
 
     <R> CommandReadOperation<R> createExplainableOperation(@Nullable final ExplainVerbosity verbosity, final Decoder<R> resultDecoder) {
-        return new CommandReadOperation<>(timeoutSettings, getNamespace().getDatabaseName(),
+        return new CommandReadOperation<>(getNamespace().getDatabaseName(),
                 (operationContext, serverDescription, connectionDescription) ->
                         asExplainCommand(getCommand(operationContext, MIN_WIRE_VERSION), verbosity), resultDecoder);
     }
 
     private BsonDocument getCommand(final OperationContext operationContext, final int maxWireVersion) {
+        validateTimeoutMode(operationContext, timeoutMode);
         BsonDocument commandDocument = new BsonDocument("find", new BsonString(namespace.getCollectionName()));
 
         appendReadConcernToCommand(operationContext.getSessionContext(), maxWireVersion, commandDocument);
@@ -469,16 +460,18 @@ public class FindOperation<T> implements AsyncExplainableReadOperation<AsyncBatc
 
     private CommandReadTransformer<BsonDocument, CommandBatchCursor<T>> transformer() {
         return (result, source, connection) ->
-                new CommandBatchCursor<>(getTimeoutMode(), result, batchSize, getMaxTimeForCursor(), decoder, comment, source, connection);
+                new CommandBatchCursor<>(getTimeoutMode(), result, batchSize, getMaxTimeForCursor(source.getOperationContext()), decoder,
+                        comment, source, connection);
     }
 
     private CommandReadTransformerAsync<BsonDocument, AsyncBatchCursor<T>> asyncTransformer() {
         return (result, source, connection) ->
-            new AsyncCommandBatchCursor<>(getTimeoutMode(), result, batchSize, getMaxTimeForCursor(), decoder, comment, source, connection);
+            new AsyncCommandBatchCursor<>(getTimeoutMode(), result, batchSize, getMaxTimeForCursor(source.getOperationContext()), decoder,
+                    comment, source, connection);
     }
 
-    private long getMaxTimeForCursor() {
-        return cursorType == CursorType.TailableAwait ? timeoutSettings.getMaxAwaitTimeMS() : 0;
+    private long getMaxTimeForCursor(final OperationContext operationContext) {
+        return cursorType == CursorType.TailableAwait ? operationContext.getTimeoutContext().getMaxAwaitTimeMS() : 0;
     }
 
     @Nullable

--- a/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
@@ -53,7 +53,6 @@ import static com.mongodb.internal.operation.DocumentHelper.putIfTrue;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.OperationHelper.addMaxTimeMSToNonTailableCursor;
 import static com.mongodb.internal.operation.OperationHelper.canRetryRead;
-import static com.mongodb.internal.operation.OperationHelper.validateTimeoutMode;
 import static com.mongodb.internal.operation.SingleBatchCursor.createEmptySingleBatchCursor;
 import static com.mongodb.internal.operation.SyncOperationHelper.CommandReadTransformer;
 import static com.mongodb.internal.operation.SyncOperationHelper.createReadCommandAndExecute;
@@ -79,7 +78,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
     private boolean nameOnly;
     private boolean authorizedCollections;
     private BsonValue comment;
-    private TimeoutMode timeoutMode;
+    private TimeoutMode timeoutMode = TimeoutMode.CURSOR_LIFETIME;
 
     public ListCollectionsOperation(final String databaseName, final Decoder<T> decoder) {
         this.databaseName = notNull("databaseName", databaseName);
@@ -216,7 +215,6 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
 
     private CommandCreator getCommandCreator() {
         return (operationContext, serverDescription, connectionDescription) -> {
-            validateTimeoutMode(operationContext, timeoutMode);
             BsonDocument commandDocument = new BsonDocument("listCollections", new BsonInt32(1))
                     .append("cursor", getCursorDocumentFromBatchSize(batchSize == 0 ? null : batchSize));
             putIfNotNull(commandDocument, "filter", filter);

--- a/driver-core/src/main/com/mongodb/internal/operation/ListDatabasesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListDatabasesOperation.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation;
 
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
@@ -45,7 +44,6 @@ import static com.mongodb.internal.operation.SyncOperationHelper.singleBatchCurs
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class ListDatabasesOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
-    private final TimeoutSettings timeoutSettings;
     private static final String DATABASES = "databases";
     private final Decoder<T> decoder;
     private boolean retryReads;
@@ -54,8 +52,7 @@ public class ListDatabasesOperation<T> implements AsyncReadOperation<AsyncBatchC
     private Boolean authorizedDatabasesOnly;
     private BsonValue comment;
 
-    public ListDatabasesOperation(final TimeoutSettings timeoutSettings, final Decoder<T> decoder) {
-        this.timeoutSettings = timeoutSettings;
+    public ListDatabasesOperation(final Decoder<T> decoder) {
         this.decoder = notNull("decoder", decoder);
     }
 
@@ -103,11 +100,6 @@ public class ListDatabasesOperation<T> implements AsyncReadOperation<AsyncBatchC
     public ListDatabasesOperation<T> comment(@Nullable final BsonValue comment) {
         this.comment = comment;
         return this;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
@@ -51,7 +51,6 @@ import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.OperationHelper.addMaxTimeMSToNonTailableCursor;
 import static com.mongodb.internal.operation.OperationHelper.canRetryRead;
-import static com.mongodb.internal.operation.OperationHelper.validateTimeoutMode;
 import static com.mongodb.internal.operation.SingleBatchCursor.createEmptySingleBatchCursor;
 import static com.mongodb.internal.operation.SyncOperationHelper.CommandReadTransformer;
 import static com.mongodb.internal.operation.SyncOperationHelper.createReadCommandAndExecute;
@@ -71,7 +70,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
     private boolean retryReads;
     private int batchSize;
     private BsonValue comment;
-    private TimeoutMode timeoutMode;
+    private TimeoutMode timeoutMode = TimeoutMode.CURSOR_LIFETIME;
 
     public ListIndexesOperation(final MongoNamespace namespace, final Decoder<T> decoder) {
         this.namespace = notNull("namespace", namespace);
@@ -166,7 +165,6 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
 
     private CommandCreator getCommandCreator() {
         return (operationContext, serverDescription, connectionDescription) -> {
-            validateTimeoutMode(operationContext, timeoutMode);
             BsonDocument commandDocument = new BsonDocument("listIndexes", new BsonString(namespace.getCollectionName()))
                     .append("cursor", getCursorDocumentFromBatchSize(batchSize == 0 ? null : batchSize));
             addMaxTimeMSToNonTailableCursor(commandDocument, timeoutMode, operationContext);

--- a/driver-core/src/main/com/mongodb/internal/operation/ListSearchIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListSearchIndexesOperation.java
@@ -20,7 +20,6 @@ import com.mongodb.ExplainVerbosity;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.model.Collation;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
@@ -46,7 +45,6 @@ import static java.util.Collections.singletonList;
 final class ListSearchIndexesOperation<T>
         implements AsyncExplainableReadOperation<AsyncBatchCursor<T>>, ExplainableReadOperation<BatchCursor<T>> {
     private static final String STAGE_LIST_SEARCH_INDEXES = "$listSearchIndexes";
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private final Decoder<T> decoder;
     @Nullable
@@ -61,11 +59,9 @@ final class ListSearchIndexesOperation<T>
     private final String indexName;
     private final boolean retryReads;
 
-    ListSearchIndexesOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final Decoder<T> decoder, @Nullable final String indexName, @Nullable final Integer batchSize,
-            @Nullable final Collation collation, @Nullable final BsonValue comment, @Nullable final Boolean allowDiskUse,
-            final boolean retryReads) {
-        this.timeoutSettings = timeoutSettings;
+    ListSearchIndexesOperation(final MongoNamespace namespace, final Decoder<T> decoder, @Nullable final String indexName,
+            @Nullable final Integer batchSize, @Nullable final Collation collation, @Nullable final BsonValue comment,
+            @Nullable final Boolean allowDiskUse, final boolean retryReads) {
         this.namespace = namespace;
         this.decoder = decoder;
         this.allowDiskUse = allowDiskUse;
@@ -74,11 +70,6 @@ final class ListSearchIndexesOperation<T>
         this.comment = comment;
         this.indexName = indexName;
         this.retryReads = retryReads;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override
@@ -122,7 +113,7 @@ final class ListSearchIndexesOperation<T>
     private AggregateOperation<T> asAggregateOperation() {
         BsonDocument searchDefinition = getSearchDefinition();
         BsonDocument listSearchIndexesStage = new BsonDocument(STAGE_LIST_SEARCH_INDEXES, searchDefinition);
-        return new AggregateOperation<>(timeoutSettings, namespace, singletonList(listSearchIndexesStage), decoder)
+        return new AggregateOperation<>(namespace, singletonList(listSearchIndexesStage), decoder)
                 .retryReads(retryReads)
                 .collation(collation)
                 .comment(comment)

--- a/driver-core/src/main/com/mongodb/internal/operation/MapReduceToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MapReduceToCollectionOperation.java
@@ -20,7 +20,6 @@ import com.mongodb.ExplainVerbosity;
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.Collation;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -59,7 +58,6 @@ import static java.util.Arrays.asList;
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class MapReduceToCollectionOperation implements AsyncWriteOperation<MapReduceStatistics>, WriteOperation<MapReduceStatistics> {
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private final BsonJavaScript mapFunction;
     private final BsonJavaScript reduceFunction;
@@ -78,10 +76,8 @@ public class MapReduceToCollectionOperation implements AsyncWriteOperation<MapRe
     private Collation collation;
     private static final List<String> VALID_ACTIONS = asList("replace", "merge", "reduce");
 
-    public MapReduceToCollectionOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final BsonJavaScript mapFunction, final BsonJavaScript reduceFunction, @Nullable final String collectionName,
-            @Nullable final WriteConcern writeConcern) {
-        this.timeoutSettings = timeoutSettings;
+    public MapReduceToCollectionOperation(final MongoNamespace namespace, final BsonJavaScript mapFunction,
+            final BsonJavaScript reduceFunction, @Nullable final String collectionName, @Nullable final WriteConcern writeConcern) {
         this.namespace = notNull("namespace", namespace);
         this.mapFunction = notNull("mapFunction", mapFunction);
         this.reduceFunction = notNull("reduceFunction", reduceFunction);
@@ -212,11 +208,6 @@ public class MapReduceToCollectionOperation implements AsyncWriteOperation<MapRe
     }
 
     @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
-    }
-
-    @Override
     public MapReduceStatistics execute(final WriteBinding binding) {
         return executeCommand(binding, namespace.getDatabaseName(), getCommandCreator(), transformer());
     }
@@ -247,7 +238,7 @@ public class MapReduceToCollectionOperation implements AsyncWriteOperation<MapRe
     }
 
     private CommandReadOperation<BsonDocument> createExplainableOperation(final ExplainVerbosity explainVerbosity) {
-        return new CommandReadOperation<>(timeoutSettings, getNamespace().getDatabaseName(),
+        return new CommandReadOperation<>(getNamespace().getDatabaseName(),
                 (operationContext, serverDescription, connectionDescription) ->
                         asExplainCommand(getCommandCreator().create(operationContext, serverDescription, connectionDescription),
                                 explainVerbosity), new BsonDocumentCodec());

--- a/driver-core/src/main/com/mongodb/internal/operation/MapReduceWithInlineResultsOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MapReduceWithInlineResultsOperation.java
@@ -19,7 +19,6 @@ package com.mongodb.internal.operation;
 import com.mongodb.ExplainVerbosity;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.model.Collation;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
 import com.mongodb.internal.binding.ReadBinding;
@@ -56,7 +55,6 @@ import static com.mongodb.internal.operation.SyncOperationHelper.executeRetryabl
  */
 public class MapReduceWithInlineResultsOperation<T> implements AsyncReadOperation<MapReduceAsyncBatchCursor<T>>,
                                                                ReadOperation<MapReduceBatchCursor<T>> {
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private final BsonJavaScript mapFunction;
     private final BsonJavaScript reduceFunction;
@@ -70,9 +68,8 @@ public class MapReduceWithInlineResultsOperation<T> implements AsyncReadOperatio
     private boolean verbose;
     private Collation collation;
 
-    public MapReduceWithInlineResultsOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final BsonJavaScript mapFunction, final BsonJavaScript reduceFunction, final Decoder<T> decoder) {
-        this.timeoutSettings = timeoutSettings;
+    public MapReduceWithInlineResultsOperation(final MongoNamespace namespace, final BsonJavaScript mapFunction,
+            final BsonJavaScript reduceFunction, final Decoder<T> decoder) {
         this.namespace = notNull("namespace", namespace);
         this.mapFunction = notNull("mapFunction", mapFunction);
         this.reduceFunction = notNull("reduceFunction", reduceFunction);
@@ -168,11 +165,6 @@ public class MapReduceWithInlineResultsOperation<T> implements AsyncReadOperatio
     }
 
     @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
-    }
-
-    @Override
     public MapReduceBatchCursor<T> execute(final ReadBinding binding) {
         return executeRetryableRead(binding, namespace.getDatabaseName(),
                 getCommandCreator(),
@@ -196,7 +188,7 @@ public class MapReduceWithInlineResultsOperation<T> implements AsyncReadOperatio
     }
 
     private CommandReadOperation<BsonDocument> createExplainableOperation(final ExplainVerbosity explainVerbosity) {
-        return new CommandReadOperation<>(timeoutSettings, namespace.getDatabaseName(),
+        return new CommandReadOperation<>(namespace.getDatabaseName(),
                 (operationContext, serverDescription, connectionDescription) ->
                         asExplainCommand(getCommandCreator().create(operationContext, serverDescription, connectionDescription),
                         explainVerbosity), new BsonDocumentCodec());

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -23,7 +23,6 @@ import com.mongodb.assertions.Assertions;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.internal.TimeoutContext;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackLoop;
 import com.mongodb.internal.async.function.AsyncCallbackRunnable;
@@ -78,7 +77,6 @@ import static com.mongodb.internal.operation.SyncOperationHelper.withSourceAndCo
  */
 public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteResult>, WriteOperation<BulkWriteResult> {
     private static final FieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace namespace;
     private final List<? extends WriteRequest> writeRequests;
     private final boolean ordered;
@@ -88,10 +86,8 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
     private BsonValue comment;
     private BsonDocument variables;
 
-    public MixedBulkWriteOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final List<? extends WriteRequest> writeRequests, final boolean ordered, final WriteConcern writeConcern,
-            final boolean retryWrites) {
-        this.timeoutSettings = timeoutSettings;
+    public MixedBulkWriteOperation(final MongoNamespace namespace, final List<? extends WriteRequest> writeRequests,
+            final boolean ordered, final WriteConcern writeConcern, final boolean retryWrites) {
         this.namespace = notNull("namespace", namespace);
         this.writeRequests = notNull("writes", writeRequests);
         this.ordered = ordered;
@@ -176,11 +172,6 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
             bulkWriteTracker.advance();
         }
         return decision;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
@@ -51,12 +51,6 @@ import static java.lang.String.format;
 final class OperationHelper {
     public static final Logger LOGGER = Loggers.getLogger("operation");
 
-    static void validateTimeoutMode(final OperationContext operationContext, @Nullable final TimeoutMode timeoutMode) {
-        if (timeoutMode != null && !operationContext.getTimeoutContext().hasTimeoutMS()) {
-            throw new MongoClientException("TimeoutMode requires timeoutMS to be set.");
-        }
-    }
-
     static void validateCollationAndWriteConcern(@Nullable final Collation collation, final WriteConcern writeConcern) {
         if (collation != null && !writeConcern.isAcknowledged()) {
             throw new MongoClientException("Specifying collation with an unacknowledged WriteConcern is not supported");

--- a/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
@@ -51,6 +51,12 @@ import static java.lang.String.format;
 final class OperationHelper {
     public static final Logger LOGGER = Loggers.getLogger("operation");
 
+    static void validateTimeoutMode(final OperationContext operationContext, @Nullable final TimeoutMode timeoutMode) {
+        if (timeoutMode != null && !operationContext.getTimeoutContext().hasTimeoutMS()) {
+            throw new MongoClientException("TimeoutMode requires timeoutMS to be set.");
+        }
+    }
+
     static void validateCollationAndWriteConcern(@Nullable final Collation collation, final WriteConcern writeConcern) {
         if (collation != null && !writeConcern.isAcknowledged()) {
             throw new MongoClientException("Specifying collation with an unacknowledged WriteConcern is not supported");
@@ -201,7 +207,7 @@ final class OperationHelper {
         addMaxTimeMSToNonTailableCursor(commandDocument, TimeoutMode.CURSOR_LIFETIME, operationContext);
     }
 
-    static void addMaxTimeMSToNonTailableCursor(final BsonDocument commandDocument, final TimeoutMode timeoutMode,
+    static void addMaxTimeMSToNonTailableCursor(final BsonDocument commandDocument, @Nullable final TimeoutMode timeoutMode,
             final OperationContext operationContext) {
         long maxTimeMS = timeoutMode == TimeoutMode.ITERATION ? 0 : operationContext.getTimeoutContext().getMaxTimeMS();
         if (maxTimeMS > 0) {

--- a/driver-core/src/main/com/mongodb/internal/operation/ReadOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ReadOperation.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation;
 
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.binding.ReadBinding;
 
 /**
@@ -25,11 +24,6 @@ import com.mongodb.internal.binding.ReadBinding;
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public interface ReadOperation<T> {
-
-    /**
-     * @return the timeout settings for this operation
-     */
-    TimeoutSettings getTimeoutSettings();
 
     /**
      * General execute which can return anything of type T

--- a/driver-core/src/main/com/mongodb/internal/operation/RenameCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/RenameCollectionOperation.java
@@ -18,7 +18,6 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -49,15 +48,13 @@ import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConce
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class RenameCollectionOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
-    private final TimeoutSettings timeoutSettings;
     private final MongoNamespace originalNamespace;
     private final MongoNamespace newNamespace;
     private final WriteConcern writeConcern;
     private boolean dropTarget;
 
-    public RenameCollectionOperation(final TimeoutSettings timeoutSettings, final MongoNamespace originalNamespace,
-            final MongoNamespace newNamespace, @Nullable final WriteConcern writeConcern) {
-        this.timeoutSettings = timeoutSettings;
+    public RenameCollectionOperation(final MongoNamespace originalNamespace, final MongoNamespace newNamespace,
+            @Nullable final WriteConcern writeConcern) {
         this.originalNamespace = notNull("originalNamespace", originalNamespace);
         this.newNamespace = notNull("newNamespace", newNamespace);
         this.writeConcern = writeConcern;
@@ -74,11 +71,6 @@ public class RenameCollectionOperation implements AsyncWriteOperation<Void>, Wri
     public RenameCollectionOperation dropTarget(final boolean dropTarget) {
         this.dropTarget = dropTarget;
         return this;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -60,11 +60,14 @@ import org.bson.conversions.Bson;
 
 import java.util.List;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 /**
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public final class SyncOperations<TDocument> {
     private final Operations<TDocument> operations;
+    private final TimeoutSettings timeoutSettings;
 
     public SyncOperations(final Class<TDocument> documentClass, final ReadPreference readPreference,
                           final CodecRegistry codecRegistry, final boolean retryReads, final TimeoutSettings timeoutSettings) {
@@ -80,7 +83,56 @@ public final class SyncOperations<TDocument> {
                           final CodecRegistry codecRegistry, final ReadConcern readConcern, final WriteConcern writeConcern,
                           final boolean retryWrites, final boolean retryReads, final TimeoutSettings timeoutSettings) {
         this.operations = new Operations<>(namespace, documentClass, readPreference, codecRegistry, readConcern, writeConcern,
-                retryWrites, retryReads, timeoutSettings);
+                retryWrites, retryReads);
+        this.timeoutSettings = timeoutSettings;
+    }
+
+    public TimeoutSettings createTimeoutSettings(final long maxTimeMS) {
+        return timeoutSettings.withMaxTimeMS(maxTimeMS);
+    }
+
+    public TimeoutSettings createTimeoutSettings(final long maxTimeMS, final long maxAwaitTimeMS) {
+        return timeoutSettings.withMaxTimeAndMaxAwaitTimeMS(maxTimeMS, maxAwaitTimeMS);
+    }
+
+    @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final CountOptions options) {
+        return createTimeoutSettings(options.getMaxTime(MILLISECONDS));
+    }
+
+    @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final EstimatedDocumentCountOptions options) {
+        return createTimeoutSettings(options.getMaxTime(MILLISECONDS));
+    }
+
+    @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final FindOptions options) {
+        return timeoutSettings.withMaxTimeAndMaxAwaitTimeMS(options.getMaxTime(MILLISECONDS), options.getMaxAwaitTime(MILLISECONDS));
+    }
+
+    @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final FindOneAndDeleteOptions options) {
+        return createTimeoutSettings(options.getMaxTime(MILLISECONDS));
+    }
+
+    @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final FindOneAndReplaceOptions options) {
+        return createTimeoutSettings(options.getMaxTime(MILLISECONDS));
+    }
+
+    @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final FindOneAndUpdateOptions options) {
+        return timeoutSettings.withMaxTimeMS(options.getMaxTime(MILLISECONDS));
+    }
+
+    // TODO (CSOT) @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final CreateIndexOptions options) {
+        return timeoutSettings.withMaxTimeMS(options.getMaxTime(MILLISECONDS));
+    }
+
+    // TODO (CSOT) @SuppressWarnings("deprecation") // MaxTime
+    public TimeoutSettings createTimeoutSettings(final DropIndexOptions options) {
+        return timeoutSettings.withMaxTimeMS(options.getMaxTime(MILLISECONDS));
     }
 
     public ReadOperation<Long> countDocuments(final Bson filter, final CountOptions options) {
@@ -97,7 +149,7 @@ public final class SyncOperations<TDocument> {
     }
 
     public <TResult> ExplainableReadOperation<BatchCursor<TResult>> find(final Bson filter, final Class<TResult> resultClass,
-                                                              final FindOptions options) {
+            final FindOptions options) {
         return operations.find(filter, resultClass, options);
     }
 
@@ -107,25 +159,25 @@ public final class SyncOperations<TDocument> {
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> distinct(final String fieldName, final Bson filter,
-                                                                  final Class<TResult> resultClass, final long maxTimeMS,
+                                                                  final Class<TResult> resultClass,
                                                                   final Collation collation, final BsonValue comment) {
-        return operations.distinct(fieldName, filter, resultClass, maxTimeMS, collation, comment);
+        return operations.distinct(fieldName, filter, resultClass, collation, comment);
     }
 
     public <TResult> ExplainableReadOperation<BatchCursor<TResult>> aggregate(final List<? extends Bson> pipeline,
-            final Class<TResult> resultClass, final long maxTimeMS, final long maxAwaitTimeMS,
+            final Class<TResult> resultClass,
             @Nullable final TimeoutMode timeoutMode, @Nullable final Integer batchSize,
             final Collation collation, final Bson hint, final String hintString, final BsonValue comment, final Bson variables,
             final Boolean allowDiskUse, final AggregationLevel aggregationLevel) {
-        return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, timeoutMode, batchSize, collation, hint, hintString,
+        return operations.aggregate(pipeline, resultClass, timeoutMode, batchSize, collation, hint, hintString,
                 comment, variables, allowDiskUse, aggregationLevel);
     }
 
-    public AggregateToCollectionOperation aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
+    public AggregateToCollectionOperation aggregateToCollection(final List<? extends Bson> pipeline,
             @Nullable final TimeoutMode timeoutMode, final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
             final Collation collation, @Nullable final Bson hint, @Nullable final String hintString, final BsonValue comment,
             final Bson variables, final AggregationLevel aggregationLevel) {
-        return operations.aggregateToCollection(pipeline, maxTimeMS, timeoutMode, allowDiskUse, bypassDocumentValidation, collation, hint, hintString,
+        return operations.aggregateToCollection(pipeline, timeoutMode, allowDiskUse, bypassDocumentValidation, collation, hint, hintString,
                 comment, variables, aggregationLevel);
     }
 
@@ -133,21 +185,21 @@ public final class SyncOperations<TDocument> {
     public WriteOperation<MapReduceStatistics> mapReduceToCollection(final String databaseName, final String collectionName,
                                                                      final String mapFunction, final String reduceFunction,
                                                                      final String finalizeFunction, final Bson filter, final int limit,
-                                                                     final long maxTimeMS, final boolean jsMode, final Bson scope,
+                                                                     final boolean jsMode, final Bson scope,
                                                                      final Bson sort, final boolean verbose,
                                                                      final com.mongodb.client.model.MapReduceAction action,
                                                                      final Boolean bypassDocumentValidation, final Collation collation) {
         return operations.mapReduceToCollection(databaseName, collectionName, mapFunction, reduceFunction, finalizeFunction, filter, limit,
-                maxTimeMS, jsMode, scope, sort, verbose, action, bypassDocumentValidation, collation);
+                jsMode, scope, sort, verbose, action, bypassDocumentValidation, collation);
     }
 
     public <TResult> ReadOperation<MapReduceBatchCursor<TResult>> mapReduce(final String mapFunction, final String reduceFunction,
                                                                             final String finalizeFunction, final Class<TResult> resultClass,
                                                                             final Bson filter, final int limit,
-                                                                            final long maxTimeMS, final boolean jsMode, final Bson scope,
+                                                                            final boolean jsMode, final Bson scope,
                                                                             final Bson sort, final boolean verbose,
                                                                             final Collation collation) {
-        return operations.mapReduce(mapFunction, reduceFunction, finalizeFunction, resultClass, filter, limit, maxTimeMS, jsMode, scope,
+        return operations.mapReduce(mapFunction, reduceFunction, finalizeFunction, resultClass, filter, limit, jsMode, scope,
                 sort, verbose, collation);
     }
 
@@ -259,14 +311,9 @@ public final class SyncOperations<TDocument> {
 
 
     public <TResult> ExplainableReadOperation<BatchCursor<TResult>> listSearchIndexes(final Class<TResult> resultClass,
-                                                                           final long maxTimeMS,
-                                                                           @Nullable final String indexName,
-                                                                           @Nullable final Integer batchSize,
-                                                                           @Nullable final Collation collation,
-                                                                           @Nullable final BsonValue comment,
-                                                                           @Nullable final Boolean allowDiskUse) {
-        return operations.listSearchIndexes(resultClass, maxTimeMS, indexName, batchSize, collation,
-               comment, allowDiskUse);
+            @Nullable final String indexName, @Nullable final Integer batchSize, @Nullable final Collation collation,
+            @Nullable final BsonValue comment, @Nullable final Boolean allowDiskUse) {
+        return operations.listSearchIndexes(resultClass, indexName, batchSize, collation, comment, allowDiskUse);
     }
 
     public WriteOperation<Void> dropIndex(final String indexName, final DropIndexOptions options) {
@@ -280,30 +327,30 @@ public final class SyncOperations<TDocument> {
     public <TResult> ReadOperation<BatchCursor<TResult>> listCollections(final String databaseName, final Class<TResult> resultClass,
                                                                          final Bson filter, final boolean collectionNamesOnly,
                                                                          final boolean authorizedCollections,
-                                                                         @Nullable final Integer batchSize, final long maxTimeMS,
+                                                                         @Nullable final Integer batchSize,
                                                                          final BsonValue comment, @Nullable final TimeoutMode timeoutMode) {
         return operations.listCollections(databaseName, resultClass, filter, collectionNamesOnly, authorizedCollections,
-                batchSize, maxTimeMS, comment, timeoutMode);
+                batchSize, comment, timeoutMode);
 
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> listDatabases(final Class<TResult> resultClass, final Bson filter,
-                                                                       final Boolean nameOnly, final long maxTimeMS,
+                                                                       final Boolean nameOnly,
                                                                        final Boolean authorizedDatabases, final BsonValue comment) {
-        return operations.listDatabases(resultClass, filter, nameOnly, maxTimeMS, authorizedDatabases, comment);
+        return operations.listDatabases(resultClass, filter, nameOnly, authorizedDatabases, comment);
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> listIndexes(final Class<TResult> resultClass, @Nullable final Integer batchSize,
-            final long maxTimeMS, final BsonValue comment, @Nullable final TimeoutMode timeoutMode) {
-        return operations.listIndexes(resultClass, batchSize, maxTimeMS, comment, timeoutMode);
+            final BsonValue comment, @Nullable final TimeoutMode timeoutMode) {
+        return operations.listIndexes(resultClass, batchSize, comment, timeoutMode);
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> changeStream(final FullDocument fullDocument,
             final FullDocumentBeforeChange fullDocumentBeforeChange, final List<? extends Bson> pipeline, final Decoder<TResult> decoder,
             final ChangeStreamLevel changeStreamLevel, @Nullable final Integer batchSize, final Collation collation,
-            final BsonValue comment, final long maxAwaitTimeMS, final BsonDocument resumeToken, final BsonTimestamp startAtOperationTime,
+            final BsonValue comment, final BsonDocument resumeToken, final BsonTimestamp startAtOperationTime,
             final BsonDocument startAfter, final boolean showExpandedEvents) {
         return operations.changeStream(fullDocument, fullDocumentBeforeChange, pipeline, decoder, changeStreamLevel, batchSize,
-                collation, comment, maxAwaitTimeMS, resumeToken, startAtOperationTime, startAfter, showExpandedEvents);
+                collation, comment, resumeToken, startAtOperationTime, startAfter, showExpandedEvents);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/TransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/TransactionOperation.java
@@ -18,7 +18,6 @@ package com.mongodb.internal.operation;
 
 import com.mongodb.Function;
 import com.mongodb.WriteConcern;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncWriteBinding;
 import com.mongodb.internal.binding.WriteBinding;
@@ -43,21 +42,14 @@ import static com.mongodb.internal.operation.SyncOperationHelper.writeConcernErr
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public abstract class TransactionOperation implements WriteOperation<Void>, AsyncWriteOperation<Void> {
-    private final TimeoutSettings timeoutSettings;
     private final WriteConcern writeConcern;
 
-    TransactionOperation(final TimeoutSettings timeoutSettings, final WriteConcern writeConcern) {
-        this.timeoutSettings = timeoutSettings;
+    TransactionOperation(final WriteConcern writeConcern) {
         this.writeConcern = notNull("writeConcern", writeConcern);
     }
 
     public WriteConcern getWriteConcern() {
         return writeConcern;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/UpdateSearchIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/UpdateSearchIndexesOperation.java
@@ -17,7 +17,6 @@
 package com.mongodb.internal.operation;
 
 import com.mongodb.MongoNamespace;
-import com.mongodb.internal.TimeoutSettings;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 
@@ -30,8 +29,8 @@ final class UpdateSearchIndexesOperation extends AbstractWriteSearchIndexOperati
     private static final String COMMAND_NAME = "updateSearchIndex";
     private final SearchIndexRequest request;
 
-    UpdateSearchIndexesOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace, final SearchIndexRequest request) {
-        super(timeoutSettings, namespace);
+    UpdateSearchIndexesOperation(final MongoNamespace namespace, final SearchIndexRequest request) {
+        super(namespace);
         this.request = request;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/WriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/WriteOperation.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation;
 
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.binding.WriteBinding;
 
 /**
@@ -25,11 +24,6 @@ import com.mongodb.internal.binding.WriteBinding;
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public interface WriteOperation<T> {
-
-    /**
-     * @return the timeout settings for this operation
-     */
-    TimeoutSettings getTimeoutSettings();
 
     /**
      * General execute which can return anything of type T

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -180,7 +180,7 @@ public final class ClusterFixture {
 
     public static ServerVersion getServerVersion() {
         if (serverVersion == null) {
-            serverVersion = getVersion(new CommandReadOperation<>(TIMEOUT_SETTINGS_WITH_TIMEOUT, "admin",
+            serverVersion = getVersion(new CommandReadOperation<>("admin",
                     new BsonDocument("buildInfo", new BsonInt32(1)), new BsonDocumentCodec())
                     .execute(new ClusterBinding(getCluster(), ReadPreference.nearest(), ReadConcern.DEFAULT, OPERATION_CONTEXT)));
         }
@@ -241,7 +241,7 @@ public final class ClusterFixture {
     }
 
     public static Document getServerStatus() {
-        return new CommandReadOperation<>(TIMEOUT_SETTINGS_WITH_TIMEOUT, "admin", new BsonDocument("serverStatus", new BsonInt32(1)),
+        return new CommandReadOperation<>("admin", new BsonDocument("serverStatus", new BsonInt32(1)),
                 new DocumentCodec())
                 .execute(getBinding());
     }
@@ -257,7 +257,7 @@ public final class ClusterFixture {
         @Override
         public void run() {
             if (cluster != null) {
-                new DropDatabaseOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, getDefaultDatabaseName(), WriteConcern.ACKNOWLEDGED).execute(getBinding());
+                new DropDatabaseOperation(getDefaultDatabaseName(), WriteConcern.ACKNOWLEDGED).execute(getBinding());
                 cluster.close();
             }
         }
@@ -295,7 +295,7 @@ public final class ClusterFixture {
         Cluster cluster = createCluster(new ConnectionString(DEFAULT_URI),
                 new SocketStreamFactory(new DefaultInetAddressResolver(), SocketSettings.builder().build(), SslSettings.builder().build()));
         try {
-            BsonDocument helloResult = new CommandReadOperation<>(TIMEOUT_SETTINGS_WITH_TIMEOUT, "admin",
+            BsonDocument helloResult = new CommandReadOperation<>("admin",
                     new BsonDocument(LEGACY_HELLO, new BsonInt32(1)), new BsonDocumentCodec())
                     .execute(new ClusterBinding(cluster, ReadPreference.nearest(), ReadConcern.DEFAULT, OPERATION_CONTEXT));
             if (helloResult.containsKey("setName")) {
@@ -583,7 +583,7 @@ public final class ClusterFixture {
 
     public static BsonDocument getServerParameters() {
         if (serverParameters == null) {
-            serverParameters = new CommandReadOperation<>(TIMEOUT_SETTINGS_WITH_TIMEOUT, "admin",
+            serverParameters = new CommandReadOperation<>("admin",
                     new BsonDocument("getParameter", new BsonString("*")), new BsonDocumentCodec())
                     .execute(getBinding());
         }
@@ -648,7 +648,7 @@ public final class ClusterFixture {
         boolean failsPointsSupported = true;
         if (!isSharded()) {
             try {
-                new CommandReadOperation<>(TIMEOUT_SETTINGS_WITH_TIMEOUT, "admin", failPointDocument, new BsonDocumentCodec())
+                new CommandReadOperation<>("admin", failPointDocument, new BsonDocumentCodec())
                         .execute(getBinding());
             } catch (MongoCommandException e) {
                 if (e.getErrorCode() == COMMAND_NOT_FOUND_ERROR_CODE) {
@@ -664,7 +664,7 @@ public final class ClusterFixture {
             BsonDocument failPointDocument = new BsonDocument("configureFailPoint", new BsonString(failPoint))
                     .append("mode", new BsonString("off"));
             try {
-                new CommandReadOperation<>(TIMEOUT_SETTINGS_WITH_TIMEOUT, "admin", failPointDocument, new BsonDocumentCodec())
+                new CommandReadOperation<>("admin", failPointDocument, new BsonDocumentCodec())
                         .execute(getBinding());
             } catch (MongoCommandException e) {
                 // ignore
@@ -674,7 +674,7 @@ public final class ClusterFixture {
 
     @SuppressWarnings("overloads")
     public static <T> T executeSync(final WriteOperation<T> op) {
-        return executeSync(op, getBinding(op.getTimeoutSettings()));
+        return executeSync(op, getBinding());
     }
 
     @SuppressWarnings("overloads")
@@ -684,7 +684,7 @@ public final class ClusterFixture {
 
     @SuppressWarnings("overloads")
     public static <T> T executeSync(final ReadOperation<T> op) {
-        return executeSync(op, getBinding(op.getTimeoutSettings()));
+        return executeSync(op, getBinding());
     }
 
     @SuppressWarnings("overloads")
@@ -694,7 +694,7 @@ public final class ClusterFixture {
 
     @SuppressWarnings("overloads")
     public static <T> T executeAsync(final AsyncWriteOperation<T> op) throws Throwable {
-        return executeAsync(op, getAsyncBinding(op.getTimeoutSettings()));
+        return executeAsync(op, getAsyncBinding());
     }
 
     @SuppressWarnings("overloads")
@@ -706,7 +706,7 @@ public final class ClusterFixture {
 
     @SuppressWarnings("overloads")
     public static <T> T executeAsync(final AsyncReadOperation<T> op) throws Throwable {
-        return executeAsync(op, getAsyncBinding(op.getTimeoutSettings()));
+        return executeAsync(op, getAsyncBinding());
     }
 
     @SuppressWarnings("overloads")

--- a/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
@@ -65,9 +65,7 @@ import java.util.concurrent.TimeUnit
 
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
 import static com.mongodb.ClusterFixture.TIMEOUT
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.checkReferenceCountReachesTarget
-import static com.mongodb.ClusterFixture.createNewOperationContext
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getAsyncBinding
 import static com.mongodb.ClusterFixture.getBinding
@@ -111,13 +109,13 @@ class OperationFunctionalSpecification extends Specification {
     }
 
     void acknowledgeWrite(final SingleConnectionBinding binding) {
-        new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), [new InsertRequest(new BsonDocument())], true,
+        new MixedBulkWriteOperation(getNamespace(), [new InsertRequest(new BsonDocument())], true,
                 ACKNOWLEDGED, false).execute(binding)
         binding.release()
     }
 
     void acknowledgeWrite(final AsyncSingleConnectionBinding binding) {
-        executeAsync(new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), [new InsertRequest(new BsonDocument())],
+        executeAsync(new MixedBulkWriteOperation(getNamespace(), [new InsertRequest(new BsonDocument())],
                 true, ACKNOWLEDGED, false), binding)
         binding.release()
     }
@@ -146,8 +144,8 @@ class OperationFunctionalSpecification extends Specification {
     def executeWithSession(operation, boolean async) {
         def executor = async ? ClusterFixture.&executeAsync : ClusterFixture.&executeSync
         def binding = async ?
-                new AsyncSessionBinding(getAsyncBinding(operation.getTimeoutSettings()))
-                : new SessionBinding(getBinding(operation.getTimeoutSettings()))
+                new AsyncSessionBinding(getAsyncBinding())
+                : new SessionBinding(getBinding())
         executor(operation, binding)
     }
 
@@ -275,7 +273,7 @@ class OperationFunctionalSpecification extends Specification {
                           BsonDocument expectedCommand=null, Boolean checkSecondaryOk=false,
                           ReadPreference readPreference=ReadPreference.primary(), Boolean retryable = false,
                           ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false) {
-        def operationContext = createNewOperationContext(operation.getTimeoutSettings())
+        def operationContext = OPERATION_CONTEXT
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> activeTransaction
                     getReadConcern() >> readConcern
@@ -352,7 +350,7 @@ class OperationFunctionalSpecification extends Specification {
                            Boolean checkCommand = true, BsonDocument expectedCommand = null, Boolean checkSecondaryOk = false,
                            ReadPreference readPreference = ReadPreference.primary(), Boolean retryable = false,
                            ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false) {
-        def operationContext = createNewOperationContext(operation.getTimeoutSettings())
+        def operationContext = OPERATION_CONTEXT
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> activeTransaction
                     getReadConcern() >> readConcern

--- a/driver-core/src/test/functional/com/mongodb/connection/ConnectionSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/ConnectionSpecification.groovy
@@ -23,7 +23,6 @@ import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.codecs.BsonDocumentCodec
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.LEGACY_HELLO
 import static com.mongodb.connection.ConnectionDescription.getDefaultMaxMessageSize
@@ -66,7 +65,7 @@ class ConnectionSpecification extends OperationFunctionalSpecification {
         source?.release()
     }
    private static BsonDocument getHelloResult() {
-        new CommandReadOperation<BsonDocument>(TIMEOUT_SETTINGS, 'admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)),
+        new CommandReadOperation<BsonDocument>('admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)),
                 new BsonDocumentCodec()).execute(getBinding())
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/ScramSha256AuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/ScramSha256AuthenticationSpecification.groovy
@@ -34,7 +34,6 @@ import spock.lang.IgnoreIf
 import spock.lang.Specification
 
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.createAsyncCluster
 import static com.mongodb.ClusterFixture.createCluster
 import static com.mongodb.ClusterFixture.getBinding
@@ -87,13 +86,13 @@ class ScramSha256AuthenticationSpecification extends Specification {
                 .append('pwd', password)
                 .append('roles', ['root'])
                 .append('mechanisms', mechanisms)
-        new CommandReadOperation<>(TIMEOUT_SETTINGS, 'admin',
+        new CommandReadOperation<>('admin',
                 new BsonDocumentWrapper<Document>(createUserCommand, new DocumentCodec()), new DocumentCodec())
                 .execute(getBinding())
     }
 
     def dropUser(final String userName) {
-        new CommandReadOperation<>(TIMEOUT_SETTINGS, 'admin', new BsonDocument('dropUser', new BsonString(userName)),
+        new CommandReadOperation<>('admin', new BsonDocument('dropUser', new BsonString(userName)),
                 new BsonDocumentCodec()).execute(getBinding())
     }
 
@@ -102,7 +101,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         def cluster = createCluster(credential)
 
         when:
-        new CommandReadOperation<Document>(TIMEOUT_SETTINGS, 'admin',
+        new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
                 .execute(new ClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, OPERATION_CONTEXT))
 
@@ -123,7 +122,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
 
         when:
         // make this synchronous
-        new CommandReadOperation<Document>(TIMEOUT_SETTINGS, 'admin',
+        new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
                 .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, OPERATION_CONTEXT),
                         callback)
@@ -144,7 +143,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         def cluster = createCluster(credential)
 
         when:
-        new CommandReadOperation<Document>(TIMEOUT_SETTINGS, 'admin',
+        new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
                 .execute(new ClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, OPERATION_CONTEXT))
 
@@ -164,7 +163,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         def callback = new FutureResultCallback()
 
         when:
-        new CommandReadOperation<Document>(TIMEOUT_SETTINGS, 'admin',
+        new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
                 .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, OPERATION_CONTEXT),
                         callback)
@@ -185,7 +184,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         def cluster = createCluster(credential)
 
         when:
-        new CommandReadOperation<Document>(TIMEOUT_SETTINGS, 'admin',
+        new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
                 .execute(new ClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, OPERATION_CONTEXT))
 
@@ -205,7 +204,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         def callback = new FutureResultCallback()
 
         when:
-        new CommandReadOperation<Document>(TIMEOUT_SETTINGS, 'admin',
+        new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
                 .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT, OPERATION_CONTEXT),
                         callback)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AbortTransactionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AbortTransactionOperationSpecification.groovy
@@ -21,7 +21,6 @@ import org.bson.BsonDocument
 
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.MAJORITY
 
@@ -34,13 +33,13 @@ class AbortTransactionOperationSpecification extends OperationFunctionalSpecific
         def expectedCommand = BsonDocument.parse('{abortTransaction: 1}')
 
         when:
-        def operation = new AbortTransactionOperation(TIMEOUT_SETTINGS, ACKNOWLEDGED)
+        def operation = new AbortTransactionOperation(ACKNOWLEDGED)
 
         then:
         testOperationInTransaction(operation, [4, 0, 0], expectedCommand, async, cannedResult)
 
         when:
-        operation = new AbortTransactionOperation(TIMEOUT_SETTINGS, MAJORITY)
+        operation = new AbortTransactionOperation(MAJORITY)
         expectedCommand.put('writeConcern', MAJORITY.asDocument())
 
         then:
@@ -57,14 +56,14 @@ class AbortTransactionOperationSpecification extends OperationFunctionalSpecific
 
         when:
         def writeConcern = MAJORITY.withWTimeout(10, TimeUnit.MILLISECONDS)
-        def operation = new AbortTransactionOperation(TIMEOUT_SETTINGS, writeConcern)
+        def operation = new AbortTransactionOperation(writeConcern)
 
         then:
         testOperationRetries(operation, [4, 0, 0], expectedCommand, async, cannedResult, true)
 
         when:
         writeConcern = MAJORITY
-        operation = new AbortTransactionOperation(TIMEOUT_SETTINGS, writeConcern)
+        operation = new AbortTransactionOperation(writeConcern)
         expectedCommand.put('writeConcern', writeConcern.asDocument())
 
         then:
@@ -72,7 +71,7 @@ class AbortTransactionOperationSpecification extends OperationFunctionalSpecific
 
         when:
         writeConcern = ACKNOWLEDGED
-        operation = new AbortTransactionOperation(TIMEOUT_SETTINGS, writeConcern)
+        operation = new AbortTransactionOperation(writeConcern)
         expectedCommand.remove('writeConcern')
 
         then:

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateToCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateToCollectionOperationSpecification.groovy
@@ -17,7 +17,6 @@
 package com.mongodb.internal.operation
 
 import com.mongodb.MongoCommandException
-import com.mongodb.MongoExecutionTimeoutException
 import com.mongodb.MongoNamespace
 import com.mongodb.MongoWriteConcernException
 import com.mongodb.OperationFunctionalSpecification
@@ -29,7 +28,6 @@ import com.mongodb.client.model.CreateCollectionOptions
 import com.mongodb.client.model.Filters
 import com.mongodb.client.model.ValidationOptions
 import com.mongodb.client.test.CollectionHelper
-import com.mongodb.internal.TimeoutSettings
 import com.mongodb.internal.client.model.AggregationLevel
 import org.bson.BsonArray
 import org.bson.BsonBoolean
@@ -42,11 +40,6 @@ import org.bson.codecs.BsonValueCodecProvider
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_TIMEOUT
-import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint
-import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
@@ -73,7 +66,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         def pipeline = [new BsonDocument('$out', new BsonString(aggregateCollectionNamespace.collectionName))]
 
         when:
-        AggregateToCollectionOperation operation = createOperation(TIMEOUT_SETTINGS, getNamespace(), pipeline, ACKNOWLEDGED)
+        AggregateToCollectionOperation operation = createOperation(getNamespace(), pipeline, ACKNOWLEDGED)
 
         then:
         operation.getAllowDiskUse() == null
@@ -89,7 +82,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
 
         when:
         AggregateToCollectionOperation operation =
-                createOperation(TIMEOUT_SETTINGS, getNamespace(), pipeline, WriteConcern.MAJORITY)
+                createOperation(getNamespace(), pipeline, WriteConcern.MAJORITY)
                 .allowDiskUse(true)
                 .bypassDocumentValidation(true)
                 .collation(defaultCollation)
@@ -106,7 +99,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         def pipeline = [new BsonDocument('$out', new BsonString(aggregateCollectionNamespace.collectionName))]
 
         when:
-        AggregateToCollectionOperation operation = createOperation(TIMEOUT_SETTINGS, getNamespace(), pipeline, ReadConcern.DEFAULT)
+        AggregateToCollectionOperation operation = createOperation(getNamespace(), pipeline, ReadConcern.DEFAULT)
                 .allowDiskUse(true)
                 .bypassDocumentValidation(true)
                 .collation(defaultCollation)
@@ -120,7 +113,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
 
     def 'should not accept an empty pipeline'() {
         when:
-        createOperation(TIMEOUT_SETTINGS, getNamespace(), [], ACKNOWLEDGED)
+        createOperation(getNamespace(), [], ACKNOWLEDGED)
 
 
         then:
@@ -129,7 +122,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
 
     def 'should be able to output to a collection'() {
         when:
-        AggregateToCollectionOperation operation = createOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, getNamespace(),
+        AggregateToCollectionOperation operation = createOperation(getNamespace(),
                 [new BsonDocument('$out', new BsonString(aggregateCollectionNamespace.collectionName))],
                 ACKNOWLEDGED)
         execute(operation, async)
@@ -144,7 +137,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
     @IgnoreIf({ serverVersionLessThan(4, 2) })
     def 'should be able to merge into a collection'() {
         when:
-        AggregateToCollectionOperation operation = createOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, getNamespace(),
+        AggregateToCollectionOperation operation = createOperation(getNamespace(),
                 [new BsonDocument('$merge', new BsonDocument('into', new BsonString(aggregateCollectionNamespace.collectionName)))])
         execute(operation, async)
 
@@ -157,7 +150,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
 
     def 'should be able to match then output to a collection'() {
         when:
-        AggregateToCollectionOperation operation = createOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, getNamespace(),
+        AggregateToCollectionOperation operation = createOperation(getNamespace(),
                 [new BsonDocument('$match', new BsonDocument('job', new BsonString('plumber'))),
                  new BsonDocument('$out', new BsonString(aggregateCollectionNamespace.collectionName))], ACKNOWLEDGED)
         execute(operation, async)
@@ -169,31 +162,10 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [true, false]
     }
 
-    def 'should throw execution timeout exception from execute'() {
-        given:
-        AggregateToCollectionOperation operation = createOperation(TIMEOUT_SETTINGS_WITH_MAX_TIME, getNamespace(),
-                [new BsonDocument('$match', new BsonDocument('job', new BsonString('plumber'))),
-                 new BsonDocument('$out', new BsonString(aggregateCollectionNamespace.collectionName))],
-                ACKNOWLEDGED)
-        enableMaxTimeFailPoint()
-
-        when:
-        execute(operation, async)
-
-        then:
-        thrown(MongoExecutionTimeoutException)
-
-        cleanup:
-        disableMaxTimeFailPoint()
-
-        where:
-        async << [true, false]
-    }
-
     @IgnoreIf({ serverVersionLessThan(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw on write concern error'() {
         given:
-        AggregateToCollectionOperation operation =createOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, getNamespace(),
+        AggregateToCollectionOperation operation = createOperation(getNamespace(),
                         [new BsonDocument('$out', new BsonString(aggregateCollectionNamespace.collectionName))],
                         new WriteConcern(5))
 
@@ -218,7 +190,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         getCollectionHelper().insertDocuments(BsonDocument.parse('{ level: 9 }'))
 
         when:
-        AggregateToCollectionOperation operation = createOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, getNamespace(),
+        AggregateToCollectionOperation operation = createOperation(getNamespace(),
                 [BsonDocument.parse('{$out: "collectionOut"}')], ACKNOWLEDGED)
         execute(operation, async)
 
@@ -247,7 +219,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
     def 'should create the expected command'() {
         when:
         def pipeline = [BsonDocument.parse('{$out: "collectionOut"}')]
-        AggregateToCollectionOperation operation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS, getNamespace(), pipeline,
+        AggregateToCollectionOperation operation = new AggregateToCollectionOperation(getNamespace(), pipeline,
                 ReadConcern.MAJORITY, WriteConcern.MAJORITY)
                 .bypassDocumentValidation(true)
         def expectedCommand = new BsonDocument('aggregate', new BsonString(getNamespace().getCollectionName()))
@@ -290,7 +262,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         getCollectionHelper().insertDocuments(BsonDocument.parse('{_id: 1, str: "foo"}'))
         def pipeline = [BsonDocument.parse('{$match: {str: "FOO"}}'),
                         new BsonDocument('$out', new BsonString(aggregateCollectionNamespace.collectionName))]
-        AggregateToCollectionOperation operation = createOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, getNamespace(), pipeline, ACKNOWLEDGED)
+        AggregateToCollectionOperation operation = createOperation(getNamespace(), pipeline, ACKNOWLEDGED)
                 .collation(caseInsensitiveCollation)
 
         when:
@@ -307,10 +279,10 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
     def 'should apply comment'() {
         given:
         def profileCollectionHelper = getCollectionHelper(new MongoNamespace(getDatabaseName(), 'system.profile'))
-        new CommandReadOperation<>(TIMEOUT_SETTINGS, getDatabaseName(), new BsonDocument('profile', new BsonInt32(2)),
+        new CommandReadOperation<>(getDatabaseName(), new BsonDocument('profile', new BsonInt32(2)),
                 new BsonDocumentCodec()).execute(getBinding())
         def expectedComment = 'this is a comment'
-        AggregateToCollectionOperation operation = createOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, getNamespace(),
+        AggregateToCollectionOperation operation = createOperation(getNamespace(),
                 [Aggregates.out('outputCollection').toBsonDocument(BsonDocument, registry)], ACKNOWLEDGED)
                 .comment(new BsonString(expectedComment))
 
@@ -322,7 +294,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         ((Document) profileDocument.get('command')).get('comment') == expectedComment
 
         cleanup:
-        new CommandReadOperation<>(TIMEOUT_SETTINGS, getDatabaseName(), new BsonDocument('profile', new BsonInt32(0)),
+        new CommandReadOperation<>(getDatabaseName(), new BsonDocument('profile', new BsonInt32(0)),
                 new BsonDocumentCodec()).execute(getBinding())
         profileCollectionHelper.drop()
 
@@ -330,19 +302,16 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [true, false]
     }
 
-    def createOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final List<BsonDocument> pipeline) {
-        new AggregateToCollectionOperation(timeoutSettings, namespace, pipeline, null, null, AggregationLevel.COLLECTION)
+    def createOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline) {
+        new AggregateToCollectionOperation(namespace, pipeline, null, null, AggregationLevel.COLLECTION)
     }
 
-    def createOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final List<BsonDocument> pipeline, final WriteConcern writeConcern) {
-        new AggregateToCollectionOperation(timeoutSettings, namespace, pipeline, null, writeConcern, AggregationLevel.COLLECTION)
+    def createOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline, final WriteConcern writeConcern) {
+        new AggregateToCollectionOperation(namespace, pipeline, null, writeConcern, AggregationLevel.COLLECTION)
     }
 
-    def createOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final List<BsonDocument> pipeline, final ReadConcern readConcern) {
-        new AggregateToCollectionOperation(timeoutSettings, namespace, pipeline, readConcern, null, AggregationLevel.COLLECTION)
+    def createOperation(final MongoNamespace namespace, final List<BsonDocument> pipeline, final ReadConcern readConcern) {
+        new AggregateToCollectionOperation(namespace, pipeline, readConcern, null, AggregationLevel.COLLECTION)
     }
 
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationProseTestSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationProseTestSpecification.groovy
@@ -33,7 +33,6 @@ import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.getAsyncCluster
 import static com.mongodb.ClusterFixture.getCluster
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
@@ -54,7 +53,7 @@ class ChangeStreamOperationProseTestSpecification extends OperationFunctionalSpe
         given:
         def helper = getHelper()
         def pipeline = [BsonDocument.parse('{$project: {"_id": 0}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
@@ -91,7 +90,7 @@ class ChangeStreamOperationProseTestSpecification extends OperationFunctionalSpe
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
         def failPointDocument = createFailPointDocument('getMore', 10107)
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         def cursor = execute(operation, async)
@@ -124,7 +123,7 @@ class ChangeStreamOperationProseTestSpecification extends OperationFunctionalSpe
     def 'should not resume for aggregation errors'() {
         given:
         def pipeline = [BsonDocument.parse('{$unsupportedStage: {_id: 0}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
@@ -53,7 +53,6 @@ import org.bson.codecs.ValueCodecProvider
 import spock.lang.IgnoreIf
 
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.getAsyncCluster
 import static com.mongodb.ClusterFixture.getCluster
 import static com.mongodb.ClusterFixture.isStandalone
@@ -69,7 +68,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
     def 'should have the correct defaults'() {
         when:
-        ChangeStreamOperation operation = new ChangeStreamOperation<Document>(TIMEOUT_SETTINGS, getNamespace(),
+        ChangeStreamOperation operation = new ChangeStreamOperation<Document>(getNamespace(),
                 FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [], new DocumentCodec())
 
         then:
@@ -82,7 +81,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
     def 'should set optional values correctly'() {
         when:
-        ChangeStreamOperation operation = new ChangeStreamOperation<Document>(TIMEOUT_SETTINGS, getNamespace(),
+        ChangeStreamOperation operation = new ChangeStreamOperation<Document>(getNamespace(),
                 FullDocument.UPDATE_LOOKUP, FullDocumentBeforeChange.DEFAULT, [], new DocumentCodec())
                 .batchSize(5)
                 .collation(defaultCollation)
@@ -112,7 +111,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
                 .append('cursor', new BsonDocument('id', new BsonInt64(0)).append('ns', new BsonString('db.coll'))
                 .append('firstBatch', new BsonArrayWrapper([])))
 
-        def operation = new ChangeStreamOperation<Document>(TIMEOUT_SETTINGS, namespace, FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<Document>(namespace, FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, new DocumentCodec(), changeStreamLevel as ChangeStreamLevel)
                 .batchSize(5)
                 .collation(defaultCollation)
@@ -148,7 +147,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
@@ -188,7 +187,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
 
@@ -215,7 +214,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "update"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
@@ -243,7 +242,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "replace"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
@@ -271,7 +270,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "delete"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
@@ -299,7 +298,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "invalidate"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
@@ -328,7 +327,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "drop"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         helper.insertDocuments(BsonDocument.parse('{ _id : 2, x : 2, y : 3 }'))
@@ -357,7 +356,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "dropDatabase"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.UPDATE_LOOKUP,
                 FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())),
                 ChangeStreamLevel.DATABASE)
@@ -387,7 +386,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "rename"}}')]
-        def operation = new ChangeStreamOperation<ChangeStreamDocument>(TIMEOUT_SETTINGS, helper.getNamespace(),
+        def operation = new ChangeStreamOperation<ChangeStreamDocument>(helper.getNamespace(),
                 FullDocument.UPDATE_LOOKUP, FullDocumentBeforeChange.DEFAULT, pipeline,
                 createCodec(BsonDocument, fromProviders(new BsonValueCodecProvider(), new ValueCodecProvider())))
         def newNamespace = new MongoNamespace('JavaDriverTest', 'newCollectionName')
@@ -416,7 +415,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         given:
         def helper = getHelper()
         def pipeline = [BsonDocument.parse('{$project: {"_id": 0}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
@@ -440,7 +439,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
@@ -469,7 +468,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         when:
@@ -510,7 +509,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         def cursor = execute(operation, async)
@@ -546,7 +545,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         def cursor = execute(operation, async)
@@ -583,7 +582,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def helper = getHelper()
 
         def pipeline = [BsonDocument.parse('{$match: {operationType: "insert"}}')]
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, pipeline, CODEC)
 
         def cursor = execute(operation, async)
@@ -616,7 +615,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
     def 'should support hasNext on the sync API'() {
         given:
         def helper = getHelper()
-        def operation = new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        def operation = new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, [], CODEC)
 
         when:
@@ -658,7 +657,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         }
 
         when: 'set resumeAfter'
-        new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .resumeAfter(new BsonDocument())
                 .execute(binding)
@@ -668,7 +667,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         !changeStream.containsKey('startAtOperationTime')
 
         when: 'set startAfter'
-        new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .startAfter(new BsonDocument())
                 .execute(binding)
@@ -679,7 +678,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
         when: 'set startAtOperationTime'
         def startAtTime = new BsonTimestamp(42)
-        new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .startAtOperationTime(startAtTime)
                 .execute(binding)
@@ -719,7 +718,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         }
 
         when: 'set resumeAfter'
-        new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .resumeAfter(new BsonDocument())
                 .executeAsync(binding, Stub(SingleResultCallback))
@@ -729,7 +728,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         !changeStream.containsKey('startAtOperationTime')
 
         when: 'set startAfter'
-        new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .startAfter(new BsonDocument())
                 .executeAsync(binding, Stub(SingleResultCallback))
@@ -740,7 +739,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
         when: 'set startAtOperationTime'
         def startAtTime = new BsonTimestamp(42)
-        new ChangeStreamOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.getNamespace(), FullDocument.DEFAULT,
+        new ChangeStreamOperation<BsonDocument>(helper.getNamespace(), FullDocument.DEFAULT,
                 FullDocumentBeforeChange.DEFAULT, [], CODEC)
                 .startAtOperationTime(startAtTime)
                 .executeAsync(binding, Stub(SingleResultCallback))

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CommitTransactionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CommitTransactionOperationSpecification.groovy
@@ -21,7 +21,6 @@ import org.bson.BsonDocument
 
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.MAJORITY
 
@@ -34,13 +33,13 @@ class CommitTransactionOperationSpecification extends OperationFunctionalSpecifi
         def expectedCommand = BsonDocument.parse('{commitTransaction: 1}')
 
         when:
-        def operation = new CommitTransactionOperation(TIMEOUT_SETTINGS, ACKNOWLEDGED)
+        def operation = new CommitTransactionOperation(ACKNOWLEDGED)
 
         then:
         testOperationInTransaction(operation, [4, 0, 0], expectedCommand, async, cannedResult)
 
         when:
-        operation = new CommitTransactionOperation(TIMEOUT_SETTINGS, MAJORITY)
+        operation = new CommitTransactionOperation(MAJORITY)
         expectedCommand.put('writeConcern', MAJORITY.asDocument())
 
         then:
@@ -57,14 +56,14 @@ class CommitTransactionOperationSpecification extends OperationFunctionalSpecifi
 
         when:
         def writeConcern = MAJORITY.withWTimeout(10, TimeUnit.MILLISECONDS)
-        def operation = new CommitTransactionOperation(TIMEOUT_SETTINGS, writeConcern)
+        def operation = new CommitTransactionOperation(writeConcern)
 
         then:
         testOperationRetries(operation, [4, 0, 0], expectedCommand, async, cannedResult, true)
 
         when:
         writeConcern = MAJORITY
-        operation = new CommitTransactionOperation(TIMEOUT_SETTINGS, writeConcern)
+        operation = new CommitTransactionOperation(writeConcern)
         expectedCommand.put('writeConcern', writeConcern.withWTimeout(10000, TimeUnit.MILLISECONDS).asDocument())
 
         then:
@@ -72,7 +71,7 @@ class CommitTransactionOperationSpecification extends OperationFunctionalSpecifi
 
         when:
         writeConcern = ACKNOWLEDGED
-        operation = new CommitTransactionOperation(TIMEOUT_SETTINGS, writeConcern)
+        operation = new CommitTransactionOperation(writeConcern)
         expectedCommand.put('writeConcern', writeConcern.withW('majority').withWTimeout(10000, TimeUnit.MILLISECONDS).asDocument())
 
         then:
@@ -88,7 +87,7 @@ class CommitTransactionOperationSpecification extends OperationFunctionalSpecifi
         def expectedCommand = BsonDocument.parse('{commitTransaction: 1, writeConcern: {w: "majority", wtimeout: 10000}}')
 
         when:
-        def operation = new CommitTransactionOperation(TIMEOUT_SETTINGS, ACKNOWLEDGED, true)
+        def operation = new CommitTransactionOperation(ACKNOWLEDGED, true)
 
         then:
         testOperationInTransaction(operation, [4, 0, 0], expectedCommand, async, cannedResult, true)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CreateCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CreateCollectionOperationSpecification.groovy
@@ -28,7 +28,6 @@ import org.bson.BsonString
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
@@ -116,7 +115,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         execute(operation, async)
 
         then:
-        new ListCollectionsOperation(TIMEOUT_SETTINGS, getDatabaseName(), new BsonDocumentCodec())
+        new ListCollectionsOperation(getDatabaseName(), new BsonDocumentCodec())
                 .execute(getBinding()).next().find { it -> it.getString('name').value == getCollectionName() }
                 .getDocument('options').getDocument('storageEngine') == operation.storageEngineOptions
 
@@ -138,7 +137,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         execute(operation, async)
 
         then:
-        new ListCollectionsOperation(TIMEOUT_SETTINGS, getDatabaseName(), new BsonDocumentCodec())
+        new ListCollectionsOperation(getDatabaseName(), new BsonDocumentCodec())
                 .execute(getBinding()).next().find { it -> it.getString('name').value == getCollectionName() }
                 .getDocument('options').getDocument('storageEngine') == operation.storageEngineOptions
         where:
@@ -279,7 +278,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
     }
 
     def getCollectionInfo(String collectionName) {
-        new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new BsonDocumentCodec()).filter(new BsonDocument('name',
+        new ListCollectionsOperation(databaseName, new BsonDocumentCodec()).filter(new BsonDocument('name',
                 new BsonString(collectionName))).execute(getBinding()).tryNext()?.head()
     }
 
@@ -290,12 +289,12 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
 
     BsonDocument storageStats() {
         if (serverVersionLessThan(6, 2)) {
-            return new CommandReadOperation<>(TIMEOUT_SETTINGS, getDatabaseName(),
+            return new CommandReadOperation<>(getDatabaseName(),
                     new BsonDocument('collStats', new BsonString(getCollectionName())),
                     new BsonDocumentCodec()).execute(getBinding())
         }
         BatchCursor<BsonDocument> cursor = new AggregateOperation(
-                TIMEOUT_SETTINGS,
+
                 getNamespace(),
                 singletonList(new BsonDocument('$collStats', new BsonDocument('storageStats', new BsonDocument()))),
                 new BsonDocumentCodec()).execute(getBinding())
@@ -311,6 +310,6 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
     }
 
     def createOperation(WriteConcern writeConcern) {
-        new CreateCollectionOperation(TIMEOUT_SETTINGS,  getDatabaseName(), getCollectionName(), writeConcern)
+        new CreateCollectionOperation(getDatabaseName(), getCollectionName(), writeConcern)
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CreateViewOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CreateViewOperationSpecification.groovy
@@ -29,7 +29,6 @@ import org.bson.BsonString
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
@@ -52,7 +51,7 @@ class CreateViewOperationSpecification extends OperationFunctionalSpecification 
         getCollectionHelper().insertDocuments([trueXDocument, falseXDocument])
 
         def pipeline = [new BsonDocument('$match', trueXDocument)]
-        def operation = new CreateViewOperation(TIMEOUT_SETTINGS, getDatabaseName(), viewName, viewOn, pipeline,
+        def operation = new CreateViewOperation(getDatabaseName(), viewName, viewOn, pipeline,
                 WriteConcern.ACKNOWLEDGED)
 
         when:
@@ -81,7 +80,7 @@ class CreateViewOperationSpecification extends OperationFunctionalSpecification 
         assert !collectionNameExists(viewOn)
         assert !collectionNameExists(viewName)
 
-        def operation = new CreateViewOperation(TIMEOUT_SETTINGS, getDatabaseName(), viewName, viewOn, [],
+        def operation = new CreateViewOperation(getDatabaseName(), viewName, viewOn, [],
                 WriteConcern.ACKNOWLEDGED)
                 .collation(defaultCollation)
 
@@ -103,7 +102,7 @@ class CreateViewOperationSpecification extends OperationFunctionalSpecification 
     @IgnoreIf({ serverVersionAtLeast(3, 4) })
     def 'should throw if server version is not 3.4 or greater'() {
         given:
-        def operation = new CreateViewOperation(TIMEOUT_SETTINGS, getDatabaseName(), getCollectionName() + '-view',
+        def operation = new CreateViewOperation(getDatabaseName(), getCollectionName() + '-view',
                 getCollectionName(), [], WriteConcern.ACKNOWLEDGED)
 
         when:
@@ -123,7 +122,7 @@ class CreateViewOperationSpecification extends OperationFunctionalSpecification 
         def viewNamespace = new MongoNamespace(getDatabaseName(), viewName)
         assert !collectionNameExists(viewName)
 
-        def operation = new CreateViewOperation(TIMEOUT_SETTINGS, getDatabaseName(), viewName, getCollectionName(), [],
+        def operation = new CreateViewOperation(getDatabaseName(), viewName, getCollectionName(), [],
                 new WriteConcern(5))
 
         when:
@@ -142,7 +141,7 @@ class CreateViewOperationSpecification extends OperationFunctionalSpecification 
     }
 
     def getCollectionInfo(String collectionName) {
-        new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new BsonDocumentCodec()).filter(new BsonDocument('name',
+        new ListCollectionsOperation(databaseName, new BsonDocumentCodec()).filter(new BsonDocument('name',
                 new BsonString(collectionName))).execute(getBinding()).tryNext()?.head()
     }
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DropCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DropCollectionOperationSpecification.groovy
@@ -24,8 +24,6 @@ import org.bson.Document
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_TIMEOUT
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
@@ -39,7 +37,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
         assert collectionNameExists(getCollectionName())
 
         when:
-        new DropCollectionOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, getNamespace(), WriteConcern.ACKNOWLEDGED).execute(getBinding())
+        new DropCollectionOperation(getNamespace(), WriteConcern.ACKNOWLEDGED).execute(getBinding())
 
         then:
         !collectionNameExists(getCollectionName())
@@ -52,7 +50,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
         assert collectionNameExists(getCollectionName())
 
         when:
-        executeAsync(new DropCollectionOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, getNamespace(), WriteConcern.ACKNOWLEDGED))
+        executeAsync(new DropCollectionOperation(getNamespace(), WriteConcern.ACKNOWLEDGED))
 
         then:
         !collectionNameExists(getCollectionName())
@@ -63,7 +61,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
         def namespace = new MongoNamespace(getDatabaseName(), 'nonExistingCollection')
 
         when:
-        new DropCollectionOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, namespace, WriteConcern.ACKNOWLEDGED).execute(getBinding())
+        new DropCollectionOperation(namespace, WriteConcern.ACKNOWLEDGED).execute(getBinding())
 
         then:
         !collectionNameExists('nonExistingCollection')
@@ -75,7 +73,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
         def namespace = new MongoNamespace(getDatabaseName(), 'nonExistingCollection')
 
         when:
-        executeAsync(new DropCollectionOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, namespace, WriteConcern.ACKNOWLEDGED))
+        executeAsync(new DropCollectionOperation(namespace, WriteConcern.ACKNOWLEDGED))
 
         then:
         !collectionNameExists('nonExistingCollection')
@@ -86,7 +84,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentTo', 'createTheCollection'))
         assert collectionNameExists(getCollectionName())
-        def operation = new DropCollectionOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, getNamespace(), new WriteConcern(5))
+        def operation = new DropCollectionOperation(getNamespace(), new WriteConcern(5))
 
         when:
         async ? executeAsync(operation) : operation.execute(getBinding())
@@ -101,7 +99,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
     }
 
     def collectionNameExists(String collectionName) {
-        def cursor = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec()).execute(getBinding())
+        def cursor = new ListCollectionsOperation(databaseName, new DocumentCodec()).execute(getBinding())
         if (!cursor.hasNext()) {
             return false
         }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DropDatabaseOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DropDatabaseOperationSpecification.groovy
@@ -25,8 +25,6 @@ import org.bson.Document
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_TIMEOUT
 import static com.mongodb.ClusterFixture.configureFailPoint
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
@@ -44,7 +42,7 @@ class DropDatabaseOperationSpecification extends OperationFunctionalSpecificatio
         assert databaseNameExists(databaseName)
 
         when:
-        execute(new DropDatabaseOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, databaseName, WriteConcern.ACKNOWLEDGED), async)
+        execute(new DropDatabaseOperation(databaseName, WriteConcern.ACKNOWLEDGED), async)
 
         then:
         !databaseNameExists(databaseName)
@@ -59,7 +57,7 @@ class DropDatabaseOperationSpecification extends OperationFunctionalSpecificatio
         def dbName = 'nonExistingDatabase'
 
         when:
-        execute(new DropDatabaseOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, dbName, WriteConcern.ACKNOWLEDGED), async)
+        execute(new DropDatabaseOperation(dbName, WriteConcern.ACKNOWLEDGED), async)
 
         then:
         !databaseNameExists(dbName)
@@ -75,7 +73,7 @@ class DropDatabaseOperationSpecification extends OperationFunctionalSpecificatio
 
         // On servers older than 4.0 that don't support this failpoint, use a crazy w value instead
         def w = serverVersionAtLeast(4, 0) ? 2 : 5
-        def operation = new DropDatabaseOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, databaseName, new WriteConcern(w))
+        def operation = new DropDatabaseOperation(databaseName, new WriteConcern(w))
         if (serverVersionAtLeast(4, 0)) {
             configureFailPoint(BsonDocument.parse('{ configureFailPoint: "failCommand", ' +
                     'mode : {times : 1}, ' +
@@ -96,7 +94,7 @@ class DropDatabaseOperationSpecification extends OperationFunctionalSpecificatio
     }
 
     def databaseNameExists(String databaseName) {
-        new ListDatabasesOperation(TIMEOUT_SETTINGS, new DocumentCodec()).execute(getBinding()).next()*.name.contains(databaseName)
+        new ListDatabasesOperation(new DocumentCodec()).execute(getBinding()).next()*.name.contains(databaseName)
     }
 
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndDeleteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndDeleteOperationSpecification.groovy
@@ -34,8 +34,6 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
 import static com.mongodb.ClusterFixture.configureFailPoint
 import static com.mongodb.ClusterFixture.disableFailPoint
 import static com.mongodb.ClusterFixture.disableOnPrimaryTransactionalWriteFailPoint
@@ -54,7 +52,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
 
     def 'should have the correct defaults'() {
         when:
-        def operation = new FindAndDeleteOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec)
 
         then:
         operation.getNamespace() == getNamespace()
@@ -73,7 +71,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         def projection = BsonDocument.parse('{ projection : 1}')
 
         when:
-        def operation = new FindAndDeleteOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec)
             .filter(filter)
             .sort(sort)
             .projection(projection)
@@ -94,7 +92,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         getCollectionHelper().insertDocuments(new DocumentCodec(), pete, sam)
 
         when:
-        def operation = new FindAndDeleteOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         Document returnedDocument = execute(operation, async)
 
@@ -115,7 +113,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         getWorkerCollectionHelper().insertDocuments(new WorkerCodec(), pete, sam)
 
         when:
-        FindAndDeleteOperation<Worker> operation = new FindAndDeleteOperation<Worker>(TIMEOUT_SETTINGS, getNamespace(),
+        FindAndDeleteOperation<Worker> operation = new FindAndDeleteOperation<Worker>(getNamespace(),
                 ACKNOWLEDGED, false, workerCodec).filter(new BsonDocument('name', new BsonString('Pete')))
         Worker returnedDocument = execute(operation, async)
 
@@ -135,7 +133,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         CollectionHelper<Document> helper = new CollectionHelper<Document>(documentCodec, getNamespace())
         Document pete = new Document('name', 'Pete').append('job', 'handyman')
         helper.insertDocuments(new DocumentCodec(), pete)
-        def operation = new FindAndDeleteOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), new WriteConcern(5, 1), false,
+        def operation = new FindAndDeleteOperation<Document>(getNamespace(), new WriteConcern(5, 1), false,
                 documentCodec).filter(new BsonDocument('name', new BsonString('Pete')))
 
         when:
@@ -167,7 +165,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
                       "writeConcernError": {"code": 91, "errmsg": "Replication is being shut down"}}}''')
         configureFailPoint(failPoint)
 
-        def operation = new FindAndDeleteOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
                 documentCodec).filter(new BsonDocument('name', new BsonString('Pete')))
 
         when:
@@ -193,11 +191,10 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         def includeTxnNumber = retryWrites && writeConcern.isAcknowledged() && serverType != STANDALONE
         def includeWriteConcern = writeConcern.isAcknowledged() && !writeConcern.isServerDefault()
         def cannedResult = new BsonDocument('value', new BsonDocumentWrapper(BsonDocument.parse('{}'), new BsonDocumentCodec()))
-        def operation = new FindAndDeleteOperation<Document>(TIMEOUT_SETTINGS_WITH_MAX_TIME, getNamespace(), writeConcern as WriteConcern,
+        def operation = new FindAndDeleteOperation<Document>(getNamespace(), writeConcern as WriteConcern,
                 retryWrites as boolean, documentCodec)
         def expectedCommand = new BsonDocument('findAndModify', new BsonString(getNamespace().getCollectionName()))
                 .append('remove', BsonBoolean.TRUE)
-                .append('maxTimeMS', new BsonInt64(100))
 
         if (includeWriteConcern) {
             expectedCommand.put('writeConcern', writeConcern.asDocument())
@@ -248,7 +245,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         getCollectionHelper().insertDocuments(new DocumentCodec(), pete, sam)
 
         when:
-        def operation = new FindAndDeleteOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, true, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, true, documentCodec)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         enableOnPrimaryTransactionalWriteFailPoint(BsonDocument.parse('{times: 1}'))
 
@@ -269,7 +266,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
     def 'should retry if the connection initially fails'() {
         when:
         def cannedResult = new BsonDocument('value', new BsonDocumentWrapper(BsonDocument.parse('{}'), new BsonDocumentCodec()))
-        def operation = new FindAndDeleteOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, true, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, true, documentCodec)
         def expectedCommand = new BsonDocument('findAndModify', new BsonString(getNamespace().getCollectionName()))
                 .append('remove', BsonBoolean.TRUE)
                 .append('txnNumber', new BsonInt64(0))
@@ -283,7 +280,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
 
     def 'should throw original error when retrying and failing'() {
         given:
-        def operation = new FindAndDeleteOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, true, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, true, documentCodec)
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
         when:
@@ -311,7 +308,7 @@ class FindAndDeleteOperationSpecification extends OperationFunctionalSpecificati
         given:
         def document = Document.parse('{_id: 1, str: "foo"}')
         getCollectionHelper().insertDocuments(document)
-        def operation = new FindAndDeleteOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false, documentCodec)
+        def operation = new FindAndDeleteOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec)
                 .filter(BsonDocument.parse('{str: "FOO"}'))
                 .collation(caseInsensitiveCollation)
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndReplaceOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndReplaceOperationSpecification.groovy
@@ -40,8 +40,6 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
 import static com.mongodb.ClusterFixture.configureFailPoint
 import static com.mongodb.ClusterFixture.disableFailPoint
 import static com.mongodb.ClusterFixture.disableOnPrimaryTransactionalWriteFailPoint
@@ -62,7 +60,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
     def 'should have the correct defaults and passed values'() {
         when:
         def replacement = new BsonDocument('replace', new BsonInt32(1))
-        def operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false, documentCodec,
+        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec,
                 replacement)
 
         then:
@@ -84,7 +82,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         def projection = new BsonDocument('projection', new BsonInt32(1))
 
         when:
-        def operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false, documentCodec,
+        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec,
                 new BsonDocument('replace', new BsonInt32(1))).filter(filter).sort(sort).projection(projection)
                 .bypassDocumentValidation(true).upsert(true).returnOriginal(false)
                 .collation(defaultCollation)
@@ -109,7 +107,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         helper.insertDocuments(new DocumentCodec(), pete, sam)
 
         when:
-        def operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
                 documentCodec, jordan)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         Document returnedDocument = execute(operation, async)
@@ -120,7 +118,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         helper.find().get(0).getString('name') == 'Jordan'
 
         when:
-        operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false, documentCodec,
+        operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec,
                 new BsonDocumentWrapper<Document>(pete, documentCodec))
                 .filter(new BsonDocument('name', new BsonString('Jordan')))
                 .returnOriginal(false)
@@ -144,7 +142,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         helper.insertDocuments(new WorkerCodec(), pete, sam)
 
         when:
-        def operation = new FindAndReplaceOperation<Worker>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndReplaceOperation<Worker>(getNamespace(), ACKNOWLEDGED, false,
                 workerCodec, replacement).filter(new BsonDocument('name', new BsonString('Pete')))
         Worker returnedDocument = execute(operation, async)
 
@@ -154,7 +152,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
 
         when:
         replacement = new BsonDocumentWrapper<Worker>(pete, workerCodec)
-        operation = new FindAndReplaceOperation<Worker>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false, workerCodec,
+        operation = new FindAndReplaceOperation<Worker>(getNamespace(), ACKNOWLEDGED, false, workerCodec,
                 replacement)
                 .filter(new BsonDocument('name', new BsonString('Jordan')))
                 .returnOriginal(false)
@@ -170,7 +168,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
     def 'should return null if query fails to match'() {
         when:
         BsonDocument jordan = BsonDocument.parse('{name: "Jordan", job: "sparky"}')
-        def operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
                 documentCodec, jordan)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         Document returnedDocument = execute(operation, async)
@@ -185,7 +183,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
     def 'should throw an exception if replacement contains update operators'() {
         given:
         def replacement = new BsonDocumentWrapper<Document>(['$inc': 1] as Document, documentCodec)
-        def operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
                 documentCodec, replacement)
 
         when:
@@ -210,7 +208,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
 
         when:
         def replacement = new BsonDocument('level', new BsonInt32(9))
-        def operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, namespace, ACKNOWLEDGED, false,
+        def operation = new FindAndReplaceOperation<Document>(namespace, ACKNOWLEDGED, false,
                 documentCodec, replacement)
         execute(operation, async)
 
@@ -249,7 +247,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         BsonDocument jordan = BsonDocument.parse('{name: "Jordan", job: "sparky"}')
 
         when:
-        def operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new FindAndReplaceOperation<Document>(getNamespace(),
                 new WriteConcern(5, 1), false, documentCodec, jordan)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         execute(operation, async)
@@ -263,7 +261,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         ex.writeResult.upsertedId == null
 
         when:
-        operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), new WriteConcern(5, 1),
+        operation = new FindAndReplaceOperation<Document>(getNamespace(), new WriteConcern(5, 1),
                 false, documentCodec, jordan).filter(new BsonDocument('name', new BsonString('Bob')))
                 .upsert(true)
         execute(operation, async)
@@ -295,7 +293,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         configureFailPoint(failPoint)
 
         BsonDocument jordan = BsonDocument.parse('{name: "Jordan", job: "sparky"}')
-        def operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED,
+        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED,
                 false, documentCodec, jordan).filter(new BsonDocument('name', new BsonString('Pete')))
 
         when:
@@ -322,11 +320,9 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         def includeWriteConcern = writeConcern.isAcknowledged() && !writeConcern.isServerDefault()
         def cannedResult = new BsonDocument('value', new BsonDocumentWrapper(BsonDocument.parse('{}'), new BsonDocumentCodec()))
         def replacement = BsonDocument.parse('{ replacement: 1}')
-        def operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS_WITH_MAX_TIME, getNamespace(), writeConcern, retryWrites,
-                documentCodec, replacement)
+        def operation = new FindAndReplaceOperation<Document>(getNamespace(), writeConcern, retryWrites, documentCodec, replacement)
         def expectedCommand = new BsonDocument('findAndModify', new BsonString(getNamespace().getCollectionName()))
                 .append('update', replacement)
-                .append('maxTimeMS', new BsonInt64(100))
         if (includeWriteConcern) {
             expectedCommand.put('writeConcern', writeConcern.asDocument())
         }
@@ -381,7 +377,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         helper.insertDocuments(new DocumentCodec(), pete, sam)
 
         when:
-        def operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, true,
+        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, true,
                 documentCodec, jordan)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
 
@@ -404,7 +400,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         when:
         def cannedResult = new BsonDocument('value', new BsonDocumentWrapper(BsonDocument.parse('{}'), new BsonDocumentCodec()))
         def replacement = BsonDocument.parse('{ replacement: 1}')
-        def operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, true,
+        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, true,
                 documentCodec, replacement)
         def expectedCommand = new BsonDocument('findAndModify', new BsonString(getNamespace().getCollectionName()))
                 .append('update', replacement)
@@ -421,7 +417,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
     def 'should throw original error when retrying and failing'() {
         given:
         def replacement = BsonDocument.parse('{ replacement: 1}')
-        def operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, true,
+        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, true,
                 documentCodec, replacement)
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
@@ -451,7 +447,7 @@ class FindAndReplaceOperationSpecification extends OperationFunctionalSpecificat
         def document = Document.parse('{_id: 1, str: "foo"}')
         getCollectionHelper().insertDocuments(document)
         def replacement = BsonDocument.parse('{str: "bar"}')
-        def operation = new FindAndReplaceOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndReplaceOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
                 documentCodec, replacement)
                 .filter(BsonDocument.parse('{str: "FOO"}'))
                 .collation(caseInsensitiveCollation)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndUpdateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindAndUpdateOperationSpecification.groovy
@@ -41,8 +41,6 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
 import static com.mongodb.ClusterFixture.configureFailPoint
 import static com.mongodb.ClusterFixture.disableFailPoint
 import static com.mongodb.ClusterFixture.disableOnPrimaryTransactionalWriteFailPoint
@@ -64,7 +62,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
     def 'should have the correct defaults and passed values'() {
         when:
         def update = new BsonDocument('update', new BsonInt32(1))
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
                 documentCodec, update)
 
         then:
@@ -83,8 +81,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
     def 'should have the correct defaults and passed values using update pipelines'() {
         when:
         def updatePipeline = new BsonArray(singletonList(new BsonDocument('update', new BsonInt32(1))))
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
-                documentCodec, updatePipeline)
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, updatePipeline)
 
         then:
         operation.getNamespace() == getNamespace()
@@ -105,7 +102,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         def projection = new BsonDocument('projection', new BsonInt32(1))
 
         when:
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(),
                 ACKNOWLEDGED, false, documentCodec, new BsonDocument('update', new BsonInt32(1)))
                 .filter(filter)
                 .sort(sort)
@@ -132,7 +129,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         def projection = new BsonDocument('projection', new BsonInt32(1))
 
         when:
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
                 documentCodec, new BsonArray(singletonList(new BsonDocument('update', new BsonInt32(1)))))
                 .filter(filter)
                 .sort(sort)
@@ -161,7 +158,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         def update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
                 documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         Document returnedDocument = execute(operation, async)
@@ -173,7 +170,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
                 documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
                 .returnOriginal(false)
@@ -197,8 +194,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         def update = new BsonArray(singletonList(new BsonDocument('$addFields', new BsonDocument('foo', new BsonInt32(1)))))
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
-                documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
                 .returnOriginal(false)
         Document returnedDocument = execute(operation, false)
@@ -209,8 +205,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         update = new BsonArray(singletonList(new BsonDocument('$addFields', new BsonDocument('foo', new BsonInt32(1)))))
-        operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
-                documentCodec, update)
+        operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
                 .returnOriginal(false)
         returnedDocument = execute(operation, false)
@@ -230,7 +225,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         def update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        def operation = new FindAndUpdateOperation<Worker>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndUpdateOperation<Worker>(getNamespace(), ACKNOWLEDGED, false,
                 workerCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         Worker returnedDocument = execute(operation, async)
@@ -242,7 +237,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        operation = new FindAndUpdateOperation<Worker>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        operation = new FindAndUpdateOperation<Worker>(getNamespace(), ACKNOWLEDGED, false,
                 workerCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
                 .returnOriginal(false)
@@ -266,8 +261,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         def update = new BsonArray(singletonList(new BsonDocument('$project', new BsonDocument('name', new BsonInt32(1)))))
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
-                documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
                 .returnOriginal(false)
         Document returnedDocument = execute(operation, async)
@@ -283,8 +277,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
     def 'should return null if query fails to match'() {
         when:
         def update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false
-                , documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         Document returnedDocument = execute(operation, async)
 
@@ -298,7 +291,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
     def 'should throw an exception if update contains fields that are not update operators'() {
         given:
         def update = new BsonDocument('x', new BsonInt32(1))
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
                 documentCodec, update)
 
         when:
@@ -316,8 +309,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
     def 'should throw an exception if update pipeline contains operations that are not supported'() {
         when:
         def update = new BsonArray(singletonList(new BsonDocument('$foo', new BsonDocument('x', new BsonInt32(1)))))
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
-                documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
         execute(operation, async)
 
         then:
@@ -325,8 +317,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         update = singletonList(new BsonInt32(1))
-        operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
-                documentCodec, update)
+        operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false, documentCodec, update)
         execute(operation, async)
 
         then:
@@ -347,7 +338,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         def update = new BsonDocument('$inc', new BsonDocument('level', new BsonInt32(-1)))
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, namespace, ACKNOWLEDGED, false,
+        def operation = new FindAndUpdateOperation<Document>(namespace, ACKNOWLEDGED, false,
                 documentCodec, update)
         execute(operation, async)
 
@@ -383,7 +374,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         def update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
 
         when:
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(),
                 new WriteConcern(5, 1), false, documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
         execute(operation, async)
@@ -397,7 +388,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         ex.writeResult.upsertedId == null
 
         when:
-        operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), new WriteConcern(5, 1), false,
+        operation = new FindAndUpdateOperation<Document>(getNamespace(), new WriteConcern(5, 1), false,
                 documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Bob')))
                 .upsert(true)
@@ -427,7 +418,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         configureFailPoint(failPoint)
 
         def update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
                 documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
 
@@ -455,11 +446,9 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         def includeWriteConcern = writeConcern.isAcknowledged() && !writeConcern.isServerDefault()
         def cannedResult = new BsonDocument('value', new BsonDocumentWrapper(BsonDocument.parse('{}'), new BsonDocumentCodec()))
         def update = BsonDocument.parse('{ update: 1}')
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS_WITH_MAX_TIME, getNamespace(), writeConcern, retryWrites,
-                documentCodec, update)
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), writeConcern, retryWrites, documentCodec, update)
         def expectedCommand = new BsonDocument('findAndModify', new BsonString(getNamespace().getCollectionName()))
                 .append('update', update)
-                .append('maxTimeMS', new BsonInt64(100))
         if (includeWriteConcern) {
             expectedCommand.put('writeConcern', writeConcern.asDocument())
         }
@@ -514,7 +503,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
 
         when:
         def update = new BsonDocument('$inc', new BsonDocument('numberOfJobs', new BsonInt32(1)))
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, true,
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, true,
                 documentCodec, update)
                 .filter(new BsonDocument('name', new BsonString('Pete')))
 
@@ -538,7 +527,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         when:
         def cannedResult = new BsonDocument('value', new BsonDocumentWrapper(BsonDocument.parse('{}'), new BsonDocumentCodec()))
         def update = BsonDocument.parse('{ update: 1}')
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, true,
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, true,
                 documentCodec, update)
         def expectedCommand = new BsonDocument('findAndModify', new BsonString(getNamespace().getCollectionName()))
                 .append('update', update)
@@ -555,7 +544,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
     def 'should throw original error when retrying and failing'() {
         given:
         def update = BsonDocument.parse('{ update: 1}')
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, true,
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, true,
                 documentCodec, update)
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
@@ -585,7 +574,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         def document = Document.parse('{_id: 1, str: "foo"}')
         getCollectionHelper().insertDocuments(document)
         def update = BsonDocument.parse('{ $set: {str: "bar"}}')
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
                 documentCodec, update)
                 .filter(BsonDocument.parse('{str: "FOO"}'))
                 .collation(caseInsensitiveCollation)
@@ -608,7 +597,7 @@ class FindAndUpdateOperationSpecification extends OperationFunctionalSpecificati
         getCollectionHelper().insertDocuments(documentOne, documentTwo)
         def update = BsonDocument.parse('{ $set: {"y.$[i].b": 2}}')
         def arrayFilters = [BsonDocument.parse('{"i.b": 3}')]
-        def operation = new FindAndUpdateOperation<Document>(TIMEOUT_SETTINGS, getNamespace(), ACKNOWLEDGED, false,
+        def operation = new FindAndUpdateOperation<Document>(getNamespace(), ACKNOWLEDGED, false,
                 documentCodec, update)
                 .returnOriginal(false)
                 .arrayFilters(arrayFilters)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ListCollectionsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ListCollectionsOperationSpecification.groovy
@@ -16,7 +16,7 @@
 
 package com.mongodb.internal.operation
 
-import com.mongodb.MongoExecutionTimeoutException
+
 import com.mongodb.MongoNamespace
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.ReadPreference
@@ -46,14 +46,8 @@ import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_TIMEOUT
-import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint
-import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
-import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.ClusterFixture.serverVersionLessThan
 
@@ -63,7 +57,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should return empty set if database does not exist'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, madeUpDatabase, new DocumentCodec())
+        def operation = new ListCollectionsOperation(madeUpDatabase, new DocumentCodec())
 
         when:
         def cursor = operation.execute(getBinding())
@@ -78,7 +72,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should return empty cursor if database does not exist asynchronously'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, madeUpDatabase, new DocumentCodec())
+        def operation = new ListCollectionsOperation(madeUpDatabase, new DocumentCodec())
 
         when:
         def cursor = executeAsync(operation)
@@ -94,7 +88,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should return collection names if a collection exists'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec())
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
         def helper = getCollectionHelper()
         def helper2 = getCollectionHelper(new MongoNamespace(databaseName, 'collection2'))
         def codec = new DocumentCodec()
@@ -115,7 +109,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
     @IgnoreIf({ serverVersionAtLeast(3, 0) })
     def 'should throw if filtering on name with something other than a string'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec())
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
                 .filter(new BsonDocument('name', new BsonRegularExpression('^[^$]*$')))
 
         when:
@@ -127,7 +121,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should filter collection names if a name filter is specified'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec())
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
                 .filter(new BsonDocument('name', new BsonString('collection2')))
         def helper = getCollectionHelper()
         def helper2 = getCollectionHelper(new MongoNamespace(databaseName, 'collection2'))
@@ -147,7 +141,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should filter capped collections'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec())
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
                 .filter(new BsonDocument('options.capped', BsonBoolean.TRUE))
         def helper = getCollectionHelper()
         getCollectionHelper().create('collection3', new CreateCollectionOptions().capped(true).sizeInBytes(1000))
@@ -167,7 +161,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
     @IgnoreIf({ serverVersionLessThan(3, 4) || serverVersionAtLeast(4, 0) })
     def 'should get all fields when nameOnly is not requested'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec())
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
         getCollectionHelper().create('collection4', new CreateCollectionOptions())
 
         when:
@@ -181,7 +175,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
     @IgnoreIf({ serverVersionLessThan(4, 0) })
     def 'should only get collection names when nameOnly is requested'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec())
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
                 .nameOnly(true)
         getCollectionHelper().create('collection5', new CreateCollectionOptions())
 
@@ -196,7 +190,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
     @IgnoreIf({ serverVersionLessThan(4, 0) })
     def 'should only get collection names when nameOnly and authorizedCollections are requested'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec())
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
                 .nameOnly(true)
                 .authorizedCollections(true)
         getCollectionHelper().create('collection6', new CreateCollectionOptions())
@@ -212,7 +206,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
     @IgnoreIf({ serverVersionLessThan(3, 4) || serverVersionAtLeast(4, 0) })
     def 'should only get all field names when nameOnly is requested on server versions that do not support nameOnly'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec())
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
                 .nameOnly(true)
         getCollectionHelper().create('collection7', new CreateCollectionOptions())
 
@@ -227,7 +221,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
     @IgnoreIf({ serverVersionLessThan(4, 0) })
     def 'should get all fields when authorizedCollections is requested and nameOnly is not requested'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec())
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
                 .nameOnly(false)
                 .authorizedCollections(true)
         getCollectionHelper().create('collection8', new CreateCollectionOptions())
@@ -242,7 +236,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should return collection names if a collection exists asynchronously'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec())
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
         def helper = getCollectionHelper()
         def helper2 = getCollectionHelper(new MongoNamespace(databaseName, 'collection2'))
         def codec = new DocumentCodec()
@@ -263,9 +257,9 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should filter indexes when calling hasNext before next'() {
         given:
-        new DropDatabaseOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, databaseName, WriteConcern.ACKNOWLEDGED).execute(getBinding())
+        new DropDatabaseOperation(databaseName, WriteConcern.ACKNOWLEDGED).execute(getBinding())
         addSeveralIndexes()
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec()).batchSize(2)
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec()).batchSize(2)
 
         when:
         def cursor = operation.execute(getBinding())
@@ -279,9 +273,9 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should filter indexes without calling hasNext before next'() {
         given:
-        new DropDatabaseOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, databaseName, WriteConcern.ACKNOWLEDGED).execute(getBinding())
+        new DropDatabaseOperation(databaseName, WriteConcern.ACKNOWLEDGED).execute(getBinding())
         addSeveralIndexes()
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec()).batchSize(2)
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec()).batchSize(2)
 
         when:
         def cursor = operation.execute(getBinding())
@@ -301,9 +295,9 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should filter indexes when calling hasNext before tryNext'() {
         given:
-        new DropDatabaseOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, databaseName, WriteConcern.ACKNOWLEDGED).execute(getBinding())
+        new DropDatabaseOperation(databaseName, WriteConcern.ACKNOWLEDGED).execute(getBinding())
         addSeveralIndexes()
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec()).batchSize(2)
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec()).batchSize(2)
 
         when:
         def cursor = operation.execute(getBinding())
@@ -323,9 +317,9 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should filter indexes without calling hasNext before tryNext'() {
         given:
-        new DropDatabaseOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, databaseName, WriteConcern.ACKNOWLEDGED).execute(getBinding())
+        new DropDatabaseOperation(databaseName, WriteConcern.ACKNOWLEDGED).execute(getBinding())
         addSeveralIndexes()
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec()).batchSize(2)
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec()).batchSize(2)
 
         when:
         def cursor = operation.execute(getBinding())
@@ -340,9 +334,9 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should filter indexes asynchronously'() {
         given:
-        new DropDatabaseOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, databaseName, WriteConcern.ACKNOWLEDGED).execute(getBinding())
+        new DropDatabaseOperation(databaseName, WriteConcern.ACKNOWLEDGED).execute(getBinding())
         addSeveralIndexes()
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec()).batchSize(2)
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec()).batchSize(2)
 
         when:
         def cursor = executeAsync(operation)
@@ -355,7 +349,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should use the set batchSize of collections'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec()).batchSize(2)
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec()).batchSize(2)
         def codec = new DocumentCodec()
         getCollectionHelper().insertDocuments(codec, ['a': 1] as Document)
         getCollectionHelper(new MongoNamespace(databaseName, 'collection2')).insertDocuments(codec, ['a': 1] as Document)
@@ -387,7 +381,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should use the set batchSize of collections asynchronously'() {
         given:
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec()).batchSize(2)
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec()).batchSize(2)
         def codec = new DocumentCodec()
         getCollectionHelper().insertDocuments(codec, ['a': 1] as Document)
         getCollectionHelper(new MongoNamespace(databaseName, 'collection2')).insertDocuments(codec, ['a': 1] as Document)
@@ -416,27 +410,6 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         cursor?.close()
     }
 
-    @IgnoreIf({ isSharded() })
-    def 'should throw execution timeout exception'() {
-        given:
-        getCollectionHelper().insertDocuments(new DocumentCodec(), new Document())
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS_WITH_MAX_TIME, databaseName, new DocumentCodec())
-
-        enableMaxTimeFailPoint()
-
-        when:
-        execute(operation, async)
-
-        then:
-        thrown(MongoExecutionTimeoutException)
-
-        cleanup:
-        disableMaxTimeFailPoint()
-
-        where:
-        async << [true, false]
-    }
-
     def 'should use the readPreference to set secondaryOk'() {
         given:
         def connection = Mock(Connection)
@@ -450,7 +423,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
             getReadPreference() >> readPreference
             getOperationContext() >> OPERATION_CONTEXT
         }
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, helper.dbName, helper.decoder)
+        def operation = new ListCollectionsOperation(helper.dbName, helper.decoder)
 
         when: '3.6.0'
         operation.execute(readBinding)
@@ -477,7 +450,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
             getReadPreference() >> readPreference
             getOperationContext() >> OPERATION_CONTEXT
         }
-        def operation = new ListCollectionsOperation(TIMEOUT_SETTINGS, helper.dbName, helper.decoder)
+        def operation = new ListCollectionsOperation(helper.dbName, helper.decoder)
 
         when: '3.6.0'
         operation.executeAsync(readBinding, Stub(SingleResultCallback))

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceWithInlineResultsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceWithInlineResultsOperationSpecification.groovy
@@ -37,7 +37,6 @@ import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonDouble
 import org.bson.BsonInt32
-import org.bson.BsonInt64
 import org.bson.BsonJavaScript
 import org.bson.BsonString
 import org.bson.BsonTimestamp
@@ -47,8 +46,6 @@ import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.connection.ServerType.STANDALONE
@@ -57,8 +54,7 @@ import static com.mongodb.internal.operation.ServerVersionHelper.MIN_WIRE_VERSIO
 
 class MapReduceWithInlineResultsOperationSpecification extends OperationFunctionalSpecification {
     private final bsonDocumentCodec = new BsonDocumentCodec()
-    def mapReduceOperation = new MapReduceWithInlineResultsOperation<BsonDocument>(TIMEOUT_SETTINGS,
-            getNamespace(),
+    def mapReduceOperation = new MapReduceWithInlineResultsOperation<BsonDocument>(getNamespace(),
             new BsonJavaScript('function(){ emit( this.name , 1 ); }'),
             new BsonJavaScript('function(key, values){ return values.length; }'),
             bsonDocumentCodec)
@@ -78,7 +74,7 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
         when:
         def mapF = new BsonJavaScript('function(){ }')
         def reduceF = new BsonJavaScript('function(key, values){ }')
-        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.namespace, mapF, reduceF,
+        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(helper.namespace, mapF, reduceF,
                 bsonDocumentCodec)
 
         then:
@@ -102,7 +98,7 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
         def finalizeF = new BsonJavaScript('function(key, value){}')
         def mapF = new BsonJavaScript('function(){ }')
         def reduceF = new BsonJavaScript('function(key, values){ }')
-        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.namespace,
+        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(helper.namespace,
                 mapF, reduceF, bsonDocumentCodec)
                 .filter(filter)
                 .finalizeFunction(finalizeF)
@@ -142,7 +138,7 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
 
     def 'should use the ReadBindings readPreference to set secondaryOk'() {
         when:
-        def operation = new MapReduceWithInlineResultsOperation<Document>(TIMEOUT_SETTINGS, helper.namespace,
+        def operation = new MapReduceWithInlineResultsOperation<Document>(helper.namespace,
                 new BsonJavaScript('function(){ }'), new BsonJavaScript('function(key, values){ }'), bsonDocumentCodec)
 
         then:
@@ -154,13 +150,12 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
 
     def 'should create the expected command'() {
         when:
-        def operation = new MapReduceWithInlineResultsOperation<Document>(TIMEOUT_SETTINGS_WITH_MAX_TIME, helper.namespace,
+        def operation = new MapReduceWithInlineResultsOperation<Document>(helper.namespace,
                 new BsonJavaScript('function(){ }'), new BsonJavaScript('function(key, values){ }'), bsonDocumentCodec)
         def expectedCommand = new BsonDocument('mapreduce', new BsonString(helper.namespace.getCollectionName()))
             .append('map', operation.getMapFunction())
             .append('reduce', operation.getReduceFunction())
             .append('out', new BsonDocument('inline', new BsonInt32(1)))
-            .append('maxTimeMS', new BsonInt64(100))
 
         then:
         testOperation(operation, serverVersion, expectedCommand, async, helper.commandResult)
@@ -204,8 +199,7 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
         given:
         def document = Document.parse('{_id: 1, str: "foo"}')
         getCollectionHelper().insertDocuments(document)
-        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(TIMEOUT_SETTINGS,
-                namespace,
+        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(namespace,
                 new BsonJavaScript('function(){ emit( this.str, 1 ); }'),
                 new BsonJavaScript('function(key, values){ return Array.sum(values); }'),
                 bsonDocumentCodec)
@@ -242,7 +236,7 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
               }''')
         appendReadConcernToCommand(sessionContext, MIN_WIRE_VERSION, commandDocument)
 
-        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.namespace,
+        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(helper.namespace,
                 new BsonJavaScript('function(){ }'), new BsonJavaScript('function(key, values){ }'), bsonDocumentCodec)
 
         when:
@@ -291,7 +285,7 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
               }''')
         appendReadConcernToCommand(sessionContext, MIN_WIRE_VERSION, commandDocument)
 
-        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(TIMEOUT_SETTINGS, helper.namespace,
+        def operation = new MapReduceWithInlineResultsOperation<BsonDocument>(helper.namespace,
                 new BsonJavaScript('function(){ }'), new BsonJavaScript('function(key, values){ }'), bsonDocumentCodec)
 
         when:

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
@@ -48,7 +48,6 @@ import org.bson.types.ObjectId
 import spock.lang.IgnoreIf
 import util.spock.annotations.Slow
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.configureFailPoint
 import static com.mongodb.ClusterFixture.disableFailPoint
 import static com.mongodb.ClusterFixture.disableOnPrimaryTransactionalWriteFailPoint
@@ -73,7 +72,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'should throw IllegalArgumentException for empty list of requests'() {
         when:
-        new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), [], true, ACKNOWLEDGED, false)
+        new MixedBulkWriteOperation(getNamespace(), [], true, ACKNOWLEDGED, false)
 
         then:
         thrown(IllegalArgumentException)
@@ -81,7 +80,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'should have the expected passed values'() {
         when:
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), requests, ordered, writeConcern, retryWrites)
+        def operation = new MixedBulkWriteOperation(getNamespace(), requests, ordered, writeConcern, retryWrites)
                 .bypassDocumentValidation(bypassValidation)
 
         then:
@@ -101,7 +100,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'when no document with the same id exists, should insert the document'() {
         given:
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))], ordered, ACKNOWLEDGED, false)
 
         when:
@@ -121,7 +120,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         def document = new BsonDocument('_id', new BsonInt32(1))
         getCollectionHelper().insertDocuments(document)
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), [new InsertRequest(document)], ordered,
+        def operation = new MixedBulkWriteOperation(getNamespace(), [new InsertRequest(document)], ordered,
                 ACKNOWLEDGED, false)
 
         when:
@@ -137,7 +136,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'RawBsonDocument should not generate an _id'() {
         given:
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new InsertRequest(RawBsonDocument.parse('{_id: 1}'))], ordered, ACKNOWLEDGED, false)
 
         when:
@@ -156,7 +155,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when documents match the query, a remove of one should remove one of them'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true))
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                                              [new DeleteRequest(new BsonDocument('x', BsonBoolean.TRUE)).multi(false)],
                                              ordered, ACKNOWLEDGED, false)
 
@@ -175,7 +174,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true),
                                               new Document('x', false))
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                                              [new DeleteRequest(new BsonDocument('x', BsonBoolean.TRUE))],
                                              ordered, ACKNOWLEDGED, false)
 
@@ -193,7 +192,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when multiple document match the query, update of one should update only one of them'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true))
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                                              [new UpdateRequest(new BsonDocument('x', BsonBoolean.TRUE),
                                                                 new BsonDocument('$set', new BsonDocument('y', new BsonInt32(1))),
                                                                 UPDATE).multi(false)],
@@ -213,7 +212,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when documents match the query, update multi should update all of them'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true))
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new UpdateRequest(new BsonDocument('x', BsonBoolean.TRUE),
                         new BsonDocument('$set', new BsonDocument('y', new BsonInt32(1))),
                         UPDATE).multi(true)], ordered, ACKNOWLEDGED, false)
@@ -233,7 +232,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         def id = new ObjectId()
         def query = new BsonDocument('_id', new BsonObjectId(id))
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new UpdateRequest(query, new BsonDocument('$set', new BsonDocument('x', new BsonInt32(2))),
                         UPDATE).upsert(true)], ordered, ACKNOWLEDGED, false)
 
@@ -252,7 +251,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         def id = new ObjectId()
         def query = new BsonDocument('_id', new BsonObjectId(id))
         given:
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                                              [new UpdateRequest(query, new BsonDocument('$set', new BsonDocument('x', new BsonInt32(2))),
                                                                 UPDATE).upsert(true).multi(true)],
                                              ordered, ACKNOWLEDGED, false)
@@ -272,7 +271,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when documents matches the query, update one with upsert should update only one of them'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true))
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                                              [new UpdateRequest(new BsonDocument('x', BsonBoolean.TRUE),
                                                                 new BsonDocument('$set', new BsonDocument('y', new BsonInt32(1))),
                                                                 UPDATE).multi(false).upsert(true)],
@@ -292,7 +291,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when documents match the query, update multi with upsert should update all of them'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true))
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                                              [new UpdateRequest(new BsonDocument('x', BsonBoolean.TRUE),
                                                                 new BsonDocument('$set', new BsonDocument('y', new BsonInt32(1))),
                                                                 UPDATE).upsert(true).multi(true)],
@@ -312,7 +311,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when updating with an empty document, update should throw IllegalArgumentException'() {
         given:
         def id = new ObjectId()
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)), new BsonDocument(), UPDATE)],
                 true, ACKNOWLEDGED, false)
 
@@ -329,7 +328,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when replacing with an empty document, update should not throw IllegalArgumentException'() {
         given:
         def id = new ObjectId()
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)), new BsonDocument(), REPLACE)],
                 true, ACKNOWLEDGED, false)
 
@@ -346,7 +345,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when updating with an invalid document, update should throw IllegalArgumentException'() {
         given:
         def id = new ObjectId()
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)), new BsonDocument('a', new BsonInt32(1)), UPDATE)],
                 true, ACKNOWLEDGED, false)
 
@@ -364,7 +363,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when replacing an invalid document, replace should throw IllegalArgumentException'() {
         given:
         def id = new ObjectId()
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)),
                         new BsonDocument('$set', new BsonDocument('x', new BsonInt32(1))), REPLACE)],
                 true, ACKNOWLEDGED, false)
@@ -383,7 +382,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     @IgnoreIf({ serverVersionLessThan(5, 0) })
     def 'when inserting a document with a field starting with a dollar sign, insert should not throw'() {
         given:
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new InsertRequest(new BsonDocument('$inc', new BsonDocument('x', new BsonInt32(1))))],
                 true, ACKNOWLEDGED, false)
 
@@ -400,7 +399,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when a document contains a key with an illegal character, replacing a document with it should throw IllegalArgumentException'() {
         given:
         def id = new ObjectId()
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)),
                         new BsonDocument('$set', new BsonDocument('x', new BsonInt32(1))),
                         REPLACE)
@@ -420,7 +419,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when no document matches the query, a replace with upsert should insert a document'() {
         given:
         def id = new ObjectId()
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                                              [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)),
                                                                 new BsonDocument('_id', new BsonObjectId(id))
                                                                         .append('x', new BsonInt32(2)),
@@ -441,7 +440,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'when a custom _id is upserted it should be in the write result'() {
         given:
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                                              [new UpdateRequest(new BsonDocument('_id', new BsonInt32(0)),
                                                                 new BsonDocument('$set', new BsonDocument('a', new BsonInt32(0))),
                                                                 UPDATE)
@@ -473,7 +472,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'unacknowledged upserts with custom _id should not error'() {
         given:
         def binding = async ? getAsyncSingleConnectionBinding() : getSingleConnectionBinding()
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                                              [new UpdateRequest(new BsonDocument('_id', new BsonInt32(0)),
                                                                 new BsonDocument('$set', new BsonDocument('a', new BsonInt32(0))),
                                                                 UPDATE)
@@ -505,7 +504,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', true), new Document('x', true))
 
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                                              [new UpdateRequest(new BsonDocument('x', BsonBoolean.TRUE),
                                                                 new BsonDocument('y', new BsonInt32(1)).append('x', BsonBoolean.FALSE),
                                                                 REPLACE).upsert(true)],
@@ -526,7 +525,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when a replacement document is 16MB, the document is still replaced'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('_id', 1))
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
                         new BsonDocument('_id', new BsonInt32(1))
                                 .append('x', new BsonBinary(new byte[1024 * 1024 * 16 - 30])),
@@ -547,7 +546,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when two update documents together exceed 16MB, the documents are still updated'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('_id', 1), new Document('_id', 2))
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
                         new BsonDocument('_id', new BsonInt32(1))
                                 .append('x', new BsonBinary(new byte[1024 * 1024 * 16 - 30])),
@@ -573,7 +572,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when documents together are just below the max message size, the documents are still inserted'() {
         given:
         def bsonBinary = new BsonBinary(new byte[16 * 1000 * 1000 - (getCollectionName().length() + 33)])
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [
                         new InsertRequest(new BsonDocument('_id', new BsonObjectId()).append('b', bsonBinary)),
                         new InsertRequest(new BsonDocument('_id', new BsonObjectId()).append('b', bsonBinary)),
@@ -594,7 +593,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when documents together are just above the max message size, the documents are still inserted'() {
         given:
         def bsonBinary = new BsonBinary(new byte[16 * 1000 * 1000 - (getCollectionName().length() + 32)])
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [
                         new InsertRequest(new BsonDocument('_id', new BsonObjectId()).append('b', bsonBinary)),
                         new InsertRequest(new BsonDocument('_id', new BsonObjectId()).append('b', bsonBinary)),
@@ -615,7 +614,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'should handle multi-length runs of ordered insert, update, replace, and remove'() {
         given:
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), getTestWrites(), ordered, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(getNamespace(), getTestWrites(), ordered, ACKNOWLEDGED, false)
 
         when:
         BulkWriteResult result = execute(operation, async)
@@ -638,13 +637,13 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'should handle multi-length runs of UNACKNOWLEDGED insert, update, replace, and remove'() {
         given:
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),  getTestWrites(), ordered, UNACKNOWLEDGED,
+        def operation = new MixedBulkWriteOperation(getNamespace(),  getTestWrites(), ordered, UNACKNOWLEDGED,
                 false)
         def binding = async ? getAsyncSingleConnectionBinding() : getSingleConnectionBinding()
 
         when:
         def result = execute(operation, binding)
-        execute(new MixedBulkWriteOperation(TIMEOUT_SETTINGS, namespace,
+        execute(new MixedBulkWriteOperation(namespace,
                 [new InsertRequest(new BsonDocument('_id', new BsonInt32(9)))], true, ACKNOWLEDGED, false,), binding)
 
         then:
@@ -674,7 +673,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         (1..numberOfWrites).each {
             writes.add(new InsertRequest(new BsonDocument()))
         }
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), writes, ordered, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(getNamespace(), writes, ordered, ACKNOWLEDGED, false)
 
         when:
         execute(operation, binding)
@@ -697,7 +696,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
             writeOperations.add(upsert)
             writeOperations.add(new DeleteRequest(new BsonDocument('key', new BsonInt32(it))))
         }
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), writeOperations, ordered, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(getNamespace(), writeOperations, ordered, ACKNOWLEDGED, false)
 
         when:
         BulkWriteResult result = execute(operation, async)
@@ -712,7 +711,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'error details should have correct index on ordered write failure'() {
         given:
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
                  new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
                          new BsonDocument('$set', new BsonDocument('x', new BsonInt32(3))),
@@ -735,7 +734,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'error details should have correct index on unordered write failure'() {
         given:
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
                  new UpdateRequest(new BsonDocument('_id', new BsonInt32(2)),
                          new BsonDocument('$set', new BsonDocument('x', new BsonInt32(3))),
@@ -764,7 +763,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         for (int i = 0; i < 2000; i++) {
             inserts.add(new InsertRequest(new BsonDocument('_id', new BsonInt32(i))))
         }
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), inserts, false, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(getNamespace(), inserts, false, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -786,7 +785,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         for (int i = 0; i < 2000; i++) {
             inserts.add(new InsertRequest(new BsonDocument('_id', new BsonInt32(i))))
         }
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), inserts, true, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(getNamespace(), inserts, true, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -806,7 +805,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     @IgnoreIf({ !isDiscoverableReplicaSet() })
     def 'should throw bulk write exception with a write concern error when wtimeout is exceeded'() {
         given:
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))],
                 false, new WriteConcern(5, 1), false)
         when:
@@ -825,7 +824,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'when there is a duplicate key error and a write concern error, both should be reported'() {
         given:
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new InsertRequest(new BsonDocument('_id', new BsonInt32(7))),
                  new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))   // duplicate key
                 ], false, new WriteConcern(4, 1), false)
@@ -848,7 +847,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'should throw on write concern error on multiple failpoint'() {
         given:
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new DeleteRequest(new BsonDocument('_id', new BsonInt32(2))), // existing key
                  new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))  // existing (duplicate) key
                 ], true, ACKNOWLEDGED, true)
@@ -880,7 +879,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'should throw IllegalArgumentException when passed an empty bulk operation'() {
         when:
-        new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), [], ordered, UNACKNOWLEDGED, false)
+        new MixedBulkWriteOperation(getNamespace(), [], ordered, UNACKNOWLEDGED, false)
 
         then:
         thrown(IllegalArgumentException)
@@ -892,7 +891,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     @IgnoreIf({ serverVersionLessThan(3, 2) })
     def 'should throw if bypassDocumentValidation is set and writeConcern is UNACKNOWLEDGED'() {
         given:
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new InsertRequest(BsonDocument.parse('{ level: 9 }'))], true, UNACKNOWLEDGED, false)
                 .bypassDocumentValidation(bypassDocumentValidation)
 
@@ -909,7 +908,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     @IgnoreIf({ serverVersionLessThan(3, 4) })
     def 'should throw if collation is set and write is UNACKNOWLEDGED'() {
         given:
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new DeleteRequest(BsonDocument.parse('{ level: 9 }')).collation(defaultCollation)], true, UNACKNOWLEDGED, false)
 
         when:
@@ -929,7 +928,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         def collectionHelper = getCollectionHelper(namespace)
         collectionHelper.create(namespace.getCollectionName(), new CreateCollectionOptions().validationOptions(
                 new ValidationOptions().validator(gte('level', 10))))
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, namespace,
+        def operation = new MixedBulkWriteOperation(namespace,
                 [new InsertRequest(BsonDocument.parse('{ level: 9 }'))], ordered, ACKNOWLEDGED, false)
 
         when:
@@ -965,7 +964,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
                 new ValidationOptions().validator(gte('level', 10))))
 
         collectionHelper.insertDocuments(BsonDocument.parse('{ x: true, level: 10}'))
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, namespace,
+        def operation = new MixedBulkWriteOperation(namespace,
                 [new UpdateRequest(BsonDocument.parse('{x: true}'), BsonDocument.parse('{$inc: {level: -1}}'), UPDATE).multi(false)],
                 ordered, ACKNOWLEDGED, false)
 
@@ -993,7 +992,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('x', 1), new Document('y', 1),
                 new Document('z', 1))
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, namespace, requests, false, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(namespace, requests, false, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -1024,7 +1023,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         def requests = [new DeleteRequest(BsonDocument.parse('{str: "FOO"}}')).collation(caseInsensitiveCollation),
                         new UpdateRequest(BsonDocument.parse('{str: "BAR"}}'), BsonDocument.parse('{str: "bar"}}'), REPLACE)
                                 .collation(caseInsensitiveCollation)]
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, namespace, requests, false, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(namespace, requests, false, ACKNOWLEDGED, false)
 
         when:
         BulkWriteResult result = execute(operation, async)
@@ -1042,7 +1041,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         def testWrites = getTestWrites()
         Collections.shuffle(testWrites)
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), testWrites, true, ACKNOWLEDGED, true)
+        def operation = new MixedBulkWriteOperation(getNamespace(), testWrites, true, ACKNOWLEDGED, true)
 
         when:
         if (serverVersionAtLeast(3, 6) && isDiscoverableReplicaSet()) {
@@ -1085,7 +1084,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         def testWrites = getTestWrites()
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), testWrites, true, ACKNOWLEDGED, true)
+        def operation = new MixedBulkWriteOperation(getNamespace(), testWrites, true, ACKNOWLEDGED, true)
 
         when:
         enableOnPrimaryTransactionalWriteFailPoint(BsonDocument.parse(failPoint))
@@ -1110,7 +1109,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         given:
         def testWrites = getTestWrites()
         getCollectionHelper().insertDocuments(getTestInserts())
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), testWrites, true, UNACKNOWLEDGED, true)
+        def operation = new MixedBulkWriteOperation(getNamespace(), testWrites, true, UNACKNOWLEDGED, true)
 
         when:
         enableOnPrimaryTransactionalWriteFailPoint(BsonDocument.parse(failPoint))
@@ -1134,7 +1133,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     def 'should retry if the connection initially fails'() {
         when:
         def cannedResult = BsonDocument.parse('{ok: 1.0, n: 1}')
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new InsertRequest(BsonDocument.parse('{ level: 9 }'))], true, ACKNOWLEDGED, true)
         def expectedCommand = new BsonDocument('insert', new BsonString(getNamespace().getCollectionName()))
                 .append('ordered', BsonBoolean.TRUE)
@@ -1149,7 +1148,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
 
     def 'should throw original error when retrying and failing'() {
         given:
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new MixedBulkWriteOperation(getNamespace(),
                 [new InsertRequest(BsonDocument.parse('{ level: 9 }'))], true, ACKNOWLEDGED, true)
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
@@ -1176,7 +1175,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     @IgnoreIf({ serverVersionLessThan(3, 6) })
     def 'should not request retryable write for multi updates or deletes'() {
         given:
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, getNamespace(), writes, true, ACKNOWLEDGED, true)
+        def operation = new MixedBulkWriteOperation(getNamespace(), writes, true, ACKNOWLEDGED, true)
 
         when:
         executeWithSession(operation, async)
@@ -1224,7 +1223,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
                         .multi(true)
                         .arrayFilters([BsonDocument.parse('{"i.b": 1}')]),
         ]
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, namespace, requests, true, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(namespace, requests, true, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -1246,7 +1245,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
                 new UpdateRequest(new BsonDocument(), BsonDocument.parse('{ $set: {"y.$[i].b": 2}}'), UPDATE)
                         .arrayFilters([BsonDocument.parse('{"i.b": 3}')])
         ]
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, namespace, requests, true, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(namespace, requests, true, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -1265,7 +1264,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
                 new UpdateRequest(new BsonDocument(), BsonDocument.parse('{ $set: {"y.$[i].b": 2}}'), UPDATE)
                         .arrayFilters([BsonDocument.parse('{"i.b": 3}')])
         ]
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, namespace, requests, true, UNACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(namespace, requests, true, UNACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -1284,7 +1283,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
                 new UpdateRequest(new BsonDocument(), BsonDocument.parse('{ $set: {"y.$[i].b": 2}}'), UPDATE)
                         .hint(BsonDocument.parse('{ _id: 1 }'))
         ]
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, namespace, requests, true, ACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(namespace, requests, true, ACKNOWLEDGED, false)
 
         when:
         execute(operation, async)
@@ -1303,7 +1302,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
                 new UpdateRequest(new BsonDocument(), BsonDocument.parse('{ $set: {"y.$[i].b": 2}}'), UPDATE)
                         .hintString('_id')
         ]
-        def operation = new MixedBulkWriteOperation(TIMEOUT_SETTINGS, namespace, requests, true, UNACKNOWLEDGED, false)
+        def operation = new MixedBulkWriteOperation(namespace, requests, true, UNACKNOWLEDGED, false)
 
         when:
         execute(operation, async)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/RenameCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/RenameCollectionOperationSpecification.groovy
@@ -25,8 +25,6 @@ import org.bson.Document
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_TIMEOUT
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
@@ -37,7 +35,7 @@ import static com.mongodb.ClusterFixture.serverVersionLessThan
 class RenameCollectionOperationSpecification extends OperationFunctionalSpecification {
 
     def cleanup() {
-        new DropCollectionOperation(TIMEOUT_SETTINGS_WITH_TIMEOUT, new MongoNamespace(getDatabaseName(), 'newCollection'),
+        new DropCollectionOperation(new MongoNamespace(getDatabaseName(), 'newCollection'),
                 WriteConcern.ACKNOWLEDGED).execute(getBinding())
     }
 
@@ -45,7 +43,7 @@ class RenameCollectionOperationSpecification extends OperationFunctionalSpecific
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentThat', 'forces creation of the Collection'))
         assert collectionNameExists(getCollectionName())
-        def operation = new RenameCollectionOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new RenameCollectionOperation(getNamespace(),
                 new MongoNamespace(getDatabaseName(), 'newCollection'), null)
 
         when:
@@ -63,7 +61,7 @@ class RenameCollectionOperationSpecification extends OperationFunctionalSpecific
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentThat', 'forces creation of the Collection'))
         assert collectionNameExists(getCollectionName())
-        def operation = new RenameCollectionOperation(TIMEOUT_SETTINGS, getNamespace(), getNamespace(), null)
+        def operation = new RenameCollectionOperation(getNamespace(), getNamespace(), null)
 
         when:
         execute(operation, async)
@@ -81,7 +79,7 @@ class RenameCollectionOperationSpecification extends OperationFunctionalSpecific
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('documentThat', 'forces creation of the Collection'))
         assert collectionNameExists(getCollectionName())
-        def operation = new RenameCollectionOperation(TIMEOUT_SETTINGS, getNamespace(),
+        def operation = new RenameCollectionOperation(getNamespace(),
                 new MongoNamespace(getDatabaseName(), 'newCollection'), new WriteConcern(5))
 
         when:
@@ -97,7 +95,7 @@ class RenameCollectionOperationSpecification extends OperationFunctionalSpecific
     }
 
     def collectionNameExists(String collectionName) {
-        def cursor = new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName, new DocumentCodec()).execute(getBinding())
+        def cursor = new ListCollectionsOperation(databaseName, new DocumentCodec()).execute(getBinding())
         if (!cursor.hasNext()) {
             return false
         }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
@@ -477,7 +477,7 @@ public abstract class AbstractConnectionPoolTest {
     }
 
     private static void executeAdminCommand(final BsonDocument command) {
-        new CommandReadOperation<>(TIMEOUT_SETTINGS, "admin", command, new BsonDocumentCodec())
+        new CommandReadOperation<>("admin", command, new BsonDocumentCodec())
                 .execute(ClusterFixture.getBinding());
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/mockito/InsufficientStubbingDetectorDemoTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/mockito/InsufficientStubbingDetectorDemoTest.java
@@ -15,7 +15,6 @@
  */
 package com.mongodb.internal.mockito;
 
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.binding.ReadBinding;
 import com.mongodb.internal.diagnostics.logging.Logger;
 import com.mongodb.internal.diagnostics.logging.Loggers;
@@ -38,7 +37,7 @@ final class InsufficientStubbingDetectorDemoTest {
 
     @BeforeEach
     void beforeEach() {
-        operation = new ListCollectionsOperation<>(TimeoutSettings.DEFAULT, "db", new BsonDocumentCodec());
+        operation = new ListCollectionsOperation<>("db", new BsonDocumentCodec());
     }
 
     @Test

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/CommitTransactionOperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/CommitTransactionOperationUnitSpecification.groovy
@@ -26,7 +26,6 @@ import com.mongodb.internal.binding.WriteBinding
 import com.mongodb.internal.session.SessionContext
 
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 
 class CommitTransactionOperationUnitSpecification extends OperationUnitSpecification {
     def 'should add UnknownTransactionCommitResult error label to MongoTimeoutException'() {
@@ -39,7 +38,7 @@ class CommitTransactionOperationUnitSpecification extends OperationUnitSpecifica
             getWriteConnectionSource() >> { throw new MongoTimeoutException('Time out!') }
             getOperationContext() >> OPERATION_CONTEXT.withSessionContext(sessionContext)
         }
-        def operation = new CommitTransactionOperation(TIMEOUT_SETTINGS, WriteConcern.ACKNOWLEDGED)
+        def operation = new CommitTransactionOperation(WriteConcern.ACKNOWLEDGED)
 
         when:
         operation.execute(writeBinding)
@@ -61,7 +60,7 @@ class CommitTransactionOperationUnitSpecification extends OperationUnitSpecifica
             }
             getOperationContext() >> OPERATION_CONTEXT.withSessionContext(sessionContext)
         }
-        def operation = new CommitTransactionOperation(TIMEOUT_SETTINGS, WriteConcern.ACKNOWLEDGED)
+        def operation = new CommitTransactionOperation(WriteConcern.ACKNOWLEDGED)
         def callback = new FutureResultCallback()
 
         when:

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/FindOperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/FindOperationUnitSpecification.groovy
@@ -27,21 +27,20 @@ import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.CursorType.TailableAwait
 
 class FindOperationUnitSpecification extends OperationUnitSpecification {
 
     def 'should find with correct command'() {
         when:
-        def operation = new FindOperation<BsonDocument>(TIMEOUT_SETTINGS, namespace, new BsonDocumentCodec())
+        def operation = new FindOperation<BsonDocument>(namespace, new BsonDocumentCodec())
         def expectedCommand = new BsonDocument('find', new BsonString(namespace.getCollectionName()))
 
         then:
         testOperation(operation, [3, 2, 0], expectedCommand, async, commandResult)
         // Overrides
         when:
-        operation = new FindOperation<BsonDocument>(TIMEOUT_SETTINGS, namespace, new BsonDocumentCodec())
+        operation = new FindOperation<BsonDocument>(namespace, new BsonDocumentCodec())
                 .filter(new BsonDocument('a', BsonBoolean.TRUE))
                 .projection(new BsonDocument('x', new BsonInt32(1)))
                 .skip(2)
@@ -105,7 +104,7 @@ class FindOperationUnitSpecification extends OperationUnitSpecification {
 
     def 'should use the readPreference to set secondaryOk for commands'() {
         when:
-        def operation = new FindOperation<Document>(TIMEOUT_SETTINGS, namespace, new DocumentCodec())
+        def operation = new FindOperation<Document>(namespace, new DocumentCodec())
 
         then:
         testOperationSecondaryOk(operation, [3, 2, 0], readPreference, async, commandResult)

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/ListCollectionsOperationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/ListCollectionsOperationTest.java
@@ -24,7 +24,6 @@ import com.mongodb.connection.ServerConnectionState;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.connection.ServerId;
 import com.mongodb.connection.ServerType;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.binding.ConnectionSource;
 import com.mongodb.internal.binding.ReadBinding;
 import com.mongodb.internal.connection.Connection;
@@ -58,7 +57,7 @@ final class ListCollectionsOperationTest {
     @BeforeEach
     void beforeEach() {
         MongoNamespace namespace = new MongoNamespace("db", "coll");
-        operation = new ListCollectionsOperation<>(TimeoutSettings.DEFAULT, namespace.getDatabaseName(), new BsonDocumentCodec());
+        operation = new ListCollectionsOperation<>(namespace.getDatabaseName(), new BsonDocumentCodec());
         mocks = mocks(namespace);
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/OperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/OperationUnitSpecification.groovy
@@ -41,7 +41,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.createNewOperationContext
+import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
 
 class OperationUnitSpecification extends Specification {
 
@@ -96,7 +96,7 @@ class OperationUnitSpecification extends Specification {
     def testSyncOperation(operation, List<Integer> serverVersion, result, Boolean checkCommand=true,
                           BsonDocument expectedCommand=null,
                           Boolean checkSecondaryOk=false, ReadPreference readPreference=ReadPreference.primary()) {
-        def operationContext = createNewOperationContext(operation.getTimeoutSettings())
+        def operationContext = OPERATION_CONTEXT
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> false
                     getReadConcern() >> ReadConcern.DEFAULT
@@ -153,7 +153,7 @@ class OperationUnitSpecification extends Specification {
                            Boolean checkCommand=true, BsonDocument expectedCommand=null,
                            Boolean checkSecondaryOk=false, ReadPreference readPreference=ReadPreference.primary()) {
 
-        def operationContext = createNewOperationContext(operation.getTimeoutSettings())
+        def operationContext = OPERATION_CONTEXT
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> false
                     getReadConcern() >> ReadConcern.DEFAULT

--- a/driver-legacy/src/main/com/mongodb/LegacyMixedBulkWriteOperation.java
+++ b/driver-legacy/src/main/com/mongodb/LegacyMixedBulkWriteOperation.java
@@ -19,7 +19,6 @@ package com.mongodb;
 import com.mongodb.bulk.BulkWriteError;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.bulk.WriteConcernError;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.internal.bulk.DeleteRequest;
 import com.mongodb.internal.bulk.InsertRequest;
@@ -48,7 +47,6 @@ import static com.mongodb.internal.bulk.WriteRequest.Type.UPDATE;
  * Operation for bulk writes for the legacy API.
  */
 final class LegacyMixedBulkWriteOperation implements WriteOperation<WriteConcernResult> {
-    private final TimeoutSettings timeoutSettings;
     private final WriteConcern writeConcern;
     private final MongoNamespace namespace;
     private final List<? extends WriteRequest> writeRequests;
@@ -57,41 +55,31 @@ final class LegacyMixedBulkWriteOperation implements WriteOperation<WriteConcern
     private final boolean retryWrites;
     private Boolean bypassDocumentValidation;
 
-    static LegacyMixedBulkWriteOperation createBulkWriteOperationForInsert(final TimeoutSettings timeoutSettings,
-            final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern, final boolean retryWrites,
-            final List<InsertRequest> insertRequests) {
-        return new LegacyMixedBulkWriteOperation(timeoutSettings, namespace, ordered, writeConcern, retryWrites, insertRequests,
-                INSERT);
+    static LegacyMixedBulkWriteOperation createBulkWriteOperationForInsert(final MongoNamespace namespace, final boolean ordered,
+            final WriteConcern writeConcern, final boolean retryWrites, final List<InsertRequest> insertRequests) {
+        return new LegacyMixedBulkWriteOperation(namespace, ordered, writeConcern, retryWrites, insertRequests, INSERT);
     }
 
-    static LegacyMixedBulkWriteOperation createBulkWriteOperationForUpdate(final TimeoutSettings timeoutSettings,
-            final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern, final boolean retryWrites,
-            final List<UpdateRequest> updateRequests) {
+    static LegacyMixedBulkWriteOperation createBulkWriteOperationForUpdate(final MongoNamespace namespace, final boolean ordered,
+            final WriteConcern writeConcern, final boolean retryWrites, final List<UpdateRequest> updateRequests) {
         assertTrue(updateRequests.stream().allMatch(updateRequest -> updateRequest.getType() == UPDATE));
-        return new LegacyMixedBulkWriteOperation(timeoutSettings, namespace, ordered, writeConcern, retryWrites, updateRequests,
-                UPDATE);
+        return new LegacyMixedBulkWriteOperation(namespace, ordered, writeConcern, retryWrites, updateRequests, UPDATE);
     }
 
-    static LegacyMixedBulkWriteOperation createBulkWriteOperationForReplace(final TimeoutSettings timeoutSettings,
-            final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern, final boolean retryWrites,
-            final List<UpdateRequest> replaceRequests) {
+    static LegacyMixedBulkWriteOperation createBulkWriteOperationForReplace(final MongoNamespace namespace, final boolean ordered,
+            final WriteConcern writeConcern, final boolean retryWrites, final List<UpdateRequest> replaceRequests) {
         assertTrue(replaceRequests.stream().allMatch(updateRequest -> updateRequest.getType() == REPLACE));
-        return new LegacyMixedBulkWriteOperation(timeoutSettings, namespace, ordered, writeConcern, retryWrites, replaceRequests,
-                REPLACE);
+        return new LegacyMixedBulkWriteOperation(namespace, ordered, writeConcern, retryWrites, replaceRequests, REPLACE);
     }
 
-    static LegacyMixedBulkWriteOperation createBulkWriteOperationForDelete(final TimeoutSettings timeoutSettings,
-            final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern, final boolean retryWrites,
-            final List<DeleteRequest> deleteRequests) {
-        return new LegacyMixedBulkWriteOperation(timeoutSettings, namespace, ordered, writeConcern, retryWrites, deleteRequests,
-                DELETE);
+    static LegacyMixedBulkWriteOperation createBulkWriteOperationForDelete(final MongoNamespace namespace, final boolean ordered,
+            final WriteConcern writeConcern, final boolean retryWrites, final List<DeleteRequest> deleteRequests) {
+        return new LegacyMixedBulkWriteOperation(namespace, ordered, writeConcern, retryWrites, deleteRequests, DELETE);
     }
 
-    private LegacyMixedBulkWriteOperation(final TimeoutSettings timeoutSettings, final MongoNamespace namespace,
-            final boolean ordered, final WriteConcern writeConcern,
+    private LegacyMixedBulkWriteOperation(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
             final boolean retryWrites, final List<? extends WriteRequest> writeRequests, final WriteRequest.Type type) {
         isTrueArgument("writeRequests not empty", !writeRequests.isEmpty());
-        this.timeoutSettings = notNull("timeoutSettings", timeoutSettings);
         this.writeRequests = notNull("writeRequests", writeRequests);
         this.type = type;
         this.ordered = ordered;
@@ -110,15 +98,10 @@ final class LegacyMixedBulkWriteOperation implements WriteOperation<WriteConcern
     }
 
     @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return timeoutSettings;
-    }
-
-    @Override
     public WriteConcernResult execute(final WriteBinding binding) {
         try {
-            BulkWriteResult result = new MixedBulkWriteOperation(timeoutSettings, namespace, writeRequests,
-                    ordered, writeConcern, retryWrites).bypassDocumentValidation(bypassDocumentValidation).execute(binding);
+            BulkWriteResult result = new MixedBulkWriteOperation(namespace, writeRequests, ordered, writeConcern, retryWrites)
+                    .bypassDocumentValidation(bypassDocumentValidation).execute(binding);
             if (result.wasAcknowledged()) {
                 return translateBulkWriteResult(result);
             } else {

--- a/driver-legacy/src/main/com/mongodb/TimeoutSettingsHelper.java
+++ b/driver-legacy/src/main/com/mongodb/TimeoutSettingsHelper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+import com.mongodb.client.model.DBCollectionCountOptions;
+import com.mongodb.client.model.DBCollectionFindAndModifyOptions;
+import com.mongodb.client.model.DBCollectionFindOptions;
+import com.mongodb.internal.TimeoutSettings;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+final class TimeoutSettingsHelper {
+
+    private TimeoutSettingsHelper() {
+    }
+
+    static TimeoutSettings createTimeoutSettings(final TimeoutSettings timeoutSettings, final long maxTimeMS) {
+        return timeoutSettings.withMaxTimeMS(maxTimeMS);
+    }
+
+    static TimeoutSettings createTimeoutSettings(final TimeoutSettings timeoutSettings, final long maxTimeMS, final long maxAwaitTimeMS) {
+        return timeoutSettings.withMaxTimeAndMaxAwaitTimeMS(maxTimeMS, maxAwaitTimeMS);
+    }
+
+    static TimeoutSettings createTimeoutSettings(final TimeoutSettings timeoutSettings, final AggregationOptions options) {
+        return createTimeoutSettings(timeoutSettings, options.getMaxTime(MILLISECONDS));
+    }
+
+    static TimeoutSettings createTimeoutSettings(final TimeoutSettings timeoutSettings, final DBCollectionCountOptions options) {
+        return createTimeoutSettings(timeoutSettings, options.getMaxTime(MILLISECONDS));
+    }
+
+    static TimeoutSettings createTimeoutSettings(final TimeoutSettings timeoutSettings, final DBCollectionFindOptions options) {
+        return timeoutSettings.withMaxTimeAndMaxAwaitTimeMS(options.getMaxTime(MILLISECONDS), options.getMaxAwaitTime(MILLISECONDS));
+    }
+
+    static TimeoutSettings createTimeoutSettings(final TimeoutSettings timeoutSettings, final DBCollectionFindAndModifyOptions options) {
+        return createTimeoutSettings(timeoutSettings, options.getMaxTime(MILLISECONDS));
+    }
+
+    @SuppressWarnings("deprecation")
+    static TimeoutSettings createTimeoutSettings(final TimeoutSettings timeoutSettings, final MapReduceCommand options) {
+        return createTimeoutSettings(timeoutSettings, options.getMaxTime(MILLISECONDS));
+    }
+
+}

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
@@ -61,7 +61,6 @@ import spock.lang.Specification
 import java.util.concurrent.TimeUnit
 
 import static Fixture.getMongoClient
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.LegacyMixedBulkWriteOperation.createBulkWriteOperationForDelete
 import static com.mongodb.LegacyMixedBulkWriteOperation.createBulkWriteOperationForUpdate
@@ -272,7 +271,7 @@ class DBCollectionSpecification extends Specification {
         collection.find().iterator().hasNext()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(),
                 collection.getObjectCodec())
                 .filter(new BsonDocument())
                 .retryReads(true))
@@ -282,7 +281,7 @@ class DBCollectionSpecification extends Specification {
         collection.find().iterator().hasNext()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(),
                 collection.getObjectCodec())
                 .filter(new BsonDocument())
                 .retryReads(true))
@@ -292,7 +291,7 @@ class DBCollectionSpecification extends Specification {
         collection.find(new BasicDBObject(), new DBCollectionFindOptions().collation(collation)).iterator().hasNext()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(),
                 collection.getObjectCodec())
                 .filter(new BsonDocument())
                 .collation(collation)
@@ -315,7 +314,7 @@ class DBCollectionSpecification extends Specification {
         collection.findOne()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(),
                 collection.getObjectCodec())
                 .filter(new BsonDocument())
                 .limit(-1)
@@ -326,7 +325,7 @@ class DBCollectionSpecification extends Specification {
         collection.findOne()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(),
                 collection.getObjectCodec())
                 .filter(new BsonDocument())
                 .limit(-1)
@@ -337,7 +336,7 @@ class DBCollectionSpecification extends Specification {
         collection.findOne(new BasicDBObject(), new DBCollectionFindOptions().collation(collation))
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(),
                 collection.getObjectCodec())
                 .filter(new BsonDocument())
                 .limit(-1)
@@ -358,7 +357,7 @@ class DBCollectionSpecification extends Specification {
         collection.findAndRemove(query)
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new FindAndDeleteOperation<DBObject>(TIMEOUT_SETTINGS, collection.
+        expect executor.getWriteOperation(), isTheSameAs(new FindAndDeleteOperation<DBObject>(collection.
                 getNamespace(), WriteConcern.ACKNOWLEDGED, retryWrites, collection.getObjectCodec()).filter(new BsonDocument()))
     }
 
@@ -378,8 +377,8 @@ class DBCollectionSpecification extends Specification {
         collection.findAndModify(query, update)
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new FindAndUpdateOperation<DBObject>(TIMEOUT_SETTINGS,
-                collection.getNamespace(), WriteConcern.ACKNOWLEDGED, retryWrites, collection.getObjectCodec(), bsonUpdate)
+        expect executor.getWriteOperation(), isTheSameAs(new FindAndUpdateOperation<DBObject>(collection.getNamespace(),
+                WriteConcern.ACKNOWLEDGED, retryWrites, collection.getObjectCodec(), bsonUpdate)
                 .filter(new BsonDocument()))
 
         when: // With options
@@ -387,8 +386,8 @@ class DBCollectionSpecification extends Specification {
                 .arrayFilters(dbObjectArrayFilters).writeConcern(WriteConcern.W3))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new FindAndUpdateOperation<DBObject>(TIMEOUT_SETTINGS,
-                collection.getNamespace(), WriteConcern.W3, retryWrites, collection.getObjectCodec(), bsonUpdate)
+        expect executor.getWriteOperation(), isTheSameAs(new FindAndUpdateOperation<DBObject>(collection.getNamespace(), WriteConcern.W3,
+                retryWrites, collection.getObjectCodec(), bsonUpdate)
                 .filter(new BsonDocument())
                 .collation(collation)
                 .arrayFilters(bsonDocumentWrapperArrayFilters))
@@ -415,7 +414,7 @@ class DBCollectionSpecification extends Specification {
         collection.findAndModify(query, replace)
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new FindAndReplaceOperation<DBObject>(TIMEOUT_SETTINGS, collection.
+        expect executor.getWriteOperation(), isTheSameAs(new FindAndReplaceOperation<DBObject>(collection.
                 getNamespace(), WriteConcern.ACKNOWLEDGED, retryWrites, collection.getObjectCodec(), bsonReplace)
                 .filter(new BsonDocument()))
 
@@ -424,8 +423,8 @@ class DBCollectionSpecification extends Specification {
                 .writeConcern(WriteConcern.W3))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new FindAndReplaceOperation<DBObject>(TIMEOUT_SETTINGS,
-                collection.getNamespace(), WriteConcern.W3, retryWrites, collection.getObjectCodec(), bsonReplace)
+        expect executor.getWriteOperation(), isTheSameAs(new FindAndReplaceOperation<DBObject>(collection.getNamespace(), WriteConcern.W3,
+                retryWrites, collection.getObjectCodec(), bsonReplace)
                 .filter(new BsonDocument())
                 .collation(collation))
     }
@@ -440,7 +439,7 @@ class DBCollectionSpecification extends Specification {
         collection.count()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new CountOperation(TIMEOUT_SETTINGS, collection.getNamespace())
+        expect executor.getReadOperation(), isTheSameAs(new CountOperation(collection.getNamespace())
                 .filter(new BsonDocument()).retryReads(true))
 
         when: // Inherits from DB
@@ -449,7 +448,7 @@ class DBCollectionSpecification extends Specification {
         executor.getReadConcern() == ReadConcern.MAJORITY
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new CountOperation(TIMEOUT_SETTINGS, collection.getNamespace())
+        expect executor.getReadOperation(), isTheSameAs(new CountOperation(collection.getNamespace())
                 .filter(new BsonDocument()).retryReads(true))
         executor.getReadConcern() == ReadConcern.MAJORITY
 
@@ -458,7 +457,7 @@ class DBCollectionSpecification extends Specification {
         collection.count(new BasicDBObject(), new DBCollectionCountOptions().collation(collation))
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new CountOperation(TIMEOUT_SETTINGS, collection.getNamespace())
+        expect executor.getReadOperation(), isTheSameAs(new CountOperation(collection.getNamespace())
                 .filter(new BsonDocument()).retryReads(true)
                 .collation(collation))
         executor.getReadConcern() == ReadConcern.LOCAL
@@ -485,7 +484,7 @@ class DBCollectionSpecification extends Specification {
 
         then:
         distinctFieldValues == [1, 2]
-        expect executor.getReadOperation(), isTheSameAs(new DistinctOperation(TIMEOUT_SETTINGS, collection.getNamespace(), 'field1',
+        expect executor.getReadOperation(), isTheSameAs(new DistinctOperation(collection.getNamespace(), 'field1',
                 new BsonValueCodec()).filter(new BsonDocument()).retryReads(true))
         executor.getReadConcern() == ReadConcern.DEFAULT
 
@@ -494,7 +493,7 @@ class DBCollectionSpecification extends Specification {
         collection.distinct('field1')
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new DistinctOperation(TIMEOUT_SETTINGS, collection.getNamespace(), 'field1',
+        expect executor.getReadOperation(), isTheSameAs(new DistinctOperation(collection.getNamespace(), 'field1',
                 new BsonValueCodec())
                 .filter(new BsonDocument()).retryReads(true))
         executor.getReadConcern() == ReadConcern.MAJORITY
@@ -504,7 +503,7 @@ class DBCollectionSpecification extends Specification {
         collection.distinct('field1', new DBCollectionDistinctOptions().collation(collation))
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new DistinctOperation(TIMEOUT_SETTINGS, collection.getNamespace(), 'field1',
+        expect executor.getReadOperation(), isTheSameAs(new DistinctOperation(collection.getNamespace(), 'field1',
                 new BsonValueCodec()).collation(collation).retryReads(true))
         executor.getReadConcern() == ReadConcern.LOCAL
     }
@@ -524,7 +523,7 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getReadOperation(), isTheSameAs(
-                new MapReduceWithInlineResultsOperation(TIMEOUT_SETTINGS, collection.getNamespace(), new BsonJavaScript('map'),
+                new MapReduceWithInlineResultsOperation(collection.getNamespace(), new BsonJavaScript('map'),
                         new BsonJavaScript('reduce'), collection.getDefaultDBObjectCodec())
                         .verbose(true)
                         .filter(new BsonDocument()))
@@ -536,7 +535,7 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getReadOperation(), isTheSameAs(
-                new MapReduceWithInlineResultsOperation(TIMEOUT_SETTINGS, collection.getNamespace(), new BsonJavaScript('map'),
+                new MapReduceWithInlineResultsOperation(collection.getNamespace(), new BsonJavaScript('map'),
                         new BsonJavaScript('reduce'), collection.getDefaultDBObjectCodec())
                         .verbose(true)
                         .filter(new BsonDocument()))
@@ -551,7 +550,7 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getReadOperation(), isTheSameAs(
-                new MapReduceWithInlineResultsOperation(TIMEOUT_SETTINGS, collection.getNamespace(), new BsonJavaScript('map'),
+                new MapReduceWithInlineResultsOperation(collection.getNamespace(), new BsonJavaScript('map'),
                         new BsonJavaScript('reduce'), collection.getDefaultDBObjectCodec())
                         .verbose(true)
                         .filter(new BsonDocument())
@@ -571,7 +570,7 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getWriteOperation(), isTheSameAs(
-                new MapReduceToCollectionOperation(TIMEOUT_SETTINGS, collection.getNamespace(), new BsonJavaScript('map'),
+                new MapReduceToCollectionOperation(collection.getNamespace(), new BsonJavaScript('map'),
                         new BsonJavaScript('reduce'), 'myColl', collection.getWriteConcern())
                         .verbose(true)
                         .filter(new BsonDocument())
@@ -582,7 +581,7 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getWriteOperation(), isTheSameAs(
-                new MapReduceToCollectionOperation(TIMEOUT_SETTINGS, collection.getNamespace(), new BsonJavaScript('map'),
+                new MapReduceToCollectionOperation(collection.getNamespace(), new BsonJavaScript('map'),
                         new BsonJavaScript('reduce'), 'myColl', collection.getWriteConcern())
                         .verbose(true)
                         .filter(new BsonDocument())
@@ -596,7 +595,7 @@ class DBCollectionSpecification extends Specification {
 
         then:
         expect executor.getWriteOperation(), isTheSameAs(
-                new MapReduceToCollectionOperation(TIMEOUT_SETTINGS, collection.getNamespace(), new BsonJavaScript('map'),
+                new MapReduceToCollectionOperation(collection.getNamespace(), new BsonJavaScript('map'),
                         new BsonJavaScript('reduce'), 'myColl', collection.getWriteConcern())
                         .verbose(true)
                         .filter(new BsonDocument())
@@ -620,7 +619,7 @@ class DBCollectionSpecification extends Specification {
         collection.aggregate(pipeline, AggregationOptions.builder().build())
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(collection.getNamespace(),
                 bsonPipeline, collection.getDefaultDBObjectCodec()).retryReads(true))
         executor.getReadConcern() == ReadConcern.DEFAULT
 
@@ -629,7 +628,7 @@ class DBCollectionSpecification extends Specification {
         collection.aggregate(pipeline, AggregationOptions.builder().build())
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(collection.getNamespace(),
                 bsonPipeline, collection.getDefaultDBObjectCodec()).retryReads(true))
         executor.getReadConcern() == ReadConcern.MAJORITY
 
@@ -638,7 +637,7 @@ class DBCollectionSpecification extends Specification {
         collection.aggregate(pipeline, AggregationOptions.builder().collation(collation).build())
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(collection.getNamespace(),
                 bsonPipeline, collection.getDefaultDBObjectCodec()).collation(collation).retryReads(true))
         executor.getReadConcern() == ReadConcern.LOCAL
     }
@@ -655,21 +654,21 @@ class DBCollectionSpecification extends Specification {
         collection.aggregate(pipeline, AggregationOptions.builder().build())
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
                 bsonPipeline, collection.getReadConcern(), collection.getWriteConcern()))
 
         when: // Inherits from DB
         collection.aggregate(pipeline, AggregationOptions.builder().build())
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
                 bsonPipeline, collection.getReadConcern(), collection.getWriteConcern()))
 
         when:
         collection.aggregate(pipeline, AggregationOptions.builder().collation(collation).build())
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateToCollectionOperation(collection.getNamespace(),
                 bsonPipeline, collection.getReadConcern(), collection.getWriteConcern()).collation(collation))
     }
 
@@ -687,7 +686,7 @@ class DBCollectionSpecification extends Specification {
         collection.explainAggregate(pipeline, options)
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(collection.getNamespace(),
                 bsonPipeline, collection.getDefaultDBObjectCodec()).retryReads(true).collation(collation)
                 .asExplainableOperation(ExplainVerbosity.QUERY_PLANNER, new BsonDocumentCodec()))
 
@@ -696,7 +695,7 @@ class DBCollectionSpecification extends Specification {
         collection.explainAggregate(pipeline, options)
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(collection.getNamespace(),
                 bsonPipeline, collection.getDefaultDBObjectCodec()).retryReads(true).collation(collation)
                 .asExplainableOperation(ExplainVerbosity.QUERY_PLANNER, new BsonDocumentCodec()))
 
@@ -705,7 +704,7 @@ class DBCollectionSpecification extends Specification {
         collection.explainAggregate(pipeline, options)
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new AggregateOperation(collection.getNamespace(),
                 bsonPipeline, collection.getDefaultDBObjectCodec()).retryReads(true).collation(collation)
                 .asExplainableOperation(ExplainVerbosity.QUERY_PLANNER, new BsonDocumentCodec()))
     }
@@ -726,7 +725,7 @@ class DBCollectionSpecification extends Specification {
         collection.update(BasicDBObject.parse(query), BasicDBObject.parse(update))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForUpdate(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForUpdate(collection.getNamespace(),
                 true, WriteConcern.ACKNOWLEDGED, retryWrites, asList(updateRequest)))
 
         when: // Inherits from DB
@@ -735,7 +734,7 @@ class DBCollectionSpecification extends Specification {
 
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForUpdate(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForUpdate(collection.getNamespace(),
                 true, WriteConcern.W3, retryWrites, asList(updateRequest)))
 
         when:
@@ -745,7 +744,7 @@ class DBCollectionSpecification extends Specification {
                 new DBCollectionUpdateOptions().collation(collation).arrayFilters(dbObjectArrayFilters))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForUpdate(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForUpdate(collection.getNamespace(),
                 true, WriteConcern.W1, retryWrites, asList(updateRequest.arrayFilters(bsonDocumentWrapperArrayFilters))))
 
         where:
@@ -768,7 +767,7 @@ class DBCollectionSpecification extends Specification {
         collection.remove(BasicDBObject.parse(query))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForDelete(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForDelete(collection.getNamespace(),
                 false, WriteConcern.ACKNOWLEDGED, retryWrites, asList(deleteRequest)))
 
         when: // Inherits from DB
@@ -776,7 +775,7 @@ class DBCollectionSpecification extends Specification {
         collection.remove(BasicDBObject.parse(query))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForDelete(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForDelete(collection.getNamespace(),
                 false, WriteConcern.W3, retryWrites, asList(deleteRequest)))
 
         when:
@@ -785,7 +784,7 @@ class DBCollectionSpecification extends Specification {
         collection.remove(BasicDBObject.parse(query), new DBCollectionRemoveOptions().collation(collation))
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForDelete(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getWriteOperation(), isTheSameAs(createBulkWriteOperationForDelete(collection.getNamespace(),
                 false, WriteConcern.W1, retryWrites, asList(deleteRequest)))
     }
 
@@ -817,7 +816,7 @@ class DBCollectionSpecification extends Specification {
         bulk().execute()
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new MixedBulkWriteOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getWriteOperation(), isTheSameAs(new MixedBulkWriteOperation(collection.getNamespace(),
                 writeRequests, ordered,
                 WriteConcern.ACKNOWLEDGED, false))
 
@@ -826,7 +825,7 @@ class DBCollectionSpecification extends Specification {
         bulk().execute()
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new MixedBulkWriteOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getWriteOperation(), isTheSameAs(new MixedBulkWriteOperation(collection.getNamespace(),
                 writeRequests, ordered, WriteConcern.W3, false))
 
         when:
@@ -834,7 +833,7 @@ class DBCollectionSpecification extends Specification {
         bulk().execute()
 
         then:
-        expect executor.getWriteOperation(), isTheSameAs(new MixedBulkWriteOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getWriteOperation(), isTheSameAs(new MixedBulkWriteOperation(collection.getNamespace(),
                 writeRequests, ordered, WriteConcern.W1, false))
 
         where:

--- a/driver-legacy/src/test/functional/com/mongodb/DBTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import java.util.Locale;
 import java.util.UUID;
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.getBinding;
@@ -346,7 +345,7 @@ public class DBTest extends DatabaseTestCase {
     }
 
     BsonDocument getCollectionInfo(final String collectionName) {
-        return new ListCollectionsOperation<>(TIMEOUT_SETTINGS, getDefaultDatabaseName(), new BsonDocumentCodec())
+        return new ListCollectionsOperation<>(getDefaultDatabaseName(), new BsonDocumentCodec())
                 .filter(new BsonDocument("name", new BsonString(collectionName))).execute(getBinding()).next().get(0);
     }
 

--- a/driver-legacy/src/test/functional/com/mongodb/LegacyMixedBulkWriteOperationSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/LegacyMixedBulkWriteOperationSpecification.groovy
@@ -28,7 +28,6 @@ import org.bson.codecs.DocumentCodec
 import org.bson.types.ObjectId
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.getSingleConnectionBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
@@ -47,7 +46,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
 
     def 'should throw IllegalArgumentException for empty list of requests'() {
         when:
-        createBulkWriteOperationForInsert(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED, true, [])
+        createBulkWriteOperationForInsert(getNamespace(), true, ACKNOWLEDGED, true, [])
 
         then:
         thrown(IllegalArgumentException)
@@ -57,7 +56,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
         given:
         def inserts = [new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
                        new InsertRequest(new BsonDocument('_id', new BsonInt32(2)))]
-        def operation = createBulkWriteOperationForInsert(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED, false, inserts)
+        def operation = createBulkWriteOperationForInsert(getNamespace(), true, ACKNOWLEDGED, false, inserts)
 
         when:
         def result = execute(operation)
@@ -74,7 +73,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should insert a single document'() {
         given:
         def insert = new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))
-        def operation = createBulkWriteOperationForInsert(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED, false, asList(insert))
+        def operation = createBulkWriteOperationForInsert(getNamespace(), true, ACKNOWLEDGED, false, asList(insert))
 
         when:
         execute(operation)
@@ -86,7 +85,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should execute unacknowledged write'() {
         given:
         def binding = getSingleConnectionBinding()
-        def operation = createBulkWriteOperationForInsert(TIMEOUT_SETTINGS, getNamespace(), true, UNACKNOWLEDGED, false,
+        def operation = createBulkWriteOperationForInsert(getNamespace(), true, UNACKNOWLEDGED, false,
                 [new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
                  new InsertRequest(new BsonDocument('_id', new BsonInt32(2)))])
 
@@ -108,7 +107,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
                 new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
                 new InsertRequest(new BsonDocument('_id', new BsonInt32(2))),
         ]
-        def operation = createBulkWriteOperationForInsert(TIMEOUT_SETTINGS, getNamespace(), false, ACKNOWLEDGED, false, documents)
+        def operation = createBulkWriteOperationForInsert(getNamespace(), false, ACKNOWLEDGED, false, documents)
 
         when:
         execute(operation)
@@ -125,7 +124,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
                 new InsertRequest(new BsonDocument('_id', new BsonInt32(1))),
                 new InsertRequest(new BsonDocument('_id', new BsonInt32(2))),
         ]
-        def operation = createBulkWriteOperationForInsert(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED, false, documents)
+        def operation = createBulkWriteOperationForInsert(getNamespace(), true, ACKNOWLEDGED, false, documents)
 
         when:
         execute(operation)
@@ -139,7 +138,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should support retryable writes'() {
         given:
         def insert = new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))
-        def operation = createBulkWriteOperationForInsert(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED, true, asList(insert))
+        def operation = createBulkWriteOperationForInsert(getNamespace(), true, ACKNOWLEDGED, true, asList(insert))
 
         when:
         executeWithSession(operation, false)
@@ -151,7 +150,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should remove a document'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document('_id', 1))
-        def operation = createBulkWriteOperationForDelete(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED, false,
+        def operation = createBulkWriteOperationForDelete(getNamespace(), true, ACKNOWLEDGED, false,
                 [new DeleteRequest(new BsonDocument('_id', new BsonInt32(1)))])
 
         when:
@@ -168,7 +167,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should return correct result for replace'() {
         given:
         def replacement = new UpdateRequest(new BsonDocument(), new BsonDocument('_id', new BsonInt32(1)), REPLACE)
-        def operation = createBulkWriteOperationForReplace(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED,
+        def operation = createBulkWriteOperationForReplace(getNamespace(), true, ACKNOWLEDGED,
                 false, asList(replacement))
 
         when:
@@ -184,12 +183,12 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should replace a single document'() {
         given:
         def insert = new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))
-        createBulkWriteOperationForInsert(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED, false, asList(insert))
+        createBulkWriteOperationForInsert(getNamespace(), true, ACKNOWLEDGED, false, asList(insert))
                 .execute(getBinding())
 
         def replacement = new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
                 new BsonDocument('_id', new BsonInt32(1)).append('x', new BsonInt32(1)), REPLACE)
-        def operation = createBulkWriteOperationForReplace(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED,
+        def operation = createBulkWriteOperationForReplace(getNamespace(), true, ACKNOWLEDGED,
                 false, asList(replacement))
 
         when:
@@ -209,7 +208,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
         def replacement = new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
                 new BsonDocument('_id', new BsonInt32(1)).append('x', new BsonInt32(1)), REPLACE)
                 .upsert(true)
-        def operation = createBulkWriteOperationForReplace(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED,
+        def operation = createBulkWriteOperationForReplace(getNamespace(), true, ACKNOWLEDGED,
                 false, asList(replacement))
 
         when:
@@ -221,7 +220,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
 
     def 'should update nothing if no documents match'() {
         given:
-        def operation = createBulkWriteOperationForUpdate(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED,
+        def operation = createBulkWriteOperationForUpdate(getNamespace(), true, ACKNOWLEDGED,
                 false, asList(new UpdateRequest(new BsonDocument('x', new BsonInt32(1)),
                 new BsonDocument('$set', new BsonDocument('y', new BsonInt32(2))), UPDATE).multi(false)))
 
@@ -241,7 +240,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
         getCollectionHelper().insertDocuments(new DocumentCodec(),
                 new Document('x', 1),
                 new Document('x', 1))
-        def operation = createBulkWriteOperationForUpdate(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED, false,
+        def operation = createBulkWriteOperationForUpdate(getNamespace(), true, ACKNOWLEDGED, false,
                 asList(new UpdateRequest(new BsonDocument('x', new BsonInt32(1)),
                         new BsonDocument('$set', new BsonDocument('y', new BsonInt32(2))), UPDATE).multi(false)))
 
@@ -261,7 +260,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
         getCollectionHelper().insertDocuments(new DocumentCodec(),
                 new Document('x', 1),
                 new Document('x', 1))
-        def operation = createBulkWriteOperationForUpdate(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED, false,
+        def operation = createBulkWriteOperationForUpdate(getNamespace(), true, ACKNOWLEDGED, false,
                 asList(new UpdateRequest(new BsonDocument('x', new BsonInt32(1)),
                         new BsonDocument('$set', new BsonDocument('y', new BsonInt32(2))), UPDATE).multi(true)))
 
@@ -278,7 +277,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
 
     def 'when upsert is true should insert a document if there are no matching documents'() {
         given:
-        def operation = createBulkWriteOperationForUpdate(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED, false,
+        def operation = createBulkWriteOperationForUpdate(getNamespace(), true, ACKNOWLEDGED, false,
                 asList(new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
                         new BsonDocument('$set', new BsonDocument('y', new BsonInt32(2))), UPDATE).upsert(true)))
 
@@ -296,7 +295,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
     def 'should return correct result for upsert'() {
         given:
         def id = new ObjectId()
-        def operation = createBulkWriteOperationForUpdate(TIMEOUT_SETTINGS, getNamespace(), true, ACKNOWLEDGED, false,
+        def operation = createBulkWriteOperationForUpdate(getNamespace(), true, ACKNOWLEDGED, false,
                 asList(new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)),
                         new BsonDocument('$set', new BsonDocument('x', new BsonInt32(1))), UPDATE).upsert(true)))
 

--- a/driver-legacy/src/test/unit/com/mongodb/DBCursorSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/DBCursorSpecification.groovy
@@ -28,10 +28,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
 import static Fixture.getMongoClient
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME_AND_AWAIT_TIME
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static spock.util.matcher.HamcrestSupport.expect
 
@@ -125,7 +122,7 @@ class DBCursorSpecification extends Specification {
         cursor.toArray()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(TIMEOUT_SETTINGS, collection.getNamespace(),
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(),
                 collection.getObjectCodec())
                 .filter(new BsonDocument())
                 .projection(new BsonDocument())
@@ -145,7 +142,7 @@ class DBCursorSpecification extends Specification {
 
         then:
         expect executor.getReadOperation(), isTheSameAs(
-                new FindOperation(TIMEOUT_SETTINGS, collection.getNamespace(), collection.getObjectCodec())
+                new FindOperation(collection.getNamespace(), collection.getObjectCodec())
                         .limit(-1)
                         .filter(new BsonDocument())
                         .projection(new BsonDocument())
@@ -184,7 +181,7 @@ class DBCursorSpecification extends Specification {
 
         then:
         expect executor.getReadOperation(), isTheSameAs(
-                new FindOperation(TIMEOUT_SETTINGS_WITH_MAX_TIME, collection.getNamespace(), collection.getObjectCodec())
+                new FindOperation(collection.getNamespace(), collection.getObjectCodec())
                 .batchSize(1)
                 .collation(collation)
                 .cursorType(cursorType)
@@ -249,8 +246,7 @@ class DBCursorSpecification extends Specification {
         cursor.toArray()
 
         then:
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation(TIMEOUT_SETTINGS_WITH_MAX_TIME_AND_AWAIT_TIME,
-                collection.getNamespace(), collection.getObjectCodec())
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation(collection.getNamespace(), collection.getObjectCodec())
                 .batchSize(1)
                 .collation(collation)
                 .cursorType(cursorType)
@@ -284,7 +280,7 @@ class DBCursorSpecification extends Specification {
 
         then:
         result == 42
-        expect executor.getReadOperation(), isTheSameAs(new CountOperation(TIMEOUT_SETTINGS, collection.getNamespace())
+        expect executor.getReadOperation(), isTheSameAs(new CountOperation(collection.getNamespace())
                                                                 .filter(new BsonDocument()).retryReads(true))
         executor.getReadConcern() == ReadConcern.MAJORITY
     }
@@ -300,7 +296,7 @@ class DBCursorSpecification extends Specification {
 
         then:
         result == 42
-        expect executor.getReadOperation(), isTheSameAs(new CountOperation(TIMEOUT_SETTINGS, collection.getNamespace())
+        expect executor.getReadOperation(), isTheSameAs(new CountOperation(collection.getNamespace())
                                                                 .filter(new BsonDocument()).retryReads(true))
         executor.getReadConcern() == ReadConcern.MAJORITY
     }

--- a/driver-legacy/src/test/unit/com/mongodb/DBSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/DBSpecification.groovy
@@ -88,7 +88,7 @@ class DBSpecification extends Specification {
 
         then:
         def operation = executor.getWriteOperation() as CreateCollectionOperation
-        expect operation, isTheSameAs(new CreateCollectionOperation(TIMEOUT_SETTINGS, 'test', 'ctest', db.getWriteConcern()))
+        expect operation, isTheSameAs(new CreateCollectionOperation('test', 'ctest', db.getWriteConcern()))
         executor.getReadConcern() == ReadConcern.MAJORITY
 
         when:
@@ -108,7 +108,7 @@ class DBSpecification extends Specification {
         operation = executor.getWriteOperation() as CreateCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new CreateCollectionOperation(TIMEOUT_SETTINGS, 'test', 'ctest', db.getWriteConcern())
+        expect operation, isTheSameAs(new CreateCollectionOperation('test', 'ctest', db.getWriteConcern())
                 .sizeInBytes(100000)
                 .maxDocuments(2000)
                 .capped(true)
@@ -136,7 +136,7 @@ class DBSpecification extends Specification {
         operation = executor.getWriteOperation() as CreateCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new CreateCollectionOperation(TIMEOUT_SETTINGS, 'test', 'ctest', db.getWriteConcern())
+        expect operation, isTheSameAs(new CreateCollectionOperation('test', 'ctest', db.getWriteConcern())
                 .collation(collation))
         executor.getReadConcern() == ReadConcern.MAJORITY
     }
@@ -166,7 +166,7 @@ class DBSpecification extends Specification {
 
         then:
         def operation = executor.getWriteOperation() as CreateViewOperation
-        expect operation, isTheSameAs(new CreateViewOperation(TIMEOUT_SETTINGS, databaseName, viewName, viewOn,
+        expect operation, isTheSameAs(new CreateViewOperation(databaseName, viewName, viewOn,
                 [new BsonDocument('$match', new BsonDocument('x', BsonBoolean.TRUE))], writeConcern))
         executor.getReadConcern() == ReadConcern.MAJORITY
 
@@ -175,7 +175,7 @@ class DBSpecification extends Specification {
         operation = executor.getWriteOperation() as CreateViewOperation
 
         then:
-        expect operation, isTheSameAs(new CreateViewOperation(TIMEOUT_SETTINGS, databaseName, viewName, viewOn,
+        expect operation, isTheSameAs(new CreateViewOperation(databaseName, viewName, viewOn,
                 [new BsonDocument('$match', new BsonDocument('x', BsonBoolean.TRUE))], writeConcern).collation(collation))
         executor.getReadConcern() == ReadConcern.MAJORITY
     }
@@ -196,7 +196,7 @@ class DBSpecification extends Specification {
         def operation = executor.getReadOperation() as ListCollectionsOperation
 
         then:
-        expect operation, isTheSameAs(new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName,
+        expect operation, isTheSameAs(new ListCollectionsOperation(databaseName,
                 new DBObjectCodec(getDefaultCodecRegistry()))
                 .nameOnly(true))
 
@@ -205,7 +205,7 @@ class DBSpecification extends Specification {
         operation = executor.getReadOperation() as ListCollectionsOperation
 
         then:
-        expect operation, isTheSameAs(new ListCollectionsOperation(TIMEOUT_SETTINGS, databaseName,
+        expect operation, isTheSameAs(new ListCollectionsOperation(databaseName,
                 new DBObjectCodec(getDefaultCodecRegistry()))
                 .nameOnly(true))
     }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorPublisher.java
@@ -107,6 +107,9 @@ public abstract class BatchCursorPublisher<T> implements Publisher<T> {
     }
 
     public Publisher<T> timeoutMode(final TimeoutMode timeoutMode) {
+        if (mongoOperationPublisher.getTimeoutSettings().getTimeoutMS() == null) {
+            throw new IllegalArgumentException("TimeoutMode requires timeoutMS to be set.");
+        }
         this.timeoutMode = timeoutMode;
         return this;
     }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorPublisher.java
@@ -19,6 +19,7 @@ package com.mongodb.reactivestreams.client.internal;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
 import com.mongodb.client.cursor.TimeoutMode;
+import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.operation.AsyncOperations;
@@ -30,6 +31,7 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.publisher.Mono;
 
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
@@ -54,6 +56,7 @@ public abstract class BatchCursorPublisher<T> implements Publisher<T> {
     }
 
     abstract AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(int initialBatchSize);
+    abstract Function<AsyncOperations<?>, TimeoutSettings> getTimeoutSettings();
 
     AsyncReadOperation<AsyncBatchCursor<T>> asAsyncFirstReadOperation() {
         return asAsyncReadOperation(1);
@@ -142,7 +145,7 @@ public abstract class BatchCursorPublisher<T> implements Publisher<T> {
     }
 
     Mono<BatchCursor<T>> batchCursor(final Supplier<AsyncReadOperation<AsyncBatchCursor<T>>> supplier) {
-        return mongoOperationPublisher.createReadOperationMono(supplier, clientSession).map(BatchCursor::new);
+        return mongoOperationPublisher.createReadOperationMono(getTimeoutSettings(), supplier, clientSession).map(BatchCursor::new);
     }
 
 }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImpl.java
@@ -20,8 +20,10 @@ import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
+import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.client.model.changestream.ChangeStreamLevel;
+import com.mongodb.internal.operation.AsyncOperations;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ChangeStreamPublisher;
@@ -36,6 +38,7 @@ import org.reactivestreams.Publisher;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -140,6 +143,11 @@ final class ChangeStreamPublisherImpl<T> extends BatchCursorPublisher<ChangeStre
             AsyncReadOperation<AsyncBatchCursor<TDocument>> asAsyncReadOperation(final int initialBatchSize) {
                 return createChangeStreamOperation(getMongoOperationPublisher().getCodecRegistry().get(clazz), initialBatchSize);
             }
+
+            @Override
+            Function<AsyncOperations<?>, TimeoutSettings> getTimeoutSettings() {
+                return (asyncOperations -> asyncOperations.createTimeoutSettings(0, maxAwaitTimeMS));
+            }
         };
     }
 
@@ -166,8 +174,14 @@ final class ChangeStreamPublisherImpl<T> extends BatchCursorPublisher<ChangeStre
         return createChangeStreamOperation(codec, initialBatchSize);
     }
 
+
+    @Override
+    Function<AsyncOperations<?>, TimeoutSettings> getTimeoutSettings() {
+        return (asyncOperations -> asyncOperations.createTimeoutSettings(0, maxAwaitTimeMS));
+    }
+
     private <S> AsyncReadOperation<AsyncBatchCursor<S>> createChangeStreamOperation(final Codec<S> codec, final int initialBatchSize) {
         return getOperations().changeStream(fullDocument, fullDocumentBeforeChange, pipeline, codec, changeStreamLevel, initialBatchSize,
-                collation, comment, maxAwaitTimeMS, resumeToken, startAtOperationTime, startAfter, showExpandedEvents);
+                collation, comment, resumeToken, startAtOperationTime, startAfter, showExpandedEvents);
     }
 }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionPublisherImpl.java
@@ -40,7 +40,6 @@ import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.assertions.Assertions.notNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 final class ClientSessionPublisherImpl extends BaseClientSessionImpl implements ClientSession {
 
@@ -144,11 +143,11 @@ final class ClientSessionPublisherImpl extends BaseClientSessionImpl implements 
             boolean alreadyCommitted = commitInProgress || transactionState == TransactionState.COMMITTED;
             commitInProgress = true;
 
-            Long maxCommitTime = transactionOptions.getMaxCommitTime(MILLISECONDS);
+            // TODO (CSOT) - JAVA-4067
+            // Long maxCommitTime = transactionOptions.getMaxCommitTime(MILLISECONDS);
             return executor.execute(
                     new CommitTransactionOperation(
                             // TODO (CSOT) - JAVA-4067
-                            mongoClient.getTimeoutSettings().withMaxCommitMS(maxCommitTime == null ? 0 : maxCommitTime),
                             assertNotNull(transactionOptions.getWriteConcern()), alreadyCommitted)
                             .recoveryToken(getRecoveryToken()),
                     readConcern, this)
@@ -179,11 +178,11 @@ final class ClientSessionPublisherImpl extends BaseClientSessionImpl implements 
             if (readConcern == null) {
                 throw new MongoInternalException("Invariant violated. Transaction options read concern can not be null");
             }
-            Long maxCommitTime = transactionOptions.getMaxCommitTime(MILLISECONDS);
+            // TODO (CSOT) - JAVA-4067
+            // Long maxCommitTime = transactionOptions.getMaxCommitTime(MILLISECONDS);
             return executor.execute(
                     new AbortTransactionOperation(
                             // TODO (CSOT) - JAVA-4067
-                            mongoClient.getTimeoutSettings().withMaxCommitMS(maxCommitTime == null ? 0 : maxCommitTime),
                             assertNotNull(transactionOptions.getWriteConcern()))
                             .recoveryToken(getRecoveryToken()),
                     readConcern, this)

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/DistinctPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/DistinctPublisherImpl.java
@@ -18,7 +18,9 @@ package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.client.cursor.TimeoutMode;
 import com.mongodb.client.model.Collation;
+import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
+import com.mongodb.internal.operation.AsyncOperations;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ClientSession;
@@ -28,6 +30,7 @@ import org.bson.BsonValue;
 import org.bson.conversions.Bson;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -95,6 +98,11 @@ final class DistinctPublisherImpl<T> extends BatchCursorPublisher<T> implements 
     @Override
     AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
         // initialBatchSize is ignored for distinct operations.
-        return getOperations().distinct(fieldName, filter, getDocumentClass(), maxTimeMS, collation, comment);
+        return getOperations().distinct(fieldName, filter, getDocumentClass(), collation, comment);
+    }
+
+    @Override
+    Function<AsyncOperations<?>, TimeoutSettings> getTimeoutSettings() {
+        return (asyncOperations -> asyncOperations.createTimeoutSettings(maxTimeMS));
     }
 }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImpl.java
@@ -18,7 +18,9 @@ package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.ReadConcern;
 import com.mongodb.client.cursor.TimeoutMode;
+import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
+import com.mongodb.internal.operation.AsyncOperations;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ClientSession;
@@ -29,6 +31,7 @@ import org.bson.BsonValue;
 import org.bson.conversions.Bson;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -95,6 +98,11 @@ final class ListCollectionsPublisherImpl<T> extends BatchCursorPublisher<T> impl
 
     AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
         return getOperations().listCollections(getNamespace().getDatabaseName(), getDocumentClass(), filter, collectionNamesOnly,
-                authorizedCollections, initialBatchSize, maxTimeMS, comment, getTimeoutMode());
+                authorizedCollections, initialBatchSize, comment, getTimeoutMode());
+    }
+
+    @Override
+    Function<AsyncOperations<?>, TimeoutSettings> getTimeoutSettings() {
+        return (asyncOperations -> asyncOperations.createTimeoutSettings(maxTimeMS));
     }
 }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListDatabasesPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListDatabasesPublisherImpl.java
@@ -17,7 +17,9 @@
 package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.client.cursor.TimeoutMode;
+import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
+import com.mongodb.internal.operation.AsyncOperations;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ClientSession;
@@ -27,6 +29,7 @@ import org.bson.BsonValue;
 import org.bson.conversions.Bson;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -89,8 +92,13 @@ final class ListDatabasesPublisherImpl<T> extends BatchCursorPublisher<T> implem
         return this;
     }
 
+    @Override
+    Function<AsyncOperations<?>, TimeoutSettings> getTimeoutSettings() {
+        return (asyncOperations -> asyncOperations.createTimeoutSettings(maxTimeMS));
+    }
+
     AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
         // initialBatchSize is ignored for distinct operations.
-        return getOperations().listDatabases(getDocumentClass(), filter, nameOnly, maxTimeMS, authorizedDatabasesOnly, comment);
+        return getOperations().listDatabases(getDocumentClass(), filter, nameOnly, authorizedDatabasesOnly, comment);
     }
 }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListIndexesPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListIndexesPublisherImpl.java
@@ -17,7 +17,9 @@
 package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.client.cursor.TimeoutMode;
+import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
+import com.mongodb.internal.operation.AsyncOperations;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ClientSession;
@@ -26,6 +28,7 @@ import org.bson.BsonString;
 import org.bson.BsonValue;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -71,6 +74,11 @@ final class ListIndexesPublisherImpl<T> extends BatchCursorPublisher<T> implemen
     }
 
     AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
-        return getOperations().listIndexes(getDocumentClass(), initialBatchSize, maxTimeMS, comment, getTimeoutMode());
+        return getOperations().listIndexes(getDocumentClass(), initialBatchSize, comment, getTimeoutMode());
+    }
+
+    @Override
+    Function<AsyncOperations<?>, TimeoutSettings> getTimeoutSettings() {
+        return (asyncOperations -> asyncOperations.createTimeoutSettings(maxTimeMS));
     }
 }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListSearchIndexesPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ListSearchIndexesPublisherImpl.java
@@ -19,8 +19,10 @@ package com.mongodb.reactivestreams.client.internal;
 import com.mongodb.ExplainVerbosity;
 import com.mongodb.client.cursor.TimeoutMode;
 import com.mongodb.client.model.Collation;
+import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.operation.AsyncExplainableReadOperation;
+import com.mongodb.internal.operation.AsyncOperations;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.ListSearchIndexesPublisher;
@@ -30,6 +32,7 @@ import org.bson.Document;
 import org.reactivestreams.Publisher;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -124,8 +127,9 @@ final class ListSearchIndexesPublisherImpl<T> extends BatchCursorPublisher<T> im
     }
 
     private <E> Publisher<E> publishExplain(final Class<E> explainResultClass, @Nullable final ExplainVerbosity verbosity) {
-        return getMongoOperationPublisher().createReadOperationMono(() ->
-                asAggregateOperation(1).asAsyncExplainableOperation(verbosity,
+        return getMongoOperationPublisher().createReadOperationMono(
+                (asyncOperations -> asyncOperations.createTimeoutSettings(maxTimeMS)),
+                () -> asAggregateOperation(1).asAsyncExplainableOperation(verbosity,
                         getCodecRegistry().get(explainResultClass)), getClientSession());
     }
 
@@ -134,9 +138,12 @@ final class ListSearchIndexesPublisherImpl<T> extends BatchCursorPublisher<T> im
         return asAggregateOperation(initialBatchSize);
     }
 
+    @Override
+    Function<AsyncOperations<?>, TimeoutSettings> getTimeoutSettings() {
+        return  (asyncOperations -> asyncOperations.createTimeoutSettings(maxTimeMS));
+    }
+
     private AsyncExplainableReadOperation<AsyncBatchCursor<T>> asAggregateOperation(final int initialBatchSize) {
-        return getOperations().listSearchIndexes(getDocumentClass(), maxTimeMS, indexName, initialBatchSize, collation,
-                comment,
-                allowDiskUse);
+        return getOperations().listSearchIndexes(getDocumentClass(), indexName, initialBatchSize, collation, comment, allowDiskUse);
     }
 }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoClientImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoClientImpl.java
@@ -90,7 +90,7 @@ public final class MongoClientImpl implements MongoClient {
         AutoEncryptionSettings autoEncryptSettings = settings.getAutoEncryptionSettings();
         this.crypt = autoEncryptSettings != null ? Crypts.createCrypt(this, autoEncryptSettings) : null;
         if (executor == null) {
-            this.executor = new OperationExecutorImpl(this, clientSessionHelper);
+            this.executor = new OperationExecutorImpl(this, clientSessionHelper, timeoutSettings);
         } else {
             this.executor = executor;
         }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
@@ -238,18 +238,22 @@ public final class MongoOperationPublisher<T> {
     }
 
     Publisher<Void> dropDatabase(@Nullable final ClientSession clientSession) {
-        return createWriteOperationMono(operations::dropDatabase, clientSession);
+        return createWriteOperationMono(operations::getTimeoutSettings, operations::dropDatabase, clientSession);
     }
 
     Publisher<Void> createCollection(
             @Nullable final ClientSession clientSession, final String collectionName, final CreateCollectionOptions options) {
-        return createWriteOperationMono(() -> operations.createCollection(collectionName, options, autoEncryptionSettings), clientSession);
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.createCollection(collectionName, options, autoEncryptionSettings), clientSession);
     }
 
     Publisher<Void> createView(
             @Nullable final ClientSession clientSession, final String viewName, final String viewOn,
             final List<? extends Bson> pipeline, final CreateViewOptions options) {
-        return createWriteOperationMono(() -> operations.createView(viewName, viewOn, pipeline, options), clientSession);
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.createView(viewName, viewOn, pipeline, options), clientSession);
     }
 
     public <R> Publisher<R> runCommand(
@@ -259,24 +263,30 @@ public final class MongoOperationPublisher<T> {
             return Mono.error(new MongoClientException("Read preference in a transaction must be primary"));
         }
         return createReadOperationMono(
+                operations::getTimeoutSettings,
                 () -> operations.commandRead(command, clazz), clientSession, notNull("readPreference", readPreference));
     }
 
 
     Publisher<Long> estimatedDocumentCount(final EstimatedDocumentCountOptions options) {
-        return createReadOperationMono(() -> operations.estimatedDocumentCount(notNull("options", options)), null);
+        return createReadOperationMono(
+                (asyncOperations -> asyncOperations.createTimeoutSettings(options)),
+                () -> operations.estimatedDocumentCount(notNull("options", options)), null);
     }
 
     Publisher<Long> countDocuments(@Nullable final ClientSession clientSession, final Bson filter, final CountOptions options) {
-        return createReadOperationMono(() -> operations.countDocuments(notNull("filter", filter), notNull("options", options)
+        return createReadOperationMono(
+                (asyncOperations -> asyncOperations.createTimeoutSettings(options)),
+                () -> operations.countDocuments(notNull("filter", filter), notNull("options", options)
         ), clientSession);
     }
 
     Publisher<BulkWriteResult> bulkWrite(
             @Nullable final ClientSession clientSession,
             final List<? extends WriteModel<? extends T>> requests, final BulkWriteOptions options) {
-        return createWriteOperationMono(() -> operations.bulkWrite(notNull("requests", requests), notNull("options", options)),
-                                        clientSession);
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.bulkWrite(notNull("requests", requests), notNull("options", options)), clientSession);
     }
 
     Publisher<InsertOneResult> insertOne(@Nullable final ClientSession clientSession, final T document, final InsertOneOptions options) {
@@ -289,8 +299,9 @@ public final class MongoOperationPublisher<T> {
     Publisher<InsertManyResult> insertMany(
             @Nullable final ClientSession clientSession, final List<? extends T> documents,
             final InsertManyOptions options) {
-        return createWriteOperationMono(() -> operations.insertMany(notNull("documents", documents), notNull("options", options)),
-                                        clientSession)
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.insertMany(notNull("documents", documents), notNull("options", options)), clientSession)
                 .map(INSERT_MANY_RESULT_MAPPER);
     }
 
@@ -357,15 +368,17 @@ public final class MongoOperationPublisher<T> {
     }
 
     Publisher<T> findOneAndDelete(@Nullable final ClientSession clientSession, final Bson filter, final FindOneAndDeleteOptions options) {
-        return createWriteOperationMono(() -> operations.findOneAndDelete(notNull("filter", filter),
-                                                                          notNull("options", options)),
-                                        clientSession);
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.findOneAndDelete(notNull("filter", filter), notNull("options", options)), clientSession);
     }
 
     Publisher<T> findOneAndReplace(
             @Nullable final ClientSession clientSession, final Bson filter, final T replacement,
             final FindOneAndReplaceOptions options) {
-        return createWriteOperationMono(() -> operations.findOneAndReplace(notNull("filter", filter),
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.findOneAndReplace(notNull("filter", filter),
                                                                            notNull("replacement", replacement),
                                                                            notNull("options", options)),
                                         clientSession);
@@ -374,7 +387,9 @@ public final class MongoOperationPublisher<T> {
     Publisher<T> findOneAndUpdate(
             @Nullable final ClientSession clientSession, final Bson filter, final Bson update,
             final FindOneAndUpdateOptions options) {
-        return createWriteOperationMono(() -> operations.findOneAndUpdate(notNull("filter", filter),
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.findOneAndUpdate(notNull("filter", filter),
                                                                           notNull("update", update),
                                                                           notNull("options", options)),
                                         clientSession);
@@ -383,14 +398,18 @@ public final class MongoOperationPublisher<T> {
     Publisher<T> findOneAndUpdate(
             @Nullable final ClientSession clientSession, final Bson filter,
             final List<? extends Bson> update, final FindOneAndUpdateOptions options) {
-        return createWriteOperationMono(() -> operations.findOneAndUpdate(notNull("filter", filter),
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.findOneAndUpdate(notNull("filter", filter),
                                                                           notNull("update", update),
                                                                           notNull("options", options)),
                                         clientSession);
     }
 
     Publisher<Void> dropCollection(@Nullable final ClientSession clientSession, final DropCollectionOptions dropCollectionOptions) {
-        return createWriteOperationMono(() -> operations.dropCollection(dropCollectionOptions, autoEncryptionSettings), clientSession);
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.dropCollection(dropCollectionOptions, autoEncryptionSettings), clientSession);
     }
 
     Publisher<String> createIndex(@Nullable final ClientSession clientSession, final Bson key, final IndexOptions options) {
@@ -401,8 +420,9 @@ public final class MongoOperationPublisher<T> {
     Publisher<String> createIndexes(
             @Nullable final ClientSession clientSession, final List<IndexModel> indexes,
             final CreateIndexOptions options) {
-        return createWriteOperationMono(() -> operations.createIndexes(notNull("indexes", indexes),
-                                                                       notNull("options", options)), clientSession)
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.createIndexes(notNull("indexes", indexes), notNull("options", options)), clientSession)
                 .thenMany(Flux.fromIterable(IndexHelper.getIndexNames(indexes, getCodecRegistry())));
     }
 
@@ -414,27 +434,37 @@ public final class MongoOperationPublisher<T> {
     }
 
     Publisher<String> createSearchIndexes(final List<SearchIndexModel> indexes) {
-        return createWriteOperationMono(() -> operations.createSearchIndexes(indexes), null)
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.createSearchIndexes(indexes), null)
                 .thenMany(Flux.fromIterable(IndexHelper.getSearchIndexNames(indexes)));
     }
 
 
     public Publisher<Void> updateSearchIndex(final String name, final Bson definition) {
-       return createWriteOperationMono(() -> operations.updateSearchIndex(name, definition), null);
+       return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.updateSearchIndex(name, definition), null);
     }
 
 
     public Publisher<Void> dropSearchIndex(final String indexName) {
-        return createWriteOperationMono(() -> operations.dropSearchIndex(indexName), null);
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.dropSearchIndex(indexName), null);
     }
 
     Publisher<Void> dropIndex(@Nullable final ClientSession clientSession, final String indexName, final DropIndexOptions options) {
-        return createWriteOperationMono(() -> operations.dropIndex(notNull("indexName", indexName), notNull("options", options)),
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.dropIndex(notNull("indexName", indexName), notNull("options", options)),
                                         clientSession);
     }
 
     Publisher<Void> dropIndex(@Nullable final ClientSession clientSession, final Bson keys, final DropIndexOptions options) {
-        return createWriteOperationMono(() -> operations.dropIndex(notNull("keys", keys), notNull("options", options)),
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.dropIndex(notNull("keys", keys), notNull("options", options)),
                                         clientSession);
     }
 
@@ -445,35 +475,45 @@ public final class MongoOperationPublisher<T> {
     Publisher<Void> renameCollection(
             @Nullable final ClientSession clientSession, final MongoNamespace newCollectionNamespace,
             final RenameCollectionOptions options) {
-        return createWriteOperationMono(() -> operations.renameCollection(notNull("newCollectionNamespace", newCollectionNamespace),
+        return createWriteOperationMono(
+                operations::getTimeoutSettings,
+                () -> operations.renameCollection(notNull("newCollectionNamespace", newCollectionNamespace),
                                                                           notNull("options", options)),
                                         clientSession);
     }
 
-    <R> Mono<R> createReadOperationMono(
-            final Supplier<AsyncReadOperation<R>> operation,
-            @Nullable final ClientSession clientSession) {
-        return createReadOperationMono(operation, clientSession, getReadPreference());
+
+    <R> Mono<R> createReadOperationMono(final Function<AsyncOperations<?>, TimeoutSettings> timeoutSettingsFunction,
+            final Supplier<AsyncReadOperation<R>> operation, @Nullable final ClientSession clientSession) {
+        return createReadOperationMono(() -> timeoutSettingsFunction.apply(operations), operation, clientSession, getReadPreference());
     }
 
-    <R> Mono<R> createReadOperationMono(
-            final Supplier<AsyncReadOperation<R>> operation,
-            @Nullable final ClientSession clientSession,
+
+    <R> Mono<R> createReadOperationMono(final Supplier<TimeoutSettings> timeoutSettingsSupplier,
+            final Supplier<AsyncReadOperation<R>> operationSupplier, @Nullable final ClientSession clientSession,
             final ReadPreference readPreference) {
-        AsyncReadOperation<R> readOperation = operation.get();
-        return executor.execute(readOperation, readPreference, getReadConcern(), clientSession);
+        AsyncReadOperation<R> readOperation = operationSupplier.get();
+        return getExecutor(timeoutSettingsSupplier.get())
+                .execute(readOperation, readPreference, getReadConcern(), clientSession);
     }
 
-    <R> Mono<R> createWriteOperationMono(final Supplier<AsyncWriteOperation<R>> operation, @Nullable final ClientSession clientSession) {
-        AsyncWriteOperation<R> writeOperation = operation.get();
-        return executor.execute(writeOperation, getReadConcern(), clientSession);
+    <R> Mono<R> createWriteOperationMono(final Function<AsyncOperations<?>, TimeoutSettings> timeoutSettingsFunction,
+            final Supplier<AsyncWriteOperation<R>> operationSupplier, @Nullable final ClientSession clientSession) {
+        return createWriteOperationMono(() -> timeoutSettingsFunction.apply(operations), operationSupplier, clientSession);
+    }
+
+    <R> Mono<R> createWriteOperationMono(final Supplier<TimeoutSettings> timeoutSettingsSupplier,
+            final Supplier<AsyncWriteOperation<R>> operationSupplier, @Nullable final ClientSession clientSession) {
+        AsyncWriteOperation<R> writeOperation = operationSupplier.get();
+        return  getExecutor(timeoutSettingsSupplier.get())
+                .execute(writeOperation, getReadConcern(), clientSession);
     }
 
     private Mono<BulkWriteResult> createSingleWriteRequestMono(
             final Supplier<AsyncWriteOperation<BulkWriteResult>> operation,
             @Nullable final ClientSession clientSession,
             final WriteRequest.Type type) {
-        return createWriteOperationMono(operation, clientSession)
+        return createWriteOperationMono(operations::getTimeoutSettings, operation, clientSession)
                 .onErrorMap(MongoBulkWriteException.class, e -> {
                     MongoException exception;
                     WriteConcernError writeConcernError = e.getWriteConcernError();
@@ -502,6 +542,10 @@ public final class MongoOperationPublisher<T> {
 
                     return exception;
                 });
+    }
+
+    private OperationExecutor getExecutor(final TimeoutSettings timeoutSettings) {
+        return executor.withTimeoutSettings(timeoutSettings);
     }
 
     private static final Function<BulkWriteResult, InsertOneResult> INSERT_ONE_RESULT_MAPPER = result -> {
@@ -548,6 +592,3 @@ public final class MongoOperationPublisher<T> {
         };
     }
 }
-
-
-

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/OperationExecutor.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/OperationExecutor.java
@@ -18,6 +18,7 @@ package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
+import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.internal.operation.AsyncWriteOperation;
 import com.mongodb.lang.Nullable;
@@ -52,4 +53,14 @@ public interface OperationExecutor {
      * @param <T> the operations result type.
      */
     <T> Mono<T> execute(AsyncWriteOperation<T> operation, ReadConcern readConcern, @Nullable ClientSession session);
+
+    /**
+     * Create a new OperationExecutor with a specific timeout settings
+     *
+     * @param timeoutSettings the TimeoutContext to use for the operations
+     * @return the new operation executor with the set timeout context
+     * @since CSOT
+     */
+    OperationExecutor withTimeoutSettings(TimeoutSettings timeoutSettings);
+
 }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/VoidReadOperationThenCursorReadOperation.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/VoidReadOperationThenCursorReadOperation.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.reactivestreams.client.internal;
 
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
@@ -38,11 +37,6 @@ class VoidReadOperationThenCursorReadOperation<T> implements AsyncReadOperation<
 
     public AsyncReadOperation<AsyncBatchCursor<T>> getCursorReadOperation() {
         return cursorReadOperation;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return readOperation.getTimeoutSettings();
     }
 
     @Override

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/VoidWriteOperationThenCursorReadOperation.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/VoidWriteOperationThenCursorReadOperation.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.reactivestreams.client.internal;
 
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
@@ -32,11 +31,6 @@ class VoidWriteOperationThenCursorReadOperation<T> implements AsyncReadOperation
                                               final AsyncReadOperation<AsyncBatchCursor<T>> cursorReadOperation) {
         this.writeOperation = writeOperation;
         this.cursorReadOperation = cursorReadOperation;
-    }
-
-    @Override
-    public TimeoutSettings getTimeoutSettings() {
-        return writeOperation.getTimeoutSettings();
     }
 
     @Override

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorPublisherTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/internal/BatchCursorPublisherTest.java
@@ -18,8 +18,10 @@ package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
+import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.operation.AsyncOperations;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import static com.mongodb.reactivestreams.client.internal.TestHelper.OPERATION_EXECUTOR;
@@ -168,6 +171,11 @@ public class BatchCursorPublisherTest {
             @Override
             AsyncReadOperation<AsyncBatchCursor<Document>> asAsyncReadOperation(final int initialBatchSize) {
                 return readOperation;
+            }
+
+            @Override
+            Function<AsyncOperations<?>, TimeoutSettings> getTimeoutSettings() {
+                return (AsyncOperations::getTimeoutSettings);
             }
         };
 

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/AggregatePublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/AggregatePublisherImplTest.java
@@ -38,9 +38,6 @@ import reactor.core.publisher.Flux;
 
 import java.util.List;
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME;
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME_AND_AWAIT_TIME;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -62,7 +59,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         AggregatePublisher<Document> publisher =
                 new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.COLLECTION);
 
-        AggregateOperation<Document> expectedOperation = new AggregateOperation<>(TIMEOUT_SETTINGS, NAMESPACE, pipeline,
+        AggregateOperation<Document> expectedOperation = new AggregateOperation<>(NAMESPACE, pipeline,
                                                                                   getDefaultCodecRegistry().get(Document.class))
                 .batchSize(Integer.MAX_VALUE)
                 .retryReads(true);
@@ -84,7 +81,7 @@ public class AggregatePublisherImplTest extends TestHelper {
                 .maxAwaitTime(1001, MILLISECONDS)
                 .maxTime(101, MILLISECONDS);
 
-        expectedOperation = new AggregateOperation<>(TIMEOUT_SETTINGS_WITH_MAX_TIME_AND_AWAIT_TIME, NAMESPACE, pipeline,
+        expectedOperation = new AggregateOperation<>(NAMESPACE, pipeline,
                 getDefaultCodecRegistry().get(Document.class))
                 .retryReads(true)
                 .allowDiskUse(true)
@@ -107,7 +104,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         AggregatePublisher<Document> publisher =
                 new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.COLLECTION);
 
-        AggregateOperation<Document> expectedOperation = new AggregateOperation<>(TIMEOUT_SETTINGS, NAMESPACE, pipeline,
+        AggregateOperation<Document> expectedOperation = new AggregateOperation<>(NAMESPACE, pipeline,
                                                                                   getDefaultCodecRegistry().get(Document.class))
                 .batchSize(Integer.MAX_VALUE)
                 .retryReads(true);
@@ -131,7 +128,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         AggregatePublisher<Document> publisher =
                 new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.COLLECTION);
 
-        AggregateOperation<Document> expectedOperation = new AggregateOperation<>(TIMEOUT_SETTINGS, NAMESPACE, pipeline,
+        AggregateOperation<Document> expectedOperation = new AggregateOperation<>(NAMESPACE, pipeline,
                                                                                   getDefaultCodecRegistry().get(Document.class))
                 .batchSize(Integer.MAX_VALUE)
                 .retryReads(true);
@@ -160,7 +157,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         AggregatePublisher<Document> publisher =
                 new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.COLLECTION);
 
-        AggregateToCollectionOperation expectedOperation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS, NAMESPACE, pipeline,
+        AggregateToCollectionOperation expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline,
                                                                                               ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED);
 
         // default input should be as expected
@@ -181,7 +178,7 @@ public class AggregatePublisherImplTest extends TestHelper {
                 .maxAwaitTime(1001, MILLISECONDS) // Ignored on $out
                 .maxTime(100, MILLISECONDS);
 
-        expectedOperation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS_WITH_MAX_TIME, NAMESPACE, pipeline,
+        expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline,
                 ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED)
                 .allowDiskUse(true)
                 .bypassDocumentValidation(true)
@@ -195,7 +192,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         assertOperationIsTheSameAs(expectedOperation, operation.getReadOperation());
 
         FindOperation<Document> expectedFindOperation =
-                new FindOperation<>(TIMEOUT_SETTINGS, collectionNamespace, getDefaultCodecRegistry().get(Document.class))
+                new FindOperation<>(collectionNamespace, getDefaultCodecRegistry().get(Document.class))
                         .batchSize(100)
                         .collation(COLLATION)
                         .filter(new BsonDocument())
@@ -207,7 +204,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         // Should handle database level aggregations
         publisher = new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.DATABASE);
 
-        expectedOperation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS, NAMESPACE, pipeline, ReadConcern.DEFAULT,
+        expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline, ReadConcern.DEFAULT,
                                                                WriteConcern.ACKNOWLEDGED);
 
         Flux.from(publisher).blockFirst();
@@ -218,7 +215,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         // Should handle toCollection
         publisher = new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.COLLECTION);
 
-        expectedOperation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS, NAMESPACE, pipeline, ReadConcern.DEFAULT,
+        expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline, ReadConcern.DEFAULT,
                                                                WriteConcern.ACKNOWLEDGED);
 
         // default input should be as expected
@@ -238,7 +235,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         AggregatePublisher<Document> publisher =
                 new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.COLLECTION);
 
-        AggregateToCollectionOperation expectedOperation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS, NAMESPACE, pipeline,
+        AggregateToCollectionOperation expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline,
                                                                                               ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED);
 
         publisher
@@ -265,7 +262,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         AggregatePublisher<Document> publisher =
                 new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.COLLECTION);
 
-        AggregateToCollectionOperation expectedOperation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS, NAMESPACE, pipeline,
+        AggregateToCollectionOperation expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline,
                                                                                               ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED);
 
         publisher
@@ -298,7 +295,7 @@ public class AggregatePublisherImplTest extends TestHelper {
                 new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.COLLECTION)
                         .toCollection();
 
-        AggregateToCollectionOperation expectedOperation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS, NAMESPACE, pipeline,
+        AggregateToCollectionOperation expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline,
                                                                                               ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED);
 
         Flux.from(toCollectionPublisher).blockFirst();
@@ -319,7 +316,7 @@ public class AggregatePublisherImplTest extends TestHelper {
                                                              AggregationLevel.COLLECTION)
                 .toCollection();
 
-        expectedOperation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS, NAMESPACE, pipelineWithNamespace, ReadConcern.DEFAULT,
+        expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipelineWithNamespace, ReadConcern.DEFAULT,
                                                                WriteConcern.ACKNOWLEDGED);
 
         Flux.from(toCollectionPublisher).blockFirst();
@@ -339,7 +336,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         AggregatePublisher<Document> publisher =
                 new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.COLLECTION);
 
-        AggregateToCollectionOperation expectedOperation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS, NAMESPACE, pipeline,
+        AggregateToCollectionOperation expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline,
                                                                                               ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED);
 
         // default input should be as expected
@@ -360,7 +357,7 @@ public class AggregatePublisherImplTest extends TestHelper {
                 .maxAwaitTime(1001, MILLISECONDS) // Ignored on $out
                 .maxTime(100, MILLISECONDS);
 
-        expectedOperation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS_WITH_MAX_TIME, NAMESPACE, pipeline,
+        expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline,
                 ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED)
                 .allowDiskUse(true)
                 .bypassDocumentValidation(true)
@@ -374,7 +371,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         assertOperationIsTheSameAs(expectedOperation, operation.getReadOperation());
 
         FindOperation<Document> expectedFindOperation =
-                new FindOperation<>(TIMEOUT_SETTINGS, collectionNamespace, getDefaultCodecRegistry().get(Document.class))
+                new FindOperation<>(collectionNamespace, getDefaultCodecRegistry().get(Document.class))
                         .batchSize(100)
                         .collation(COLLATION)
                         .filter(new BsonDocument())
@@ -386,7 +383,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         // Should handle database level aggregations
         publisher = new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.DATABASE);
 
-        expectedOperation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS, NAMESPACE, pipeline, ReadConcern.DEFAULT,
+        expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline, ReadConcern.DEFAULT,
                                                                WriteConcern.ACKNOWLEDGED);
 
         Flux.from(publisher).blockFirst();
@@ -397,7 +394,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         // Should handle toCollection
         publisher = new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.COLLECTION);
 
-        expectedOperation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS, NAMESPACE, pipeline, ReadConcern.DEFAULT,
+        expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline, ReadConcern.DEFAULT,
                                                                WriteConcern.ACKNOWLEDGED);
 
         // default input should be as expected
@@ -417,7 +414,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         AggregatePublisher<Document> publisher =
                 new AggregatePublisherImpl<>(null, createMongoOperationPublisher(executor), pipeline, AggregationLevel.COLLECTION);
 
-        AggregateToCollectionOperation expectedOperation = new AggregateToCollectionOperation(TIMEOUT_SETTINGS, NAMESPACE, pipeline,
+        AggregateToCollectionOperation expectedOperation = new AggregateToCollectionOperation(NAMESPACE, pipeline,
                                                                                               ReadConcern.DEFAULT, WriteConcern.ACKNOWLEDGED);
 
         // default input should be as expected
@@ -428,7 +425,7 @@ public class AggregatePublisherImplTest extends TestHelper {
         assertOperationIsTheSameAs(expectedOperation, operation.getReadOperation());
 
         FindOperation<Document> expectedFindOperation =
-                new FindOperation<>(TIMEOUT_SETTINGS, collectionNamespace, getDefaultCodecRegistry().get(Document.class))
+                new FindOperation<>(collectionNamespace, getDefaultCodecRegistry().get(Document.class))
                 .filter(new BsonDocument())
                 .batchSize(Integer.MAX_VALUE)
                 .retryReads(true);

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImplTest.java
@@ -37,8 +37,6 @@ import reactor.core.publisher.Flux;
 
 import java.util.List;
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_AWAIT_TIME;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -59,7 +57,7 @@ public class ChangeStreamPublisherImplTest extends TestHelper {
                                                                                     Document.class, pipeline, ChangeStreamLevel.COLLECTION);
 
         ChangeStreamOperation<ChangeStreamDocument<Document>> expectedOperation =
-                new ChangeStreamOperation<>(TIMEOUT_SETTINGS, NAMESPACE, FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, pipeline,
+                new ChangeStreamOperation<>(NAMESPACE, FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, pipeline,
                         codec)
                         .batchSize(Integer.MAX_VALUE)
                         .retryReads(true);
@@ -78,7 +76,7 @@ public class ChangeStreamPublisherImplTest extends TestHelper {
                 .maxAwaitTime(101, MILLISECONDS)
                 .fullDocument(FullDocument.UPDATE_LOOKUP);
 
-        expectedOperation = new ChangeStreamOperation<>(TIMEOUT_SETTINGS_WITH_MAX_AWAIT_TIME, NAMESPACE, FullDocument.UPDATE_LOOKUP,
+        expectedOperation = new ChangeStreamOperation<>(NAMESPACE, FullDocument.UPDATE_LOOKUP,
                 FullDocumentBeforeChange.DEFAULT,
                 pipeline,
                                                         codec).retryReads(true);
@@ -106,7 +104,7 @@ public class ChangeStreamPublisherImplTest extends TestHelper {
                 .withDocumentClass(BsonDocument.class);
 
         ChangeStreamOperation<BsonDocument> expectedOperation =
-                new ChangeStreamOperation<>(TIMEOUT_SETTINGS, NAMESPACE, FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, pipeline,
+                new ChangeStreamOperation<>(NAMESPACE, FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, pipeline,
                                             getDefaultCodecRegistry().get(BsonDocument.class))
                         .batchSize(batchSize)
                         .comment(new BsonInt32(1))

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/DistinctPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/DistinctPublisherImplTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,7 +43,7 @@ public class DistinctPublisherImplTest extends TestHelper {
         DistinctPublisher<Document> publisher =
                 new DistinctPublisherImpl<>(null, createMongoOperationPublisher(executor), fieldName, new Document());
 
-        DistinctOperation<Document> expectedOperation = new DistinctOperation<>(TIMEOUT_SETTINGS, NAMESPACE, fieldName,
+        DistinctOperation<Document> expectedOperation = new DistinctOperation<>(NAMESPACE, fieldName,
                                                                                 getDefaultCodecRegistry().get(Document.class))
                 .retryReads(true).filter(new BsonDocument());
 

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/FindPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/FindPublisherImplTest.java
@@ -31,8 +31,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME_AND_AWAIT_TIME;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -52,7 +50,7 @@ public class FindPublisherImplTest extends TestHelper {
         TestOperationExecutor executor = createOperationExecutor(asList(getBatchCursor(), getBatchCursor()));
         FindPublisher<Document> publisher = new FindPublisherImpl<>(null, createMongoOperationPublisher(executor), new Document());
 
-        FindOperation<Document> expectedOperation = new FindOperation<>(TIMEOUT_SETTINGS, NAMESPACE,
+        FindOperation<Document> expectedOperation = new FindOperation<>(NAMESPACE,
                                                                         getDefaultCodecRegistry().get(Document.class))
                 .batchSize(Integer.MAX_VALUE)
                 .retryReads(true)
@@ -86,8 +84,8 @@ public class FindPublisherImplTest extends TestHelper {
                 .showRecordId(false)
                 .allowDiskUse(false);
 
-        expectedOperation = new FindOperation<>(TIMEOUT_SETTINGS_WITH_MAX_TIME_AND_AWAIT_TIME, NAMESPACE,
-                getDefaultCodecRegistry().get(Document.class))
+        expectedOperation = new FindOperation<>(NAMESPACE,
+                                                getDefaultCodecRegistry().get(Document.class))
                 .retryReads(true)
                 .filter(new BsonDocument())
                 .allowDiskUse(false)

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListCollectionNamesPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListCollectionNamesPublisherImplTest.java
@@ -17,7 +17,6 @@
 package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.ReadPreference;
-import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.operation.ListCollectionsOperation;
 import com.mongodb.reactivestreams.client.ListCollectionNamesPublisher;
 import org.bson.BsonDocument;
@@ -46,8 +45,8 @@ final class ListCollectionNamesPublisherImplTest extends TestHelper {
                         .withDocumentClass(Document.class), true))
                 .authorizedCollections(true);
 
-        ListCollectionsOperation<Document> expectedOperation = new ListCollectionsOperation<>(TimeoutSettings.DEFAULT, DATABASE_NAME,
-                                                                                            getDefaultCodecRegistry().get(Document.class))
+        ListCollectionsOperation<Document> expectedOperation = new ListCollectionsOperation<>(DATABASE_NAME,
+                                                                                              getDefaultCodecRegistry().get(Document.class))
                 .batchSize(Integer.MAX_VALUE)
                 .nameOnly(true)
                 .authorizedCollections(true)
@@ -65,8 +64,8 @@ final class ListCollectionNamesPublisherImplTest extends TestHelper {
                 .maxTime(10, SECONDS)
                 .batchSize(100);
 
-        expectedOperation = new ListCollectionsOperation<>(TimeoutSettings.DEFAULT.withMaxTimeMS(10_000), DATABASE_NAME,
-                getDefaultCodecRegistry().get(Document.class))
+        expectedOperation = new ListCollectionsOperation<>(DATABASE_NAME,
+                                                           getDefaultCodecRegistry().get(Document.class))
                 .nameOnly(true)
                 .authorizedCollections(true)
                 .retryReads(true)

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListCollectionsPublisherImplTest.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -44,7 +42,7 @@ public class ListCollectionsPublisherImplTest extends TestHelper {
         ListCollectionsPublisher<String> publisher = new ListCollectionsPublisherImpl<>(null, createMongoOperationPublisher(executor)
                 .withDocumentClass(String.class), true);
 
-        ListCollectionsOperation<String> expectedOperation = new ListCollectionsOperation<>(TIMEOUT_SETTINGS, DATABASE_NAME,
+        ListCollectionsOperation<String> expectedOperation = new ListCollectionsOperation<>(DATABASE_NAME,
                                                                                             getDefaultCodecRegistry().get(String.class))
                 .batchSize(Integer.MAX_VALUE)
                 .nameOnly(true).retryReads(true);
@@ -61,8 +59,8 @@ public class ListCollectionsPublisherImplTest extends TestHelper {
                 .maxTime(100, MILLISECONDS)
                 .batchSize(100);
 
-        expectedOperation = new ListCollectionsOperation<>(TIMEOUT_SETTINGS_WITH_MAX_TIME, DATABASE_NAME,
-                getDefaultCodecRegistry().get(String.class))
+        expectedOperation = new ListCollectionsOperation<>(DATABASE_NAME,
+                                                           getDefaultCodecRegistry().get(String.class))
                 .nameOnly(true)
                 .retryReads(true)
                 .filter(new BsonDocument("filter", new BsonInt32(1)))

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListDatabasesPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListDatabasesPublisherImplTest.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -43,7 +41,7 @@ public class ListDatabasesPublisherImplTest extends TestHelper {
         TestOperationExecutor executor = createOperationExecutor(asList(getBatchCursor(), getBatchCursor()));
         ListDatabasesPublisher<Document> publisher = new ListDatabasesPublisherImpl<>(null, createMongoOperationPublisher(executor));
 
-        ListDatabasesOperation<Document> expectedOperation = new ListDatabasesOperation<>(TIMEOUT_SETTINGS,
+        ListDatabasesOperation<Document> expectedOperation = new ListDatabasesOperation<>(
                 getDefaultCodecRegistry().get(Document.class))
                 .retryReads(true);
 
@@ -60,7 +58,7 @@ public class ListDatabasesPublisherImplTest extends TestHelper {
                 .maxTime(100, MILLISECONDS)
                 .batchSize(100);
 
-        expectedOperation = new ListDatabasesOperation<>(TIMEOUT_SETTINGS_WITH_MAX_TIME,
+        expectedOperation = new ListDatabasesOperation<>(
                 getDefaultCodecRegistry().get(Document.class))
                 .retryReads(true)
                 .authorizedDatabasesOnly(true)

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListIndexesPublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ListIndexesPublisherImplTest.java
@@ -25,8 +25,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -45,7 +43,7 @@ public class ListIndexesPublisherImplTest extends TestHelper {
         ListIndexesPublisher<Document> publisher = new ListIndexesPublisherImpl<>(null, createMongoOperationPublisher(executor));
 
         ListIndexesOperation<Document> expectedOperation =
-                new ListIndexesOperation<>(TIMEOUT_SETTINGS, NAMESPACE, getDefaultCodecRegistry().get(Document.class))
+                new ListIndexesOperation<>(NAMESPACE, getDefaultCodecRegistry().get(Document.class))
                         .batchSize(Integer.MAX_VALUE)
                         .retryReads(true);
 
@@ -60,7 +58,7 @@ public class ListIndexesPublisherImplTest extends TestHelper {
                 .maxTime(100, MILLISECONDS);
 
         expectedOperation =
-                new ListIndexesOperation<>(TIMEOUT_SETTINGS_WITH_MAX_TIME, NAMESPACE, getDefaultCodecRegistry().get(Document.class))
+                new ListIndexesOperation<>(NAMESPACE, getDefaultCodecRegistry().get(Document.class))
                         .batchSize(100)
                         .retryReads(true);
 

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MapReducePublisherImplTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MapReducePublisherImplTest.java
@@ -34,8 +34,6 @@ import org.mockito.Mockito;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME;
 import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -60,7 +58,7 @@ public class MapReducePublisherImplTest extends TestHelper {
                 new MapReducePublisherImpl<>(null, createMongoOperationPublisher(executor), MAP_FUNCTION, REDUCE_FUNCTION);
 
         MapReduceWithInlineResultsOperation<Document> expectedOperation = new MapReduceWithInlineResultsOperation<>(
-                TIMEOUT_SETTINGS, NAMESPACE, new BsonJavaScript(MAP_FUNCTION), new BsonJavaScript(REDUCE_FUNCTION),
+                NAMESPACE, new BsonJavaScript(MAP_FUNCTION), new BsonJavaScript(REDUCE_FUNCTION),
                 getDefaultCodecRegistry().get(Document.class)).verbose(true);
 
         // default input should be as expected
@@ -86,7 +84,7 @@ public class MapReducePublisherImplTest extends TestHelper {
                 .verbose(false);
 
         expectedOperation = new MapReduceWithInlineResultsOperation<>(
-                TIMEOUT_SETTINGS_WITH_MAX_TIME, NAMESPACE, new BsonJavaScript(MAP_FUNCTION), new BsonJavaScript(REDUCE_FUNCTION),
+                NAMESPACE, new BsonJavaScript(MAP_FUNCTION), new BsonJavaScript(REDUCE_FUNCTION),
                 getDefaultCodecRegistry().get(Document.class))
                 .verbose(true)
                 .collation(COLLATION)
@@ -115,7 +113,7 @@ public class MapReducePublisherImplTest extends TestHelper {
                 new MapReducePublisherImpl<>(null, createMongoOperationPublisher(executor), MAP_FUNCTION, REDUCE_FUNCTION)
                         .collectionName(NAMESPACE.getCollectionName());
 
-        MapReduceToCollectionOperation expectedOperation = new MapReduceToCollectionOperation(TIMEOUT_SETTINGS, NAMESPACE,
+        MapReduceToCollectionOperation expectedOperation = new MapReduceToCollectionOperation(NAMESPACE,
                                                                                               new BsonJavaScript(MAP_FUNCTION), new BsonJavaScript(REDUCE_FUNCTION), NAMESPACE.getCollectionName(),
                                                                                               WriteConcern.ACKNOWLEDGED).verbose(true);
 
@@ -136,8 +134,8 @@ public class MapReducePublisherImplTest extends TestHelper {
                 .sort(Sorts.ascending("sort"))
                 .verbose(false);
 
-        expectedOperation = new MapReduceToCollectionOperation(TIMEOUT_SETTINGS_WITH_MAX_TIME, NAMESPACE, new BsonJavaScript(MAP_FUNCTION),
-                new BsonJavaScript(REDUCE_FUNCTION), NAMESPACE.getCollectionName(), WriteConcern.ACKNOWLEDGED)
+        expectedOperation = new MapReduceToCollectionOperation(NAMESPACE, new BsonJavaScript(MAP_FUNCTION),
+                                                               new BsonJavaScript(REDUCE_FUNCTION), NAMESPACE.getCollectionName(), WriteConcern.ACKNOWLEDGED)
                 .verbose(true)
                 .collation(COLLATION)
                 .bypassDocumentValidation(true)

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoOperationPublisherTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoOperationPublisherTest.java
@@ -32,17 +32,27 @@ import org.bson.codecs.EncoderContext;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_TIMEOUT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 
 public class MongoOperationPublisherTest {
-    private static final OperationExecutor OPERATION_EXECUTOR = mock(OperationExecutor.class);
+
+    private static final OperationExecutor OPERATION_EXECUTOR;
+
+    static {
+        OPERATION_EXECUTOR = mock(OperationExecutor.class);
+        Mockito.lenient().doAnswer(invocation -> OPERATION_EXECUTOR)
+                .when(OPERATION_EXECUTOR)
+                .withTimeoutSettings(any());
+    }
     private static final MongoNamespace MONGO_NAMESPACE = new MongoNamespace("a.b");
 
     private static final MongoOperationPublisher<Document> DEFAULT_MOP = new MongoOperationPublisher<>(

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/TestHelper.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/TestHelper.java
@@ -82,6 +82,9 @@ public class TestHelper {
 
     static {
         OperationExecutor executor = mock(OperationExecutor.class);
+        Mockito.lenient().doAnswer(invocation -> executor)
+                .when(executor).withTimeoutSettings(any());
+
         Mockito.lenient().doAnswer(invocation -> Mono.empty())
                 .when(executor)
                 .execute(any(), any(), any());

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/TestOperationExecutor.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/TestOperationExecutor.java
@@ -18,6 +18,7 @@ package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
+import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.operation.AsyncReadOperation;
 import com.mongodb.internal.operation.AsyncWriteOperation;
 import com.mongodb.lang.Nullable;
@@ -57,6 +58,11 @@ public class TestOperationExecutor implements OperationExecutor {
         clientSessions.add(session);
         writeOperations.add(operation);
         return createMono();
+    }
+
+    @Override
+    public OperationExecutor withTimeoutSettings(final TimeoutSettings timeoutSettings) {
+        return this;
     }
 
     <T> Mono<T> createMono() {

--- a/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
@@ -98,8 +98,9 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
             throw new IllegalStateException("The last stage of the aggregation pipeline must be $out or $merge");
         }
 
-        getExecutor().execute(operations.aggregateToCollection(pipeline, maxTimeMS, getTimeoutMode(), allowDiskUse,
-                bypassDocumentValidation, collation, hint, hintString, comment, variables, aggregationLevel),
+        getExecutor().execute(
+                operations.aggregateToCollection(pipeline, getTimeoutMode(), allowDiskUse,
+                        bypassDocumentValidation, collation, hint, hintString, comment, variables, aggregationLevel),
                 getReadPreference(), getReadConcern(), getClientSession());
     }
 
@@ -122,7 +123,7 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @Deprecated
     public AggregateIterable<TResult> maxTime(final long maxTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
         this.maxTimeMS = TimeUnit.MILLISECONDS.convert(maxTime, timeUnit);
@@ -200,8 +201,9 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
 
     private <E> E executeExplain(final Class<E> explainResultClass, @Nullable final ExplainVerbosity verbosity) {
         notNull("explainDocumentClass", explainResultClass);
-        return getExecutor().execute(asAggregateOperation().asExplainableOperation(verbosity, codecRegistry.get(explainResultClass)),
-                getReadPreference(), getReadConcern(), getClientSession());
+        return getExecutor().execute(
+                asAggregateOperation().asExplainableOperation(verbosity, codecRegistry.get(explainResultClass)), getReadPreference(),
+                getReadConcern(), getClientSession());
     }
 
     @Override
@@ -209,8 +211,9 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
         MongoNamespace outNamespace = getOutNamespace();
         if (outNamespace != null) {
             validateTimeoutMode();
-            getExecutor().execute(operations.aggregateToCollection(pipeline, maxTimeMS, getTimeoutMode(), allowDiskUse,
-                    bypassDocumentValidation, collation, hint, hintString, comment, variables, aggregationLevel),
+            getExecutor().execute(
+                    operations.aggregateToCollection(pipeline, getTimeoutMode(), allowDiskUse,
+                            bypassDocumentValidation, collation, hint, hintString, comment, variables, aggregationLevel),
                     getReadPreference(), getReadConcern(), getClientSession());
 
             FindOptions findOptions = new FindOptions().collation(collation);
@@ -224,9 +227,13 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
         }
     }
 
+    protected OperationExecutor getExecutor() {
+        return getExecutor(operations.createTimeoutSettings(maxTimeMS, maxAwaitTimeMS));
+    }
+
     private ExplainableReadOperation<BatchCursor<TResult>> asAggregateOperation() {
-        return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, getTimeoutMode(), getBatchSize(), collation,
-                hint, hintString, comment, variables, allowDiskUse, aggregationLevel);
+        return operations.aggregate(pipeline, resultClass, getTimeoutMode(), getBatchSize(), collation, hint, hintString, comment,
+                variables, allowDiskUse, aggregationLevel);
     }
 
     @Nullable

--- a/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
@@ -147,6 +147,12 @@ public class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeS
             public ReadOperation<BatchCursor<TDocument>> asReadOperation() {
                 throw new UnsupportedOperationException();
             }
+
+            @Override
+
+            protected OperationExecutor getExecutor() {
+                return ChangeStreamIterableImpl.this.getExecutor();
+            }
         };
     }
 
@@ -207,9 +213,14 @@ public class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeS
         throw new UnsupportedOperationException();
     }
 
+
+    protected OperationExecutor getExecutor() {
+        return getExecutor(operations.createTimeoutSettings(0, maxAwaitTimeMS));
+    }
+
     private ReadOperation<BatchCursor<RawBsonDocument>> createChangeStreamOperation() {
         return operations.changeStream(fullDocument, fullDocumentBeforeChange, pipeline, new RawBsonDocumentCodec(), changeStreamLevel,
-                getBatchSize(), collation, comment, maxAwaitTimeMS, resumeToken, startAtOperationTime, startAfter, showExpandedEvents);
+                getBatchSize(), collation, comment, resumeToken, startAtOperationTime, startAfter, showExpandedEvents);
     }
 
     private BatchCursor<RawBsonDocument> execute() {

--- a/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
@@ -24,7 +24,6 @@ import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoIterable;
-import com.mongodb.client.cursor.TimeoutMode;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.FullDocument;
@@ -89,7 +88,6 @@ public class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeS
         this.codec = ChangeStreamDocument.createCodec(notNull("resultClass", resultClass), codecRegistry);
         this.changeStreamLevel = notNull("changeStreamLevel", changeStreamLevel);
         this.operations = new SyncOperations<>(namespace, resultClass, readPreference, codecRegistry, retryReads, timeoutSettings);
-        super.timeoutMode(TimeoutMode.ITERATION);
     }
 
     @Override

--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
@@ -39,7 +39,6 @@ import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.assertions.Assertions.notNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSession {
 
@@ -145,11 +144,11 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
                     throw new MongoInternalException("Invariant violated.  Transaction options read concern can not be null");
                 }
                 commitInProgress = true;
-                Long maxCommitTime = transactionOptions.getMaxCommitTime(MILLISECONDS);
+                // TODO (CSOT) - JAVA-4067
+                // Long maxCommitTime = transactionOptions.getMaxCommitTime(MILLISECONDS);
                 delegate.getOperationExecutor().execute(
                         new CommitTransactionOperation(
                                 // TODO (CSOT) - JAVA-4067
-                                delegate.getTimeoutSettings().withMaxCommitMS(maxCommitTime == null ? 0 : maxCommitTime),
                                 assertNotNull(transactionOptions.getWriteConcern()),
                         transactionState == TransactionState.COMMITTED)
                                 .recoveryToken(getRecoveryToken()),
@@ -181,10 +180,10 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
                 if (readConcern == null) {
                     throw new MongoInternalException("Invariant violated.  Transaction options read concern can not be null");
                 }
-                Long maxCommitTime = transactionOptions.getMaxCommitTime(MILLISECONDS);
+                // TODO (CSOT) - JAVA-4067
+                // Long maxCommitTime = transactionOptions.getMaxCommitTime(MILLISECONDS);
                 delegate.getOperationExecutor().execute(new AbortTransactionOperation(
                         // TODO (CSOT) - JAVA-4067
-                        delegate.getTimeoutSettings().withMaxCommitMS(maxCommitTime == null ? 0 : maxCommitTime),
                         assertNotNull(transactionOptions.getWriteConcern()))
                         .recoveryToken(getRecoveryToken()), readConcern, this);
             }

--- a/driver-sync/src/main/com/mongodb/client/internal/DistinctIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/DistinctIterableImpl.java
@@ -105,6 +105,11 @@ class DistinctIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult
 
     @Override
     public ReadOperation<BatchCursor<TResult>> asReadOperation() {
-        return operations.distinct(fieldName, filter, resultClass, maxTimeMS, collation, comment);
+        return operations.distinct(fieldName, filter, resultClass, collation, comment);
+    }
+
+
+    protected OperationExecutor getExecutor() {
+        return getExecutor(operations.createTimeoutSettings(maxTimeMS));
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
@@ -208,8 +208,8 @@ class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> im
     @Nullable
     @Override
     public TResult first() {
-        try (BatchCursor<TResult> batchCursor = getExecutor().execute(operations.findFirst(filter, resultClass, findOptions),
-                getReadPreference(), getReadConcern(), getClientSession())) {
+        try (BatchCursor<TResult> batchCursor = getExecutor().execute(
+                operations.findFirst(filter, resultClass, findOptions), getReadPreference(), getReadConcern(), getClientSession())) {
             return batchCursor.hasNext() ? batchCursor.next().iterator().next() : null;
         }
     }
@@ -234,10 +234,15 @@ class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> im
         return executeExplain(explainResultClass, notNull("verbosity", verbosity));
     }
 
+
+    protected OperationExecutor getExecutor() {
+        return getExecutor(operations.createTimeoutSettings(findOptions));
+    }
+
     private <E> E executeExplain(final Class<E> explainResultClass, @Nullable final ExplainVerbosity verbosity) {
         notNull("explainDocumentClass", explainResultClass);
-        return getExecutor().execute(asReadOperation().asExplainableOperation(verbosity, codecRegistry.get(explainResultClass)),
-                getReadPreference(), getReadConcern(), getClientSession());
+        return getExecutor().execute(
+                asReadOperation().asExplainableOperation(verbosity, codecRegistry.get(explainResultClass)), getReadPreference(), getReadConcern(), getClientSession());
     }
 
     public ExplainableReadOperation<BatchCursor<TResult>> asReadOperation() {

--- a/driver-sync/src/main/com/mongodb/client/internal/ListCollectionsIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ListCollectionsIterableImpl.java
@@ -106,6 +106,11 @@ class ListCollectionsIterableImpl<TResult> extends MongoIterableImpl<TResult> im
     @Override
     public ReadOperation<BatchCursor<TResult>> asReadOperation() {
         return operations.listCollections(databaseName, resultClass, filter, collectionNamesOnly, authorizedCollections,
-                getBatchSize(), maxTimeMS, comment, getTimeoutMode());
+                getBatchSize(), comment, getTimeoutMode());
+    }
+
+
+    protected OperationExecutor getExecutor() {
+        return getExecutor(operations.createTimeoutSettings(maxTimeMS));
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/ListDatabasesIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ListDatabasesIterableImpl.java
@@ -109,6 +109,11 @@ public class ListDatabasesIterableImpl<TResult> extends MongoIterableImpl<TResul
 
     @Override
     public ReadOperation<BatchCursor<TResult>> asReadOperation() {
-        return operations.listDatabases(resultClass, filter, nameOnly, maxTimeMS, authorizedDatabasesOnly, comment);
+        return operations.listDatabases(resultClass, filter, nameOnly, authorizedDatabasesOnly, comment);
+    }
+
+
+    protected OperationExecutor getExecutor() {
+        return getExecutor(operations.createTimeoutSettings(maxTimeMS));
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/ListIndexesIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ListIndexesIterableImpl.java
@@ -84,6 +84,10 @@ class ListIndexesIterableImpl<TResult> extends MongoIterableImpl<TResult> implem
 
     @Override
     public ReadOperation<BatchCursor<TResult>> asReadOperation() {
-        return operations.listIndexes(resultClass, getBatchSize(), maxTimeMS, comment, getTimeoutMode());
+        return operations.listIndexes(resultClass, getBatchSize(), comment, getTimeoutMode());
+    }
+
+    protected OperationExecutor getExecutor() {
+        return getExecutor(operations.createTimeoutSettings(maxTimeMS));
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/ListSearchIndexesIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ListSearchIndexesIterableImpl.java
@@ -142,12 +142,18 @@ final class ListSearchIndexesIterableImpl<TResult> extends MongoIterableImpl<TRe
     }
 
     private <E> E executeExplain(final Class<E> explainResultClass, @Nullable final ExplainVerbosity verbosity) {
-        return getExecutor().execute(asAggregateOperation().asExplainableOperation(verbosity, codecRegistry.get(explainResultClass)),
-                getReadPreference(), getReadConcern(), getClientSession());
+        return getExecutor().execute(asAggregateOperation()
+                        .asExplainableOperation(verbosity, codecRegistry.get(explainResultClass)), getReadPreference(), getReadConcern(), getClientSession());
     }
 
     private ExplainableReadOperation<BatchCursor<TResult>> asAggregateOperation() {
-        return operations.listSearchIndexes(resultClass, maxTimeMS, indexName, getBatchSize(), collation, comment,
+        return operations.listSearchIndexes(resultClass, indexName, getBatchSize(), collation, comment,
                 allowDiskUse);
     }
+
+
+    protected OperationExecutor getExecutor() {
+        return getExecutor(operations.createTimeoutSettings(maxTimeMS));
+    }
+
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/MapReduceIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MapReduceIterableImpl.java
@@ -188,11 +188,16 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
         }
     }
 
+
+    protected OperationExecutor getExecutor() {
+        return getExecutor(operations.createTimeoutSettings(maxTimeMS));
+    }
+
     @Override
     public ReadOperation<BatchCursor<TResult>> asReadOperation() {
         if (inline) {
             ReadOperation<MapReduceBatchCursor<TResult>> operation = operations.mapReduce(mapFunction, reduceFunction, finalizeFunction,
-                    resultClass, filter, limit, maxTimeMS, jsMode, scope, sort, verbose, collation);
+                    resultClass, filter, limit, jsMode, scope, sort, verbose, collation);
             return new WrappedMapReduceReadOperation<>(operation);
         } else {
             getExecutor().execute(createMapReduceToCollectionOperation(), getReadConcern(), getClientSession());
@@ -211,7 +216,7 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
 
     private WriteOperation<MapReduceStatistics> createMapReduceToCollectionOperation() {
         return operations.mapReduceToCollection(databaseName, collectionName, mapFunction, reduceFunction, finalizeFunction, filter,
-                limit, maxTimeMS, jsMode, scope, sort, verbose, action, bypassDocumentValidation, collation
+                limit, jsMode, scope, sort, verbose, action, bypassDocumentValidation, collation
         );
     }
 
@@ -225,11 +230,6 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
 
         WrappedMapReduceReadOperation(final ReadOperation<MapReduceBatchCursor<TResult>> operation) {
             this.operation = operation;
-        }
-
-        @Override
-        public TimeoutSettings getTimeoutSettings() {
-            return operation.getTimeoutSettings();
         }
 
         @Override

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
@@ -216,8 +216,7 @@ public class MongoDatabaseImpl implements MongoDatabase {
         if (clientSession != null && clientSession.hasActiveTransaction() && !readPreference.equals(ReadPreference.primary())) {
             throw new MongoClientException("Read preference in a transaction must be primary");
         }
-        return executor.execute(operations.commandRead(command, resultClass),
-                readPreference, readConcern, clientSession);
+        return getExecutor().execute(operations.commandRead(command, resultClass), readPreference, readConcern, clientSession);
     }
 
     @Override
@@ -232,7 +231,7 @@ public class MongoDatabaseImpl implements MongoDatabase {
     }
 
     private void executeDrop(@Nullable final ClientSession clientSession) {
-        executor.execute(operations.dropDatabase(), readConcern, clientSession);
+        getExecutor().execute(operations.dropDatabase(), readConcern, clientSession);
     }
 
     @Override
@@ -302,8 +301,8 @@ public class MongoDatabaseImpl implements MongoDatabase {
 
     private void executeCreateCollection(@Nullable final ClientSession clientSession, final String collectionName,
                                          final CreateCollectionOptions createCollectionOptions) {
-        executor.execute(operations.createCollection(collectionName, createCollectionOptions, autoEncryptionSettings), readConcern,
-                clientSession);
+        getExecutor().execute(operations.createCollection(collectionName, createCollectionOptions, autoEncryptionSettings),
+                        readConcern, clientSession);
     }
 
     @Override
@@ -411,6 +410,10 @@ public class MongoDatabaseImpl implements MongoDatabase {
     private void executeCreateView(@Nullable final ClientSession clientSession, final String viewName, final String viewOn,
                                    final List<? extends Bson> pipeline, final CreateViewOptions createViewOptions) {
         notNull("createViewOptions", createViewOptions);
-        executor.execute(operations.createView(viewName, viewOn, pipeline, createViewOptions), readConcern, clientSession);
+        getExecutor().execute(operations.createView(viewName, viewOn, pipeline, createViewOptions), readConcern, clientSession);
+    }
+
+    private OperationExecutor getExecutor() {
+        return executor.withTimeoutSettings(timeoutSettings);
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoIterableImpl.java
@@ -63,8 +63,10 @@ public abstract class MongoIterableImpl<TResult> implements MongoIterable<TResul
         return clientSession;
     }
 
-    OperationExecutor getExecutor() {
-        return executor;
+    protected abstract OperationExecutor getExecutor();
+
+    OperationExecutor getExecutor(final TimeoutSettings timeoutSettings) {
+        return executor.withTimeoutSettings(timeoutSettings);
     }
 
     ReadPreference getReadPreference() {
@@ -146,6 +148,6 @@ public abstract class MongoIterableImpl<TResult> implements MongoIterable<TResul
     }
 
     private BatchCursor<TResult> execute() {
-        return executor.execute(asReadOperation(), readPreference, readConcern, clientSession);
+        return getExecutor().execute(asReadOperation(), readPreference, readConcern, clientSession);
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoIterableImpl.java
@@ -102,6 +102,9 @@ public abstract class MongoIterableImpl<TResult> implements MongoIterable<TResul
     }
 
     public MongoIterable<TResult> timeoutMode(final TimeoutMode timeoutMode) {
+        if (timeoutSettings.getTimeoutMS() == null) {
+            throw new IllegalArgumentException("TimeoutMode requires timeoutMS to be set.");
+        }
         this.timeoutMode = timeoutMode;
         return this;
     }

--- a/driver-sync/src/main/com/mongodb/client/internal/OperationExecutor.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/OperationExecutor.java
@@ -19,6 +19,7 @@ package com.mongodb.client.internal;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.client.ClientSession;
+import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.operation.ReadOperation;
 import com.mongodb.internal.operation.WriteOperation;
 import com.mongodb.lang.Nullable;
@@ -33,10 +34,10 @@ public interface OperationExecutor {
     /**
      * Execute the read operation with the given read preference.
      *
-     * @param <T> the operations result type.
-     * @param operation the read operation.
+     * @param <T>            the operations result type.
+     * @param operation      the read operation.
      * @param readPreference the read preference.
-     * @param readConcern the read concern
+     * @param readConcern    the read concern
      * @return the result of executing the operation.
      */
     <T> T execute(ReadOperation<T> operation, ReadPreference readPreference, ReadConcern readConcern);
@@ -44,9 +45,9 @@ public interface OperationExecutor {
     /**
      * Execute the write operation.
      *
-     * @param operation the write operation.
+     * @param <T>         the operations result type.
+     * @param operation   the write operation.
      * @param readConcern the read concern
-     * @param <T> the operations result type.
      * @return the result of executing the operation.
      */
     <T> T execute(WriteOperation<T> operation, ReadConcern readConcern);
@@ -54,11 +55,11 @@ public interface OperationExecutor {
     /**
      * Execute the read operation with the given read preference.
      *
-     * @param <T> the operations result type.
-     * @param operation the read operation.
+     * @param <T>            the operations result type.
+     * @param operation      the read operation.
      * @param readPreference the read preference.
-     * @param readConcern the read concern
-     * @param session the session to associate this operation with
+     * @param readConcern    the read concern
+     * @param session        the session to associate this operation with
      * @return the result of executing the operation.
      */
     <T> T execute(ReadOperation<T> operation, ReadPreference readPreference, ReadConcern readConcern, @Nullable ClientSession session);
@@ -66,11 +67,20 @@ public interface OperationExecutor {
     /**
      * Execute the write operation.
      *
-     * @param operation the write operation.
+     * @param <T>         the operations result type.
+     * @param operation   the write operation.
      * @param readConcern the read concern
-     * @param session the session to associate this operation with
-     * @param <T> the operations result type.
+     * @param session     the session to associate this operation with
      * @return the result of executing the operation.
      */
     <T> T execute(WriteOperation<T> operation, ReadConcern readConcern, @Nullable ClientSession session);
+
+    /**
+     * Create a new OperationExecutor with a specific TimeoutContext
+     *
+     * @param timeoutSettings the TimeoutContext to use for the operations
+     * @return the new operation executor with the set timeout context
+     * @since CSOT
+     */
+    OperationExecutor withTimeoutSettings(TimeoutSettings timeoutSettings);
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractMainTransactionsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractMainTransactionsTest.java
@@ -55,6 +55,13 @@ public abstract class AbstractMainTransactionsTest extends AbstractUnifiedTest {
                         || description.equals("distinct"))
                 && isSharded()
                 && serverVersionLessThan(4, 4));
+
+        // TODO (CSOT) - JAVA-4067
+        assumeFalse(description.equals("add UnknownTransactionCommitResult label to MaxTimeMSExpired"));
+        assumeFalse(description.equals("add UnknownTransactionCommitResult label to writeConcernError MaxTimeMSExpired"));
+        assumeFalse(description.equals("defaultTransactionOptions override client options"));
+        assumeFalse(description.equals("startTransaction options override defaults"));
+        assumeFalse(description.equals("transaction options inherited from defaultTransactionOptions"));
     }
 
     @Parameterized.Parameters(name = "{0}: {1}")

--- a/driver-sync/src/test/functional/com/mongodb/client/WithTransactionHelperTransactionsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/WithTransactionHelperTransactionsTest.java
@@ -45,6 +45,9 @@ public class WithTransactionHelperTransactionsTest extends AbstractUnifiedTest {
                                                  final BsonDocument definition, final boolean skipTest) {
         super(filename, description, databaseName, collectionName, data, definition, skipTest, true);
         assumeFalse(isServerlessTest());
+
+        // TODO (CSOT) - JAVA-4067 / JAVA-4066
+        assumeFalse(description.equals("commit is not retried after MaxTimeMSExpired error"));
     }
 
     @Override

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
@@ -242,29 +242,30 @@ final class UnifiedCrudHelper extends UnifiedHelper {
         ListCollectionsIterable<BsonDocument> iterable = session == null
                 ? database.listCollections(BsonDocument.class)
                 : database.listCollections(session, BsonDocument.class);
-        for (Map.Entry<String, BsonValue> cur : arguments.entrySet()) {
-            switch (cur.getKey()) {
-                case "session":
-                    break;
-                case "filter":
-                    iterable.filter(cur.getValue().asDocument());
-                    break;
-                case "batchSize":
-                    iterable.batchSize(cur.getValue().asNumber().intValue());
-                    break;
-                case "timeoutMode":
-                    setTimeoutMode(iterable, cur);
-                    break;
-                case "maxTimeMS":
-                    iterable.maxTime(cur.getValue().asNumber().longValue(), TimeUnit.MILLISECONDS);
-                    break;
-                default:
-                    throw new UnsupportedOperationException("Unsupported argument: " + cur.getKey());
+        return resultOf(() -> {
+            for (Map.Entry<String, BsonValue> cur : arguments.entrySet()) {
+                switch (cur.getKey()) {
+                    case "session":
+                        break;
+                    case "filter":
+                        iterable.filter(cur.getValue().asDocument());
+                        break;
+                    case "batchSize":
+                        iterable.batchSize(cur.getValue().asNumber().intValue());
+                        break;
+                    case "timeoutMode":
+                        setTimeoutMode(iterable, cur);
+                        break;
+                    case "maxTimeMS":
+                        iterable.maxTime(cur.getValue().asNumber().longValue(), TimeUnit.MILLISECONDS);
+                        break;
+                    default:
+                        throw new UnsupportedOperationException("Unsupported argument: " + cur.getKey());
+                }
             }
-        }
 
-        return resultOf(() ->
-                new BsonArray(iterable.into(new ArrayList<>())));
+            return new BsonArray(iterable.into(new ArrayList<>()));
+        });
     }
 
     OperationResult executeListCollectionNames(final BsonDocument operation) {
@@ -298,17 +299,17 @@ final class UnifiedCrudHelper extends UnifiedHelper {
     }
 
     OperationResult executeListIndexes(final BsonDocument operation) {
-        ListIndexesIterable<BsonDocument> iterable = createListIndexesIterable(operation);
-
-        return resultOf(() ->
-                new BsonArray(iterable.into(new ArrayList<>())));
+        return resultOf(() -> {
+            ListIndexesIterable<BsonDocument> iterable = createListIndexesIterable(operation);
+            return new BsonArray(iterable.into(new ArrayList<>()));
+        });
     }
 
     OperationResult executeListIndexNames(final BsonDocument operation) {
-        ListIndexesIterable<BsonDocument> iterable = createListIndexesIterable(operation);
-
-        return resultOf(() ->
-                new BsonArray(iterable.into(new ArrayList<>()).stream().map(document -> document.getString("name")).collect(toList())));
+        return resultOf(() -> {
+            ListIndexesIterable<BsonDocument> iterable = createListIndexesIterable(operation);
+            return new BsonArray(iterable.into(new ArrayList<>()).stream().map(document -> document.getString("name")).collect(toList()));
+        });
     }
 
     private ListIndexesIterable<BsonDocument> createListIndexesIterable(final BsonDocument operation) {
@@ -339,19 +340,19 @@ final class UnifiedCrudHelper extends UnifiedHelper {
     }
 
     OperationResult executeFind(final BsonDocument operation) {
-        FindIterable<BsonDocument> iterable = createFindIterable(operation);
-        return resultOf(() ->
-                new BsonArray(iterable.into(new ArrayList<>())));
+        return resultOf(() -> {
+            FindIterable<BsonDocument> iterable = createFindIterable(operation);
+            return new BsonArray(iterable.into(new ArrayList<>()));
+        });
     }
 
     OperationResult executeFindOne(final BsonDocument operation) {
-        FindIterable<BsonDocument> iterable = createFindIterable(operation);
-        return resultOf(iterable::first);
+        return resultOf(() ->  createFindIterable(operation).first());
     }
 
     OperationResult createFindCursor(final BsonDocument operation) {
-        FindIterable<BsonDocument> iterable = createFindIterable(operation);
         return resultOf(() -> {
+            FindIterable<BsonDocument> iterable = createFindIterable(operation);
             entities.addCursor(operation.getString("saveResultAsEntity", new BsonString(createRandomEntityId())).getValue(),
                     iterable.cursor());
             return null;
@@ -647,40 +648,40 @@ final class UnifiedCrudHelper extends UnifiedHelper {
         } else {
             throw new UnsupportedOperationException("Unsupported entity type with name: " + entityName);
         }
-        for (Map.Entry<String, BsonValue> cur : arguments.entrySet()) {
-            switch (cur.getKey()) {
-                case "pipeline":
-                case "session":
-                    break;
-                case "batchSize":
-                    iterable.batchSize(cur.getValue().asNumber().intValue());
-                    break;
-                case "allowDiskUse":
-                    iterable.allowDiskUse(cur.getValue().asBoolean().getValue());
-                    break;
-                case "let":
-                    iterable.let(cur.getValue().asDocument());
-                    break;
-                case "comment":
-                    iterable.comment(cur.getValue());
-                    break;
-                case "timeoutMode":
-                    setTimeoutMode(iterable, cur);
-                    break;
-                case "maxTimeMS":
-                    iterable.maxTime(cur.getValue().asNumber().longValue(), TimeUnit.MILLISECONDS);
-                    break;
-                case "maxAwaitTimeMS":
-                    iterable.maxAwaitTime(cur.getValue().asNumber().longValue(), TimeUnit.MILLISECONDS);
-                    break;
-                default:
-                    throw new UnsupportedOperationException("Unsupported argument: " + cur.getKey());
-            }
-        }
-        String lastStageName = pipeline.isEmpty() ? null : pipeline.get(pipeline.size() - 1).getFirstKey();
-        boolean useToCollection = Objects.equals(lastStageName, "$out") || Objects.equals(lastStageName, "$merge");
 
         return resultOf(() -> {
+            for (Map.Entry<String, BsonValue> cur : arguments.entrySet()) {
+                switch (cur.getKey()) {
+                    case "pipeline":
+                    case "session":
+                        break;
+                    case "batchSize":
+                        iterable.batchSize(cur.getValue().asNumber().intValue());
+                        break;
+                    case "allowDiskUse":
+                        iterable.allowDiskUse(cur.getValue().asBoolean().getValue());
+                        break;
+                    case "let":
+                        iterable.let(cur.getValue().asDocument());
+                        break;
+                    case "comment":
+                        iterable.comment(cur.getValue());
+                        break;
+                    case "timeoutMode":
+                        setTimeoutMode(iterable, cur);
+                        break;
+                    case "maxTimeMS":
+                        iterable.maxTime(cur.getValue().asNumber().longValue(), TimeUnit.MILLISECONDS);
+                        break;
+                    case "maxAwaitTimeMS":
+                        iterable.maxAwaitTime(cur.getValue().asNumber().longValue(), TimeUnit.MILLISECONDS);
+                        break;
+                    default:
+                        throw new UnsupportedOperationException("Unsupported argument: " + cur.getKey());
+                }
+            }
+            String lastStageName = pipeline.isEmpty() ? null : pipeline.get(pipeline.size() - 1).getFirstKey();
+            boolean useToCollection = Objects.equals(lastStageName, "$out") || Objects.equals(lastStageName, "$merge");
             if (!pipeline.isEmpty() && useToCollection) {
                 iterable.toCollection();
                 return null;
@@ -1834,8 +1835,14 @@ final class UnifiedCrudHelper extends UnifiedHelper {
             timeoutModeMethod.invoke(iterable, timeoutMode);
         } catch (NoSuchMethodException e) {
             throw new UnsupportedOperationException("Unsupported timeoutMode method for class: " + iterable.getClass(), e);
-        } catch (InvocationTargetException | IllegalAccessException e) {
+        } catch (IllegalAccessException e) {
             throw new UnsupportedOperationException("Unable to set timeoutMode method for class: " + iterable.getClass(), e);
+        } catch (InvocationTargetException e) {
+            Throwable targetException = e.getTargetException();
+            if (targetException instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) targetException;
+            }
+            throw new UnsupportedOperationException("Unable to set timeoutMode method for class: " + iterable.getClass(), targetException);
         }
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -304,6 +304,7 @@ public abstract class UnifiedTest {
     private void assertOperation(final UnifiedTestContext context, final BsonDocument operation, final int operationIndex) {
         OperationResult result = executeOperation(context, operation, operationIndex);
         context.getAssertionContext().push(ContextElement.ofCompletedOperation(operation, result, operationIndex));
+
         if (!operation.getBoolean("ignoreResultAndError", BsonBoolean.FALSE).getValue()) {
             if (operation.containsKey("expectResult")) {
                 assertNull(context.getAssertionContext().getMessage("The operation expects a result but an exception occurred"),

--- a/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
@@ -597,8 +597,8 @@ class GridFSBucketSpecification extends Specification {
 
         then:
         executor.getReadPreference() == primary()
-        expect executor.getReadOperation(), isTheSameAs(new FindOperation<GridFSFile>(TIMEOUT_SETTINGS,
-                new MongoNamespace('test.fs.files'), decoder).filter(new BsonDocument()))
+        expect executor.getReadOperation(), isTheSameAs(new FindOperation<GridFSFile>(new MongoNamespace('test.fs.files'), decoder)
+                .filter(new BsonDocument()))
 
         when:
         def filter = new BsonDocument('filename', new BsonString('filename'))
@@ -608,7 +608,7 @@ class GridFSBucketSpecification extends Specification {
         then:
         executor.getReadPreference() == secondary()
         expect executor.getReadOperation(), isTheSameAs(
-                new FindOperation<GridFSFile>(TIMEOUT_SETTINGS, new MongoNamespace('test.fs.files'), decoder).filter(filter))
+                new FindOperation<GridFSFile>(new MongoNamespace('test.fs.files'), decoder).filter(filter))
     }
 
     def 'should throw an exception if file not found when opening by name'() {

--- a/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSFindIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSFindIterableSpecification.groovy
@@ -38,7 +38,6 @@ import spock.lang.Specification
 
 import java.util.function.Consumer
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
@@ -68,7 +67,7 @@ class GridFSFindIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new FindOperation<GridFSFile>(TIMEOUT_SETTINGS, namespace, gridFSFileCodec)
+        expect operation, isTheSameAs(new FindOperation<GridFSFile>(namespace, gridFSFileCodec)
                 .filter(new BsonDocument()).retryReads(true))
         readPreference == secondary()
 
@@ -86,7 +85,7 @@ class GridFSFindIterableSpecification extends Specification {
         operation = executor.getReadOperation() as FindOperation<GridFSFile>
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new FindOperation<GridFSFile>(TIMEOUT_SETTINGS_WITH_MAX_TIME, namespace, gridFSFileCodec)
+        expect operation, isTheSameAs(new FindOperation<GridFSFile>(namespace, gridFSFileCodec)
                 .filter(new BsonDocument('filter', new BsonInt32(2)))
                 .sort(new BsonDocument('sort', new BsonInt32(2)))
                 .batchSize(99)
@@ -112,7 +111,7 @@ class GridFSFindIterableSpecification extends Specification {
         def operation = executor.getReadOperation() as FindOperation<GridFSFile>
 
         then:
-        expect operation, isTheSameAs(new FindOperation<GridFSFile>(TIMEOUT_SETTINGS, namespace, gridFSFileCodec)
+        expect operation, isTheSameAs(new FindOperation<GridFSFile>(namespace, gridFSFileCodec)
                 .filter(new BsonDocument('filter', new BsonInt32(1)))
                 .sort(new BsonDocument('sort', new BsonInt32(1)))
                 .cursorType(CursorType.NonTailable)

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/AggregateIterableSpecification.groovy
@@ -41,8 +41,6 @@ import spock.lang.Specification
 
 import java.util.function.Consumer
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME_AND_AWAIT_TIME
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
@@ -74,7 +72,7 @@ class AggregateIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new AggregateOperation<Document>(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new AggregateOperation<Document>(namespace,
                 [new BsonDocument('$match', new BsonInt32(1))], new DocumentCodec())
                 .retryReads(true))
         readPreference == secondary()
@@ -91,7 +89,7 @@ class AggregateIterableSpecification extends Specification {
         operation = executor.getReadOperation() as AggregateOperation<Document>
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new AggregateOperation<Document>(TIMEOUT_SETTINGS_WITH_MAX_TIME_AND_AWAIT_TIME, namespace,
+        expect operation, isTheSameAs(new AggregateOperation<Document>(namespace,
                 [new BsonDocument('$match', new BsonInt32(1))], new DocumentCodec())
                 .retryReads(true)
                 .collation(collation)
@@ -110,7 +108,7 @@ class AggregateIterableSpecification extends Specification {
         operation = executor.getReadOperation() as AggregateOperation<Document>
 
         then: 'should use hint not hint string'
-        expect operation, isTheSameAs(new AggregateOperation<Document>(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new AggregateOperation<Document>(namespace,
                 [new BsonDocument('$match', new BsonInt32(1))], new DocumentCodec())
                 .hint(new BsonDocument('a', new BsonInt32(1))))
     }
@@ -135,7 +133,7 @@ class AggregateIterableSpecification extends Specification {
         def operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
                 [new BsonDocument('$match', new BsonInt32(1)), new BsonDocument('$out', new BsonString(collectionName))],
                 readConcern, writeConcern, AggregationLevel.COLLECTION)
                 .allowDiskUse(true)
@@ -166,7 +164,7 @@ class AggregateIterableSpecification extends Specification {
         operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS_WITH_MAX_TIME, namespace,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
                 [new BsonDocument('$match', new BsonInt32(1)), new BsonDocument('$out', new BsonString(collectionName))],
                 readConcern, writeConcern,
                 AggregationLevel.DATABASE)
@@ -197,7 +195,7 @@ class AggregateIterableSpecification extends Specification {
         operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
                 [new BsonDocument('$match', new BsonInt32(1)), new BsonDocument('$out', new BsonString(collectionName))],
                 readConcern, writeConcern)
                 .allowDiskUse(true)
@@ -220,7 +218,7 @@ class AggregateIterableSpecification extends Specification {
         def operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
                 [new BsonDocument('$match', new BsonInt32(1)), new BsonDocument('$out', new BsonString(collectionName))],
                 readConcern, writeConcern, AggregationLevel.COLLECTION)
                 .hint(new BsonString('x_1')))
@@ -235,7 +233,7 @@ class AggregateIterableSpecification extends Specification {
         operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then: 'should use the hint not the hint string'
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
                 [new BsonDocument('$match', new BsonInt32(1)), new BsonDocument('$out', new BsonString(collectionName))],
                 readConcern, writeConcern, AggregationLevel.COLLECTION)
                 .hint(new BsonDocument('x', new BsonInt32(1))))
@@ -262,7 +260,7 @@ class AggregateIterableSpecification extends Specification {
         def operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
                 [new BsonDocument('$match', new BsonInt32(1)),
                  new BsonDocument('$merge', new BsonDocument('into', new BsonString(collectionName)))],
                 readConcern, writeConcern,
@@ -294,7 +292,7 @@ class AggregateIterableSpecification extends Specification {
         operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS_WITH_MAX_TIME, namespace,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
                 [new BsonDocument('$match', new BsonInt32(1)),
                  new BsonDocument('$merge', new BsonDocument('into',
                          new BsonDocument('db', new BsonString('db2')).append('coll', new BsonString(collectionName))))],
@@ -327,7 +325,7 @@ class AggregateIterableSpecification extends Specification {
         operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS_WITH_MAX_TIME, namespace,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
                 [new BsonDocument('$match', new BsonInt32(1)),
                  new BsonDocument('$merge', new BsonDocument('into', new BsonString(collectionName)))],
                 readConcern, writeConcern,
@@ -358,7 +356,7 @@ class AggregateIterableSpecification extends Specification {
         operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
                 [new BsonDocument('$match', new BsonInt32(1)),
                  new BsonDocument('$merge', new BsonDocument('into', new BsonString(collectionName)))],
                 readConcern, writeConcern)
@@ -383,7 +381,7 @@ class AggregateIterableSpecification extends Specification {
         def operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, namespace, pipeline, readConcern,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace, pipeline, readConcern,
                 writeConcern, AggregationLevel.COLLECTION))
 
         when:
@@ -426,7 +424,7 @@ class AggregateIterableSpecification extends Specification {
         def operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
                 [new BsonDocument('$match', new BsonInt32(1)), BsonDocument.parse('{$out: {s3: true}}')],
                 readConcern, writeConcern, AggregationLevel.COLLECTION)
         )
@@ -445,7 +443,7 @@ class AggregateIterableSpecification extends Specification {
         operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
                 [new BsonDocument('$match', new BsonInt32(1)), BsonDocument.parse('{$out: {s3: true}}')],
                 readConcern, writeConcern, AggregationLevel.DATABASE)
         )
@@ -464,7 +462,7 @@ class AggregateIterableSpecification extends Specification {
         operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
                 [new BsonDocument('$match', new BsonInt32(1)), BsonDocument.parse('{$out: {s3: true}}')],
                 readConcern, writeConcern))
 
@@ -482,7 +480,7 @@ class AggregateIterableSpecification extends Specification {
         operation = executor.getReadOperation() as AggregateToCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new AggregateToCollectionOperation(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new AggregateToCollectionOperation(namespace,
                 [new BsonDocument('$match', new BsonInt32(1)),
                  BsonDocument.parse('{$out: {db: "testDB", coll: "testCollection"}}')], readConcern, writeConcern))
 

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ChangeStreamIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ChangeStreamIterableSpecification.groovy
@@ -42,7 +42,6 @@ import spock.lang.Specification
 
 import java.util.function.Consumer
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_AWAIT_TIME
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
@@ -72,7 +71,7 @@ class ChangeStreamIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new ChangeStreamOperation<Document>(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new ChangeStreamOperation<Document>(namespace,
                 FullDocument.DEFAULT, FullDocumentBeforeChange.DEFAULT, [BsonDocument.parse('{$match: 1}')], codec,
                 ChangeStreamLevel.COLLECTION)
                 .retryReads(true))
@@ -91,7 +90,7 @@ class ChangeStreamIterableSpecification extends Specification {
         operation = executor.getReadOperation() as ChangeStreamOperation<Document>
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new ChangeStreamOperation<Document>(TIMEOUT_SETTINGS_WITH_MAX_AWAIT_TIME, namespace,
+        expect operation, isTheSameAs(new ChangeStreamOperation<Document>(namespace,
                 FullDocument.UPDATE_LOOKUP, FullDocumentBeforeChange.WHEN_AVAILABLE, [BsonDocument.parse('{$match: 1}')], codec,
                 ChangeStreamLevel.COLLECTION)
                 .retryReads(true)

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/DistinctIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/DistinctIterableSpecification.groovy
@@ -37,7 +37,6 @@ import spock.lang.Specification
 
 import java.util.function.Consumer
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
@@ -66,7 +65,7 @@ class DistinctIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new DistinctOperation<Document>(TIMEOUT_SETTINGS, namespace, 'field', new DocumentCodec())
+        expect operation, isTheSameAs(new DistinctOperation<Document>(namespace, 'field', new DocumentCodec())
                 .filter(new BsonDocument()).retryReads(true))
         readPreference == secondary()
 
@@ -77,7 +76,7 @@ class DistinctIterableSpecification extends Specification {
 
         then: 'should use the overrides'
         expect operation, isTheSameAs(
-                new DistinctOperation<Document>(TIMEOUT_SETTINGS_WITH_MAX_TIME, namespace, 'field', new DocumentCodec())
+                new DistinctOperation<Document>(namespace, 'field', new DocumentCodec())
                         .filter(new BsonDocument('field', new BsonInt32(1))).collation(collation).retryReads(true))
     }
 

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/FindIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/FindIterableSpecification.groovy
@@ -39,7 +39,6 @@ import spock.lang.Specification
 import java.util.function.Consumer
 
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME_AND_AWAIT_TIME
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -84,7 +83,7 @@ class FindIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new FindOperation<Document>(TIMEOUT_SETTINGS, namespace, new DocumentCodec())
+        expect operation, isTheSameAs(new FindOperation<Document>(namespace, new DocumentCodec())
                 .filter(new BsonDocument('filter', new BsonInt32(1)))
                 .sort(new BsonDocument('sort', new BsonInt32(1)))
                 .projection(new BsonDocument('projection', new BsonInt32(1)))
@@ -129,7 +128,7 @@ class FindIterableSpecification extends Specification {
 
         then: 'should use the overrides'
         expect operation, isTheSameAs(
-                new FindOperation<Document>(TIMEOUT_SETTINGS_WITH_MAX_TIME_AND_AWAIT_TIME, namespace, new DocumentCodec())
+                new FindOperation<Document>(namespace, new DocumentCodec())
                         .filter(new BsonDocument('filter', new BsonInt32(2)))
                         .sort(new BsonDocument('sort', new BsonInt32(2)))
                         .projection(new BsonDocument('projection', new BsonInt32(2)))
@@ -166,7 +165,7 @@ class FindIterableSpecification extends Specification {
         operation = executor.getReadOperation() as FindOperation<Document>
 
         then: 'should set an empty doc for the filter'
-        expect operation, isTheSameAs(new FindOperation<Document>(TIMEOUT_SETTINGS, namespace, new DocumentCodec())
+        expect operation, isTheSameAs(new FindOperation<Document>(namespace, new DocumentCodec())
                 .filter(new BsonDocument()).retryReads(true))
     }
 
@@ -209,7 +208,7 @@ class FindIterableSpecification extends Specification {
         def operation = executor.getReadOperation() as FindOperation<Document>
 
         then:
-        expect operation, isTheSameAs(new FindOperation<Document>(TIMEOUT_SETTINGS, namespace, new DocumentCodec())
+        expect operation, isTheSameAs(new FindOperation<Document>(namespace, new DocumentCodec())
                 .filter(new BsonDocument('filter', new BsonInt32(1)))
                 .sort(new BsonDocument('sort', new BsonInt32(1)))
                 .cursorType(CursorType.NonTailable)

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ListCollectionsIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ListCollectionsIterableSpecification.groovy
@@ -33,7 +33,6 @@ import spock.lang.Specification
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
@@ -63,7 +62,7 @@ class ListCollectionsIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new ListCollectionsOperation<Document>(TIMEOUT_SETTINGS, 'db', new DocumentCodec())
+        expect operation, isTheSameAs(new ListCollectionsOperation<Document>('db', new DocumentCodec())
                 .filter(new BsonDocument('filter', new BsonInt32(1))).batchSize(100)
                 .retryReads(true)
                 .authorizedCollections(false))
@@ -75,7 +74,7 @@ class ListCollectionsIterableSpecification extends Specification {
         operation = executor.getReadOperation() as ListCollectionsOperation<Document>
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new ListCollectionsOperation<Document>(TIMEOUT_SETTINGS_WITH_MAX_TIME, 'db', new DocumentCodec())
+        expect operation, isTheSameAs(new ListCollectionsOperation<Document>('db', new DocumentCodec())
                 .filter(new BsonDocument('filter', new BsonInt32(2))).batchSize(99)
                 .retryReads(true))
 
@@ -85,7 +84,7 @@ class ListCollectionsIterableSpecification extends Specification {
         operation = executor.getReadOperation() as ListCollectionsOperation<Document>
 
         then: 'should create operation with nameOnly'
-        expect operation, isTheSameAs(new ListCollectionsOperation<Document>(TIMEOUT_SETTINGS, 'db', new DocumentCodec()).nameOnly(true)
+        expect operation, isTheSameAs(new ListCollectionsOperation<Document>('db', new DocumentCodec()).nameOnly(true)
                 .retryReads(true))
 
         when: 'requesting `authorizedCollections`'
@@ -93,7 +92,7 @@ class ListCollectionsIterableSpecification extends Specification {
         operation = executor.getReadOperation() as ListCollectionsOperation<Document>
 
         then: 'should create operation with `authorizedCollections`'
-        expect operation, isTheSameAs(new ListCollectionsOperation<Document>(TIMEOUT_SETTINGS, 'db', new DocumentCodec())
+        expect operation, isTheSameAs(new ListCollectionsOperation<Document>('db', new DocumentCodec())
                 .authorizedCollections(true)
                 .nameOnly(true)
                 .retryReads(true))

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ListDatabasesIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ListDatabasesIterableSpecification.groovy
@@ -30,7 +30,6 @@ import spock.lang.Specification
 
 import java.util.function.Consumer
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
@@ -57,7 +56,7 @@ class ListDatabasesIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new ListDatabasesOperation<Document>(TIMEOUT_SETTINGS, new DocumentCodec())
+        expect operation, isTheSameAs(new ListDatabasesOperation<Document>(new DocumentCodec())
                 .retryReads(true))
         readPreference == secondary()
 
@@ -67,7 +66,7 @@ class ListDatabasesIterableSpecification extends Specification {
         operation = executor.getReadOperation() as ListDatabasesOperation<Document>
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new ListDatabasesOperation<Document>(TIMEOUT_SETTINGS_WITH_MAX_TIME, new DocumentCodec())
+        expect operation, isTheSameAs(new ListDatabasesOperation<Document>(new DocumentCodec())
                 .filter(BsonDocument.parse('{a: 1}')).nameOnly(true).retryReads(true))
 
         when: 'overriding initial options'
@@ -76,7 +75,7 @@ class ListDatabasesIterableSpecification extends Specification {
         operation = executor.getReadOperation() as ListDatabasesOperation<Document>
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new ListDatabasesOperation<Document>(TIMEOUT_SETTINGS_WITH_MAX_TIME, new DocumentCodec())
+        expect operation, isTheSameAs(new ListDatabasesOperation<Document>(new DocumentCodec())
                 .filter(BsonDocument.parse('{a: 1}')).nameOnly(true).authorizedDatabasesOnly(true).retryReads(true))
     }
 

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ListIndexesIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ListIndexesIterableSpecification.groovy
@@ -31,7 +31,6 @@ import spock.lang.Specification
 
 import java.util.function.Consumer
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
@@ -59,7 +58,7 @@ class ListIndexesIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new ListIndexesOperation<Document>(TIMEOUT_SETTINGS, namespace, new DocumentCodec())
+        expect operation, isTheSameAs(new ListIndexesOperation<Document>(namespace, new DocumentCodec())
                 .batchSize(100).retryReads(true))
         readPreference == secondary()
 
@@ -71,7 +70,7 @@ class ListIndexesIterableSpecification extends Specification {
         operation = executor.getReadOperation() as ListIndexesOperation<Document>
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new ListIndexesOperation<Document>(TIMEOUT_SETTINGS_WITH_MAX_TIME, namespace, new DocumentCodec())
+        expect operation, isTheSameAs(new ListIndexesOperation<Document>(namespace, new DocumentCodec())
                 .batchSize(99).retryReads(true))
     }
 

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MapReduceIterableSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MapReduceIterableSpecification.groovy
@@ -42,7 +42,6 @@ import spock.lang.Specification
 
 import java.util.function.Consumer
 
-import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.secondary
@@ -73,7 +72,7 @@ class MapReduceIterableSpecification extends Specification {
         def readPreference = executor.getReadPreference()
 
         then:
-        expect operation, isTheSameAs(new MapReduceWithInlineResultsOperation<Document>(TIMEOUT_SETTINGS, namespace,
+        expect operation, isTheSameAs(new MapReduceWithInlineResultsOperation<Document>(namespace,
                 new BsonJavaScript('map'), new BsonJavaScript('reduce'), new DocumentCodec())
                 .verbose(true))
         readPreference == secondary()
@@ -92,7 +91,7 @@ class MapReduceIterableSpecification extends Specification {
         operation = (executor.getReadOperation() as MapReduceIterableImpl.WrappedMapReduceReadOperation<Document>).getOperation()
 
         then: 'should use the overrides'
-        expect operation, isTheSameAs(new MapReduceWithInlineResultsOperation<Document>(TIMEOUT_SETTINGS_WITH_MAX_TIME, namespace,
+        expect operation, isTheSameAs(new MapReduceWithInlineResultsOperation<Document>(namespace,
                 new BsonJavaScript('map'), new BsonJavaScript('reduce'), new DocumentCodec())
                 .filter(new BsonDocument('filter', new BsonInt32(1)))
                 .finalizeFunction(new BsonJavaScript('finalize'))
@@ -129,7 +128,7 @@ class MapReduceIterableSpecification extends Specification {
         mapReduceIterable.iterator()
 
         def operation = executor.getWriteOperation() as MapReduceToCollectionOperation
-        def expectedOperation = new MapReduceToCollectionOperation(TIMEOUT_SETTINGS_WITH_MAX_TIME, namespace,
+        def expectedOperation = new MapReduceToCollectionOperation(namespace,
                 new BsonJavaScript('map'), new BsonJavaScript('reduce'), 'collName', writeConcern)
                 .databaseName(collectionNamespace.getDatabaseName())
                 .filter(new BsonDocument('filter', new BsonInt32(1)))

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoDatabaseSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoDatabaseSpecification.groovy
@@ -214,7 +214,7 @@ class MongoDatabaseSpecification extends Specification {
         def operation = executor.getWriteOperation() as DropDatabaseOperation
 
         then:
-        expect operation, isTheSameAs(new DropDatabaseOperation(TIMEOUT_SETTINGS, name, writeConcern))
+        expect operation, isTheSameAs(new DropDatabaseOperation(name, writeConcern))
         executor.getClientSession() == session
 
         where:
@@ -268,7 +268,7 @@ class MongoDatabaseSpecification extends Specification {
         def operation = executor.getWriteOperation() as CreateCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new CreateCollectionOperation(TIMEOUT_SETTINGS, name, collectionName, writeConcern))
+        expect operation, isTheSameAs(new CreateCollectionOperation(name, collectionName, writeConcern))
         executor.getClientSession() == session
 
         when:
@@ -287,7 +287,7 @@ class MongoDatabaseSpecification extends Specification {
         operation = executor.getWriteOperation() as CreateCollectionOperation
 
         then:
-        expect operation, isTheSameAs(new CreateCollectionOperation(TIMEOUT_SETTINGS, name, collectionName, writeConcern)
+        expect operation, isTheSameAs(new CreateCollectionOperation(name, collectionName, writeConcern)
                 .collation(collation)
                 .capped(true)
                 .maxDocuments(100)
@@ -319,7 +319,7 @@ class MongoDatabaseSpecification extends Specification {
         def operation = executor.getWriteOperation() as CreateViewOperation
 
         then:
-        expect operation, isTheSameAs(new CreateViewOperation(TIMEOUT_SETTINGS, name, viewName, viewOn,
+        expect operation, isTheSameAs(new CreateViewOperation(name, viewName, viewOn,
                 [new BsonDocument('$match', new BsonDocument('x', BsonBoolean.TRUE))], writeConcern))
         executor.getClientSession() == session
 
@@ -328,7 +328,7 @@ class MongoDatabaseSpecification extends Specification {
         operation = executor.getWriteOperation() as CreateViewOperation
 
         then:
-        expect operation, isTheSameAs(new CreateViewOperation(TIMEOUT_SETTINGS, name, viewName, viewOn,
+        expect operation, isTheSameAs(new CreateViewOperation(name, viewName, viewOn,
                 [new BsonDocument('$match', new BsonDocument('x', BsonBoolean.TRUE))], writeConcern).collation(collation))
         executor.getClientSession() == session
 
@@ -341,7 +341,7 @@ class MongoDatabaseSpecification extends Specification {
         def viewName = 'view1'
         def viewOn = 'col1'
         def database = new MongoDatabaseImpl(name, codecRegistry, readPreference, writeConcern, false, false,
-                readConcern, JAVA_LEGACY, null, null, Stub(OperationExecutor))
+                readConcern, JAVA_LEGACY, null, TIMEOUT_SETTINGS, Stub(OperationExecutor))
 
         when:
         database.createView(viewName, viewOn, null)

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/TestOperationExecutor.java
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/TestOperationExecutor.java
@@ -19,6 +19,7 @@ package com.mongodb.client.internal;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.client.ClientSession;
+import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.operation.ReadOperation;
 import com.mongodb.internal.operation.WriteOperation;
 import com.mongodb.lang.Nullable;
@@ -66,6 +67,11 @@ public class TestOperationExecutor implements OperationExecutor {
         writeOperations.add(operation);
         readConcerns.add(readConcern);
         return getResponse();
+    }
+
+    @Override
+    public OperationExecutor withTimeoutSettings(final TimeoutSettings timeoutSettings) {
+        return this;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Decoupled Operations from TimeoutSettings.

Added `OperationExecutor#withTimeoutSettings` to pass in timeout settings. 

JAVA-5176