### PR TITLE
Make sure `TestDef` is created and used only when there is enough data to do that

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -117,6 +117,7 @@ public abstract class UnifiedTest {
     private UnifiedTestContext rootContext;
     private boolean ignoreExtraEvents;
     private BsonDocument startingClusterTime;
+    @Nullable
     private TestDef testDef;
 
     private class UnifiedTestContext {
@@ -215,11 +216,13 @@ public abstract class UnifiedTest {
         rootContext = new UnifiedTestContext();
         rootContext.getAssertionContext().push(ContextElement.ofTest(definition));
         ignoreExtraEvents = false;
-        testDef = testDef(directoryName, fileDescription, testDescription, isReactive());
-        UnifiedTestModifications.doSkips(testDef);
+        if (directoryName != null && fileDescription != null && testDescription != null) {
+            testDef = testDef(directoryName, fileDescription, testDescription, isReactive());
+            UnifiedTestModifications.doSkips(testDef);
 
-        boolean skip = testDef.wasAssignedModifier(UnifiedTestModifications.Modifier.SKIP);
-        assumeFalse(skip, "Skipping test");
+            boolean skip = testDef.wasAssignedModifier(UnifiedTestModifications.Modifier.SKIP);
+            assumeFalse(skip, "Skipping test");
+        }
         skips(fileDescription, testDescription);
 
         assertTrue(
@@ -268,8 +271,9 @@ public abstract class UnifiedTest {
                 this::createMongoClient,
                 this::createGridFSBucket,
                 this::createClientEncryption);
-
-        postSetUp(testDef);
+        if (testDef != null) {
+            postSetUp(testDef);
+        }
     }
 
     protected void postSetUp(final TestDef def) {
@@ -281,7 +285,9 @@ public abstract class UnifiedTest {
             failPoint.disableFailPoint();
         }
         entities.close();
-        postCleanUp(testDef);
+        if (testDef != null) {
+            postCleanUp(testDef);
+        }
     }
 
     protected void postCleanUp(final TestDef testDef) {

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -281,9 +281,9 @@ public final class UnifiedTestModifications {
         private final List<Modifier> modifiers = new ArrayList<>();
 
         private TestDef(final String dir, final String file, final String test, final boolean reactive) {
-            this.dir = dir;
-            this.file = file;
-            this.test = test;
+            this.dir = assertNotNull(dir);
+            this.file = assertNotNull(file);
+            this.test = assertNotNull(test);
             this.reactive = reactive;
         }
 


### PR DESCRIPTION
When `com.mongodb.client.unified.UnifiedTest` is used by `com.mongodb.workload.WorkloadExecutor` for running tests with Astrolabe, `TestDef` shouldn't be created.

JAVA-5716