### PR TITLE
Ensure bson-kotlin handles possible NPE

### DIFF
--- a/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/DataClassCodec.kt
+++ b/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/DataClassCodec.kt
@@ -236,6 +236,8 @@ internal data class DataClassCodec<T : Any>(
                 } else {
                     this.get(clazz, types)
                 }
+            codec ?: throw CodecConfigurationException("Can't find a codec for $clazz.")
+
             return kParameter.findAnnotation<BsonRepresentation>()?.let {
                 if (codec !is RepresentationConfigurable<*>) {
                     throw CodecConfigurationException(

--- a/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/samples/DataClasses.kt
+++ b/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/samples/DataClasses.kt
@@ -151,6 +151,11 @@ data class DataClassWithBsonConstructor(val id: String, val count: Int) {
     @BsonCreator constructor(id: String) : this(id, -1)
 }
 
+data class DataClassWithBsonRepresentation(
+    @BsonId val id: String,
+    @BsonRepresentation(BsonType.OBJECT_ID) val altId: String
+)
+
 data class DataClassWithInvalidBsonRepresentation(@BsonRepresentation(BsonType.STRING) val id: BsonMaxKey)
 
 data class DataClassWithFailingInit(val id: String) {


### PR DESCRIPTION
If the user provides their own CodecRegistry it could return `null` from CodecRegistry#get(clazz)

JAVA-5477