### PR TITLE
Fix bson-kotlinx `encodeNullableSerializableValue` null handling

### DIFF
--- a/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/DataClassCodecTest.kt
+++ b/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/DataClassCodecTest.kt
@@ -25,6 +25,7 @@ import org.bson.codecs.configuration.CodecConfigurationException
 import org.bson.codecs.configuration.CodecRegistries.fromProviders
 import org.bson.codecs.kotlin.samples.Box
 import org.bson.codecs.kotlin.samples.DataClassEmbedded
+import org.bson.codecs.kotlin.samples.DataClassLastItemDefaultsToNull
 import org.bson.codecs.kotlin.samples.DataClassListOfDataClasses
 import org.bson.codecs.kotlin.samples.DataClassListOfListOfDataClasses
 import org.bson.codecs.kotlin.samples.DataClassListOfSealed
@@ -51,6 +52,7 @@ import org.bson.codecs.kotlin.samples.DataClassWithEnum
 import org.bson.codecs.kotlin.samples.DataClassWithEnumMapKey
 import org.bson.codecs.kotlin.samples.DataClassWithFailingInit
 import org.bson.codecs.kotlin.samples.DataClassWithInvalidBsonRepresentation
+import org.bson.codecs.kotlin.samples.DataClassWithListThatLastItemDefaultsToNull
 import org.bson.codecs.kotlin.samples.DataClassWithMutableList
 import org.bson.codecs.kotlin.samples.DataClassWithMutableMap
 import org.bson.codecs.kotlin.samples.DataClassWithMutableSet
@@ -131,6 +133,20 @@ class DataClassCodecTest {
 
         val withStoredNulls = BsonDocument.parse("""{"boolean": null, "string": null, "listSimple": null}""")
         assertDecodesTo(withStoredNulls, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithListThatLastItemDefaultsToNull() {
+        val expected =
+            """{
+            | "elements": [{"required": "required"}, {"required": "required"}],
+            |}"""
+                .trimMargin()
+
+        val dataClass =
+            DataClassWithListThatLastItemDefaultsToNull(
+                listOf(DataClassLastItemDefaultsToNull("required"), DataClassLastItemDefaultsToNull("required")))
+        assertRoundTrips(expected, dataClass)
     }
 
     @Test

--- a/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/samples/DataClasses.kt
+++ b/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/samples/DataClasses.kt
@@ -57,6 +57,10 @@ data class DataClassWithDefaults(
 
 data class DataClassWithNulls(val boolean: Boolean?, val string: String?, val listSimple: List<String?>?)
 
+data class DataClassWithListThatLastItemDefaultsToNull(val elements: List<DataClassLastItemDefaultsToNull>)
+
+data class DataClassLastItemDefaultsToNull(val required: String, val optional: String? = null)
+
 data class DataClassSelfReferential(
     val name: String,
     val left: DataClassSelfReferential? = null,

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
@@ -142,6 +142,8 @@ internal class DefaultBsonEncoder(
     override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
         deferredElementHandler.with(
             {
+                // When using generics its possible for `value` to be null
+                // See: https://youtrack.jetbrains.com/issue/KT-66206
                 if (value != null || configuration.explicitNulls) {
                     encodeName(it)
                     super.encodeSerializableValue(serializer, value)

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
@@ -156,6 +156,8 @@ internal class DefaultBsonEncoder(
             if (value != null || configuration.explicitNulls) {
                 encodeName(it)
                 super.encodeNullableSerializableValue(serializer, value)
+            } else {
+                deferredElementName = null
             }
         }
             ?: super.encodeNullableSerializableValue(serializer, value)

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
@@ -45,6 +45,7 @@ import org.bson.codecs.kotlinx.samples.DataClassContainsOpen
 import org.bson.codecs.kotlinx.samples.DataClassContainsValueClass
 import org.bson.codecs.kotlinx.samples.DataClassEmbedded
 import org.bson.codecs.kotlinx.samples.DataClassKey
+import org.bson.codecs.kotlinx.samples.DataClassLastItemDefaultsToNull
 import org.bson.codecs.kotlinx.samples.DataClassListOfDataClasses
 import org.bson.codecs.kotlinx.samples.DataClassListOfListOfDataClasses
 import org.bson.codecs.kotlinx.samples.DataClassListOfSealed
@@ -78,6 +79,7 @@ import org.bson.codecs.kotlinx.samples.DataClassWithEncodeDefault
 import org.bson.codecs.kotlinx.samples.DataClassWithEnum
 import org.bson.codecs.kotlinx.samples.DataClassWithEnumMapKey
 import org.bson.codecs.kotlinx.samples.DataClassWithFailingInit
+import org.bson.codecs.kotlinx.samples.DataClassWithListThatLastItemDefaultsToNull
 import org.bson.codecs.kotlinx.samples.DataClassWithMutableList
 import org.bson.codecs.kotlinx.samples.DataClassWithMutableMap
 import org.bson.codecs.kotlinx.samples.DataClassWithMutableSet
@@ -253,6 +255,27 @@ class KotlinSerializerCodecTest {
         val dataClass = DataClassWithNulls(null, null, null)
         assertRoundTrips(emptyDocument, dataClass)
         assertRoundTrips(expectedNulls, dataClass, altConfiguration)
+    }
+
+    @Test
+    fun testDataClassWithListThatLastItemDefaultsToNull() {
+        val expectedWithOutNulls =
+            """{
+            | "elements": [{"required": "required"}, {"required": "required"}],
+            |}"""
+                .trimMargin()
+
+        val dataClass =
+            DataClassWithListThatLastItemDefaultsToNull(
+                listOf(DataClassLastItemDefaultsToNull("required"), DataClassLastItemDefaultsToNull("required")))
+        assertRoundTrips(expectedWithOutNulls, dataClass)
+
+        val expectedWithNulls =
+            """{
+            | "elements": [{"required": "required", "optional": null}, {"required": "required", "optional": null}],
+            |}"""
+                .trimMargin()
+        assertRoundTrips(expectedWithNulls, dataClass, BsonConfiguration(explicitNulls = true))
     }
 
     @Test

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
@@ -83,6 +83,11 @@ data class DataClassWithDefaults(
 @Serializable data class DataClassWithNulls(val boolean: Boolean?, val string: String?, val listSimple: List<String?>?)
 
 @Serializable
+data class DataClassWithListThatLastItemDefaultsToNull(val elements: List<DataClassLastItemDefaultsToNull>)
+
+@Serializable data class DataClassLastItemDefaultsToNull(val required: String, val optional: String? = null)
+
+@Serializable
 data class DataClassSelfReferential(
     val name: String,
     val left: DataClassSelfReferential? = null,


### PR DESCRIPTION
Ensures that the `deferredElement` name is reset as it does in `encodeSerializableValue`. 
Test case ported to bson-kotlin

JAVA-5524