### PR TITLE
JAVA-5342 Fix encoding nullable generics

### DIFF
--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
@@ -139,6 +139,18 @@ internal class DefaultBsonEncoder(
         return true
     }
 
+    override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
+        deferredElementName?.let {
+            if (value != null || configuration.explicitNulls) {
+                encodeName(it)
+                super.encodeSerializableValue(serializer, value)
+            } else {
+                deferredElementName = null
+            }
+        }
+            ?: super.encodeSerializableValue(serializer, value)
+    }
+
     override fun <T : Any> encodeNullableSerializableValue(serializer: SerializationStrategy<T>, value: T?) {
         deferredElementName?.let {
             if (value != null || configuration.explicitNulls) {
@@ -158,7 +170,14 @@ internal class DefaultBsonEncoder(
     override fun encodeDouble(value: Double) = writer.writeDouble(value)
     override fun encodeInt(value: Int) = writer.writeInt32(value)
     override fun encodeLong(value: Long) = writer.writeInt64(value)
-    override fun encodeNull() = writer.writeNull()
+    override fun encodeNull() {
+        deferredElementName?.let {
+            if (configuration.explicitNulls) {
+                encodeName(it)
+            }
+        }
+        writer.writeNull()
+    }
 
     override fun encodeString(value: String) {
         when (state) {

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
@@ -33,6 +33,7 @@ import org.bson.BsonUndefined
 import org.bson.codecs.DecoderContext
 import org.bson.codecs.EncoderContext
 import org.bson.codecs.configuration.CodecConfigurationException
+import org.bson.codecs.kotlinx.samples.Box
 import org.bson.codecs.kotlinx.samples.DataClassBsonValues
 import org.bson.codecs.kotlinx.samples.DataClassContainsOpen
 import org.bson.codecs.kotlinx.samples.DataClassContainsValueClass
@@ -76,6 +77,7 @@ import org.bson.codecs.kotlinx.samples.DataClassWithMutableMap
 import org.bson.codecs.kotlinx.samples.DataClassWithMutableSet
 import org.bson.codecs.kotlinx.samples.DataClassWithNestedParameterized
 import org.bson.codecs.kotlinx.samples.DataClassWithNestedParameterizedDataClass
+import org.bson.codecs.kotlinx.samples.DataClassWithNullableGeneric
 import org.bson.codecs.kotlinx.samples.DataClassWithNulls
 import org.bson.codecs.kotlinx.samples.DataClassWithPair
 import org.bson.codecs.kotlinx.samples.DataClassWithParameterizedDataClass
@@ -200,6 +202,27 @@ class KotlinSerializerCodecTest {
         val dataClass = DataClassWithNulls(null, null, null)
         assertRoundTrips(emptyDocument, dataClass)
         assertRoundTrips(expectedNulls, dataClass, altConfiguration)
+    }
+
+    @Test
+    fun testDataClassWithNullableGenericsNotNull() {
+        val expected =
+            """{
+            | "box": {"boxed": "String"}
+            |}"""
+                .trimMargin()
+
+        val dataClass = DataClassWithNullableGeneric(Box("String"))
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithNullableGenericsNull() {
+        val expectedDefault = """{"box": {}}"""
+        val dataClass = DataClassWithNullableGeneric(Box(null))
+        assertRoundTrips(expectedDefault, dataClass)
+        val expectedNull = """{"box": {"boxed": null}}"""
+        assertRoundTrips(expectedNull, dataClass, altConfiguration)
     }
 
     @Test

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
@@ -294,3 +294,7 @@ data class DataClassWithFailingInit(val id: String) {
 }
 
 @Serializable data class DataClassWithSequence(val value: Sequence<String>)
+
+@Serializable data class Box<T>(val boxed: T)
+
+@Serializable data class DataClassWithNullableGeneric(val box: Box<String?>)


### PR DESCRIPTION
Encoding a generic class object with a nullable type parameter, like `DataClassWithNullableGeneric`, will fail with `org.bson.BsonInvalidOperationException: writeString can only be called when State is VALUE, not when State is NAME` or `org.bson.BsonInvalidOperationException: writeNull can only be called when State is VALUE, not when State is NAME` depending on whether `boxed` is null.
```kotlin
@Serializable data class Box<T>(val boxed: T)
@Serializable data class DataClassWithNullableGeneric(val box: Box<String?>)
```

JAVA-5342