### PR TITLE
JAVA-5479: Add GitHub Actions based release automation

### DIFF
--- a/.github/workflows/bump-and-tag.sh
+++ b/.github/workflows/bump-and-tag.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-# TODO: should this always assume that release X.Y.Z will always be created from X.Y.Z-SNAPSHOT"?
+# This script assumes that release X.Y.Z will always be created from X.Y.Z-SNAPSHOT"
 echo "Replace snapshot version with release version ${RELEASE_VERSION} in build.gradle"
 sed --in-place "s/version = '.*-SNAPSHOT'/version = '${RELEASE_VERSION}'/g" build.gradle
 

--- a/.github/workflows/bump-and-tag.sh
+++ b/.github/workflows/bump-and-tag.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+# TODO: should this always assume that release X.Y.Z will always be created from X.Y.Z-SNAPSHOT"?
+echo "Replace snapshot version with release version ${RELEASE_VERSION} in build.gradle"
+sed --in-place "s/version = '.*-SNAPSHOT'/version = '${RELEASE_VERSION}'/g" build.gradle
+
+echo "Create package commit for ${RELEASE_VERSION}"
+git commit -m "Version: bump ${RELEASE_VERSION}" build.gradle
+
+echo "Create release tag for ${RELEASE_VERSION}"
+git tag -a -m "${RELEASE_VERSION}" r${RELEASE_VERSION}
+
+echo "Bump to snapshot version for ${NEXT_VERSION}"
+sed --in-place "s/version = '${RELEASE_VERSION}'/version = '${NEXT_VERSION}-SNAPSHOT'/g" build.gradle
+
+echo "Create commit for version bump to ${NEXT_VERSION}"
+git commit -m "Version: bump ${NEXT_VERSION}-SNAPSHOT" build.gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   prepare-release:
+    environment: release
     name: "Prepare release"
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,22 +10,31 @@ on:
         type: "string"
 
 env:
-  GH_TOKEN: ${{ github.token }}
   # TODO: Adding the mongodb-dbx-release-automation app to the repository will allow fetching a one-time token and pushing
   # changes on behalf of the app. This also allows bypassing branch protection rules
-  # When the app was added, these values can be changed to use the app's data
-  GIT_AUTHOR_NAME: "DBX Java Release Bot"
-  GIT_AUTHOR_EMAIL: "dbx-java@mongodb.com"
+  GIT_AUTHOR_NAME: "mongodb-dbx-release-bot[bot]"
+  GIT_AUTHOR_EMAIL: "167856002+mongodb-dbx-release-bot[bot]@users.noreply.github.com"
 
 jobs:
   prepare-release:
     name: "Prepare release"
     runs-on: ubuntu-latest
     permissions:
+      # Write permission for id-token is necessary to generate a new token for the GitHub App
+      id-token: write
       # Write permission for contents is to ensure we're allowed to push to the repository
       contents: write
 
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: "Store GitHub token in environment"
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
+
       - name: "Create release output"
         run: echo '🎬 Release process for version ${{ env.RELEASE_VERSION }} started by @${{ github.triggering_actor }}' >> $GITHUB_STEP_SUMMARY
 
@@ -33,6 +42,7 @@ jobs:
         with:
           # fetch-depth 0 is required to fetch all branches and tags
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: "Store version numbers in env variables"
         # The awk command to increase the version number was copied from

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: "Release New Version"
+run-name: "Release ${{ inputs.version }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to be released (e.g. 1.2.3)"
+        required: true
+        type: "string"
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  # TODO: Adding the mongodb-dbx-release-automation app to the repository will allow fetching a one-time token and pushing
+  # changes on behalf of the app. This also allows bypassing branch protection rules
+  # When the app was added, these values can be changed to use the app's data
+  GIT_AUTHOR_NAME: "DBX Java Release Bot"
+  GIT_AUTHOR_EMAIL: "dbx-java@mongodb.com"
+
+jobs:
+  prepare-release:
+    name: "Prepare release"
+    runs-on: ubuntu-latest
+    permissions:
+      # Write permission for contents is to ensure we're allowed to push to the repository
+      contents: write
+
+    steps:
+      - name: "Create release output"
+        run: echo '🎬 Release process for version ${{ env.RELEASE_VERSION }} started by @${{ github.triggering_actor }}' >> $GITHUB_STEP_SUMMARY
+
+      - uses: actions/checkout@v4
+        with:
+          # fetch-depth 0 is required to fetch all branches and tags
+          fetch-depth: 0
+
+      - name: "Store version numbers in env variables"
+        # The awk command to increase the version number was copied from
+        # StackOverflow: https://stackoverflow.com/a/61921674/3959933
+        run: |
+          echo RELEASE_VERSION=${{ inputs.version }} >> $GITHUB_ENV
+          echo NEXT_VERSION=$(echo ${{ inputs.version }} | awk -F. -v OFS=. '{$NF += 1 ; print}') >> $GITHUB_ENV
+          echo RELEASE_BRANCH=$(echo ${{ inputs.version }} | awk -F. -v OFS=. '{$NF = "x" ; print}') >> $GITHUB_ENV
+
+      - name: "Ensure release tag does not already exist"
+        run: |
+          if [[ $(git tag -l r${RELEASE_VERSION}) == r${RELEASE_VERSION} ]]; then
+            echo '❌ Release failed: tag for version ${{ inputs.version }} already exists' >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+      # For patch releases (A.B.C where C != 0), we expect the release to be
+      # triggered from the A.B.x maintenance branch
+      - name: "Fail if patch release is created from wrong release branch"
+        if: ${{ !endsWith(inputs.version, '.0') && env.RELEASE_BRANCH != github.ref_name }}
+        run: |
+          echo '❌ Release failed due to branch mismatch: expected ${{ inputs.version }} to be released from ${{ env.RELEASE_BRANCH }}, got ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
+          exit 1
+
+      # For non-patch releases (A.B.C where C == 0), we expect the release to
+      # be triggered from master or the A.B.x maintenance branch
+      - name: "Fail if non-patch release is created from wrong release branch"
+        if: ${{ endsWith(inputs.version, '.0') && env.RELEASE_BRANCH != github.ref_name && github.ref_name != 'master' }}
+        run: |
+          echo '❌ Release failed due to branch mismatch: expected ${{ inputs.version }} to be released from ${{ env.RELEASE_BRANCH }} or master, got ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
+          exit 1
+
+      # If a non-patch release is created from a branch other than its
+      # maintenance branch, create that branch from the current one and push it
+      - name: "Create new release branch for non-patch release"
+        if: ${{ endsWith(inputs.version, '.0') && env.RELEASE_BRANCH != github.ref_name }}
+        run: |
+          echo '🆕 Creating new release branch ${RELEASE_BRANCH} from ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
+          git checkout -b ${RELEASE_BRANCH}
+
+      - name: "Set git author information"
+        run: |
+          git config user.name "${GIT_AUTHOR_NAME}"
+          git config user.email "${GIT_AUTHOR_EMAIL}"
+
+      # This step bumps version numbers in build.gradle and creates git artifacts for the release
+      # TODO: this could leverage the git-sign action with some minor changes
+      # See https://github.com/mongodb-labs/drivers-github-tools/tree/main?tab=readme-ov-file#git-sign
+      - name: "Bump version numbers and create release tag"
+        run: .github/workflows/bump-and-tag.sh
+
+      - name: "Push release branch and tag"
+        run: |
+          git push origin ${RELEASE_BRANCH}
+          git push origin r${{ env.RELEASE_VERSION }}
+
+      - name: "Create draft release with generated changelog"
+        run: |
+          echo "RELEASE_URL=$(\
+          gh release create r${RELEASE_VERSION} \
+            --target ${{ env.RELEASE_BRANCH }} \
+            --title "Java Driver ${{ env.RELEASE_VERSION }} ($(date '+%B %d, %Y'))" \
+            --generate-notes \
+            --draft\
+          )" >> "$GITHUB_ENV"
+
+      - name: "Set summary"
+        run: |
+          echo '🚀 Created tag and drafted release for version [${{ env.RELEASE_VERSION }}](${{ env.RELEASE_URL }})' >> $GITHUB_STEP_SUMMARY
+          echo '✍️ You may now update the release notes and publish the release when ready' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,6 @@ on:
         required: true
         type: "string"
 
-env:
-  # TODO: Adding the mongodb-dbx-release-automation app to the repository will allow fetching a one-time token and pushing
-  # changes on behalf of the app. This also allows bypassing branch protection rules
-  GIT_AUTHOR_NAME: "mongodb-dbx-release-bot[bot]"
-  GIT_AUTHOR_EMAIL: "167856002+mongodb-dbx-release-bot[bot]@users.noreply.github.com"
-
 jobs:
   prepare-release:
     environment: release
@@ -27,23 +21,13 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: "Store GitHub token in environment"
-        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
-
       - name: "Create release output"
         run: echo '🎬 Release process for version ${{ env.RELEASE_VERSION }} started by @${{ github.triggering_actor }}' >> $GITHUB_STEP_SUMMARY
 
-      - uses: actions/checkout@v4
+      - uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
         with:
-          # fetch-depth 0 is required to fetch all branches and tags
-          fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: "Store version numbers in env variables"
         # The awk command to increase the version number was copied from

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,6 @@ jobs:
           git config user.email "${GIT_AUTHOR_EMAIL}"
 
       # This step bumps version numbers in build.gradle and creates git artifacts for the release
-      # TODO: this could leverage the git-sign action with some minor changes
-      # See https://github.com/mongodb-labs/drivers-github-tools/tree/main?tab=readme-ov-file#git-sign
       - name: "Bump version numbers and create release tag"
         run: .github/workflows/bump-and-tag.sh
 


### PR DESCRIPTION
This PR adds a GitHub Actions Workflow to create releases. The process is as follows:

* Users with write access trigger a new workflow run for the "Release new version" workflow, entering the version to be released
* The automation does some sanity checks on the branch name:
** Release `<major>.<minor>.0` must be released from the maintenance branch (i.e. `<major>.<minor>.x`) or the `master` branch. If the `master` branch is selected, the automation will attempt to create a new maintenance branch
** Release `<major>.<minor>.<patch>` must be released from the maintenance branch (i.e. `<major>.<minor>.x`) - releasing from any other branches is not allowed
* The automation then updates the build version to `<major>.<minor>.<patch>` in `build.gradle`, commits this change and creates a tag
* After tagging, the version in `build.gradle` is updated to `<major>.<minor>.<patch+1>-SNAPSHOT` and again committed
* The maintenance branch and tag are pushed to the repository
* A draft release with generated release notes is created

I've tested the flow in my fork where I've confirmed it works. However, a couple of changes may be appropriate still:
- The automation currently uses the GitHub token of the user triggering the release. Since commits are being pushed directly, branch protection rules may interfere with the release process. In this case, we should add the `mongodb-dbx-release-bot` app to the repository and generate a token for the app. We can then allow the app to bypass branch protections
- If not all users with write access should have permission to create releases, we can set up an environment in GitHub settings and require that an authorised user approves the workflow run
- The release commits and tag are not signed; this could be added using the [git-sign action](https://github.com/mongodb-labs/drivers-github-tools/tree/main?tab=readme-ov-file#git-sign)
- Other release requirements related to the SSDLC effort (e.g. generating a SAST report, uploading SBOM, etc.) are not added yet and can be integrated based on the shared driver's GitHub Actions once they are ready.

Any additional build tasks (e.g. creating a package to upload to a package manager) can be done in a separate workflow that runs when a tag is pushed.