### PR TITLE
Add Client Operation Timeout to Change Streams

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -257,8 +257,8 @@ configure(javaCodeCheckedProjects) {
         testImplementation platform('org.spockframework:spock-bom:2.1-groovy-3.0')
         testImplementation 'org.spockframework:spock-core'
         testImplementation 'org.spockframework:spock-junit4'
-        testImplementation("org.mockito:mockito-core:4.0.0")
-        testImplementation("org.mockito:mockito-inline:4.0.0")
+        testImplementation 'org.mockito:mockito-core:4.0.0'
+        testImplementation 'org.mockito:mockito-inline:4.0.0'
         testImplementation 'cglib:cglib-nodep:2.2.2'
         testImplementation 'org.objenesis:objenesis:1.3'
         testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -257,8 +257,8 @@ configure(javaCodeCheckedProjects) {
         testImplementation platform('org.spockframework:spock-bom:2.1-groovy-3.0')
         testImplementation 'org.spockframework:spock-core'
         testImplementation 'org.spockframework:spock-junit4'
-        testImplementation("org.mockito:mockito-core:3.8.0")
-        testImplementation("org.mockito:mockito-inline:3.8.0")
+        testImplementation("org.mockito:mockito-core:4.0.0")
+        testImplementation("org.mockito:mockito-inline:4.0.0")
         testImplementation 'cglib:cglib-nodep:2.2.2'
         testImplementation 'org.objenesis:objenesis:1.3'
         testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -165,7 +165,7 @@ public class TimeoutContext {
     }
 
     public long getMaxAwaitTimeMS() {
-        return hasTimeoutMS() ? 0 : timeoutSettings.getMaxAwaitTimeMS();
+        return timeoutSettings.getMaxAwaitTimeMS();
     }
 
     public long getMaxTimeMS() {

--- a/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AggregateOperationImpl.java
@@ -153,7 +153,7 @@ class AggregateOperationImpl<T> implements AsyncReadOperation<AsyncBatchCursor<T
     /**
      * When {@link TimeoutContext#hasTimeoutMS()} then {@link TimeoutSettings#getMaxAwaitTimeMS()} usage in {@code getMore} commands
      * depends on the type of cursor. For {@link CursorType#TailableAwait} it is used, for others it is not.
-     * {@link CursorType#TailableAwait} is used mainly used for change streams in {@link AggregateOperationImpl}.
+     * {@link CursorType#TailableAwait} is used mainly for change streams in {@link AggregateOperationImpl}.
      *
      * @param cursorType
      * @return this

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncChangeStreamBatchCursor.java
@@ -17,6 +17,7 @@
 package com.mongodb.internal.operation;
 
 import com.mongodb.MongoException;
+import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.async.AsyncAggregateResponseBatchCursor;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
@@ -42,6 +43,7 @@ import static java.lang.String.format;
 
 final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T> {
     private final AsyncReadBinding binding;
+    private final TimeoutContext timeoutContext;
     private final ChangeStreamOperation<T> changeStreamOperation;
     private final int maxWireVersion;
 
@@ -63,6 +65,7 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
         this.wrapped = new AtomicReference<>(assertNotNull(wrapped));
         this.binding = binding;
         binding.retain();
+        this.timeoutContext = binding.getOperationContext().getTimeoutContext();
         this.resumeToken = resumeToken;
         this.maxWireVersion = maxWireVersion;
         isClosed = new AtomicBoolean();
@@ -80,6 +83,7 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
 
     @Override
     public void close() {
+        resetTimeout();
         if (isClosed.compareAndSet(false, true)) {
             try {
                 nullifyAndCloseWrapped();
@@ -177,6 +181,7 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
     }
 
     private void resumeableOperation(final AsyncBlock asyncBlock, final SingleResultCallback<List<T>> callback, final boolean tryNext) {
+        resetTimeout();
         SingleResultCallback<List<T>> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
         if (isClosed()) {
             errHandlingCallback.onResult(null, new MongoException(format("%s called after the cursor was closed.",
@@ -219,12 +224,12 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
                 changeStreamOperation.setChangeStreamOptionsForResume(resumeToken,
                         assertNotNull(source).getServerDescription().getMaxWireVersion());
                 source.release();
-                changeStreamOperation.executeAsync(binding, (result, t1) -> {
+                changeStreamOperation.executeAsync(binding, (asyncBatchCursor, t1) -> {
                     if (t1 != null) {
                         callback.onResult(null, t1);
                     } else {
                         try {
-                            setWrappedOrCloseIt(assertNotNull((AsyncChangeStreamBatchCursor<T>) result).getWrapped());
+                            setWrappedOrCloseIt(assertNotNull((AsyncChangeStreamBatchCursor<T>) asyncBatchCursor).getWrapped());
                         } finally {
                             try {
                                 binding.release(); // release the new change stream batch cursor's reference to the binding
@@ -236,5 +241,11 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
                 });
             }
         });
+    }
+
+    private void resetTimeout() {
+        if (timeoutContext.hasTimeoutMS()) {
+            timeoutContext.resetTimeout();
+        }
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandBatchCursor.java
@@ -212,6 +212,10 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
         return commandCursorResult;
     }
 
+    void setCloseImmediately(final boolean closeImmediately) {
+        this.resourceManager.setCloseImmediately(closeImmediately);
+    }
+
     @ThreadSafe
     private static final class ResourceManager extends CursorResourceManager<AsyncConnectionSource, AsyncConnection> {
 

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandBatchCursor.java
@@ -212,8 +212,8 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
         return commandCursorResult;
     }
 
-    void setCloseImmediately(final boolean closeImmediately) {
-        this.resourceManager.setCloseImmediately(closeImmediately);
+    void setCloseWithoutTimeoutReset(final boolean closeWithoutTimeoutReset) {
+        this.resourceManager.setCloseWithoutTimeoutReset(closeWithoutTimeoutReset);
     }
 
     @ThreadSafe

--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursor.java
@@ -222,14 +222,14 @@ final class ChangeStreamBatchCursor<T> implements AggregateResponseBatchCursor<T
     }
 
     private void resumeChangeStream() {
-            wrapped.close();
+        wrapped.close();
 
-            withReadConnectionSource(binding, source -> {
-                changeStreamOperation.setChangeStreamOptionsForResume(resumeToken, source.getServerDescription().getMaxWireVersion());
-                return null;
-            });
-            wrapped = ((ChangeStreamBatchCursor<T>) changeStreamOperation.execute(binding)).getWrapped();
-            binding.release(); // release the new change stream batch cursor's reference to the binding
+        withReadConnectionSource(binding, source -> {
+            changeStreamOperation.setChangeStreamOptionsForResume(resumeToken, source.getServerDescription().getMaxWireVersion());
+            return null;
+        });
+        wrapped = ((ChangeStreamBatchCursor<T>) changeStreamOperation.execute(binding)).getWrapped();
+        binding.release(); // release the new change stream batch cursor's reference to the binding
     }
 
     private void resumeAfterTimeout() {

--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
@@ -16,10 +16,12 @@
 
 package com.mongodb.internal.operation;
 
+import com.mongodb.CursorType;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
+import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.async.AsyncBatchCursor;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncReadBinding;
@@ -42,6 +44,7 @@ import java.util.List;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.client.cursor.TimeoutMode.CURSOR_LIFETIME;
 
 /**
  * An operation that executes an {@code $changeStream} aggregation.
@@ -71,7 +74,7 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
             final FullDocumentBeforeChange fullDocumentBeforeChange, final List<BsonDocument> pipeline, final Decoder<T> decoder,
             final ChangeStreamLevel changeStreamLevel) {
         this.wrapped = new AggregateOperationImpl<>(namespace, pipeline, RAW_BSON_DOCUMENT_CODEC, getAggregateTarget(),
-                getPipelineCreator());
+                getPipelineCreator()).cursorType(CursorType.TailableAwait);
         this.fullDocument = notNull("fullDocument", fullDocument);
         this.fullDocumentBeforeChange = notNull("fullDocumentBeforeChange", fullDocumentBeforeChange);
         this.decoder = notNull("decoder", decoder);
@@ -167,9 +170,34 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
         return this;
     }
 
+    /**
+     * Gets an aggregate operation with consideration for timeout settings.
+     * <p>
+     * Change streams act similarly to tailable awaitData cursors, with identical timeoutMS option behavior.
+     * Key distinctions include:
+     * - The timeoutMS option must be applied at the start of the aggregate operation for change streams.
+     * - Change streams support resumption on next() calls. The driver handles automatic resumption for transient errors.
+     * <p>
+     *
+     * As a result, when {@code timeoutContext.hasTimeoutMS()} the CURSOR_LIFETIME setting is utilized to manage the underlying cursor's
+     * lifespan in change streams.
+     *
+     * @param timeoutContext
+     * @return An AggregateOperationImpl
+     */
+    private AggregateOperationImpl<RawBsonDocument> getAggregateOperation(final TimeoutContext timeoutContext) {
+        if (timeoutContext.hasTimeoutMS()) {
+            return wrapped.timeoutMode(CURSOR_LIFETIME);
+        }
+        return wrapped;
+    }
+
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
-        CommandBatchCursor<RawBsonDocument> cursor = (CommandBatchCursor<RawBsonDocument>) wrapped.execute(binding);
+        TimeoutContext timeoutContext = binding.getOperationContext().getTimeoutContext();
+        CommandBatchCursor<RawBsonDocument> cursor = (CommandBatchCursor<RawBsonDocument>) getAggregateOperation(timeoutContext).execute(binding);
+        cursor.setCloseImmediately(true);
+
             return new ChangeStreamBatchCursor<>(ChangeStreamOperation.this, cursor, binding,
                     setChangeStreamOptions(cursor.getPostBatchResumeToken(), cursor.getOperationTime(),
                             cursor.getMaxWireVersion(), cursor.isFirstBatchEmpty()), cursor.getMaxWireVersion());
@@ -177,11 +205,13 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
 
     @Override
     public void executeAsync(final AsyncReadBinding binding, final SingleResultCallback<AsyncBatchCursor<T>> callback) {
-        wrapped.executeAsync(binding, (result, t) -> {
+        TimeoutContext timeoutContext = binding.getOperationContext().getTimeoutContext();
+        getAggregateOperation(timeoutContext).executeAsync(binding, (result, t) -> {
             if (t != null) {
                 callback.onResult(null, t);
             } else {
                 AsyncCommandBatchCursor<RawBsonDocument> cursor = (AsyncCommandBatchCursor<RawBsonDocument>) assertNotNull(result);
+
                 callback.onResult(new AsyncChangeStreamBatchCursor<>(ChangeStreamOperation.this, cursor, binding,
                         setChangeStreamOptions(cursor.getPostBatchResumeToken(), cursor.getOperationTime(),
                                 cursor.getMaxWireVersion(), cursor.isFirstBatchEmpty()), cursor.getMaxWireVersion()), null);

--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
@@ -196,7 +196,7 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
     public BatchCursor<T> execute(final ReadBinding binding) {
         TimeoutContext timeoutContext = binding.getOperationContext().getTimeoutContext();
         CommandBatchCursor<RawBsonDocument> cursor = (CommandBatchCursor<RawBsonDocument>) getAggregateOperation(timeoutContext).execute(binding);
-        cursor.setCloseImmediately(true);
+        cursor.setCloseWithoutTimeoutReset(true);
 
             return new ChangeStreamBatchCursor<>(ChangeStreamOperation.this, cursor, binding,
                     setChangeStreamOptions(cursor.getPostBatchResumeToken(), cursor.getOperationTime(),
@@ -211,7 +211,7 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
                 callback.onResult(null, t);
             } else {
                 AsyncCommandBatchCursor<RawBsonDocument> cursor = (AsyncCommandBatchCursor<RawBsonDocument>) assertNotNull(result);
-                cursor.setCloseImmediately(true);
+                cursor.setCloseWithoutTimeoutReset(true);
 
                 callback.onResult(new AsyncChangeStreamBatchCursor<>(ChangeStreamOperation.this, cursor, binding,
                         setChangeStreamOptions(cursor.getPostBatchResumeToken(), cursor.getOperationTime(),

--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamOperation.java
@@ -211,6 +211,7 @@ public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCu
                 callback.onResult(null, t);
             } else {
                 AsyncCommandBatchCursor<RawBsonDocument> cursor = (AsyncCommandBatchCursor<RawBsonDocument>) assertNotNull(result);
+                cursor.setCloseImmediately(true);
 
                 callback.onResult(new AsyncChangeStreamBatchCursor<>(ChangeStreamOperation.this, cursor, binding,
                         setChangeStreamOptions(cursor.getPostBatchResumeToken(), cursor.getOperationTime(),

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursor.java
@@ -24,13 +24,13 @@ import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerCursor;
 import com.mongodb.annotations.ThreadSafe;
-import com.mongodb.client.cursor.TimeoutMode;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerType;
 import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.binding.ConnectionSource;
 import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.connection.OperationContext;
+import com.mongodb.client.cursor.TimeoutMode;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
@@ -59,6 +59,9 @@ import static com.mongodb.internal.operation.CommandBatchCursorHelper.translateC
 class CommandBatchCursor<T> implements AggregateResponseBatchCursor<T> {
 
     private final MongoNamespace namespace;
+    /**
+     * maxAwaitTimeMS
+     */
     private final long maxTimeMS;
     private final Decoder<T> decoder;
     @Nullable
@@ -258,6 +261,9 @@ class CommandBatchCursor<T> implements AggregateResponseBatchCursor<T> {
         return commandCursorResult;
     }
 
+    void setCloseImmediately(final boolean closeImmediately) {
+        this.resourceManager.setCloseImmediately(closeImmediately);
+    }
     @ThreadSafe
     private static final class ResourceManager extends CursorResourceManager<ConnectionSource, Connection> {
 

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursor.java
@@ -24,13 +24,14 @@ import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerCursor;
 import com.mongodb.annotations.ThreadSafe;
+import com.mongodb.client.cursor.TimeoutMode;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerType;
+import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.binding.ConnectionSource;
 import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.connection.OperationContext;
-import com.mongodb.client.cursor.TimeoutMode;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
@@ -59,9 +60,6 @@ import static com.mongodb.internal.operation.CommandBatchCursorHelper.translateC
 class CommandBatchCursor<T> implements AggregateResponseBatchCursor<T> {
 
     private final MongoNamespace namespace;
-    /**
-     * maxAwaitTimeMS
-     */
     private final long maxTimeMS;
     private final Decoder<T> decoder;
     @Nullable
@@ -261,9 +259,16 @@ class CommandBatchCursor<T> implements AggregateResponseBatchCursor<T> {
         return commandCursorResult;
     }
 
-    void setCloseImmediately(final boolean closeImmediately) {
-        this.resourceManager.setCloseImmediately(closeImmediately);
+    /**
+     * Configures the cursor's behavior to close without resetting its timeout. If {@code true}, the cursor attempts to close immediately
+     * without resetting its {@link TimeoutContext#getTimeout()} if present. This is useful when managing the cursor's close behavior externally.
+     *
+     * @param closeWithoutTimeoutReset
+     */
+    void setCloseWithoutTimeoutReset(final boolean closeWithoutTimeoutReset) {
+        this.resourceManager.setCloseWithoutTimeoutReset(closeWithoutTimeoutReset);
     }
+
     @ThreadSafe
     private static final class ResourceManager extends CursorResourceManager<ConnectionSource, Connection> {
 

--- a/driver-core/src/main/com/mongodb/internal/operation/CursorResourceManager.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CursorResourceManager.java
@@ -67,7 +67,7 @@ abstract class CursorResourceManager<CS extends ReferenceCounted, C extends Refe
     @Nullable
     private volatile ServerCursor serverCursor;
     private volatile boolean skipReleasingServerResourcesOnClose;
-    private boolean closeImmediately;
+    private boolean closeWithoutTimeoutReset;
 
     CursorResourceManager(
             final TimeoutContext timeoutContext,
@@ -92,7 +92,7 @@ abstract class CursorResourceManager<CS extends ReferenceCounted, C extends Refe
         }
         this.skipReleasingServerResourcesOnClose = false;
         this.serverCursor = serverCursor;
-        this.closeImmediately = false;
+        this.closeWithoutTimeoutReset = false;
     }
 
     /**
@@ -142,13 +142,13 @@ abstract class CursorResourceManager<CS extends ReferenceCounted, C extends Refe
     }
 
     void resetTimeout() {
-        if (!closeImmediately && timeoutContext.hasTimeoutMS()) {
+        if (!closeWithoutTimeoutReset && timeoutContext.hasTimeoutMS()) {
             timeoutContext.resetTimeout();
         }
     }
 
-    void setCloseImmediately(final boolean closeImmediately) {
-        this.closeImmediately = closeImmediately;
+    void setCloseWithoutTimeoutReset(final boolean closeImmediately) {
+        this.closeWithoutTimeoutReset = closeImmediately;
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/operation/CursorResourceManager.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CursorResourceManager.java
@@ -67,6 +67,7 @@ abstract class CursorResourceManager<CS extends ReferenceCounted, C extends Refe
     @Nullable
     private volatile ServerCursor serverCursor;
     private volatile boolean skipReleasingServerResourcesOnClose;
+    private boolean closeImmediately;
 
     CursorResourceManager(
             final TimeoutContext timeoutContext,
@@ -91,6 +92,7 @@ abstract class CursorResourceManager<CS extends ReferenceCounted, C extends Refe
         }
         this.skipReleasingServerResourcesOnClose = false;
         this.serverCursor = serverCursor;
+        this.closeImmediately = false;
     }
 
     /**
@@ -140,9 +142,13 @@ abstract class CursorResourceManager<CS extends ReferenceCounted, C extends Refe
     }
 
     void resetTimeout() {
-        if (timeoutContext.hasTimeoutMS()) {
+        if (!closeImmediately && timeoutContext.hasTimeoutMS()) {
             timeoutContext.resetTimeout();
         }
+    }
+
+    void setCloseImmediately(final boolean closeImmediately) {
+        this.closeImmediately = closeImmediately;
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
@@ -201,7 +201,7 @@ final class OperationHelper {
         addMaxTimeMSToNonTailableCursor(commandDocument, TimeoutMode.CURSOR_LIFETIME, operationContext);
     }
 
-    static void addMaxTimeMSToNonTailableCursor(final BsonDocument commandDocument, @Nullable final TimeoutMode timeoutMode,
+    static void addMaxTimeMSToNonTailableCursor(final BsonDocument commandDocument, final TimeoutMode timeoutMode,
             final OperationContext operationContext) {
         long maxTimeMS = timeoutMode == TimeoutMode.ITERATION ? 0 : operationContext.getTimeoutContext().getMaxTimeMS();
         if (maxTimeMS > 0) {

--- a/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
@@ -176,6 +176,10 @@ public final class CollectionHelper<T> {
         insertDocuments(asList(documents));
     }
 
+    public void insertDocuments(final WriteConcern writeConcern, final BsonDocument... documents) {
+        insertDocuments(asList(documents), writeConcern);
+    }
+
     public void insertDocuments(final List<BsonDocument> documents) {
         insertDocuments(documents, getBinding());
     }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/TestCommandListener.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/TestCommandListener.java
@@ -144,6 +144,10 @@ public class TestCommandListener implements CommandListener {
                 .orElseThrow(() -> new IllegalArgumentException(commandName + " not found in command failed event list"));
     }
 
+    public List<CommandFailedEvent> getCommandFailedEvents() {
+        return getEvents(CommandFailedEvent.class, Integer.MAX_VALUE);
+    }
+
     public List<CommandStartedEvent> getCommandStartedEvents() {
         return getEvents(CommandStartedEvent.class, Integer.MAX_VALUE);
     }

--- a/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/change-streams.json
+++ b/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/change-streams.json
@@ -311,7 +311,7 @@
           "object": "collection",
           "arguments": {
             "pipeline": [],
-            "timeoutMS": 90
+            "timeoutMS": 80
           },
           "saveResultAsEntity": "changeStream"
         },

--- a/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/change-streams.json
+++ b/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/change-streams.json
@@ -311,7 +311,7 @@
           "object": "collection",
           "arguments": {
             "pipeline": [],
-            "timeoutMS": 20
+            "timeoutMS": 100
           },
           "saveResultAsEntity": "changeStream"
         },
@@ -331,7 +331,7 @@
                   "aggregate"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 12,
+                "blockTimeMS": 40,
                 "errorCode": 7,
                 "errorLabels": [
                   "ResumableChangeStreamError"
@@ -535,7 +535,7 @@
                   "getMore"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 15
+                "blockTimeMS": 150
               }
             }
           }
@@ -545,7 +545,7 @@
           "object": "collection",
           "arguments": {
             "pipeline": [],
-            "timeoutMS": 10
+            "timeoutMS": 100
           },
           "saveResultAsEntity": "changeStream"
         },

--- a/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/change-streams.json
+++ b/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/change-streams.json
@@ -311,7 +311,7 @@
           "object": "collection",
           "arguments": {
             "pipeline": [],
-            "timeoutMS": 100
+            "timeoutMS": 90
           },
           "saveResultAsEntity": "changeStream"
         },

--- a/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
@@ -61,7 +61,6 @@ final class TimeoutContextTest {
                     assertAll(
                             () -> assertTrue(timeoutContext.hasTimeoutMS()),
                             () -> assertTrue(timeoutContext.getMaxTimeMS() > 0),
-                            () -> assertEquals(0, timeoutContext.getMaxAwaitTimeMS()),
                             () -> assertTrue(timeoutContext.getMaxCommitTimeMS() > 0)
                     );
                 }),
@@ -89,6 +88,13 @@ final class TimeoutContextTest {
                             () -> assertEquals(0, timeoutContext.getMaxTimeMS()),
                             () -> assertEquals(101, timeoutContext.getMaxAwaitTimeMS()),
                             () -> assertEquals(0, timeoutContext.getMaxCommitTimeMS())
+                    );
+                }),
+                dynamicTest("MaxAwaitTimeMS set with timeoutMS", () -> {
+                    TimeoutContext timeoutContext =
+                            new TimeoutContext(TIMEOUT_SETTINGS_WITH_MAX_AWAIT_TIME.withWTimeoutMS(1L));
+                    assertAll(
+                            () -> assertEquals(101, timeoutContext.getMaxAwaitTimeMS())
                     );
                 }),
                 dynamicTest("MaxTimeMS and MaxAwaitTimeMS set", () -> {

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/ChangeStreamBatchCursorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/ChangeStreamBatchCursorTest.java
@@ -30,13 +30,9 @@ import org.bson.BsonInt32;
 import org.bson.Document;
 import org.bson.RawBsonDocument;
 import org.bson.codecs.DocumentCodec;
-import org.junit.Rule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
-import org.mockito.quality.Strictness;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,8 +57,6 @@ import static org.mockito.Mockito.when;
 final class ChangeStreamBatchCursorTest {
 
     private static final List<RawBsonDocument> RESULT_FROM_NEW_CURSOR = new ArrayList<>();
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
     private final int maxWireVersion = ServerVersionHelper.SIX_DOT_ZERO_WIRE_VERSION;
     private ServerDescription serverDescription;
     private TimeoutContext timeoutContext;
@@ -78,7 +72,7 @@ final class ChangeStreamBatchCursorTest {
 
     @Test
     @DisplayName("should return result on next")
-    public void shouldReturnResultOnNext() {
+    void shouldReturnResultOnNext() {
         when(commandBatchCursor.next()).thenReturn(RESULT_FROM_NEW_CURSOR);
         ChangeStreamBatchCursor<Document> cursor = createChangeStreamCursor();
 

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/ChangeStreamBatchCursorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/ChangeStreamBatchCursorTest.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.operation;
+
+import com.mongodb.MongoException;
+import com.mongodb.MongoNotPrimaryException;
+import com.mongodb.MongoOperationTimeoutException;
+import com.mongodb.ServerAddress;
+import com.mongodb.connection.ServerDescription;
+import com.mongodb.internal.TimeoutContext;
+import com.mongodb.internal.binding.ConnectionSource;
+import com.mongodb.internal.binding.ReadBinding;
+import com.mongodb.internal.connection.Connection;
+import com.mongodb.internal.connection.OperationContext;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.Document;
+import org.bson.RawBsonDocument;
+import org.bson.codecs.DocumentCodec;
+import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.mongodb.internal.operation.CommandBatchCursorHelper.MESSAGE_IF_CLOSED_AS_CURSOR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+final class ChangeStreamBatchCursorTest {
+
+    private static final List<RawBsonDocument> RESULT_FROM_NEW_CURSOR = new ArrayList<>();
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+    private final int maxWireVersion = ServerVersionHelper.SIX_DOT_ZERO_WIRE_VERSION;
+    private ServerDescription serverDescription;
+    private TimeoutContext timeoutContext;
+    private OperationContext operationContext;
+    private Connection connection;
+    private ConnectionSource connectionSource;
+    private ReadBinding readBinding;
+    private BsonDocument resumeToken;
+    private CommandBatchCursor<RawBsonDocument> commandBatchCursor;
+    private CommandBatchCursor<RawBsonDocument> newCommandBatchCursor;
+    private ChangeStreamBatchCursor<Document> newChangeStreamCursor;
+    private ChangeStreamOperation<Document> changeStreamOperation;
+
+    @Test
+    @DisplayName("should return result on next")
+    public void shouldReturnResultOnNext() {
+        when(commandBatchCursor.next()).thenReturn(RESULT_FROM_NEW_CURSOR);
+        ChangeStreamBatchCursor<Document> cursor = createChangeStreamCursor();
+
+        //when
+        List<Document> next = cursor.next();
+
+        //then
+        assertEquals(RESULT_FROM_NEW_CURSOR, next);
+        verify(timeoutContext, times(1)).resetTimeout();
+        verify(commandBatchCursor, times(1)).next();
+        verify(commandBatchCursor, atLeastOnce()).getPostBatchResumeToken();
+        verifyNoMoreInteractions(commandBatchCursor);
+        verify(changeStreamOperation, times(1)).getDecoder();
+        verifyNoMoreInteractions(changeStreamOperation);
+    }
+
+    @Test
+    @DisplayName("should throw timeout exception without resume attempt on next")
+    void shouldThrowTimeoutExceptionWithoutResumeAttemptOnNext() {
+        when(commandBatchCursor.next()).thenThrow(new MongoOperationTimeoutException("timeout"));
+        ChangeStreamBatchCursor<Document> cursor = createChangeStreamCursor();
+        //when
+        assertThrows(MongoOperationTimeoutException.class, cursor::next);
+
+        //then
+        verify(timeoutContext, times(1)).resetTimeout();
+        verify(commandBatchCursor, times(1)).next();
+        verify(commandBatchCursor, atLeastOnce()).getPostBatchResumeToken();
+        verifyNoMoreInteractions(commandBatchCursor);
+        verifyNoResumeAttemptCalled();
+    }
+
+    @Test
+    @DisplayName("should perform resume attempt on next when resumable error is thrown")
+    void shouldPerformResumeAttemptOnNextWhenResumableErrorIsThrown() {
+        when(commandBatchCursor.next()).thenThrow(new MongoNotPrimaryException(new BsonDocument(), new ServerAddress()));
+        ChangeStreamBatchCursor<Document> cursor = createChangeStreamCursor();
+        //when
+        List<Document> next = cursor.next();
+
+        //then
+        assertEquals(RESULT_FROM_NEW_CURSOR, next);
+        verify(timeoutContext, times(1)).resetTimeout();
+        verify(commandBatchCursor, times(1)).next();
+        verify(commandBatchCursor, atLeastOnce()).getPostBatchResumeToken();
+        verifyResumeAttemptCalled();
+        verify(changeStreamOperation, times(1)).getDecoder();
+        verify(newCommandBatchCursor, times(1)).next();
+        verify(newCommandBatchCursor, atLeastOnce()).getPostBatchResumeToken();
+        verifyNoMoreInteractions(newCommandBatchCursor);
+        verifyNoMoreInteractions(changeStreamOperation);
+    }
+
+
+    @Test
+    @DisplayName("should resume only once on subsequent calls after timeout error")
+    void shouldResumeOnlyOnceOnSubsequentCallsAfterTimeoutError() {
+        when(commandBatchCursor.next()).thenThrow(new MongoOperationTimeoutException("timeout"));
+        ChangeStreamBatchCursor<Document> cursor = createChangeStreamCursor();
+        //when
+        assertThrows(MongoOperationTimeoutException.class, cursor::next);
+
+        //then
+        verify(timeoutContext, times(1)).resetTimeout();
+        verify(commandBatchCursor, times(1)).next();
+        verify(commandBatchCursor, atLeastOnce()).getPostBatchResumeToken();
+        verifyNoMoreInteractions(commandBatchCursor);
+        verifyNoResumeAttemptCalled();
+        clearInvocations(commandBatchCursor, newCommandBatchCursor, timeoutContext, changeStreamOperation, readBinding);
+
+        //when seconds next is called. Resume is attempted.
+        List<Document> next = cursor.next();
+
+        //then
+        assertEquals(Collections.emptyList(), next);
+        verify(timeoutContext, times(1)).resetTimeout();
+        verify(commandBatchCursor, times(1)).close();
+        verifyNoMoreInteractions(commandBatchCursor);
+        verify(changeStreamOperation).setChangeStreamOptionsForResume(resumeToken, maxWireVersion);
+        verify(changeStreamOperation, times(1)).getDecoder();
+        verify(changeStreamOperation, times(1)).execute(readBinding);
+        verifyNoMoreInteractions(changeStreamOperation);
+        verify(newCommandBatchCursor, times(1)).next();
+        verify(newCommandBatchCursor, atLeastOnce()).getPostBatchResumeToken();
+        clearInvocations(commandBatchCursor, newCommandBatchCursor, timeoutContext, changeStreamOperation, readBinding);
+
+        //when third next is called. No resume is attempted.
+        List<Document> next2 = cursor.next();
+
+        //then
+        assertEquals(Collections.emptyList(), next2);
+        verifyNoInteractions(commandBatchCursor);
+        verify(timeoutContext, times(1)).resetTimeout();
+        verify(newCommandBatchCursor, times(1)).next();
+        verify(newCommandBatchCursor, atLeastOnce()).getPostBatchResumeToken();
+        verifyNoMoreInteractions(newCommandBatchCursor);
+        verify(changeStreamOperation, times(1)).getDecoder();
+        verifyNoMoreInteractions(changeStreamOperation);
+        verifyNoInteractions(readBinding);
+        verifyNoMoreInteractions(changeStreamOperation);
+    }
+
+    @Test
+    @DisplayName("should propagate any errors occurred in aggregate operation during creating new change stream when previous next timed out")
+    void shouldPropagateAnyErrorsOccurredInAggregateOperation() {
+        when(commandBatchCursor.next()).thenThrow(new MongoOperationTimeoutException("timeout"));
+        MongoNotPrimaryException resumableError = new MongoNotPrimaryException(new BsonDocument(), new ServerAddress());
+        when(changeStreamOperation.execute(readBinding)).thenThrow(resumableError);
+
+        ChangeStreamBatchCursor<Document> cursor = createChangeStreamCursor();
+        //when
+        assertThrows(MongoOperationTimeoutException.class, cursor::next);
+        clearInvocations(commandBatchCursor, newCommandBatchCursor, timeoutContext, changeStreamOperation, readBinding);
+        assertThrows(MongoNotPrimaryException.class, cursor::next);
+
+        //then
+        verify(timeoutContext, times(1)).resetTimeout();
+        verifyResumeAttemptCalled();
+        verifyNoMoreInteractions(changeStreamOperation);
+        verifyNoInteractions(newCommandBatchCursor);
+    }
+
+
+    @Test
+    @DisplayName("should perform a resume attempt in subsequent next call when previous resume attempt in next timed out")
+    void shouldResumeAfterTimeoutInAggregateOnNextCall() {
+        //given
+        ChangeStreamBatchCursor<Document> cursor = createChangeStreamCursor();
+
+        //first next operation times out on getMore
+        when(commandBatchCursor.next()).thenThrow(new MongoOperationTimeoutException("timeout during next call"));
+        assertThrows(MongoOperationTimeoutException.class, cursor::next);
+        clearInvocations(commandBatchCursor, newCommandBatchCursor, timeoutContext, changeStreamOperation, readBinding);
+
+        //second next operation times out on resume attempt when creating change stream
+        when(changeStreamOperation.execute(readBinding)).thenThrow(new MongoOperationTimeoutException("timeout during resumption"));
+        assertThrows(MongoOperationTimeoutException.class, cursor::next);
+        clearInvocations(commandBatchCursor, newCommandBatchCursor, timeoutContext, changeStreamOperation);
+
+        doReturn(newChangeStreamCursor).when(changeStreamOperation).execute(readBinding);
+
+        //when third operation succeeds to resume and call next
+        List<Document> next = cursor.next();
+
+        //then
+        assertEquals(RESULT_FROM_NEW_CURSOR, next);
+        verify(timeoutContext, times(1)).resetTimeout();
+
+        verifyResumeAttemptCalled();
+        verify(changeStreamOperation, times(1)).getDecoder();
+        verifyNoMoreInteractions(changeStreamOperation);
+
+        verify(newCommandBatchCursor, times(1)).next();
+        verify(newCommandBatchCursor, atLeastOnce()).getPostBatchResumeToken();
+        verifyNoMoreInteractions(newCommandBatchCursor);
+    }
+
+    @Test
+    @DisplayName("should close change stream when resume operation fails due to non-timeout error")
+    void shouldCloseChangeStreamWhenResumeOperationFailsDueToNonTimeoutError() {
+        //given
+        ChangeStreamBatchCursor<Document> cursor = createChangeStreamCursor();
+
+        //first next operation times out on getMore
+        when(commandBatchCursor.next()).thenThrow(new MongoOperationTimeoutException("timeout during next call"));
+        assertThrows(MongoOperationTimeoutException.class, cursor::next);
+        clearInvocations(commandBatchCursor, newCommandBatchCursor, timeoutContext, changeStreamOperation, readBinding);
+
+        //when second next operation errors on resume attempt when creating change stream
+        when(changeStreamOperation.execute(readBinding)).thenThrow(new MongoNotPrimaryException(new BsonDocument(), new ServerAddress()));
+        assertThrows(MongoNotPrimaryException.class, cursor::next);
+
+        //then
+        verify(timeoutContext, times(1)).resetTimeout();
+        verifyResumeAttemptCalled();
+        verifyNoMoreInteractions(changeStreamOperation);
+        verifyNoInteractions(newCommandBatchCursor);
+        clearInvocations(commandBatchCursor, newCommandBatchCursor, timeoutContext, changeStreamOperation, readBinding);
+
+
+        //when third next operation errors with cursor closed exception
+        doThrow(new IllegalStateException(MESSAGE_IF_CLOSED_AS_CURSOR)).when(commandBatchCursor).next();
+        MongoException mongoException = assertThrows(MongoException.class, cursor::next);
+
+        //then
+        assertEquals(MESSAGE_IF_CLOSED_AS_CURSOR, mongoException.getMessage());
+        verify(timeoutContext, times(1)).resetTimeout();
+        verifyNoResumeAttemptCalled();
+    }
+
+    private ChangeStreamBatchCursor<Document> createChangeStreamCursor() {
+        ChangeStreamBatchCursor<Document> cursor =
+                new ChangeStreamBatchCursor<>(changeStreamOperation, commandBatchCursor, readBinding, null, maxWireVersion);
+        clearInvocations(commandBatchCursor, newCommandBatchCursor, timeoutContext, changeStreamOperation, readBinding);
+        return cursor;
+    }
+
+    private void verifyNoResumeAttemptCalled() {
+        verifyNoInteractions(changeStreamOperation);
+        verifyNoInteractions(newCommandBatchCursor);
+        verifyNoInteractions(readBinding);
+    }
+
+
+    private void verifyResumeAttemptCalled() {
+        verify(commandBatchCursor, times(1)).close();
+        verify(changeStreamOperation).setChangeStreamOptionsForResume(resumeToken, maxWireVersion);
+        verify(changeStreamOperation, times(1)).execute(readBinding);
+        verifyNoMoreInteractions(commandBatchCursor);
+    }
+
+    @BeforeEach
+    void setUp() {
+        resumeToken = new BsonDocument("_id", new BsonInt32(1));
+        serverDescription = mock(ServerDescription.class);
+        when(serverDescription.getMaxWireVersion()).thenReturn(maxWireVersion);
+
+        timeoutContext = mock(TimeoutContext.class);
+        when(timeoutContext.hasTimeoutMS()).thenReturn(true);
+        doNothing().when(timeoutContext).resetTimeout();
+
+        operationContext = mock(OperationContext.class);
+        when(operationContext.getTimeoutContext()).thenReturn(timeoutContext);
+        connection = mock(Connection.class);
+        when(connection.command(any(), any(), any(), any(), any(), any())).thenReturn(null);
+        connectionSource = mock(ConnectionSource.class);
+        when(connectionSource.getConnection()).thenReturn(connection);
+        when(connectionSource.release()).thenReturn(1);
+        when(connectionSource.getServerDescription()).thenReturn(serverDescription);
+
+        readBinding = mock(ReadBinding.class);
+        when(readBinding.getOperationContext()).thenReturn(operationContext);
+        when(readBinding.retain()).thenReturn(readBinding);
+        when(readBinding.release()).thenReturn(1);
+        when(readBinding.getReadConnectionSource()).thenReturn(connectionSource);
+
+
+        commandBatchCursor = mock(CommandBatchCursor.class);
+        when(commandBatchCursor.getPostBatchResumeToken()).thenReturn(resumeToken);
+        doNothing().when(commandBatchCursor).close();
+
+        newCommandBatchCursor = mock(CommandBatchCursor.class);
+        when(newCommandBatchCursor.getPostBatchResumeToken()).thenReturn(resumeToken);
+        when(newCommandBatchCursor.next()).thenReturn(RESULT_FROM_NEW_CURSOR);
+        doNothing().when(newCommandBatchCursor).close();
+
+        newChangeStreamCursor = mock(ChangeStreamBatchCursor.class);
+        when(newChangeStreamCursor.getWrapped()).thenReturn(newCommandBatchCursor);
+
+        changeStreamOperation = mock(ChangeStreamOperation.class);
+        when(changeStreamOperation.getDecoder()).thenReturn(new DocumentCodec());
+        doNothing().when(changeStreamOperation).setChangeStreamOptionsForResume(resumeToken, maxWireVersion);
+        when(changeStreamOperation.execute(readBinding)).thenReturn(newChangeStreamCursor);
+    }
+
+}

--- a/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoCursor.kt
+++ b/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoCursor.kt
@@ -75,6 +75,9 @@ public sealed interface MongoCursor<T : Any> : Iterator<T>, Closeable {
  *      }
  *  }
  * ```
+ * If a [com.mongodb.MongoOperationTimeoutException] occurs before any events are received, it indicates that the server
+ * has timed out before it could finish processing the existing oplog. In such cases, it is recommended to close the current
+ * stream and recreate it with a higher timeout setting.
  *
  * @param T The type of documents the cursor contains
  */

--- a/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoCursor.kt
+++ b/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoCursor.kt
@@ -76,6 +76,10 @@ public sealed interface MongoCursor<T : Any> : Iterator<T>, Closeable {
  *  }
  * ```
  *
+ * A [com.mongodb.MongoOperationTimeoutException] does not invalidate the [MongoChangeStreamCursor], but is immediately
+ * propagated to the caller. Subsequent method calls will attempt to resume operation by establishing a new change
+ * stream on the server, without performing a `getMore` request first.
+ *
  * If a [com.mongodb.MongoOperationTimeoutException] occurs before any events are received, it indicates that the server
  * has timed out before it could finish processing the existing oplog. In such cases, it is recommended to close the
  * current stream and recreate it with a higher timeout setting.

--- a/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoCursor.kt
+++ b/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/MongoCursor.kt
@@ -75,9 +75,10 @@ public sealed interface MongoCursor<T : Any> : Iterator<T>, Closeable {
  *      }
  *  }
  * ```
+ *
  * If a [com.mongodb.MongoOperationTimeoutException] occurs before any events are received, it indicates that the server
- * has timed out before it could finish processing the existing oplog. In such cases, it is recommended to close the current
- * stream and recreate it with a higher timeout setting.
+ * has timed out before it could finish processing the existing oplog. In such cases, it is recommended to close the
+ * current stream and recreate it with a higher timeout setting.
  *
  * @param T The type of documents the cursor contains
  */

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/AggregatePublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/AggregatePublisherImpl.java
@@ -94,8 +94,7 @@ final class AggregatePublisherImpl<T> extends BatchCursorPublisher<T> implements
 
     @Override
     public AggregatePublisher<T> maxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        this.maxAwaitTimeMS = TimeUnit.MILLISECONDS.convert(maxAwaitTime, timeUnit);
+        this.maxAwaitTimeMS = validateMaxAwaitTime(maxAwaitTime, timeUnit);
         return this;
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/BatchCursorPublisher.java
@@ -31,10 +31,12 @@ import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import reactor.core.publisher.Mono;
 
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
+import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 
 @VisibleForTesting(otherwise = VisibleForTesting.AccessModifier.PROTECTED)
@@ -151,4 +153,15 @@ public abstract class BatchCursorPublisher<T> implements Publisher<T> {
         return mongoOperationPublisher.createReadOperationMono(getTimeoutSettings(), supplier, clientSession).map(BatchCursor::new);
     }
 
+
+    protected long validateMaxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
+        notNull("timeUnit", timeUnit);
+        Long timeoutMS = mongoOperationPublisher.getTimeoutSettings().getTimeoutMS();
+        long maxAwaitTimeMS = TimeUnit.MILLISECONDS.convert(maxAwaitTime, timeUnit);
+
+        isTrueArgument("maxAwaitTimeMS must be less than timeoutMS", timeoutMS == null || timeoutMS == 0
+                || timeoutMS > maxAwaitTimeMS);
+
+        return maxAwaitTimeMS;
+    }
 }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImpl.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static com.mongodb.assertions.Assertions.notNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 
 final class ChangeStreamPublisherImpl<T> extends BatchCursorPublisher<ChangeStreamDocument<T>>

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/ChangeStreamPublisherImpl.java
@@ -124,8 +124,7 @@ final class ChangeStreamPublisherImpl<T> extends BatchCursorPublisher<ChangeStre
 
     @Override
     public ChangeStreamPublisher<T> maxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        this.maxAwaitTimeMS = MILLISECONDS.convert(maxAwaitTime, timeUnit);
+        this.maxAwaitTimeMS = validateMaxAwaitTime(maxAwaitTime, timeUnit);
         return this;
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/FindPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/FindPublisherImpl.java
@@ -79,7 +79,7 @@ final class FindPublisherImpl<T> extends BatchCursorPublisher<T> implements Find
 
     @Override
     public FindPublisher<T> maxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
+        validateMaxAwaitTime(maxAwaitTime, timeUnit);
         findOptions.maxAwaitTime(maxAwaitTime, timeUnit);
         return this;
     }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideOperationTimeoutProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideOperationTimeoutProseTest.java
@@ -56,12 +56,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
+import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
+import static com.mongodb.ClusterFixture.isServerlessTest;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.ClusterFixture.sleep;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 
@@ -225,6 +228,8 @@ public final class ClientSideOperationTimeoutProseTest extends AbstractClientSid
     @Test
     public void testTimeoutMSAppliesToFullResumeAttemptInNextCall() {
         assumeTrue(serverVersionAtLeast(4, 4));
+        assumeTrue(isDiscoverableReplicaSet());
+        assumeFalse(isServerlessTest());
 
         //given
         long rtt = ClusterFixture.getPrimaryRTT();
@@ -279,6 +284,8 @@ public final class ClientSideOperationTimeoutProseTest extends AbstractClientSid
     @Test
     public void testTimeoutMSAppliedToInitialAggregate() {
         assumeTrue(serverVersionAtLeast(4, 4));
+        assumeTrue(isDiscoverableReplicaSet());
+        assumeFalse(isServerlessTest());
 
         //given
         long rtt = ClusterFixture.getPrimaryRTT();
@@ -326,6 +333,8 @@ public final class ClientSideOperationTimeoutProseTest extends AbstractClientSid
     @Test
     public void testTimeoutMsRefreshedForGetMoreWhenMaxAwaitTimeMsNotSet() {
         assumeTrue(serverVersionAtLeast(4, 4));
+        assumeTrue(isDiscoverableReplicaSet());
+        assumeFalse(isServerlessTest());
 
         //given
         BsonTimestamp startTime = new BsonTimestamp((int) Instant.now().getEpochSecond(), 0);
@@ -387,6 +396,8 @@ public final class ClientSideOperationTimeoutProseTest extends AbstractClientSid
     @Test
     public void testTimeoutMsRefreshedForGetMoreWhenMaxAwaitTimeMsSet() {
         assumeTrue(serverVersionAtLeast(4, 4));
+        assumeTrue(isDiscoverableReplicaSet());
+        assumeFalse(isServerlessTest());
 
         //given
         BsonTimestamp startTime = new BsonTimestamp((int) Instant.now().getEpochSecond(), 0);
@@ -441,6 +452,8 @@ public final class ClientSideOperationTimeoutProseTest extends AbstractClientSid
     @Test
     public void testTimeoutMsISHonoredForNnextOperationWhenSeveralGetMoreExecutedInternally() {
         assumeTrue(serverVersionAtLeast(4, 4));
+        assumeTrue(isDiscoverableReplicaSet());
+        assumeFalse(isServerlessTest());
 
         //given
         long rtt = ClusterFixture.getPrimaryRTT();

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideOperationTimeoutProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideOperationTimeoutProseTest.java
@@ -494,8 +494,8 @@ public final class ClientSideOperationTimeoutProseTest extends AbstractClientSid
 
     private static void assertCommandStartedEventsInOder(final List<String> expectedCommandNames,
                                                          final List<CommandStartedEvent> commandStartedEvents) {
-        assertEquals(expectedCommandNames.size(), commandStartedEvents.size(), "Expected: " + expectedCommandNames + ". Actual: " +
-                commandStartedEvents.stream()
+        assertEquals(expectedCommandNames.size(), commandStartedEvents.size(), "Expected: " + expectedCommandNames + ". Actual: "
+                + commandStartedEvents.stream()
                         .map(CommandStartedEvent::getCommand)
                         .map(BsonDocument::toJson)
                         .collect(Collectors.toList()));

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideOperationTimeoutProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideOperationTimeoutProseTest.java
@@ -335,7 +335,7 @@ public final class ClientSideOperationTimeoutProseTest extends AbstractClientSid
 
         long rtt = ClusterFixture.getPrimaryRTT();
         try (MongoClient client = createReactiveClient(getMongoClientSettingsBuilder()
-                .timeout(1000, TimeUnit.MILLISECONDS))) {
+                .timeout(rtt + 1000, TimeUnit.MILLISECONDS))) {
 
             MongoCollection<Document> collection = client.getDatabase(namespace.getDatabaseName())
                     .getCollection(namespace.getCollectionName()).withReadPreference(ReadPreference.primary());
@@ -395,7 +395,7 @@ public final class ClientSideOperationTimeoutProseTest extends AbstractClientSid
 
         long rtt = ClusterFixture.getPrimaryRTT();
         try (MongoClient client = createReactiveClient(getMongoClientSettingsBuilder()
-                .timeout(300, TimeUnit.MILLISECONDS))) {
+                .timeout(rtt + 300, TimeUnit.MILLISECONDS))) {
 
             MongoCollection<Document> collection = client.getDatabase(namespace.getDatabaseName())
                     .getCollection(namespace.getCollectionName()).withReadPreference(ReadPreference.primary());

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideOperationTimeoutProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideOperationTimeoutProseTest.java
@@ -18,21 +18,37 @@ package com.mongodb.reactivestreams.client;
 
 import com.mongodb.ClusterFixture;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoNamespace;
 import com.mongodb.MongoOperationTimeoutException;
 import com.mongodb.MongoSocketReadTimeoutException;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
 import com.mongodb.client.AbstractClientSideOperationsTimeoutProseTest;
+import com.mongodb.client.model.CreateCollectionOptions;
+import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.event.CommandFailedEvent;
+import com.mongodb.event.CommandStartedEvent;
 import com.mongodb.reactivestreams.client.gridfs.GridFSBucket;
 import com.mongodb.reactivestreams.client.gridfs.GridFSBuckets;
 import com.mongodb.reactivestreams.client.syncadapter.SyncGridFSBucket;
 import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
+import org.bson.Document;
 import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
+import reactor.test.StepVerifier;
 
 import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -41,6 +57,8 @@ import java.util.concurrent.TimeoutException;
 
 import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.ClusterFixture.sleep;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -85,6 +103,7 @@ public final class ClientSideOperationTimeoutProseTest extends AbstractClientSid
     @Tag("setsFailPoint")
     @DisplayName("6. GridFS Upload - uploads via openUploadStream can be timed out")
     @Test
+    @Override
     public void testGridFSUploadViaOpenUploadStreamTimeout() {
         assumeTrue(serverVersionAtLeast(4, 4));
         long rtt = ClusterFixture.getPrimaryRTT();
@@ -141,6 +160,7 @@ public final class ClientSideOperationTimeoutProseTest extends AbstractClientSid
     @Tag("setsFailPoint")
     @DisplayName("6. GridFS Upload - Aborting an upload stream can be timed out")
     @Test
+    @Override
     public void testAbortingGridFsUploadStreamTimeout() throws ExecutionException, InterruptedException, TimeoutException {
         assumeTrue(serverVersionAtLeast(4, 4));
         long rtt = ClusterFixture.getPrimaryRTT();
@@ -195,5 +215,274 @@ public final class ClientSideOperationTimeoutProseTest extends AbstractClientSid
             // When subscription is cancelled, we should not receive any more events.
             testSubscriber.assertNoTerminalEvent();
         }
+    }
+
+    /**
+     * Not a prose spec test. However, it is additional test case for better coverage.
+     */
+    @Tag("setsFailPoint")
+    @DisplayName("TimeoutMS applies to full resume attempt in a next call")
+    @Test
+    public void testTimeoutMSAppliesToFullResumeAttemptInNextCall() {
+        assumeTrue(serverVersionAtLeast(4, 4));
+
+        //given
+        long rtt = ClusterFixture.getPrimaryRTT();
+        try (MongoClient client = createReactiveClient(getMongoClientSettingsBuilder()
+                .timeout(rtt + 500, TimeUnit.MILLISECONDS))) {
+
+            MongoNamespace namespace = generateNamespace();
+            MongoCollection<Document> collection = client.getDatabase(namespace.getDatabaseName())
+                    .getCollection(namespace.getCollectionName()).withReadPreference(ReadPreference.primary());
+
+            collectionHelper.runAdminCommand("{"
+                    + "    configureFailPoint: \"failCommand\","
+                    + "    mode: { times: 1},"
+                    + "    data: {"
+                    + "        failCommands: [\"getMore\" ],"
+                    + "        errorCode: 7,"
+                    + "        errorLabels: [\"ResumableChangeStreamError\" ]"
+                    + "    }"
+                    + "}");
+
+            //when
+            ChangeStreamPublisher<Document> documentChangeStreamPublisher = collection.watch(
+                            singletonList(Document.parse("{ '$match': {'operationType': 'insert'}}")));
+
+            Assertions.assertThrows(MongoOperationTimeoutException.class,
+                    () -> Flux.from(documentChangeStreamPublisher).blockFirst(TIMEOUT_DURATION));
+            //then
+            sleep(200); //let publisher invalidate the cursor after the error.
+            List<CommandStartedEvent> commandStartedEvents = commandListener.getCommandStartedEvents();
+
+            List<String> expectedCommandNames = Arrays.asList("aggregate", "getMore", "killCursors", "aggregate", "getMore", "killCursors");
+            assertCommandStartedEventsInOder(expectedCommandNames, commandStartedEvents);
+
+            List<CommandFailedEvent> commandFailedEvents = commandListener.getCommandFailedEvents();
+            assertEquals(2, commandFailedEvents.size());
+
+            CommandFailedEvent firstGetMoreFailedEvent = commandFailedEvents.get(0);
+            assertEquals("getMore", firstGetMoreFailedEvent.getCommandName());
+            assertInstanceOf(MongoCommandException.class, firstGetMoreFailedEvent.getThrowable());
+
+            CommandFailedEvent secondGetMoreFailedEvent = commandFailedEvents.get(1);
+            assertEquals("getMore", secondGetMoreFailedEvent.getCommandName());
+            assertInstanceOf(MongoOperationTimeoutException.class, secondGetMoreFailedEvent.getThrowable());
+        }
+    }
+
+    /**
+     * Not a prose spec test. However, it is additional test case for better coverage.
+     */
+    @Tag("setsFailPoint")
+    @DisplayName("TimeoutMS applied to initial aggregate")
+    @Test
+    public void testTimeoutMSAppliedToInitialAggregate() {
+        assumeTrue(serverVersionAtLeast(4, 4));
+
+        //given
+        long rtt = ClusterFixture.getPrimaryRTT();
+        try (MongoClient client = createReactiveClient(getMongoClientSettingsBuilder()
+                .timeout(rtt + 200, TimeUnit.MILLISECONDS))) {
+
+            MongoNamespace namespace = generateNamespace();
+            MongoCollection<Document> collection = client.getDatabase(namespace.getDatabaseName())
+                    .getCollection(namespace.getCollectionName()).withReadPreference(ReadPreference.primary());
+            ChangeStreamPublisher<Document> documentChangeStreamPublisher = collection.watch(
+                            singletonList(Document.parse("{ '$match': {'operationType': 'insert'}}")))
+                    .fullDocument(FullDocument.UPDATE_LOOKUP);
+
+            collectionHelper.runAdminCommand("{"
+                    + "    configureFailPoint: \"failCommand\","
+                    + "    mode: { times: 1},"
+                    + "    data: {"
+                    + "        failCommands: [\"aggregate\" ],"
+                    + "        blockConnection: true,"
+                    + "        blockTimeMS: " + (rtt + 201)
+                    + "    }"
+                    + "}");
+
+            //when
+            Assertions.assertThrows(MongoOperationTimeoutException.class,
+                    () -> Flux.from(documentChangeStreamPublisher).blockFirst(TIMEOUT_DURATION));
+
+            //We do not expect cursor to have been created. However, publisher closes cursor asynchronously, thus we give it some time
+            // to make sure that cursor has not been closed (which would indicate that it was created).
+            sleep(200);
+
+            //then
+            List<CommandStartedEvent> commandStartedEvents = commandListener.getCommandStartedEvents();
+            assertEquals(1, commandStartedEvents.size());
+            assertEquals("aggregate", commandStartedEvents.get(0).getCommandName());
+            assertOnlyOneCommandTimeoutFailure("aggregate");
+        }
+    }
+
+    /**
+     * Not a prose spec test. However, it is additional test case for better coverage.
+     */
+    @Tag("setsFailPoint")
+    @DisplayName("TimeoutMS is refreshed for getMore if maxAwaitTimeMS is not set")
+    @Test
+    public void testTimeoutMsRefreshedForGetMoreWhenMaxAwaitTimeMsNotSet() {
+        assumeTrue(serverVersionAtLeast(4, 4));
+
+        //given
+        BsonTimestamp startTime = new BsonTimestamp((int) Instant.now().getEpochSecond(), 0);
+        collectionHelper.create(namespace.getCollectionName(), new CreateCollectionOptions());
+        sleep(2000);
+
+
+        long rtt = ClusterFixture.getPrimaryRTT();
+        try (MongoClient client = createReactiveClient(getMongoClientSettingsBuilder()
+                .timeout(1000, TimeUnit.MILLISECONDS))) {
+
+            MongoCollection<Document> collection = client.getDatabase(namespace.getDatabaseName())
+                    .getCollection(namespace.getCollectionName()).withReadPreference(ReadPreference.primary());
+
+            collectionHelper.runAdminCommand("{"
+                    + "    configureFailPoint: \"failCommand\","
+                    + "    mode: { times: 2},"
+                    + "    data: {"
+                    + "        failCommands: [\"getMore\" ],"
+                    + "        blockConnection: true,"
+                    + "        blockTimeMS: " + (rtt + 800)
+                    + "    }"
+                    + "}");
+
+            //when
+            ChangeStreamPublisher<Document> documentChangeStreamPublisher = collection.watch()
+                    .startAtOperationTime(startTime);
+            StepVerifier.create(documentChangeStreamPublisher, 2)
+            //then
+                    .thenAwait(Duration.ofMillis(300))
+                    .then(() -> collectionHelper.insertDocuments(WriteConcern.MAJORITY,
+                            BsonDocument.parse("{x: 1}"),
+                            BsonDocument.parse("{x: 2}"),
+                            BsonDocument.parse("{x: 3}"),
+                            BsonDocument.parse("{x: 4}")))
+                    .expectNextCount(2)
+                    .thenAwait(Duration.ofMillis(1000))
+                    .thenRequest(2)
+                    .expectNextCount(2)
+                    .thenAwait(Duration.ofMillis(1000))
+                    .thenRequest(2)
+                    .expectError(MongoOperationTimeoutException.class)
+                    .verify();
+
+            sleep(200); //let publisher invalidate the cursor after the error.
+
+            List<CommandStartedEvent> commandStartedEvents = commandListener.getCommandStartedEvents();
+            List<String> expectedCommandNames = Arrays.asList("aggregate", "getMore", "getMore", "getMore", "killCursors");
+            assertCommandStartedEventsInOder(expectedCommandNames, commandStartedEvents);
+            assertOnlyOneCommandTimeoutFailure("getMore");
+        }
+    }
+
+    /**
+     * Not a prose spec test. However, it is additional test case for better coverage.
+     */
+    @Tag("setsFailPoint")
+    @DisplayName("TimeoutMS is refreshed for getMore if maxAwaitTimeMS is set")
+    @Test
+    public void testTimeoutMsRefreshedForGetMoreWhenMaxAwaitTimeMsSet() {
+        assumeTrue(serverVersionAtLeast(4, 4));
+
+        //given
+        BsonTimestamp startTime = new BsonTimestamp((int) Instant.now().getEpochSecond(), 0);
+        collectionHelper.create(namespace.getCollectionName(), new CreateCollectionOptions());
+        sleep(2000);
+
+        long rtt = ClusterFixture.getPrimaryRTT();
+        try (MongoClient client = createReactiveClient(getMongoClientSettingsBuilder()
+                .timeout(300, TimeUnit.MILLISECONDS))) {
+
+            MongoCollection<Document> collection = client.getDatabase(namespace.getDatabaseName())
+                    .getCollection(namespace.getCollectionName()).withReadPreference(ReadPreference.primary());
+
+            collectionHelper.runAdminCommand("{"
+                    + "    configureFailPoint: \"failCommand\","
+                    + "    mode: { times: 2},"
+                    + "    data: {"
+                    + "        failCommands: [\"aggregate\", \"getMore\"],"
+                    + "        blockConnection: true,"
+                    + "        blockTimeMS: " + (rtt + 200)
+                    + "    }"
+                    + "}");
+
+            //when
+            ChangeStreamPublisher<Document> documentChangeStreamPublisher = collection.watch()
+                    .maxAwaitTime(1, TimeUnit.MILLISECONDS)
+                    .startAtOperationTime(startTime);
+            StepVerifier.create(documentChangeStreamPublisher, 2)
+            //then
+                    .thenAwait(Duration.ofMillis(300))
+                    .then(() -> collectionHelper.insertDocuments(WriteConcern.MAJORITY,
+                            BsonDocument.parse("{x: 1}"),
+                            BsonDocument.parse("{x: 2}")))
+                    .thenAwait(Duration.ofMillis(300))
+                    .thenRequest(2)
+                    .thenCancel()
+                    .verify();
+
+            sleep(200); //let publisher invalidate the cursor after the error.
+
+            List<CommandStartedEvent> commandStartedEvents = commandListener.getCommandStartedEvents();
+            List<String> expectedCommandNames = Arrays.asList("aggregate", "getMore", "killCursors");
+            assertCommandStartedEventsInOder(expectedCommandNames, commandStartedEvents);
+        }
+    }
+
+    /**
+     * Not a prose spec test. However, it is additional test case for better coverage.
+     */
+    @Tag("setsFailPoint")
+    @DisplayName("TimeoutMS is honored for next operation when several getMore executed internally")
+    @Test
+    public void testTimeoutMsISHonoredForNnextOperationWhenSeveralGetMoreExecutedInternally() {
+        assumeTrue(serverVersionAtLeast(4, 4));
+
+        //given
+        long rtt = ClusterFixture.getPrimaryRTT();
+        try (MongoClient client = createReactiveClient(getMongoClientSettingsBuilder()
+                .timeout(rtt + 2500, TimeUnit.MILLISECONDS))) {
+
+            MongoCollection<Document> collection = client.getDatabase(namespace.getDatabaseName())
+                    .getCollection(namespace.getCollectionName()).withReadPreference(ReadPreference.primary());
+
+            //when
+            ChangeStreamPublisher<Document> documentChangeStreamPublisher = collection.watch();
+            StepVerifier.create(documentChangeStreamPublisher, 2)
+            //then
+                    .expectError(MongoOperationTimeoutException.class)
+                    .verify();
+
+            sleep(200); //let publisher invalidate the cursor after the error.
+
+            List<CommandStartedEvent> commandStartedEvents = commandListener.getCommandStartedEvents();
+            assertCommandStartedEventsInOder(Arrays.asList("aggregate", "getMore", "getMore", "getMore", "killCursors"),
+                    commandStartedEvents);
+            assertOnlyOneCommandTimeoutFailure("getMore");
+        }
+    }
+
+    private static void assertCommandStartedEventsInOder(final List<String> expectedCommandNames,
+                                                         final List<CommandStartedEvent> commandStartedEvents) {
+        assertEquals(expectedCommandNames.size(), commandStartedEvents.size());
+
+        for (int i = 0; i < expectedCommandNames.size(); i++) {
+            CommandStartedEvent commandStartedEvent = commandStartedEvents.get(i);
+
+            assertEquals(expectedCommandNames.get(i), commandStartedEvent.getCommandName());
+        }
+    }
+
+    private void assertOnlyOneCommandTimeoutFailure(final String command) {
+        List<CommandFailedEvent> commandFailedEvents = commandListener.getCommandFailedEvents();
+        assertEquals(1, commandFailedEvents.size());
+
+        CommandFailedEvent failedAggregateCommandEvent = commandFailedEvents.get(0);
+        assertEquals(command, commandFailedEvents.get(0).getCommandName());
+        assertInstanceOf(MongoOperationTimeoutException.class, failedAggregateCommandEvent.getThrowable());
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCursor.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCursor.java
@@ -99,6 +99,7 @@ class SyncMongoCursor<T> implements MongoCursor<T> {
                 throw new MongoTimeoutException("Timeout waiting for subscription");
             }
             batchCursorCompletableFuture.get(TIMEOUT, TimeUnit.SECONDS);
+            Hooks.resetOnEachOperator();
             sleep(getSleepAfterCursorOpen());
         } catch (InterruptedException e) {
             throw interruptAndCreateMongoInterruptedException("Interrupted waiting for asynchronous cursor establishment", e);

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCursor.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoCursor.java
@@ -29,6 +29,7 @@ import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
 
 import java.util.NoSuchElementException;
 import java.util.concurrent.BlockingDeque;
@@ -215,6 +216,11 @@ class SyncMongoCursor<T> implements MongoCursor<T> {
                                        final CompletableFuture<BatchCursor> batchCursorCompletableFuture) {
             this.sub = sub;
             this.batchCursorCompletableFuture = batchCursorCompletableFuture;
+        }
+
+        @Override
+        public Context currentContext() {
+            return sub.currentContext();
         }
 
         @Override

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ClientSideOperationTimeoutTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ClientSideOperationTimeoutTest.java
@@ -52,9 +52,24 @@ public class ClientSideOperationTimeoutTest extends UnifiedReactiveStreamsTest {
             final BsonArray initialData, final BsonDocument definition) {
         super(schemaVersion, runOnRequirements, entities, initialData, definition);
         this.testDescription = testDescription;
-        assumeFalse("TODO (CSOT) - JAVA-4054", fileDescription.equals("timeoutMS behaves correctly for change streams"));
-
         // Time sensitive - cannot just create a cursor with publishers
+
+        assumeFalse("No iterateOnce support. There is alternative prose test for it.",
+                testDescription.equals("timeoutMS is refreshed for getMore if maxAwaitTimeMS is not set"));
+
+        assumeFalse("No iterateOnce support. There is alternative prose test for it.",
+                testDescription.equals("timeoutMS is refreshed for getMore if maxAwaitTimeMS is set"));
+        /*
+           The Reactive Streams specification prevents us from allowing a subsequent next call (event in reactive terms) after a timeout error,
+           conflicting with the CSOT spec requirement not to invalidate the change stream and to try resuming and establishing a new change
+           stream on the server. We immediately let users know about a timeout error, which then closes the stream/publisher.
+         */
+        assumeFalse("It is not possible due to a conflict with the Reactive Streams specification .",
+                testDescription.equals("change stream can be iterated again if previous iteration times out"));
+
+        assumeFalse("Flaky and racy due to asynchronous behaviour. There is alternative prose test for it.",
+                testDescription.equals("timeoutMS applies to full resume attempt in a next call"));
+
         assumeFalse(testDescription.endsWith("createChangeStream on client"));
         assumeFalse(testDescription.endsWith("createChangeStream on database"));
         assumeFalse(testDescription.endsWith("createChangeStream on collection"));

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ClientSideOperationTimeoutTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ClientSideOperationTimeoutTest.java
@@ -56,7 +56,6 @@ public class ClientSideOperationTimeoutTest extends UnifiedReactiveStreamsTest {
 
         assumeFalse("No iterateOnce support. There is alternative prose test for it.",
                 testDescription.equals("timeoutMS is refreshed for getMore if maxAwaitTimeMS is not set"));
-
         assumeFalse("No iterateOnce support. There is alternative prose test for it.",
                 testDescription.equals("timeoutMS is refreshed for getMore if maxAwaitTimeMS is set"));
         /*
@@ -66,9 +65,10 @@ public class ClientSideOperationTimeoutTest extends UnifiedReactiveStreamsTest {
          */
         assumeFalse("It is not possible due to a conflict with the Reactive Streams specification .",
                 testDescription.equals("change stream can be iterated again if previous iteration times out"));
-
         assumeFalse("Flaky and racy due to asynchronous behaviour. There is alternative prose test for it.",
                 testDescription.equals("timeoutMS applies to full resume attempt in a next call"));
+        assumeFalse("No way to catch an error on BarchCursor creation. There is alternative prose test for it.",
+                testDescription.equals("timeoutMS applied to initial aggregate"));
 
         assumeFalse(testDescription.endsWith("createChangeStream on client"));
         assumeFalse(testDescription.endsWith("createChangeStream on database"));

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ClientSideOperationTimeoutTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ClientSideOperationTimeoutTest.java
@@ -52,6 +52,7 @@ public class ClientSideOperationTimeoutTest extends UnifiedReactiveStreamsTest {
             final BsonArray initialData, final BsonDocument definition) {
         super(schemaVersion, runOnRequirements, entities, initialData, definition);
         this.testDescription = testDescription;
+        assumeFalse("TODO (CSOT) - JAVA-4054", fileDescription.equals("timeoutMS behaves correctly for change streams"));
 
         // Time sensitive - cannot just create a cursor with publishers
         assumeFalse(testDescription.endsWith("createChangeStream on client"));

--- a/driver-sync/src/main/com/mongodb/client/MongoChangeStreamCursor.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoChangeStreamCursor.java
@@ -33,6 +33,12 @@ import org.bson.BsonDocument;
  * }
  * }</pre>
  *
+ * <p>
+ * If a {@link com.mongodb.MongoOperationTimeoutException} occurs before any events are received, it indicates that the server
+ * has timed out before it could finish processing the existing oplog. In such cases, it is recommended to close the current stream
+ * and recreate it with a higher timeout setting.
+ * <p>
+ *
  * @since 3.11
  * @param <TResult> The type of documents the cursor contains
  */

--- a/driver-sync/src/main/com/mongodb/client/MongoChangeStreamCursor.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoChangeStreamCursor.java
@@ -33,11 +33,15 @@ import org.bson.BsonDocument;
  * }
  * }</pre>
  *
+ *
+ * <p>
+ * A {@link com.mongodb.MongoOperationTimeoutException} does not invalidate the {@link MongoChangeStreamCursor}, but is immediately
+ * propagated to the caller. Subsequent method call will attempt to resume operation by establishing a new change stream on the server,
+ * without doing {@code getMore} request first. </p>
  * <p>
  * If a {@link com.mongodb.MongoOperationTimeoutException} occurs before any events are received, it indicates that the server
  * has timed out before it could finish processing the existing oplog. In such cases, it is recommended to close the current stream
  * and recreate it with a higher timeout setting.
- * <p>
  *
  * @since 3.11
  * @param <TResult> The type of documents the cursor contains

--- a/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
@@ -132,8 +132,7 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
 
     @Override
     public AggregateIterable<TResult> maxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        this.maxAwaitTimeMS = TimeUnit.MILLISECONDS.convert(maxAwaitTime, timeUnit);
+        this.maxAwaitTimeMS = validateMaxAwaitTime(maxAwaitTime, timeUnit);
         return this;
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
@@ -117,7 +116,7 @@ public class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeS
     @Override
     public ChangeStreamIterable<TResult> maxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
         notNull("timeUnit", timeUnit);
-        this.maxAwaitTimeMS = MILLISECONDS.convert(maxAwaitTime, timeUnit);
+        this.maxAwaitTimeMS = TimeUnit.MILLISECONDS.convert(maxAwaitTime, timeUnit);
         return this;
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
@@ -115,8 +115,7 @@ public class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeS
 
     @Override
     public ChangeStreamIterable<TResult> maxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
-        this.maxAwaitTimeMS = TimeUnit.MILLISECONDS.convert(maxAwaitTime, timeUnit);
+        this.maxAwaitTimeMS =  validateMaxAwaitTime(maxAwaitTime, timeUnit);
         return this;
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
@@ -90,7 +90,7 @@ class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> im
 
     @Override
     public FindIterable<TResult> maxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
-        notNull("timeUnit", timeUnit);
+        validateMaxAwaitTime(maxAwaitTime, timeUnit);
         findOptions.maxAwaitTime(maxAwaitTime, timeUnit);
         return this;
     }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
@@ -199,7 +199,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     public MongoCollection<TDocument> withTimeout(final long timeout, final TimeUnit timeUnit) {
         isTrueArgument("timeout >= 0", timeout >= 0);
         notNull("timeUnit", timeUnit);
-        TimeoutSettings newTimeoutSettings = timeoutSettings.withTimeoutMS(timeUnit.convert(timeout, TimeUnit.MILLISECONDS));
+        TimeoutSettings newTimeoutSettings = timeoutSettings.withTimeoutMS(TimeUnit.MILLISECONDS.convert(timeout, timeUnit));
         return new MongoCollectionImpl<>(namespace, documentClass, codecRegistry, readPreference, writeConcern, retryWrites,
                 retryReads, readConcern, uuidRepresentation, autoEncryptionSettings, newTimeoutSettings, executor);
     }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
@@ -152,7 +152,7 @@ public class MongoDatabaseImpl implements MongoDatabase {
     public MongoDatabase withTimeout(final long timeout, final TimeUnit timeUnit) {
         isTrueArgument("timeout >= 0", timeout >= 0);
         notNull("timeUnit", timeUnit);
-        TimeoutSettings newTimeoutSettings = timeoutSettings.withTimeoutMS(timeUnit.convert(timeout, TimeUnit.MILLISECONDS));
+        TimeoutSettings newTimeoutSettings = timeoutSettings.withTimeoutMS(TimeUnit.MILLISECONDS.convert(timeout, timeUnit));
         return new MongoDatabaseImpl(name, codecRegistry, readPreference, writeConcern, retryWrites, retryReads, readConcern,
                 uuidRepresentation, autoEncryptionSettings, newTimeoutSettings, executor);
     }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoIterableImpl.java
@@ -29,8 +29,10 @@ import com.mongodb.internal.operation.ReadOperation;
 import com.mongodb.lang.Nullable;
 
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 
 /**
@@ -154,4 +156,15 @@ public abstract class MongoIterableImpl<TResult> implements MongoIterable<TResul
         return getExecutor().execute(asReadOperation(), readPreference, readConcern, clientSession);
     }
 
+
+    protected long validateMaxAwaitTime(final long maxAwaitTime, final TimeUnit timeUnit) {
+        notNull("timeUnit", timeUnit);
+        Long timeoutMS = timeoutSettings.getTimeoutMS();
+        long maxAwaitTimeMS = TimeUnit.MILLISECONDS.convert(maxAwaitTime, timeUnit);
+
+        isTrueArgument("maxAwaitTimeMS must be less than timeoutMS", timeoutMS == null || timeoutMS == 0
+                || timeoutMS > maxAwaitTimeMS);
+
+        return maxAwaitTimeMS;
+    }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoIterableImpl.java
@@ -153,4 +153,5 @@ public abstract class MongoIterableImpl<TResult> implements MongoIterable<TResul
     private BatchCursor<TResult> execute() {
         return getExecutor().execute(asReadOperation(), readPreference, readConcern, clientSession);
     }
+
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideOperationsTimeoutProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideOperationsTimeoutProseTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
     protected static final String GRID_FS_BUCKET_NAME = "db.fs";
     private static final AtomicInteger COUNTER = new AtomicInteger();
 
-    private MongoNamespace namespace;
+    protected MongoNamespace namespace;
     protected MongoNamespace gridFsFileNamespace;
     protected MongoNamespace gridFsChunksNamespace;
 
@@ -275,6 +275,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
 
     @Tag("setsFailPoint")
     @DisplayName("6. GridFS Upload - uploads via openUploadStream can be timed out")
+    @Test
     public void testGridFSUploadViaOpenUploadStreamTimeout() {
         assumeTrue(serverVersionAtLeast(4, 4));
         long rtt = ClusterFixture.getPrimaryRTT();
@@ -475,7 +476,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
         );
     }
 
-    private MongoNamespace generateNamespace() {
+    protected MongoNamespace generateNamespace() {
         return new MongoNamespace(getDefaultDatabaseName(),
                 getClass().getSimpleName() + "_" + COUNTER.incrementAndGet());
     }

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideOperationTimeoutTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideOperationTimeoutTest.java
@@ -79,13 +79,11 @@ public class ClientSideOperationTimeoutTest extends UnifiedSyncTest {
                 || testDescription.contains("runCommand on database"));
         assumeFalse("No count command helper", testDescription.endsWith("count on collection"));
         assumeFalse("No operation based overrides", fileDescription.equals("timeoutMS can be overridden for an operation"));
-        assumeFalse("No iterateOnce support", testDescription.equals("timeoutMS is refreshed for getMore if maxAwaitTimeMS is not set"));
 
         assumeFalse("TODO (CSOT) - JAVA-5259 No client.withTimeout", testDescription.endsWith("on client"));
 
         checkTransactionSessionSupport(fileDescription, testDescription);
 
-        assumeFalse("TODO (CSOT) - JAVA-4054", fileDescription.equals("timeoutMS behaves correctly for change streams"));
         assumeFalse("TODO (CSOT) - JAVA-4052", fileDescription.startsWith("timeoutMS behaves correctly for retryable operations"));
         assumeFalse("TODO (CSOT) - JAVA-4052", fileDescription.startsWith("legacy timeouts behave correctly for retryable operations"));
 

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
@@ -1556,34 +1556,33 @@ final class UnifiedCrudHelper extends UnifiedHelper {
             throw new UnsupportedOperationException("No entity found for id: " + entityName);
         }
 
-        for (Map.Entry<String, BsonValue> cur : arguments.entrySet()) {
-            switch (cur.getKey()) {
-                case "batchSize":
-                    iterable.batchSize(cur.getValue().asNumber().intValue());
-                    break;
-                case "pipeline":
-                    break;
-                case "comment":
-                    iterable.comment(cur.getValue());
-                    break;
-                case "fullDocument":
-                    iterable.fullDocument(FullDocument.fromString(cur.getValue().asString().getValue()));
-                    break;
-                case "fullDocumentBeforeChange":
-                    iterable.fullDocumentBeforeChange(FullDocumentBeforeChange.fromString(cur.getValue().asString().getValue()));
-                    break;
-                case "maxAwaitTimeMS":
-                    iterable.maxAwaitTime(cur.getValue().asNumber().longValue(), TimeUnit.MILLISECONDS);
-                    break;
-                case "showExpandedEvents":
-                    iterable.showExpandedEvents(cur.getValue().asBoolean().getValue());
-                    break;
-                default:
-                    throw new UnsupportedOperationException("Unsupported argument: " + cur.getKey());
-            }
-        }
-
         return resultOf(() -> {
+            for (Map.Entry<String, BsonValue> cur : arguments.entrySet()) {
+                switch (cur.getKey()) {
+                    case "batchSize":
+                        iterable.batchSize(cur.getValue().asNumber().intValue());
+                        break;
+                    case "pipeline":
+                        break;
+                    case "comment":
+                        iterable.comment(cur.getValue());
+                        break;
+                    case "fullDocument":
+                        iterable.fullDocument(FullDocument.fromString(cur.getValue().asString().getValue()));
+                        break;
+                    case "fullDocumentBeforeChange":
+                        iterable.fullDocumentBeforeChange(FullDocumentBeforeChange.fromString(cur.getValue().asString().getValue()));
+                        break;
+                    case "maxAwaitTimeMS":
+                        iterable.maxAwaitTime(cur.getValue().asNumber().longValue(), TimeUnit.MILLISECONDS);
+                        break;
+                    case "showExpandedEvents":
+                        iterable.showExpandedEvents(cur.getValue().asBoolean().getValue());
+                        break;
+                    default:
+                        throw new UnsupportedOperationException("Unsupported argument: " + cur.getKey());
+                }
+            }
             MongoCursor<BsonDocument> changeStreamWrappingCursor = createChangeStreamWrappingCursor(iterable);
             entities.addCursor(operation.getString("saveResultAsEntity",
                     new BsonString(createRandomEntityId())).getValue(), changeStreamWrappingCursor);
@@ -1600,6 +1599,18 @@ final class UnifiedCrudHelper extends UnifiedHelper {
         }
 
         return resultOf(cursor::next);
+    }
+
+
+    public OperationResult executeIterateOnce(final BsonDocument operation) {
+        String id = operation.getString("object").getValue();
+        MongoCursor<BsonDocument> cursor = entities.getCursor(id);
+
+        if (operation.containsKey("arguments")) {
+            throw new UnsupportedOperationException("Unexpected arguments " + operation.get("arguments"));
+        }
+
+        return resultOf(cursor::tryNext);
     }
 
     public OperationResult close(final BsonDocument operation) {

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -468,6 +468,8 @@ public abstract class UnifiedTest {
                     return crudHelper.close(operation);
                 case "iterateUntilDocumentOrError":
                     return crudHelper.executeIterateUntilDocumentOrError(operation);
+                case "iterateOnce":
+                    return crudHelper.executeIterateOnce(operation);
                 case "delete":
                     return gridFSHelper.executeDelete(operation);
                 case "drop":


### PR DESCRIPTION
<h4> Changes made: </h4>

- Trigger timeout error when maxAwaitTimeMS exceeds a timeoutMS.
- Apply timeoutMS to initial aggregate and subsequent next calls, without appending maxTimeMS to getMore.
- Attempt to resume change stream on subsequent next call if previous next failed with timeout error.
- Use maxAwaitTimeMS as maxTimeMS in getMore commands.
- Preserve change stream validity upon timeout errors. 

<h4> NOTE </h4>

The [Reactive Streams specification](https://github.com/reactive-streams/reactive-streams-jvm#1.6) prevents us from allowing a subsequent next call (event in reactive terms) after a timeout error, conflicting with the CSOT spec requirement not to invalidate the change stream and to try resuming and establishing a new change stream on the server. We immediately let users know about a timeout error, which then closes the stream/publisher.

JAVA-4054