### PR TITLE
Allow generic base classes for POJOs

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/LazyPropertyModelCodec.java
+++ b/bson/src/main/org/bson/codecs/pojo/LazyPropertyModelCodec.java
@@ -173,6 +173,9 @@ class LazyPropertyModelCodec<T> implements Codec<T> {
 
         @Override
         public void encode(final BsonWriter writer, final T value, final EncoderContext encoderContext) {
+            if(value.getClass().equals(classModel.getType())) {
+                throw exception();
+            }
             tryEncode(codecRegistry.get(value.getClass()), writer, value, encoderContext);
         }
 

--- a/bson/src/main/org/bson/codecs/pojo/LazyPropertyModelCodec.java
+++ b/bson/src/main/org/bson/codecs/pojo/LazyPropertyModelCodec.java
@@ -163,19 +163,41 @@ class LazyPropertyModelCodec<T> implements Codec<T> {
     static final class NeedSpecializationCodec<T> extends PojoCodec<T> {
         private final ClassModel<T> classModel;
         private final DiscriminatorLookup discriminatorLookup;
+        private final CodecRegistry codecRegistry;
 
-        NeedSpecializationCodec(final ClassModel<T> classModel, final DiscriminatorLookup discriminatorLookup) {
+        NeedSpecializationCodec(final ClassModel<T> classModel, final DiscriminatorLookup discriminatorLookup, final CodecRegistry codecRegistry) {
             this.classModel = classModel;
             this.discriminatorLookup = discriminatorLookup;
-        }
-
-        @Override
-        public T decode(final BsonReader reader, final DecoderContext decoderContext) {
-            throw exception();
+            this.codecRegistry = codecRegistry;
         }
 
         @Override
         public void encode(final BsonWriter writer, final T value, final EncoderContext encoderContext) {
+            tryEncode(codecRegistry.get(value.getClass()), writer, value, encoderContext);
+        }
+
+        @Override
+        public T decode(final BsonReader reader, final DecoderContext decoderContext) {
+            return tryDecode(reader, decoderContext);
+        }
+
+        @SuppressWarnings("unchecked")
+        private <A> void tryEncode(final Codec<A> codec,  final BsonWriter writer, final T value, final EncoderContext encoderContext) {
+            try {
+                codec.encode(writer, (A) value, encoderContext);
+            } catch (Exception e) {
+                throw exception();
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        public T tryDecode(final BsonReader reader, final DecoderContext decoderContext) {
+            Codec<T> codec = PojoCodecImpl.<T>getCodecFromDocument(reader, classModel.useDiscriminator(), classModel.getDiscriminatorKey(),
+                    codecRegistry, discriminatorLookup, null, classModel.getName());
+            if (codec != null) {
+                return codec.decode(reader, decoderContext);
+            }
+
             throw exception();
         }
 

--- a/bson/src/main/org/bson/codecs/pojo/LazyPropertyModelCodec.java
+++ b/bson/src/main/org/bson/codecs/pojo/LazyPropertyModelCodec.java
@@ -173,7 +173,7 @@ class LazyPropertyModelCodec<T> implements Codec<T> {
 
         @Override
         public void encode(final BsonWriter writer, final T value, final EncoderContext encoderContext) {
-            if(value.getClass().equals(classModel.getType())) {
+            if (value.getClass().equals(classModel.getType())) {
                 throw exception();
             }
             tryEncode(codecRegistry.get(value.getClass()), writer, value, encoderContext);

--- a/bson/src/main/org/bson/codecs/pojo/PojoCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/pojo/PojoCodecProvider.java
@@ -97,7 +97,7 @@ public final class PojoCodecProvider implements CodecProvider {
             final List<PropertyCodecProvider> propertyCodecProviders, final DiscriminatorLookup discriminatorLookup) {
         return shouldSpecialize(classModel)
                 ? new PojoCodecImpl<>(classModel, codecRegistry, propertyCodecProviders, discriminatorLookup)
-                : new LazyPropertyModelCodec.NeedSpecializationCodec<>(classModel, discriminatorLookup);
+                : new LazyPropertyModelCodec.NeedSpecializationCodec<>(classModel, discriminatorLookup, codecRegistry);
     }
 
     /**

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -559,7 +559,6 @@ public final class PojoCustomTest extends PojoTestCase {
     }
 
 
-    // TODO: this now fails with a StackOverflowError, which is not desirable
     @Test
     public void testCannotEncodeUnspecializedClasses() {
         CodecRegistry registry = fromProviders(getPojoCodecProviderBuilder(GenericTreeModel.class).build());

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -563,7 +563,7 @@ public final class PojoCustomTest extends PojoTestCase {
     @Test
     public void testCannotEncodeUnspecializedClasses() {
         CodecRegistry registry = fromProviders(getPojoCodecProviderBuilder(GenericTreeModel.class).build());
-        assertThrows(StackOverflowError.class, () ->
+        assertThrows(CodecConfigurationException.class, () ->
                 encode(registry.get(GenericTreeModel.class), getGenericTreeModel(), false));
     }
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -38,11 +38,14 @@ import org.bson.codecs.pojo.entities.BsonRepresentationUnsupportedInt;
 import org.bson.codecs.pojo.entities.BsonRepresentationUnsupportedString;
 import org.bson.codecs.pojo.entities.ConcreteAndNestedAbstractInterfaceModel;
 import org.bson.codecs.pojo.entities.ConcreteCollectionsModel;
+import org.bson.codecs.pojo.entities.ConcreteModel;
+import org.bson.codecs.pojo.entities.ConcreteField;
 import org.bson.codecs.pojo.entities.ConcreteStandAloneAbstractInterfaceModel;
 import org.bson.codecs.pojo.entities.ConstructorNotPublicModel;
 import org.bson.codecs.pojo.entities.ConventionModel;
 import org.bson.codecs.pojo.entities.ConverterModel;
 import org.bson.codecs.pojo.entities.CustomPropertyCodecOptionalModel;
+import org.bson.codecs.pojo.entities.GenericBaseModel;
 import org.bson.codecs.pojo.entities.GenericHolderModel;
 import org.bson.codecs.pojo.entities.GenericTreeModel;
 import org.bson.codecs.pojo.entities.InterfaceBasedModel;
@@ -546,14 +549,26 @@ public final class PojoCustomTest extends PojoTestCase {
     }
 
     @Test
+    public void testGenericBaseClass() {
+        CodecRegistry registry = fromProviders(new ValueCodecProvider(), PojoCodecProvider.builder().automatic(true).build());
+
+        ConcreteModel model = new ConcreteModel(new ConcreteField("name1"));
+
+        String json = "{\"_t\": \"org.bson.codecs.pojo.entities.ConcreteModel\", \"field\": {\"name\": \"name1\"}}";
+        roundTrip(PojoCodecProvider.builder().automatic(true), GenericBaseModel.class, model, json);
+    }
+
+
+    // TODO: this now fails with a StackOverflowError, which is not desirable
+    @Test
     public void testCannotEncodeUnspecializedClasses() {
         CodecRegistry registry = fromProviders(getPojoCodecProviderBuilder(GenericTreeModel.class).build());
-        assertThrows(CodecConfigurationException.class, () ->
+        assertThrows(StackOverflowError.class, () ->
                 encode(registry.get(GenericTreeModel.class), getGenericTreeModel(), false));
     }
 
     @Test
-    public void testCannotDecodeUnspecializedClasses() {
+    public void testCannotDecodeUnspecializedClassesWithoutADiscriminator() {
         assertThrows(CodecConfigurationException.class, () ->
                 decodingShouldFail(getCodec(GenericTreeModel.class),
                         "{'field1': 'top', 'field2': 1, "

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoTestCase.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoTestCase.java
@@ -90,8 +90,12 @@ abstract class PojoTestCase {
     }
 
     <T> void roundTrip(final PojoCodecProvider.Builder builder, final T value, final String json) {
-        encodesTo(getCodecRegistry(builder), value, json);
-        decodesTo(getCodecRegistry(builder), json, value);
+        roundTrip(builder, value.getClass(), value, json);
+    }
+
+    <T> void roundTrip(final PojoCodecProvider.Builder builder, final Class<?> clazz, final T value, final String json) {
+        encodesTo(getCodecRegistry(builder), clazz, value, json);
+        decodesTo(getCodecRegistry(builder), clazz, json, value);
     }
 
     <T> void threadedRoundTrip(final PojoCodecProvider.Builder builder, final T value, final String json) {
@@ -109,21 +113,30 @@ abstract class PojoTestCase {
         decodesTo(registry, json, value);
     }
 
+    <T> void roundTrip(final CodecRegistry registry, final Class<T> clazz, final T value, final String json) {
+        encodesTo(registry, clazz, value, json);
+        decodesTo(registry, clazz, json, value);
+    }
+
     <T> void encodesTo(final PojoCodecProvider.Builder builder, final T value, final String json) {
         encodesTo(builder, value, json, false);
     }
 
     <T> void encodesTo(final PojoCodecProvider.Builder builder, final T value, final String json, final boolean collectible) {
-        encodesTo(getCodecRegistry(builder), value, json, collectible);
+        encodesTo(getCodecRegistry(builder), value.getClass(), value, json, collectible);
     }
 
     <T> void encodesTo(final CodecRegistry registry, final T value, final String json) {
-        encodesTo(registry, value, json, false);
+        encodesTo(registry, value.getClass(), value, json, false);
+    }
+
+    <T> void encodesTo(final CodecRegistry registry, final Class<?> clazz, final T value, final String json) {
+        encodesTo(registry, clazz, value, json, false);
     }
 
     @SuppressWarnings("unchecked")
-    <T> void encodesTo(final CodecRegistry registry, final T value, final String json, final boolean collectible) {
-        Codec<T> codec = (Codec<T>) registry.get(value.getClass());
+    <T> void encodesTo(final CodecRegistry registry, final Class<?> clazz, final T value, final String json, final boolean collectible) {
+        Codec<T> codec = (Codec<T>) registry.get(clazz);
         encodesTo(codec, value, json, collectible);
     }
 
@@ -144,7 +157,12 @@ abstract class PojoTestCase {
 
     @SuppressWarnings("unchecked")
     <T> void decodesTo(final CodecRegistry registry, final String json, final T expected) {
-        Codec<T> codec = (Codec<T>) registry.get(expected.getClass());
+        decodesTo(registry, expected.getClass(), json, expected);
+    }
+
+    @SuppressWarnings("unchecked")
+    <T> void decodesTo(final CodecRegistry registry, final Class<?> clazz, final String json, final T expected) {
+        Codec<T> codec = (Codec<T>) registry.get(clazz);
         decodesTo(codec, json, expected);
     }
 

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/BaseField.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/BaseField.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+import java.util.Objects;
+
+public abstract class BaseField {
+    private String name;
+
+    public BaseField(final String name) {
+        this.name = name;
+    }
+
+    protected BaseField() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BaseField baseField = (BaseField) o;
+        return Objects.equals(name, baseField.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name);
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/ConcreteField.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/ConcreteField.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+public class ConcreteField extends BaseField {
+
+    public ConcreteField() {
+    }
+
+    public ConcreteField(final String name) {
+        super(name);
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/ConcreteModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/ConcreteModel.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+public class ConcreteModel extends GenericBaseModel<ConcreteField> {
+
+    public ConcreteModel() {
+    }
+
+    public ConcreteModel(final ConcreteField field) {
+        super(field);
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/GenericBaseModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/GenericBaseModel.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+import java.util.Objects;
+
+@BsonDiscriminator()
+public class GenericBaseModel<T extends BaseField> {
+
+    private T field;
+
+    public GenericBaseModel(final T field) {
+        this.field = field;
+    }
+
+    public GenericBaseModel() {
+    }
+
+    public T getField() {
+        return field;
+    }
+
+    public void setField(final T field) {
+        this.field = field;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GenericBaseModel<?> that = (GenericBaseModel<?>) o;
+        return Objects.equals(field, that.field);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(field);
+    }
+}


### PR DESCRIPTION
This change fixes a regression which prevents the driver from encoding and decoding concrete classes which extend generic base classes, when the base class is specified as the generic type of the MongoCollection.

JAVA-5173