### PR TITLE
Attribute release commit and tag to user triggering the workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,9 @@ jobs:
       # Set commit author information to the user that triggered the release workflow
       - name: "Set git author information"
         run: |
+          GITHUB_USER_NAME=$(gh api users/${{ github.actor }} --jq '.name')
           GITHUB_USER_ID=$(gh api users/${{ github.actor }} --jq '.id')
-          git config user.name "${{ github.actor }}"
+          git config user.name "${GITHUB_USER_NAME}}"
           git config user.email "${GITHUB_USER_ID}+${{ github.actor }}@users.noreply.github.com"
 
       # This step bumps version numbers in build.gradle and creates git artifacts for the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,6 @@ on:
         required: true
         type: "string"
 
-env:
-  GIT_AUTHOR_EMAIL: "167856002+mongodb-dbx-release-bot[bot]@users.noreply.github.com"
-  GIT_AUTHOR_NAME: "mongodb-dbx-release-bot[bot]"
-
 jobs:
   prepare-release:
     environment: release
@@ -72,10 +68,12 @@ jobs:
           echo '🆕 Creating new release branch ${RELEASE_BRANCH} from ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
           git checkout -b ${RELEASE_BRANCH}
 
+      # Set commit author information to the user that triggered the release workflow
       - name: "Set git author information"
         run: |
-          git config user.name "${GIT_AUTHOR_NAME}"
-          git config user.email "${GIT_AUTHOR_EMAIL}"
+          GITHUB_USER_ID=$(gh api users/${{ github.actor }} --jq '.id')
+          git config user.name "${{ github.actor }}"
+          git config user.email "${GITHUB_USER_ID}+${{ github.actor }}@users.noreply.github.com"
 
       # This step bumps version numbers in build.gradle and creates git artifacts for the release
       - name: "Bump version numbers and create release tag"


### PR DESCRIPTION
With this change, commits made by the release automation and the git tag itself will be attributed to the user triggering the workflow. We can do so without knowing the email address of a user by using GitHub's anonymous email address format `<id>+<name>@users.noreply.github.com`.

This fixes the issue where the tag run in Evergreen does not know which employee created the release, which is relevant for the internal Papertrail service.