### PR TITLE
Correct Scaladoc references to methods and classes.

### DIFF
--- a/driver-scala/src/main/scala/org/mongodb/scala/AggregateObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/AggregateObservable.scala
@@ -202,7 +202,7 @@ case class AggregateObservable[TResult](private val wrapped: AggregatePublisher[
   /**
    * Sets the timeoutMode for the cursor.
    *
-   * Requires the `timeout` to be set, either in the [[com.mongodb.MongoClientSettings]],
+   * Requires the `timeout` to be set, either in the [[MongoClientSettings]],
    * via [[MongoDatabase]] or via [[MongoCollection]]
    *
    * If the `timeout` is set then:

--- a/driver-scala/src/main/scala/org/mongodb/scala/DistinctObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/DistinctObservable.scala
@@ -114,7 +114,7 @@ case class DistinctObservable[TResult](private val wrapped: DistinctPublisher[TR
   /**
    * Sets the timeoutMode for the cursor.
    *
-   * Requires the `timeout` to be set, either in the [[com.mongodb.MongoClientSettings]],
+   * Requires the `timeout` to be set, either in the [[MongoClientSettings]],
    * via [[MongoDatabase]] or via [[MongoCollection]]
    *
    * @param timeoutMode the timeout mode

--- a/driver-scala/src/main/scala/org/mongodb/scala/FindObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/FindObservable.scala
@@ -336,7 +336,7 @@ case class FindObservable[TResult](private val wrapped: FindPublisher[TResult]) 
   /**
    * Sets the timeoutMode for the cursor.
    *
-   * Requires the `timeout` to be set, either in the [[com.mongodb.MongoClientSettings]],
+   * Requires the `timeout` to be set, either in the [[MongoClientSettings]],
    * via [[MongoDatabase]] or via [[MongoCollection]]
    *
    * If the `timeout` is set then:

--- a/driver-scala/src/main/scala/org/mongodb/scala/ListCollectionsObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/ListCollectionsObservable.scala
@@ -99,7 +99,7 @@ case class ListCollectionsObservable[TResult](wrapped: ListCollectionsPublisher[
   /**
    * Sets the timeoutMode for the cursor.
    *
-   * Requires the `timeout` to be set, either in the [[com.mongodb.MongoClientSettings]],
+   * Requires the `timeout` to be set, either in the [[MongoClientSettings]],
    * via [[MongoDatabase]] or via [[MongoCollection]]
    *
    * @param timeoutMode the timeout mode

--- a/driver-scala/src/main/scala/org/mongodb/scala/ListDatabasesObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/ListDatabasesObservable.scala
@@ -128,7 +128,7 @@ case class ListDatabasesObservable[TResult](wrapped: ListDatabasesPublisher[TRes
   /**
    * Sets the timeoutMode for the cursor.
    *
-   * Requires the `timeout` to be set, either in the [[com.mongodb.MongoClientSettings]],
+   * Requires the `timeout` to be set, either in the [[MongoClientSettings]],
    * via [[MongoDatabase]] or via [[MongoCollection]]
    *
    * @param timeoutMode the timeout mode

--- a/driver-scala/src/main/scala/org/mongodb/scala/ListIndexesObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/ListIndexesObservable.scala
@@ -86,7 +86,7 @@ case class ListIndexesObservable[TResult](wrapped: ListIndexesPublisher[TResult]
   /**
    * Sets the timeoutMode for the cursor.
    *
-   * Requires the `timeout` to be set, either in the [[com.mongodb.MongoClientSettings]],
+   * Requires the `timeout` to be set, either in the [[MongoClientSettings]],
    * via [[MongoDatabase]] or via [[MongoCollection]]
    *
    * @param timeoutMode the timeout mode

--- a/driver-scala/src/main/scala/org/mongodb/scala/ListSearchIndexesObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/ListSearchIndexesObservable.scala
@@ -126,7 +126,7 @@ case class ListSearchIndexesObservable[TResult](wrapped: ListSearchIndexesPublis
   /**
    * Sets the timeoutMode for the cursor.
    *
-   * Requires the `timeout` to be set, either in the [[com.mongodb.MongoClientSettings]],
+   * Requires the `timeout` to be set, either in the [[MongoClientSettings]],
    * via [[MongoDatabase]] or via [[MongoCollection]]
    *
    * If the `timeout` is set then:

--- a/driver-scala/src/main/scala/org/mongodb/scala/MapReduceObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MapReduceObservable.scala
@@ -225,7 +225,7 @@ case class MapReduceObservable[TResult](wrapped: MapReducePublisher[TResult]) ex
   /**
    * Sets the timeoutMode for the cursor.
    *
-   * Requires the `timeout` to be set, either in the [[com.mongodb.MongoClientSettings]],
+   * Requires the `timeout` to be set, either in the [[MongoClientSettings]],
    * via [[MongoDatabase]] or via [[MongoCollection]]
    *
    * @param timeoutMode the timeout mode

--- a/driver-scala/src/main/scala/org/mongodb/scala/gridfs/GridFSBucket.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/gridfs/GridFSBucket.scala
@@ -183,7 +183,7 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
    * chunks have been uploaded, it creates a files collection document for `filename` in the files collection.
    *
    * Note: When this [[GridFSBucket]] is set with a operation timeout (via timeout inherited from [[MongoDatabase]]
-   * settings or [[GridFSBucket#withTimeout()]]), timeout breaches may occur due to the [[Observable]]
+   * settings or [[withTimeout]]), timeout breaches may occur due to the [[Observable]]
    * lacking inherent read timeout support, which might extend the operation beyond the specified timeout limit.
    *
    * @param filename the filename for the stream
@@ -201,7 +201,7 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
    * chunks have been uploaded, it creates a files collection document for `filename` in the files collection.
    *
    * Note: When this [[GridFSBucket]] is set with a operation timeout (via timeout inherited from [[MongoDatabase]]
-   * settings or [[GridFSBucket#withTimeout()]]), timeout breaches may occur due to the [[Observable]]
+   * settings or [[withTimeout]]), timeout breaches may occur due to the [[Observable]]
    * lacking inherent read timeout support, which might extend the operation beyond the specified timeout limit.
    *
    * @param filename the filename for the stream
@@ -224,7 +224,7 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
    * chunks have been uploaded, it creates a files collection document for `filename` in the files collection.
    *
    * Note: When this [[GridFSBucket]] is set with a operation timeout (via timeout inherited from [[MongoDatabase]]
-   * settings or [[GridFSBucket#withTimeout()]]), timeout breaches may occur due to the [[Observable]]
+   * settings or [[withTimeout]]), timeout breaches may occur due to the [[Observable]]
    * lacking inherent read timeout support, which might extend the operation beyond the specified timeout limit.
    *
    * @param id       the custom id value of the file
@@ -247,7 +247,7 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
    * chunks have been uploaded, it creates a files collection document for `filename` in the files collection.
    *
    * Note: When this [[GridFSBucket]] is set with a operation timeout (via timeout inherited from [[MongoDatabase]]
-   * settings or [[GridFSBucket#withTimeout()]]), timeout breaches may occur due to the [[Observable]]
+   * settings or [[withTimeout]]), timeout breaches may occur due to the [[Observable]]
    * lacking inherent read timeout support, which might extend the operation beyond the specified timeout limit.
    *
    * @param id       the custom id value of the file
@@ -272,7 +272,7 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
    * chunks have been uploaded, it creates a files collection document for `filename` in the files collection.
    *
    * Note: When this [[GridFSBucket]] is set with a operation timeout (via timeout inherited from [[MongoDatabase]]
-   * settings or [[GridFSBucket#withTimeout()]]), timeout breaches may occur due to the [[Observable]]
+   * settings or [[withTimeout]]), timeout breaches may occur due to the [[Observable]]
    * lacking inherent read timeout support, which might extend the operation beyond the specified timeout limit.
    *
    * @param clientSession the client session with which to associate this operation
@@ -296,7 +296,7 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
    * chunks have been uploaded, it creates a files collection document for `filename` in the files collection.
    *
    * Note: When this [[GridFSBucket]] is set with a operation timeout (via timeout inherited from [[MongoDatabase]]
-   * settings or [[GridFSBucket#withTimeout()]]), timeout breaches may occur due to the [[Observable]]
+   * settings or [[withTimeout]]), timeout breaches may occur due to the [[Observable]]
    * lacking inherent read timeout support, which might extend the operation beyond the specified timeout limit.
    *
    * @param clientSession the client session with which to associate this operation
@@ -322,7 +322,7 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
    * chunks have been uploaded, it creates a files collection document for `filename` in the files collection.
    *
    * Note: When this [[GridFSBucket]] is set with a operation timeout (via timeout inherited from [[MongoDatabase]]
-   * settings or [[GridFSBucket#withTimeout()]]), timeout breaches may occur due to the [[Observable]]
+   * settings or [[withTimeout]]), timeout breaches may occur due to the [[Observable]]
    * lacking inherent read timeout support, which might extend the operation beyond the specified timeout limit.
    *
    * @param clientSession the client session with which to associate this operation
@@ -348,7 +348,7 @@ case class GridFSBucket(private val wrapped: JGridFSBucket) {
    * chunks have been uploaded, it creates a files collection document for `filename` in the files collection.
    *
    * Note: When this [[GridFSBucket]] is set with a operation timeout (via timeout inherited from [[MongoDatabase]]
-   * settings or [[GridFSBucket#withTimeout()]]), timeout breaches may occur due to the [[Observable]]
+   * settings or [[withTimeout]]), timeout breaches may occur due to the [[Observable]]
    * lacking inherent read timeout support, which might extend the operation beyond the specified timeout limit.
    *
    * @param clientSession the client session with which to associate this operation


### PR DESCRIPTION
Correct Scaladoc references to methods and classes that were producing warnings.