### PR TITLE
Update `pool-checkout-returned-connection-maxConnecting.json` to work with different pool implementations

### DIFF
--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/cmap-format/pool-checkout-returned-connection-maxConnecting.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/cmap-format/pool-checkout-returned-connection-maxConnecting.json
@@ -23,6 +23,7 @@
     }
   },
   "poolOptions": {
+    "maxConnecting": 2,
     "maxPoolSize": 10,
     "waitQueueTimeoutMS": 5000
   },
@@ -72,9 +73,8 @@
       "connection": "conn0"
     },
     {
-      "name": "waitForEvent",
-      "event": "ConnectionCheckedOut",
-      "count": 4
+      "name": "wait",
+      "ms": 100
     }
   ],
   "events": [
@@ -103,14 +103,6 @@
     {
       "type": "ConnectionCheckedOut",
       "connectionId": 1,
-      "address": 42
-    },
-    {
-      "type": "ConnectionCheckedOut",
-      "address": 42
-    },
-    {
-      "type": "ConnectionCheckedOut",
       "address": 42
     }
   ],


### PR DESCRIPTION
JAVA-5696