### PR TITLE
Pull mongohouse image from ADL ECR repo (#1274)

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -160,12 +160,11 @@ functions:
     - command: shell.exec
       params:
         script: |
-          DRIVERS_TOOLS="${DRIVERS_TOOLS}" sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
     - command: shell.exec
       params:
-        background: true
         script: |
-          DRIVERS_TOOLS="${DRIVERS_TOOLS}" sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-local.sh
+          DRIVERS_TOOLS="${DRIVERS_TOOLS}" bash ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-image.sh
 
   "run load-balancer":
     - command: shell.exec

--- a/driver-core/src/test/resources/atlas-data-lake/getMore.json
+++ b/driver-core/src/test/resources/atlas-data-lake/getMore.json
@@ -4,6 +4,7 @@
   "tests": [
     {
       "description": "A successful find event with getMore",
+      "comment": "UPDATED final batchSize to 3 as batchSize is no longer calculated see: DRIVERS-1448 ",
       "operations": [
         {
           "object": "collection",
@@ -45,7 +46,7 @@
         {
           "command_started_event": {
             "command": {
-              "batchSize": 1
+              "batchSize": 3
             },
             "command_name": "getMore",
             "database_name": "cursors"


### PR DESCRIPTION
Updated ADL test batch size assertion to match Java driver behavioral change introduced in JAVA-5159

Backport of (#1274)

JAVA-5235

(cherry picked from commit 9286233d5a6bc33c3a022c524810f04368118851)