### PR TITLE
JAVA-5788 Improve ByteBufferBsonOutput::writeCharacters

### DIFF
--- a/bson/src/main/org/bson/ByteBuf.java
+++ b/bson/src/main/org/bson/ByteBuf.java
@@ -126,6 +126,13 @@ public interface ByteBuf  {
     ByteBuf flip();
 
     /**
+     * States whether this buffer is backed by an accessible byte array.
+     *
+     * @return {@code true} if, and only if, this buffer is backed by an array and is not read-only
+     */
+    boolean hasArray();
+
+    /**
      * <p>Returns the byte array that backs this buffer <em>(optional operation)</em>.</p>
      *
      * <p>Modifications to this buffer's content will cause the returned array's content to be modified, and vice versa.</p>

--- a/bson/src/main/org/bson/ByteBufNIO.java
+++ b/bson/src/main/org/bson/ByteBufNIO.java
@@ -104,6 +104,11 @@ public class ByteBufNIO implements ByteBuf {
     }
 
     @Override
+    public boolean hasArray() {
+        return buf.hasArray();
+    }
+
+    @Override
     public byte[] array() {
         return buf.array();
     }

--- a/bson/src/main/org/bson/io/OutputBuffer.java
+++ b/bson/src/main/org/bson/io/OutputBuffer.java
@@ -196,11 +196,15 @@ public abstract class OutputBuffer extends OutputStream implements BsonOutput {
         writeInt64(value);
     }
 
-    private int writeCharacters(final String str, final boolean checkForNullCharacters) {
+    protected int writeCharacters(final String str, final boolean checkForNullCharacters) {
+        return writeCharacters(str, 0, checkForNullCharacters);
+    }
+
+    protected final int writeCharacters(final String str, int start, final boolean checkForNullCharacters) {
         int len = str.length();
         int total = 0;
 
-        for (int i = 0; i < len;) {
+        for (int i = start; i < len;) {
             int c = Character.codePointAt(str, i);
 
             if (checkForNullCharacters && c == 0x0) {

--- a/driver-core/src/main/com/mongodb/internal/connection/CompositeByteBuf.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CompositeByteBuf.java
@@ -209,6 +209,11 @@ class CompositeByteBuf implements ByteBuf {
     }
 
     @Override
+    public boolean hasArray() {
+        return false;
+    }
+
+    @Override
     public byte[] array() {
         throw new UnsupportedOperationException("Not implemented yet!");
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/netty/NettyByteBuf.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/netty/NettyByteBuf.java
@@ -95,6 +95,10 @@ public final class NettyByteBuf implements ByteBuf {
         return this;
     }
 
+    public boolean hasArray() {
+        return proxied.hasArray();
+    }
+
     @Override
     public byte[] array() {
         return proxied.array();


### PR DESCRIPTION
Fixes [JAVA-5788](https://jira.mongodb.org/browse/JAVA-5788)

While running few benchmarks vs https://github.com/quarkusio/quarkus-super-heroes/blob/main/README.md using native image (graal CE) we found

![image](https://github.com/user-attachments/assets/81f6fd28-b5e3-4446-a561-e063962a45c0)

`writeCharacters` heap-based code path to be bloated by:
- many not inlined calls: which Graal CE should be blamed since it has a very simple and naive inliner
- an excessive usage of logic to handle the current buffer to be used to write chars into
- zero loop unrolling due to the complexity of the main loop; since native image cannot profile branches cannot "shape" the assembly to grant latin to be a fast path

This patch is manually inlining the fast paths for both latin chars and heap buffers, assuming them to have enough available space.
This should help immensely JVM mode as well (i.e. JDK Hotspot) - so if there's any JMH bench I can re-use or run to verify it would be great.

NOTE: i could change the assumption which make the optimization to be triggered to be more "elastic" and use the heap buffers (byte[]) remaining capacity and perform checkpoints to refill it, too, but it would make the logic way more complex - still more elastic. 
Let me know what you prefer :pray: 


