### PR TITLE
Revert making BsonEncoder / BsonDecoder internal

### DIFF
--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonDecoder.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonDecoder.kt
@@ -51,10 +51,10 @@ import org.bson.types.ObjectId
  * For custom serialization handlers
  */
 @ExperimentalSerializationApi
-internal sealed interface BsonDecoder : Decoder, CompositeDecoder {
+public sealed interface BsonDecoder : Decoder, CompositeDecoder {
 
     /** Factory helper for creating concrete BsonDecoder implementations */
-    companion object {
+    public companion object {
 
         @Suppress("SwallowedException")
         private val hasJsonDecoder: Boolean by lazy {
@@ -66,7 +66,7 @@ internal sealed interface BsonDecoder : Decoder, CompositeDecoder {
             }
         }
 
-        fun createBsonDecoder(
+        internal fun createBsonDecoder(
             reader: AbstractBsonReader,
             serializersModule: SerializersModule,
             configuration: BsonConfiguration
@@ -75,7 +75,7 @@ internal sealed interface BsonDecoder : Decoder, CompositeDecoder {
             else BsonDecoderImpl(reader, serializersModule, configuration)
         }
 
-        fun createBsonArrayDecoder(
+        internal fun createBsonArrayDecoder(
             descriptor: SerialDescriptor,
             reader: AbstractBsonReader,
             serializersModule: SerializersModule,
@@ -85,7 +85,7 @@ internal sealed interface BsonDecoder : Decoder, CompositeDecoder {
             else BsonArrayDecoder(descriptor, reader, serializersModule, configuration)
         }
 
-        fun createBsonDocumentDecoder(
+        internal fun createBsonDocumentDecoder(
             descriptor: SerialDescriptor,
             reader: AbstractBsonReader,
             serializersModule: SerializersModule,
@@ -95,7 +95,7 @@ internal sealed interface BsonDecoder : Decoder, CompositeDecoder {
             else BsonDocumentDecoder(descriptor, reader, serializersModule, configuration)
         }
 
-        fun createBsonPolymorphicDecoder(
+        internal fun createBsonPolymorphicDecoder(
             descriptor: SerialDescriptor,
             reader: AbstractBsonReader,
             serializersModule: SerializersModule,
@@ -105,7 +105,7 @@ internal sealed interface BsonDecoder : Decoder, CompositeDecoder {
             else BsonPolymorphicDecoder(descriptor, reader, serializersModule, configuration)
         }
 
-        fun createBsonMapDecoder(
+        internal fun createBsonMapDecoder(
             descriptor: SerialDescriptor,
             reader: AbstractBsonReader,
             serializersModule: SerializersModule,
@@ -117,9 +117,9 @@ internal sealed interface BsonDecoder : Decoder, CompositeDecoder {
     }
 
     /** @return the decoded ObjectId */
-    fun decodeObjectId(): ObjectId
+    public fun decodeObjectId(): ObjectId
     /** @return the decoded BsonValue */
-    fun decodeBsonValue(): BsonValue
+    public fun decodeBsonValue(): BsonValue
 }
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonDecoder.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonDecoder.kt
@@ -37,10 +37,11 @@ import org.bson.BsonType
 import org.bson.BsonValue
 import org.bson.codecs.BsonValueCodec
 import org.bson.codecs.DecoderContext
-import org.bson.codecs.kotlinx.BsonDecoder.Companion.createBsonArrayDecoder
-import org.bson.codecs.kotlinx.BsonDecoder.Companion.createBsonDocumentDecoder
-import org.bson.codecs.kotlinx.BsonDecoder.Companion.createBsonMapDecoder
-import org.bson.codecs.kotlinx.BsonDecoder.Companion.createBsonPolymorphicDecoder
+import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonArrayDecoder
+import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonDecoder
+import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonDocumentDecoder
+import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonMapDecoder
+import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonPolymorphicDecoder
 import org.bson.internal.NumberCodecHelper
 import org.bson.internal.StringCodecHelper
 import org.bson.types.ObjectId
@@ -52,69 +53,6 @@ import org.bson.types.ObjectId
  */
 @ExperimentalSerializationApi
 public sealed interface BsonDecoder : Decoder, CompositeDecoder {
-
-    /** Factory helper for creating concrete BsonDecoder implementations */
-    public companion object {
-
-        @Suppress("SwallowedException")
-        private val hasJsonDecoder: Boolean by lazy {
-            try {
-                Class.forName("kotlinx.serialization.json.JsonDecoder")
-                true
-            } catch (e: ClassNotFoundException) {
-                false
-            }
-        }
-
-        internal fun createBsonDecoder(
-            reader: AbstractBsonReader,
-            serializersModule: SerializersModule,
-            configuration: BsonConfiguration
-        ): BsonDecoder {
-            return if (hasJsonDecoder) JsonBsonDecoderImpl(reader, serializersModule, configuration)
-            else BsonDecoderImpl(reader, serializersModule, configuration)
-        }
-
-        internal fun createBsonArrayDecoder(
-            descriptor: SerialDescriptor,
-            reader: AbstractBsonReader,
-            serializersModule: SerializersModule,
-            configuration: BsonConfiguration
-        ): BsonArrayDecoder {
-            return if (hasJsonDecoder) JsonBsonArrayDecoder(descriptor, reader, serializersModule, configuration)
-            else BsonArrayDecoder(descriptor, reader, serializersModule, configuration)
-        }
-
-        internal fun createBsonDocumentDecoder(
-            descriptor: SerialDescriptor,
-            reader: AbstractBsonReader,
-            serializersModule: SerializersModule,
-            configuration: BsonConfiguration
-        ): BsonDocumentDecoder {
-            return if (hasJsonDecoder) JsonBsonDocumentDecoder(descriptor, reader, serializersModule, configuration)
-            else BsonDocumentDecoder(descriptor, reader, serializersModule, configuration)
-        }
-
-        internal fun createBsonPolymorphicDecoder(
-            descriptor: SerialDescriptor,
-            reader: AbstractBsonReader,
-            serializersModule: SerializersModule,
-            configuration: BsonConfiguration
-        ): BsonPolymorphicDecoder {
-            return if (hasJsonDecoder) JsonBsonPolymorphicDecoder(descriptor, reader, serializersModule, configuration)
-            else BsonPolymorphicDecoder(descriptor, reader, serializersModule, configuration)
-        }
-
-        internal fun createBsonMapDecoder(
-            descriptor: SerialDescriptor,
-            reader: AbstractBsonReader,
-            serializersModule: SerializersModule,
-            configuration: BsonConfiguration
-        ): BsonMapDecoder {
-            return if (hasJsonDecoder) JsonBsonMapDecoder(descriptor, reader, serializersModule, configuration)
-            else BsonMapDecoder(descriptor, reader, serializersModule, configuration)
-        }
-    }
 
     /** @return the decoded ObjectId */
     public fun decodeObjectId(): ObjectId
@@ -325,7 +263,7 @@ internal open class BsonPolymorphicDecoder(
             it.reset()
             mark = null
         }
-        return deserializer.deserialize(BsonDecoder.createBsonDecoder(reader, serializersModule, configuration))
+        return deserializer.deserialize(createBsonDecoder(reader, serializersModule, configuration))
     }
 
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonDecoder.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonDecoder.kt
@@ -37,11 +37,11 @@ import org.bson.BsonType
 import org.bson.BsonValue
 import org.bson.codecs.BsonValueCodec
 import org.bson.codecs.DecoderContext
-import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonArrayDecoder
-import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonDecoder
-import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonDocumentDecoder
-import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonMapDecoder
-import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonPolymorphicDecoder
+import org.bson.codecs.kotlinx.utils.BsonCodecUtils.createBsonArrayDecoder
+import org.bson.codecs.kotlinx.utils.BsonCodecUtils.createBsonDecoder
+import org.bson.codecs.kotlinx.utils.BsonCodecUtils.createBsonDocumentDecoder
+import org.bson.codecs.kotlinx.utils.BsonCodecUtils.createBsonMapDecoder
+import org.bson.codecs.kotlinx.utils.BsonCodecUtils.createBsonPolymorphicDecoder
 import org.bson.internal.NumberCodecHelper
 import org.bson.internal.StringCodecHelper
 import org.bson.types.ObjectId

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
@@ -39,10 +39,10 @@ import org.bson.types.ObjectId
  * For custom serialization handlers
  */
 @ExperimentalSerializationApi
-internal sealed interface BsonEncoder : Encoder, CompositeEncoder {
+public sealed interface BsonEncoder : Encoder, CompositeEncoder {
 
     /** Factory helper for creating concrete BsonEncoder implementations */
-    companion object {
+    public companion object {
         @Suppress("SwallowedException")
         private val hasJsonEncoder: Boolean by lazy {
             try {
@@ -53,7 +53,7 @@ internal sealed interface BsonEncoder : Encoder, CompositeEncoder {
             }
         }
 
-        fun createBsonEncoder(
+        public fun createBsonEncoder(
             writer: BsonWriter,
             serializersModule: SerializersModule,
             configuration: BsonConfiguration
@@ -68,14 +68,14 @@ internal sealed interface BsonEncoder : Encoder, CompositeEncoder {
      *
      * @param value the ObjectId
      */
-    fun encodeObjectId(value: ObjectId)
+    public fun encodeObjectId(value: ObjectId)
 
     /**
      * Encodes a BsonValue
      *
      * @param value the BsonValue
      */
-    fun encodeBsonValue(value: BsonValue)
+    public fun encodeBsonValue(value: BsonValue)
 }
 
 /**

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/BsonEncoder.kt
@@ -41,28 +41,6 @@ import org.bson.types.ObjectId
 @ExperimentalSerializationApi
 public sealed interface BsonEncoder : Encoder, CompositeEncoder {
 
-    /** Factory helper for creating concrete BsonEncoder implementations */
-    public companion object {
-        @Suppress("SwallowedException")
-        private val hasJsonEncoder: Boolean by lazy {
-            try {
-                Class.forName("kotlinx.serialization.json.JsonEncoder")
-                true
-            } catch (e: ClassNotFoundException) {
-                false
-            }
-        }
-
-        public fun createBsonEncoder(
-            writer: BsonWriter,
-            serializersModule: SerializersModule,
-            configuration: BsonConfiguration
-        ): BsonEncoder {
-            return if (hasJsonEncoder) JsonBsonEncoder(writer, serializersModule, configuration)
-            else BsonEncoderImpl(writer, serializersModule, configuration)
-        }
-    }
-
     /**
      * Encodes an ObjectId
      *

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodec.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodec.kt
@@ -34,8 +34,8 @@ import org.bson.codecs.Codec
 import org.bson.codecs.DecoderContext
 import org.bson.codecs.EncoderContext
 import org.bson.codecs.configuration.CodecConfigurationException
-import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonDecoder
-import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonEncoder
+import org.bson.codecs.kotlinx.utils.BsonCodecUtils.createBsonDecoder
+import org.bson.codecs.kotlinx.utils.BsonCodecUtils.createBsonEncoder
 import org.bson.codecs.pojo.annotations.BsonCreator
 import org.bson.codecs.pojo.annotations.BsonDiscriminator
 import org.bson.codecs.pojo.annotations.BsonExtraElements

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodec.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodec.kt
@@ -34,6 +34,8 @@ import org.bson.codecs.Codec
 import org.bson.codecs.DecoderContext
 import org.bson.codecs.EncoderContext
 import org.bson.codecs.configuration.CodecConfigurationException
+import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonDecoder
+import org.bson.codecs.kotlinx.utils.BsonEncoderDecoderUtils.createBsonEncoder
 import org.bson.codecs.pojo.annotations.BsonCreator
 import org.bson.codecs.pojo.annotations.BsonDiscriminator
 import org.bson.codecs.pojo.annotations.BsonExtraElements
@@ -172,13 +174,13 @@ private constructor(
     }
 
     override fun encode(writer: BsonWriter, value: T, encoderContext: EncoderContext) {
-        serializer.serialize(BsonEncoder.createBsonEncoder(writer, serializersModule, bsonConfiguration), value)
+        serializer.serialize(createBsonEncoder(writer, serializersModule, bsonConfiguration), value)
     }
 
     override fun getEncoderClass(): Class<T> = kClass.java
 
     override fun decode(reader: BsonReader, decoderContext: DecoderContext): T {
         require(reader is AbstractBsonReader)
-        return serializer.deserialize(BsonDecoder.createBsonDecoder(reader, serializersModule, bsonConfiguration))
+        return serializer.deserialize(createBsonDecoder(reader, serializersModule, bsonConfiguration))
     }
 }

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/utils/BsonCodecUtils.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/utils/BsonCodecUtils.kt
@@ -37,7 +37,7 @@ import org.bson.codecs.kotlinx.JsonBsonMapDecoder
 import org.bson.codecs.kotlinx.JsonBsonPolymorphicDecoder
 
 @ExperimentalSerializationApi
-internal object BsonEncoderDecoderUtils {
+internal object BsonCodecUtils {
 
     @Suppress("SwallowedException")
     private val hasJsonEncoder: Boolean by lazy {

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/utils/BsonEncoderDecoderUtils.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/utils/BsonEncoderDecoderUtils.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.kotlinx.utils
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.modules.SerializersModule
+import org.bson.AbstractBsonReader
+import org.bson.BsonWriter
+import org.bson.codecs.kotlinx.BsonArrayDecoder
+import org.bson.codecs.kotlinx.BsonConfiguration
+import org.bson.codecs.kotlinx.BsonDecoder
+import org.bson.codecs.kotlinx.BsonDecoderImpl
+import org.bson.codecs.kotlinx.BsonDocumentDecoder
+import org.bson.codecs.kotlinx.BsonEncoder
+import org.bson.codecs.kotlinx.BsonEncoderImpl
+import org.bson.codecs.kotlinx.BsonMapDecoder
+import org.bson.codecs.kotlinx.BsonPolymorphicDecoder
+import org.bson.codecs.kotlinx.JsonBsonArrayDecoder
+import org.bson.codecs.kotlinx.JsonBsonDecoderImpl
+import org.bson.codecs.kotlinx.JsonBsonDocumentDecoder
+import org.bson.codecs.kotlinx.JsonBsonEncoder
+import org.bson.codecs.kotlinx.JsonBsonMapDecoder
+import org.bson.codecs.kotlinx.JsonBsonPolymorphicDecoder
+
+@ExperimentalSerializationApi
+internal object BsonEncoderDecoderUtils {
+
+    @Suppress("SwallowedException")
+    private val hasJsonEncoder: Boolean by lazy {
+        try {
+            Class.forName("kotlinx.serialization.json.JsonEncoder")
+            true
+        } catch (e: ClassNotFoundException) {
+            false
+        }
+    }
+
+    @Suppress("SwallowedException")
+    private val hasJsonDecoder: Boolean by lazy {
+        try {
+            Class.forName("kotlinx.serialization.json.JsonDecoder")
+            true
+        } catch (e: ClassNotFoundException) {
+            false
+        }
+    }
+
+    internal fun createBsonEncoder(
+        writer: BsonWriter,
+        serializersModule: SerializersModule,
+        configuration: BsonConfiguration
+    ): BsonEncoder {
+        return if (hasJsonEncoder) JsonBsonEncoder(writer, serializersModule, configuration)
+        else BsonEncoderImpl(writer, serializersModule, configuration)
+    }
+
+    internal fun createBsonDecoder(
+        reader: AbstractBsonReader,
+        serializersModule: SerializersModule,
+        configuration: BsonConfiguration
+    ): BsonDecoder {
+        return if (hasJsonDecoder) JsonBsonDecoderImpl(reader, serializersModule, configuration)
+        else BsonDecoderImpl(reader, serializersModule, configuration)
+    }
+
+    internal fun createBsonArrayDecoder(
+        descriptor: SerialDescriptor,
+        reader: AbstractBsonReader,
+        serializersModule: SerializersModule,
+        configuration: BsonConfiguration
+    ): BsonArrayDecoder {
+        return if (hasJsonDecoder) JsonBsonArrayDecoder(descriptor, reader, serializersModule, configuration)
+        else BsonArrayDecoder(descriptor, reader, serializersModule, configuration)
+    }
+
+    internal fun createBsonDocumentDecoder(
+        descriptor: SerialDescriptor,
+        reader: AbstractBsonReader,
+        serializersModule: SerializersModule,
+        configuration: BsonConfiguration
+    ): BsonDocumentDecoder {
+        return if (hasJsonDecoder) JsonBsonDocumentDecoder(descriptor, reader, serializersModule, configuration)
+        else BsonDocumentDecoder(descriptor, reader, serializersModule, configuration)
+    }
+
+    internal fun createBsonPolymorphicDecoder(
+        descriptor: SerialDescriptor,
+        reader: AbstractBsonReader,
+        serializersModule: SerializersModule,
+        configuration: BsonConfiguration
+    ): BsonPolymorphicDecoder {
+        return if (hasJsonDecoder) JsonBsonPolymorphicDecoder(descriptor, reader, serializersModule, configuration)
+        else BsonPolymorphicDecoder(descriptor, reader, serializersModule, configuration)
+    }
+
+    internal fun createBsonMapDecoder(
+        descriptor: SerialDescriptor,
+        reader: AbstractBsonReader,
+        serializersModule: SerializersModule,
+        configuration: BsonConfiguration
+    ): BsonMapDecoder {
+        return if (hasJsonDecoder) JsonBsonMapDecoder(descriptor, reader, serializersModule, configuration)
+        else BsonMapDecoder(descriptor, reader, serializersModule, configuration)
+    }
+}


### PR DESCRIPTION
Made BsonEncoder / Decoder internal as part of the JsonElement support, however, this reduces the flexibility of the API and that change should be reverted

JAVA-5623