### PR TITLE
Fix driver-lambda evg failure

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -1942,6 +1942,8 @@ axes:
 task_groups:
   - name: "atlas-deployed-task-group"
     max_hosts: -1
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
     setup_group:
       - func: fetch source
       - func: prepare resources
@@ -1965,8 +1967,6 @@ task_groups:
           add_expansions_to_env: true
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
-    setup_group_can_fail_task: true
-    setup_group_timeout_secs: 1800
     tasks:
       - "atlas-search-index-management-task"
       - "aws-lambda-deployed-task"

--- a/driver-lambda/template.yaml
+++ b/driver-lambda/template.yaml
@@ -37,26 +37,6 @@ Resources:
           Properties:
             Path: /mongodb
             Method: get
-  ApplicationResourceGroup:
-    Type: AWS::ResourceGroups::Group
-    Properties:
-      Name:
-        Fn::Join:
-          - ''
-          - - ApplicationInsights-SAM-
-            - Ref: AWS::StackName
-      ResourceQuery:
-        Type: CLOUDFORMATION_STACK_1_0
-  ApplicationInsightsMonitoring:
-    Type: AWS::ApplicationInsights::Application
-    Properties:
-      ResourceGroupName:
-        Fn::Join:
-          - ''
-          - - ApplicationInsights-SAM-
-            - Ref: AWS::StackName
-      AutoConfigurationEnabled: true
-    DependsOn: ApplicationResourceGroup
 Outputs:
   LambdaTestApi:
     Description: API Gateway endpoint URL for Prod stage for Lambda Test function


### PR DESCRIPTION
Fixes:

```
[2025/03/05 08:41:23.652] Error: Failed to create/update the stack: dbx-java-lambda-00d14e44d1ccd960, Waiter StackCreateComplete failed: Waiter encountered a terminal failure state: For expression "Stacks[].StackStatus" we matched expected path: "ROLLBACK_COMPLETE" at least once
```

Passes on evergreen [here](https://spruce.mongodb.com/version/67c872b11fdb9c000613253f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

This follows [the fix implemented in C# here](https://github.com/mongodb/mongo-csharp-driver/pull/1606#discussion_r1939981182).