### PR TITLE
JAVA-5775 Filter null values in Filters.and / Filters.or

### DIFF
--- a/driver-kotlin-extensions/src/main/kotlin/com/mongodb/kotlin/client/model/Filters.kt
+++ b/driver-kotlin-extensions/src/main/kotlin/com/mongodb/kotlin/client/model/Filters.kt
@@ -288,7 +288,7 @@ public object Filters {
      * @param filters the list of filters to and together
      * @return the filter
      */
-    public fun and(filters: Iterable<Bson?>): Bson = Filters.and(filters)
+    public fun and(filters: Iterable<Bson?>): Bson = Filters.and(filters.filterNotNull())
 
     /**
      * Creates a filter that performs a logical AND of the provided list of filters. Note that this will only generate
@@ -309,7 +309,7 @@ public object Filters {
      * @param filters the list of filters to and together
      * @return the filter
      */
-    public fun or(filters: Iterable<Bson?>): Bson = Filters.or(filters)
+    public fun or(filters: Iterable<Bson?>): Bson = Filters.or(filters.filterNotNull())
 
     /**
      * Creates a filter that preforms a logical OR of the provided list of filters.

--- a/driver-kotlin-extensions/src/test/kotlin/com/mongodb/kotlin/client/model/FiltersTest.kt
+++ b/driver-kotlin-extensions/src/test/kotlin/com/mongodb/kotlin/client/model/FiltersTest.kt
@@ -159,11 +159,18 @@ class FiltersTest {
     @Test
     fun testOrSupport() {
         val expected = BsonDocument.parse("""{${'$'}or: [{"name": "Ada"}, {"age": 20 }]}""")
+
         val bson = or(eq(Person::name, person.name), eq(Person::age, person.age))
         assertEquals(expected, bson.document)
 
         val kmongoDsl = or(Person::name eq person.name, Person::age eq person.age)
         assertEquals(expected, kmongoDsl.document)
+
+        val bsonWithNull = or(eq(Person::name, person.name), eq(Person::age, person.age), null)
+        assertEquals(expected, bsonWithNull.document)
+
+        val kmongoDslWithNull = or(Person::name eq person.name, Person::age eq person.age, null)
+        assertEquals(expected, kmongoDslWithNull.document)
     }
 
     @Test
@@ -186,11 +193,18 @@ class FiltersTest {
     @Test
     fun testAndSupport() {
         val expected = BsonDocument.parse("""{${'$'}and: [{"name": "Ada"}, {"age": 20 }]}""")
+
         val bson = and(eq(Person::name, person.name), eq(Person::age, person.age))
         assertEquals(expected, bson.document)
 
         val kmongoDsl = and(Person::name.eq(person.name), Person::age.eq(person.age))
         assertEquals(expected, kmongoDsl.document)
+
+        val bsonWithNull = and(eq(Person::name, person.name), eq(Person::age, person.age), null)
+        assertEquals(expected, bsonWithNull.document)
+
+        val kmongoDslWithNull = and(Person::name.eq(person.name), Person::age.eq(person.age), null)
+        assertEquals(expected, kmongoDslWithNull.document)
     }
 
     @Test


### PR DESCRIPTION
Fixes the behavior of `Filters.and` and `Filters.or`, which both accept nullable `Bson` values, but a filter that actually contains a null value throws a `NullpointerException` in `toBsonDocument`.
This PR filters the null values before passing them to `AndFilter`/`OrFilter`.