### PR TITLE
Ensure kotlinx.datetime.LocalTime exists before adding the serializer

### DIFF
--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/DateTimeSerializers.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/DateTimeSerializers.kt
@@ -54,11 +54,16 @@ import org.bson.codecs.kotlinx.utils.SerializationModuleUtils.isClassAvailable
 public val dateTimeSerializersModule: SerializersModule by lazy {
     var module = SerializersModule {}
     if (isClassAvailable("kotlinx.datetime.Instant")) {
-        module +=
-            InstantAsBsonDateTime.serializersModule +
-                LocalDateAsBsonDateTime.serializersModule +
-                LocalDateTimeAsBsonDateTime.serializersModule +
-                LocalTimeAsBsonDateTime.serializersModule
+        module += InstantAsBsonDateTime.serializersModule
+    }
+    if (isClassAvailable("kotlinx.datetime.LocalDate")) {
+        module += LocalDateAsBsonDateTime.serializersModule
+    }
+    if (isClassAvailable("kotlinx.datetime.LocalDateTime")) {
+        module += LocalDateTimeAsBsonDateTime.serializersModule
+    }
+    if (isClassAvailable("kotlinx.datetime.LocalTime")) {
+        module += LocalTimeAsBsonDateTime.serializersModule
     }
     module
 }


### PR DESCRIPTION
LocalTime was added in kotlinx.datetime v0.4.0 and won't be available if older versions of kotlinx datetime are on the classpath.

JAVA-5641