### PR TITLE
Skip rangePreview tests on server 8.0+

### DIFF
--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Aggregate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Correctness.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Delete.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-InsertFind.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Date-Update.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Aggregate.json
@@ -2,10 +2,10 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Correctness.json
@@ -2,10 +2,10 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Delete.json
@@ -2,10 +2,10 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
@@ -2,10 +2,10 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-InsertFind.json
@@ -2,10 +2,10 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Decimal-Update.json
@@ -2,10 +2,10 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Update.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Aggregate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Correctness.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Delete.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-InsertFind.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Double-Update.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Delete.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Update.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Aggregate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Correctness.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Delete.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-InsertFind.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Int-Update.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Aggregate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Aggregate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Correctness.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Correctness.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Delete.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Delete.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-InsertFind.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-InsertFind.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Update.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-Long-Update.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-WrongType.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/fle2v2-Range-WrongType.json
@@ -2,12 +2,12 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionRangeExplicitEncryptionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionRangeExplicitEncryptionTest.java
@@ -60,6 +60,7 @@ import java.util.Map;
 import static com.mongodb.ClusterFixture.isServerlessTest;
 import static com.mongodb.ClusterFixture.isStandalone;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.ClusterFixture.serverVersionLessThan;
 import static com.mongodb.client.Fixture.getDefaultDatabase;
 import static com.mongodb.client.Fixture.getDefaultDatabaseName;
 import static com.mongodb.client.Fixture.getMongoClient;
@@ -91,6 +92,7 @@ public abstract class AbstractClientSideEncryptionRangeExplicitEncryptionTest {
 
     @BeforeEach
     public void setUp(final Type type) {
+        assumeTrue(serverVersionLessThan(8, 0));
         assumeTrue(serverVersionAtLeast(6, 2));
         assumeFalse(isStandalone());
         assumeFalse(isServerlessTest());


### PR DESCRIPTION
JAVA-5321

Skip tests using the `rangePreview` algorithm for server 8.0+:
- Skip specification tests with the name `fle2v2-Range-*`
- Skip the prose test `22. Range Explicit Encryption`.

This PR does not resolve DRIVERS-2767. This PR is intended to prevent failures in driver of latest server builds until `range` tests are added.