### PR TITLE
Add kmip tests, use mongoCrypt snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
     zstdVersion = '1.5.5-3'
     awsSdkV2Version = '2.18.9'
     awsSdkV1Version = '1.12.337'
-    mongoCryptVersion = '1.8.0-SNAPSHOT'
+    mongoCryptVersion = '1.10.0-SNAPSHOT'
     projectReactorVersion = '2022.0.0'
     junitBomVersion = '5.8.2'
     logbackVersion = '1.3.14'

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
     zstdVersion = '1.5.5-3'
     awsSdkV2Version = '2.18.9'
     awsSdkV1Version = '1.12.337'
-    mongoCryptVersion = '1.8.0'
+    mongoCryptVersion = '1.8.0-SNAPSHOT'
     projectReactorVersion = '2022.0.0'
     junitBomVersion = '5.8.2'
     logbackVersion = '1.3.14'

--- a/driver-core/src/main/com/mongodb/client/model/vault/DataKeyOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/vault/DataKeyOptions.java
@@ -128,6 +128,8 @@ public class DataKeyOptions {
      *   omitted, the driver creates a random 96 byte KMIP Secret Data managed object.</li>
      *   <li>endpoint: a String, the endpoint as a host with required port. e.g. "example.com:443". If endpoint is not provided, it
      *   defaults to the required endpoint from the KMS providers map.</li>
+     *   <li>delegated: If true (recommended), the KMIP server must decrypt this key. If delegated is not provided,
+     *   defaults to false. </li>
      * </ul>
      * <p>
      * If the kmsProvider is "local" the masterKey is not applicable.

--- a/driver-core/src/main/com/mongodb/client/model/vault/DataKeyOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/vault/DataKeyOptions.java
@@ -128,8 +128,9 @@ public class DataKeyOptions {
      *   omitted, the driver creates a random 96 byte KMIP Secret Data managed object.</li>
      *   <li>endpoint: a String, the endpoint as a host with required port. e.g. "example.com:443". If endpoint is not provided, it
      *   defaults to the required endpoint from the KMS providers map.</li>
-     *   <li>delegated: If true (recommended), the KMIP server must decrypt this key. If delegated is not provided,
-     *   defaults to false. </li>
+     *   <li>delegated: If true (recommended), the KMIP server will perform
+     *   encryption and decryption. If delegated is not provided, defaults
+     *   to false.</li>
      * </ul>
      * <p>
      * If the kmsProvider is "local" the masterKey is not applicable.

--- a/driver-core/src/test/resources/client-side-encryption/legacy/azureKMS.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/azureKMS.json
@@ -78,6 +78,17 @@
           "bsonType": "string",
           "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
         }
+      },
+      "encrypted_string_kmip_delegated": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$uuid": "7411e9af-c688-4df7-8143-5e60ae96cba6"
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
       }
     },
     "bsonType": "object"

--- a/driver-core/src/test/resources/client-side-encryption/legacy/gcpKMS.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/gcpKMS.json
@@ -78,6 +78,17 @@
           "bsonType": "string",
           "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
         }
+      },
+      "encrypted_string_kmip_delegated": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$uuid": "7411e9af-c688-4df7-8143-5e60ae96cba6"
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
       }
     },
     "bsonType": "object"

--- a/driver-core/src/test/resources/client-side-encryption/legacy/kmipKMS.json
+++ b/driver-core/src/test/resources/client-side-encryption/legacy/kmipKMS.json
@@ -78,6 +78,17 @@
           "bsonType": "string",
           "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
         }
+      },
+      "encrypted_string_kmip_delegated": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$uuid": "7411e9af-c688-4df7-8143-5e60ae96cba6"
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
       }
     },
     "bsonType": "object"
@@ -116,6 +127,38 @@
       "keyAltNames": [
         "altname",
         "kmip_altname"
+      ]
+    },
+    {
+      "_id": {
+        "$uuid": "7411e9af-c688-4df7-8143-5e60ae96cba6"
+      },
+      "keyMaterial": {
+        "$binary": {
+          "base64": "5TLMFWlguBWe5GUESTvOVtkdBsCrynhnV72XRyZ66/nk+EP9/1oEp1t1sg0+vwCTqULHjBiUE6DRx2mYD/Eup1+u2Jgz9/+1sV1drXeOPALNPkSgiZiDbIb67zRi+wTABEcKcegJH+FhmSGxwUoQAiHCsCbcvia5P8tN1lt98YQ=",
+          "subType": "00"
+        }
+      },
+      "creationDate": {
+        "$date": {
+          "$numberLong": "1634220190041"
+        }
+      },
+      "updateDate": {
+        "$date": {
+          "$numberLong": "1634220190041"
+        }
+      },
+      "status": {
+        "$numberInt": "0"
+      },
+      "masterKey": {
+        "provider": "kmip",
+        "delegated": true,
+        "keyId": "11"
+      },
+      "keyAltNames": [
+        "delegated"
       ]
     }
   ],
@@ -211,6 +254,102 @@
               "encrypted_string_kmip": {
                 "$binary": {
                   "base64": "AXQR6a/GiE33gUNeYK6Wy6UCKCwtKFIsL8eKObDVxvqGupJNUk7kXswHhB7G5j/C1D+6no+Asra0KgSU43bTL3ooIBLVyIzbV5CDJYqzAsa4WQ==",
+                  "subType": "06"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Insert a document with auto encryption using KMIP delegated KMS provider",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "kmip": {}
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encrypted_string_kmip_delegated": "string0"
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "default"
+              }
+            },
+            "command_name": "listCollections"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "datakeys",
+              "filter": {
+                "$or": [
+                  {
+                    "_id": {
+                      "$in": [
+                        {
+                          "$uuid": "7411e9af-c688-4df7-8143-5e60ae96cba6"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "keyAltNames": {
+                      "$in": []
+                    }
+                  }
+                ]
+              },
+              "$db": "keyvault"
+            },
+            "command_name": "find"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default",
+              "documents": [
+                {
+                  "_id": 1,
+                  "encrypted_string_kmip_delegated": {
+                    "$binary": {
+                      "base64": "AXQR6a/GiE33gUNeYK6Wy6YCkB+8NVfAAjIbvLqyXIg6g1a8tXrym92DPoqmxpcdQyH0vQM3aFNMz7tZwQBimKs29ztZV/LWjM633HhO5ACl9A==",
+                      "subType": "06"
+                    }
+                  }
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "insert"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "encrypted_string_kmip_delegated": {
+                "$binary": {
+                  "base64": "AXQR6a/GiE33gUNeYK6Wy6YCkB+8NVfAAjIbvLqyXIg6g1a8tXrym92DPoqmxpcdQyH0vQM3aFNMz7tZwQBimKs29ztZV/LWjM633HhO5ACl9A==",
                   "subType": "06"
                 }
               }

--- a/driver-core/src/test/resources/unified-test-format/client-side-encryption/createDataKey.json
+++ b/driver-core/src/test/resources/unified-test-format/client-side-encryption/createDataKey.json
@@ -338,6 +338,70 @@
       ]
     },
     {
+      "description": "create datakey with KMIP delegated KMS provider",
+      "operations": [
+        {
+          "name": "createDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "kmsProvider": "kmip",
+            "opts": {
+              "masterKey": {
+                "delegated": true
+              }
+            }
+          },
+          "expectResult": {
+            "$$type": "binData"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "insert": "datakeys",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$$type": "binData"
+                      },
+                      "keyMaterial": {
+                        "$$type": "binData"
+                      },
+                      "creationDate": {
+                        "$$type": "date"
+                      },
+                      "updateDate": {
+                        "$$type": "date"
+                      },
+                      "status": {
+                        "$$exists": true
+                      },
+                      "masterKey": {
+                        "provider": "kmip",
+                        "keyId": {
+                          "$$type": "string"
+                        },
+                        "delegated": true
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "description": "create datakey with local KMS provider",
       "operations": [
         {

--- a/driver-core/src/test/resources/unified-test-format/client-side-encryption/rewrapManyDataKey.json
+++ b/driver-core/src/test/resources/unified-test-format/client-side-encryption/rewrapManyDataKey.json
@@ -246,6 +246,36 @@
           "masterKey": {
             "provider": "local"
           }
+        },
+        {
+          "_id": {
+            "$uuid": "7411e9af-c688-4df7-8143-5e60ae96cba5"
+          },
+          "keyAltNames": [
+            "kmip_delegated_key"
+          ],
+          "keyMaterial": {
+            "$binary": {
+              "base64": "5TLMFWlguBWe5GUESTvOVtkdBsCrynhnV72XRyZ66/nk+EP9/1oEp1t1sg0+vwCTqULHjBiUE6DRx2mYD/Eup1+u2Jgz9/+1sV1drXeOPALNPkSgiZiDbIb67zRi+wTABEcKcegJH+FhmSGxwUoQAiHCsCbcvia5P8tN1lt98YQ=",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1641024000000"
+            }
+          },
+          "status": 1,
+          "masterKey": {
+            "provider": "kmip",
+            "keyId": "11",
+            "delegated": true
+          }
         }
       ]
     }
@@ -317,8 +347,8 @@
           "expectResult": {
             "bulkWriteResult": {
               "insertedCount": 0,
-              "matchedCount": 4,
-              "modifiedCount": 4,
+              "matchedCount": 5,
+              "modifiedCount": 5,
               "deletedCount": 0,
               "upsertedCount": 0,
               "upsertedIds": {},
@@ -467,6 +497,34 @@
                       "upsert": {
                         "$$unsetOrMatches": false
                       }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "aws",
+                            "key": "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d",
+                            "region": "us-east-1"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "writeConcern": {
@@ -502,8 +560,8 @@
           "expectResult": {
             "bulkWriteResult": {
               "insertedCount": 0,
-              "matchedCount": 4,
-              "modifiedCount": 4,
+              "matchedCount": 5,
+              "modifiedCount": 5,
               "deletedCount": 0,
               "upsertedCount": 0,
               "upsertedIds": {},
@@ -652,6 +710,34 @@
                       "upsert": {
                         "$$unsetOrMatches": false
                       }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "azure",
+                            "keyVaultEndpoint": "key-vault-csfle.vault.azure.net",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "writeConcern": {
@@ -689,8 +775,8 @@
           "expectResult": {
             "bulkWriteResult": {
               "insertedCount": 0,
-              "matchedCount": 4,
-              "modifiedCount": 4,
+              "matchedCount": 5,
+              "modifiedCount": 5,
               "deletedCount": 0,
               "upsertedCount": 0,
               "upsertedIds": {},
@@ -847,6 +933,36 @@
                       "upsert": {
                         "$$unsetOrMatches": false
                       }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "gcp",
+                            "projectId": "devprod-drivers",
+                            "location": "global",
+                            "keyRing": "key-ring-csfle",
+                            "keyName": "key-name-csfle"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "writeConcern": {
@@ -878,8 +994,8 @@
           "expectResult": {
             "bulkWriteResult": {
               "insertedCount": 0,
-              "matchedCount": 4,
-              "modifiedCount": 4,
+              "matchedCount": 5,
+              "modifiedCount": 5,
               "deletedCount": 0,
               "upsertedCount": 0,
               "upsertedIds": {},
@@ -1032,6 +1148,257 @@
                       "upsert": {
                         "$$unsetOrMatches": false
                       }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip",
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": "majority"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rewrap with new KMIP delegated KMS provider",
+      "operations": [
+        {
+          "name": "rewrapManyDataKey",
+          "object": "clientEncryption0",
+          "arguments": {
+            "filter": {
+              "keyAltNames": {
+                "$ne": "kmip_delegated_key"
+              }
+            },
+            "opts": {
+              "provider": "kmip",
+              "masterKey": {
+                "delegated": true
+              }
+            }
+          },
+          "expectResult": {
+            "bulkWriteResult": {
+              "insertedCount": 0,
+              "matchedCount": 5,
+              "modifiedCount": 5,
+              "deletedCount": 0,
+              "upsertedCount": 0,
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "keyAltNames": {
+                      "$ne": "kmip_delegated_key"
+                    }
+                  },
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "databaseName": "keyvault",
+                "command": {
+                  "update": "datakeys",
+                  "ordered": true,
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip",
+                            "delegated": true,
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip",
+                            "delegated": true,
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip",
+                            "delegated": true,
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip",
+                            "delegated": true,
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "kmip",
+                            "delegated": true,
+                            "keyId": {
+                              "$$type": "string"
+                            }
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "writeConcern": {
@@ -1063,8 +1430,8 @@
           "expectResult": {
             "bulkWriteResult": {
               "insertedCount": 0,
-              "matchedCount": 4,
-              "modifiedCount": 4,
+              "matchedCount": 5,
+              "modifiedCount": 5,
               "deletedCount": 0,
               "upsertedCount": 0,
               "upsertedIds": {},
@@ -1205,6 +1572,32 @@
                       "upsert": {
                         "$$unsetOrMatches": false
                       }
+                    },
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "provider": "local"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "writeConcern": {
@@ -1229,8 +1622,8 @@
           "expectResult": {
             "bulkWriteResult": {
               "insertedCount": 0,
-              "matchedCount": 5,
-              "modifiedCount": 5,
+              "matchedCount": 6,
+              "modifiedCount": 6,
               "deletedCount": 0,
               "upsertedCount": 0,
               "upsertedIds": {},
@@ -1296,6 +1689,16 @@
             },
             {
               "_id": {
+                "$uuid": "7411e9af-c688-4df7-8143-5e60ae96cba5"
+              },
+              "masterKey": {
+                "provider": "kmip",
+                "keyId": "11",
+                "delegated": true
+              }
+            },
+            {
+              "_id": {
                 "$binary": {
                   "base64": "a21pcGttaXBrbWlwa21pcA==",
                   "subType": "04"
@@ -1343,6 +1746,32 @@
                   "update": "datakeys",
                   "ordered": true,
                   "updates": [
+                    {
+                      "q": {
+                        "_id": {
+                          "$$type": "binData"
+                        }
+                      },
+                      "u": {
+                        "$set": {
+                          "masterKey": {
+                            "$$type": "object"
+                          },
+                          "keyMaterial": {
+                            "$$type": "binData"
+                          }
+                        },
+                        "$currentDate": {
+                          "updateDate": true
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    },
                     {
                       "q": {
                         "_id": {


### PR DESCRIPTION
JAVA-5300

Copies tests, updates docs, and uses the (erroneously named) 1.8.0-SNAPSHOT which has the `delegated` feature available.

See also, update/fix in: https://github.com/mongodb/specifications/pull/1591