### PR TITLE
Exclude `com.oracle.svm.core.annotate` from `Import-Package` for OSGi

### DIFF
--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -82,6 +82,7 @@ afterEvaluate {
             '!sun.misc.*',  // Used by DirectBufferDeallocator only for java 8
             '!sun.nio.ch.*',  // Used by DirectBufferDeallocator only for java 8
             '!javax.annotation.*', // Brought in by com.google.code.findbugs:annotations
+            '!com.oracle.svm.core.annotate.*', // this dependency is provided by the GraalVM runtime
             'io.netty.*;resolution:=optional',
             'com.amazonaws.*;resolution:=optional',
             'software.amazon.awssdk.*;resolution:=optional',


### PR DESCRIPTION
`com.oracle.svm.core.annotate` comes from the `compileOnly "org.graalvm.sdk:graal-sdk:$graalSdkVersion"` dependency. This dependency is provided by the GraalVM runtime, and [Gradle instructs us to use the {{compileOnly}} configuration for provided dependencies](https://docs.gradle.org/current/userguide/migrating_from_maven.html#migmvn:migrating_deps).

JAVA-5632