### PR TITLE
Migrate `com.mongodb.client.unified.UnifiedTest` and all its descendants to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
     awsSdkV1Version = '1.12.337'
     mongoCryptVersion = '1.8.0'
     projectReactorVersion = '2022.0.0'
-    junitBomVersion = '5.8.2'
+    junitBomVersion = '5.10.2'
     logbackVersion = '1.3.14'
     gitVersion = getGitVersion()
 }

--- a/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/UnifiedCrudTest.kt
+++ b/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/UnifiedCrudTest.kt
@@ -15,32 +15,21 @@
  */
 package com.mongodb.kotlin.client.coroutine
 
-import com.mongodb.client.unified.UnifiedCrudTest.customSkips
+import com.mongodb.client.unified.UnifiedCrudTest.doSkips
 import java.io.IOException
 import java.net.URISyntaxException
-import org.bson.BsonArray
-import org.bson.BsonDocument
-import org.junit.runners.Parameterized
+import org.junit.jupiter.params.provider.Arguments
 
-internal class UnifiedCrudTest(
-    fileDescription: String?,
-    testDescription: String,
-    schemaVersion: String,
-    runOnRequirements: BsonArray?,
-    entitiesArray: BsonArray,
-    initialData: BsonArray,
-    definition: BsonDocument
-) : UnifiedTest(fileDescription, schemaVersion, runOnRequirements, entitiesArray, initialData, definition) {
+internal class UnifiedCrudTest() : UnifiedTest() {
 
-    init {
-        customSkips(fileDescription, testDescription)
+    override fun skips(fileDescription: String, testDescription: String) {
+        doSkips(fileDescription, testDescription)
     }
 
     companion object {
         @JvmStatic
-        @Parameterized.Parameters(name = "{0}: {1}")
         @Throws(URISyntaxException::class, IOException::class)
-        fun data(): Collection<Array<Any?>?>? {
+        fun data(): Collection<Arguments>? {
             return getTestData("unified-test-format/crud")
         }
     }

--- a/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/UnifiedTest.kt
+++ b/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/UnifiedTest.kt
@@ -23,17 +23,8 @@ import com.mongodb.client.gridfs.GridFSBucket
 import com.mongodb.client.unified.UnifiedTest as JUnifiedTest
 import com.mongodb.client.vault.ClientEncryption
 import com.mongodb.kotlin.client.coroutine.syncadapter.SyncMongoClient
-import org.bson.BsonArray
-import org.bson.BsonDocument
 
-internal abstract class UnifiedTest(
-    fileDescription: String?,
-    schemaVersion: String,
-    runOnRequirements: BsonArray?,
-    entitiesArray: BsonArray,
-    initialData: BsonArray,
-    definition: BsonDocument
-) : JUnifiedTest(fileDescription, schemaVersion, runOnRequirements, entitiesArray, initialData, definition) {
+internal abstract class UnifiedTest() : JUnifiedTest() {
 
     override fun createMongoClient(settings: MongoClientSettings): JMongoClient =
         SyncMongoClient(MongoClient.create(settings))

--- a/driver-kotlin-sync/src/integration/kotlin/com/mongodb/kotlin/client/UnifiedCrudTest.kt
+++ b/driver-kotlin-sync/src/integration/kotlin/com/mongodb/kotlin/client/UnifiedCrudTest.kt
@@ -15,32 +15,21 @@
  */
 package com.mongodb.kotlin.client
 
-import com.mongodb.client.unified.UnifiedCrudTest.customSkips
+import com.mongodb.client.unified.UnifiedCrudTest.doSkips
 import java.io.IOException
 import java.net.URISyntaxException
-import org.bson.BsonArray
-import org.bson.BsonDocument
-import org.junit.runners.Parameterized
+import org.junit.jupiter.params.provider.Arguments
 
-internal class UnifiedCrudTest(
-    fileDescription: String?,
-    testDescription: String,
-    schemaVersion: String,
-    runOnRequirements: BsonArray?,
-    entitiesArray: BsonArray,
-    initialData: BsonArray,
-    definition: BsonDocument
-) : UnifiedTest(fileDescription, schemaVersion, runOnRequirements, entitiesArray, initialData, definition) {
+internal class UnifiedCrudTest() : UnifiedTest() {
 
-    init {
-        customSkips(fileDescription, testDescription)
+    override fun skips(fileDescription: String, testDescription: String) {
+        doSkips(fileDescription, testDescription)
     }
 
     companion object {
         @JvmStatic
-        @Parameterized.Parameters(name = "{0}: {1}")
         @Throws(URISyntaxException::class, IOException::class)
-        fun data(): Collection<Array<Any?>?>? {
+        fun data(): Collection<Arguments>? {
             return getTestData("unified-test-format/crud")
         }
     }

--- a/driver-kotlin-sync/src/integration/kotlin/com/mongodb/kotlin/client/UnifiedTest.kt
+++ b/driver-kotlin-sync/src/integration/kotlin/com/mongodb/kotlin/client/UnifiedTest.kt
@@ -23,17 +23,8 @@ import com.mongodb.client.gridfs.GridFSBucket
 import com.mongodb.client.unified.UnifiedTest as JUnifiedTest
 import com.mongodb.client.vault.ClientEncryption
 import com.mongodb.kotlin.client.syncadapter.SyncMongoClient
-import org.bson.BsonArray
-import org.bson.BsonDocument
 
-internal abstract class UnifiedTest(
-    fileDescription: String?,
-    schemaVersion: String,
-    runOnRequirements: BsonArray?,
-    entitiesArray: BsonArray,
-    initialData: BsonArray,
-    definition: BsonDocument
-) : JUnifiedTest(fileDescription, schemaVersion, runOnRequirements, entitiesArray, initialData, definition) {
+internal abstract class UnifiedTest() : JUnifiedTest() {
 
     override fun createMongoClient(settings: MongoClientSettings): JMongoClient =
         SyncMongoClient(MongoClient.create(settings))

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ChangeStreamsTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ChangeStreamsTest.java
@@ -19,8 +19,9 @@ package com.mongodb.reactivestreams.client.unified;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
-import org.junit.After;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -32,9 +33,9 @@ import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.dis
 import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.disableWaitForBatchCursorCreation;
 import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.enableSleepAfterCursorOpen;
 import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.enableWaitForBatchCursorCreation;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public final class ChangeStreamsTest extends UnifiedReactiveStreamsTest {
+final class ChangeStreamsTest extends UnifiedReactiveStreamsTest {
 
     private static final List<String> ERROR_REQUIRED_FROM_CHANGE_STREAM_INITIALIZATION_TESTS =
             Arrays.asList(
@@ -54,32 +55,44 @@ public final class ChangeStreamsTest extends UnifiedReactiveStreamsTest {
                             + "but instead depend on a server error"
             );
 
-
-    public ChangeStreamsTest(@SuppressWarnings("unused") final String fileDescription,
-                             @SuppressWarnings("unused") final String testDescription,
-                             final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                             final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         assumeFalse(ERROR_REQUIRED_FROM_CHANGE_STREAM_INITIALIZATION_TESTS.contains(testDescription));
         assumeFalse(EVENT_SENSITIVE_TESTS.contains(testDescription));
+    }
 
+    @BeforeEach
+    @Override
+    public void setUp(@Nullable final String fileDescription,
+            @Nullable final String testDescription,
+            final String schemaVersion,
+            @Nullable final BsonArray runOnRequirements,
+            final BsonArray entitiesArray,
+            final BsonArray initialData,
+            final BsonDocument definition) {
+        super.setUp(
+                fileDescription,
+                testDescription,
+                schemaVersion,
+                runOnRequirements,
+                entitiesArray,
+                initialData,
+                definition);
         enableSleepAfterCursorOpen(256);
-
         if (REQUIRES_BATCH_CURSOR_CREATION_WAITING.contains(testDescription)) {
             enableWaitForBatchCursorCreation();
         }
     }
 
-    @After
+    @AfterEach
+    @Override
     public void cleanUp() {
         super.cleanUp();
         disableSleep();
         disableWaitForBatchCursorCreation();
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/change-streams");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ClientSideEncryptionTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ClientSideEncryptionTest.java
@@ -16,27 +16,14 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class ClientSideEncryptionTest extends UnifiedReactiveStreamsTest {
-    public ClientSideEncryptionTest(@SuppressWarnings("unused") final String fileDescription,
-            @SuppressWarnings("unused") final String testDescription,
-            final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-            final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class ClientSideEncryptionTest extends UnifiedReactiveStreamsTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/client-side-encryption");
     }
-
 }
-

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/CollectionManagementTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/CollectionManagementTest.java
@@ -16,28 +16,21 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class CollectionManagementTest extends UnifiedReactiveStreamsTest {
-    public CollectionManagementTest(@SuppressWarnings("unused") final String fileDescription,
-                                    @SuppressWarnings("unused") final String testDescription,
-                                    final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                                    final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+final class CollectionManagementTest extends UnifiedReactiveStreamsTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         assumeFalse(testDescription.equals("modifyCollection to changeStreamPreAndPostImages enabled"));
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/collection-management");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/CommandLoggingTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/CommandLoggingTest.java
@@ -16,30 +16,23 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class CommandLoggingTest extends UnifiedReactiveStreamsTest {
-    public CommandLoggingTest(@SuppressWarnings("unused") final String fileDescription,
-                              @SuppressWarnings("unused") final String testDescription,
-                              final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                              final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+final class CommandLoggingTest extends UnifiedReactiveStreamsTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         // The driver has a hack where getLastError command is executed as part of the handshake in order to get a connectionId
         // even when the hello command response doesn't contain it.
         assumeFalse(fileDescription.equals("pre-42-server-connection-id"));
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/command-logging");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/CommandMonitoringTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/CommandMonitoringTest.java
@@ -16,30 +16,23 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class CommandMonitoringTest extends UnifiedReactiveStreamsTest {
-    public CommandMonitoringTest(@SuppressWarnings("unused") final String fileDescription,
-                                 @SuppressWarnings("unused") final String testDescription,
-                                 final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                                 final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+final class CommandMonitoringTest extends UnifiedReactiveStreamsTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         // The driver has a hack where getLastError command is executed as part of the handshake in order to get a connectionId
         // even when the hello command response doesn't contain it.
         assumeFalse(fileDescription.equals("pre-42-server-connection-id"));
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/command-monitoring");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ConnectionPoolLoggingTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ConnectionPoolLoggingTest.java
@@ -16,33 +16,23 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class ConnectionPoolLoggingTest extends UnifiedReactiveStreamsTest {
-
-
-    public ConnectionPoolLoggingTest(@SuppressWarnings("unused") final String fileDescription,
-                                     @SuppressWarnings("unused") final String testDescription,
-                                     final String schemaVersion,
-                                     @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
-                                     final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+final class ConnectionPoolLoggingTest extends UnifiedReactiveStreamsTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         // The implementation of the functionality related to clearing the connection pool before closing the connection
         // will be carried out once the specification is finalized and ready.
         assumeFalse(testDescription.equals("Connection checkout fails due to error establishing connection"));
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/connection-monitoring-and-pooling/logging");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/IndexManagmentTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/IndexManagmentTest.java
@@ -16,27 +16,14 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class IndexManagmentTest extends UnifiedReactiveStreamsTest {
-
-    public IndexManagmentTest(@SuppressWarnings("unused") final String fileDescription,
-                              @SuppressWarnings("unused") final String testDescription,
-                              final String schemaVersion,
-                              @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
-                              final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class IndexManagmentTest extends UnifiedReactiveStreamsTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/index-management");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ServerSelectionLoggingTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ServerSelectionLoggingTest.java
@@ -16,25 +16,14 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public final class ServerSelectionLoggingTest extends UnifiedReactiveStreamsTest {
-    public ServerSelectionLoggingTest(@SuppressWarnings("unused") final String fileDescription,
-                             @SuppressWarnings("unused") final String testDescription,
-                             final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                             final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class ServerSelectionLoggingTest extends UnifiedReactiveStreamsTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/server-selection/logging");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/SessionsTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/SessionsTest.java
@@ -16,24 +16,14 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class SessionsTest extends UnifiedReactiveStreamsTest {
-    public SessionsTest(@SuppressWarnings("unused") final String fileDescription, @SuppressWarnings("unused") final String testDescription,
-                        final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                        final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class SessionsTest extends UnifiedReactiveStreamsTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/sessions");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedCrudTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedCrudTest.java
@@ -16,27 +16,21 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static com.mongodb.client.unified.UnifiedCrudTest.customSkips;
+import static com.mongodb.client.unified.UnifiedCrudTest.doSkips;
 
-public class UnifiedCrudTest extends UnifiedReactiveStreamsTest {
-    public UnifiedCrudTest(final String fileDescription, final String testDescription, final String schemaVersion,
-                            @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
-                            final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-        customSkips(fileDescription, testDescription);
+final class UnifiedCrudTest extends UnifiedReactiveStreamsTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
+        doSkips(fileDescription, testDescription);
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/crud");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedGridFSTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedGridFSTest.java
@@ -16,30 +16,24 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class UnifiedGridFSTest extends UnifiedReactiveStreamsTest {
-    public UnifiedGridFSTest(@SuppressWarnings("unused") final String fileDescription, final String testDescription,
-                             final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                             final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+final class UnifiedGridFSTest extends UnifiedReactiveStreamsTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         // contentType is deprecated in GridFS spec, and 4.x Java driver no longer support it, so skipping this test
         assumeFalse(testDescription.equals("upload when contentType is provided"));
         // Re-enable when JAVA-4214 is fixed
         assumeFalse(testDescription.equals("delete when files entry does not exist and there are orphaned chunks"));
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/gridfs");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedReactiveStreamsTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedReactiveStreamsTest.java
@@ -23,7 +23,6 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.gridfs.GridFSBucket;
 import com.mongodb.client.unified.UnifiedTest;
 import com.mongodb.client.vault.ClientEncryption;
-import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.gridfs.GridFSBuckets;
 import com.mongodb.reactivestreams.client.internal.vault.ClientEncryptionImpl;
@@ -31,18 +30,9 @@ import com.mongodb.reactivestreams.client.syncadapter.SyncClientEncryption;
 import com.mongodb.reactivestreams.client.syncadapter.SyncGridFSBucket;
 import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
 import com.mongodb.reactivestreams.client.syncadapter.SyncMongoDatabase;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
 
 public abstract class UnifiedReactiveStreamsTest extends UnifiedTest {
-    public UnifiedReactiveStreamsTest(@Nullable final String fileDescription, final String schemaVersion, final BsonArray runOnRequirements,
-            final BsonArray entitiesArray, final BsonArray initialData, final BsonDocument definition) {
-        super(fileDescription, schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
-    }
-
-    public UnifiedReactiveStreamsTest(final String schemaVersion, final BsonArray runOnRequirements,
-            final BsonArray entitiesArray, final BsonArray initialData, final BsonDocument definition) {
-        this(null, schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
+    protected UnifiedReactiveStreamsTest() {
     }
 
     @Override

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedRetryableReadsTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedRetryableReadsTest.java
@@ -16,24 +16,45 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
+import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
-import org.junit.After;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static com.mongodb.client.unified.UnifiedRetryableReadsTest.customSkips;
+import static com.mongodb.client.unified.UnifiedRetryableReadsTest.doSkips;
 import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.disableWaitForBatchCursorCreation;
 import static com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient.enableWaitForBatchCursorCreation;
 
-public class UnifiedRetryableReadsTest extends UnifiedReactiveStreamsTest {
-    public UnifiedRetryableReadsTest(final String fileDescription, final String testDescription, final String schemaVersion,
-            final BsonArray runOnRequirements, final BsonArray entitiesArray, final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
-        customSkips(fileDescription, testDescription);
+final class UnifiedRetryableReadsTest extends UnifiedReactiveStreamsTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
+        doSkips(fileDescription, testDescription);
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp(
+            final String fileDescription,
+            final String testDescription,
+            final String schemaVersion,
+            @Nullable final BsonArray runOnRequirements,
+            final BsonArray entitiesArray,
+            final BsonArray initialData,
+            final BsonDocument definition) {
+        super.setUp(
+                fileDescription,
+                testDescription,
+                schemaVersion,
+                runOnRequirements,
+                entitiesArray,
+                initialData,
+                definition);
         if (fileDescription.startsWith("changeStreams") || testDescription.contains("ChangeStream")) {
             // Several reactive change stream tests fail if we don't block waiting for batch cursor creation.
             enableWaitForBatchCursorCreation();
@@ -42,14 +63,14 @@ public class UnifiedRetryableReadsTest extends UnifiedReactiveStreamsTest {
         }
     }
 
-    @After
+    @Override
+    @AfterEach
     public void cleanUp() {
         super.cleanUp();
         disableWaitForBatchCursorCreation();
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/retryable-reads");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedRetryableWritesTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedRetryableWritesTest.java
@@ -16,27 +16,21 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static com.mongodb.client.unified.UnifiedRetryableWritesTest.customSkips;
+import static com.mongodb.client.unified.UnifiedRetryableWritesTest.doSkips;
 
-public class UnifiedRetryableWritesTest extends UnifiedReactiveStreamsTest {
-    public UnifiedRetryableWritesTest(@SuppressWarnings("unused") final String fileDescription,
-                                      @SuppressWarnings("unused") final String testDescription,
-                                      final String schemaVersion, final BsonArray runOnRequirements, final BsonArray entitiesArray,
-                                      final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
-        customSkips(testDescription);
+final class UnifiedRetryableWritesTest extends UnifiedReactiveStreamsTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
+        doSkips(testDescription);
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/retryable-writes");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedServerDiscoveryAndMonitoringTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedServerDiscoveryAndMonitoringTest.java
@@ -16,32 +16,19 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.Before;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class UnifiedServerDiscoveryAndMonitoringTest extends UnifiedReactiveStreamsTest {
-    public UnifiedServerDiscoveryAndMonitoringTest(@SuppressWarnings("unused") final String fileDescription,
-            @SuppressWarnings("unused") final String testDescription,
-            final String schemaVersion,
-            @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
-            final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class UnifiedServerDiscoveryAndMonitoringTest extends UnifiedReactiveStreamsTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/server-discovery-and-monitoring");
     }
 
-    @Before
-    public void before() {
-        com.mongodb.client.unified.UnifiedServerDiscoveryAndMonitoringTest.skipTests(getDefinition());
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
+        com.mongodb.client.unified.UnifiedServerDiscoveryAndMonitoringTest.doSkips(getDefinition());
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedTransactionsTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedTransactionsTest.java
@@ -16,9 +16,7 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -26,14 +24,11 @@ import java.util.Collection;
 
 import static com.mongodb.ClusterFixture.isSharded;
 import static com.mongodb.ClusterFixture.serverVersionLessThan;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class UnifiedTransactionsTest extends UnifiedReactiveStreamsTest {
-    public UnifiedTransactionsTest(@SuppressWarnings("unused") final String fileDescription,
-                                   @SuppressWarnings("unused") final String testDescription,
-                                   final String schemaVersion, final BsonArray runOnRequirements, final BsonArray entitiesArray,
-                                   final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
+final class UnifiedTransactionsTest extends UnifiedReactiveStreamsTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         assumeFalse(fileDescription.equals("count"));
         if (serverVersionLessThan(4, 4) && isSharded()) {
             assumeFalse(fileDescription.equals("pin-mongos") && testDescription.equals("distinct"));
@@ -43,8 +38,7 @@ public class UnifiedTransactionsTest extends UnifiedReactiveStreamsTest {
         }
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/transactions");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedWriteConcernTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedWriteConcernTest.java
@@ -16,23 +16,14 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class UnifiedWriteConcernTest extends UnifiedReactiveStreamsTest {
-    public UnifiedWriteConcernTest(@SuppressWarnings("unused") final String fileDescription,
-            @SuppressWarnings("unused") final String testDescription, final String schemaVersion, final BsonArray runOnRequirements,
-            final BsonArray entitiesArray, final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class UnifiedWriteConcernTest extends UnifiedReactiveStreamsTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/write-concern");
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/VersionedApiTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/VersionedApiTest.java
@@ -16,25 +16,14 @@
 
 package com.mongodb.reactivestreams.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class VersionedApiTest extends UnifiedReactiveStreamsTest {
-    public VersionedApiTest(@SuppressWarnings("unused") final String fileDescription,
-                            @SuppressWarnings("unused") final String testDescription,
-                            final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                            final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class VersionedApiTest extends UnifiedReactiveStreamsTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("versioned-api");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/ChangeStreamsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/ChangeStreamsTest.java
@@ -16,25 +16,14 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public final class ChangeStreamsTest extends UnifiedSyncTest {
-    public ChangeStreamsTest(@SuppressWarnings("unused") final String fileDescription,
-                             @SuppressWarnings("unused") final String testDescription,
-                             final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                             final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class ChangeStreamsTest extends UnifiedSyncTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/change-streams");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/ClientSideEncryptionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/ClientSideEncryptionTest.java
@@ -16,27 +16,14 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class ClientSideEncryptionTest extends UnifiedSyncTest {
-    public ClientSideEncryptionTest(@SuppressWarnings("unused") final String fileDescription,
-            @SuppressWarnings("unused") final String testDescription,
-            final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-            final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class ClientSideEncryptionTest extends UnifiedSyncTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/client-side-encryption");
     }
 }
-

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/CollectionManagementTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/CollectionManagementTest.java
@@ -16,28 +16,21 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class CollectionManagementTest extends UnifiedSyncTest {
-    public CollectionManagementTest(@SuppressWarnings("unused") final String fileDescription,
-                                    @SuppressWarnings("unused") final String testDescription,
-                                    final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                                    final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+final class CollectionManagementTest extends UnifiedSyncTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         assumeFalse(testDescription.equals("modifyCollection to changeStreamPreAndPostImages enabled"));
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/collection-management");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/CommandLoggingTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/CommandLoggingTest.java
@@ -16,35 +16,25 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
 import static com.mongodb.ClusterFixture.isServerlessTest;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class CommandLoggingTest extends UnifiedSyncTest {
-
-
-    public CommandLoggingTest(@SuppressWarnings("unused") final String fileDescription,
-                              @SuppressWarnings("unused") final String testDescription,
-                              final String schemaVersion,
-                              @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
-                              final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+final class CommandLoggingTest extends UnifiedSyncTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         assumeFalse(isServerlessTest());
         // The driver has a hack where getLastError command is executed as part of the handshake in order to get a connectionId
         // even when the hello command response doesn't contain it.
         assumeFalse(fileDescription.equals("pre-42-server-connection-id"));
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/command-logging");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/CommandMonitoringTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/CommandMonitoringTest.java
@@ -16,35 +16,25 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
 import static com.mongodb.ClusterFixture.isServerlessTest;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class CommandMonitoringTest extends UnifiedSyncTest {
-
-
-    public CommandMonitoringTest(@SuppressWarnings("unused") final String fileDescription,
-                                 @SuppressWarnings("unused") final String testDescription,
-                                 final String schemaVersion,
-                                 @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
-                                 final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+final class CommandMonitoringTest extends UnifiedSyncTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         assumeFalse(isServerlessTest());
         // The driver has a hack where getLastError command is executed as part of the handshake in order to get a connectionId
         // even when the hello command response doesn't contain it.
         assumeFalse(fileDescription.equals("pre-42-server-connection-id"));
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/command-monitoring");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/ConnectionPoolLoggingTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/ConnectionPoolLoggingTest.java
@@ -16,32 +16,23 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class ConnectionPoolLoggingTest extends UnifiedSyncTest {
-
-    public ConnectionPoolLoggingTest(@SuppressWarnings("unused") final String fileDescription,
-            @SuppressWarnings("unused") final String testDescription,
-            final String schemaVersion,
-            @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
-            final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+final class ConnectionPoolLoggingTest extends UnifiedSyncTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         // The implementation of the functionality related to clearing the connection pool before closing the connection
         // will be carried out once the specification is finalized and ready.
         assumeFalse(testDescription.equals("Connection checkout fails due to error establishing connection"));
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/connection-monitoring-and-pooling/logging");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/IndexManagmentTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/IndexManagmentTest.java
@@ -16,27 +16,14 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class IndexManagmentTest extends UnifiedSyncTest {
-
-    public IndexManagmentTest(@SuppressWarnings("unused") final String fileDescription,
-                              @SuppressWarnings("unused") final String testDescription,
-                              final String schemaVersion,
-                              @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
-                              final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class IndexManagmentTest extends UnifiedSyncTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/index-management");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/LoadBalancerTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/LoadBalancerTest.java
@@ -16,26 +16,14 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class LoadBalancerTest extends UnifiedSyncTest {
-
-    public LoadBalancerTest(final String fileDescription,
-                            @SuppressWarnings("unused") final String testDescription,
-                            final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                            final BsonArray initialData, final BsonDocument definition) {
-        super(fileDescription, schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class LoadBalancerTest extends UnifiedSyncTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/load-balancers");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/ServerSelectionLoggingTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/ServerSelectionLoggingTest.java
@@ -16,25 +16,14 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public final class ServerSelectionLoggingTest extends UnifiedSyncTest {
-    public ServerSelectionLoggingTest(@SuppressWarnings("unused") final String fileDescription,
-                             @SuppressWarnings("unused") final String testDescription,
-                             final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                             final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class ServerSelectionLoggingTest extends UnifiedSyncTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/server-selection/logging");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/SessionsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/SessionsTest.java
@@ -16,25 +16,14 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class SessionsTest extends UnifiedSyncTest {
-
-    public SessionsTest(@SuppressWarnings("unused") final String fileDescription, @SuppressWarnings("unused") final String testDescription,
-                        final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                        final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class SessionsTest extends UnifiedSyncTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/sessions");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedAtlasDataLakeTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedAtlasDataLakeTest.java
@@ -16,30 +16,22 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
 import static com.mongodb.ClusterFixture.isDataLakeTest;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-public class UnifiedAtlasDataLakeTest extends UnifiedSyncTest {
-
-    public UnifiedAtlasDataLakeTest(@SuppressWarnings("unused") final String fileDescription,
-            @SuppressWarnings("unused") final String testDescription, final String schemaVersion,
-            @Nullable final BsonArray runOnRequirements, final BsonArray entities, final BsonArray initialData,
-            final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+final class UnifiedAtlasDataLakeTest extends UnifiedSyncTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         assumeTrue(isDataLakeTest());
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/atlas-data-lake-testing");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedAuthTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedAuthTest.java
@@ -16,24 +16,14 @@
 
 package com.mongodb.client.unified;
 
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class UnifiedAuthTest extends UnifiedSyncTest {
-    public UnifiedAuthTest(@SuppressWarnings("unused") final String fileDescription,
-                           @SuppressWarnings("unused") final String testDescription,
-                           final String schemaVersion, final BsonArray runOnRequirements, final BsonArray entitiesArray,
-                           final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class UnifiedAuthTest extends UnifiedSyncTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/auth");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudTest.java
@@ -16,10 +16,7 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -27,19 +24,10 @@ import java.util.Collection;
 
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class UnifiedCrudTest extends UnifiedSyncTest {
-
-    public UnifiedCrudTest(@SuppressWarnings("unused") final String fileDescription,
-                           @SuppressWarnings("unused") final String testDescription,
-                           final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                           final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-        customSkips(fileDescription, testDescription);
-    }
-
-    public static void customSkips(final String fileDescription, final String testDescription) {
+public final class UnifiedCrudTest extends UnifiedSyncTest {
+    public static void doSkips(final String fileDescription, final String testDescription) {
         assumeFalse(testDescription.equals("Deprecated count with empty collection"));
         assumeFalse(testDescription.equals("Deprecated count with collation"));
         assumeFalse(testDescription.equals("Deprecated count without a filter"));
@@ -57,7 +45,12 @@ public class UnifiedCrudTest extends UnifiedSyncTest {
         }
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
+        doSkips(fileDescription, testDescription);
+    }
+
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/crud");
-    }}
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedGridFSTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedGridFSTest.java
@@ -16,28 +16,22 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class UnifiedGridFSTest extends UnifiedSyncTest {
-
-    public UnifiedGridFSTest(@SuppressWarnings("unused") final String fileDescription, final String testDescription,
-                             final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                             final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
+final class UnifiedGridFSTest extends UnifiedSyncTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         // contentType is deprecated in GridFS spec, and 4.x Java driver no longer support it, so skipping this test
         assumeFalse(testDescription.equals("upload when contentType is provided"));
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/gridfs");
-    }}
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedRetryableReadsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedRetryableReadsTest.java
@@ -16,24 +16,21 @@
 
 package com.mongodb.client.unified;
 
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class UnifiedRetryableReadsTest extends UnifiedSyncTest {
-    public UnifiedRetryableReadsTest(final String fileDescription, final String testDescription, final String schemaVersion,
-            final BsonArray runOnRequirements, final BsonArray entitiesArray, final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
-        customSkips(fileDescription, testDescription);
+public final class UnifiedRetryableReadsTest extends UnifiedSyncTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
+        doSkips(fileDescription, testDescription);
     }
 
-    public static void customSkips(final String fileDescription, @SuppressWarnings("unused") final String testDescription) {
+    public static void doSkips(final String fileDescription, @SuppressWarnings("unused") final String testDescription) {
         // Skipped because driver removed the deprecated count methods
         assumeFalse(fileDescription.equals("count"));
         assumeFalse(fileDescription.equals("count-serverErrors"));
@@ -44,8 +41,7 @@ public class UnifiedRetryableReadsTest extends UnifiedSyncTest {
         assumeFalse(fileDescription.equals("listCollectionObjects-serverErrors"));
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/retryable-reads");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedRetryableWritesTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedRetryableWritesTest.java
@@ -16,9 +16,7 @@
 
 package com.mongodb.client.unified;
 
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -27,18 +25,15 @@ import java.util.Collection;
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isSharded;
 import static com.mongodb.ClusterFixture.serverVersionLessThan;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class UnifiedRetryableWritesTest extends UnifiedSyncTest {
-    public UnifiedRetryableWritesTest(@SuppressWarnings("unused") final String fileDescription,
-                                      @SuppressWarnings("unused") final String testDescription,
-                                      final String schemaVersion, final BsonArray runOnRequirements, final BsonArray entitiesArray,
-                                      final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
-        customSkips(testDescription);
+public final class UnifiedRetryableWritesTest extends UnifiedSyncTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
+        doSkips(testDescription);
     }
 
-    public static void customSkips(final String description) {
+    public static void doSkips(final String description) {
         if (isSharded() && serverVersionLessThan(5, 0)) {
             assumeFalse(description.contains("succeeds after WriteConcernError"));
             assumeFalse(description.contains("succeeds after retryable writeConcernError"));
@@ -48,8 +43,7 @@ public class UnifiedRetryableWritesTest extends UnifiedSyncTest {
         }
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/retryable-writes");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedServerDiscoveryAndMonitoringTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedServerDiscoveryAndMonitoringTest.java
@@ -16,43 +16,31 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
-import org.junit.Before;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class UnifiedServerDiscoveryAndMonitoringTest extends UnifiedSyncTest {
-
-    public UnifiedServerDiscoveryAndMonitoringTest(@SuppressWarnings("unused") final String fileDescription,
-            @SuppressWarnings("unused") final String testDescription,
-            final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-            final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+public final class UnifiedServerDiscoveryAndMonitoringTest extends UnifiedSyncTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/server-discovery-and-monitoring");
     }
 
-    @Before
-    public void before() {
-        skipTests(getDefinition());
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
+        doSkips(getDefinition());
     }
 
-    public static void skipTests(final BsonDocument definition) {
+    public static void doSkips(final BsonDocument definition) {
         String description = definition.getString("description", new BsonString("")).getValue();
-        assumeFalse("Skipping because our server monitoring events behave differently for now",
-                description.equals("connect with serverMonitoringMode=auto >=4.4"));
-        assumeFalse("Skipping because our server monitoring events behave differently for now",
-                description.equals("connect with serverMonitoringMode=stream >=4.4"));
+        assumeFalse(description.equals("connect with serverMonitoringMode=auto >=4.4"),
+                "Skipping because our server monitoring events behave differently for now");
+        assumeFalse(description.equals("connect with serverMonitoringMode=stream >=4.4"),
+                "Skipping because our server monitoring events behave differently for now");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedSyncTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedSyncTest.java
@@ -25,19 +25,9 @@ import com.mongodb.client.gridfs.GridFSBucket;
 import com.mongodb.client.gridfs.GridFSBuckets;
 import com.mongodb.client.internal.ClientEncryptionImpl;
 import com.mongodb.client.vault.ClientEncryption;
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
 
 public abstract class UnifiedSyncTest extends UnifiedTest {
-    public UnifiedSyncTest(@Nullable final String fileDescription, final String schemaVersion, final BsonArray runOnRequirements,
-            final BsonArray entitiesArray, final BsonArray initialData, final BsonDocument definition) {
-        super(fileDescription, schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
-    }
-
-    public UnifiedSyncTest(final String schemaVersion, final BsonArray runOnRequirements,
-            final BsonArray entitiesArray, final BsonArray initialData, final BsonDocument definition) {
-        this(null, schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
+    protected UnifiedSyncTest() {
     }
 
     @Override

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -41,6 +41,7 @@ import com.mongodb.internal.connection.TestCommandListener;
 import com.mongodb.internal.connection.TestConnectionPoolListener;
 import com.mongodb.lang.NonNull;
 import com.mongodb.lang.Nullable;
+import com.mongodb.test.AfterBeforeParameterResolver;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -49,12 +50,13 @@ import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.codecs.BsonDocumentCodec;
-import org.junit.After;
-import org.junit.AssumptionViolatedException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentest4j.TestAbortedException;
 
 import java.io.File;
 import java.io.IOException;
@@ -80,35 +82,36 @@ import static com.mongodb.client.test.CollectionHelper.killAllSessions;
 import static com.mongodb.client.unified.RunOnRequirementsMatcher.runOnRequirementsMet;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static util.JsonPoweredTestHelper.getTestDocument;
 import static util.JsonPoweredTestHelper.getTestFiles;
 
-@RunWith(Parameterized.class)
+@ExtendWith(AfterBeforeParameterResolver.class)
 public abstract class UnifiedTest {
     private static final Set<String> PRESTART_POOL_ASYNC_WORK_MANAGER_FILE_DESCRIPTIONS = Collections.singleton(
             "wait queue timeout errors include details about checked out connections");
 
     @Nullable
-    private final String fileDescription;
-    private final String schemaVersion;
-    private final BsonArray runOnRequirements;
-    private final BsonArray entitiesArray;
-    private final BsonArray initialData;
-    private final BsonDocument definition;
-    private final Entities entities = new Entities();
-    private final UnifiedCrudHelper crudHelper;
-    private final UnifiedGridFSHelper gridFSHelper = new UnifiedGridFSHelper(entities);
-    private final UnifiedClientEncryptionHelper clientEncryptionHelper = new UnifiedClientEncryptionHelper(entities);
-    private final List<FailPoint> failPoints = new ArrayList<>();
-    private final UnifiedTestContext rootContext = new UnifiedTestContext();
+    private String fileDescription;
+    private String schemaVersion;
+    @Nullable
+    private BsonArray runOnRequirements;
+    private BsonArray entitiesArray;
+    private BsonArray initialData;
+    private BsonDocument definition;
+    private Entities entities;
+    private UnifiedCrudHelper crudHelper;
+    private UnifiedGridFSHelper gridFSHelper;
+    private UnifiedClientEncryptionHelper clientEncryptionHelper;
+    private List<FailPoint> failPoints;
+    private UnifiedTestContext rootContext;
     private boolean ignoreExtraEvents;
     private BsonDocument startingClusterTime;
 
@@ -140,16 +143,7 @@ public abstract class UnifiedTest {
         }
     }
 
-    public UnifiedTest(@Nullable final String fileDescription, final String schemaVersion, @Nullable final BsonArray runOnRequirements,
-            final BsonArray entitiesArray, final BsonArray initialData, final BsonDocument definition) {
-        this.fileDescription = fileDescription;
-        this.schemaVersion = schemaVersion;
-        this.runOnRequirements = runOnRequirements;
-        this.entitiesArray = entitiesArray;
-        this.initialData = initialData;
-        this.definition = definition;
-        this.rootContext.getAssertionContext().push(ContextElement.ofTest(definition));
-        crudHelper = new UnifiedCrudHelper(entities, definition.getString("description").getValue());
+    protected UnifiedTest() {
     }
 
     protected void ignoreExtraEvents() {
@@ -161,8 +155,8 @@ public abstract class UnifiedTest {
     }
 
     @NonNull
-    protected static Collection<Object[]> getTestData(final String directory) throws URISyntaxException, IOException {
-        List<Object[]> data = new ArrayList<>();
+    protected static Collection<Arguments> getTestData(final String directory) throws URISyntaxException, IOException {
+        List<Arguments> data = new ArrayList<>();
         for (File file : getTestFiles("/" + directory + "/")) {
             BsonDocument fileDocument = getTestDocument(file);
 
@@ -174,15 +168,15 @@ public abstract class UnifiedTest {
     }
 
     @NonNull
-    private static Object[] createTestData(final BsonDocument fileDocument, final BsonDocument testDocument) {
-        return new Object[]{
+    private static Arguments createTestData(final BsonDocument fileDocument, final BsonDocument testDocument) {
+        return Arguments.of(
                 fileDocument.getString("description").getValue(),
                 testDocument.getString("description").getValue(),
                 fileDocument.getString("schemaVersion").getValue(),
                 fileDocument.getArray("runOnRequirements", null),
                 fileDocument.getArray("createEntities", new BsonArray()),
                 fileDocument.getArray("initialData", new BsonArray()),
-                testDocument};
+                testDocument);
     }
 
     protected BsonDocument getDefinition() {
@@ -195,9 +189,31 @@ public abstract class UnifiedTest {
 
     protected abstract ClientEncryption createClientEncryption(MongoClient keyVaultClient, ClientEncryptionSettings clientEncryptionSettings);
 
-    @Before
-    public void setUp() {
-        assertTrue(String.format("Unsupported schema version %s", schemaVersion),
+    @BeforeEach
+    public void setUp(
+            @Nullable final String fileDescription,
+            @Nullable final String testDescription,
+            final String schemaVersion,
+            @Nullable final BsonArray runOnRequirements,
+            final BsonArray entitiesArray,
+            final BsonArray initialData,
+            final BsonDocument definition) {
+        this.fileDescription = fileDescription;
+        this.schemaVersion = schemaVersion;
+        this.runOnRequirements = runOnRequirements;
+        this.entitiesArray = entitiesArray;
+        this.initialData = initialData;
+        this.definition = definition;
+        entities = new Entities();
+        crudHelper = new UnifiedCrudHelper(entities, definition.getString("description").getValue());
+        gridFSHelper = new UnifiedGridFSHelper(entities);
+        clientEncryptionHelper = new UnifiedClientEncryptionHelper(entities);
+        failPoints = new ArrayList<>();
+        rootContext = new UnifiedTestContext();
+        rootContext.getAssertionContext().push(ContextElement.ofTest(definition));
+        ignoreExtraEvents = false;
+        skips(fileDescription, testDescription);
+        assertTrue(
                 schemaVersion.equals("1.0")
                         || schemaVersion.equals("1.1")
                         || schemaVersion.equals("1.2")
@@ -217,18 +233,19 @@ public abstract class UnifiedTest {
                         || schemaVersion.equals("1.16")
                         || schemaVersion.equals("1.17")
                         || schemaVersion.equals("1.18")
-                        || schemaVersion.equals("1.19"));
+                        || schemaVersion.equals("1.19"),
+                String.format("Unsupported schema version %s", schemaVersion));
         if (runOnRequirements != null) {
-            assumeTrue("Run-on requirements not met",
-                    runOnRequirementsMet(runOnRequirements, getMongoClientSettings(), getServerVersion()));
+            assumeTrue(runOnRequirementsMet(runOnRequirements, getMongoClientSettings(), getServerVersion()),
+                    "Run-on requirements not met");
         }
         if (definition.containsKey("runOnRequirements")) {
-            assumeTrue("Run-on requirements not met",
-                    runOnRequirementsMet(definition.getArray("runOnRequirements", new BsonArray()), getMongoClientSettings(),
-                            getServerVersion()));
+            assumeTrue(runOnRequirementsMet(definition.getArray("runOnRequirements", new BsonArray()), getMongoClientSettings(),
+                            getServerVersion()),
+                    "Run-on requirements not met");
         }
         if (definition.containsKey("skipReason")) {
-            throw new AssumptionViolatedException(definition.getString("skipReason").getValue());
+            throw new TestAbortedException(definition.getString("skipReason").getValue());
         }
 
         if (!isDataLakeTest()) {
@@ -244,7 +261,7 @@ public abstract class UnifiedTest {
                 this::createClientEncryption);
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         for (FailPoint failPoint : failPoints) {
             failPoint.disableFailPoint();
@@ -252,8 +269,23 @@ public abstract class UnifiedTest {
         entities.close();
     }
 
-    @Test
-    public void shouldPassAllOutcomes() {
+    /**
+     * This method is called once per {@link #setUp(String, String, String, BsonArray, BsonArray, BsonArray, BsonDocument)},
+     * unless {@link #setUp(String, String, String, BsonArray, BsonArray, BsonArray, BsonDocument)} fails unexpectedly.
+     */
+    protected void skips(final String fileDescription, final String testDescription) {
+    }
+
+    @ParameterizedTest(name = "{0}: {1}")
+    @MethodSource("data")
+    public void shouldPassAllOutcomes(
+            @Nullable final String fileDescription,
+            @Nullable final String testDescription,
+            final String schemaVersion,
+            @Nullable final BsonArray runOnRequirements,
+            final BsonArray entitiesArray,
+            final BsonArray initialData,
+            final BsonDocument definition) {
         BsonArray operations = definition.getArray("operations");
         for (int i = 0; i < operations.size(); i++) {
             BsonValue cur = operations.get(i);
@@ -326,7 +358,7 @@ public abstract class UnifiedTest {
             List<BsonDocument> expectedOutcome = curDocument.getArray("documents").stream().map(BsonValue::asDocument).collect(toList());
             List<BsonDocument> actualOutcome = new CollectionHelper<>(new BsonDocumentCodec(), namespace).find();
             context.getAssertionContext().push(ContextElement.ofOutcome(namespace, expectedOutcome, actualOutcome));
-            assertEquals(context.getAssertionContext().getMessage("Outcomes are not equal"), expectedOutcome, actualOutcome);
+            assertEquals(expectedOutcome, actualOutcome, context.getAssertionContext().getMessage("Outcomes are not equal"));
             context.getAssertionContext().pop();
         }
     }
@@ -350,16 +382,16 @@ public abstract class UnifiedTest {
         context.getAssertionContext().push(ContextElement.ofCompletedOperation(operation, result, operationIndex));
         if (!operation.getBoolean("ignoreResultAndError", BsonBoolean.FALSE).getValue()) {
             if (operation.containsKey("expectResult")) {
-                assertNull(context.getAssertionContext().getMessage("The operation expects a result but an exception occurred"),
-                        result.getException());
+                assertNull(result.getException(),
+                        context.getAssertionContext().getMessage("The operation expects a result but an exception occurred"));
                 context.getValueMatcher().assertValuesMatch(operation.get("expectResult"), result.getResult());
             } else if (operation.containsKey("expectError")) {
-                assertNotNull(context.getAssertionContext().getMessage("The operation expects an error but no exception was thrown"),
-                        result.getException());
+                assertNotNull(result.getException(),
+                        context.getAssertionContext().getMessage("The operation expects an error but no exception was thrown"));
                 context.getErrorMatcher().assertErrorsMatch(operation.getDocument("expectError"), result.getException());
             } else {
-                assertNull(context.getAssertionContext().getMessage("The operation expects no error but an exception occurred"),
-                        result.getException());
+                assertNull(result.getException(),
+                        context.getAssertionContext().getMessage("The operation expects no error but an exception occurred"));
             }
         }
         context.getAssertionContext().pop();
@@ -776,8 +808,8 @@ public abstract class UnifiedTest {
 
         context.getAssertionContext().push(ContextElement.ofTopologyType(expectedTopologyType));
 
-        assertEquals(context.getAssertionContext().getMessage("Unexpected topology type"), getClusterType(expectedTopologyType),
-                clusterDescription.getType());
+        assertEquals(getClusterType(expectedTopologyType), clusterDescription.getType(),
+                context.getAssertionContext().getMessage("Unexpected topology type"));
 
         context.getAssertionContext().pop();
         return OperationResult.NONE;
@@ -860,8 +892,8 @@ public abstract class UnifiedTest {
     private OperationResult executeAssertNumberConnectionsCheckedOut(final UnifiedTestContext context, final BsonDocument operation) {
         TestConnectionPoolListener listener = entities.getConnectionPoolListener(
                 operation.getDocument("arguments").getString("client").getValue());
-        assertEquals(context.getAssertionContext().getMessage("Number of checked out connections must match expected"),
-                operation.getDocument("arguments").getNumber("connections").intValue(), listener.getNumConnectionsCheckedOut());
+        assertEquals(operation.getDocument("arguments").getNumber("connections").intValue(), listener.getNumConnectionsCheckedOut(),
+                context.getAssertionContext().getMessage("Number of checked out connections must match expected"));
         return OperationResult.NONE;
     }
 
@@ -883,9 +915,9 @@ public abstract class UnifiedTest {
         BsonDocument expected = ((CommandStartedEvent) events.get(0)).getCommand().getDocument("lsid");
         BsonDocument actual = ((CommandStartedEvent) events.get(1)).getCommand().getDocument("lsid");
         if (same) {
-            assertEquals(eventsJson, expected, actual);
+            assertEquals(expected, actual, eventsJson);
         } else {
-            assertNotEquals(eventsJson, expected, actual);
+            assertNotEquals(expected, actual, eventsJson);
         }
         return OperationResult.NONE;
     }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestFailureValidator.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestFailureValidator.java
@@ -19,49 +19,73 @@ package com.mongodb.client.unified;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class UnifiedTestFailureValidator extends UnifiedSyncTest {
+final class UnifiedTestFailureValidator extends UnifiedSyncTest {
     private Throwable exception;
 
-    public UnifiedTestFailureValidator(@SuppressWarnings("unused") final String fileDescription,
-                                       @SuppressWarnings("unused") final String testDescription,
-                                       final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                                       final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Before
-    public void setUp() {
+    @Override
+    @BeforeEach
+    public void setUp(
+            @Nullable final String fileDescription,
+            @Nullable final String testDescription,
+            final String schemaVersion,
+            @Nullable final BsonArray runOnRequirements,
+            final BsonArray entitiesArray,
+            final BsonArray initialData,
+            final BsonDocument definition) {
         try {
-            super.setUp();
+            super.setUp(
+                    fileDescription,
+                    testDescription,
+                    schemaVersion,
+                    runOnRequirements,
+                    entitiesArray,
+                    initialData,
+                    definition);
         } catch (AssertionError | Exception e) {
             exception = e;
         }
     }
 
-    @Test
-    public void shouldPassAllOutcomes() {
+    @Override
+    @ParameterizedTest
+    @MethodSource("data")
+    public void shouldPassAllOutcomes(
+            @Nullable final String fileDescription,
+            @Nullable final String testDescription,
+            final String schemaVersion,
+            @Nullable final BsonArray runOnRequirements,
+            final BsonArray entitiesArray,
+            final BsonArray initialData,
+            final BsonDocument definition) {
         if (exception == null) {
             try {
-                super.shouldPassAllOutcomes();
+                super.shouldPassAllOutcomes(
+                        fileDescription,
+                        testDescription,
+                        schemaVersion,
+                        runOnRequirements,
+                        entitiesArray,
+                        initialData,
+                        definition);
             } catch (AssertionError | Exception e) {
                 exception = e;
             }
         }
-        assertNotNull("Expected exception but not was thrown", exception);
+        assertNotNull(exception, "Expected exception but not was thrown");
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/valid-fail");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestValidator.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestValidator.java
@@ -16,37 +16,24 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.Before;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
 import static com.mongodb.ClusterFixture.serverVersionLessThan;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class UnifiedTestValidator extends UnifiedSyncTest {
-    public UnifiedTestValidator(@SuppressWarnings("unused") final String fileDescription,
-                                @SuppressWarnings("unused") final String testDescription,
-                                final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                                final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-        assumeFalse("MongoDB releases prior to 4.4 incorrectly add errorLabels as a field within the writeConcernError document "
-                        + "instead of as a top-level field.  Rather than handle that in code, we skip the test on older server versions.",
-                testDescription.equals("InsertOne fails after multiple retryable writeConcernErrors") && serverVersionLessThan(4, 4));
+final class UnifiedTestValidator extends UnifiedSyncTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
+        assumeFalse(testDescription.equals("InsertOne fails after multiple retryable writeConcernErrors") && serverVersionLessThan(4, 4),
+                "MongoDB releases prior to 4.4 incorrectly add errorLabels as a field within the writeConcernError document "
+                        + "instead of as a top-level field.  Rather than handle that in code, we skip the test on older server versions.");
     }
 
-    @Before
-    public void setUp() {
-        super.setUp();
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/valid-pass");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTransactionsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTransactionsTest.java
@@ -16,9 +16,7 @@
 
 package com.mongodb.client.unified;
 
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -26,14 +24,11 @@ import java.util.Collection;
 
 import static com.mongodb.ClusterFixture.isSharded;
 import static com.mongodb.ClusterFixture.serverVersionLessThan;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class UnifiedTransactionsTest extends UnifiedSyncTest {
-    public UnifiedTransactionsTest(@SuppressWarnings("unused") final String fileDescription,
-                                   @SuppressWarnings("unused") final String testDescription,
-                                   final String schemaVersion, final BsonArray runOnRequirements, final BsonArray entitiesArray,
-                                   final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
+final class UnifiedTransactionsTest extends UnifiedSyncTest {
+    @Override
+    protected void skips(final String fileDescription, final String testDescription) {
         assumeFalse(fileDescription.equals("count"));
         if (serverVersionLessThan(4, 4) && isSharded()) {
             assumeFalse(fileDescription.equals("pin-mongos") && testDescription.equals("distinct"));
@@ -43,8 +38,7 @@ public class UnifiedTransactionsTest extends UnifiedSyncTest {
         }
     }
 
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/transactions");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedWriteConcernTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedWriteConcernTest.java
@@ -16,23 +16,14 @@
 
 package com.mongodb.client.unified;
 
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class UnifiedWriteConcernTest extends UnifiedSyncTest {
-    public UnifiedWriteConcernTest(@SuppressWarnings("unused") final String fileDescription,
-            @SuppressWarnings("unused") final String testDescription, final String schemaVersion, final BsonArray runOnRequirements,
-            final BsonArray entitiesArray, final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class UnifiedWriteConcernTest extends UnifiedSyncTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/write-concern");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/VersionedApiTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/VersionedApiTest.java
@@ -16,26 +16,14 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class VersionedApiTest extends UnifiedSyncTest {
-
-    public VersionedApiTest(@SuppressWarnings("unused") final String fileDescription,
-                            @SuppressWarnings("unused") final String testDescription,
-                            final String schemaVersion, @Nullable final BsonArray runOnRequirements, final BsonArray entities,
-                            final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entities, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class VersionedApiTest extends UnifiedSyncTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("versioned-api");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/WithTransactionHelperTransactionsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/WithTransactionHelperTransactionsTest.java
@@ -16,24 +16,14 @@
 
 package com.mongodb.client.unified;
 
-import org.bson.BsonArray;
-import org.bson.BsonDocument;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
-public class WithTransactionHelperTransactionsTest extends UnifiedSyncTest {
-    public WithTransactionHelperTransactionsTest(@SuppressWarnings("unused") final String fileDescription,
-            @SuppressWarnings("unused") final String testDescription,
-            final String schemaVersion, final BsonArray runOnRequirements, final BsonArray entitiesArray,
-            final BsonArray initialData, final BsonDocument definition) {
-        super(schemaVersion, runOnRequirements, entitiesArray, initialData, definition);
-    }
-
-    @Parameterized.Parameters(name = "{0}: {1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+final class WithTransactionHelperTransactionsTest extends UnifiedSyncTest {
+    private static Collection<Arguments> data() throws URISyntaxException, IOException {
         return getTestData("unified-test-format/transactions-convenient-api");
     }
 }

--- a/driver-workload-executor/src/main/com/mongodb/workload/WorkloadExecutor.java
+++ b/driver-workload-executor/src/main/com/mongodb/workload/WorkloadExecutor.java
@@ -85,12 +85,7 @@ public class WorkloadExecutor {
         }
         BsonDocument testDocument = testArray.get(0).asDocument();
 
-        UnifiedTest unifiedTest = new UnifiedSyncTest(fileDocument.getString("schemaVersion").getValue(),
-                fileDocument.getArray("runOnRequirements", null),
-                fileDocument.getArray("createEntities", new BsonArray()),
-                fileDocument.getArray("initialData", new BsonArray()),
-                testDocument) {
-
+        UnifiedTest unifiedTest = new UnifiedSyncTest() {
             @Override
             protected boolean terminateLoop() {
                 return terminateLoop;
@@ -98,8 +93,25 @@ public class WorkloadExecutor {
         };
 
         try {
-            unifiedTest.setUp();
-            unifiedTest.shouldPassAllOutcomes();
+            String schemaVersion = fileDocument.getString("schemaVersion").getValue();
+            BsonArray runOnRequirements = fileDocument.getArray("runOnRequirements", null);
+            BsonArray createEntities = fileDocument.getArray("createEntities", new BsonArray());
+            BsonArray initialData = fileDocument.getArray("initialData", new BsonArray());
+            unifiedTest.setUp(null,
+                    null,
+                    schemaVersion,
+                    runOnRequirements,
+                    createEntities,
+                    initialData,
+                    testDocument);
+            unifiedTest.shouldPassAllOutcomes(
+                    null,
+                    null,
+                    schemaVersion,
+                    runOnRequirements,
+                    createEntities,
+                    initialData,
+                    testDocument);
             Entities entities = unifiedTest.getEntities();
 
             long iterationCount = -1;


### PR DESCRIPTION
- ~~Had to move most of `UnifiedTest.setUp` to `UnifiedTest.shouldPassAllOutcomes` because there is no out of the box way to inject test parameters in `UnifiedTest.setUp`, and [JUnit Pioneer](https://junit-pioneer.org/docs) also does not have such an extension. This is, however, technically possible based on JUnit 5 docs, and https://stackoverflow.com/a/69265907 suggests a solution.~~
  - Started implementing a solution based on https://stackoverflow.com/a/69265907, then discovered that we already have it implemented as `AfterBeforeParameterResolver`, so just reused.

I also added some more new and potentially useful info to [JAVA-5393: Retry non-buggy flaky tests](https://jira.mongodb.org/browse/JAVA-5393).

JAVA-5495