### PR TITLE
Retry drop on Interrupted server error

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
@@ -103,6 +103,13 @@ public final class CollectionHelper<T> {
             } catch (MongoWriteConcernException e) {
                 LOGGER.info("Retrying drop collection after a write concern error: " + e);
                 // repeat until success!
+            } catch (MongoCommandException e) {
+                if ("Interrupted".equals(e.getErrorCodeName())) {
+                    LOGGER.info("Retrying drop collection after an Interrupted error: " + e);
+                    // repeat until success!
+                } else {
+                    throw e;
+                }
             }
         }
     }


### PR DESCRIPTION
JAVA-5352

I've observed this failure a few times since migrating more unified tests.  Appears to happen only on 4.0 sharded clusters.  I ran a patch of all those variants twice and was able to trigger the new retry logic in one of the eight runs, and it looks like the Interrupted error happens just once and the next drop execution succeeds.  So the change is effective.