### PR TITLE
Fixing default module name for kotlin-extensions

### DIFF
--- a/driver-kotlin-extensions/build.gradle.kts
+++ b/driver-kotlin-extensions/build.gradle.kts
@@ -165,4 +165,4 @@ tasks.javadocJar.configure {
 // ===========================
 tasks.sourcesJar { from(project.sourceSets.main.map { it.kotlin }) }
 
-afterEvaluate { tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.driver.kotlin.core" } } }
+afterEvaluate { tasks.jar { manifest { attributes["Automatic-Module-Name"] = "org.mongodb.driver.kotlin.extensions" } } }


### PR DESCRIPTION
Fixes JAVA-5751

<img width="1054" alt="image" src="https://github.com/user-attachments/assets/838736f0-81ff-4ceb-9788-6a20cc42509f" />
