### PR TITLE
Fix Evergreen config file error

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -144,8 +144,8 @@ functions:
 
   "create and upload SSDLC release assets":
     - command: shell.exec
-      shell: "bash"
       params:
+        shell: "bash"
         working_dir: "src"
         env:
           PRODUCT_NAME: ${product_name}


### PR DESCRIPTION
Noticed this due to warning when validating the config file:

```
~/git/mongo-java-driver (main)$ evergreen validate .evergreen/.evg.yml
WARNING: strict unmarshalling YAML: load project error(s): error unmarshalling yaml strict: input fields may not match the command fields: yaml: unmarshal errors:
  line 146: cannot unmarshal !!seq into struct { Function string "yaml:\"func,omitempty\" bson:\"func,omitempty\""; Type string "yaml:\"type,omitempty\" bson:\"type,omitempty\""; DisplayName string "yaml:\"display_name,omitempty\" bson:\"display_name,omitempty\""; Command string "yaml:\"command,omitempty\" bson:\"command,omitempty\""; Variants []string "yaml:\"variants,omitempty\" bson:\"variants,omitempty\""; TimeoutSecs int "yaml:\"timeout_secs,omitempty\" bson:\"timeout_secs,omitempty\""; Params map[string]interface {} "yaml:\"params,omitempty\" bson:\"params,omitempty\""; ParamsYAML string "yaml:\"params_yaml,omitempty\" bson:\"params_yaml,omitempty\""; Vars map[string]string "yaml:\"vars,omitempty\" bson:\"vars,omitempty\""; RetryOnFailure bool "yaml:\"retry_on_failure,omitempty\" bson:\"retry_on_failure,omitempty\""; FailureMetadataTags []string "yaml:\"failure_metadata_tags,omitempty\" bson:\"failure_metadata_tags,omitempty\"" }
NOTICE: task 'aws-ECS-auth-test' defined but not used by any variants; consider using or disabling
```