### PR TITLE
Remove hasExpired and expiry checks in retries

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -135,15 +135,9 @@ public class TimeoutContext {
     }
 
     /**
-     * Checks the expiry of the timeout.
-     *
-     * @return true if the timeout has been set and it has expired
+     * Runs the runnable if the timeout is expired.
+     * @param onExpired the runnable to run
      */
-    public boolean hasExpired() {
-        // TODO (CSOT) this method leaks Timeout internals, should be removed (not inlined, but inverted using lambdas)
-        return Timeout.nullAsInfinite(timeout).call(NANOSECONDS, () -> false, (ns) -> false, () -> true);
-    }
-
     public void onExpired(final Runnable onExpired) {
         Timeout.nullAsInfinite(timeout).onExpired(onExpired);
     }
@@ -374,7 +368,6 @@ public class TimeoutContext {
         return checkoutStart.timeoutAfterOrInfiniteIfNegative(ms, MILLISECONDS);
     }
 
-    // TODO (CSOT) method not used in production;
     @Nullable
     public Timeout getTimeout() {
         return timeout;

--- a/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
+++ b/driver-core/src/main/com/mongodb/internal/TimeoutContext.java
@@ -144,6 +144,10 @@ public class TimeoutContext {
         return Timeout.nullAsInfinite(timeout).call(NANOSECONDS, () -> false, (ns) -> false, () -> true);
     }
 
+    public void onExpired(final Runnable onExpired) {
+        Timeout.nullAsInfinite(timeout).onExpired(onExpired);
+    }
+
     /**
      * Sets the recent min round trip time
      * @param minRoundTripTimeMS the min round trip time
@@ -370,6 +374,7 @@ public class TimeoutContext {
         return checkoutStart.timeoutAfterOrInfiniteIfNegative(ms, MILLISECONDS);
     }
 
+    // TODO (CSOT) method not used in production;
     @Nullable
     public Timeout getTimeout() {
         return timeout;

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
@@ -197,8 +197,7 @@ public final class RetryState {
          * A MongoOperationTimeoutException indicates that the operation timed out, either during command execution or server selection.
          * The timeout for server selection is determined by the computedServerSelectionMS = min(serverSelectionTimeoutMS, timeoutMS).
          *
-         * The isLastAttempt() method checks if the timeoutMS has expired, which could be greater than the computedServerSelectionMS.
-         * Therefore, it's important to check if the exception is an instance of MongoOperationTimeoutException to detect a timeout.
+         * It is important to check if the exception is an instance of MongoOperationTimeoutException to detect a timeout.
          */
         if (isLastAttempt() || attemptException instanceof MongoOperationTimeoutException) {
             previouslyChosenException = newlyChosenException;

--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStream.java
@@ -163,9 +163,9 @@ public class SocketStream implements Stream {
     public void write(final List<ByteBuf> buffers, final OperationContext operationContext) throws IOException {
         for (final ByteBuf cur : buffers) {
             outputStream.write(cur.array(), 0, cur.limit());
-            if (operationContext.getTimeoutContext().hasExpired()) {
+            operationContext.getTimeoutContext().onExpired(() -> {
                 throwMongoTimeoutException("Socket write exceeded the timeout limit.");
-            }
+            });
         }
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/TimeoutContextTest.java
@@ -16,6 +16,8 @@
 package com.mongodb.internal;
 
 import com.mongodb.MongoOperationTimeoutException;
+import com.mongodb.internal.time.Timeout;
+import com.mongodb.lang.Nullable;
 import com.mongodb.session.ClientSession;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,7 @@ import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME;
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_MAX_TIME_AND_AWAIT_TIME;
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_TIMEOUT;
 import static com.mongodb.ClusterFixture.sleep;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -182,9 +185,13 @@ final class TimeoutContextTest {
                 new TimeoutContext(TIMEOUT_SETTINGS.withTimeoutMS(9999999L));
         TimeoutContext noTimeout = new TimeoutContext(TIMEOUT_SETTINGS);
         sleep(100);
-        assertFalse(noTimeout.hasExpired());
-        assertFalse(longTimeout.hasExpired());
-        assertTrue(smallTimeout.hasExpired());
+        assertFalse(hasExpired(noTimeout.getTimeout()));
+        assertFalse(hasExpired(longTimeout.getTimeout()));
+        assertTrue(hasExpired(smallTimeout.getTimeout()));
+    }
+
+    private static boolean hasExpired(@Nullable final Timeout timeout) {
+        return Timeout.nullAsInfinite(timeout).call(NANOSECONDS, () -> false, (ns) -> false, () -> true);
     }
 
     @Test

--- a/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
@@ -21,6 +21,7 @@ import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.function.LoopState.AttachmentKey;
 import com.mongodb.internal.operation.retry.AttachmentKeys;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -330,6 +331,25 @@ final class RetryStateTest {
         }));
     }
 
+    @Ignore // TODO (CSOT) update this
+    @Test
+    void advanceOrThrowPredicateThrowsTimeoutAfterFirstAttempt() {
+        RetryState retryState = new RetryState(TIMEOUT_CONTEXT_EXPIRED_GLOBAL_TIMEOUT);
+        RuntimeException predicateException = new RuntimeException() {
+        };
+        RuntimeException attemptException = new RuntimeException() {
+        };
+        MongoOperationTimeoutException mongoOperationTimeoutException = assertThrows(MongoOperationTimeoutException.class,
+                () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> {
+                    assertTrue(rs.isFirstAttempt());
+                    assertEquals(attemptException, e);
+                    throw predicateException;
+                }));
+
+        assertEquals(EXPECTED_TIMEOUT_MESSAGE, mongoOperationTimeoutException.getMessage());
+        assertEquals(attemptException, mongoOperationTimeoutException.getCause());
+    }
+
     @ParameterizedTest
     @MethodSource({"infiniteTimeout", "noTimeout"})
     void advanceOrThrowPredicateThrows(final TimeoutContext timeoutContext) {
@@ -395,6 +415,31 @@ final class RetryStateTest {
                     assertEquals(attemptException, e);
                     return false;
                 }));
+    }
+
+    @Ignore // TODO (CSOT) update this
+    @Test
+    void advanceOrThrowTransformThrowsTimeoutExceptionAfterFirstAttempt() {
+        RetryState retryState = new RetryState(TIMEOUT_CONTEXT_EXPIRED_GLOBAL_TIMEOUT);
+        RuntimeException attemptException = new RuntimeException() {
+        };
+        RuntimeException transformerResult = new RuntimeException() {
+        };
+        MongoOperationTimeoutException mongoOperationTimeoutException =
+                assertThrows(MongoOperationTimeoutException.class, () -> retryState.advanceOrThrow(attemptException,
+                        (e1, e2) -> {
+                            assertNull(e1);
+                            assertEquals(attemptException, e2);
+                            return transformerResult;
+                        },
+                        (rs, e) -> {
+                            assertEquals(attemptException, e);
+                            return false;
+                        }));
+
+        assertEquals(EXPECTED_TIMEOUT_MESSAGE, mongoOperationTimeoutException.getMessage());
+        assertEquals(transformerResult, mongoOperationTimeoutException.getCause());
+
     }
 
     @ParameterizedTest


### PR DESCRIPTION
JAVA-5379

This removes `hasExpired`, and expiry checks in retries (retries rely exclusively on timeout exceptions being thrown by blocking operations, to signal that the retry should halt).