### PR TITLE
Split atlas-deployed-task-group across multiple hosts

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -1941,6 +1941,7 @@ axes:
 
 task_groups:
   - name: "atlas-deployed-task-group"
+    max_hosts: -1
     setup_group:
       - func: fetch source
       - func: prepare resources


### PR DESCRIPTION
Fix [for](https://evergreen.mongodb.com/task_log_raw/mongo_java_driver_atlas_search_variant_aws_lambda_deployed_task_patch_b0e19bcd1e3407a17c6f16cc3f6e7c5110abed6e_67c70d3ed5d35a0007293fc8_25_03_04_14_25_03/0?type=T#L1970):

```
[2025/03/04 06:02:47.725] .evergreen/run-deployed-lambda-aws-tests.sh: line 13: /.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh: No such file or directory
[2025/03/04 06:02:47.725] Command 'subprocess.exec' (step 2 of 2) failed: process encountered problem: exit code 1.
[2025/03/04 06:02:47.725] Finished command 'subprocess.exec' (step 2 of 2) in 21.486419677s.
[2025/03/04 06:02:47.725] Running task commands failed: running command: command failed: process encountered problem: exit code 1
```