### PR TITLE
Add ANNOTATION_TYPE for other annotation to inherite this @BsonId

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/annotations/BsonId.java
+++ b/bson/src/main/org/bson/codecs/pojo/annotations/BsonId.java
@@ -33,6 +33,6 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
 public @interface BsonId {
 }


### PR DESCRIPTION
I want to extend the functionality of @BsonId by inheriting them, but currently custom annotations can't inherit @BsonId. This can make the code bloated.

https://github.com/zfoo-project/zfoo/blob/main/orm/src/test/java/com/zfoo/orm/entity/MailEntity.java