### PR TITLE
OIDC admin credentials

### DIFF
--- a/.evergreen/run-mongodb-oidc-test.sh
+++ b/.evergreen/run-mongodb-oidc-test.sh
@@ -34,7 +34,12 @@ fi
 which java
 export OIDC_TESTS_ENABLED=true
 
-./gradlew -Dorg.mongodb.test.uri="$MONGODB_URI" \
+# use admin credentials for tests
+TO_REPLACE="mongodb://"
+REPLACEMENT="mongodb://$OIDC_ADMIN_USER:$OIDC_ADMIN_PWD@"
+ADMIN_URI=${MONGODB_URI/$TO_REPLACE/$REPLACEMENT}
+
+./gradlew -Dorg.mongodb.test.uri="$ADMIN_URI" \
   --stacktrace --debug --info --no-build-cache driver-core:cleanTest \
   driver-sync:test --tests OidcAuthenticationProseTests --tests UnifiedAuthTest \
   driver-reactive-streams:test --tests OidcAuthenticationAsyncProseTests \

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/Entities.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/Entities.java
@@ -18,6 +18,7 @@ package com.mongodb.client.unified;
 
 import com.mongodb.ClientEncryptionSettings;
 import com.mongodb.ClientSessionOptions;
+import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCredential;
 import com.mongodb.ReadConcern;
@@ -534,6 +535,11 @@ public final class Entities {
                                 throw new UnsupportedOperationException(
                                         "Unsupported authMechanismProperties for authMechanism: " + value);
                             }
+
+                            // override the org.mongodb.test.uri connection string
+                            String uri = getenv("MONGODB_URI");
+                            ConnectionString cs = new ConnectionString(uri);
+                            clientSettingsBuilder.applyConnectionString(cs);
 
                             String env = assertNotNull(getenv("OIDC_ENV"));
                             MongoCredential oidcCredential = MongoCredential

--- a/driver-sync/src/test/functional/com/mongodb/internal/connection/OidcAuthenticationProseTests.java
+++ b/driver-sync/src/test/functional/com/mongodb/internal/connection/OidcAuthenticationProseTests.java
@@ -245,7 +245,7 @@ public class OidcAuthenticationProseTests {
                 .credential(credential)
                 .build();
         assertCause(IllegalArgumentException.class,
-                "ALLOWED_HOSTS must not be specified only when OIDC_HUMAN_CALLBACK is specified",
+                "ALLOWED_HOSTS must be specified only when OIDC_HUMAN_CALLBACK is specified",
                 () -> {
                     try (MongoClient mongoClient = createMongoClient(settings)) {
                         performFind(mongoClient);

--- a/driver-sync/src/test/functional/com/mongodb/internal/connection/OidcAuthenticationProseTests.java
+++ b/driver-sync/src/test/functional/com/mongodb/internal/connection/OidcAuthenticationProseTests.java
@@ -234,6 +234,8 @@ public class OidcAuthenticationProseTests {
 
     @Test
     public void test2p5InvalidAllowedHosts() {
+        assumeTestEnvironment();
+
         String uri = "mongodb://localhost/?authMechanism=MONGODB-OIDC&&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:123";
         ConnectionString cs = new ConnectionString(uri);
         MongoCredential credential = assertNotNull(cs.getCredential())


### PR DESCRIPTION
Fixes failing tests: reverts removal of admin credentials for OIDC tests, and corrects a typo in a validation test.
JAVA-5450