### PR TITLE
JAVA-5776 Make KProperty<T>.path() public

### DIFF
--- a/driver-kotlin-extensions/src/main/kotlin/com/mongodb/kotlin/client/model/Properties.kt
+++ b/driver-kotlin-extensions/src/main/kotlin/com/mongodb/kotlin/client/model/Properties.kt
@@ -67,7 +67,7 @@ public operator fun <T0, K, T1, T2> KProperty1<T0, Map<out K, T1>?>.div(
  * - BsonProperty annotation
  * - Property name
  */
-internal fun <T> KProperty<T>.path(): String {
+public fun <T> KProperty<T>.path(): String {
     return if (this is KPropertyPath<*, T>) {
         this.name
     } else {


### PR DESCRIPTION
As mentioned in JAVA-5776, I think this function should be public so custom functions can use the same path cache and name resolution as those provided by the driver.