### PR TITLE
Make `CAPI`, `jna.Native`/`Structure` initializable at run time

### DIFF
--- a/mongodb-crypt/src/main/resources/META-INF/native-image/native-image.properties
+++ b/mongodb-crypt/src/main/resources/META-INF/native-image/native-image.properties
@@ -1,0 +1,20 @@
+#
+# Copyright 2008-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+Args =\
+  --initialize-at-run-time=\
+    com.mongodb.internal.crypt.capi.CAPI,\
+    com.sun.jna.Native,\
+    com.sun.jna.Structure


### PR DESCRIPTION
Ideally, we could create a project that uses Quarkus, and test the solution. But I am not going to work on that now.

JAVA-5683