### PR TITLE
JAVA-5791 Sync `non-lb-connection-establishment`

### DIFF
--- a/driver-core/src/test/resources/unified-test-format/load-balancers/non-lb-connection-establishment.json
+++ b/driver-core/src/test/resources/unified-test-format/load-balancers/non-lb-connection-establishment.json
@@ -57,6 +57,19 @@
   "tests": [
     {
       "description": "operations against non-load balanced clusters fail if URI contains loadBalanced=true",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.0.99",
+          "topologies": [
+            "single"
+          ]
+        },
+        {
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",


### PR DESCRIPTION
Sync `non-lb-connection-establishment` test to https://github.com/mongodb/specifications/commit/d05c33e0a6124ee7d1a9de665084d540b2ff06c5

Intended to proactively avoid tests failure once drivers start testing 8.1 builds. See DRIVERS-3108. Drivers are not-yet testing 8.1 (see [slack](https://mongodb.slack.com/archives/C72LB5RPV/p1739884710850709)).

JAVA-5791
