### PR TITLE
Allow empty commits for OIDC evergreen script

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -992,7 +992,7 @@ tasks:
               ${PREPARE_SHELL}
               cd src
               git add .
-              git commit -m "add files"
+              git commit --allow-empty -m "add files"
               # uncompressed tar used to allow appending .git folder
               export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/mongo-java-driver.tar
               git archive -o $AZUREOIDC_DRIVERS_TAR_FILE HEAD
@@ -1010,7 +1010,7 @@ tasks:
               ${PREPARE_SHELL}
               cd src
               git add .
-              git commit -m "add files"
+              git commit --allow-empty -m "add files"
               # uncompressed tar used to allow appending .git folder
               export GCPOIDC_DRIVERS_TAR_FILE=/tmp/mongo-java-driver.tar
               git archive -o $GCPOIDC_DRIVERS_TAR_FILE HEAD


### PR DESCRIPTION
JAVA-5450 (part)

[Logs](https://evergreen.mongodb.com/task_log_raw/mongo_java_driver_testgcpoidc_variant_oidc_auth_test_gcp_330d3b172edad4d9072552127937bd51493e1365_24_05_03_14_22_30/0?type=T#L2891). Intended to resolve `git` exiting with 1 when on master. Cannot test until it is on master. Passes when [not on master](https://spruce.mongodb.com/version/663953cf3a5c0f000746ed63/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC). 
```
On branch master
Your branch is up to date with 'origin/master'.
nothing to commit, working tree clean
```