### PR TITLE
change modifiedCount to type long

### DIFF
--- a/driver-core/src/main/com/mongodb/client/result/UpdateResult.java
+++ b/driver-core/src/main/com/mongodb/client/result/UpdateResult.java
@@ -83,10 +83,10 @@ public abstract class UpdateResult {
 
     private static class AcknowledgedUpdateResult extends UpdateResult {
         private final long matchedCount;
-        private final Long modifiedCount;
+        private final long modifiedCount;
         private final BsonValue upsertedId;
 
-        AcknowledgedUpdateResult(final long matchedCount, final Long modifiedCount, @Nullable final BsonValue upsertedId) {
+        AcknowledgedUpdateResult(final long matchedCount, final long modifiedCount, @Nullable final BsonValue upsertedId) {
             this.matchedCount = matchedCount;
             this.modifiedCount = modifiedCount;
             this.upsertedId = upsertedId;


### PR DESCRIPTION
`modifiedCount` should be `long` instead of `Long`. If not:

```java
public long getModifiedCount() {
    return modifiedCount;
}
```

could throws exception.

**NOTE: The `public int hashCode()` method must to be updated accordingly**