### PR TITLE
Fix `CursorResourceManager.close`

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/CursorResourceManager.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CursorResourceManager.java
@@ -182,7 +182,7 @@ abstract class CursorResourceManager<CS extends ReferenceCounted, C extends Refe
     void close() {
         boolean doClose = withLock(lock, () -> {
             State localState = state;
-            if (localState == State.OPERATION_IN_PROGRESS) {
+            if (localState.inProgress()) {
                 state = State.CLOSE_PENDING;
             } else if (localState != State.CLOSED) {
                 state = State.CLOSED;

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncCommandBatchCursorFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncCommandBatchCursorFunctionalTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -297,6 +298,24 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
 
         assertDoesNotThrow(() -> checkReferenceCountReachesTarget(connectionSource, 1));
         assertTrue(cursor.isClosed());
+    }
+
+    @Test
+    void attemptJava5516() {
+        BsonDocument commandResult = executeFindCommand(5, 2);
+        cursor = new AsyncCommandBatchCursor<>(commandResult, 2, 0, DOCUMENT_DECODER,
+                                               null, connectionSource, connection);
+        assertNotNull(cursorNext());
+        // Calling `close` twice is the key to reproducing.
+        // It does not matter whether we call `close` twice from the same thread or not.
+        ForkJoinPool.commonPool().execute(() -> cursor.close());
+        ForkJoinPool.commonPool().execute(() -> cursor.close());
+        try {
+            assertNotNull(cursorNext());
+            assertNotNull(cursorNext());
+        } catch (IllegalStateException e) {
+            // one of the expected outcomes, because we call `cursorNext` concurrently with `close`
+        }
     }
 
     @Test

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/CursorResourceManagerTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/CursorResourceManagerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.operation;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.ServerCursor;
+import com.mongodb.internal.binding.AsyncConnectionSource;
+import com.mongodb.internal.binding.ReferenceCounted;
+import com.mongodb.internal.connection.Connection;
+import com.mongodb.internal.mockito.MongoMockito;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.when;
+
+final class CursorResourceManagerTest {
+    @Test
+    void doubleCloseExecutedConcurrentlyWithOperationBeingInProgressShouldNotFail() {
+        CursorResourceManager<?, ?> cursorResourceManager = new CursorResourceManager<ReferenceCounted, ReferenceCounted>(
+                new MongoNamespace("db", "coll"),
+                MongoMockito.mock(AsyncConnectionSource.class, mock -> {
+                    when(mock.retain()).thenReturn(mock);
+                    when(mock.release()).thenReturn(1);
+                }),
+                null,
+                MongoMockito.mock(ServerCursor.class)) {
+            @Override
+            void markAsPinned(final ReferenceCounted connectionToPin, final Connection.PinningMode pinningMode) {
+            }
+
+            @Override
+            void doClose() {
+            }
+        };
+        cursorResourceManager.tryStartOperation();
+        try {
+            assertDoesNotThrow(() -> {
+                cursorResourceManager.close();
+                cursorResourceManager.close();
+                cursorResourceManager.setServerCursor(null);
+            });
+        } finally {
+            cursorResourceManager.endOperation();
+        }
+    }
+}


### PR DESCRIPTION
This PR is an alternative to https://github.com/mongodb/mongo-java-driver/pull/1439.

The commit https://github.com/mongodb/mongo-java-driver/pull/1440/commits/b7be8c856f8e500dcc10ca39757c8dccf33769c3 introduces a draft reproducer of the bug reported in JAVA-5516. Then the following commit fixes it. The reproducer is not guaranteed to reproduce the error, but usually does so in just a few attempts on my machine. With the fix I was unable to reproduce the error.

The commit https://github.com/mongodb/mongo-java-driver/pull/1440/commits/510548421e663d391a89557a9940afeacba2dc9c introduces a reproducer that we can actually check into the codebase.

JAVA-5516