### PR TITLE
Fix `QueryBatchCursor.ResourceManager.close` (#1440)

### DIFF
--- a/driver-core/src/test/unit/com/mongodb/internal/operation/QueryBatchCursorResourceManagerTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/QueryBatchCursorResourceManagerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.operation;
+
+import com.mongodb.ServerAddress;
+import com.mongodb.ServerCursor;
+import com.mongodb.internal.binding.ConnectionSource;
+import com.mongodb.internal.connection.QueryResult;
+import org.bson.BsonDocument;
+import org.bson.codecs.BsonDocumentCodec;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+final class QueryBatchCursorResourceManagerTest {
+    @Test
+    void doubleCloseExecutedConcurrentlyWithOperationBeingInProgressShouldNotFail() {
+        ConnectionSource connectionSourceMock = mock(ConnectionSource.class);
+        when(connectionSourceMock.retain()).thenReturn(connectionSourceMock);
+        when(connectionSourceMock.release()).thenReturn(1);
+        ServerAddress serverAddress = new ServerAddress();
+        try (QueryBatchCursor<BsonDocument> cursor = new QueryBatchCursor<>(
+                new QueryResult<>(null, emptyList(), 0, serverAddress),
+                1, 1, new BsonDocumentCodec())) {
+            QueryBatchCursor<?>.ResourceManager cursorResourceManager = cursor.new ResourceManager(
+                    connectionSourceMock, null, new ServerCursor(1, serverAddress));
+            cursorResourceManager.tryStartOperation();
+            try {
+                assertDoesNotThrow(() -> {
+                    cursorResourceManager.close();
+                    cursorResourceManager.close();
+                    cursorResourceManager.setServerCursor(null);
+                });
+            } finally {
+                cursorResourceManager.endOperation();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a backport of https://github.com/mongodb/mongo-java-driver/pull/1440 to `4.11.x`.
    
JAVA-5516