### PR TITLE
Retry flaky unified tests

### DIFF
--- a/driver-core/src/main/com/mongodb/assertions/Assertions.java
+++ b/driver-core/src/main/com/mongodb/assertions/Assertions.java
@@ -181,6 +181,19 @@ public final class Assertions {
 
     /**
      * @param value A value to check.
+     * @param message The message.
+     * @return {@code true}.
+     * @throws AssertionError If {@code value} is {@code false}.
+     */
+    public static boolean assertTrue(final boolean value, final String message) throws AssertionError {
+        if (!value) {
+            throw new AssertionError(message);
+        }
+        return true;
+    }
+
+    /**
+     * @param value A value to check.
      * @return {@code false}.
      * @throws AssertionError If {@code value} is {@code true}.
      */

--- a/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/UnifiedCrudTest.kt
+++ b/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/UnifiedCrudTest.kt
@@ -24,7 +24,7 @@ internal class UnifiedCrudTest() : UnifiedTest() {
         @JvmStatic
         @Throws(URISyntaxException::class, IOException::class)
         fun data(): Collection<Arguments>? {
-            return getTestData("unified-test-format/crud")
+            return getTestData("unified-test-format/crud", true)
         }
     }
 }

--- a/driver-kotlin-sync/src/integration/kotlin/com/mongodb/kotlin/client/UnifiedCrudTest.kt
+++ b/driver-kotlin-sync/src/integration/kotlin/com/mongodb/kotlin/client/UnifiedCrudTest.kt
@@ -24,7 +24,7 @@ internal class UnifiedCrudTest() : UnifiedTest() {
         @JvmStatic
         @Throws(URISyntaxException::class, IOException::class)
         fun data(): Collection<Arguments>? {
-            return getTestData("unified-test-format/crud")
+            return getTestData("unified-test-format/crud", false)
         }
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ClientSideOperationTimeoutTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/ClientSideOperationTimeoutTest.java
@@ -99,18 +99,25 @@ public class ClientSideOperationTimeoutTest extends UnifiedReactiveStreamsTest {
     @MethodSource("data")
     @Override
     public void shouldPassAllOutcomes(
+            final String testName,
             @Nullable final String fileDescription,
             @Nullable final String testDescription,
             @Nullable final String directoryName,
+            final int attemptNumber,
+            final int totalAttempts,
             final String schemaVersion,
             @Nullable final BsonArray runOnRequirements,
             final BsonArray entitiesArray,
             final BsonArray initialData,
             final BsonDocument definition) {
         try {
-            super.shouldPassAllOutcomes(fileDescription,
+            super.shouldPassAllOutcomes(
+                    testName,
+                    fileDescription,
                     testDescription,
                     directoryName,
+                    attemptNumber,
+                    totalAttempts,
                     schemaVersion,
                     runOnRequirements,
                     entitiesArray,

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedReactiveStreamsTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/unified/UnifiedReactiveStreamsTest.java
@@ -24,6 +24,7 @@ import com.mongodb.client.gridfs.GridFSBucket;
 import com.mongodb.client.unified.UnifiedTest;
 import com.mongodb.client.unified.UnifiedTestModifications;
 import com.mongodb.client.vault.ClientEncryption;
+import com.mongodb.lang.NonNull;
 import com.mongodb.reactivestreams.client.MongoClients;
 import com.mongodb.reactivestreams.client.gridfs.GridFSBuckets;
 import com.mongodb.reactivestreams.client.internal.vault.ClientEncryptionImpl;
@@ -31,6 +32,11 @@ import com.mongodb.reactivestreams.client.syncadapter.SyncClientEncryption;
 import com.mongodb.reactivestreams.client.syncadapter.SyncGridFSBucket;
 import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
 import com.mongodb.reactivestreams.client.syncadapter.SyncMongoDatabase;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
 
 import static com.mongodb.client.unified.UnifiedTestModifications.Modifier;
 import static com.mongodb.client.unified.UnifiedTestModifications.TestDef;
@@ -93,5 +99,10 @@ public abstract class UnifiedReactiveStreamsTest extends UnifiedTest {
         if (testDef.wasAssignedModifier(Modifier.SLEEP_AFTER_CURSOR_OPEN)) {
             disableSleep();
         }
+    }
+
+    @NonNull
+    protected static Collection<Arguments> getTestData(final String directory) throws URISyntaxException, IOException {
+        return getTestData(directory, true);
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideOperationsTimeoutProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideOperationsTimeoutProseTest.java
@@ -134,7 +134,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
     }
 
     @SuppressWarnings("try")
-    @FlakyTest(maxAttempts = 3) // TODO-JAVA-5809
+    @FlakyTest(maxAttempts = 3)
     @DisplayName("4. Background Connection Pooling - timeoutMS used for handshake commands")
     public void testBackgroundConnectionPoolingTimeoutMSUsedForHandshakeCommands() {
         assumeTrue(serverVersionAtLeast(4, 4));
@@ -171,7 +171,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
     }
 
     @SuppressWarnings("try")
-    @FlakyTest(maxAttempts = 3) // TODO-JAVA-5809
+    @FlakyTest(maxAttempts = 3)
     @DisplayName("4. Background Connection Pooling - timeoutMS is refreshed for each handshake command")
     public void testBackgroundConnectionPoolingTimeoutMSIsRefreshedForEachHandshakeCommand() {
         assumeTrue(serverVersionAtLeast(4, 4));
@@ -205,7 +205,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
         }
     }
 
-    @FlakyTest(maxAttempts = 3) // TODO-JAVA-5809
+    @FlakyTest(maxAttempts = 3)
     @DisplayName("5. Blocking Iteration Methods - Tailable cursors")
     public void testBlockingIterationMethodsTailableCursor() {
         assumeTrue(serverVersionAtLeast(4, 4));
@@ -242,7 +242,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
         }
     }
 
-    @FlakyTest(maxAttempts = 3) // TODO-JAVA-5809
+    @FlakyTest(maxAttempts = 3)
     @DisplayName("5. Blocking Iteration Methods - Change Streams")
     public void testBlockingIterationMethodsChangeStream() {
         assumeTrue(serverVersionAtLeast(4, 4));
@@ -290,7 +290,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
     }
 
     @DisplayName("6. GridFS Upload - uploads via openUploadStream can be timed out")
-    @FlakyTest(maxAttempts = 3) // TODO-JAVA-5809
+    @FlakyTest(maxAttempts = 3)
     public void testGridFSUploadViaOpenUploadStreamTimeout() {
         assumeTrue(serverVersionAtLeast(4, 4));
         long rtt = ClusterFixture.getPrimaryRTT();
@@ -469,7 +469,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
 
     @SuppressWarnings("try")
     @DisplayName("9. End Session. The timeout specified via the MongoClient timeoutMS option")
-    @FlakyTest(maxAttempts = 3) // TODO-JAVA-5809
+    @FlakyTest(maxAttempts = 3)
     public void test9EndSessionClientTimeout() {
         assumeTrue(serverVersionAtLeast(4, 4));
         assumeFalse(isStandalone());

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideOperationsTimeoutProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideOperationsTimeoutProseTest.java
@@ -134,7 +134,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
     }
 
     @SuppressWarnings("try")
-    @FlakyTest(maxAttempts = 3)
+    @FlakyTest(maxAttempts = 3) // TODO-JAVA-5809
     @DisplayName("4. Background Connection Pooling - timeoutMS used for handshake commands")
     public void testBackgroundConnectionPoolingTimeoutMSUsedForHandshakeCommands() {
         assumeTrue(serverVersionAtLeast(4, 4));
@@ -171,7 +171,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
     }
 
     @SuppressWarnings("try")
-    @FlakyTest(maxAttempts = 3)
+    @FlakyTest(maxAttempts = 3) // TODO-JAVA-5809
     @DisplayName("4. Background Connection Pooling - timeoutMS is refreshed for each handshake command")
     public void testBackgroundConnectionPoolingTimeoutMSIsRefreshedForEachHandshakeCommand() {
         assumeTrue(serverVersionAtLeast(4, 4));
@@ -205,7 +205,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
         }
     }
 
-    @FlakyTest(maxAttempts = 3)
+    @FlakyTest(maxAttempts = 3) // TODO-JAVA-5809
     @DisplayName("5. Blocking Iteration Methods - Tailable cursors")
     public void testBlockingIterationMethodsTailableCursor() {
         assumeTrue(serverVersionAtLeast(4, 4));
@@ -242,7 +242,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
         }
     }
 
-    @FlakyTest(maxAttempts = 3)
+    @FlakyTest(maxAttempts = 3) // TODO-JAVA-5809
     @DisplayName("5. Blocking Iteration Methods - Change Streams")
     public void testBlockingIterationMethodsChangeStream() {
         assumeTrue(serverVersionAtLeast(4, 4));
@@ -290,7 +290,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
     }
 
     @DisplayName("6. GridFS Upload - uploads via openUploadStream can be timed out")
-    @FlakyTest(maxAttempts = 3)
+    @FlakyTest(maxAttempts = 3) // TODO-JAVA-5809
     public void testGridFSUploadViaOpenUploadStreamTimeout() {
         assumeTrue(serverVersionAtLeast(4, 4));
         long rtt = ClusterFixture.getPrimaryRTT();
@@ -469,7 +469,7 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
 
     @SuppressWarnings("try")
     @DisplayName("9. End Session. The timeout specified via the MongoClient timeoutMS option")
-    @FlakyTest(maxAttempts = 3)
+    @FlakyTest(maxAttempts = 3) // TODO-JAVA-5809
     public void test9EndSessionClientTimeout() {
         assumeTrue(serverVersionAtLeast(4, 4));
         assumeFalse(isStandalone());

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedSyncTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedSyncTest.java
@@ -25,6 +25,12 @@ import com.mongodb.client.gridfs.GridFSBucket;
 import com.mongodb.client.gridfs.GridFSBuckets;
 import com.mongodb.client.internal.ClientEncryptionImpl;
 import com.mongodb.client.vault.ClientEncryption;
+import com.mongodb.lang.NonNull;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collection;
 
 public abstract class UnifiedSyncTest extends UnifiedTest {
     protected UnifiedSyncTest() {
@@ -43,5 +49,10 @@ public abstract class UnifiedSyncTest extends UnifiedTest {
     @Override
     protected ClientEncryption createClientEncryption(final MongoClient keyVaultClient, final ClientEncryptionSettings clientEncryptionSettings) {
         return new ClientEncryptionImpl(keyVaultClient, clientEncryptionSettings);
+    }
+
+    @NonNull
+    protected static Collection<Arguments> getTestData(final String directory) throws URISyntaxException, IOException {
+        return getTestData(directory, false);
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -185,11 +185,7 @@ public abstract class UnifiedTest {
                 }
 
                 for (int attempt = 1; attempt <= attempts; attempt++) {
-                    String testName = !retry
-                            ? MessageFormat.format("{0}: {1}", fileDescription, testDescription)
-                            : MessageFormat.format(
-                                    "{0}: {1} ({2} of {3})",
-                                    fileDescription, testDescription, attempt, attempts);
+                    String testName = MessageFormat.format("{0}: {1}", fileDescription, testDescription);
                     data.add(Arguments.of(
                             testName,
                             fileDescription,

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -387,7 +387,7 @@ public abstract class UnifiedTest {
             if (forceFlaky) {
                 throw e;
             }
-            if (testDef!= null && !testDef.matchesThrowable(e)) {
+            if (testDef != null && !testDef.matchesThrowable(e)) {
                 // if the throwable is not matched, test definitions were not intended to apply; rethrow it
                 throw e;
             }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -389,7 +389,7 @@ public abstract class UnifiedTest {
             if (isLastAttempt) {
                 throw e;
             }
-            
+
             ignoreRemaining.remove(testName);
             abort("Ignoring failure and retrying attempt " + attemptNumber);
         }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestFailureValidator.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestFailureValidator.java
@@ -36,9 +36,12 @@ final class UnifiedTestFailureValidator extends UnifiedSyncTest {
     @Override
     @BeforeEach
     public void setUp(
+            final String testName,
             @Nullable final String fileDescription,
             @Nullable final String testDescription,
             final String directoryName,
+            final int attemptNumber,
+            final int totalAttempts,
             final String schemaVersion,
             @Nullable final BsonArray runOnRequirements,
             final BsonArray entitiesArray,
@@ -46,9 +49,12 @@ final class UnifiedTestFailureValidator extends UnifiedSyncTest {
             final BsonDocument definition) {
         try {
             super.setUp(
+                    testName,
                     fileDescription,
                     testDescription,
                     directoryName,
+                    attemptNumber,
+                    totalAttempts,
                     schemaVersion,
                     runOnRequirements,
                     entitiesArray,
@@ -63,9 +69,12 @@ final class UnifiedTestFailureValidator extends UnifiedSyncTest {
     @ParameterizedTest
     @MethodSource("data")
     public void shouldPassAllOutcomes(
+            final String testName,
             @Nullable final String fileDescription,
             @Nullable final String testDescription,
             @Nullable final String directoryName,
+            final int attemptNumber,
+            final int totalAttempts,
             final String schemaVersion,
             @Nullable final BsonArray runOnRequirements,
             final BsonArray entitiesArray,
@@ -74,9 +83,12 @@ final class UnifiedTestFailureValidator extends UnifiedSyncTest {
         if (exception == null) {
             try {
                 super.shouldPassAllOutcomes(
+                        testName,
                         fileDescription,
                         testDescription,
                         directoryName,
+                        attemptNumber,
+                        totalAttempts,
                         schemaVersion,
                         runOnRequirements,
                         entitiesArray,

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -42,17 +42,16 @@ import static java.lang.String.format;
 public final class UnifiedTestModifications {
     public static void applyCustomizations(final TestDef def) {
 
-        // TODO reasons for retry
         // Exception in encryption library: ChangeCipherSpec message sequence violation
-        def.retry("TODO reason")
+        def.retry("") // TODO-JAVA-5809
                 .whenFailureContains("ChangeCipherSpec message sequence violation")
                 .test("client-side-encryption", "namedKMS-createDataKey", "create datakey with named KMIP KMS provider");
 
-        def.retry("TODO reason")
+        def.retry("") // TODO-JAVA-5809
                 .whenFailureContains("Number of checked out connections must match expected")
                 .test("load-balancers", "cursors are correctly pinned to connections for load-balanced clusters", "pinned connections are returned after a network error during a killCursors request");
 
-        def.retry("TODO reason")
+        def.retry("") // TODO-JAVA-5809
                 .test("client-side-encryption", "namedKMS-rewrapManyDataKey", "rewrap to kmip:name1");
 
         // atlas-data-lake
@@ -62,7 +61,7 @@ public final class UnifiedTestModifications {
                 .directory("atlas-data-lake-testing");
 
         // change-streams
-        def.skipNoncompliantReactive("error required from change stream initialization") // TODO reason?
+        def.skipNoncompliantReactive("error required from change stream initialization") // TODO-JAVA-5711 reason?
                 .test("change-streams", "change-streams", "Test with document comment - pre 4.4");
         def.skipNoncompliantReactive("event sensitive tests. We can't guarantee the amount of GetMore commands sent in the reactive driver")
                 .test("change-streams", "change-streams", "Test that comment is set on getMore")
@@ -78,17 +77,17 @@ public final class UnifiedTestModifications {
 
         // client-side-operation-timeout (CSOT)
 
-        // TODO
+        // TODO-JAVA-5712
 
         // collection-management
 
-        def.skipNoncompliant("") // TODO reason?
+        def.skipNoncompliant("") // TODO-JAVA-5711 reason?
                 .test("collection-management", "modifyCollection-pre_and_post_images", "modifyCollection to changeStreamPreAndPostImages enabled");
 
         // command-logging-and-monitoring
 
-        def.skipNoncompliant("TODO")
-                .when(() -> !def.isReactive() && isServerlessTest()) // TODO why reactive check?
+        def.skipNoncompliant("") // TODO-JAVA-5711
+                .when(() -> !def.isReactive() && isServerlessTest()) // TODO-JAVA-5711 why reactive check?
                 .directory("command-logging")
                 .directory("command-monitoring");
 
@@ -101,7 +100,7 @@ public final class UnifiedTestModifications {
 
         // connection-monitoring-and-pooling
 
-        // TODO reason, jira
+        // TODO-JAVA-5711 reason, jira
         // added as part of https://jira.mongodb.org/browse/JAVA-4976 , but unknown Jira to complete
         // The implementation of the functionality related to clearing the connection pool before closing the connection
         // will be carried out once the specification is finalized and ready.

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.client.unified;
 
-import com.mongodb.assertions.Assertions;
 import org.opentest4j.AssertionFailedError;
 
 import java.util.ArrayList;
@@ -31,12 +30,14 @@ import static com.mongodb.ClusterFixture.isServerlessTest;
 import static com.mongodb.ClusterFixture.isSharded;
 import static com.mongodb.ClusterFixture.serverVersionLessThan;
 import static com.mongodb.assertions.Assertions.assertNotNull;
+import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.client.unified.UnifiedTestModifications.Modifier.IGNORE_EXTRA_EVENTS;
 import static com.mongodb.client.unified.UnifiedTestModifications.Modifier.RETRY;
 import static com.mongodb.client.unified.UnifiedTestModifications.Modifier.SKIP;
 import static com.mongodb.client.unified.UnifiedTestModifications.Modifier.SLEEP_AFTER_CURSOR_CLOSE;
 import static com.mongodb.client.unified.UnifiedTestModifications.Modifier.SLEEP_AFTER_CURSOR_OPEN;
 import static com.mongodb.client.unified.UnifiedTestModifications.Modifier.WAIT_FOR_BATCH_CURSOR_CREATION;
+import static java.lang.String.format;
 
 public final class UnifiedTestModifications {
     public static void applyCustomizations(final TestDef def) {
@@ -291,7 +292,7 @@ public final class UnifiedTestModifications {
          * @param ticket reason for skipping the test; must start with a Jira URL
          */
         public TestApplicator skipJira(final String ticket) {
-            Assertions.assertTrue(ticket.startsWith("https://jira.mongodb.org/browse/JAVA-"));
+            assertTrue(ticket.startsWith("https://jira.mongodb.org/browse/JAVA-"));
             return new TestApplicator(this, ticket, SKIP);
         }
 
@@ -496,6 +497,8 @@ public final class UnifiedTestModifications {
          * message will be checked. Otherwise, the throwable will be checked.
          */
         public TestApplicator whenFailureContains(final String messageFragment) {
+            assertTrue(this.modifiersToApply.contains(RETRY),
+                    format("Modifier %s was not specified before calling whenFailureContains", RETRY));
             this.matchesThrowable = (final Throwable e) -> {
                 // inspect the cause for failed assertions with a cause
                 if (e instanceof AssertionFailedError && e.getCause() != null) {

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -43,16 +43,27 @@ public final class UnifiedTestModifications {
     public static void applyCustomizations(final TestDef def) {
 
         // Exception in encryption library: ChangeCipherSpec message sequence violation
-        def.retry("") // TODO-JAVA-5809
+        def.retryReactive("") // TODO-JAVA-5809
                 .whenFailureContains("ChangeCipherSpec message sequence violation")
                 .test("client-side-encryption", "namedKMS-createDataKey", "create datakey with named KMIP KMS provider");
 
-        def.retry("") // TODO-JAVA-5809
+        def.retryReactive("") // TODO-JAVA-5809
                 .whenFailureContains("Number of checked out connections must match expected")
                 .test("load-balancers", "cursors are correctly pinned to connections for load-balanced clusters", "pinned connections are returned after a network error during a killCursors request");
 
-        def.retry("") // TODO-JAVA-5809
+        def.retryReactive("") // TODO-JAVA-5809
                 .test("client-side-encryption", "namedKMS-rewrapManyDataKey", "rewrap to kmip:name1");
+
+        def.retry("") // TODO-JAVA-5809
+                .whenFailureContains("Read timed out")
+                .test("client-side-encryption", "rewrapManyDataKey", "rewrap with new Azure KMS provider")
+                .test("client-side-encryption", "rewrapManyDataKey", "rewrap with new KMIP KMS provider");
+
+        def.retryReactive("") // TODO-JAVA-5809
+                .test("load-balancers", "cursors are correctly pinned to connections for load-balanced clusters", "pinned connections are returned after a network error during a killCursors request");
+
+        def.retryReactive("") // TODO-JAVA-5809
+                .test("server-selection.logging", "operation-id", "Failed bulkWrite operation: log messages have operationIds");
 
         // atlas-data-lake
 
@@ -339,12 +350,19 @@ public final class UnifiedTestModifications {
             return new TestApplicator(this, reason, SKIP);
         }
 
-
         /**
          * The test will be retried, for the reason provided
          */
         public TestApplicator retry(final String reason) {
             return new TestApplicator(this, reason, RETRY);
+        }
+
+        /**
+         * The reactive test will be retried, for the reason provided
+         */
+        public TestApplicator retryReactive(final String reason) {
+            return new TestApplicator(this, reason, RETRY)
+                    .when(this::isReactive);
         }
 
         public TestApplicator modify(final Modifier... modifiers) {

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -42,29 +42,6 @@ import static java.lang.String.format;
 public final class UnifiedTestModifications {
     public static void applyCustomizations(final TestDef def) {
 
-        // Exception in encryption library: ChangeCipherSpec message sequence violation
-        def.retryReactive("") // TODO-JAVA-5809
-                .whenFailureContains("ChangeCipherSpec message sequence violation")
-                .test("client-side-encryption", "namedKMS-createDataKey", "create datakey with named KMIP KMS provider");
-
-        def.retryReactive("") // TODO-JAVA-5809
-                .whenFailureContains("Number of checked out connections must match expected")
-                .test("load-balancers", "cursors are correctly pinned to connections for load-balanced clusters", "pinned connections are returned after a network error during a killCursors request");
-
-        def.retryReactive("") // TODO-JAVA-5809
-                .test("client-side-encryption", "namedKMS-rewrapManyDataKey", "rewrap to kmip:name1");
-
-        def.retry("") // TODO-JAVA-5809
-                .whenFailureContains("Read timed out")
-                .test("client-side-encryption", "rewrapManyDataKey", "rewrap with new Azure KMS provider")
-                .test("client-side-encryption", "rewrapManyDataKey", "rewrap with new KMIP KMS provider");
-
-        def.retryReactive("") // TODO-JAVA-5809
-                .test("load-balancers", "cursors are correctly pinned to connections for load-balanced clusters", "pinned connections are returned after a network error during a killCursors request");
-
-        def.retryReactive("") // TODO-JAVA-5809
-                .test("server-selection.logging", "operation-id", "Failed bulkWrite operation: log messages have operationIds");
-
         // atlas-data-lake
 
         def.skipAccordingToSpec("Data lake tests should only run on data lake")

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -489,6 +489,12 @@ public final class UnifiedTestModifications {
             return this;
         }
 
+        /**
+         * The modification, if it is a RETRY, will only be applied when the
+         * failure message contains the provided message fragment. If an
+         * {@code AssertionFailedError} occurs, and has a cause, the cause's
+         * message will be checked. Otherwise, the throwable will be checked.
+         */
         public TestApplicator whenFailureContains(final String messageFragment) {
             this.matchesThrowable = (final Throwable e) -> {
                 // inspect the cause for failed assertions with a cause
@@ -526,11 +532,15 @@ public final class UnifiedTestModifications {
          */
         SKIP,
         /**
-         * Retry the test on failure.
+         * Ignore results and retry the test on failure. Will not repeat the
+         * test if the test succeeds. Multiple copies of the test are used to
+         * facilitate retries.
          */
         RETRY,
         /**
-         * Retry the test multiple times, without ignoring failures.
+         * The test will be retried multiple times, without the results being
+         * ignored. This is a helper that can be used, in patches, to check
+         * if certain tests are (still) flaky.
          */
         FORCE_FLAKY,
     }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -28,6 +28,7 @@ import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isServerlessTest;
 import static com.mongodb.ClusterFixture.isSharded;
 import static com.mongodb.ClusterFixture.serverVersionLessThan;
+import static com.mongodb.client.unified.UnifiedTestModifications.Modifier.FORCE_FLAKY;
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.client.unified.UnifiedTestModifications.Modifier.IGNORE_EXTRA_EVENTS;
 import static com.mongodb.client.unified.UnifiedTestModifications.Modifier.SKIP;
@@ -37,6 +38,14 @@ import static com.mongodb.client.unified.UnifiedTestModifications.Modifier.WAIT_
 
 public final class UnifiedTestModifications {
     public static void doSkips(final TestDef def) {
+
+        // TODO reasons for retry
+        def.modify(FORCE_FLAKY)
+                // Exception in encryption library: ChangeCipherSpec message sequence violation
+                .test("client-side-encryption", "namedKMS-createDataKey", "create datakey with named KMIP KMS provider")
+                // Number of checked out connections must match expected
+                .test("load-balancers", "cursors are correctly pinned to connections for load-balanced clusters", "pinned connections are returned after a network error during a killCursors request")
+                .test("client-side-encryption", "namedKMS-rewrapManyDataKey", "rewrap to kmip:name1");
 
         // atlas-data-lake
 
@@ -478,5 +487,13 @@ public final class UnifiedTestModifications {
          * Skip the test.
          */
         SKIP,
+        /**
+         * Retry the test on failure.
+         */
+        RETRY,
+        /**
+         * Retry the test multiple times, without ignoring failures.
+         */
+        FORCE_FLAKY,
     }
 }

--- a/driver-workload-executor/src/main/com/mongodb/workload/WorkloadExecutor.java
+++ b/driver-workload-executor/src/main/com/mongodb/workload/WorkloadExecutor.java
@@ -98,18 +98,24 @@ public class WorkloadExecutor {
             BsonArray createEntities = fileDocument.getArray("createEntities", new BsonArray());
             BsonArray initialData = fileDocument.getArray("initialData", new BsonArray());
             unifiedTest.setUp(
+                    "",
                     null,
                     null,
                     null,
+                    1,
+                    1,
                     schemaVersion,
                     runOnRequirements,
                     createEntities,
                     initialData,
                     testDocument);
             unifiedTest.shouldPassAllOutcomes(
+                    "",
                     null,
                     null,
                     null,
+                    1,
+                    1,
                     schemaVersion,
                     runOnRequirements,
                     createEntities,


### PR DESCRIPTION
JAVA-5795

See [WRITING-28651](https://jira.mongodb.org/browse/WRITING-28651)

This creates N copies (attempts) of the unified tests, and places a try-catch around shouldPassAllOutcomes. If an attempt passes, ensuing attempts are ignored. Failures are ignored, except the last attempt.

This is not intended to fully resolve the issue, but is a low-cost fix that should reduce failing tests.

