### PR TITLE
Fix exception propagation in Async API methods

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/AsyncFunction.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncFunction.java
@@ -37,7 +37,7 @@ public interface AsyncFunction<T, R> {
     void unsafeFinish(T value, SingleResultCallback<R> callback);
 
     /**
-     * Must be invoked at end of async chain  or when executing a callback handler supplied by the caller.
+     * Must be invoked at end of async chain or when executing a callback handler supplied by the caller.
      *
      * @param callback the callback provided by the method the chain is used in.
      */

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncFunction.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncFunction.java
@@ -18,6 +18,8 @@ package com.mongodb.internal.async;
 
 import com.mongodb.lang.Nullable;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * See {@link AsyncRunnable}
  * <p>
@@ -33,4 +35,28 @@ public interface AsyncFunction<T, R> {
      * @param callback the callback
      */
     void unsafeFinish(T value, SingleResultCallback<R> callback);
+
+    /**
+     * Must be invoked at end of async chain  or when executing a callback handler supplied by the caller.
+     *
+     * @param callback the callback provided by the method the chain is used in.
+     */
+    default void finish(final T value, final SingleResultCallback<R> callback) {
+        final AtomicBoolean callbackInvoked = new AtomicBoolean(false);
+        try {
+            this.unsafeFinish(value, (v, e) -> {
+                if (!callbackInvoked.compareAndSet(false, true)) {
+                    throw new AssertionError("Callback has been already completed. It could happen "
+                            + "if code throws an exception after invoking an async method.");
+                }
+                callback.onResult(v, e);
+            });
+        } catch (Throwable t) {
+            if (!callbackInvoked.compareAndSet(false, true)) {
+                throw t;
+            } else {
+                callback.completeExceptionally(t);
+            }
+        }
+    }
 }

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncFunction.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncFunction.java
@@ -46,8 +46,8 @@ public interface AsyncFunction<T, R> {
         try {
             this.unsafeFinish(value, (v, e) -> {
                 if (!callbackInvoked.compareAndSet(false, true)) {
-                    throw new AssertionError("Callback has been already completed. It could happen "
-                            + "if code throws an exception after invoking an async method.");
+                    throw new AssertionError(String.format("Callback has been already completed. It could happen "
+                            + "if code throws an exception after invoking an async method. Value: %s", v), e);
                 }
                 callback.onResult(v, e);
             });

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncRunnable.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncRunnable.java
@@ -169,9 +169,6 @@ public interface AsyncRunnable extends AsyncSupplier<Void>, AsyncConsumer<Void> 
      */
     default AsyncRunnable thenRun(final AsyncRunnable runnable) {
         return (c) -> {
-            /* This call of 'unsafeFinish' initiates the async chain and should be triggered from the thread that called 'finish()'.
-               However, the callback provided to 'unsafeFinish' may execute on a different thread, thus 'finish()' instead of 'unsafeFinish()'
-               must be used within callbacks. */
             this.unsafeFinish((r, e) -> {
                 if (e == null) {
                     /* If 'runnable' is executed on a different thread from the one that executed the initial 'finish()',

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncSupplier.java
@@ -55,7 +55,7 @@ public interface AsyncSupplier<T> extends AsyncFunction<Void, T> {
     }
 
     /**
-     * Must be invoked at end of async chain  or when executing a callback handler supplied by the caller.
+     * Must be invoked at end of async chain or when executing a callback handler supplied by the caller.
      *
      * @see #thenApply(AsyncFunction)
      * @see #thenConsume(AsyncConsumer)

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncSupplier.java
@@ -67,8 +67,8 @@ public interface AsyncSupplier<T> extends AsyncFunction<Void, T> {
         try {
             this.unsafeFinish((v, e) -> {
                 if (!callbackInvoked.compareAndSet(false, true)) {
-                    throw new AssertionError("Callback has been already completed. It could happen "
-                            + "if code throws an exception after invoking an async method.");
+                    throw new AssertionError(String.format("Callback has been already completed. It could happen "
+                            + "if code throws an exception after invoking an async method. Value: %s", v), e);
                 }
                 callback.onResult(v, e);
             });

--- a/driver-core/src/main/com/mongodb/internal/async/AsyncSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncSupplier.java
@@ -18,6 +18,7 @@ package com.mongodb.internal.async;
 
 import com.mongodb.lang.Nullable;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
 
@@ -54,18 +55,25 @@ public interface AsyncSupplier<T> extends AsyncFunction<Void, T> {
     }
 
     /**
-     * Must be invoked at end of async chain.
+     * Must be invoked at end of async chain  or when executing a callback handler supplied by the caller.
+     *
+     * @see #thenApply(AsyncFunction)
+     * @see #thenConsume(AsyncConsumer)
+     * @see #onErrorIf(Predicate, AsyncFunction)
      * @param callback the callback provided by the method the chain is used in
      */
     default void finish(final SingleResultCallback<T> callback) {
-        final boolean[] callbackInvoked = {false};
+        final AtomicBoolean callbackInvoked = new AtomicBoolean(false);
         try {
             this.unsafeFinish((v, e) -> {
-                callbackInvoked[0] = true;
+                if (!callbackInvoked.compareAndSet(false, true)) {
+                    throw new AssertionError("Callback has been already completed. It could happen "
+                            + "if code throws an exception after invoking an async method.");
+                }
                 callback.onResult(v, e);
             });
         } catch (Throwable t) {
-            if (callbackInvoked[0]) {
+            if (!callbackInvoked.compareAndSet(false, true)) {
                 throw t;
             } else {
                 callback.completeExceptionally(t);
@@ -80,9 +88,9 @@ public interface AsyncSupplier<T> extends AsyncFunction<Void, T> {
      */
     default <R> AsyncSupplier<R> thenApply(final AsyncFunction<T, R> function) {
         return (c) -> {
-            this.unsafeFinish((v, e) -> {
+            this.finish((v, e) -> {
                 if (e == null) {
-                    function.unsafeFinish(v, c);
+                    function.finish(v, c);
                 } else {
                     c.completeExceptionally(e);
                 }
@@ -99,7 +107,7 @@ public interface AsyncSupplier<T> extends AsyncFunction<Void, T> {
         return (c) -> {
             this.unsafeFinish((v, e) -> {
                 if (e == null) {
-                    consumer.unsafeFinish(v, c);
+                    consumer.finish(v, c);
                 } else {
                     c.completeExceptionally(e);
                 }
@@ -131,7 +139,7 @@ public interface AsyncSupplier<T> extends AsyncFunction<Void, T> {
                 return;
             }
             if (errorMatched) {
-                errorFunction.unsafeFinish(e, callback);
+                errorFunction.finish(e, callback);
             } else {
                 callback.completeExceptionally(e);
             }

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -610,6 +610,7 @@ public class InternalStreamConnection implements InternalConnection {
                         return;
                     }
                     assertNotNull(responseBuffers);
+                    T commandResult;
                     try {
                         updateSessionContext(operationContext.getSessionContext(), responseBuffers);
                         boolean commandOk =
@@ -624,13 +625,14 @@ public class InternalStreamConnection implements InternalConnection {
                         }
                         commandEventSender.sendSucceededEvent(responseBuffers);
 
-                        T result1 = getCommandResult(decoder, responseBuffers, messageId, operationContext.getTimeoutContext());
-                        callback.onResult(result1, null);
+                        commandResult = getCommandResult(decoder, responseBuffers, messageId, operationContext.getTimeoutContext());
                     } catch (Throwable localThrowable) {
                         callback.onResult(null, localThrowable);
+                        return;
                     } finally {
                         responseBuffers.close();
                     }
+                    callback.onResult(commandResult, null);
                 }));
             }
         });

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
@@ -104,8 +104,8 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
                         InternalConnectionInitializationDescription initializationDescription;
                         try {
                             initializationDescription = createInitializationDescription(helloResult, internalConnection, startTime);
-                        } catch (Throwable localException) {
-                            callback.onResult(null, localException);
+                        } catch (Throwable localThrowable) {
+                            callback.onResult(null, localThrowable);
                             return;
                         }
                         callback.onResult(initializationDescription, null);

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
@@ -101,7 +101,13 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
                         callback.onResult(null, t instanceof MongoException ? mapHelloException((MongoException) t) : t);
                     } else {
                         setSpeculativeAuthenticateResponse(helloResult);
-                        callback.onResult(createInitializationDescription(helloResult, internalConnection, startTime), null);
+                        try {
+                            InternalConnectionInitializationDescription initializationDescription =
+                                    createInitializationDescription(helloResult, internalConnection, startTime);
+                            callback.onResult(initializationDescription, null);
+                        } catch (Throwable e) {
+                            callback.onResult(null, e);
+                        }
                     }
                 });
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
@@ -101,13 +101,14 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
                         callback.onResult(null, t instanceof MongoException ? mapHelloException((MongoException) t) : t);
                     } else {
                         setSpeculativeAuthenticateResponse(helloResult);
+                        InternalConnectionInitializationDescription initializationDescription;
                         try {
-                            InternalConnectionInitializationDescription initializationDescription =
-                                    createInitializationDescription(helloResult, internalConnection, startTime);
-                            callback.onResult(initializationDescription, null);
-                        } catch (Throwable e) {
-                            callback.onResult(null, e);
+                            initializationDescription = createInitializationDescription(helloResult, internalConnection, startTime);
+                        } catch (Throwable localException) {
+                            callback.onResult(null, localException);
+                            return;
                         }
+                        callback.onResult(initializationDescription, null);
                     }
                 });
     }

--- a/driver-core/src/test/unit/com/mongodb/internal/async/AsyncFunctionsAbstractTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/AsyncFunctionsAbstractTest.java
@@ -19,6 +19,8 @@ import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.TimeoutSettings;
 import org.junit.jupiter.api.Test;
 
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
@@ -26,29 +28,6 @@ import static com.mongodb.internal.async.AsyncRunnable.beginAsync;
 
 abstract class AsyncFunctionsAbstractTest extends AsyncFunctionsTestBase {
     private static final TimeoutContext TIMEOUT_CONTEXT = new TimeoutContext(new TimeoutSettings(0, 0, 0, 0L, 0));
-
-//   @Test
-//   void test(){
-//
-//         SingleResultCallback<Void> userCallback = (result, t) -> {
-//              if (t != null) {
-//                  System.out.println("Error:" + t.getMessage());
-//              }
-//              System.out.println("Result:"  + result);
-//         };
-//
-//       beginAsync().thenRun(c -> {
-//           // Async imitation
-//           new Thread() {
-//               public void run() {
-//                   c.complete(c);
-//               }
-//           }.start();
-//       }).thenRun(callback -> {
-//           // Assume this is plain code
-//           throw new RuntimeException("Error adada");
-//       }).finish(userCallback);
-//   }
 
     @Test
     void test1Method() {
@@ -783,72 +762,72 @@ abstract class AsyncFunctionsAbstractTest extends AsyncFunctionsTestBase {
 
     @Test
     void testDerivation() {
-//        // Demonstrates the progression from nested async to the API.
-//
-//        // Stand-ins for sync-async methods; these "happily" do not throw
-//        // exceptions, to avoid complicating this demo async code.
-//        Consumer<Integer> happySync = (i) -> {
-//            getNextOption(1);
-//            listenerAdd("affected-success-" + i);
-//        };
-//        BiConsumer<Integer, SingleResultCallback<Void>> happyAsync = (i, c) -> {
-//            happySync.accept(i);
-//            c.complete(c);
-//        };
-//
-//        // Standard nested async, no error handling:
-//        assertBehavesSameVariations(1,
-//                () -> {
-//                    happySync.accept(1);
-//                    happySync.accept(2);
-//                },
-//                (callback) -> {
-//                    happyAsync.accept(1, (v, e) -> {
-//                        happyAsync.accept(2, callback);
-//                    });
-//                });
-//
-//        // When both methods are naively extracted, they are out of order:
-//        assertBehavesSameVariations(1,
-//                () -> {
-//                    happySync.accept(1);
-//                    happySync.accept(2);
-//                },
-//                (callback) -> {
-//                    SingleResultCallback<Void> second = (v, e) -> {
-//                        happyAsync.accept(2, callback);
-//                    };
-//                    SingleResultCallback<Void> first = (v, e) -> {
-//                        happyAsync.accept(1, second);
-//                    };
-//                    first.onResult(null, null);
-//                });
-//
-//        // We create an "AsyncRunnable" that takes a callback, which
-//        // decouples any async methods from each other, allowing them
-//        // to be declared in a sync-like order, and without nesting:
-//        assertBehavesSameVariations(1,
-//                () -> {
-//                    happySync.accept(1);
-//                    happySync.accept(2);
-//                },
-//                (callback) -> {
-//                    AsyncRunnable first = (SingleResultCallback<Void> c) -> {
-//                        happyAsync.accept(1, c);
-//                    };
-//                    AsyncRunnable second = (SingleResultCallback<Void> c) -> {
-//                        happyAsync.accept(2, c);
-//                    };
-//                    // This is a simplified variant of the "then" methods;
-//                    // it has no error handling. It takes methods A and B,
-//                    // and returns C, which is B(A()).
-//                    AsyncRunnable combined = (c) -> {
-//                        first.unsafeFinish((r, e) -> {
-//                            second.unsafeFinish(c);
-//                        });
-//                    };
-//                    combined.unsafeFinish(callback);
-//                });
+        // Demonstrates the progression from nested async to the API.
+
+        // Stand-ins for sync-async methods; these "happily" do not throw
+        // exceptions, to avoid complicating this demo async code.
+        Consumer<Integer> happySync = (i) -> {
+            getNextOption(1);
+            listenerAdd("affected-success-" + i);
+        };
+        BiConsumer<Integer, SingleResultCallback<Void>> happyAsync = (i, c) -> {
+            happySync.accept(i);
+            c.complete(c);
+        };
+
+        // Standard nested async, no error handling:
+        assertBehavesSameVariations(1,
+                () -> {
+                    happySync.accept(1);
+                    happySync.accept(2);
+                },
+                (callback) -> {
+                    happyAsync.accept(1, (v, e) -> {
+                        happyAsync.accept(2, callback);
+                    });
+                });
+
+        // When both methods are naively extracted, they are out of order:
+        assertBehavesSameVariations(1,
+                () -> {
+                    happySync.accept(1);
+                    happySync.accept(2);
+                },
+                (callback) -> {
+                    SingleResultCallback<Void> second = (v, e) -> {
+                        happyAsync.accept(2, callback);
+                    };
+                    SingleResultCallback<Void> first = (v, e) -> {
+                        happyAsync.accept(1, second);
+                    };
+                    first.onResult(null, null);
+                });
+
+        // We create an "AsyncRunnable" that takes a callback, which
+        // decouples any async methods from each other, allowing them
+        // to be declared in a sync-like order, and without nesting:
+        assertBehavesSameVariations(1,
+                () -> {
+                    happySync.accept(1);
+                    happySync.accept(2);
+                },
+                (callback) -> {
+                    AsyncRunnable first = (SingleResultCallback<Void> c) -> {
+                        happyAsync.accept(1, c);
+                    };
+                    AsyncRunnable second = (SingleResultCallback<Void> c) -> {
+                        happyAsync.accept(2, c);
+                    };
+                    // This is a simplified variant of the "then" methods;
+                    // it has no error handling. It takes methods A and B,
+                    // and returns C, which is B(A()).
+                    AsyncRunnable combined = (c) -> {
+                        first.unsafeFinish((r, e) -> {
+                            second.unsafeFinish(c);
+                        });
+                    };
+                    combined.unsafeFinish(callback);
+                });
 
         // This combining method is added as a default method on AsyncRunnable,
         // and a "finish" method wraps the resulting methods. This also adds

--- a/driver-core/src/test/unit/com/mongodb/internal/async/SameThreadAsyncFunctionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/SameThreadAsyncFunctionsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.async;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.internal.async.AsyncRunnable.beginAsync;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("The same thread async functions")
+public class SameThreadAsyncFunctionsTest extends AsyncFunctionsAbstractTest {
+    @Override
+    public ExecutorService createAsyncExecutor() {
+        return new AbstractExecutorService() {
+            @Override
+            public void execute(@NotNull final Runnable command) {
+                command.run();
+            }
+
+            @Override
+            public void shutdown() {
+            }
+
+            @NotNull
+            @Override
+            public List<Runnable> shutdownNow() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public boolean isShutdown() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isTerminated() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean awaitTermination(final long timeout, @NotNull final TimeUnit unit) {
+                return true;
+            }
+        };
+    }
+
+    @Test
+    void testInvalid() {
+        setIsTestingAbruptCompletion(false);
+        setAsyncStep(true);
+        IllegalStateException illegalStateException = new IllegalStateException("must not cause second callback invocation");
+
+        assertThrows(IllegalStateException.class, () -> {
+            beginAsync().thenRun(c -> {
+                async(3, c);
+                throw illegalStateException;
+            }).finish((v, e) -> {
+                assertNotEquals(e, illegalStateException);
+            });
+        });
+        assertThrows(IllegalStateException.class, () -> {
+            beginAsync().thenRun(c -> {
+                async(3, c);
+            }).finish((v, e) -> {
+                throw illegalStateException;
+            });
+        });
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/async/SameThreadAsyncFunctionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/SameThreadAsyncFunctionsTest.java
@@ -34,37 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class SameThreadAsyncFunctionsTest extends AsyncFunctionsAbstractTest {
     @Override
     public ExecutorService createAsyncExecutor() {
-        return new AbstractExecutorService() {
-            @Override
-            public void execute(@NotNull final Runnable command) {
-                command.run();
-            }
-
-            @Override
-            public void shutdown() {
-            }
-
-            @NotNull
-            @Override
-            public List<Runnable> shutdownNow() {
-                return Collections.emptyList();
-            }
-
-            @Override
-            public boolean isShutdown() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean isTerminated() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean awaitTermination(final long timeout, @NotNull final TimeUnit unit) {
-                return true;
-            }
-        };
+        return new SameThreadExecutorService();
     }
 
     @Test
@@ -88,5 +58,37 @@ public class SameThreadAsyncFunctionsTest extends AsyncFunctionsAbstractTest {
                 throw illegalStateException;
             });
         });
+    }
+
+    private static class SameThreadExecutorService extends AbstractExecutorService {
+        @Override
+        public void execute(@NotNull final Runnable command) {
+            command.run();
+        }
+
+        @Override
+        public void shutdown() {
+        }
+
+        @NotNull
+        @Override
+        public List<Runnable> shutdownNow() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isTerminated() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean awaitTermination(final long timeout, @NotNull final TimeUnit unit) {
+            return true;
+        }
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/async/SeparateThreadAsyncFunctionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/SeparateThreadAsyncFunctionsTest.java
@@ -55,9 +55,7 @@ public class SeparateThreadAsyncFunctionsTest extends AsyncFunctionsAbstractTest
         setIsTestingAbruptCompletion(false);
         setAsyncStep(true);
         IllegalStateException illegalStateException = new IllegalStateException("must not cause second callback invocation");
-
         AtomicBoolean callbackInvoked = new AtomicBoolean(false);
-        CompletableFuture<Void> finalCallbackWasInvoked = new CompletableFuture<>();
 
         //when
         beginAsync().thenRun(c -> {
@@ -69,7 +67,6 @@ public class SeparateThreadAsyncFunctionsTest extends AsyncFunctionsAbstractTest
                 })
                 .finish((v, e) -> {
                             assertEquals(illegalStateException, e);
-                            finalCallbackWasInvoked.complete(null);
                         }
                 );
 
@@ -87,13 +84,11 @@ public class SeparateThreadAsyncFunctionsTest extends AsyncFunctionsAbstractTest
         setIsTestingAbruptCompletion(false);
         setAsyncStep(true);
         IllegalStateException illegalStateException = new IllegalStateException("must not cause second callback invocation");
-        CompletableFuture<Void> finalCallbackWasInvoked = new CompletableFuture<>();
 
         //when
         beginAsync().thenRun(c -> {
             async(3, c);
         }).finish((v, e) -> {
-            finalCallbackWasInvoked.complete(null);
             throw illegalStateException;
         });
 

--- a/driver-core/src/test/unit/com/mongodb/internal/async/SeparateThreadAsyncFunctionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/SeparateThreadAsyncFunctionsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.async;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.mongodb.internal.async.AsyncRunnable.beginAsync;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("Separate thread async functions")
+public class SeparateThreadAsyncFunctionsTest extends AsyncFunctionsAbstractTest {
+
+    private UncaughtExceptionHandler uncaughtExceptionHandler;
+
+    @Override
+    public ExecutorService createAsyncExecutor() {
+        uncaughtExceptionHandler = new UncaughtExceptionHandler();
+        return Executors.newFixedThreadPool(1, r -> {
+            Thread thread = new Thread(r);
+            thread.setUncaughtExceptionHandler(uncaughtExceptionHandler);
+            return thread;
+        });
+    }
+
+    /**
+     * This test covers the scenario where a callback is erroneously invoked after a callback had been completed.
+     * Such behavior is considered a bug and is not expected. An AssertionError should be thrown if an asynchronous invocation
+     * attempts to use a callback that has already been marked as completed.
+     */
+    @Test
+    void shouldPropagateAssertionErrorIfCallbackHasBeenCompletedAfterAsyncInvocation() {
+        //given
+        setIsTestingAbruptCompletion(false);
+        setAsyncStep(true);
+        IllegalStateException illegalStateException = new IllegalStateException("must not cause second callback invocation");
+
+        AtomicBoolean callbackInvoked = new AtomicBoolean(false);
+        CompletableFuture<Void> finalCallbackWasInvoked = new CompletableFuture<>();
+
+        //when
+        beginAsync().thenRun(c -> {
+                    async(3, c);
+                    throw illegalStateException;
+                }).thenRun(c -> {
+                    assertInvokedOnce(callbackInvoked);
+                    c.complete(c);
+                })
+                .finish((v, e) -> {
+                            assertEquals(illegalStateException, e);
+                            finalCallbackWasInvoked.complete(null);
+                        }
+                );
+
+        //then
+        Throwable exception = uncaughtExceptionHandler.getException();
+        assertNotNull(exception);
+        assertEquals(AssertionError.class, exception.getClass());
+        assertEquals("Callback has been already completed. It could happen "
+                + "if code throws an exception after invoking an async method.", exception.getMessage());
+    }
+
+    @Test
+    void shouldPropagateUnexpectedExceptionFromFinishCallback() {
+        //given
+        setIsTestingAbruptCompletion(false);
+        setAsyncStep(true);
+        IllegalStateException illegalStateException = new IllegalStateException("must not cause second callback invocation");
+        CompletableFuture<Void> finalCallbackWasInvoked = new CompletableFuture<>();
+
+        //when
+        beginAsync().thenRun(c -> {
+            async(3, c);
+        }).finish((v, e) -> {
+            finalCallbackWasInvoked.complete(null);
+            throw illegalStateException;
+        });
+
+        //then
+        Throwable exception = uncaughtExceptionHandler.getException();
+        assertNotNull(exception);
+        assertEquals(illegalStateException, exception);
+    }
+
+    private static void assertInvokedOnce(final AtomicBoolean callbackInvoked1) {
+        assertTrue(callbackInvoked1.compareAndSet(false, true));
+    }
+
+    private final class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+
+        private final CompletableFuture<Throwable> completable = new CompletableFuture<>();
+
+        @Override
+        public void uncaughtException(final Thread t, final Throwable e) {
+            completable.complete(e);
+        }
+
+        public Throwable getException() {
+           return await(completable, "No exception was thrown");
+        }
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/async/SeparateThreadAsyncFunctionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/SeparateThreadAsyncFunctionsTest.java
@@ -75,7 +75,7 @@ public class SeparateThreadAsyncFunctionsTest extends AsyncFunctionsAbstractTest
         assertNotNull(exception);
         assertEquals(AssertionError.class, exception.getClass());
         assertEquals("Callback has been already completed. It could happen "
-                + "if code throws an exception after invoking an async method.", exception.getMessage());
+                + "if code throws an exception after invoking an async method. Value: null", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
- Resolve an issue where exceptions thrown during thenRun, thenSupply, and related operations in the asynchronous API were not properly propagated to the completion callback. This issue was addressed by replacing `unsafeFinish` with `finish`, ensuring that exceptions are caught and correctly passed to the completion callback when executed on different threads.

- Update existing Async API tests to ensure they simulate separate async thread execution.

JAVA-5562