### PR TITLE
Replace `ClientBulkWriteException.getError` with `getCause`

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
@@ -215,7 +215,8 @@ public final class OperationHelper {
     public static MongoException unwrap(final MongoException exception) {
         MongoException result = exception;
         if (exception instanceof ClientBulkWriteException) {
-            result = ((ClientBulkWriteException) exception).getError().orElse(exception);
+            MongoException topLevelError = ((ClientBulkWriteException) exception).getCause();
+            result = topLevelError == null ? exception : topLevelError;
         }
         return result;
     }

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideOperationsTimeoutProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideOperationsTimeoutProseTest.java
@@ -99,7 +99,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -736,8 +735,8 @@ public abstract class AbstractClientSideOperationsTimeoutProseTest {
                     new Document("a", join("", nCopies(maxBsonObjectSize - 500, "b"))));
             MongoException topLevelError = assertThrows(ClientBulkWriteException.class, () ->
                     client.bulkWrite(nCopies(maxMessageSizeBytes / maxBsonObjectSize + 1, model)))
-                    .getError()
-                    .<AssertionError>orElseThrow(() -> fail("Expected a top-level error"));
+                    .getCause();
+            assertNotNull(topLevelError);
             assertInstanceOf(MongoOperationTimeoutException.class, topLevelError);
             assertEquals(2, commandListener.getCommandStartedEvents("bulkWrite").size());
         }


### PR DESCRIPTION
This PR addresses the following `BULK-TODO`: https://github.com/mongodb/mongo-java-driver/pull/1509#discussion_r1786649241.