### PR TITLE
Exclude `com.oracle.svm.core.annotate` from `Import-Package` for OSGi

### DIFF
--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -82,6 +82,7 @@ afterEvaluate {
             '!sun.misc.*',  // Used by DirectBufferDeallocator only for java 8
             '!sun.nio.ch.*',  // Used by DirectBufferDeallocator only for java 8
             '!javax.annotation.*', // Brought in by com.google.code.findbugs:annotations
+            '!com.oracle.svm.core.annotate.*', // this dependency is provided by the GraalVM runtime
             'io.netty.*;resolution:=optional',
             'com.amazonaws.*;resolution:=optional',
             'software.amazon.awssdk.*;resolution:=optional',


### PR DESCRIPTION
This is a backport of https://github.com/mongodb/mongo-java-driver/pull/1518 to 5.2.x.

JAVA-5632