### PR TITLE
PojoCodec - use both BsonDiscriminator key and value for lookup

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/DiscriminatorLookup.java
+++ b/bson/src/main/org/bson/codecs/pojo/DiscriminatorLookup.java
@@ -17,34 +17,38 @@
 package org.bson.codecs.pojo;
 
 import org.bson.codecs.configuration.CodecConfigurationException;
+import org.bson.diagnostics.Logger;
+import org.bson.diagnostics.Loggers;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.lang.String.format;
 
 final class DiscriminatorLookup {
-    private final Map<String, Class<?>> discriminatorClassMap = new ConcurrentHashMap<>();
+    private static final Logger LOGGER = Loggers.getLogger("PojoCodec");
+    private final Map<Discriminator, Class<?>> discriminatorClassMap = new ConcurrentHashMap<>();
     private final Set<String> packages;
 
     DiscriminatorLookup(final Map<Class<?>, ClassModel<?>> classModels, final Set<String> packages) {
         for (ClassModel<?> classModel : classModels.values()) {
-            if (classModel.getDiscriminator() != null) {
-                discriminatorClassMap.put(classModel.getDiscriminator(), classModel.getType());
-            }
+            addClassModel(classModel);
         }
         this.packages = packages;
     }
 
-    public Class<?> lookup(final String discriminator) {
+    public Class<?> lookup(final String discriminatorKey, final String discriminatorValue) {
+        Discriminator discriminator = new Discriminator(discriminatorKey, discriminatorValue);
+
         if (discriminatorClassMap.containsKey(discriminator)) {
             return discriminatorClassMap.get(discriminator);
         }
 
-        Class<?> clazz = getClassForName(discriminator);
+        Class<?> clazz = getClassForName(discriminatorValue);
         if (clazz == null) {
-            clazz = searchPackages(discriminator);
+            clazz = searchPackages(discriminatorValue);
         }
 
         if (clazz == null) {
@@ -57,7 +61,12 @@ final class DiscriminatorLookup {
 
     void addClassModel(final ClassModel<?> classModel) {
         if (classModel.getDiscriminator() != null) {
-            discriminatorClassMap.put(classModel.getDiscriminator(), classModel.getType());
+            Discriminator discriminator = Discriminator.create(classModel);
+            Class<?> cachedClass = discriminatorClassMap.computeIfAbsent(discriminator, (cachedDiscriminator) -> classModel.getType());
+            if (cachedClass != classModel.getType()) {
+                LOGGER.error(format("Duplicate %s registered for both: `%s` and `%s`",
+                        discriminator, cachedClass.getName(), classModel.getType().getName()));
+            }
         }
     }
 
@@ -80,5 +89,44 @@ final class DiscriminatorLookup {
             }
         }
         return clazz;
+    }
+
+    static final class Discriminator {
+        private final String key;
+        private final String value;
+
+        static Discriminator create(final ClassModel<?> classModel) {
+            return new Discriminator(classModel.getDiscriminatorKey(), classModel.getDiscriminator());
+        }
+
+        Discriminator(final String key, final String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return "Discriminator{"
+                    + "key='" + key + '\''
+                    + ", value='" + value + '\''
+                    + '}';
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final Discriminator that = (Discriminator) o;
+            return Objects.equals(key, that.key) && Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, value);
+        }
     }
 }

--- a/bson/src/main/org/bson/codecs/pojo/PojoCodecImpl.java
+++ b/bson/src/main/org/bson/codecs/pojo/PojoCodecImpl.java
@@ -290,7 +290,7 @@ final class PojoCodecImpl<T> extends PojoCodec<T> {
                 if (discriminatorKey.equals(name)) {
                     discriminatorKeyFound = true;
                     try {
-                        Class<?> discriminatorClass = discriminatorLookup.lookup(reader.readString());
+                        Class<?> discriminatorClass = discriminatorLookup.lookup(discriminatorKey, reader.readString());
                         if (codec == null || !codec.getEncoderClass().equals(discriminatorClass)) {
                             codec = (Codec<C>) registry.get(discriminatorClass);
                         }

--- a/bson/src/main/org/bson/codecs/pojo/PojoCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/pojo/PojoCodecProvider.java
@@ -23,8 +23,8 @@ import org.bson.diagnostics.Loggers;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -105,7 +105,7 @@ public final class PojoCodecProvider implements CodecProvider {
      */
     public static final class Builder {
         private final Set<String> packages = new HashSet<>();
-        private final Map<Class<?>, ClassModel<?>> classModels = new HashMap<>();
+        private final Map<Class<?>, ClassModel<?>> classModels = new LinkedHashMap<>();
         private final List<Class<?>> clazzes = new ArrayList<>();
         private List<Convention> conventions = null;
         private final List<PropertyCodecProvider> propertyCodecProviders = new ArrayList<>();

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCustomTest.java
@@ -38,8 +38,8 @@ import org.bson.codecs.pojo.entities.BsonRepresentationUnsupportedInt;
 import org.bson.codecs.pojo.entities.BsonRepresentationUnsupportedString;
 import org.bson.codecs.pojo.entities.ConcreteAndNestedAbstractInterfaceModel;
 import org.bson.codecs.pojo.entities.ConcreteCollectionsModel;
-import org.bson.codecs.pojo.entities.ConcreteModel;
 import org.bson.codecs.pojo.entities.ConcreteField;
+import org.bson.codecs.pojo.entities.ConcreteModel;
 import org.bson.codecs.pojo.entities.ConcreteStandAloneAbstractInterfaceModel;
 import org.bson.codecs.pojo.entities.ConstructorNotPublicModel;
 import org.bson.codecs.pojo.entities.ConventionModel;
@@ -79,6 +79,9 @@ import org.bson.codecs.pojo.entities.conventions.CollectionsGetterNullModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorConstructorPrimitivesModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorConstructorThrowsExceptionModel;
 import org.bson.codecs.pojo.entities.conventions.CreatorMethodThrowsExceptionModel;
+import org.bson.codecs.pojo.entities.conventions.DiscriminatorModelA;
+import org.bson.codecs.pojo.entities.conventions.DiscriminatorModelB;
+import org.bson.codecs.pojo.entities.conventions.DiscriminatorModelC;
 import org.bson.codecs.pojo.entities.conventions.MapGetterImmutableModel;
 import org.bson.codecs.pojo.entities.conventions.MapGetterMutableModel;
 import org.bson.codecs.pojo.entities.conventions.MapGetterNonEmptyModel;
@@ -662,6 +665,20 @@ public final class PojoCustomTest extends PojoTestCase {
                 + "'myLongField': {'$numberLong': '42'}}}";
 
         roundTrip(actualRegistry, model, json);
+    }
+
+    @Test
+    public void testDiscriminatorDuplicateValues() {
+        PojoCodecProvider.Builder builder = getPojoCodecProviderBuilder(
+                DiscriminatorModelA.class,
+                DiscriminatorModelB.class,
+                DiscriminatorModelC.class);
+
+        roundTrip(builder, new DiscriminatorModelA().setStringField("ok"), "{'_cls': 'DiscriminatorModel', 'stringField': 'ok'}");
+        roundTrip(builder, new DiscriminatorModelB().setStringField("ok"), "{'_t': 'DiscriminatorModel', 'stringField': 'ok'}");
+
+        // Encodes as expected but won't round trip as DiscriminatorModelA has the same discriminator.
+        encodesTo(builder, new DiscriminatorModelC().setStringField("ok"), "{'_cls': 'DiscriminatorModel', 'stringField': 'ok'}");
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/DiscriminatorModelA.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/DiscriminatorModelA.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.pojo.entities.conventions;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+import java.util.Objects;
+
+@BsonDiscriminator(key = "_cls", value = "DiscriminatorModel")
+public class DiscriminatorModelA {
+    private String stringField;
+
+    public DiscriminatorModelA setStringField(final String stringField) {
+        this.stringField = stringField;
+        return this;
+    }
+
+    public String getStringField() {
+        return stringField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DiscriminatorModelA that = (DiscriminatorModelA) o;
+        return Objects.equals(stringField, that.stringField);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(stringField);
+    }
+
+    @Override
+    public String toString() {
+        return "DiscriminatorModelA{stringField='" + stringField + "'}";
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/DiscriminatorModelB.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/DiscriminatorModelB.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.pojo.entities.conventions;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+import java.util.Objects;
+
+@BsonDiscriminator(key = "_t", value = "DiscriminatorModel")
+public class DiscriminatorModelB {
+    private String stringField;
+
+    public DiscriminatorModelB setStringField(final String stringField) {
+        this.stringField = stringField;
+        return this;
+    }
+
+    public String getStringField() {
+        return stringField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DiscriminatorModelB that = (DiscriminatorModelB) o;
+        return Objects.equals(stringField, that.stringField);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(stringField);
+    }
+
+    @Override
+    public String toString() {
+        return "DiscriminatorModelB{stringField='" + stringField + "'}";
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/DiscriminatorModelC.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/conventions/DiscriminatorModelC.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.pojo.entities.conventions;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+import java.util.Objects;
+
+@BsonDiscriminator(key = "_cls", value = "DiscriminatorModel")
+public class DiscriminatorModelC {
+    private String stringField;
+
+    public DiscriminatorModelC setStringField(final String stringField) {
+        this.stringField = stringField;
+        return this;
+    }
+
+    public String getStringField() {
+        return stringField;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DiscriminatorModelC that = (DiscriminatorModelC) o;
+        return Objects.equals(stringField, that.stringField);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(stringField);
+    }
+
+    @Override
+    public String toString() {
+        return "DiscriminatorModelC{stringField='" + stringField + "'}";
+    }
+}


### PR DESCRIPTION
Previously, only the value of a discriminator was used as the key for discriminator lookups. Now both key and values are used.

Updated the PojoCodecProvider to use a LinkedHashMap to keep the registration order of classes / classModels.

Added an ERROR level log if duplicate BsonDiscriminators are discovered.

JAVA-5566