### PR TITLE
Test on Java 21

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -1789,6 +1789,10 @@ axes:
   - id: jdk
     display_name: JDK
     values:
+      - id: "jdk21"
+        display_name: JDK21
+        variables:
+          JAVA_VERSION: "21"
       - id: "jdk17"
         display_name: JDK17
         variables:
@@ -2037,7 +2041,8 @@ buildvariants:
     - name: "test"
 
 - matrix_name: "tests-jdk-secure"
-  matrix_spec: { auth: "auth", ssl: "ssl", jdk: [ "jdk8", "jdk17" ], version: [ "3.6", "4.0", "4.2", "4.4", "5.0", "6.0", "7.0", "latest" ],
+  matrix_spec: { auth: "auth", ssl: "ssl", jdk: [ "jdk8", "jdk17", "jdk21"],
+                 version: [ "3.6", "4.0", "4.2", "4.4", "5.0", "6.0", "7.0", "latest" ],
                  topology: "*", os: "linux" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
   tags: ["tests-variant"]
@@ -2052,26 +2057,28 @@ buildvariants:
     - name: "test"
 
 - matrix_name: "tests-require-api-version"
-  matrix_spec: { api-version: "required", auth: "auth", ssl: "nossl", jdk: ["jdk17"], version: ["5.0", "6.0", "7.0", "latest"], topology: "standalone", os: "linux" }
+  matrix_spec: { api-version: "required", auth: "auth", ssl: "nossl", jdk: ["jdk21"], version: ["5.0", "6.0", "7.0", "latest"],
+                 topology: "standalone", os: "linux" }
   display_name: "${version} ${topology} ${api-version} "
   tags: ["tests-variant"]
   tasks:
     - name: "test"
 
 - matrix_name: "tests-load-balancer-secure"
-  matrix_spec: { auth: "auth", ssl: "ssl", jdk: ["jdk17"], version: ["5.0", "6.0", "7.0", "latest"], topology: "sharded-cluster", os: "ubuntu" }
+  matrix_spec: { auth: "auth", ssl: "ssl", jdk: ["jdk21"], version: ["5.0", "6.0", "7.0", "latest"], topology: "sharded-cluster",
+                 os: "ubuntu" }
   display_name: "Load Balancer ${version} ${auth} ${ssl} ${jdk} ${os}"
   tasks:
     - name: "load-balancer-test"
 
 - matrix_name: "tests-serverless"
-  matrix_spec: { jdk: ["jdk17"], os: "ubuntu" }
+  matrix_spec: { jdk: ["jdk21"], os: "ubuntu" }
   display_name: "Serverless"
   tasks:
     - name: "serverless-test"
 
 - matrix_name: "tests-slow"
-  matrix_spec: { auth: "noauth", ssl: "nossl", jdk: "jdk17", version: ["7.0"], topology: "standalone", os: "linux" }
+  matrix_spec: { auth: "noauth", ssl: "nossl", jdk: "jdk21", version: ["7.0"], topology: "standalone", os: "linux" }
   display_name: "Slow: ${version} ${topology} ${ssl} ${jdk} ${os} "
   tags: ["tests-slow-variant"]
   tasks:
@@ -2113,7 +2120,7 @@ buildvariants:
      - name: "socket-test"
 
 - matrix_name: "test-gssapi"
-  matrix_spec: { jdk: ["jdk8", "jdk17"], os: "linux", gssapi-login-context-name: "*"}
+  matrix_spec: { jdk: ["jdk8", "jdk17", "jdk21"], os: "linux", gssapi-login-context-name: "*"}
   display_name: "GSSAPI (Kerberos) Auth test ${jdk} ${os} ${gssapi-login-context-name}"
   tags: ["test-gssapi-variant"]
   tasks:
@@ -2145,7 +2152,7 @@ buildvariants:
     - name: "test_atlas_task_group_search_indexes"
 
 - matrix_name: "aws-auth-test"
-  matrix_spec: { ssl: "nossl", jdk: ["jdk8", "jdk17"], version: ["4.4", "5.0", "6.0", "7.0", "latest"], os: "ubuntu",
+  matrix_spec: { ssl: "nossl", jdk: ["jdk8", "jdk17", "jdk21"], version: ["4.4", "5.0", "6.0", "7.0", "latest"], os: "ubuntu",
                  aws-credential-provider: "*" }
   display_name: "MONGODB-AWS Basic Auth test ${version} ${jdk} ${aws-credential-provider}"
   run_on: ubuntu2004-small
@@ -2153,7 +2160,7 @@ buildvariants:
     - name: "aws-auth-test-with-regular-aws-credentials"
 
 - matrix_name: "aws-ec2-auth-test"
-  matrix_spec: { ssl: "nossl", jdk: ["jdk17"], version: ["7.0"], os: "ubuntu", aws-credential-provider: "*" }
+  matrix_spec: { ssl: "nossl", jdk: ["jdk21"], version: ["7.0"], os: "ubuntu", aws-credential-provider: "*" }
   display_name: "MONGODB-AWS Advanced Auth test ${version} ${jdk} ${aws-credential-provider}"
   run_on: ubuntu2004-small
   tasks:
@@ -2164,14 +2171,14 @@ buildvariants:
     - name: "aws-auth-test-with-web-identity-credentials"
 
 - matrix_name: "accept-api-version-2-test"
-  matrix_spec: { ssl: "nossl", auth: "noauth", jdk: "jdk17", version: ["5.0", "6.0", "7.0", "latest"], topology: "standalone", os: "linux" }
+  matrix_spec: { ssl: "nossl", auth: "noauth", jdk: "jdk21", version: ["5.0", "6.0", "7.0", "latest"], topology: "standalone", os: "linux" }
   display_name: "Accept API Version 2 ${version}"
   run_on: ubuntu2004-small
   tasks:
     - name: "accept-api-version-2-test"
 
 - matrix_name: "ocsp-test"
-  matrix_spec: { auth: "noauth", ssl: "ssl", jdk: "jdk17", version: ["4.4", "5.0", "6.0", "7.0", "latest"], os: "ubuntu" }
+  matrix_spec: { auth: "noauth", ssl: "ssl", jdk: "jdk21", version: ["4.4", "5.0", "6.0", "7.0", "latest"], os: "ubuntu" }
   display_name: "OCSP test ${version} ${os}"
   tasks:
     - name: ".ocsp"
@@ -2201,14 +2208,15 @@ buildvariants:
     - name: "reactive-streams-tck-test"
 
 - matrix_name: "scala-tests"
-  matrix_spec: { auth: "noauth", ssl: "nossl", jdk: "jdk17", version: ["7.0"], topology: "replicaset", scala: "*", os: "ubuntu" }
+  matrix_spec: { auth: "noauth", ssl: "nossl", jdk: ["jdk8", "jdk17", "jdk21"], version: ["7.0"], topology: "replicaset",
+                 scala: "*", os: "ubuntu" }
   display_name: "${scala} ${version} ${topology} ${os}"
   tags: ["test-scala-variant"]
   tasks:
     - name: "scala-tests"
 
 - matrix_name: "kotlin-tests"
-  matrix_spec: { auth: "noauth", ssl: "nossl", jdk: ["jdk8", "jdk17"], version: ["7.0"], topology: "replicaset", os: "ubuntu" }
+  matrix_spec: { auth: "noauth", ssl: "nossl", jdk: ["jdk8", "jdk17", "jdk21"], version: ["7.0"], topology: "replicaset", os: "ubuntu" }
   display_name: "Kotlin: ${jdk} ${version} ${topology} ${os}"
   tags: ["test-kotlin-variant"]
   tasks:

--- a/.evergreen/javaConfig.bash
+++ b/.evergreen/javaConfig.bash
@@ -3,6 +3,7 @@
 export JDK8="/opt/java/jdk8"
 export JDK11="/opt/java/jdk11"
 export JDK17="/opt/java/jdk17"
+export JDK21="/opt/java/jdk21"
 
 if [ -d "$JDK17" ]; then
   export JAVA_HOME=$JDK17

--- a/.evergreen/run-scala-tests.sh
+++ b/.evergreen/run-scala-tests.sh
@@ -34,4 +34,5 @@ fi
 echo "Running scala tests with Scala $SCALA"
 
 ./gradlew -version
-./gradlew -PscalaVersion=$SCALA --stacktrace --info scalaCheck -Dorg.mongodb.test.uri=${MONGODB_URI} ${MULTI_MONGOS_URI_SYSTEM_PROPERTY}
+./gradlew -PjavaVersion=${JAVA_VERSION} -PscalaVersion=$SCALA --stacktrace --info scalaCheck \
+    -Dorg.mongodb.test.uri=${MONGODB_URI} ${MULTI_MONGOS_URI_SYSTEM_PROPERTY}

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -144,5 +144,5 @@ else
               ${MULTI_MONGOS_URI_SYSTEM_PROPERTY} ${API_VERSION} ${GRADLE_EXTRA_VARS} ${ASYNC_TYPE} \
               ${JAVA_SYSPROP_NETTY_SSL_PROVIDER} \
               -Dorg.mongodb.test.fle.on.demand.credential.test.failure.enabled=true \
-              --stacktrace --info --continue test integrationTest
+              --stacktrace --info --continue test
 fi

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -144,5 +144,5 @@ else
               ${MULTI_MONGOS_URI_SYSTEM_PROPERTY} ${API_VERSION} ${GRADLE_EXTRA_VARS} ${ASYNC_TYPE} \
               ${JAVA_SYSPROP_NETTY_SSL_PROVIDER} \
               -Dorg.mongodb.test.fle.on.demand.credential.test.failure.enabled=true \
-              --stacktrace --info --continue test
+              --stacktrace --info --continue test integrationTest
 fi

--- a/build.gradle
+++ b/build.gradle
@@ -256,8 +256,12 @@ configure(javaCodeCheckedProjects) {
         testImplementation platform('org.spockframework:spock-bom:2.1-groovy-3.0')
         testImplementation 'org.spockframework:spock-core'
         testImplementation 'org.spockframework:spock-junit4'
-        testImplementation("org.mockito:mockito-core:3.8.0")
-        testImplementation("org.mockito:mockito-inline:3.8.0")
+        if ('8'.equals(findProperty("javaVersion"))) {
+            testImplementation("org.mockito:mockito-core:4.6.1")
+            testImplementation("org.mockito:mockito-inline:4.6.1")
+        } else {
+            testImplementation("org.mockito:mockito-core:5.11.0")
+        }
         testImplementation 'cglib:cglib-nodep:2.2.2'
         testImplementation 'org.objenesis:objenesis:1.3'
         testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SocketStreamHelperSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SocketStreamHelperSpecification.groovy
@@ -55,10 +55,18 @@ class SocketStreamHelperSpecification extends Specification {
 
         // If the Java 11+ extended socket options for keep alive probes are available, check those values.
         if (Arrays.stream(ExtendedSocketOptions.getDeclaredFields()).anyMatch{ f -> f.getName().equals('TCP_KEEPCOUNT') }) {
-            Method getOptionMethod = Socket.getMethod('getOption', SocketOption)
-            getOptionMethod.invoke(socket, ExtendedSocketOptions.getDeclaredField('TCP_KEEPCOUNT').get(null)) == 9
-            getOptionMethod.invoke(socket, ExtendedSocketOptions.getDeclaredField('TCP_KEEPIDLE').get(null)) == 120
-            getOptionMethod.invoke(socket, ExtendedSocketOptions.getDeclaredField('TCP_KEEPINTERVAL').get(null)) == 10
+            Method getOptionMethod
+            try {
+                getOptionMethod = Socket.getMethod('getOption', SocketOption)
+            } catch (NoSuchMethodException e) {
+                // ignore, the `Socket.getOption` method was added in Java SE 9 and does not exist in Java SE 8
+                getOptionMethod = null
+            }
+            if (getOptionMethod != null) {
+                getOptionMethod.invoke(socket, ExtendedSocketOptions.getDeclaredField('TCP_KEEPCOUNT').get(null)) == 9
+                getOptionMethod.invoke(socket, ExtendedSocketOptions.getDeclaredField('TCP_KEEPIDLE').get(null)) == 120
+                getOptionMethod.invoke(socket, ExtendedSocketOptions.getDeclaredField('TCP_KEEPINTERVAL').get(null)) == 10
+            }
         }
 
         cleanup:

--- a/driver-reactive-streams/build.gradle
+++ b/driver-reactive-streams/build.gradle
@@ -31,7 +31,12 @@ dependencies {
     testImplementation project(':driver-core').sourceSets.test.output
     testImplementation 'org.reactivestreams:reactive-streams-tck:1.0.4'
     testImplementation 'io.projectreactor:reactor-test'
-    testImplementation 'org.mockito:mockito-junit-jupiter:3.5.13'
+    if ('8'.equals(findProperty("javaVersion"))) {
+        testImplementation 'org.mockito:mockito-junit-jupiter:4.6.1'
+    } else {
+        testImplementation 'org.mockito:mockito-junit-jupiter:5.11.0'
+    }
+
     testRuntimeOnly project(path: ':driver-core', configuration: 'consumableTestRuntimeOnly')
 }
 

--- a/driver-scala/src/integration/scala/org/mongodb/scala/TestMongoClientHelper.scala
+++ b/driver-scala/src/integration/scala/org/mongodb/scala/TestMongoClientHelper.scala
@@ -29,7 +29,7 @@ object TestMongoClientHelper {
 
   val mongoClientURI: String = {
     val uri = Properties.propOrElse(MONGODB_URI_SYSTEM_PROPERTY_NAME, DEFAULT_URI)
-    if (!uri.isBlank) uri else DEFAULT_URI
+    if (!uri.codePoints().allMatch((cp: Int) => Character.isWhitespace(cp))) uri else DEFAULT_URI
   }
   val connectionString: ConnectionString = ConnectionString(mongoClientURI)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ scalaVersions=2.11.12,2.12.15,2.13.6
 defaultScalaVersions=2.13.6
 runOnceTasks=clean,release
 org.gradle.java.installations.auto-download=false
-org.gradle.java.installations.fromEnv=JDK8,JDK11,JDK17
+org.gradle.java.installations.fromEnv=JDK8,JDK11,JDK17,JDK21


### PR DESCRIPTION
This PR builds up on https://github.com/mongodb/mongo-java-driver/pull/1242.

* Add JDK 21 to Gradle configuration
* Add JDK 21 to the test matrix
* Replace JDK 17 with JDK 21 for tasks that are ony run using latest JDK
* Update dependencies (some now have to be conditional)
* Update `run-scala-tests.sh` to use `JAVA_VERSION`
* Run the `scala-tests` task with JDK 8, 17, 21 similarly to `kotlin-tests`
* Fix test code that assumed Java SE 9+

JAVA-5164