### PR TITLE
Convert Bson to BsonDocument for hint

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/bulk/DeleteRequest.java
+++ b/driver-core/src/main/com/mongodb/internal/bulk/DeleteRequest.java
@@ -19,7 +19,6 @@ package com.mongodb.internal.bulk;
 import com.mongodb.client.model.Collation;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
-import org.bson.conversions.Bson;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -32,7 +31,7 @@ public final class DeleteRequest extends WriteRequest {
     private final BsonDocument filter;
     private boolean isMulti = true;
     private Collation collation;
-    private Bson hint;
+    private BsonDocument hint;
     private String hintString;
 
     public DeleteRequest(final BsonDocument filter) {
@@ -63,11 +62,11 @@ public final class DeleteRequest extends WriteRequest {
     }
 
     @Nullable
-    public Bson getHint() {
+    public BsonDocument getHint() {
         return hint;
     }
 
-    public DeleteRequest hint(@Nullable final Bson hint) {
+    public DeleteRequest hint(@Nullable final BsonDocument hint) {
         this.hint = hint;
         return this;
     }

--- a/driver-core/src/main/com/mongodb/internal/bulk/UpdateRequest.java
+++ b/driver-core/src/main/com/mongodb/internal/bulk/UpdateRequest.java
@@ -20,7 +20,6 @@ import com.mongodb.client.model.Collation;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
-import org.bson.conversions.Bson;
 
 import java.util.List;
 
@@ -39,7 +38,7 @@ public final class UpdateRequest extends WriteRequest {
     private boolean isUpsert = false;
     private Collation collation;
     private List<BsonDocument> arrayFilters;
-    @Nullable private Bson hint;
+    @Nullable private BsonDocument hint;
     @Nullable private String hintString;
 
     public UpdateRequest(final BsonDocument filter, @Nullable final BsonValue update, final Type updateType) {
@@ -111,11 +110,11 @@ public final class UpdateRequest extends WriteRequest {
     }
 
     @Nullable
-    public Bson getHint() {
+    public BsonDocument getHint() {
         return hint;
     }
 
-    public UpdateRequest hint(@Nullable final Bson hint) {
+    public UpdateRequest hint(@Nullable final BsonDocument hint) {
         this.hint = hint;
         return this;
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/SplittablePayload.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SplittablePayload.java
@@ -246,8 +246,8 @@ public final class SplittablePayload {
                 }
                 if (update.getHint() != null) {
                     writer.writeName("hint");
-                    BsonDocument hint = assertNotNull(update.getHint()).toBsonDocument(BsonDocument.class, null);
-                    getCodec(hint).encode(writer, hint, EncoderContext.builder().build());
+                    getCodec(assertNotNull(update.getHint())).encode(writer, assertNotNull(update.getHint()),
+                            EncoderContext.builder().build());
                 } else if (update.getHintString() != null) {
                     writer.writeString("hint", update.getHintString());
                 }
@@ -265,7 +265,7 @@ public final class SplittablePayload {
                 }
                 if (deleteRequest.getHint() != null) {
                     writer.writeName("hint");
-                    BsonDocument hint = assertNotNull(deleteRequest.getHint()).toBsonDocument(BsonDocument.class, null);
+                    BsonDocument hint = assertNotNull(deleteRequest.getHint());
                     getCodec(hint).encode(writer, hint, EncoderContext.builder().build());
                 } else if (deleteRequest.getHintString() != null) {
                     writer.writeString("hint", deleteRequest.getHintString());

--- a/driver-core/src/main/com/mongodb/internal/operation/BaseFindAndModifyOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/BaseFindAndModifyOperation.java
@@ -31,7 +31,6 @@ import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.FieldNameValidator;
 import org.bson.codecs.Decoder;
-import org.bson.conversions.Bson;
 
 import java.util.concurrent.TimeUnit;
 
@@ -62,7 +61,7 @@ public abstract class BaseFindAndModifyOperation<T> implements AsyncWriteOperati
     private BsonDocument sort;
     private long maxTimeMS;
     private Collation collation;
-    private Bson hint;
+    private BsonDocument hint;
     private String hintString;
     private BsonValue comment;
     private BsonDocument variables;
@@ -151,11 +150,11 @@ public abstract class BaseFindAndModifyOperation<T> implements AsyncWriteOperati
     }
 
     @Nullable
-    public Bson getHint() {
+    public BsonDocument getHint() {
         return hint;
     }
 
-    public BaseFindAndModifyOperation<T> hint(@Nullable final Bson hint) {
+    public BaseFindAndModifyOperation<T> hint(@Nullable final BsonDocument hint) {
         this.hint = hint;
         return this;
     }
@@ -216,7 +215,7 @@ public abstract class BaseFindAndModifyOperation<T> implements AsyncWriteOperati
             if (getHint() != null || getHintString() != null) {
                 validateHintForFindAndModify(connectionDescription, getWriteConcern());
                 if (getHint() != null) {
-                    commandDocument.put("hint", getHint().toBsonDocument(BsonDocument.class, null));
+                    commandDocument.put("hint", getHint());
                 } else {
                     commandDocument.put("hint", new BsonString(getHintString()));
                 }

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndDeleteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndDeleteOperation.java
@@ -27,7 +27,6 @@ import org.bson.BsonDocument;
 import org.bson.BsonValue;
 import org.bson.FieldNameValidator;
 import org.bson.codecs.Decoder;
-import org.bson.conversions.Bson;
 
 import java.util.concurrent.TimeUnit;
 
@@ -68,7 +67,7 @@ public class FindAndDeleteOperation<T> extends BaseFindAndModifyOperation<T> {
     }
 
     @Override
-    public FindAndDeleteOperation<T> hint(@Nullable final Bson hint) {
+    public FindAndDeleteOperation<T> hint(@Nullable final BsonDocument hint) {
         super.hint(hint);
         return this;
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
@@ -29,7 +29,6 @@ import org.bson.BsonDocument;
 import org.bson.BsonValue;
 import org.bson.FieldNameValidator;
 import org.bson.codecs.Decoder;
-import org.bson.conversions.Bson;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -111,7 +110,7 @@ public class FindAndReplaceOperation<T> extends BaseFindAndModifyOperation<T> {
     }
 
     @Override
-    public FindAndReplaceOperation<T> hint(@Nullable final Bson hint) {
+    public FindAndReplaceOperation<T> hint(@Nullable final BsonDocument hint) {
         super.hint(hint);
         return this;
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndUpdateOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndUpdateOperation.java
@@ -30,7 +30,6 @@ import org.bson.BsonDocument;
 import org.bson.BsonValue;
 import org.bson.FieldNameValidator;
 import org.bson.codecs.Decoder;
-import org.bson.conversions.Bson;
 
 import java.util.HashMap;
 import java.util.List;
@@ -139,7 +138,7 @@ public class FindAndUpdateOperation<T> extends BaseFindAndModifyOperation<T> {
     }
 
     @Override
-    public FindAndUpdateOperation<T> hint(@Nullable final Bson hint) {
+    public FindAndUpdateOperation<T> hint(@Nullable final BsonDocument hint) {
         super.hint(hint);
         return this;
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -322,7 +322,7 @@ final class Operations<TDocument> {
                 .sort(toBsonDocument(options.getSort()))
                 .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                 .collation(options.getCollation())
-                .hint(options.getHint())
+                .hint(toBsonDocument(options.getHint()))
                 .hintString(options.getHintString())
                 .comment(options.getComment())
                 .let(toBsonDocument(options.getLet()));
@@ -340,7 +340,7 @@ final class Operations<TDocument> {
                 .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
                 .bypassDocumentValidation(options.getBypassDocumentValidation())
                 .collation(options.getCollation())
-                .hint(options.getHint())
+                .hint(toBsonDocument(options.getHint()))
                 .hintString(options.getHintString())
                 .comment(options.getComment())
                 .let(toBsonDocument(options.getLet()));
@@ -358,7 +358,7 @@ final class Operations<TDocument> {
                 .bypassDocumentValidation(options.getBypassDocumentValidation())
                 .collation(options.getCollation())
                 .arrayFilters(toBsonDocumentList(options.getArrayFilters()))
-                .hint(options.getHint())
+                .hint(toBsonDocument(options.getHint()))
                 .hintString(options.getHintString())
                 .comment(options.getComment())
                 .let(toBsonDocument(options.getLet()));
@@ -377,7 +377,7 @@ final class Operations<TDocument> {
                 .bypassDocumentValidation(options.getBypassDocumentValidation())
                 .collation(options.getCollation())
                 .arrayFilters(toBsonDocumentList(options.getArrayFilters()))
-                .hint(options.getHint())
+                .hint(toBsonDocument(options.getHint()))
                 .hintString(options.getHintString())
                 .comment(options.getComment())
                 .let(toBsonDocument(options.getLet()));
@@ -470,7 +470,7 @@ final class Operations<TDocument> {
                         WriteRequest.Type.REPLACE)
                         .upsert(replaceOneModel.getReplaceOptions().isUpsert())
                         .collation(replaceOneModel.getReplaceOptions().getCollation())
-                        .hint(replaceOneModel.getReplaceOptions().getHint())
+                        .hint(toBsonDocument(replaceOneModel.getReplaceOptions().getHint()))
                         .hintString(replaceOneModel.getReplaceOptions().getHintString());
             } else if (writeModel instanceof UpdateOneModel) {
                 UpdateOneModel<TDocument> updateOneModel = (UpdateOneModel<TDocument>) writeModel;
@@ -481,7 +481,7 @@ final class Operations<TDocument> {
                         .upsert(updateOneModel.getOptions().isUpsert())
                         .collation(updateOneModel.getOptions().getCollation())
                         .arrayFilters(toBsonDocumentList(updateOneModel.getOptions().getArrayFilters()))
-                        .hint(updateOneModel.getOptions().getHint())
+                        .hint(toBsonDocument(updateOneModel.getOptions().getHint()))
                         .hintString(updateOneModel.getOptions().getHintString());
             } else if (writeModel instanceof UpdateManyModel) {
                 UpdateManyModel<TDocument> updateManyModel = (UpdateManyModel<TDocument>) writeModel;
@@ -492,19 +492,19 @@ final class Operations<TDocument> {
                         .upsert(updateManyModel.getOptions().isUpsert())
                         .collation(updateManyModel.getOptions().getCollation())
                         .arrayFilters(toBsonDocumentList(updateManyModel.getOptions().getArrayFilters()))
-                        .hint(updateManyModel.getOptions().getHint())
+                        .hint(toBsonDocument(updateManyModel.getOptions().getHint()))
                         .hintString(updateManyModel.getOptions().getHintString());
             } else if (writeModel instanceof DeleteOneModel) {
                 DeleteOneModel<TDocument> deleteOneModel = (DeleteOneModel<TDocument>) writeModel;
                 writeRequest = new DeleteRequest(assertNotNull(toBsonDocument(deleteOneModel.getFilter()))).multi(false)
                         .collation(deleteOneModel.getOptions().getCollation())
-                        .hint(deleteOneModel.getOptions().getHint())
+                        .hint(toBsonDocument(deleteOneModel.getOptions().getHint()))
                         .hintString(deleteOneModel.getOptions().getHintString());
             } else if (writeModel instanceof DeleteManyModel) {
                 DeleteManyModel<TDocument> deleteManyModel = (DeleteManyModel<TDocument>) writeModel;
                 writeRequest = new DeleteRequest(assertNotNull(toBsonDocument(deleteManyModel.getFilter()))).multi(true)
                         .collation(deleteManyModel.getOptions().getCollation())
-                        .hint(deleteManyModel.getOptions().getHint())
+                        .hint(toBsonDocument(deleteManyModel.getOptions().getHint()))
                         .hintString(deleteManyModel.getOptions().getHintString());
             } else {
                 throw new UnsupportedOperationException(format("WriteModel of type %s is not supported", writeModel.getClass()));


### PR DESCRIPTION
Unlike every other instance of Bson in the CRUD API, the hint option for write operations was not converted to a BsonDocument prior to passing it down to the operation layer.  This is a problem because the operation layer doesn't have a CodecRegistry available, and so can not properly due the conversion.

In this commit, all hint options are converted to BsonDocument in the same place as all the other Bson options, where a CodecRegistry is available to properly do the conversion.

JAVA-5357

Note that no additional tests have been added.  The coverage for hint is the same as for all the other Bson-typed options (e.g. filter, projection).  