### PR TITLE
Do minor improvements to how we use field validators

### DIFF
--- a/bson/src/main/org/bson/AbstractBsonWriter.java
+++ b/bson/src/main/org/bson/AbstractBsonWriter.java
@@ -47,7 +47,7 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
      * @param settings The writer settings.
      */
     protected AbstractBsonWriter(final BsonWriterSettings settings) {
-        this(settings, new NoOpFieldNameValidator());
+        this(settings, NoOpFieldNameValidator.INSTANCE);
     }
 
     /**

--- a/bson/src/main/org/bson/BsonBinaryWriter.java
+++ b/bson/src/main/org/bson/BsonBinaryWriter.java
@@ -67,7 +67,7 @@ public class BsonBinaryWriter extends AbstractBsonWriter {
      */
     public BsonBinaryWriter(final BsonWriterSettings settings, final BsonBinaryWriterSettings binaryWriterSettings,
                             final BsonOutput bsonOutput) {
-        this(settings, binaryWriterSettings, bsonOutput, new NoOpFieldNameValidator());
+        this(settings, binaryWriterSettings, bsonOutput, NoOpFieldNameValidator.INSTANCE);
     }
 
     /**

--- a/bson/src/main/org/bson/NoOpFieldNameValidator.java
+++ b/bson/src/main/org/bson/NoOpFieldNameValidator.java
@@ -16,7 +16,12 @@
 
 package org.bson;
 
-class NoOpFieldNameValidator implements FieldNameValidator {
+final class NoOpFieldNameValidator implements FieldNameValidator {
+    static final NoOpFieldNameValidator INSTANCE = new NoOpFieldNameValidator();
+
+    private NoOpFieldNameValidator() {
+    }
+
     @Override
     public boolean validate(final String fieldName) {
         return true;

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandHelper.java
@@ -105,7 +105,7 @@ public final class CommandHelper {
                                                     final InternalConnection internalConnection,
                                                     final ClusterConnectionMode clusterConnectionMode,
                                                     @Nullable final ServerApi serverApi) {
-        return new CommandMessage(new MongoNamespace(database, COMMAND_COLLECTION_NAME), command, new NoOpFieldNameValidator(), primary(),
+        return new CommandMessage(new MongoNamespace(database, COMMAND_COLLECTION_NAME), command, NoOpFieldNameValidator.INSTANCE, primary(),
                 MessageSettings
                         .builder()
                          // Note: server version will be 0.0 at this point when called from InternalConnectionInitializer,

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
@@ -308,7 +308,7 @@ class DefaultServerMonitor implements ServerMonitor {
         private CommandMessage createCommandMessage(final BsonDocument command, final InternalConnection connection,
                 final ServerDescription currentServerDescription) {
             return new CommandMessage(new MongoNamespace("admin", COMMAND_COLLECTION_NAME), command,
-                    new NoOpFieldNameValidator(), primary(),
+                    NoOpFieldNameValidator.INSTANCE, primary(),
                     MessageSettings.builder()
                             .maxWireVersion(connection.getDescription().getMaxWireVersion())
                             .build(),

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncCommandBatchCursor.java
@@ -37,6 +37,7 @@ import com.mongodb.internal.connection.AsyncConnection;
 import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.internal.operation.AsyncOperationHelper.AsyncCallableConnectionWithCallback;
+import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
@@ -53,7 +54,6 @@ import static com.mongodb.assertions.Assertions.doesNotThrow;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.FIRST_BATCH;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.MESSAGE_IF_CLOSED_AS_CURSOR;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.NEXT_BATCH;
-import static com.mongodb.internal.operation.CommandBatchCursorHelper.NO_OP_FIELD_NAME_VALIDATOR;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.getKillCursorsCommand;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.getMoreCommandDocument;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.logCommandCursorResult;
@@ -177,7 +177,7 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
             final SingleResultCallback<List<T>> callback) {
         connection.commandAsync(namespace.getDatabaseName(),
                 getMoreCommandDocument(serverCursor.getId(), connection.getDescription(), namespace, batchSize, comment),
-                NO_OP_FIELD_NAME_VALIDATOR, ReadPreference.primary(),
+                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 CommandResultDocumentCodec.create(decoder, NEXT_BATCH),
                 assertNotNull(resourceManager.getConnectionSource()).getOperationContext(),
                 (commandResult, t) -> {
@@ -334,7 +334,7 @@ class AsyncCommandBatchCursor<T> implements AsyncAggregateResponseBatchCursor<T>
             timeoutContext.resetToDefaultMaxTime();
 
             localConnection.commandAsync(namespace.getDatabaseName(), getKillCursorsCommand(namespace, localServerCursor),
-                    NO_OP_FIELD_NAME_VALIDATOR, ReadPreference.primary(), new BsonDocumentCodec(),
+                    NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(),
                     operationContext, (r, t) -> callback.onResult(null, null));
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
@@ -225,7 +225,7 @@ final class AsyncOperationHelper {
         Assertions.notNull("binding", binding);
         SingleResultCallback<T> addingRetryableLabelCallback = addingRetryableLabelCallback(callback,
                 connection.getDescription().getMaxWireVersion());
-        connection.commandAsync(database, command, new NoOpFieldNameValidator(), ReadPreference.primary(), new BsonDocumentCodec(),
+        connection.commandAsync(database, command, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(),
                 binding.getOperationContext(), transformingWriteCallback(transformer, connection, addingRetryableLabelCallback));
     }
 
@@ -306,7 +306,7 @@ final class AsyncOperationHelper {
             callback.onResult(null, e);
             return;
         }
-        connection.commandAsync(database, command, new NoOpFieldNameValidator(), source.getReadPreference(), decoder,
+        connection.commandAsync(database, command, NoOpFieldNameValidator.INSTANCE, source.getReadPreference(), decoder,
                 operationContext, transformingReadCallback(transformer, source, connection, callback));
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/BulkWriteBatch.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/BulkWriteBatch.java
@@ -77,7 +77,6 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 public final class BulkWriteBatch {
     private static final CodecRegistry REGISTRY = fromProviders(new BsonValueCodecProvider());
     private static final Decoder<BsonDocument> DECODER = REGISTRY.get(BsonDocument.class);
-    private static final FieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
 
     private final MongoNamespace namespace;
     private final ConnectionDescription connectionDescription;
@@ -281,13 +280,13 @@ public final class BulkWriteBatch {
         if (batchType == UPDATE || batchType == REPLACE) {
             Map<String, FieldNameValidator> rootMap;
             if (batchType == REPLACE) {
-                rootMap = singletonMap("u", new ReplacingDocumentFieldNameValidator());
+                rootMap = singletonMap("u", ReplacingDocumentFieldNameValidator.INSTANCE);
             } else {
                 rootMap = singletonMap("u", new UpdateFieldNameValidator());
             }
-            return new MappedFieldNameValidator(NO_OP_FIELD_NAME_VALIDATOR, rootMap);
+            return new MappedFieldNameValidator(NoOpFieldNameValidator.INSTANCE, rootMap);
         } else {
-            return NO_OP_FIELD_NAME_VALIDATOR;
+            return NoOpFieldNameValidator.INSTANCE;
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/BulkWriteBatch.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/BulkWriteBatch.java
@@ -54,7 +54,6 @@ import org.bson.codecs.Decoder;
 import org.bson.codecs.configuration.CodecRegistry;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -69,6 +68,7 @@ import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.OperationHelper.isRetryableWrite;
 import static com.mongodb.internal.operation.WriteConcernHelper.createWriteConcernError;
+import static java.util.Collections.singletonMap;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 
 /**
@@ -279,11 +279,11 @@ public final class BulkWriteBatch {
 
     FieldNameValidator getFieldNameValidator() {
         if (batchType == UPDATE || batchType == REPLACE) {
-            Map<String, FieldNameValidator> rootMap = new HashMap<>();
+            Map<String, FieldNameValidator> rootMap;
             if (batchType == REPLACE) {
-                rootMap.put("u", new ReplacingDocumentFieldNameValidator());
+                rootMap = singletonMap("u", new ReplacingDocumentFieldNameValidator());
             } else {
-                rootMap.put("u", new UpdateFieldNameValidator());
+                rootMap = singletonMap("u", new UpdateFieldNameValidator());
             }
             return new MappedFieldNameValidator(NO_OP_FIELD_NAME_VALIDATOR, rootMap);
         } else {

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursor.java
@@ -33,6 +33,7 @@ import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.binding.ConnectionSource;
 import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.connection.OperationContext;
+import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
@@ -52,7 +53,6 @@ import static com.mongodb.internal.operation.CommandBatchCursorHelper.FIRST_BATC
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.MESSAGE_IF_CLOSED_AS_CURSOR;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.MESSAGE_IF_CLOSED_AS_ITERATOR;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.NEXT_BATCH;
-import static com.mongodb.internal.operation.CommandBatchCursorHelper.NO_OP_FIELD_NAME_VALIDATOR;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.getKillCursorsCommand;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.getMoreCommandDocument;
 import static com.mongodb.internal.operation.CommandBatchCursorHelper.logCommandCursorResult;
@@ -237,7 +237,7 @@ class CommandBatchCursor<T> implements AggregateResponseBatchCursor<T> {
                         assertNotNull(
                             connection.command(namespace.getDatabaseName(),
                                  getMoreCommandDocument(serverCursor.getId(), connection.getDescription(), namespace, batchSize, comment),
-                                 NO_OP_FIELD_NAME_VALIDATOR,
+                                 NoOpFieldNameValidator.INSTANCE,
                                  ReadPreference.primary(),
                                  CommandResultDocumentCodec.create(decoder, NEXT_BATCH),
                                  assertNotNull(resourceManager.getConnectionSource()).getOperationContext())));
@@ -374,7 +374,7 @@ class CommandBatchCursor<T> implements AggregateResponseBatchCursor<T> {
             timeoutContext.resetToDefaultMaxTime();
 
             localConnection.command(namespace.getDatabaseName(), getKillCursorsCommand(namespace, localServerCursor),
-                    NO_OP_FIELD_NAME_VALIDATOR, ReadPreference.primary(), new BsonDocumentCodec(), operationContext);
+                    NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), operationContext);
         }
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursorHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandBatchCursorHelper.java
@@ -22,7 +22,6 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.MongoQueryException;
 import com.mongodb.ServerCursor;
 import com.mongodb.connection.ConnectionDescription;
-import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
@@ -30,7 +29,6 @@ import org.bson.BsonInt32;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
 import org.bson.BsonValue;
-import org.bson.FieldNameValidator;
 
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.internal.operation.OperationHelper.LOGGER;
@@ -42,7 +40,6 @@ final class CommandBatchCursorHelper {
 
     static final String FIRST_BATCH = "firstBatch";
     static final String NEXT_BATCH = "nextBatch";
-    static final FieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
     static final String MESSAGE_IF_CLOSED_AS_CURSOR = "Cursor has been closed";
     static final String MESSAGE_IF_CLOSED_AS_ITERATOR = "Iterator has been closed";
 

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndDeleteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndDeleteOperation.java
@@ -89,7 +89,7 @@ public class FindAndDeleteOperation<T> extends BaseFindAndModifyOperation<T> {
     }
 
     protected FieldNameValidator getFieldNameValidator() {
-        return new NoOpFieldNameValidator();
+        return NoOpFieldNameValidator.INSTANCE;
     }
 
     protected void specializeCommand(final BsonDocument commandDocument, final ConnectionDescription connectionDescription) {

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
@@ -132,8 +132,8 @@ public class FindAndReplaceOperation<T> extends BaseFindAndModifyOperation<T> {
 
     protected FieldNameValidator getFieldNameValidator() {
         return new MappedFieldNameValidator(
-                new NoOpFieldNameValidator(),
-                singletonMap("update", new ReplacingDocumentFieldNameValidator()));
+                NoOpFieldNameValidator.INSTANCE,
+                singletonMap("update", ReplacingDocumentFieldNameValidator.INSTANCE));
     }
 
     protected void specializeCommand(final BsonDocument commandDocument, final ConnectionDescription connectionDescription) {

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndReplaceOperation.java
@@ -30,11 +30,9 @@ import org.bson.BsonValue;
 import org.bson.FieldNameValidator;
 import org.bson.codecs.Decoder;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.operation.DocumentHelper.putIfTrue;
+import static java.util.Collections.singletonMap;
 
 /**
  * An operation that atomically finds and replaces a single document.
@@ -133,9 +131,9 @@ public class FindAndReplaceOperation<T> extends BaseFindAndModifyOperation<T> {
     }
 
     protected FieldNameValidator getFieldNameValidator() {
-        Map<String, FieldNameValidator> map = new HashMap<>();
-        map.put("update", new ReplacingDocumentFieldNameValidator());
-        return new MappedFieldNameValidator(new NoOpFieldNameValidator(), map);
+        return new MappedFieldNameValidator(
+                new NoOpFieldNameValidator(),
+                singletonMap("update", new ReplacingDocumentFieldNameValidator()));
     }
 
     protected void specializeCommand(final BsonDocument commandDocument, final ConnectionDescription connectionDescription) {

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndUpdateOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndUpdateOperation.java
@@ -160,7 +160,7 @@ public class FindAndUpdateOperation<T> extends BaseFindAndModifyOperation<T> {
     }
 
     protected FieldNameValidator getFieldNameValidator() {
-        return new MappedFieldNameValidator(new NoOpFieldNameValidator(), singletonMap("update", new UpdateFieldNameValidator()));
+        return new MappedFieldNameValidator(NoOpFieldNameValidator.INSTANCE, singletonMap("update", new UpdateFieldNameValidator()));
     }
 
     protected void specializeCommand(final BsonDocument commandDocument, final ConnectionDescription connectionDescription) {

--- a/driver-core/src/main/com/mongodb/internal/operation/FindAndUpdateOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindAndUpdateOperation.java
@@ -31,13 +31,12 @@ import org.bson.BsonValue;
 import org.bson.FieldNameValidator;
 import org.bson.codecs.Decoder;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.internal.operation.DocumentHelper.putIfTrue;
+import static java.util.Collections.singletonMap;
 
 /**
  * An operation that atomically finds and updates a single document.
@@ -161,9 +160,7 @@ public class FindAndUpdateOperation<T> extends BaseFindAndModifyOperation<T> {
     }
 
     protected FieldNameValidator getFieldNameValidator() {
-        Map<String, FieldNameValidator> map = new HashMap<>();
-        map.put("update", new UpdateFieldNameValidator());
-        return new MappedFieldNameValidator(new NoOpFieldNameValidator(), map);
+        return new MappedFieldNameValidator(new NoOpFieldNameValidator(), singletonMap("update", new UpdateFieldNameValidator()));
     }
 
     protected void specializeCommand(final BsonDocument commandDocument, final ConnectionDescription connectionDescription) {

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -47,7 +47,6 @@ import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 import org.bson.BsonValue;
-import org.bson.FieldNameValidator;
 
 import java.util.List;
 import java.util.Optional;
@@ -77,7 +76,6 @@ import static com.mongodb.internal.operation.SyncOperationHelper.withSourceAndCo
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
 public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteResult>, WriteOperation<BulkWriteResult> {
-    private static final FieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
     private final MongoNamespace namespace;
     private final List<? extends WriteRequest> writeRequests;
     private final boolean ordered;
@@ -408,14 +406,14 @@ public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteRes
 
     @Nullable
     private BsonDocument executeCommand(final OperationContext operationContext, final Connection connection, final BulkWriteBatch batch) {
-        return connection.command(namespace.getDatabaseName(), batch.getCommand(), NO_OP_FIELD_NAME_VALIDATOR, null, batch.getDecoder(),
+        return connection.command(namespace.getDatabaseName(), batch.getCommand(), NoOpFieldNameValidator.INSTANCE, null, batch.getDecoder(),
                 operationContext, shouldAcknowledge(batch, operationContext.getSessionContext()),
                 batch.getPayload(), batch.getFieldNameValidator());
     }
 
     private void executeCommandAsync(final OperationContext operationContext, final AsyncConnection connection, final BulkWriteBatch batch,
             final SingleResultCallback<BsonDocument> callback) {
-        connection.commandAsync(namespace.getDatabaseName(), batch.getCommand(), NO_OP_FIELD_NAME_VALIDATOR, null, batch.getDecoder(),
+        connection.commandAsync(namespace.getDatabaseName(), batch.getCommand(), NoOpFieldNameValidator.INSTANCE, null, batch.getDecoder(),
                 operationContext, shouldAcknowledge(batch, operationContext.getSessionContext()),
                 batch.getPayload(), batch.getFieldNameValidator(), callback);
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
@@ -210,7 +210,7 @@ final class SyncOperationHelper {
                                 commandCreator.create(binding.getOperationContext(),
                                         source.getServerDescription(),
                                         connection.getDescription()),
-                                new NoOpFieldNameValidator(), primary(), BSON_DOCUMENT_CODEC, binding.getOperationContext())),
+                                NoOpFieldNameValidator.INSTANCE, primary(), BSON_DOCUMENT_CODEC, binding.getOperationContext())),
                         connection));
     }
 
@@ -219,7 +219,7 @@ final class SyncOperationHelper {
                                    final Decoder<D> decoder, final CommandWriteTransformer<D, T> transformer) {
         return withSourceAndConnection(binding::getWriteConnectionSource, false, (source, connection) ->
                 transformer.apply(assertNotNull(
-                        connection.command(database, command, new NoOpFieldNameValidator(), primary(), decoder,
+                        connection.command(database, command, NoOpFieldNameValidator.INSTANCE, primary(), decoder,
                                 binding.getOperationContext())), connection));
     }
 
@@ -228,7 +228,7 @@ final class SyncOperationHelper {
                                 final Connection connection, final CommandWriteTransformer<BsonDocument, T> transformer) {
         notNull("binding", binding);
         return transformer.apply(assertNotNull(
-                connection.command(database, command, new NoOpFieldNameValidator(), primary(), BSON_DOCUMENT_CODEC,
+                connection.command(database, command, NoOpFieldNameValidator.INSTANCE, primary(), BSON_DOCUMENT_CODEC,
                         binding.getOperationContext())),
                 connection);
     }
@@ -295,7 +295,7 @@ final class SyncOperationHelper {
         BsonDocument command = commandCreator.create(operationContext, source.getServerDescription(),
                 connection.getDescription());
         retryState.attach(AttachmentKeys.commandDescriptionSupplier(), command::getFirstKey, false);
-        return transformer.apply(assertNotNull(connection.command(database, command, new NoOpFieldNameValidator(),
+        return transformer.apply(assertNotNull(connection.command(database, command, NoOpFieldNameValidator.INSTANCE,
                 source.getReadPreference(), decoder, operationContext)), source, connection);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/TransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/TransactionOperation.java
@@ -57,7 +57,7 @@ public abstract class TransactionOperation implements WriteOperation<Void>, Asyn
     public Void execute(final WriteBinding binding) {
         isTrue("in transaction", binding.getOperationContext().getSessionContext().hasActiveTransaction());
         TimeoutContext timeoutContext = binding.getOperationContext().getTimeoutContext();
-        return executeRetryableWrite(binding, "admin", null, new NoOpFieldNameValidator(),
+        return executeRetryableWrite(binding, "admin", null, NoOpFieldNameValidator.INSTANCE,
                                      new BsonDocumentCodec(), getCommandCreator(),
                 writeConcernErrorTransformer(timeoutContext), getRetryCommandModifier(timeoutContext));
     }
@@ -66,7 +66,7 @@ public abstract class TransactionOperation implements WriteOperation<Void>, Asyn
     public void executeAsync(final AsyncWriteBinding binding, final SingleResultCallback<Void> callback) {
         isTrue("in transaction", binding.getOperationContext().getSessionContext().hasActiveTransaction());
         TimeoutContext timeoutContext = binding.getOperationContext().getTimeoutContext();
-        executeRetryableWriteAsync(binding, "admin", null, new NoOpFieldNameValidator(),
+        executeRetryableWriteAsync(binding, "admin", null, NoOpFieldNameValidator.INSTANCE,
                                    new BsonDocumentCodec(), getCommandCreator(),
                 writeConcernErrorTransformerAsync(timeoutContext), getRetryCommandModifier(timeoutContext),
                                    errorHandlingCallback(callback, LOGGER));

--- a/driver-core/src/main/com/mongodb/internal/session/ServerSessionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/session/ServerSessionPool.java
@@ -156,7 +156,7 @@ public class ServerSessionPool {
                     operationContext).getServer().getConnection(operationContext);
 
             connection.command("admin",
-                    new BsonDocument("endSessions", new BsonArray(identifiers)), new NoOpFieldNameValidator(),
+                    new BsonDocument("endSessions", new BsonArray(identifiers)), NoOpFieldNameValidator.INSTANCE,
                     ReadPreference.primaryPreferred(), new BsonDocumentCodec(), operationContext);
         } catch (MongoException e) {
             // ignore exceptions

--- a/driver-core/src/main/com/mongodb/internal/validator/MappedFieldNameValidator.java
+++ b/driver-core/src/main/com/mongodb/internal/validator/MappedFieldNameValidator.java
@@ -55,10 +55,6 @@ public class MappedFieldNameValidator implements FieldNameValidator {
 
     @Override
     public FieldNameValidator getValidatorForField(final String fieldName) {
-        if (fieldNameToValidatorMap.containsKey(fieldName)) {
-            return fieldNameToValidatorMap.get(fieldName);
-        } else {
-            return defaultValidator;
-        }
+        return fieldNameToValidatorMap.getOrDefault(fieldName, defaultValidator);
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/validator/NoOpFieldNameValidator.java
+++ b/driver-core/src/main/com/mongodb/internal/validator/NoOpFieldNameValidator.java
@@ -23,7 +23,12 @@ import org.bson.FieldNameValidator;
  *
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
-public class NoOpFieldNameValidator implements FieldNameValidator {
+public final class NoOpFieldNameValidator implements FieldNameValidator {
+    public static final NoOpFieldNameValidator INSTANCE = new NoOpFieldNameValidator();
+
+    private NoOpFieldNameValidator() {
+    }
+
     @Override
     public boolean validate(final String fieldName) {
         return true;

--- a/driver-core/src/main/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidator.java
+++ b/driver-core/src/main/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidator.java
@@ -30,10 +30,13 @@ import static java.lang.String.format;
  *
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
-public class ReplacingDocumentFieldNameValidator implements FieldNameValidator {
-    private static final NoOpFieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
+public final class ReplacingDocumentFieldNameValidator implements FieldNameValidator {
+    public static final ReplacingDocumentFieldNameValidator INSTANCE = new ReplacingDocumentFieldNameValidator();
     // Have to support DBRef fields
     private static final List<String> EXCEPTIONS = Arrays.asList("$db", "$ref", "$id");
+
+    private ReplacingDocumentFieldNameValidator() {
+    }
 
     @Override
     public boolean validate(final String fieldName) {
@@ -49,6 +52,6 @@ public class ReplacingDocumentFieldNameValidator implements FieldNameValidator {
     @Override
     public FieldNameValidator getValidatorForField(final String fieldName) {
         // Only top-level fields are validated
-        return NO_OP_FIELD_NAME_VALIDATOR;
+        return NoOpFieldNameValidator.INSTANCE;
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/validator/UpdateFieldNameValidator.java
+++ b/driver-core/src/main/com/mongodb/internal/validator/UpdateFieldNameValidator.java
@@ -26,12 +26,12 @@ import static java.lang.String.format;
  *
  * <p>This class is not part of the public API and may be removed or changed at any time</p>
  */
-public class UpdateFieldNameValidator implements org.bson.FieldNameValidator {
-    private int numFields = 0;
+public final class UpdateFieldNameValidator implements org.bson.FieldNameValidator {
+    private boolean encounteredField = false;
 
     @Override
     public boolean validate(final String fieldName) {
-        numFields++;
+        encounteredField = true;
         return fieldName.startsWith("$");
     }
 
@@ -43,17 +43,17 @@ public class UpdateFieldNameValidator implements org.bson.FieldNameValidator {
 
     @Override
     public FieldNameValidator getValidatorForField(final String fieldName) {
-        return new NoOpFieldNameValidator();
+        return NoOpFieldNameValidator.INSTANCE;
     }
 
     @Override
     public void start() {
-        numFields = 0;
+        encounteredField = false;
     }
 
     @Override
     public void end() {
-        if (numFields == 0) {
+        if (!encounteredField) {
             throw new IllegalArgumentException("Invalid BSON document for an update. The document may not be empty.");
         }
     }

--- a/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
@@ -53,10 +53,8 @@ import com.mongodb.internal.operation.MixedBulkWriteOperation
 import com.mongodb.internal.operation.ReadOperation
 import com.mongodb.internal.operation.WriteOperation
 import com.mongodb.internal.session.SessionContext
-import com.mongodb.internal.validator.NoOpFieldNameValidator
 import org.bson.BsonDocument
 import org.bson.Document
-import org.bson.FieldNameValidator
 import org.bson.codecs.DocumentCodec
 import spock.lang.Shared
 import spock.lang.Specification
@@ -536,10 +534,4 @@ class OperationFunctionalSpecification extends Specification {
             .locale('en')
             .collationStrength(CollationStrength.SECONDARY)
             .build()
-
-    static final FieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator()
-
-    static boolean serverVersionIsGreaterThan(List<Integer> actualVersion, List<Integer> minVersion) {
-        new ServerVersion(actualVersion).compareTo(new ServerVersion(minVersion)) >= 0
-    }
 }

--- a/driver-core/src/test/functional/com/mongodb/client/model/OperationTest.java
+++ b/driver-core/src/test/functional/com/mongodb/client/model/OperationTest.java
@@ -21,14 +21,12 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.async.FutureResultCallback;
 import com.mongodb.client.test.CollectionHelper;
 import com.mongodb.internal.connection.ServerHelper;
-import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonDouble;
 import org.bson.BsonValue;
 import org.bson.Document;
-import org.bson.FieldNameValidator;
 import org.bson.codecs.BsonDocumentCodec;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.DocumentCodec;
@@ -61,7 +59,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public abstract class OperationTest {
 
     protected static final DocumentCodec DOCUMENT_DECODER = new DocumentCodec();
-    protected static final FieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
 
     @BeforeEach
     public void beforeEach() {

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
@@ -110,7 +110,7 @@ public class SingleServerClusterTest {
 
         // when
         BsonDocument result = connection.command(getDefaultDatabaseName(), new BsonDocument("count", new BsonString(collectionName)),
-                new NoOpFieldNameValidator(), ReadPreference.primary(), new BsonDocumentCodec(), operationContext);
+                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), operationContext);
 
         // then
         assertEquals(new BsonDouble(1.0).intValue(), result.getNumber("ok").intValue());

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncCommandBatchCursorFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncCommandBatchCursorFunctionalTest.java
@@ -26,6 +26,7 @@ import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.OperationTest;
 import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.connection.AsyncConnection;
+import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -349,7 +350,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         this.<BsonDocument>block(cb -> localConnection.commandAsync(getNamespace().getDatabaseName(),
                 new BsonDocument("killCursors", new BsonString(getNamespace().getCollectionName()))
                         .append("cursors", new BsonArray(singletonList(new BsonInt64(serverCursor.getId())))),
-                NO_OP_FIELD_NAME_VALIDATOR, ReadPreference.primary(), new BsonDocumentCodec(), connectionSource.getOperationContext(), cb));
+                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), connectionSource.getOperationContext(), cb));
         localConnection.release();
 
         cursorNext();
@@ -414,7 +415,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         }
 
         BsonDocument results = block(cb -> connection.commandAsync(getDatabaseName(), findCommand,
-                NO_OP_FIELD_NAME_VALIDATOR, readPreference, CommandResultDocumentCodec.create(DOCUMENT_DECODER, FIRST_BATCH),
+                NoOpFieldNameValidator.INSTANCE, readPreference, CommandResultDocumentCodec.create(DOCUMENT_DECODER, FIRST_BATCH),
                 connectionSource.getOperationContext(), cb));
 
         assertNotNull(results);

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CommandBatchCursorFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CommandBatchCursorFunctionalTest.java
@@ -25,6 +25,7 @@ import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.OperationTest;
 import com.mongodb.internal.binding.ConnectionSource;
 import com.mongodb.internal.connection.Connection;
+import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -439,7 +440,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         localConnection.command(getNamespace().getDatabaseName(),
                 new BsonDocument("killCursors", new BsonString(getNamespace().getCollectionName()))
                         .append("cursors", new BsonArray(singletonList(new BsonInt64(serverCursor.getId())))),
-                NO_OP_FIELD_NAME_VALIDATOR, ReadPreference.primary(), new BsonDocumentCodec(), connectionSource.getOperationContext());
+                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), connectionSource.getOperationContext());
         localConnection.release();
 
         cursor.next();
@@ -529,7 +530,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         }
 
         BsonDocument results = connection.command(getDatabaseName(), findCommand,
-                NO_OP_FIELD_NAME_VALIDATOR, readPreference,
+                NoOpFieldNameValidator.INSTANCE, readPreference,
                 CommandResultDocumentCodec.create(DOCUMENT_DECODER, FIRST_BATCH),
                 connectionSource.getOperationContext());
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/TestOperationHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/TestOperationHelper.java
@@ -56,7 +56,7 @@ final class TestOperationHelper {
                 connection.command(namespace.getDatabaseName(),
                         new BsonDocument("getMore", new BsonInt64(serverCursor.getId()))
                                 .append("collection", new BsonString(namespace.getCollectionName())),
-                        new NoOpFieldNameValidator(), ReadPreference.primary(), new BsonDocumentCodec(), OPERATION_CONTEXT));
+                        NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), OPERATION_CONTEXT));
     }
 
     static void makeAdditionalGetMoreCall(final MongoNamespace namespace, final ServerCursor serverCursor,
@@ -66,7 +66,7 @@ final class TestOperationHelper {
             connection.commandAsync(namespace.getDatabaseName(),
                     new BsonDocument("getMore", new BsonInt64(serverCursor.getId()))
                             .append("collection", new BsonString(namespace.getCollectionName())),
-                    new NoOpFieldNameValidator(), ReadPreference.primary(), new BsonDocumentCodec(), OPERATION_CONTEXT, callback);
+                    NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), OPERATION_CONTEXT, callback);
             callback.get();
         });
     }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageSpecification.groovy
@@ -51,7 +51,7 @@ class CommandMessageSpecification extends Specification {
 
     def namespace = new MongoNamespace('db.test')
     def command = new BsonDocument('find', new BsonString(namespace.collectionName))
-    def fieldNameValidator = new NoOpFieldNameValidator()
+    def fieldNameValidator = NoOpFieldNameValidator.INSTANCE
 
     def 'should encode command message with OP_MSG when server version is >= 3.6'() {
         given:
@@ -149,7 +149,7 @@ class CommandMessageSpecification extends Specification {
     def 'should get command document'() {
         given:
         def message = new CommandMessage(namespace, originalCommandDocument, fieldNameValidator, ReadPreference.primary(),
-                MessageSettings.builder().maxWireVersion(maxWireVersion).build(), true, payload, new NoOpFieldNameValidator(),
+                MessageSettings.builder().maxWireVersion(maxWireVersion).build(), true, payload, NoOpFieldNameValidator.INSTANCE,
                 ClusterConnectionMode.MULTIPLE, null)
         def output = new ByteBufferBsonOutput(new SimpleBufferProvider())
         message.encode(output, new OperationContext(IgnorableRequestContext.INSTANCE, NoOpSessionContext.INSTANCE,

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageTest.java
@@ -28,7 +28,6 @@ import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 import org.bson.BsonTimestamp;
-import org.bson.FieldNameValidator;
 import org.bson.io.BasicOutputBuffer;
 import org.junit.jupiter.api.Test;
 
@@ -44,12 +43,11 @@ class CommandMessageTest {
 
     private static final MongoNamespace NAMESPACE = new MongoNamespace("db.test");
     private static final BsonDocument COMMAND = new BsonDocument("find", new BsonString(NAMESPACE.getCollectionName()));
-    private static final FieldNameValidator FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
 
     @Test
     void encodeShouldThrowTimeoutExceptionWhenTimeoutContextIsCalled() {
         //given
-        CommandMessage commandMessage = new CommandMessage(NAMESPACE, COMMAND, FIELD_NAME_VALIDATOR, ReadPreference.primary(),
+        CommandMessage commandMessage = new CommandMessage(NAMESPACE, COMMAND, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 MessageSettings.builder()
                         .maxWireVersion(FOUR_DOT_ZERO_WIRE_VERSION)
                         .serverType(ServerType.REPLICA_SET_SECONDARY)
@@ -75,7 +73,7 @@ class CommandMessageTest {
     @Test
     void encodeShouldNotAddExtraElementsFromTimeoutContextWhenConnectedToMongoCrypt() {
         //given
-        CommandMessage commandMessage = new CommandMessage(NAMESPACE, COMMAND, FIELD_NAME_VALIDATOR, ReadPreference.primary(),
+        CommandMessage commandMessage = new CommandMessage(NAMESPACE, COMMAND, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 MessageSettings.builder()
                         .maxWireVersion(FOUR_DOT_ZERO_WIRE_VERSION)
                         .serverType(ServerType.REPLICA_SET_SECONDARY)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerConnectionSpecification.groovy
@@ -39,7 +39,7 @@ class DefaultServerConnectionSpecification extends Specification {
     def 'should execute command protocol asynchronously'() {
         given:
         def command = new BsonDocument(LEGACY_HELLO_LOWER, new BsonInt32(1))
-        def validator = new NoOpFieldNameValidator()
+        def validator = NoOpFieldNameValidator.INSTANCE
         def codec = new BsonDocumentCodec()
         def executor = Mock(ProtocolExecutor)
         def connection = new DefaultServerConnection(internalConnection, executor, ClusterConnectionMode.MULTIPLE)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
@@ -44,7 +44,6 @@ import com.mongodb.internal.time.Timeout
 import com.mongodb.internal.validator.NoOpFieldNameValidator
 import org.bson.BsonDocument
 import org.bson.BsonInt32
-import org.bson.FieldNameValidator
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.Specification
 
@@ -56,7 +55,6 @@ import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 
 class DefaultServerSpecification extends Specification {
-    private static final FieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator()
     def serverId = new ServerId(new ClusterId(), new ServerAddress())
 
     def 'should get a connection'() {
@@ -311,13 +309,13 @@ class DefaultServerSpecification extends Specification {
         when:
         if (async) {
             CountDownLatch latch = new CountDownLatch(1)
-            testConnection.commandAsync('admin', new BsonDocument('ping', new BsonInt32(1)), NO_OP_FIELD_NAME_VALIDATOR,
+            testConnection.commandAsync('admin', new BsonDocument('ping', new BsonInt32(1)), NoOpFieldNameValidator.INSTANCE,
                     ReadPreference.primary(), new BsonDocumentCodec(), operationContext) {
                 BsonDocument result, Throwable t -> latch.countDown()
             }
             latch.await()
         } else {
-            testConnection.command('admin', new BsonDocument('ping', new BsonInt32(1)), NO_OP_FIELD_NAME_VALIDATOR,
+            testConnection.command('admin', new BsonDocument('ping', new BsonInt32(1)), NoOpFieldNameValidator.INSTANCE,
                     ReadPreference.primary(), new BsonDocumentCodec(), operationContext)
         }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
@@ -78,7 +78,7 @@ class InternalStreamConnectionSpecification extends Specification {
     private static final ServerId SERVER_ID = new ServerId(new ClusterId(), new ServerAddress())
 
     def cmdNamespace = new MongoNamespace('admin.$cmd')
-    def fieldNameValidator = new NoOpFieldNameValidator()
+    def fieldNameValidator = NoOpFieldNameValidator.INSTANCE
     def helper = new StreamHelper()
     def serverAddress = new ServerAddress()
     def connectionId = new ConnectionId(SERVER_ID, 1, 1)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
@@ -57,7 +57,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def replyDocument = new BsonDocument('ok', new BsonInt32(1))
         def failureException = new MongoInternalException('failure!')
         def message = new CommandMessage(namespace, commandDocument,
-                new NoOpFieldNameValidator(), ReadPreference.primary(), messageSettings, MULTIPLE, null)
+                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), messageSettings, MULTIPLE, null)
         def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
         message.encode(bsonOutput, new OperationContext(IgnorableRequestContext.INSTANCE, NoOpSessionContext.INSTANCE,
                 Stub(TimeoutContext), null))
@@ -101,7 +101,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def commandDocument = new BsonDocument('ping', new BsonInt32(1))
         def replyDocument = new BsonDocument('ok', new BsonInt32(42))
         def failureException = new MongoInternalException('failure!')
-        def message = new CommandMessage(namespace, commandDocument, new NoOpFieldNameValidator(), ReadPreference.primary(),
+        def message = new CommandMessage(namespace, commandDocument, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 messageSettings, MULTIPLE, null)
         def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
         message.encode(bsonOutput, new OperationContext(IgnorableRequestContext.INSTANCE, NoOpSessionContext.INSTANCE,
@@ -158,7 +158,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def namespace = new MongoNamespace('test.driver')
         def messageSettings = MessageSettings.builder().maxWireVersion(LATEST_WIRE_VERSION).build()
         def commandDocument = new BsonDocument('fake', new BsonBinary(new byte[2048]))
-        def message = new CommandMessage(namespace, commandDocument, new NoOpFieldNameValidator(), ReadPreference.primary(),
+        def message = new CommandMessage(namespace, commandDocument, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 messageSettings, SINGLE, null)
         def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
         message.encode(bsonOutput, new OperationContext(IgnorableRequestContext.INSTANCE, NoOpSessionContext.INSTANCE,
@@ -192,7 +192,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def namespace = new MongoNamespace('test.driver')
         def messageSettings = MessageSettings.builder().maxWireVersion(LATEST_WIRE_VERSION).build()
         def commandDocument = new BsonDocument('createUser', new BsonString('private'))
-        def message = new CommandMessage(namespace, commandDocument, new NoOpFieldNameValidator(), ReadPreference.primary(),
+        def message = new CommandMessage(namespace, commandDocument, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 messageSettings, SINGLE, null)
         def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
         message.encode(bsonOutput, new OperationContext(IgnorableRequestContext.INSTANCE, NoOpSessionContext.INSTANCE,

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/StreamHelper.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/StreamHelper.groovy
@@ -168,7 +168,7 @@ class StreamHelper {
 
     static hello() {
         CommandMessage command = new CommandMessage(new MongoNamespace('admin', COMMAND_COLLECTION_NAME),
-                new BsonDocument(LEGACY_HELLO, new BsonInt32(1)), new NoOpFieldNameValidator(), ReadPreference.primary(),
+                new BsonDocument(LEGACY_HELLO, new BsonInt32(1)), NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 MessageSettings.builder().build(), SINGLE, null)
         OutputBuffer outputBuffer = new BasicOutputBuffer()
         command.encode(outputBuffer, new OperationContext(

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/UsageTrackingConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/UsageTrackingConnectionSpecification.groovy
@@ -172,7 +172,7 @@ class UsageTrackingConnectionSpecification extends Specification {
 
         when:
         connection.sendAndReceive(new CommandMessage(new MongoNamespace('test.coll'),
-                new BsonDocument('ping', new BsonInt32(1)), new NoOpFieldNameValidator(), primary(),
+                new BsonDocument('ping', new BsonInt32(1)), NoOpFieldNameValidator.INSTANCE, primary(),
                 MessageSettings.builder().build(), SINGLE, null), new BsonDocumentCodec(),  OPERATION_CONTEXT)
 
         then:
@@ -189,7 +189,7 @@ class UsageTrackingConnectionSpecification extends Specification {
 
         when:
         connection.sendAndReceiveAsync(new CommandMessage(new MongoNamespace('test.coll'),
-                new BsonDocument('ping', new BsonInt32(1)), new NoOpFieldNameValidator(), primary(),
+                new BsonDocument('ping', new BsonInt32(1)), NoOpFieldNameValidator.INSTANCE, primary(),
                 MessageSettings.builder().build(), SINGLE, null),
                 new BsonDocumentCodec(), OPERATION_CONTEXT, futureResultCallback)
         futureResultCallback.get()

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncOperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncOperationHelperSpecification.groovy
@@ -91,7 +91,7 @@ class AsyncOperationHelperSpecification extends Specification {
 
         when:
         executeRetryableWriteAsync(asyncWriteBinding, dbName, primary(),
-                new NoOpFieldNameValidator(), decoder, commandCreator, FindAndModifyHelper.asyncTransformer(),
+                NoOpFieldNameValidator.INSTANCE, decoder, commandCreator, FindAndModifyHelper.asyncTransformer(),
                 { cmd -> cmd }, callback)
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/SyncOperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/SyncOperationHelperSpecification.groovy
@@ -107,7 +107,7 @@ class SyncOperationHelperSpecification extends Specification {
 
         when:
         executeRetryableWrite(writeBinding, dbName, primary(),
-                new NoOpFieldNameValidator(), decoder, commandCreator, FindAndModifyHelper.transformer())
+                NoOpFieldNameValidator.INSTANCE, decoder, commandCreator, FindAndModifyHelper.transformer())
                 { cmd -> cmd }
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidatorTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/validator/ReplacingDocumentFieldNameValidatorTest.java
@@ -18,28 +18,27 @@ package com.mongodb.internal.validator;
 
 import org.junit.Test;
 
+import static com.mongodb.internal.validator.ReplacingDocumentFieldNameValidator.INSTANCE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ReplacingDocumentFieldNameValidatorTest {
-    private final ReplacingDocumentFieldNameValidator fieldNameValidator = new ReplacingDocumentFieldNameValidator();
-
     @Test
     public void testFieldValidationSuccess() {
-        assertTrue(fieldNameValidator.validate("ok"));
+        assertTrue(INSTANCE.validate("ok"));
     }
 
     @Test
     public void testFieldNameStartsWithDollarValidation() {
-        assertFalse(fieldNameValidator.validate("$1"));
-        assertTrue(fieldNameValidator.validate("$db"));
-        assertTrue(fieldNameValidator.validate("$ref"));
-        assertTrue(fieldNameValidator.validate("$id"));
+        assertFalse(INSTANCE.validate("$1"));
+        assertTrue(INSTANCE.validate("$db"));
+        assertTrue(INSTANCE.validate("$ref"));
+        assertTrue(INSTANCE.validate("$id"));
     }
 
     @Test
     public void testNestedDocumentsAreNotValidated() {
-        assertEquals(NoOpFieldNameValidator.class, fieldNameValidator.getValidatorForField("nested").getClass());
+        assertEquals(NoOpFieldNameValidator.class, INSTANCE.getValidatorForField("nested").getClass());
     }
 }

--- a/driver-legacy/src/main/com/mongodb/MongoClient.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClient.java
@@ -851,7 +851,7 @@ public class MongoClient implements Closeable {
                     try {
                         BsonDocument killCursorsCommand = new BsonDocument("killCursors", new BsonString(cur.namespace.getCollectionName()))
                                 .append("cursors", new BsonArray(singletonList(new BsonInt64(cur.serverCursor.getId()))));
-                        connection.command(cur.namespace.getDatabaseName(), killCursorsCommand, new NoOpFieldNameValidator(),
+                        connection.command(cur.namespace.getDatabaseName(), killCursorsCommand, NoOpFieldNameValidator.INSTANCE,
                                 ReadPreference.primary(), new BsonDocumentCodec(), source.getOperationContext());
                     } finally {
                         connection.release();

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/CryptConnectionSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/CryptConnectionSpecification.groovy
@@ -84,7 +84,7 @@ class CryptConnectionSpecification extends Specification {
         def response = cryptConnection.command('db',
                 new BsonDocumentWrapper(new Document('find', 'test')
                         .append('filter', new Document('ssid', '555-55-5555')), codec),
-                new NoOpFieldNameValidator(), ReadPreference.primary(), codec, operationContext)
+                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), codec, operationContext)
 
         then:
         _ * wrappedConnection.getDescription() >> {
@@ -133,8 +133,8 @@ class CryptConnectionSpecification extends Specification {
         when:
         def response = cryptConnection.command('db',
                 new BsonDocumentWrapper(new Document('insert', 'test'), codec),
-                new NoOpFieldNameValidator(), ReadPreference.primary(), new BsonDocumentCodec(),
-                operationContext, true, payload, new NoOpFieldNameValidator(),)
+                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(),
+                operationContext, true, payload, NoOpFieldNameValidator.INSTANCE,)
 
         then:
         _ * wrappedConnection.getDescription() >> {
@@ -190,8 +190,8 @@ class CryptConnectionSpecification extends Specification {
         when:
         def response = cryptConnection.command('db',
                 new BsonDocumentWrapper(new Document('insert', 'test'), codec),
-                new NoOpFieldNameValidator(), ReadPreference.primary(), new BsonDocumentCodec(), operationContext, true, payload,
-                new NoOpFieldNameValidator())
+                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), operationContext, true, payload,
+                NoOpFieldNameValidator.INSTANCE)
 
         then:
         _ * wrappedConnection.getDescription() >> {


### PR DESCRIPTION
A few improvements I noticed while working on the new `bulkWrite` command support. Doing them separately here to avoid drive-by changes in the implementation of `bulkWrite`.