### PR TITLE
Add index hint support for distinct command

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
@@ -181,8 +181,9 @@ public final class AsyncOperations<TDocument> {
     }
 
     public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> distinct(final String fieldName, final Bson filter,
-            final Class<TResult> resultClass, final Collation collation, final BsonValue comment) {
-        return operations.distinct(fieldName, filter, resultClass, collation, comment);
+            final Class<TResult> resultClass, final Collation collation, final BsonValue comment, final Bson hint,
+            final String hintString) {
+        return operations.distinct(fieldName, filter, resultClass, collation, comment, hint, hintString);
     }
 
     public <TResult> AsyncExplainableReadOperation<AsyncBatchCursor<TResult>> aggregate(

--- a/driver-core/src/main/com/mongodb/internal/operation/DistinctOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DistinctOperation.java
@@ -54,6 +54,8 @@ public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor
     private BsonDocument filter;
     private Collation collation;
     private BsonValue comment;
+    private BsonValue hint;
+    private String hintString;
 
     public DistinctOperation(final MongoNamespace namespace, final String fieldName, final Decoder<T> decoder) {
         this.namespace = notNull("namespace", namespace);
@@ -97,6 +99,24 @@ public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor
         return this;
     }
 
+    public BsonValue getHint() {
+        return hint;
+    }
+
+    public DistinctOperation<T> hint(@Nullable final BsonValue hint) {
+        this.hint = hint;
+        return this;
+    }
+
+    public String getHintString() {
+        return hintString;
+    }
+
+    public DistinctOperation<T> hintString(@Nullable final String hint) {
+        this.hintString = hint;
+        return this;
+    }
+
     @Override
     public BatchCursor<T> execute(final ReadBinding binding) {
         return executeRetryableRead(binding, namespace.getDatabaseName(), getCommandCreator(), createCommandDecoder(),
@@ -124,6 +144,7 @@ public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor
                 commandDocument.put("collation", collation.asDocument());
             }
             putIfNotNull(commandDocument, "comment", comment);
+            putIfNotNull(commandDocument, "hint", hint);
             return commandDocument;
         };
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/DistinctOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/DistinctOperation.java
@@ -55,7 +55,6 @@ public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor
     private Collation collation;
     private BsonValue comment;
     private BsonValue hint;
-    private String hintString;
 
     public DistinctOperation(final MongoNamespace namespace, final String fieldName, final Decoder<T> decoder) {
         this.namespace = notNull("namespace", namespace);
@@ -105,15 +104,6 @@ public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor
 
     public DistinctOperation<T> hint(@Nullable final BsonValue hint) {
         this.hint = hint;
-        return this;
-    }
-
-    public String getHintString() {
-        return hintString;
-    }
-
-    public DistinctOperation<T> hintString(@Nullable final String hint) {
-        this.hintString = hint;
         return this;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -217,13 +217,14 @@ final class Operations<TDocument> {
     }
 
     <TResult> DistinctOperation<TResult> distinct(final String fieldName, @Nullable final Bson filter, final Class<TResult> resultClass,
-            final Collation collation, final BsonValue comment) {
+            final Collation collation, final BsonValue comment, @Nullable final Bson hint, @Nullable final String hintString) {
         return new DistinctOperation<>(assertNotNull(namespace),
                 fieldName, codecRegistry.get(resultClass))
                 .retryReads(retryReads)
                 .filter(filter == null ? null : filter.toBsonDocument(documentClass, codecRegistry))
                 .collation(collation)
-                .comment(comment);
+                .comment(comment)
+                .hint(hint != null ? toBsonDocument(hint) : (hintString != null ? new BsonString(hintString) : null));
     }
 
     <TResult> AggregateOperation<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -218,13 +218,19 @@ final class Operations<TDocument> {
 
     <TResult> DistinctOperation<TResult> distinct(final String fieldName, @Nullable final Bson filter, final Class<TResult> resultClass,
             final Collation collation, final BsonValue comment, @Nullable final Bson hint, @Nullable final String hintString) {
-        return new DistinctOperation<>(assertNotNull(namespace),
+        DistinctOperation<TResult> operation = new DistinctOperation<>(assertNotNull(namespace),
                 fieldName, codecRegistry.get(resultClass))
                 .retryReads(retryReads)
                 .filter(filter == null ? null : filter.toBsonDocument(documentClass, codecRegistry))
                 .collation(collation)
-                .comment(comment)
-                .hint(hint != null ? toBsonDocument(hint) : (hintString != null ? new BsonString(hintString) : null));
+                .comment(comment);
+
+        if (hint != null) {
+            operation.hint(toBsonDocument(hint));
+        } else if (hintString != null) {
+            operation.hint(new BsonString(hintString));
+        }
+        return operation;
     }
 
     <TResult> AggregateOperation<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -165,8 +165,9 @@ public final class SyncOperations<TDocument> {
 
     public <TResult> ReadOperation<BatchCursor<TResult>> distinct(final String fieldName, final Bson filter,
                                                                   final Class<TResult> resultClass,
-                                                                  final Collation collation, final BsonValue comment) {
-        return operations.distinct(fieldName, filter, resultClass, collation, comment);
+                                                                  final Collation collation, final BsonValue comment,
+                                                                  final Bson hint, final String hintString) {
+        return operations.distinct(fieldName, filter, resultClass, collation, comment, hint, hintString);
     }
 
     public <TResult> ExplainableReadOperation<BatchCursor<TResult>> aggregate(final List<? extends Bson> pipeline,

--- a/driver-core/src/test/resources/unified-test-format/crud/distinct-hint.json
+++ b/driver-core/src/test/resources/unified-test-format/crud/distinct-hint.json
@@ -1,0 +1,139 @@
+{
+  "description": "distinct-hint",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "7.1.0"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "distinct-hint-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "distinct-hint-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "distinct with hint string",
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection0",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": 1
+            },
+            "hint": "_id_"
+          },
+          "expectResult": [
+            11
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "distinct": "coll0",
+                  "key": "x",
+                  "query": {
+                    "_id": 1
+                  },
+                  "hint": "_id_"
+                },
+                "commandName": "distinct",
+                "databaseName": "distinct-hint-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "distinct with hint document",
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection0",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": 1
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            11
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "distinct": "coll0",
+                  "key": "x",
+                  "query": {
+                    "_id": 1
+                  },
+                  "hint": {
+                    "_id": 1
+                  }
+                },
+                "commandName": "distinct",
+                "databaseName": "distinct-hint-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/syncadapter/SyncDistinctIterable.kt
+++ b/driver-kotlin-coroutine/src/integration/kotlin/com/mongodb/kotlin/client/coroutine/syncadapter/SyncDistinctIterable.kt
@@ -33,6 +33,8 @@ data class SyncDistinctIterable<T : Any>(val wrapped: DistinctFlow<T>) :
     override fun collation(collation: Collation?): SyncDistinctIterable<T> = apply { wrapped.collation(collation) }
     override fun comment(comment: String?): SyncDistinctIterable<T> = apply { wrapped.comment(comment) }
     override fun comment(comment: BsonValue?): SyncDistinctIterable<T> = apply { wrapped.comment(comment) }
+    override fun hint(hint: Bson?): SyncDistinctIterable<T> = apply { wrapped.hint(hint) }
+    override fun hintString(hint: String?): SyncDistinctIterable<T> = apply { wrapped.hintString(hint) }
     override fun timeoutMode(timeoutMode: TimeoutMode): SyncDistinctIterable<T> = apply {
         wrapped.timeoutMode(timeoutMode)
     }

--- a/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/DistinctFlow.kt
+++ b/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/DistinctFlow.kt
@@ -19,6 +19,7 @@ import com.mongodb.annotations.Alpha
 import com.mongodb.annotations.Reason
 import com.mongodb.client.cursor.TimeoutMode
 import com.mongodb.client.model.Collation
+import com.mongodb.lang.Nullable
 import com.mongodb.reactivestreams.client.DistinctPublisher
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.Flow
@@ -102,6 +103,22 @@ public class DistinctFlow<T : Any>(private val wrapped: DistinctPublisher<T>) : 
      * @return this
      */
     public fun comment(comment: BsonValue?): DistinctFlow<T> = apply { wrapped.comment(comment) }
+
+    /**
+     * Sets the hint for which index to use. A null value means no hint is set.
+     *
+     * @param hint the hint
+     * @return this
+     */
+    public fun hint(@Nullable hint: Bson?): DistinctFlow<T> = apply { wrapped.hint(hint) }
+
+    /**
+     * Sets the hint for which index to use. A null value means no hint is set.
+     *
+     * @param hint the name of the index which should be used for the operation
+     * @return this
+     */
+    public fun hintString(@Nullable hint: String?): DistinctFlow<T> = apply { wrapped.hintString(hint) }
 
     public override suspend fun collect(collector: FlowCollector<T>): Unit = wrapped.asFlow().collect(collector)
 }

--- a/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/DistinctFlow.kt
+++ b/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/DistinctFlow.kt
@@ -115,6 +115,8 @@ public class DistinctFlow<T : Any>(private val wrapped: DistinctPublisher<T>) : 
     /**
      * Sets the hint for which index to use. A null value means no hint is set.
      *
+     * Note: If [DistinctFlow.hint] is set that will be used instead of any hint string.
+     *
      * @param hint the name of the index which should be used for the operation
      * @return this
      */

--- a/driver-kotlin-sync/src/integration/kotlin/com/mongodb/kotlin/client/syncadapter/SyncDistinctIterable.kt
+++ b/driver-kotlin-sync/src/integration/kotlin/com/mongodb/kotlin/client/syncadapter/SyncDistinctIterable.kt
@@ -36,4 +36,6 @@ internal class SyncDistinctIterable<T : Any>(val wrapped: DistinctIterable<T>) :
     override fun collation(collation: Collation?): SyncDistinctIterable<T> = apply { wrapped.collation(collation) }
     override fun comment(comment: String?): SyncDistinctIterable<T> = apply { wrapped.comment(comment) }
     override fun comment(comment: BsonValue?): SyncDistinctIterable<T> = apply { wrapped.comment(comment) }
+    override fun hint(hint: Bson?): SyncDistinctIterable<T> = apply { wrapped.hint(hint) }
+    override fun hintString(hint: String?): SyncDistinctIterable<T> = apply { wrapped.hintString(hint) }
 }

--- a/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/DistinctIterable.kt
+++ b/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/DistinctIterable.kt
@@ -20,6 +20,7 @@ import com.mongodb.annotations.Reason
 import com.mongodb.client.DistinctIterable as JDistinctIterable
 import com.mongodb.client.cursor.TimeoutMode
 import com.mongodb.client.model.Collation
+import com.mongodb.lang.Nullable
 import java.util.concurrent.TimeUnit
 import org.bson.BsonValue
 import org.bson.conversions.Bson
@@ -99,4 +100,20 @@ public class DistinctIterable<T : Any?>(private val wrapped: JDistinctIterable<T
      * @return this
      */
     public fun comment(comment: BsonValue?): DistinctIterable<T> = apply { wrapped.comment(comment) }
+
+    /**
+     * Sets the hint for which index to use. A null value means no hint is set.
+     *
+     * @param hint the hint
+     * @return this
+     */
+    public fun hint(@Nullable hint: Bson?): DistinctIterable<T> = apply { wrapped.hint(hint) }
+
+    /**
+     * Sets the hint for which index to use. A null value means no hint is set.
+     *
+     * @param hint the name of the index which should be used for the operation
+     * @return this
+     */
+    public fun hintString(@Nullable hint: String?): DistinctIterable<T> = apply { wrapped.hintString(hint) }
 }

--- a/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/DistinctIterable.kt
+++ b/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/DistinctIterable.kt
@@ -112,6 +112,8 @@ public class DistinctIterable<T : Any?>(private val wrapped: JDistinctIterable<T
     /**
      * Sets the hint for which index to use. A null value means no hint is set.
      *
+     * Note: If [DistinctFlow.hint] is set that will be used instead of any hint string.
+     *
      * @param hint the name of the index which should be used for the operation
      * @return this
      */

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/DistinctPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/DistinctPublisher.java
@@ -98,6 +98,24 @@ public interface DistinctPublisher<TResult> extends Publisher<TResult> {
     DistinctPublisher<TResult> comment(@Nullable BsonValue comment);
 
     /**
+     * Sets the hint for which index to use. A null value means no hint is set.
+     *
+     * @param hint the hint
+     * @return this
+     * @since 5.3
+     */
+    DistinctPublisher<TResult> hint(@Nullable Bson hint);
+
+    /**
+     * Sets the hint for which index to use. A null value means no hint is set.
+     *
+     * @param hint the name of the index which should be used for the operation
+     * @return this
+     * @since 5.3
+     */
+    DistinctPublisher<TResult> hintString(@Nullable String hint);
+
+    /**
      * Sets the timeoutMode for the cursor.
      *
      * <p>

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/DistinctPublisherImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/DistinctPublisherImpl.java
@@ -41,6 +41,8 @@ final class DistinctPublisherImpl<T> extends BatchCursorPublisher<T> implements 
     private long maxTimeMS;
     private Collation collation;
     private BsonValue comment;
+    private Bson hint;
+    private String hintString;
 
     DistinctPublisherImpl(
             @Nullable final ClientSession clientSession,
@@ -89,6 +91,18 @@ final class DistinctPublisherImpl<T> extends BatchCursorPublisher<T> implements 
     }
 
     @Override
+    public DistinctPublisher<T> hint(@Nullable final Bson hint) {
+        this.hint = hint;
+        return this;
+    }
+
+    @Override
+    public DistinctPublisher<T> hintString(@Nullable final String hint) {
+        this.hintString = hint;
+        return this;
+    }
+
+    @Override
     public DistinctPublisher<T> timeoutMode(final TimeoutMode timeoutMode) {
         super.timeoutMode(timeoutMode);
         return this;
@@ -97,7 +111,7 @@ final class DistinctPublisherImpl<T> extends BatchCursorPublisher<T> implements 
     @Override
     AsyncReadOperation<AsyncBatchCursor<T>> asAsyncReadOperation(final int initialBatchSize) {
         // initialBatchSize is ignored for distinct operations.
-        return getOperations().distinct(fieldName, filter, getDocumentClass(), collation, comment);
+        return getOperations().distinct(fieldName, filter, getDocumentClass(), collation, comment, hint, hintString);
     }
 
     @Override

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncDistinctIterable.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncDistinctIterable.java
@@ -78,7 +78,7 @@ class SyncDistinctIterable<T> extends SyncMongoIterable<T> implements DistinctIt
     }
 
     @Override
-    public DistinctIterable<T> hintString(final String hint) {
+    public DistinctIterable<T> hintString(@Nullable final String hint) {
         wrapped.hintString(hint);
         return this;
     }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncDistinctIterable.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncDistinctIterable.java
@@ -72,6 +72,18 @@ class SyncDistinctIterable<T> extends SyncMongoIterable<T> implements DistinctIt
     }
 
     @Override
+    public DistinctIterable<T> hint(@Nullable final Bson hint) {
+        wrapped.hint(hint);
+        return this;
+    }
+
+    @Override
+    public DistinctIterable<T> hintString(final String hint) {
+        wrapped.hintString(hint);
+        return this;
+    }
+
+    @Override
     public DistinctIterable<T> timeoutMode(final TimeoutMode timeoutMode) {
         wrapped.timeoutMode(timeoutMode);
         return this;

--- a/driver-scala/src/integration/scala/org/mongodb/scala/syncadapter/SyncDistinctIterable.scala
+++ b/driver-scala/src/integration/scala/org/mongodb/scala/syncadapter/SyncDistinctIterable.scala
@@ -61,4 +61,15 @@ case class SyncDistinctIterable[T](wrapped: DistinctObservable[T])
     wrapped.comment(comment)
     this
   }
+
+  override def hint(hint: Bson): DistinctIterable[T] = {
+    wrapped.hint(hint)
+    this
+  }
+
+  override def hintString(hint: String): DistinctIterable[T] = {
+    wrapped.hintString(hint)
+    this
+  }
+
 }

--- a/driver-scala/src/main/scala/org/mongodb/scala/DistinctObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/DistinctObservable.scala
@@ -116,6 +116,7 @@ case class DistinctObservable[TResult](private val wrapped: DistinctPublisher[TR
    *
    * @param hint the hint
    * @return this
+   * @note if [[hint]] is set that will be used instead of any hint string.
    * @since 5.3
    */
   def hint(hint: Bson): DistinctObservable[TResult] = {

--- a/driver-scala/src/main/scala/org/mongodb/scala/DistinctObservable.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/DistinctObservable.scala
@@ -112,6 +112,30 @@ case class DistinctObservable[TResult](private val wrapped: DistinctPublisher[TR
   }
 
   /**
+   * Sets the hint for this operation. A null value means no hint is set.
+   *
+   * @param hint the hint
+   * @return this
+   * @since 5.3
+   */
+  def hint(hint: Bson): DistinctObservable[TResult] = {
+    wrapped.hint(hint)
+    this
+  }
+
+  /**
+   * Sets the hint for this operation. A null value means no hint is set.
+   *
+   * @param hint the name of the index which should be used for the operation
+   * @return this
+   * @since 5.3
+   */
+  def hintString(hint: String): DistinctObservable[TResult] = {
+    wrapped.hintString(hint)
+    this
+  }
+
+  /**
    * Sets the timeoutMode for the cursor.
    *
    * Requires the `timeout` to be set, either in the [[MongoClientSettings]],

--- a/driver-sync/src/main/com/mongodb/client/DistinctIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/DistinctIterable.java
@@ -93,6 +93,24 @@ public interface DistinctIterable<TResult> extends MongoIterable<TResult> {
     DistinctIterable<TResult> comment(@Nullable BsonValue comment);
 
     /**
+     * Sets the hint for which index to use. A null value means no hint is set.
+     *
+     * @param hint the hint
+     * @return this
+     * @since 5.3
+     */
+    DistinctIterable<TResult> hint(@Nullable Bson hint);
+
+    /**
+     * Sets the hint to apply.
+     *
+     * @param hint the name of the index which should be used for the operation
+     * @return this
+     * @since 5.3
+     */
+    DistinctIterable<TResult> hintString(@Nullable String hint);
+
+    /**
      * Sets the timeoutMode for the cursor.
      *
      * <p>

--- a/driver-sync/src/main/com/mongodb/client/DistinctIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/DistinctIterable.java
@@ -104,6 +104,8 @@ public interface DistinctIterable<TResult> extends MongoIterable<TResult> {
     /**
      * Sets the hint to apply.
      *
+     * <p>Note: If {@link DistinctIterable#hint(Bson)} is set that will be used instead of any hint string.</p>
+     *
      * @param hint the name of the index which should be used for the operation
      * @return this
      * @since 5.3

--- a/driver-sync/src/main/com/mongodb/client/internal/DistinctIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/DistinctIterableImpl.java
@@ -47,6 +47,8 @@ class DistinctIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult
     private long maxTimeMS;
     private Collation collation;
     private BsonValue comment;
+    private Bson hint;
+    private String hintString;
 
     DistinctIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace, final Class<TDocument> documentClass,
                          final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
@@ -103,10 +105,21 @@ class DistinctIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult
     }
 
     @Override
-    public ReadOperation<BatchCursor<TResult>> asReadOperation() {
-        return operations.distinct(fieldName, filter, resultClass, collation, comment);
+    public DistinctIterable<TResult> hint(@Nullable final Bson hint) {
+        this.hint = hint;
+        return this;
     }
 
+    @Override
+    public DistinctIterable<TResult> hintString(@Nullable final String hint) {
+        this.hintString = hint;
+        return this;
+    }
+
+    @Override
+    public ReadOperation<BatchCursor<TResult>> asReadOperation() {
+        return operations.distinct(fieldName, filter, resultClass, collation, comment, hint, hintString);
+    }
 
     protected OperationExecutor getExecutor() {
         return getExecutor(operations.createTimeoutSettings(maxTimeMS));

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
@@ -492,6 +492,13 @@ final class UnifiedCrudHelper extends UnifiedHelper {
                 case "comment":
                     iterable.comment(cur.getValue());
                     break;
+                case "hint":
+                    if (cur.getValue().isString()) {
+                        iterable.hintString(cur.getValue().asString().getValue());
+                    } else {
+                        iterable.hint(cur.getValue().asDocument());
+                    }
+                    break;
                 case "filter":
                     iterable.filter(cur.getValue().asDocument());
                     break;


### PR DESCRIPTION
### Ticket
[JAVA-5686](https://jira.mongodb.org/browse/JAVA-5686?filter=-1)

### Description
This PR adds index hint support for `distinct` command for java, kotlin, and scala. It also syncs CRUD unified spec tests to [77b1f78458cf25b525cde2274e33acd5db2581d2](https://github.com/mongodb/specifications/commit/77b1f78458cf25b525cde2274e33acd5db2581d2).

### Testing
- [X] ran `./gradlew check`
- [X] local testing - ran `UnifiedCRUDTest.java`
