### PR TITLE
Fix regression in timeout handling.

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -187,7 +187,7 @@ public class TimeoutContext {
 
     public void runMaxTimeMS(final LongConsumer onRemaining) {
         if (maxTimeSupplier != null) {
-            onRemaining.accept(maxTimeSupplier.get());
+            runWithFixedTimout(maxTimeSupplier.get(), onRemaining);
         }
         if (timeout != null) {
             timeout.shortenBy(minRoundTripTimeMS, MILLISECONDS)
@@ -198,7 +198,13 @@ public class TimeoutContext {
                                 throw createMongoRoundTripTimeoutException();
                             });
         } else {
-            onRemaining.accept(timeoutSettings.getMaxTimeMS());
+            runWithFixedTimout(timeoutSettings.getMaxTimeMS(), onRemaining);
+        }
+    }
+
+    private static void runWithFixedTimout(final long ms, final LongConsumer onRemaining) {
+        if (ms != 0) {
+            onRemaining.accept(ms);
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -187,11 +187,11 @@ public class TimeoutContext {
 
     public void runMaxTimeMS(final LongConsumer onRemaining) {
         if (maxTimeSupplier != null) {
-            runWithFixedTimout(maxTimeSupplier.get(), onRemaining);
+            runWithFixedTimeout(maxTimeSupplier.get(), onRemaining);
             return;
         }
         if (timeout == null) {
-            runWithFixedTimout(timeoutSettings.getMaxTimeMS(), onRemaining);
+            runWithFixedTimeout(timeoutSettings.getMaxTimeMS(), onRemaining);
             return;
         }
         timeout.shortenBy(minRoundTripTimeMS, MILLISECONDS)
@@ -204,7 +204,7 @@ public class TimeoutContext {
 
     }
 
-    private static void runWithFixedTimout(final long ms, final LongConsumer onRemaining) {
+    private static void runWithFixedTimeout(final long ms, final LongConsumer onRemaining) {
         if (ms != 0) {
             onRemaining.accept(ms);
         }

--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -188,18 +188,20 @@ public class TimeoutContext {
     public void runMaxTimeMS(final LongConsumer onRemaining) {
         if (maxTimeSupplier != null) {
             runWithFixedTimout(maxTimeSupplier.get(), onRemaining);
+            return;
         }
-        if (timeout != null) {
-            timeout.shortenBy(minRoundTripTimeMS, MILLISECONDS)
-                    .run(MILLISECONDS,
-                            () -> {},
-                            onRemaining,
-                            () -> {
-                                throw createMongoRoundTripTimeoutException();
-                            });
-        } else {
+        if (timeout == null) {
             runWithFixedTimout(timeoutSettings.getMaxTimeMS(), onRemaining);
+            return;
         }
+        timeout.shortenBy(minRoundTripTimeMS, MILLISECONDS)
+                .run(MILLISECONDS,
+                        () -> {},
+                        onRemaining,
+                        () -> {
+                            throw createMongoRoundTripTimeoutException();
+                        });
+
     }
 
     private static void runWithFixedTimout(final long ms, final LongConsumer onRemaining) {

--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -185,26 +185,20 @@ public class TimeoutContext {
         return timeoutSettings.getMaxAwaitTimeMS();
     }
 
-    public void runMaxTimeMSTimeout(final Runnable onInfinite, final LongConsumer onRemaining,
-            final Runnable onExpired) {
+    public void runMaxTimeMS(final LongConsumer onRemaining) {
         if (maxTimeSupplier != null) {
-            runWithFixedTimout(maxTimeSupplier.get(), onInfinite, onRemaining);
-            return;
+            onRemaining.accept(maxTimeSupplier.get());
         }
-
         if (timeout != null) {
             timeout.shortenBy(minRoundTripTimeMS, MILLISECONDS)
-                    .run(MILLISECONDS, onInfinite, onRemaining, onExpired);
+                    .run(MILLISECONDS,
+                            () -> {},
+                            onRemaining,
+                            () -> {
+                                throw createMongoRoundTripTimeoutException();
+                            });
         } else {
-            runWithFixedTimout(timeoutSettings.getMaxTimeMS(), onInfinite, onRemaining);
-        }
-    }
-
-    private static void runWithFixedTimout(final long ms, final Runnable onInfinite, final LongConsumer onRemaining) {
-        if (ms == 0) {
-            onInfinite.run();
-        } else {
-            onRemaining.accept(ms);
+            onRemaining.accept(timeoutSettings.getMaxTimeMS());
         }
     }
 
@@ -214,7 +208,10 @@ public class TimeoutContext {
 
     /**
      * The override will be provided as the remaining value in
-     * {@link #runMaxTimeMSTimeout}, where 0 will invoke the onExpired path
+     * {@link #runMaxTimeMS}, where 0 is ignored.
+     * <p>
+     * NOTE: Suitable for static user-defined values only (i.e MaxAwaitTimeMS),
+     * not for running timeouts that adjust dynamically.
      */
     public void setMaxTimeOverride(final long maxTimeMS) {
         this.maxTimeSupplier = () -> maxTimeMS;
@@ -222,7 +219,7 @@ public class TimeoutContext {
 
     /**
      * The override will be provided as the remaining value in
-     * {@link #runMaxTimeMSTimeout}, where 0 will invoke the onExpired path
+     * {@link #runMaxTimeMS}, where 0 is ignored.
      */
     public void setMaxTimeOverrideToMaxCommitTime() {
         this.maxTimeSupplier = () -> getMaxCommitTimeMS();
@@ -242,12 +239,12 @@ public class TimeoutContext {
         return timeoutOrAlternative(0);
     }
 
-    public Timeout createConnectTimeoutMs() {
-        // null timeout treated as infinite will be later than the other
-
-        return Timeout.earliest(
-                Timeout.expiresIn(getTimeoutSettings().getConnectTimeoutMS(), MILLISECONDS, ZERO_DURATION_MEANS_INFINITE),
-                Timeout.nullAsInfinite(timeout));
+    public int getConnectTimeoutMs() {
+        final long connectTimeoutMS = getTimeoutSettings().getConnectTimeoutMS();
+        return Math.toIntExact(Timeout.nullAsInfinite(timeout).call(MILLISECONDS,
+                () -> connectTimeoutMS,
+                (ms) -> connectTimeoutMS == 0 ? ms : Math.min(ms, connectTimeoutMS),
+                () -> throwMongoTimeoutException("The operation timeout has expired.")));
     }
 
     public void resetTimeout() {

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
@@ -222,12 +222,9 @@ public final class CommandMessage extends RequestMessage {
 
         List<BsonElement> extraElements = new ArrayList<>();
         if (!getSettings().isCryptd()) {
-            timeoutContext.runMaxTimeMSTimeout(
-                    () -> {},
-                    (ms) -> extraElements.add(new BsonElement("maxTimeMS", new BsonInt64(ms))),
-                    () -> {
-                        throw TimeoutContext.createMongoRoundTripTimeoutException();
-                    });
+           timeoutContext.runMaxTimeMS(maxTimeMS ->
+                   extraElements.add(new BsonElement("maxTimeMS", new BsonInt64(maxTimeMS)))
+           );
         }
         extraElements.add(new BsonElement("$db", new BsonString(new MongoNamespace(getCollectionName()).getDatabaseName())));
         if (sessionContext.getClusterTime() != null) {

--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStreamHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStreamHelper.java
@@ -27,9 +27,7 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.net.SocketOption;
 
-import static com.mongodb.internal.TimeoutContext.throwMongoTimeoutException;
 import static com.mongodb.internal.connection.SslHelper.configureSslSocket;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
 final class SocketStreamHelper {
@@ -75,10 +73,7 @@ final class SocketStreamHelper {
             final SslSettings sslSettings) throws IOException {
         configureSocket(socket, operationContext, settings);
         configureSslSocket(socket, sslSettings, inetSocketAddress);
-        operationContext.getTimeoutContext().createConnectTimeoutMs().checkedRun(MILLISECONDS,
-                () -> socket.connect(inetSocketAddress, 0),
-                (ms) -> socket.connect(inetSocketAddress, Math.toIntExact(ms)),
-                () -> throwMongoTimeoutException("The operation timeout has expired."));
+        socket.connect(inetSocketAddress, operationContext.getTimeoutContext().getConnectTimeoutMs());
     }
 
     static void configureSocket(final Socket socket, final OperationContext operationContext, final SocketSettings settings) throws SocketException {

--- a/driver-core/src/main/com/mongodb/internal/connection/netty/NettyStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/netty/NettyStream.java
@@ -71,7 +71,6 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.internal.Locks.withLock;
-import static com.mongodb.internal.TimeoutContext.throwMongoTimeoutException;
 import static com.mongodb.internal.connection.ServerAddressHelper.getSocketAddresses;
 import static com.mongodb.internal.connection.SslHelper.enableHostNameVerification;
 import static com.mongodb.internal.connection.SslHelper.enableSni;
@@ -192,10 +191,8 @@ final class NettyStream implements Stream {
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(workerGroup);
             bootstrap.channel(socketChannelClass);
-            operationContext.getTimeoutContext().createConnectTimeoutMs().checkedRun(MILLISECONDS,
-                    () -> bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 0),
-                    (ms) -> bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Math.toIntExact(ms)),
-                    () -> throwMongoTimeoutException("The operation timeout has expired."));
+            bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS,
+                    operationContext.getTimeoutContext().getConnectTimeoutMs());
             bootstrap.option(ChannelOption.TCP_NODELAY, true);
             bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
 

--- a/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
@@ -197,16 +197,19 @@ final class TimeoutContextTest {
 
         assertThrows(MongoOperationTimeoutException.class, smallTimeout::getReadTimeoutMS);
         assertThrows(MongoOperationTimeoutException.class, smallTimeout::getWriteTimeoutMS);
+        assertThrows(MongoOperationTimeoutException.class, smallTimeout::getConnectTimeoutMs);
         assertThrows(MongoOperationTimeoutException.class, () -> getMaxTimeMS(smallTimeout));
         assertThrows(MongoOperationTimeoutException.class, smallTimeout::getMaxCommitTimeMS);
         assertThrows(MongoOperationTimeoutException.class, () -> smallTimeout.timeoutOrAlternative(1));
         assertDoesNotThrow(longTimeout::getReadTimeoutMS);
         assertDoesNotThrow(longTimeout::getWriteTimeoutMS);
+        assertDoesNotThrow(longTimeout::getConnectTimeoutMs);
         assertDoesNotThrow(() -> getMaxTimeMS(longTimeout));
         assertDoesNotThrow(longTimeout::getMaxCommitTimeMS);
         assertDoesNotThrow(() -> longTimeout.timeoutOrAlternative(1));
         assertDoesNotThrow(noTimeout::getReadTimeoutMS);
         assertDoesNotThrow(noTimeout::getWriteTimeoutMS);
+        assertDoesNotThrow(noTimeout::getConnectTimeoutMs);
         assertDoesNotThrow(() -> getMaxTimeMS(noTimeout));
         assertDoesNotThrow(noTimeout::getMaxCommitTimeMS);
         assertDoesNotThrow(() -> noTimeout.timeoutOrAlternative(1));

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageTest.java
@@ -60,7 +60,7 @@ class CommandMessageTest {
         BasicOutputBuffer bsonOutput = new BasicOutputBuffer();
         SessionContext sessionContext = mock(SessionContext.class);
         TimeoutContext timeoutContext = mock(TimeoutContext.class, mock -> {
-            doThrow(new MongoOperationTimeoutException("test")).when(mock).runMaxTimeMSTimeout(any(), any(), any());
+            doThrow(new MongoOperationTimeoutException("test")).when(mock).runMaxTimeMS(any());
         });
         OperationContext operationContext = mock(OperationContext.class, mock -> {
             when(mock.getSessionContext()).thenReturn(sessionContext);


### PR DESCRIPTION
- Resolve regression where CSOT exception is exposed despite CSOT being disabled.
- Correct premature decrease in connect timeout before connection initiation.
- Encapsulating logic within TimeoutContext.

JAVA-5439