### PR TITLE
Remove support for MongoDB 3.6

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -1802,10 +1802,6 @@ axes:
         display_name: "4.0"
         variables:
            VERSION: "4.0"
-      - id: "3.6"
-        display_name: "3.6"
-        variables:
-           VERSION: "3.6"
   - id: os
     display_name: OS
     values:
@@ -2223,7 +2219,7 @@ buildvariants:
     - name: "test"
 
 - matrix_name: "tests-jdk8-unsecure"
-  matrix_spec: { auth: "noauth", ssl: "nossl", jdk: "jdk8", version: ["3.6", "4.0", "4.2", "4.4", "5.0", "6.0", "7.0", "latest"],
+  matrix_spec: { auth: "noauth", ssl: "nossl", jdk: "jdk8", version: ["4.0", "4.2", "4.4", "5.0", "6.0", "7.0", "latest"],
                  topology: "*", os: "linux" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
   tags: ["tests-variant"]
@@ -2232,7 +2228,7 @@ buildvariants:
 
 - matrix_name: "tests-jdk-secure"
   matrix_spec: { auth: "auth", ssl: "ssl", jdk: [ "jdk8", "jdk17", "jdk21"],
-                 version: [ "3.6", "4.0", "4.2", "4.4", "5.0", "6.0", "7.0", "latest" ],
+                 version: ["4.0", "4.2", "4.4", "5.0", "6.0", "7.0", "latest" ],
                  topology: "*", os: "linux" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
   tags: ["tests-variant"]

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultAuthenticator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultAuthenticator.java
@@ -32,7 +32,6 @@ import static com.mongodb.AuthenticationMechanism.SCRAM_SHA_1;
 import static com.mongodb.AuthenticationMechanism.SCRAM_SHA_256;
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.isTrueArgument;
-import static com.mongodb.internal.operation.ServerVersionHelper.serverIsLessThanVersionFourDotZero;
 import static java.lang.String.format;
 
 class DefaultAuthenticator extends Authenticator implements SpeculativeAuthenticator {
@@ -48,29 +47,19 @@ class DefaultAuthenticator extends Authenticator implements SpeculativeAuthentic
 
     @Override
     void authenticate(final InternalConnection connection, final ConnectionDescription connectionDescription) {
-        if (serverIsLessThanVersionFourDotZero(connectionDescription)) {
-            new ScramShaAuthenticator(getMongoCredentialWithCache().withMechanism(SCRAM_SHA_1), getClusterConnectionMode(), getServerApi())
-                    .authenticate(connection, connectionDescription);
-        } else {
-            try {
-                setDelegate(connectionDescription);
-                delegate.authenticate(connection, connectionDescription);
-            } catch (Exception e) {
-                throw wrapException(e);
-            }
+        try {
+            setDelegate(connectionDescription);
+            delegate.authenticate(connection, connectionDescription);
+        } catch (Exception e) {
+            throw wrapException(e);
         }
     }
 
     @Override
     void authenticateAsync(final InternalConnection connection, final ConnectionDescription connectionDescription,
                            final SingleResultCallback<Void> callback) {
-        if (serverIsLessThanVersionFourDotZero(connectionDescription)) {
-            new ScramShaAuthenticator(getMongoCredentialWithCache().withMechanism(SCRAM_SHA_1), getClusterConnectionMode(), getServerApi())
-                    .authenticateAsync(connection, connectionDescription, callback);
-        } else {
-            setDelegate(connectionDescription);
-            delegate.authenticateAsync(connection, connectionDescription, callback);
-        }
+        setDelegate(connectionDescription);
+        delegate.authenticateAsync(connection, connectionDescription, callback);
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
@@ -33,10 +33,6 @@ public final class ServerVersionHelper {
     public static final int SIX_DOT_ZERO_WIRE_VERSION = 17;
     private static final int SEVEN_DOT_ZERO_WIRE_VERSION = 21;
 
-    public static boolean serverIsAtLeastVersionFourDotZero(final ConnectionDescription description) {
-        return description.getMaxWireVersion() >= FOUR_DOT_ZERO_WIRE_VERSION;
-    }
-
     public static boolean serverIsAtLeastVersionFourDotTwo(final ConnectionDescription description) {
         return description.getMaxWireVersion() >= FOUR_DOT_TWO_WIRE_VERSION;
     }
@@ -47,10 +43,6 @@ public final class ServerVersionHelper {
 
     public static boolean serverIsAtLeastVersionFiveDotZero(final ConnectionDescription description) {
         return description.getMaxWireVersion() >= FIVE_DOT_ZERO_WIRE_VERSION;
-    }
-
-    public static boolean serverIsLessThanVersionFourDotZero(final ConnectionDescription description) {
-        return description.getMaxWireVersion() < FOUR_DOT_ZERO_WIRE_VERSION;
     }
 
     public static boolean serverIsLessThanVersionFourDotTwo(final ConnectionDescription description) {

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -330,11 +330,8 @@ public final class ClusterFixture {
 
     private static ReadWriteBinding getBinding(final Cluster cluster, final ReadPreference readPreference) {
         if (!BINDING_MAP.containsKey(readPreference)) {
-            ReadWriteBinding binding = new ClusterBinding(cluster, readPreference, ReadConcern.DEFAULT, getServerApi(),
-                    IgnorableRequestContext.INSTANCE);
-            if (serverVersionAtLeast(3, 6)) {
-                binding = new SessionBinding(binding);
-            }
+            ReadWriteBinding binding = new SessionBinding(new ClusterBinding(cluster, readPreference, ReadConcern.DEFAULT, getServerApi(),
+                    IgnorableRequestContext.INSTANCE));
             BINDING_MAP.put(readPreference, binding);
         }
         return BINDING_MAP.get(readPreference);
@@ -367,11 +364,8 @@ public final class ClusterFixture {
 
     public static AsyncReadWriteBinding getAsyncBinding(final Cluster cluster, final ReadPreference readPreference) {
         if (!ASYNC_BINDING_MAP.containsKey(readPreference)) {
-            AsyncReadWriteBinding binding = new AsyncClusterBinding(cluster, readPreference, ReadConcern.DEFAULT, getServerApi(),
-                    IgnorableRequestContext.INSTANCE);
-            if (serverVersionAtLeast(3, 6)) {
-                binding = new AsyncSessionBinding(binding);
-            }
+            AsyncReadWriteBinding binding = new AsyncSessionBinding(new AsyncClusterBinding(cluster, readPreference, ReadConcern.DEFAULT,
+                    getServerApi(), IgnorableRequestContext.INSTANCE));
             ASYNC_BINDING_MAP.put(readPreference, binding);
         }
         return ASYNC_BINDING_MAP.get(readPreference);

--- a/driver-core/src/test/functional/com/mongodb/client/CommandMonitoringTestHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/CommandMonitoringTestHelper.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.CrudTestHelper.replaceTypeAssertionWithActual;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -90,11 +89,9 @@ public final class CommandMonitoringTestHelper {
                 }
 
                 // Not clear whether these global fields should be included, but also not clear how to efficiently exclude them
-                if (serverVersionAtLeast(3, 6)) {
-                    commandDocument.put("$db", new BsonString(actualDatabaseName));
-                    if (operation != null && operation.containsKey("read_preference")) {
-                        commandDocument.put("$readPreference", operation.getDocument("read_preference"));
-                    }
+                commandDocument.put("$db", new BsonString(actualDatabaseName));
+                if (operation != null && operation.containsKey("read_preference")) {
+                    commandDocument.put("$readPreference", operation.getDocument("read_preference"));
                 }
                 commandEvent = new CommandStartedEvent(null, 1, 1, null, actualDatabaseName, commandName,
                         commandDocument);

--- a/driver-legacy/src/main/com/mongodb/MapReduceCommand.java
+++ b/driver-legacy/src/main/com/mongodb/MapReduceCommand.java
@@ -222,7 +222,7 @@ public class MapReduceCommand {
     /**
      * Sets the max execution time for this command, in the given time unit.
      *
-     * @param maxTime  the maximum execution time. A non-zero value requires a server version &gt;= 2.6
+     * @param maxTime  the maximum execution time.
      * @param timeUnit the time unit that maxTime is specified in
      * @since 2.12.0
      */

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionAggregationTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionAggregationTest.java
@@ -28,7 +28,6 @@ import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isSharded;
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.connection.ClusterType.REPLICA_SET;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -104,7 +103,6 @@ public class DBCollectionAggregationTest extends DatabaseTestCase {
 
     @Test
     public void testExplain() {
-        assumeTrue(serverVersionAtLeast(3, 6));
         List<DBObject> pipeline = new ArrayList<>(prepareData());
         CommandResult out = collection.explainAggregate(pipeline, AggregationOptions.builder().build());
         assertTrue(out.keySet().iterator().hasNext());
@@ -133,7 +131,6 @@ public class DBCollectionAggregationTest extends DatabaseTestCase {
     @Test
     public void testWriteConcern() {
         assumeThat(isDiscoverableReplicaSet(), is(true));
-        assumeTrue(serverVersionAtLeast(3, 4));
         DBCollection collection = database.getCollection("testWriteConcern");
         collection.setWriteConcern(new WriteConcern(5));
         try {

--- a/driver-legacy/src/test/functional/com/mongodb/DBCursorTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCursorTest.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.isSharded;
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -394,13 +393,7 @@ public class DBCursorTest extends DatabaseTestCase {
             assertEquals(1, profileCollection.count());
 
             DBObject profileDocument = profileCollection.findOne();
-            if (serverVersionAtLeast(3, 6)) {
-                assertEquals(expectedComment, ((DBObject) profileDocument.get("command")).get("comment"));
-            } else if (serverVersionAtLeast(3, 2)) {
-                assertEquals(expectedComment, ((DBObject) profileDocument.get("query")).get("comment"));
-            } else {
-                assertEquals(expectedComment, ((DBObject) profileDocument.get("query")).get("$comment"));
-            }
+            assertEquals(expectedComment, ((DBObject) profileDocument.get("query")).get("$comment"));
         } finally {
             database.command(new BasicDBObject("profile", 0));
             profileCollection.drop();

--- a/driver-legacy/src/test/functional/com/mongodb/DBTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBTest.java
@@ -36,7 +36,6 @@ import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.getBinding;
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isSharded;
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.DBObjectMatchers.hasFields;
 import static com.mongodb.DBObjectMatchers.hasSubdocument;
 import static com.mongodb.Fixture.getDefaultDatabaseName;
@@ -162,7 +161,6 @@ public class DBTest extends DatabaseTestCase {
 
     @Test
     public void shouldCreateCollectionWithTheSetCollation() {
-        assumeThat(serverVersionAtLeast(3, 4), is(true));
         // Given
         collection.drop();
         Collation collation = Collation.builder()

--- a/driver-legacy/src/test/functional/com/mongodb/MapReduceTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/MapReduceTest.java
@@ -29,7 +29,6 @@ import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isSharded;
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.ClusterFixture.serverVersionLessThan;
 import static com.mongodb.DBObjectMatchers.hasFields;
 import static com.mongodb.DBObjectMatchers.hasSubdocument;
@@ -48,7 +47,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
-import static org.junit.Assume.assumeTrue;
 
 @SuppressWarnings("deprecation")
 public class MapReduceTest extends DatabaseTestCase {
@@ -108,7 +106,6 @@ public class MapReduceTest extends DatabaseTestCase {
     @Test
     public void testWriteConcern() {
         assumeThat(isDiscoverableReplicaSet(), is(true));
-        assumeTrue(serverVersionAtLeast(3, 4));
         DBCollection collection = database.getCollection("testWriteConcernForMapReduce");
         collection.insert(new BasicDBObject("x", new String[]{"a", "b"}).append("s", 1));
         collection.setWriteConcern(new WriteConcern(5));

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/BatchCursorPublisherErrorTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/BatchCursorPublisherErrorTest.java
@@ -34,13 +34,11 @@ import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
 import static com.mongodb.reactivestreams.client.Fixture.drop;
 import static com.mongodb.reactivestreams.client.Fixture.getDefaultDatabase;
 import static com.mongodb.reactivestreams.client.Fixture.getMongoClient;
-import static com.mongodb.reactivestreams.client.Fixture.serverVersionAtLeast;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.IntStream.rangeClosed;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
 public class BatchCursorPublisherErrorTest {
@@ -49,7 +47,6 @@ public class BatchCursorPublisherErrorTest {
 
     @BeforeEach
     public void setup() {
-        assumeTrue(serverVersionAtLeast(3, 6));
         collection = getDefaultDatabase().getCollection("changeStreamsCancellationTest");
         Mono.from(collection.insertMany(rangeClosed(1, 11)
                 .boxed()

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ChangeStreamsCancellationTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ChangeStreamsCancellationTest.java
@@ -27,7 +27,6 @@ import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
 import static com.mongodb.reactivestreams.client.Fixture.drop;
 import static com.mongodb.reactivestreams.client.Fixture.getDefaultDatabase;
 import static com.mongodb.reactivestreams.client.Fixture.isReplicaSet;
-import static com.mongodb.reactivestreams.client.Fixture.serverVersionAtLeast;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -37,7 +36,7 @@ public class ChangeStreamsCancellationTest {
 
     @BeforeEach
     public void setup() {
-        assumeTrue(isReplicaSet() && serverVersionAtLeast(3, 6));
+        assumeTrue(isReplicaSet());
         collection = getDefaultDatabase().getCollection("changeStreamsCancellationTest");
     }
 

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ReadConcernTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ReadConcernTest.java
@@ -30,12 +30,10 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 
 import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.CommandMonitoringTestHelper.assertEventsEquality;
 import static com.mongodb.reactivestreams.client.Fixture.getDefaultDatabaseName;
 import static com.mongodb.reactivestreams.client.Fixture.getMongoClientBuilderFromConnectionString;
 import static java.util.Collections.singletonList;
-import static org.junit.Assume.assumeTrue;
 
 public class ReadConcernTest {
     private TestCommandListener commandListener;
@@ -43,7 +41,6 @@ public class ReadConcernTest {
 
     @Before
     public void setUp() {
-        assumeTrue(canRunTests());
         commandListener = new TestCommandListener();
         mongoClient = MongoClients.create(getMongoClientBuilderFromConnectionString()
                 .addCommandListener(commandListener)
@@ -73,9 +70,5 @@ public class ReadConcernTest {
 
         assertEventsEquality(singletonList(new CommandStartedEvent(null, 1, 1, null, getDefaultDatabaseName(), "find", commandDocument)),
                 events);
-    }
-
-    private boolean canRunTests() {
-        return serverVersionAtLeast(3, 2);
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/RetryableWritesProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/RetryableWritesProseTest.java
@@ -33,7 +33,6 @@ import static com.mongodb.ClusterFixture.TIMEOUT_DURATION;
 import static com.mongodb.ClusterFixture.getServerStatus;
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isSharded;
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.ClusterFixture.serverVersionLessThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -113,6 +112,6 @@ public class RetryableWritesProseTest extends DatabaseTestCase {
 
         return ((isSharded() || isDiscoverableReplicaSet())
                 && storageEngine != null && storageEngine.get("name").equals("mmapv1")
-                && serverVersionAtLeast(3, 6) && serverVersionLessThan(4, 2));
+                && serverVersionLessThan(4, 2));
     }
 }

--- a/driver-sync/src/examples/documentation/DocumentationSamples.java
+++ b/driver-sync/src/examples/documentation/DocumentationSamples.java
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.Fixture.getDefaultDatabaseName;
 import static com.mongodb.client.Fixture.getMongoClient;
 import static com.mongodb.client.model.Accumulators.sum;
@@ -507,8 +506,6 @@ public final class DocumentationSamples extends DatabaseTestCase {
     @Test
     public void testAggregate() {
 
-        assumeTrue(serverVersionAtLeast(3, 6));
-
         MongoCollection<Document> salesCollection = database.getCollection("sales");
 
         // Start Aggregation Example 1
@@ -663,7 +660,7 @@ public final class DocumentationSamples extends DatabaseTestCase {
 
     @Test
     public void testWatch() throws InterruptedException {
-        assumeTrue(isDiscoverableReplicaSet() && serverVersionAtLeast(3, 6));
+        assumeTrue(isDiscoverableReplicaSet());
 
         MongoCollection<Document> inventory = collection;
         AtomicBoolean stop = new AtomicBoolean(false);
@@ -725,9 +722,6 @@ public final class DocumentationSamples extends DatabaseTestCase {
 
     @Test
     public void testCreateIndexes() {
-
-        assumeTrue(serverVersionAtLeast(3, 2));
-
         // Start Index Example 1
         collection.createIndex(Indexes.ascending("score"));
         // End Index Example 1

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractExplainTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractExplainTest.java
@@ -54,8 +54,6 @@ public abstract class AbstractExplainTest {
 
     @Test
     public void testExplainOfFind() {
-        assumeTrue(serverVersionAtLeast(3, 0));
-
         MongoCollection<BsonDocument> collection = client.getDatabase(getDefaultDatabaseName())
                 .getCollection("explainTest", BsonDocument.class);
         collection.drop();
@@ -147,7 +145,6 @@ public abstract class AbstractExplainTest {
     public void testExplainOfAggregateWithOldResponseStructure() {
         // Aggregate explain is supported on earlier versions, but the structure of the response on which we're asserting in this test
         // changed radically in 4.2. So here we just assert that we got a non-error respinse
-        assumeTrue(serverVersionAtLeast(3, 6));
         assumeTrue(serverVersionLessThan(4, 2));
 
         MongoCollection<BsonDocument> collection = client.getDatabase(getDefaultDatabaseName())

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractSessionsProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractSessionsProseTest.java
@@ -79,8 +79,6 @@ public abstract class AbstractSessionsProseTest {
     // Test 13 from #13-existing-sessions-are-not-checked-into-a-cleared-pool-after-forking
     @Test
     public void shouldCreateServerSessionOnlyAfterConnectionCheckout() throws InterruptedException {
-        assumeTrue(serverVersionAtLeast(3, 6));
-
         Set<BsonDocument> lsidSet = ConcurrentHashMap.newKeySet();
         MongoCollection<Document> collection;
         try (MongoClient client = getMongoClient(

--- a/driver-sync/src/test/functional/com/mongodb/client/ChangeStreamProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ChangeStreamProseTest.java
@@ -455,7 +455,7 @@ public class ChangeStreamProseTest extends DatabaseTestCase {
     }
 
     private boolean canRunTests() {
-        return isDiscoverableReplicaSet() && serverVersionAtLeast(3, 6);
+        return isDiscoverableReplicaSet();
     }
 
     private AggregateResponseBatchCursor<?> getBatchCursor(final MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor)

--- a/driver-sync/src/test/functional/com/mongodb/client/CrudProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/CrudProseTest.java
@@ -82,8 +82,6 @@ public class CrudProseTest extends DatabaseTestCase {
      */
     @Test
     public void testWriteErrorDetailsIsPropagated() {
-        assumeTrue(serverVersionAtLeast(3, 2));
-
         getCollectionHelper().create(getCollectionName(),
                 new CreateCollectionOptions()
                         .validationOptions(new ValidationOptions()

--- a/driver-sync/src/test/functional/com/mongodb/client/ReadConcernTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ReadConcernTest.java
@@ -31,11 +31,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.CommandMonitoringTestHelper.assertEventsEquality;
 import static com.mongodb.client.Fixture.getDefaultDatabaseName;
 import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
-import static org.junit.Assume.assumeTrue;
 
 public class ReadConcernTest {
     private MongoClient mongoClient;
@@ -43,8 +41,6 @@ public class ReadConcernTest {
 
     @Before
     public void setUp() {
-        assumeTrue(canRunTests());
-
         commandListener = new TestCommandListener();
         mongoClient = MongoClients.create(getMongoClientSettingsBuilder()
                 .addCommandListener(commandListener)
@@ -72,9 +68,5 @@ public class ReadConcernTest {
 
         assertEventsEquality(Arrays.asList(new CommandStartedEvent(null, 1, 1, null, getDefaultDatabaseName(),
                         "find", commandDocument)), events);
-    }
-
-    private boolean canRunTests() {
-        return serverVersionAtLeast(3, 2);
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesProseTest.java
@@ -261,6 +261,6 @@ public class RetryableWritesProseTest extends DatabaseTestCase {
 
         return ((isSharded() || isDiscoverableReplicaSet())
                 && storageEngine != null && storageEngine.get("name").equals("mmapv1")
-                && serverVersionAtLeast(3, 6) && serverVersionLessThan(4, 2));
+                && serverVersionLessThan(4, 2));
     }
 }


### PR DESCRIPTION
* Remove branching code in the driver based on 3.6 version checks
* Remove testing of 3.5
* Clean up tests

JAVA-5294