### PR TITLE
Remove remaining beta annotations for encrypted fields.

### DIFF
--- a/driver-core/src/main/com/mongodb/MongoUpdatedEncryptedFieldsException.java
+++ b/driver-core/src/main/com/mongodb/MongoUpdatedEncryptedFieldsException.java
@@ -15,8 +15,6 @@
  */
 package com.mongodb;
 
-import com.mongodb.annotations.Beta;
-import com.mongodb.annotations.Reason;
 import org.bson.BsonDocument;
 
 import static com.mongodb.assertions.Assertions.assertNotNull;
@@ -27,7 +25,6 @@ import static com.mongodb.assertions.Assertions.assertNotNull;
  *
  * @since 4.9
  */
-@Beta(Reason.SERVER)
 public final class MongoUpdatedEncryptedFieldsException extends MongoClientException {
     private static final long serialVersionUID = 1;
 

--- a/driver-core/src/main/com/mongodb/client/model/CreateCollectionOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/CreateCollectionOptions.java
@@ -17,8 +17,6 @@
 package com.mongodb.client.model;
 
 import com.mongodb.AutoEncryptionSettings;
-import com.mongodb.annotations.Beta;
-import com.mongodb.annotations.Reason;
 import com.mongodb.lang.Nullable;
 import org.bson.conversions.Bson;
 
@@ -354,7 +352,6 @@ public class CreateCollectionOptions {
      * @since 4.7
      * @mongodb.server.release 7.0
      */
-    @Beta(Reason.SERVER)
     @Nullable
     public Bson getEncryptedFields() {
         return encryptedFields;
@@ -371,7 +368,6 @@ public class CreateCollectionOptions {
      * @mongodb.driver.manual core/security-client-side-encryption/ In-use encryption
      * @mongodb.server.release 7.0
      */
-    @Beta(Reason.SERVER)
     public CreateCollectionOptions encryptedFields(@Nullable final Bson encryptedFields) {
         this.encryptedFields = encryptedFields;
         return this;

--- a/driver-core/src/main/com/mongodb/client/model/CreateEncryptedCollectionParams.java
+++ b/driver-core/src/main/com/mongodb/client/model/CreateEncryptedCollectionParams.java
@@ -16,8 +16,6 @@
 
 package com.mongodb.client.model;
 
-import com.mongodb.annotations.Beta;
-import com.mongodb.annotations.Reason;
 import com.mongodb.client.model.vault.DataKeyOptions;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
@@ -29,7 +27,6 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 4.9
  */
-@Beta(Reason.SERVER)
 public final class CreateEncryptedCollectionParams {
     private final String kmsProvider;
     @Nullable

--- a/driver-core/src/main/com/mongodb/client/model/DropCollectionOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/DropCollectionOptions.java
@@ -17,8 +17,6 @@
 package com.mongodb.client.model;
 
 import com.mongodb.AutoEncryptionSettings;
-import com.mongodb.annotations.Beta;
-import com.mongodb.annotations.Reason;
 import com.mongodb.lang.Nullable;
 import org.bson.conversions.Bson;
 
@@ -40,7 +38,6 @@ public class DropCollectionOptions {
      * @since 4.7
      * @mongodb.server.release 7.0
      */
-    @Beta(Reason.SERVER)
     @Nullable
     public Bson getEncryptedFields() {
         return encryptedFields;
@@ -57,7 +54,6 @@ public class DropCollectionOptions {
      * @mongodb.server.release 7.0
      * @mongodb.driver.manual core/security-client-side-encryption/ In-use encryption
      */
-    @Beta(Reason.SERVER)
     public DropCollectionOptions encryptedFields(@Nullable final Bson encryptedFields) {
         this.encryptedFields = encryptedFields;
         return this;

--- a/driver-core/src/main/com/mongodb/client/model/vault/EncryptOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/vault/EncryptOptions.java
@@ -16,8 +16,6 @@
 
 package com.mongodb.client.model.vault;
 
-import com.mongodb.annotations.Beta;
-import com.mongodb.annotations.Reason;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonBinary;
 
@@ -192,7 +190,6 @@ public class EncryptOptions {
      * @mongodb.driver.manual /core/queryable-encryption/ queryable encryption
      */
     @Nullable
-    @Beta(Reason.SERVER)
     public RangeOptions getRangeOptions() {
         return rangeOptions;
     }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypt.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/crypt/Crypt.java
@@ -19,8 +19,6 @@ package com.mongodb.reactivestreams.client.internal.crypt;
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoInternalException;
-import com.mongodb.annotations.Beta;
-import com.mongodb.annotations.Reason;
 import com.mongodb.client.model.vault.DataKeyOptions;
 import com.mongodb.client.model.vault.EncryptOptions;
 import com.mongodb.client.model.vault.RewrapManyDataKeyOptions;
@@ -191,7 +189,6 @@ public class Crypt implements Closeable {
      * @since 4.9
      * @mongodb.server.release 6.2
      */
-    @Beta(Reason.SERVER)
     public Mono<BsonDocument> encryptExpression(final BsonDocument expression, final EncryptOptions options, @Nullable final Timeout operationTimeout) {
         return executeStateMachine(() ->
                 mongoCrypt.createEncryptExpressionContext(new BsonDocument("v", expression), asMongoExplicitEncryptOptions(options)), operationTimeout


### PR DESCRIPTION
Encrypted fields are used as part of Range encryption which is no longer in server preview.

JAVA-5441