### PR TITLE
Fix pom scope for Scala projects

### DIFF
--- a/bson-scala/build.gradle
+++ b/bson-scala/build.gradle
@@ -18,7 +18,7 @@ description = "A Scala wrapper / extension to the bson library"
 archivesBaseName = 'mongo-scala-bson'
 
 dependencies {
-    implementation project(path: ':bson', configuration: 'default')
+    api project(path: ':bson', configuration: 'default')
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ configure(javaProjects) {
 
 configure(scalaProjects) {
     apply plugin: 'scala'
+    apply plugin: 'java-library'
     apply plugin: 'idea'
     apply plugin: "com.adtran.scala-multiversion-plugin"
     apply plugin: "com.diffplug.spotless"

--- a/driver-scala/build.gradle
+++ b/driver-scala/build.gradle
@@ -19,8 +19,8 @@ archivesBaseName = 'mongo-scala-driver'
 
 
 dependencies {
-    implementation project(path: ':bson-scala', configuration: 'default')
-    implementation project(path: ':driver-reactive-streams', configuration: 'default')
+    api project(path: ':bson-scala', configuration: 'default')
+    api project(path: ':driver-reactive-streams', configuration: 'default')
     compileOnly 'com.google.code.findbugs:jsr305:1.3.9'
 
     testImplementation project(':driver-sync')


### PR DESCRIPTION
Required the `api` dependency method from the `java-library` plugin. Now the scope is `compile` instead of runtime.

JAVA-5647