### PR TITLE
Exclude `:graalvm-native-image-app` from being published

### DIFF
--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -17,7 +17,7 @@ import static org.gradle.util.CollectionUtils.single
  */
 
 
-def projectsThatDoNotPublishJavaDocs = project(":util").allprojects + project(":driver-benchmarks") + project("driver-workload-executor") + project("driver-lambda")
+def projectsThatDoNotPublishJavaDocs = project(":util").allprojects + project(":driver-benchmarks") + project("driver-workload-executor") + project("driver-lambda") + project(":graalvm-native-image-app")
 def javaMainProjects = subprojects - projectsThatDoNotPublishJavaDocs
 
 task docs {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -68,7 +68,7 @@ ext {
     }
 }
 
-def projectsNotPublishedToMaven = project(":util").allprojects + project(":driver-benchmarks") + project("driver-workload-executor") + project("driver-lambda")
+def projectsNotPublishedToMaven = project(":util").allprojects + project(":driver-benchmarks") + project("driver-workload-executor") + project("driver-lambda") + project(":graalvm-native-image-app")
 def publishedProjects = subprojects - projectsNotPublishedToMaven
 def scalaProjects = publishedProjects.findAll { it.name.contains('scala') }
 def javaProjects = publishedProjects - scalaProjects


### PR DESCRIPTION
Tested by manually doing the following:

- `rm -r ~/.m2/repository/org/mongodb`
- `rm -r ./build/docs`
- `./gradlew clean docs publishToMavenLocal -x signMavenJavaPublication`
- - check that `./build/docs/bson` exists and `./build/docs/graalvm-native-image-app` does not.
- check that `~/.m2/repository/org/mongodb/bson` exists and `~/.m2/repository/org/mongodb/graalvm-native-image-app` does not.

JAVA-5414