### PR TITLE
Enable tests that require failCommand with appName on initial handshake before 4.9

### DIFF
--- a/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/command-execution.json
+++ b/driver-core/src/test/resources/unified-test-format/client-side-operation-timeout/command-execution.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.9",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.9",
+      "minServerVersion": "4.4.7",
       "topologies": [
         "single",
         "replicaset",

--- a/driver-core/src/test/resources/unified-test-format/load-balancers/sdam-error-handling.json
+++ b/driver-core/src/test/resources/unified-test-format/load-balancers/sdam-error-handling.json
@@ -263,7 +263,7 @@
       "description": "errors during the initial connection hello are ignored",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.9"
+          "minServerVersion": "4.4.7"
         }
       ],
       "operations": [

--- a/driver-core/src/test/resources/unified-test-format/server-discovery-and-monitoring/hello-command-error.json
+++ b/driver-core/src/test/resources/unified-test-format/server-discovery-and-monitoring/hello-command-error.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.10",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.9",
+      "minServerVersion": "4.4.7",
       "serverless": "forbid",
       "topologies": [
         "single",

--- a/driver-core/src/test/resources/unified-test-format/server-discovery-and-monitoring/hello-network-error.json
+++ b/driver-core/src/test/resources/unified-test-format/server-discovery-and-monitoring/hello-network-error.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.10",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.9",
+      "minServerVersion": "4.4.7",
       "serverless": "forbid",
       "topologies": [
         "single",

--- a/driver-core/src/test/resources/unified-test-format/server-discovery-and-monitoring/minPoolSize-error.json
+++ b/driver-core/src/test/resources/unified-test-format/server-discovery-and-monitoring/minPoolSize-error.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.10",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.9",
+      "minServerVersion": "4.4.7",
       "serverless": "forbid",
       "topologies": [
         "single"


### PR DESCRIPTION
https://jira.mongodb.org/browse/JAVA-5445

I tested it locally with evergreen patch. The previously "skipped" tests are enabled and passed (for 4.4 build variants)

e.g. https://spruce.mongodb.com/task/mongo_java_driver_tests_jdk_secure__version~4.4_os~linux_topology~standalone_auth~auth_ssl~ssl_jdk~jdk17_test_patch_5ebeec89c47f747524554e7a64f58918ac559c16_66f9750c8ea18700077234d0_24_09_29_15_41_01?execution=0&page=0&sortBy=STATUS&sortDir=ASC&testname=hello-command-error