### PR TITLE
Optimize GridFS throughput by removing redundant byte array cloning.

### DIFF
--- a/driver-sync/src/main/com/mongodb/client/gridfs/GridFSBucketImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/gridfs/GridFSBucketImpl.java
@@ -57,7 +57,7 @@ final class GridFSBucketImpl implements GridFSBucket {
     private final String bucketName;
     private final int chunkSizeBytes;
     private final MongoCollection<GridFSFile> filesCollection;
-    private final MongoCollection<Document> chunksCollection;
+    private final MongoCollection<BsonDocument> chunksCollection;
     private volatile boolean checkedIndexes;
 
     GridFSBucketImpl(final MongoDatabase database) {
@@ -71,7 +71,7 @@ final class GridFSBucketImpl implements GridFSBucket {
     }
 
     GridFSBucketImpl(final String bucketName, final int chunkSizeBytes, final MongoCollection<GridFSFile> filesCollection,
-                     final MongoCollection<Document> chunksCollection) {
+                     final MongoCollection<BsonDocument> chunksCollection) {
         this.bucketName = notNull("bucketName", bucketName);
         this.chunkSizeBytes = chunkSizeBytes;
         this.filesCollection = notNull("filesCollection", filesCollection);
@@ -459,8 +459,8 @@ final class GridFSBucketImpl implements GridFSBucket {
         );
     }
 
-    private static MongoCollection<Document> getChunksCollection(final MongoDatabase database, final String bucketName) {
-        return database.getCollection(bucketName + ".chunks").withCodecRegistry(MongoClientSettings.getDefaultCodecRegistry());
+    private static MongoCollection<BsonDocument> getChunksCollection(final MongoDatabase database, final String bucketName) {
+        return database.getCollection(bucketName + ".chunks", BsonDocument.class).withCodecRegistry(MongoClientSettings.getDefaultCodecRegistry());
     }
 
     private void checkCreateIndex(@Nullable final ClientSession clientSession) {

--- a/driver-sync/src/main/com/mongodb/client/gridfs/GridFSDownloadStreamImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/gridfs/GridFSDownloadStreamImpl.java
@@ -224,7 +224,7 @@ class GridFSDownloadStreamImpl extends GridFSDownloadStream {
             if (batchSize == 1) {
                 discardCursor();
             }
-            if (chunk.get("n").asInt32().getValue() != startChunkIndex) {
+            if (chunk.getInt32("n").getValue() != startChunkIndex) {
                 throw new MongoGridFSException(format("Could not find file chunk for file_id: %s at chunk index %s.",
                         fileId, startChunkIndex));
             }
@@ -246,7 +246,7 @@ class GridFSDownloadStreamImpl extends GridFSDownloadStream {
 
     private byte[] getBufferFromChunk(@Nullable final BsonDocument chunk, final int expectedChunkIndex) {
 
-        if (chunk == null || chunk.get("n").asInt32().getValue() != expectedChunkIndex) {
+        if (chunk == null || chunk.getInt32("n").getValue() != expectedChunkIndex) {
             throw new MongoGridFSException(format("Could not find file chunk for file_id: %s at chunk index %s.",
                     fileId, expectedChunkIndex));
         }
@@ -254,7 +254,7 @@ class GridFSDownloadStreamImpl extends GridFSDownloadStream {
         if (!(chunk.get("data") instanceof BsonBinary)) {
             throw new MongoGridFSException("Unexpected data format for the chunk");
         }
-        byte[] data = chunk.get("data").asBinary().getData();
+        byte[] data = chunk.getBinary("data").getData();
 
         long expectedDataLength = 0;
         boolean extraChunk = false;

--- a/driver-sync/src/main/com/mongodb/client/gridfs/GridFSDownloadStreamImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/gridfs/GridFSDownloadStreamImpl.java
@@ -23,9 +23,10 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.gridfs.model.GridFSFile;
 import com.mongodb.lang.Nullable;
+import org.bson.BsonBinary;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
 import org.bson.BsonValue;
-import org.bson.Document;
-import org.bson.types.Binary;
 
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -37,12 +38,12 @@ import static java.lang.String.format;
 class GridFSDownloadStreamImpl extends GridFSDownloadStream {
     private final ClientSession clientSession;
     private final GridFSFile fileInfo;
-    private final MongoCollection<Document> chunksCollection;
+    private final MongoCollection<BsonDocument> chunksCollection;
     private final BsonValue fileId;
     private final long length;
     private final int chunkSizeInBytes;
     private final int numberOfChunks;
-    private MongoCursor<Document> cursor;
+    private MongoCursor<BsonDocument> cursor;
     private int batchSize;
     private int chunkIndex;
     private int bufferOffset;
@@ -55,10 +56,10 @@ class GridFSDownloadStreamImpl extends GridFSDownloadStream {
     private boolean closed = false;
 
     GridFSDownloadStreamImpl(@Nullable final ClientSession clientSession, final GridFSFile fileInfo,
-                             final MongoCollection<Document> chunksCollection) {
+                             final MongoCollection<BsonDocument> chunksCollection) {
         this.clientSession = clientSession;
         this.fileInfo = notNull("file information", fileInfo);
-        this.chunksCollection = notNull("chunks collection", chunksCollection);
+        this.chunksCollection = notNull("chunks collection",  chunksCollection);
 
         fileId = fileInfo.getId();
         length = fileInfo.getLength();
@@ -213,17 +214,17 @@ class GridFSDownloadStreamImpl extends GridFSDownloadStream {
     }
 
     @Nullable
-    private Document getChunk(final int startChunkIndex) {
+    private BsonDocument getChunk(final int startChunkIndex) {
         if (cursor == null) {
             cursor = getCursor(startChunkIndex);
         }
-        Document chunk = null;
+        BsonDocument chunk = null;
         if (cursor.hasNext()) {
             chunk = cursor.next();
             if (batchSize == 1) {
                 discardCursor();
             }
-            if (chunk.getInteger("n") != startChunkIndex) {
+            if (chunk.get("n").asInt32().getValue() != startChunkIndex) {
                 throw new MongoGridFSException(format("Could not find file chunk for file_id: %s at chunk index %s.",
                         fileId, startChunkIndex));
             }
@@ -232,28 +233,28 @@ class GridFSDownloadStreamImpl extends GridFSDownloadStream {
         return chunk;
     }
 
-    private MongoCursor<Document> getCursor(final int startChunkIndex) {
-        FindIterable<Document> findIterable;
-        Document filter = new Document("files_id", fileId).append("n", new Document("$gte", startChunkIndex));
+    private MongoCursor<BsonDocument> getCursor(final int startChunkIndex) {
+        FindIterable<BsonDocument> findIterable;
+        BsonDocument filter = new BsonDocument("files_id", fileId).append("n", new BsonDocument("$gte", new BsonInt32(startChunkIndex)));
         if (clientSession != null) {
             findIterable = chunksCollection.find(clientSession, filter);
         } else {
             findIterable = chunksCollection.find(filter);
         }
-        return findIterable.batchSize(batchSize).sort(new Document("n", 1)).iterator();
+        return findIterable.batchSize(batchSize).sort(new BsonDocument("n", new BsonInt32(1))).iterator();
     }
 
-    private byte[] getBufferFromChunk(@Nullable final Document chunk, final int expectedChunkIndex) {
+    private byte[] getBufferFromChunk(@Nullable final BsonDocument chunk, final int expectedChunkIndex) {
 
-        if (chunk == null || chunk.getInteger("n") != expectedChunkIndex) {
+        if (chunk == null || chunk.get("n").asInt32().getValue() != expectedChunkIndex) {
             throw new MongoGridFSException(format("Could not find file chunk for file_id: %s at chunk index %s.",
                     fileId, expectedChunkIndex));
         }
 
-        if (!(chunk.get("data") instanceof Binary)) {
+        if (!(chunk.get("data") instanceof BsonBinary)) {
             throw new MongoGridFSException("Unexpected data format for the chunk");
         }
-        byte[] data = chunk.get("data", Binary.class).getData();
+        byte[] data = chunk.get("data").asBinary().getData();
 
         long expectedDataLength = 0;
         boolean extraChunk = false;

--- a/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
@@ -429,7 +429,7 @@ class GridFSBucketSpecification extends Specification {
         def bsonFileId = new BsonObjectId(fileId)
         def fileInfo = new GridFSFile(bsonFileId, filename, 10, 255, new Date(), new Document())
         def mongoCursor =  Mock(MongoCursor)
-        def findIterable =  Mock(FindIterable)
+        def gridFsFileFindIterable =  Mock(FindIterable)
         def findChunkIterable =  Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def tenBytes = new byte[10]
@@ -450,14 +450,14 @@ class GridFSBucketSpecification extends Specification {
 
         then:
         if (clientSession != null) {
-            1 * filesCollection.find(clientSession) >> findIterable
+            1 * filesCollection.find(clientSession) >> gridFsFileFindIterable
         } else {
-            1 * filesCollection.find() >> findIterable
+            1 * filesCollection.find() >> gridFsFileFindIterable
         }
-        1 * findIterable.filter(new BsonDocument('filename', new BsonString(filename))) >> findIterable
-        1 * findIterable.skip(_) >> findIterable
-        1 * findIterable.sort(_) >> findIterable
-        1 * findIterable.first() >> fileInfo
+        1 * gridFsFileFindIterable.filter(new Document('filename', filename)) >> gridFsFileFindIterable
+        1 * gridFsFileFindIterable.skip(_) >> gridFsFileFindIterable
+        1 * gridFsFileFindIterable.sort(_) >> gridFsFileFindIterable
+        1 * gridFsFileFindIterable.first() >> fileInfo
 
         if (clientSession != null) {
             1 * chunksCollection.find(clientSession, _) >> findChunkIterable

--- a/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
@@ -35,12 +35,13 @@ import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
 import com.mongodb.internal.operation.BatchCursor
 import com.mongodb.internal.operation.FindOperation
+import org.bson.BsonBinary
 import org.bson.BsonDocument
+import org.bson.BsonInt32
 import org.bson.BsonObjectId
 import org.bson.BsonString
 import org.bson.Document
 import org.bson.codecs.DocumentCodecProvider
-import org.bson.types.Binary
 import org.bson.types.ObjectId
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -327,7 +328,9 @@ class GridFSBucketSpecification extends Specification {
         def findIterable =  Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def tenBytes = new byte[10]
-        def chunkDocument = new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(tenBytes))
+        def chunkDocument = new BsonDocument('files_id', fileInfo.getId())
+                .append('n', new BsonInt32(0))
+                .append('data', new BsonBinary(tenBytes))
         def chunksCollection = Mock(MongoCollection)
         def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def outputStream = new ByteArrayOutputStream(10)
@@ -346,7 +349,7 @@ class GridFSBucketSpecification extends Specification {
         } else {
             1 * filesCollection.find() >> findIterable
         }
-        1 * findIterable.filter(new Document('_id', bsonFileId)) >> findIterable
+        1 * findIterable.filter(new BsonDocument('_id', bsonFileId)) >> findIterable
         1 * findIterable.first() >> fileInfo
 
         then:
@@ -376,7 +379,9 @@ class GridFSBucketSpecification extends Specification {
         def findIterable =  Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def tenBytes = new byte[10]
-        def chunkDocument = new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(tenBytes))
+        def chunkDocument = new BsonDocument('files_id', fileInfo.getId())
+                .append('n', new BsonInt32(0))
+                .append('data', new BsonBinary(tenBytes))
         def chunksCollection = Mock(MongoCollection)
         def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def outputStream = new ByteArrayOutputStream(10)
@@ -395,7 +400,7 @@ class GridFSBucketSpecification extends Specification {
         } else {
             1 * filesCollection.find() >> findIterable
         }
-        1 * findIterable.filter(new Document('_id', bsonFileId)) >> findIterable
+        1 * findIterable.filter(new BsonDocument('_id', bsonFileId)) >> findIterable
         1 * findIterable.first() >> fileInfo
 
         then:
@@ -428,7 +433,9 @@ class GridFSBucketSpecification extends Specification {
         def findChunkIterable =  Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def tenBytes = new byte[10]
-        def chunkDocument = new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(tenBytes))
+        def chunkDocument = new BsonDocument('files_id', fileInfo.getId())
+                .append('n', new BsonInt32(0))
+                .append('data', new BsonBinary(tenBytes))
         def chunksCollection = Mock(MongoCollection)
         def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def outputStream = new ByteArrayOutputStream(10)
@@ -447,7 +454,7 @@ class GridFSBucketSpecification extends Specification {
         } else {
             1 * filesCollection.find() >> findIterable
         }
-        1 * findIterable.filter(new Document('filename', filename)) >> findIterable
+        1 * findIterable.filter(new BsonDocument('filename', new BsonString(filename))) >> findIterable
         1 * findIterable.skip(_) >> findIterable
         1 * findIterable.sort(_) >> findIterable
         1 * findIterable.first() >> fileInfo

--- a/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSDownloadStreamSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSDownloadStreamSpecification.groovy
@@ -22,9 +22,11 @@ import com.mongodb.client.FindIterable
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoCursor
 import com.mongodb.client.gridfs.model.GridFSFile
+import org.bson.BsonBinary
+import org.bson.BsonDocument
+import org.bson.BsonInt32
 import org.bson.BsonObjectId
 import org.bson.Document
-import org.bson.types.Binary
 import org.bson.types.ObjectId
 import spock.lang.Specification
 
@@ -43,15 +45,16 @@ class GridFSDownloadStreamSpecification extends Specification {
         when:
         def twoBytes = new byte[2]
         def oneByte = new byte[1]
-        def findQuery = new Document('files_id', fileInfo.getId()).append('n', new Document('$gte', 0))
-        def sort = new Document('n', 1)
-        def chunkDocument = new Document('files_id', fileInfo.getId())
-                .append('n', 0)
-                .append('data', new Binary(twoBytes))
+        def findQuery = new BsonDocument('files_id', fileInfo.getId())
+                .append('n', new BsonDocument('$gte', new BsonInt32(0)))
+        def sort = new BsonDocument('n', new BsonInt32(1))
+        def chunkDocument = new BsonDocument('files_id', fileInfo.getId())
+                .append('n', new BsonInt32(0))
+                .append('data', new BsonBinary(twoBytes))
 
-        def secondChunkDocument = new Document('files_id', fileInfo.getId())
-                .append('n', 1)
-                .append('data', new Binary(oneByte))
+        def secondChunkDocument = new BsonDocument('files_id', fileInfo.getId())
+                .append('n', new BsonInt32(1))
+                .append('data', new BsonBinary(oneByte))
 
         def mongoCursor = Mock(MongoCursor)
         def findIterable = Mock(FindIterable)
@@ -112,16 +115,19 @@ class GridFSDownloadStreamSpecification extends Specification {
         when:
         def twoBytes = new byte[2]
         def oneByte = new byte[1]
-        def findQuery = new Document('files_id', fileInfo.getId()).append('n', new Document('$gte', 0))
-        def secondFindQuery = new Document('files_id', fileInfo.getId()).append('n', new Document('$gte', 1))
-        def sort = new Document('n', 1)
-        def chunkDocument = new Document('files_id', fileInfo.getId())
-                .append('n', 0)
-                .append('data', new Binary(twoBytes))
+        def findQuery = new BsonDocument('files_id', fileInfo.getId()).append('n',
+                new BsonDocument('$gte',
+                new BsonInt32(0)))
+        def secondFindQuery = new BsonDocument('files_id', fileInfo.getId())
+                .append('n', new BsonDocument('$gte', new BsonInt32(1)))
+        def sort = new BsonDocument('n', new BsonInt32(1))
+        def chunkDocument = new BsonDocument('files_id', fileInfo.getId())
+                .append('n', new BsonInt32(0))
+                .append('data', new BsonBinary(twoBytes))
 
-        def secondChunkDocument = new Document('files_id', fileInfo.getId())
-                .append('n', 1)
-                .append('data', new Binary(oneByte))
+        def secondChunkDocument = new BsonDocument('files_id', fileInfo.getId())
+                .append('n', new BsonInt32(1))
+                .append('data', new BsonBinary(oneByte))
 
         def mongoCursor = Mock(MongoCursor)
         def findIterable = Mock(FindIterable)
@@ -194,13 +200,17 @@ class GridFSDownloadStreamSpecification extends Specification {
         def firstChunkBytes = 1..32 as byte[]
         def lastChunkBytes = 33 .. 57 as byte[]
 
-        def sort = new Document('n', 1)
+        def sort = new BsonDocument('n', new BsonInt32(1))
 
-        def findQueries = [new Document('files_id', fileInfo.getId()).append('n', new Document('$gte', 0)),
-                           new Document('files_id', fileInfo.getId()).append('n', new Document('$gte', 131071))]
+        def findQueries = [new BsonDocument('files_id', fileInfo.getId())
+                                   .append('n', new BsonDocument('$gte', new BsonInt32(0))),
+                           new BsonDocument('files_id', fileInfo.getId())
+                                   .append('n', new BsonDocument('$gte', new BsonInt32(131071)))]
         def chunkDocuments =
-                [new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(firstChunkBytes)),
-                 new Document('files_id', fileInfo.getId()).append('n', 131071).append('data', new Binary(lastChunkBytes))]
+                [new BsonDocument('files_id', fileInfo.getId())
+                         .append('n', new BsonInt32(0)).append('data', new BsonBinary(firstChunkBytes)),
+                 new BsonDocument('files_id', fileInfo.getId())
+                         .append('n', new BsonInt32(131071)).append('data', new BsonBinary(lastChunkBytes))]
 
         def mongoCursor = Mock(MongoCursor)
         def findIterable = Mock(FindIterable)
@@ -276,7 +286,9 @@ class GridFSDownloadStreamSpecification extends Specification {
         def expected10Bytes = 11 .. 20 as byte[]
         def firstChunkBytes = 1..25 as byte[]
 
-        def chunkDocument = new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(firstChunkBytes))
+        def chunkDocument = new BsonDocument('files_id', fileInfo.getId())
+                .append('n', new BsonInt32(0))
+                .append('data', new BsonBinary(firstChunkBytes))
 
         def mongoCursor = Mock(MongoCursor)
         def findIterable = Mock(FindIterable)
@@ -340,8 +352,12 @@ class GridFSDownloadStreamSpecification extends Specification {
         def secondChunkBytes = 26 .. 50 as byte[]
 
         def chunkDocuments =
-                [new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(firstChunkBytes)),
-                 new Document('files_id', fileInfo.getId()).append('n', 1).append('data', new Binary(secondChunkBytes))]
+                [new BsonDocument('files_id', fileInfo.getId())
+                         .append('n', new BsonInt32(0))
+                         .append('data', new BsonBinary(firstChunkBytes)),
+                 new BsonDocument('files_id', fileInfo.getId())
+                         .append('n', new BsonInt32(1))
+                         .append('data', new BsonBinary(secondChunkBytes))]
 
         def mongoCursor = Mock(MongoCursor)
         def findIterable = Mock(FindIterable)
@@ -416,7 +432,9 @@ class GridFSDownloadStreamSpecification extends Specification {
         def fileInfo = new GridFSFile(new BsonObjectId(new ObjectId()), 'filename', 25L, 25, new Date(), new Document())
 
         def chunkBytes = 1..25 as byte[]
-        def chunkDocument = new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(chunkBytes))
+        def chunkDocument = new BsonDocument('files_id', fileInfo.getId())
+                .append('n', new BsonInt32(0))
+                .append('data', new BsonBinary(chunkBytes))
 
         def mongoCursor = Mock(MongoCursor)
         def findIterable = Mock(FindIterable)
@@ -584,9 +602,9 @@ class GridFSDownloadStreamSpecification extends Specification {
 
     def 'should throw if chunk data differs from the expected'() {
         given:
-        def chunkDocument = new Document('files_id', fileInfo.getId())
-                .append('n', 0)
-                .append('data', new Binary(data))
+        def chunkDocument = new BsonDocument('files_id', fileInfo.getId())
+                .append('n', new BsonInt32(0))
+                .append('data', new BsonBinary(data))
 
         def mongoCursor = Mock(MongoCursor)
         def findIterable = Mock(FindIterable)

--- a/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSUploadStreamSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/gridfs/GridFSUploadStreamSpecification.groovy
@@ -20,10 +20,11 @@ import com.mongodb.MongoGridFSException
 import com.mongodb.client.ClientSession
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.gridfs.model.GridFSFile
+import org.bson.BsonDocument
+import org.bson.BsonInt32
 import org.bson.BsonObjectId
 import org.bson.BsonString
 import org.bson.Document
-import org.bson.types.Binary
 import spock.lang.Specification
 
 class GridFSUploadStreamSpecification extends Specification {
@@ -110,18 +111,18 @@ class GridFSUploadStreamSpecification extends Specification {
         then:
         if (clientSession != null) {
             1 * chunksCollection.insertOne(clientSession) {
-                verifyAll(it, Document) {
+                verifyAll(it, BsonDocument) {
                     it.get('files_id') == filesId
-                    it.getInteger('n') == 0
-                    it.get('data', Binary).getData() == content
+                    it.getInt32('n') == new BsonInt32(0)
+                    it.getBinary('data').getData() == content
                 }
             }
         } else {
             1 * chunksCollection.insertOne {
-                verifyAll(it, Document) {
+                verifyAll(it, BsonDocument) {
                     it.get('files_id') == filesId
-                    it.getInteger('n') == 0
-                    it.get('data', Binary).getData() == content
+                    it.getInt32('n') == new BsonInt32(0)
+                    it.getBinary('data').getData() == content
                 }
             }
         }


### PR DESCRIPTION
### Description
This PR introduces performance improvement in the GridFS implementation of the sync Java driver, specifically targeting the `GridFSDownloadStream` and `GridFSUploadStream` classes. It was identified that byte arrays are cloned twice internally via the `Binary` class, which impacts throughput.

## Key Changes:
Modified `GridFSDownloadStream` and `GridFSUploadStream` to use `BsonDocument `instead of `Document.` The `BsonDocument` implementation avoids the unnecessary copying in the `BsonBinary` class, thus enhancing performance.

## Performance Improvements:
**GridFS Download:**
Stable Region Mean on main branch = 769.21 MBps
Perf result mean = 1030.63 MBps
Improvement: Approximately 34.02% increase in throughput

**GridFS Upload:**
Stable Region Mean on main branch = 450.62 MBps
Perf result mean = 515.84 MBps
Improvement: Approximately 14.48% increase in throughput

## Additional Information:
For further details and results of performance tests executed on this patch, please refer to the [performance test results](https://spruce.mongodb.com/task/mongo_java_driver_perf_perf_patch_339bd2cabe4baa7a624588978400a0777d257e9b_665f022c98f4ac0007ae6873_24_06_04_12_01_50/trend-charts?execution=0).


JAVA-5485