### PR TITLE
Include links to the Evergreen build and to the driver security testing summary in the SSDLC report (#1426)

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -150,6 +150,8 @@ functions:
         env:
           PRODUCT_NAME: ${product_name}
           PRODUCT_VERSION: ${product_version}
+          PRODUCT_RELEASE_CREATOR: ${author}
+          EVERGREEN_VERSION_ID: ${version_id}
         script: .evergreen/ssdlc-report.sh
     - command: ec2.assume_role
       params:

--- a/.evergreen/ssdlc-report.sh
+++ b/.evergreen/ssdlc-report.sh
@@ -5,13 +5,23 @@ set -eu
 # Supported/used environment variables:
 # PRODUCT_NAME
 # PRODUCT_VERSION
+# PRODUCT_RELEASE_CREATOR
+# EVERGREEN_VERSION_ID
 
 if [ -z "${PRODUCT_NAME}" ]; then
-    echo "PRODUCT_NAME must be set to a non-empty string"
+    printf "\nPRODUCT_NAME must be set to a non-empty string\n"
     exit 1
 fi
 if [ -z "${PRODUCT_VERSION}" ]; then
-    echo "PRODUCT_VERSION must be set to a non-empty string"
+    printf "\nPRODUCT_VERSION must be set to a non-empty string\n"
+    exit 1
+fi
+if [ -z "${PRODUCT_RELEASE_CREATOR}" ]; then
+    printf "\PRODUCT_RELEASE_CREATOR must be set to a non-empty string\n"
+    exit 1
+fi
+if [ -z "${EVERGREEN_VERSION_ID}" ]; then
+    printf "\EVERGREEN_VERSION_ID must be set to a non-empty string\n"
     exit 1
 fi
 
@@ -22,7 +32,11 @@ RELATIVE_DIR_PATH="$(dirname "${BASH_SOURCE[0]:-$0}")"
 source "${RELATIVE_DIR_PATH}/javaConfig.bash"
 
 printf "\nCreating SSDLC reports\n"
-
+printf "\nProduct name: %s\n" "${PRODUCT_NAME}"
+printf "\nProduct version: %s\n" "${PRODUCT_VERSION}"
+printf "\nProduct release creator: %s\n" "${PRODUCT_RELEASE_CREATOR}"
+declare -r EVERGREEN_BUILD_URL="https://spruce.mongodb.com/version/${EVERGREEN_VERSION_ID}"
+printf "\nEvergreen build URL: %s\n" "${EVERGREEN_BUILD_URL}"
 declare -r SSDLC_PATH="${RELATIVE_DIR_PATH}/../build/ssdlc"
 declare -r SSDLC_STATIC_ANALYSIS_REPORTS_PATH="${SSDLC_PATH}/static-analysis-reports"
 mkdir "${SSDLC_PATH}"
@@ -52,14 +66,16 @@ declare -r SSDLC_REPORT_PATH="${SSDLC_PATH}/ssdlc_compliance_report.md"
 cp "${TEMPLATE_SSDLC_REPORT_PATH}" "${SSDLC_REPORT_PATH}"
 declare -a SED_EDIT_IN_PLACE_OPTION
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  SED_EDIT_IN_PLACE_OPTION=(-i '')
+    SED_EDIT_IN_PLACE_OPTION=(-i '')
 else
-  SED_EDIT_IN_PLACE_OPTION=(-i)
+    SED_EDIT_IN_PLACE_OPTION=(-i)
 fi
 sed "${SED_EDIT_IN_PLACE_OPTION[@]}" \
     -e "s/\${product_name}/${PRODUCT_NAME}/g" \
     -e "s/\${product_version}/${PRODUCT_VERSION}/g" \
     -e "s/\${report_date_utc}/$(date -u +%Y-%m-%d)/g" \
+    -e "s/\${product_release_creator}/${PRODUCT_RELEASE_CREATOR}/g" \
+    -e "s>\${evergreen_build_url}>${EVERGREEN_BUILD_URL}>g" \
     "${SSDLC_REPORT_PATH}"
 printf "%s\n" "${SSDLC_REPORT_PATH}"
 

--- a/.evergreen/template_ssdlc_compliance_report.md
+++ b/.evergreen/template_ssdlc_compliance_report.md
@@ -13,30 +13,18 @@ This report is available at
     <td>${product_version}</td>
   </tr>
   <tr>
+    <th>Release creator</th>
+    <td>
+        ${product_release_creator}
+        <p>
+            Refer to data in Papertrail for more details.
+            There is currently no official way to serve that data.
+        </p>        
+    </td>
+  </tr>
+  <tr>
     <th>Report date, UTC</th>
     <td>${report_date_utc}</td>
-  </tr>
-</table>
-
-## Release creator  
-
-This information is available in multiple ways:
-
-<table>
-  <tr>
-    <th>Evergreen</th>
-    <td>
-        Go to
-        <a href="https://evergreen.mongodb.com/waterfall/mongo-java-driver?bv_filter=Publish%20Release">
-            https://evergreen.mongodb.com/waterfall/mongo-java-driver?bv_filter=Publish%20Release</a>,
-        find the build triggered from Git tag <code>r${product_version}</code>, see who authored it.
-    </td>
-  </tr>
-  <tr>
-    <th>Papertrail</th>
-    <td>
-        Refer to data in Papertrail. There is currently no official way to serve that data.
-    </td>
   </tr>
 </table>
 
@@ -47,7 +35,7 @@ Blocked on <https://jira.mongodb.org/browse/JAVA-5429>.
 The MongoDB SSDLC policy is available at
 <https://docs.google.com/document/d/1u0m4Kj2Ny30zU74KoEFCN4L6D_FbEYCaJ3CQdCYXTMc>.
 
-## Third-darty dependency information
+## Third-party dependency information
 
 There are no dependencies to report vulnerabilities of.
 Our [SBOM](https://docs.devprod.prod.corp.mongodb.com/mms/python/src/sbom/silkbomb/docs/CYCLONEDX/) lite
@@ -55,13 +43,22 @@ is <https://github.com/mongodb/mongo-java-driver/blob/r${product_version}/sbom.j
 
 ## Static analysis findings  
 
-The static analysis findings are all available at
+The static analysis findings are available at
 <https://d-9067613a84.awsapps.com/start/#/console?account_id=857654397073&role_name=Drivers.User&destination=https%3a%2f%2fus-west-1.console.aws.amazon.com%2fs3%2fbuckets%2fjava-driver-release-assets%3fregion%3dus-west-1%26bucketType%3dgeneral%26prefix%3d${product_name}%2f${product_version}%2fstatic-analysis-reports%2f>.
 All the findings in the aforementioned reports
 are either of the MongoDB status "False Positive" or "No Fix Needed",
 because code that has any other findings cannot technically get into the product.
 
 <https://github.com/mongodb/mongo-java-driver/blob/r${product_version}/config/spotbugs/exclude.xml> may also be of interest.
+
+## Security testing results
+
+The testing results are available at
+<${evergreen_build_url}>.
+
+See the driver security testing summary
+<https://docs.google.com/document/d/1y2K_RY4GZVXpQvv4JH_35mSzFRTawNJ3mibpvSBU8H0>
+for the description of what is tested.
 
 ## Signature information
 


### PR DESCRIPTION
This is a backport of https://github.com/mongodb/mongo-java-driver/pull/1426 to `5.1.x`.

JAVA-5500