### PR TITLE
Fix test failures on 8.0 sharded clusters

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
@@ -109,6 +109,11 @@ public final class CollectionHelper<T> {
         }
     }
 
+    public static BsonDocument getCurrentClusterTime() {
+        return new CommandReadOperation<BsonDocument>("admin", new BsonDocument("ping", new BsonInt32(1)), new BsonDocumentCodec())
+                .execute(getBinding()).getDocument("$clusterTime", null);
+    }
+
     public MongoNamespace getNamespace() {
         return namespace;
     }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -214,7 +214,7 @@ public abstract class UnifiedTest {
         if (definition.containsKey("skipReason")) {
             throw new AssumptionViolatedException(definition.getString("skipReason").getValue());
         }
-        startingClusterTime = addInitialData();
+        startingClusterTime = addInitialDataAndGetClusterTime();
         entities.init(entitiesArray, startingClusterTime,
                 fileDescription != null && PRESTART_POOL_ASYNC_WORK_MANAGER_FILE_DESCRIPTIONS.contains(fileDescription),
                 this::createMongoClient,
@@ -893,7 +893,7 @@ public abstract class UnifiedTest {
         return events.subList(events.size() - 2, events.size());
     }
 
-    private BsonDocument addInitialData() {
+    private BsonDocument addInitialDataAndGetClusterTime() {
         for (BsonValue cur : initialData.getValues()) {
             BsonDocument curDataSet = cur.asDocument();
             CollectionHelper<BsonDocument> helper = new CollectionHelper<>(new BsonDocumentCodec(),

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -73,6 +73,7 @@ import java.util.stream.Collectors;
 import static com.mongodb.ClusterFixture.getServerVersion;
 import static com.mongodb.client.Fixture.getMongoClient;
 import static com.mongodb.client.Fixture.getMongoClientSettings;
+import static com.mongodb.client.test.CollectionHelper.getCurrentClusterTime;
 import static com.mongodb.client.unified.RunOnRequirementsMatcher.runOnRequirementsMet;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -105,6 +106,7 @@ public abstract class UnifiedTest {
     private final UnifiedClientEncryptionHelper clientEncryptionHelper = new UnifiedClientEncryptionHelper(entities);
     private final List<FailPoint> failPoints = new ArrayList<>();
     private final UnifiedTestContext rootContext = new UnifiedTestContext();
+    private BsonDocument startingClusterTime;
 
     private class UnifiedTestContext {
         private final AssertionContext context = new AssertionContext();
@@ -212,12 +214,12 @@ public abstract class UnifiedTest {
         if (definition.containsKey("skipReason")) {
             throw new AssumptionViolatedException(definition.getString("skipReason").getValue());
         }
-        entities.init(entitiesArray,
+        startingClusterTime = addInitialData();
+        entities.init(entitiesArray, startingClusterTime,
                 fileDescription != null && PRESTART_POOL_ASYNC_WORK_MANAGER_FILE_DESCRIPTIONS.contains(fileDescription),
                 this::createMongoClient,
                 this::createGridFSBucket,
                 this::createClientEncryption);
-        addInitialData();
     }
 
     @After
@@ -561,6 +563,7 @@ public abstract class UnifiedTest {
 
     private OperationResult executeCreateEntities(final BsonDocument operation) {
         entities.init(operation.getDocument("arguments").getArray("entities"),
+                startingClusterTime,
                 false,
                 this::createMongoClient,
                 this::createGridFSBucket,
@@ -890,7 +893,7 @@ public abstract class UnifiedTest {
         return events.subList(events.size() - 2, events.size());
     }
 
-    private void addInitialData() {
+    private BsonDocument addInitialData() {
         for (BsonValue cur : initialData.getValues()) {
             BsonDocument curDataSet = cur.asDocument();
             CollectionHelper<BsonDocument> helper = new CollectionHelper<>(new BsonDocumentCodec(),
@@ -905,5 +908,6 @@ public abstract class UnifiedTest {
                         WriteConcern.MAJORITY);
             }
         }
+        return getCurrentClusterTime();
     }
 }


### PR DESCRIPTION
Advance cluster time on all session entities in unified tests to one after the initial data is created

JAVA-5334