### PR TITLE
[JAVA-5224] Make ReadConcernMajorityNotAvailableYet a retryable error

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursorHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursorHelper.java
@@ -35,7 +35,7 @@ import static java.util.Arrays.asList;
 final class ChangeStreamBatchCursorHelper {
     @VisibleForTesting(otherwise = PRIVATE)
     static final List<Integer> RETRYABLE_SERVER_ERROR_CODES =
-            asList(6, 7, 63, 89, 91, 133, 150, 189, 234, 262, 9001, 10107, 11600, 11602, 13388, 13435, 13436);
+            asList(6, 7, 63, 89, 91, 133, 134, 150, 189, 234, 262, 9001, 10107, 11600, 11602, 13388, 13435, 13436);
     @VisibleForTesting(otherwise = PRIVATE)
     static final String RESUMABLE_CHANGE_STREAM_ERROR_LABEL = "ResumableChangeStreamError";
 

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -127,7 +127,7 @@ final class CommandOperationHelper {
         return RetryState.withNonRetryableState();
     }
 
-    private static final List<Integer> RETRYABLE_ERROR_CODES = asList(6, 7, 89, 91, 189, 262, 9001, 13436, 13435, 11602, 11600, 10107);
+    private static final List<Integer> RETRYABLE_ERROR_CODES = asList(6, 7, 89, 91, 134, 189, 262, 9001, 13436, 13435, 11602, 11600, 10107);
     static boolean isRetryableException(final Throwable t) {
         if (!(t instanceof MongoException)) {
             return false;

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -167,8 +167,6 @@ public final class UnifiedTestModifications {
                 .file("retryable-reads", "listDatabaseObjects-serverErrors")
                 .file("retryable-reads", "listCollectionObjects")
                 .file("retryable-reads", "listCollectionObjects-serverErrors");
-        def.skipJira("https://jira.mongodb.org/browse/JAVA-5224")
-                .test("retryable-reads", "ReadConcernMajorityNotAvailableYet is a retryable read", "Find succeeds on second attempt after ReadConcernMajorityNotAvailableYet");
 
         // retryable-writes
 


### PR DESCRIPTION
This closes JAVA-5224 by adding `ReadConcernMajorityNotAvailableYet` (134) to retryable error codes list.