### PR TITLE
Support placeholder values in BsonReader and BsonWriter

### DIFF
--- a/bson/src/main/org/bson/AbstractBsonReader.java
+++ b/bson/src/main/org/bson/AbstractBsonReader.java
@@ -265,6 +265,8 @@ public abstract class AbstractBsonReader implements BsonReader {
      */
     protected abstract void doReadUndefined();
 
+    protected abstract BsonPlaceholder doReadPlaceholder();
+
     /**
      * Handles any logic required to skip the name (reader must be positioned on a name).
      */
@@ -480,6 +482,13 @@ public abstract class AbstractBsonReader implements BsonReader {
     }
 
     @Override
+    public void readPlaceholder() {
+        checkPreconditions("readPlaceholder", BsonType.PLACEHOLDER);
+        setState(getNextState());
+        doReadPlaceholder();
+    }
+
+    @Override
     public void skipName() {
         if (isClosed()) {
             throw new IllegalStateException("This instance has been closed");
@@ -636,6 +645,12 @@ public abstract class AbstractBsonReader implements BsonReader {
     public void readUndefined(final String name) {
         verifyName(name);
         readUndefined();
+    }
+
+    @Override
+    public void readPlaceholder(final String name) {
+        verifyName(name);
+        readPlaceholder();
     }
 
     /**

--- a/bson/src/main/org/bson/AbstractBsonWriter.java
+++ b/bson/src/main/org/bson/AbstractBsonWriter.java
@@ -266,6 +266,11 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
      */
     protected abstract void doWriteUndefined();
 
+    /**
+     * Handles the logic of writing a placeholder  value
+     */
+    protected abstract void doWritePlaceholder();
+
     @Override
     public void writeStartDocument(final String name) {
         writeName(name);
@@ -649,6 +654,19 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
     }
 
     @Override
+    public void writePlaceholder() {
+        checkPreconditions("writeUndefined", State.VALUE);
+        doWritePlaceholder();
+        setState(getNextState());
+    }
+
+    @Override
+    public void writePlaceholder(String name) {
+        writeName(name);
+        writePlaceholder();
+    }
+
+    @Override
     public void writeUndefined() {
         checkPreconditions("writeUndefined", State.VALUE);
         doWriteUndefined();
@@ -896,6 +914,10 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
                 reader.readMaxKey();
                 writeMaxKey();
                 break;
+            case PLACEHOLDER:
+                reader.readPlaceholder();
+                writePlaceholder();
+                break;
             default:
                 throw new IllegalArgumentException("unhandled BSON type: " + reader.getCurrentBsonType());
         }
@@ -1000,6 +1022,9 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
                 break;
             case MAX_KEY:
                 writeMaxKey();
+                break;
+            case PLACEHOLDER:
+                writePlaceholder();
                 break;
             default:
                 throw new IllegalArgumentException("unhandled BSON type: " + value.getBsonType());

--- a/bson/src/main/org/bson/BSONCallbackAdapter.java
+++ b/bson/src/main/org/bson/BSONCallbackAdapter.java
@@ -193,6 +193,11 @@ class BSONCallbackAdapter extends AbstractBsonWriter {
     }
 
     @Override
+    public void doWritePlaceholder() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected Context getContext() {
         return (Context) super.getContext();
     }

--- a/bson/src/main/org/bson/BsonBinaryReader.java
+++ b/bson/src/main/org/bson/BsonBinaryReader.java
@@ -260,6 +260,11 @@ public class BsonBinaryReader extends AbstractBsonReader {
     }
 
     @Override
+    protected BsonPlaceholder doReadPlaceholder() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void doReadStartArray() {
         int startPosition = bsonInput.getPosition(); // position of size field
         int size = readSize();

--- a/bson/src/main/org/bson/BsonBinaryWriter.java
+++ b/bson/src/main/org/bson/BsonBinaryWriter.java
@@ -298,6 +298,11 @@ public class BsonBinaryWriter extends AbstractBsonWriter {
     }
 
     @Override
+    public void doWritePlaceholder() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void pipe(final BsonReader reader) {
         notNull("reader", reader);
         pipeDocument(reader, null);

--- a/bson/src/main/org/bson/BsonDocumentReader.java
+++ b/bson/src/main/org/bson/BsonDocumentReader.java
@@ -186,6 +186,11 @@ public class BsonDocumentReader extends AbstractBsonReader {
     }
 
     @Override
+    protected BsonPlaceholder doReadPlaceholder() {
+        return currentValue.asPlaceholder();
+    }
+
+    @Override
     protected void doSkipName() {
     }
 

--- a/bson/src/main/org/bson/BsonDocumentWriter.java
+++ b/bson/src/main/org/bson/BsonDocumentWriter.java
@@ -195,6 +195,11 @@ public class BsonDocumentWriter extends AbstractBsonWriter {
     }
 
     @Override
+    protected void doWritePlaceholder() {
+        write(new BsonPlaceholder());
+    }
+
+    @Override
     protected Context getContext() {
         return (Context) super.getContext();
     }

--- a/bson/src/main/org/bson/BsonPlaceholder.java
+++ b/bson/src/main/org/bson/BsonPlaceholder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008 - 2013 10gen, Inc. <http://10gen.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.bson;
+
+public final class BsonPlaceholder extends BsonValue {
+    @Override
+    public BsonType getBsonType() {
+        return BsonType.PLACEHOLDER;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+}

--- a/bson/src/main/org/bson/BsonReader.java
+++ b/bson/src/main/org/bson/BsonReader.java
@@ -373,6 +373,18 @@ public interface BsonReader extends Closeable {
     void readUndefined(String name);
 
     /**
+     * Reads a placeholder from the reader.
+     */
+    void readPlaceholder();
+
+    /**
+     * Reads a placeholder element from the reader.
+     *
+     * @param name The name of the element.
+     */
+    void readPlaceholder(String name);
+
+    /**
      * Skips the name (reader must be positioned on a name).
      */
     void skipName();

--- a/bson/src/main/org/bson/BsonType.java
+++ b/bson/src/main/org/bson/BsonType.java
@@ -112,7 +112,11 @@ public enum BsonType {
     /**
      * A BSON MaxKey value.
      */
-    MAX_KEY(0x7f);
+    MAX_KEY(0x7f),
+
+    // This seems problematic, but is necessary to get everything else to work
+    // Using a value larger than a byte to avoid conflicting with future BSON types
+    PLACEHOLDER(0x80);
 
     private static final BsonType[] LOOKUP_TABLE = new BsonType[MIN_KEY.getValue() + 1];
 

--- a/bson/src/main/org/bson/BsonValue.java
+++ b/bson/src/main/org/bson/BsonValue.java
@@ -405,6 +405,10 @@ public abstract class BsonValue {
         return this instanceof BsonJavaScript;
     }
 
+    public boolean isPlaceholder() {
+        return this instanceof BsonPlaceholder;
+    }
+
     /**
      * Returns true if this is a BsonJavaScriptWithScope, false otherwise.
      *
@@ -419,5 +423,10 @@ public abstract class BsonValue {
             throw new BsonInvalidOperationException(format("Value expected to be of type %s is of unexpected type %s",
                                                            expectedType, getBsonType()));
         }
+    }
+
+    public BsonPlaceholder asPlaceholder() {
+        throwIfInvalidType(BsonType.PLACEHOLDER);
+        return (BsonPlaceholder) this;
     }
 }

--- a/bson/src/main/org/bson/BsonWriter.java
+++ b/bson/src/main/org/bson/BsonWriter.java
@@ -351,6 +351,24 @@ public interface BsonWriter {
     void writeUndefined(String name);
 
     /**
+     * Writes a placeholder element to the writer.
+     * <p>
+     *     Not all implememntations support placeholders
+     * </p>
+     */
+    void writePlaceholder();
+
+    /**
+     * Writes a placeholder element to the writer.
+     * <p>
+     *     Not all implememntations support placeholders
+     * </p>
+     *
+     * @param name The name of the element.
+     */
+    void writePlaceholder(String name);
+
+    /**
      * Reads a single document from a BsonReader and writes it to this.
      *
      * @param reader The source.

--- a/bson/src/main/org/bson/codecs/BsonPlaceholderCodec.java
+++ b/bson/src/main/org/bson/codecs/BsonPlaceholderCodec.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs;
+
+import org.bson.BsonPlaceholder;
+import org.bson.BsonReader;
+import org.bson.BsonWriter;
+
+/**
+ * @see org.bson.BsonType#PLACEHOLDER
+ * @since ***
+ */
+public class BsonPlaceholderCodec implements Codec<BsonPlaceholder> {
+    @Override
+    public BsonPlaceholder decode(final BsonReader reader, final DecoderContext decoderContext) {
+        reader.readPlaceholder();
+        return new BsonPlaceholder();
+    }
+
+    @Override
+    public void encode(final BsonWriter writer, final BsonPlaceholder value, final EncoderContext encoderContext) {
+        writer.writePlaceholder();
+    }
+
+    @Override
+    public Class<BsonPlaceholder> getEncoderClass() {
+        return BsonPlaceholder.class;
+    }
+}

--- a/bson/src/main/org/bson/codecs/BsonValueCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/BsonValueCodecProvider.java
@@ -33,6 +33,7 @@ import org.bson.BsonMaxKey;
 import org.bson.BsonMinKey;
 import org.bson.BsonNull;
 import org.bson.BsonObjectId;
+import org.bson.BsonPlaceholder;
 import org.bson.BsonRegularExpression;
 import org.bson.BsonString;
 import org.bson.BsonSymbol;
@@ -137,6 +138,7 @@ public class BsonValueCodecProvider implements CodecProvider {
         addCodec(new BsonSymbolCodec());
         addCodec(new BsonTimestampCodec());
         addCodec(new BsonUndefinedCodec());
+        addCodec(new BsonPlaceholderCodec());
     }
 
     private <T extends BsonValue> void addCodec(final Codec<T> codec) {
@@ -167,6 +169,7 @@ public class BsonValueCodecProvider implements CodecProvider {
         map.put(BsonType.SYMBOL, BsonSymbol.class);
         map.put(BsonType.TIMESTAMP, BsonTimestamp.class);
         map.put(BsonType.UNDEFINED, BsonUndefined.class);
+        map.put(BsonType.PLACEHOLDER, BsonPlaceholder.class);
 
         DEFAULT_BSON_TYPE_CLASS_MAP = new BsonTypeClassMap(map);
     }

--- a/bson/src/main/org/bson/json/DefaultPlaceholderConverter.java
+++ b/bson/src/main/org/bson/json/DefaultPlaceholderConverter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2008 - 2013 10gen, Inc. <http://10gen.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.bson.json;
+
+import org.bson.BsonPlaceholder;
+
+public class DefaultPlaceholderConverter implements Converter<BsonPlaceholder>{
+    @Override
+    public void convert(final BsonPlaceholder value, final StrictJsonWriter writer) {
+        writer.writeRaw("?");
+    }
+}

--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -23,6 +23,7 @@ import org.bson.BsonBinarySubType;
 import org.bson.BsonContextType;
 import org.bson.BsonDbPointer;
 import org.bson.BsonInvalidOperationException;
+import org.bson.BsonPlaceholder;
 import org.bson.BsonReaderMark;
 import org.bson.BsonRegularExpression;
 import org.bson.BsonTimestamp;
@@ -250,6 +251,9 @@ public class JsonReader extends AbstractBsonReader {
                     currentValue = visitUUIDConstructor();
                 } else if ("new".equals(value)) {
                     visitNew();
+                } else if ("?".equals(value)) {
+                    setCurrentBsonType(BsonType.PLACEHOLDER);
+                    currentValue = new BsonPlaceholder();
                 } else {
                     noValueFound = true;
                 }
@@ -406,6 +410,11 @@ public class JsonReader extends AbstractBsonReader {
 
     @Override
     protected void doReadUndefined() {
+    }
+
+    @Override
+    protected BsonPlaceholder doReadPlaceholder() {
+        return (BsonPlaceholder) currentValue;
     }
 
     @Override

--- a/bson/src/main/org/bson/json/JsonScanner.java
+++ b/bson/src/main/org/bson/json/JsonScanner.java
@@ -95,7 +95,7 @@ class JsonScanner {
             default:
                 if (c == '-' || Character.isDigit(c)) {
                     return scanNumber((char) c);
-                } else if (c == '$' || c == '_' || Character.isLetter(c)) {
+                } else if (c == '$' || c == '_' || c == '?' || Character.isLetter(c)) {
                     return scanUnquotedString((char) c);
                 } else {
                     int position = buffer.getPosition();

--- a/bson/src/main/org/bson/json/JsonWriter.java
+++ b/bson/src/main/org/bson/json/JsonWriter.java
@@ -20,6 +20,7 @@ import org.bson.AbstractBsonWriter;
 import org.bson.BsonBinary;
 import org.bson.BsonContextType;
 import org.bson.BsonDbPointer;
+import org.bson.BsonPlaceholder;
 import org.bson.BsonRegularExpression;
 import org.bson.BsonTimestamp;
 import org.bson.types.Decimal128;
@@ -223,6 +224,11 @@ public class JsonWriter extends AbstractBsonWriter {
     @Override
     public void doWriteUndefined() {
         settings.getUndefinedConverter().convert(null, strictJsonWriter);
+    }
+
+    @Override
+    protected void doWritePlaceholder() {
+        settings.getPlaceholderConverter().convert(new BsonPlaceholder(), strictJsonWriter);
     }
 
     @Override

--- a/bson/src/main/org/bson/json/JsonWriterSettings.java
+++ b/bson/src/main/org/bson/json/JsonWriterSettings.java
@@ -20,6 +20,7 @@ import org.bson.BsonBinary;
 import org.bson.BsonMaxKey;
 import org.bson.BsonMinKey;
 import org.bson.BsonNull;
+import org.bson.BsonPlaceholder;
 import org.bson.BsonRegularExpression;
 import org.bson.BsonTimestamp;
 import org.bson.BsonUndefined;
@@ -77,6 +78,7 @@ public final class JsonWriterSettings extends BsonWriterSettings {
     private static final LegacyExtendedJsonRegularExpressionConverter LEGACY_EXTENDED_JSON_REGULAR_EXPRESSION_CONVERTER =
             new LegacyExtendedJsonRegularExpressionConverter();
     private static final ShellRegularExpressionConverter SHELL_REGULAR_EXPRESSION_CONVERTER = new ShellRegularExpressionConverter();
+    private static final DefaultPlaceholderConverter DEFAULT_PLACEHOLDER_CONVERTER = new DefaultPlaceholderConverter();
 
     private final boolean indent;
     private final String newLineCharacters;
@@ -100,6 +102,8 @@ public final class JsonWriterSettings extends BsonWriterSettings {
     private final Converter<BsonMinKey> minKeyConverter;
     private final Converter<BsonMaxKey> maxKeyConverter;
     private final Converter<String> javaScriptConverter;
+    private final Converter<BsonPlaceholder> placeholderConverter;
+
 
     /**
      * Create a builder for JsonWriterSettings, which are immutable.
@@ -259,6 +263,12 @@ public final class JsonWriterSettings extends BsonWriterSettings {
             regularExpressionConverter = LEGACY_EXTENDED_JSON_REGULAR_EXPRESSION_CONVERTER;
         } else {
             regularExpressionConverter = SHELL_REGULAR_EXPRESSION_CONVERTER;
+        }
+
+        if (builder.placeholderConverter != null) {
+            placeholderConverter = builder.placeholderConverter;
+        } else {
+            placeholderConverter = DEFAULT_PLACEHOLDER_CONVERTER;
         }
     }
 
@@ -480,6 +490,17 @@ public final class JsonWriterSettings extends BsonWriterSettings {
     }
 
     /**
+     * A converter from placeholder values to JSON.
+     *
+     * @return this
+     * @since ***
+     */
+    public Converter<BsonPlaceholder> getPlaceholderConverter() {
+        return placeholderConverter;
+    }
+
+
+    /**
      * A builder for JsonWriterSettings
      *
      * @since 3.5
@@ -507,6 +528,7 @@ public final class JsonWriterSettings extends BsonWriterSettings {
         private Converter<BsonMinKey> minKeyConverter;
         private Converter<BsonMaxKey> maxKeyConverter;
         private Converter<String> javaScriptConverter;
+        private Converter<BsonPlaceholder> placeholderConverter;
 
         /**
          * Build a JsonWriterSettings instance.
@@ -761,6 +783,17 @@ public final class JsonWriterSettings extends BsonWriterSettings {
          * @return this
          */
         public Builder javaScriptConverter(final Converter<String> javaScriptConverter) {
+            this.javaScriptConverter = javaScriptConverter;
+            return this;
+        }
+
+        /**
+         * Sets the converter from placeholder values to JSON.
+         *
+         * @param placeholderConverter the converter
+         * @return this
+         */
+        public Builder placeholderConverter(final Converter<String> placeholderConverter) {
             this.javaScriptConverter = javaScriptConverter;
             return this;
         }

--- a/bson/src/test/unit/org/bson/BsonHelper.java
+++ b/bson/src/test/unit/org/bson/BsonHelper.java
@@ -56,6 +56,7 @@ public final class BsonHelper {
                 new BsonSymbol("ruby stuff"),
                 new BsonTimestamp(0x12345678, 5),
                 new BsonUndefined(),
+                new BsonPlaceholder(),
                 new BsonBinary((byte) 80, new byte[]{5, 4, 3, 2, 1}),
                 new BsonArray(asList(
                         new BsonInt32(1),

--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -1270,6 +1270,17 @@ public class JsonReaderTest {
     }
 
     @Test
+    public void testPlaceholder() {
+        String json = "?";
+        testStringAndStream(json, bsonReader -> {
+            assertEquals(BsonType.PLACEHOLDER, bsonReader.readBsonType());
+            bsonReader.readPlaceholder();
+            assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+            return null;
+        });
+    }
+
+    @Test
     public void testMultipleMarks() {
         String json = "{a : { b : 1 }}";
         testStringAndStream(json, bsonReader -> {

--- a/bson/src/test/unit/org/bson/json/JsonWriterTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonWriterTest.java
@@ -665,4 +665,13 @@ public class JsonWriterTest {
         String expected = "{\"dbPointer\": {\"$ref\": \"my.test\", \"$id\": {\"$oid\": \"4d0ce088e447ad08b4721a37\"}}}";
         assertEquals(expected, stringWriter.toString());
     }
+
+    @Test
+    public void testPlaceholder() {
+        writer.writeStartDocument();
+        writer.writePlaceholder("p");
+        writer.writeEndDocument();
+        String expected = "{\"p\": ?}";
+        assertEquals(expected, stringWriter.toString());
+    }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/BsonWriterDecorator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BsonWriterDecorator.java
@@ -262,6 +262,16 @@ public class BsonWriterDecorator implements BsonWriter {
     }
 
     @Override
+    public void writePlaceholder() {
+        bsonWriter.writePlaceholder();
+    }
+
+    @Override
+    public void writePlaceholder(final String name) {
+        bsonWriter.writePlaceholder(name);
+    }
+
+    @Override
     public void writeUndefined() {
         bsonWriter.writeUndefined();
     }


### PR DESCRIPTION
This is an attempt to add support for placeholder values in JSON, so that our Hibernate dialect can support native queries like

```
{ 
   aggregate: "book",
   pipeline: [
       {
          $match: {
              title: ?
          }
       }
   ]
}
```
instead of the less intuitive: 

```
{ 
   aggregate: "book",
   pipeline: [
       {
          $match: {
              title: {$undefined: true}
           }
       }
   ]
}
```

It could also be used for non-native queries, but it's less important there.  It would be more to make the query logs look more sensible, i.e.

```
DEBUG o.h.p.entity.AbstractEntityPersister -  Insert (0): {"insert": "books", "documents": [{"author": ?, "publishYear": ?, "title": ?, "_id": ?}]}
DEBUG o.h.p.entity.AbstractEntityPersister -  Update (0): {"update": "books", "updates": [{"q": {"_id": {"$eq": ?}}, "u": {"$set": {"author": ?, "publishYear": ?, "title": ?}}, "multi": true}]}
DEBUG o.h.p.entity.AbstractEntityPersister -  Delete (0): {"delete": "books", "deletes": [{"q": {"_id": {"$eq": ?}}, "limit": {"$numberInt": "0"}}]}
```

instead of 

```
DEBUG o.h.p.entity.AbstractEntityPersister -  Insert (0): {"insert": "books", "documents": [{"authorFirstName": {"$undefined": true}, "authorLastName": {"$undefined": true}, "publishYear": {"$undefined": true}, "title": {"$undefined": true}, "_id": {"$undefined": true}}]}
DEBUG o.h.p.entity.AbstractEntityPersister -  Update (0): {"update": "books", "updates": [{"q": {"_id": {"$eq": {"$undefined": true}}}, "u": {"$set": {"authorFirstName": {"$undefined": true}, "authorLastName": {"$undefined": true}, "publishYear": {"$undefined": true}, "title": {"$undefined": true}}}, "multi": true}]}
DEBUG o.h.p.entity.AbstractEntityPersister -  Delete (0): {"delete": "books", "deletes": [{"q": {"_id": {"$eq": {"$undefined": true}}}, "limit": {"$numberInt": "0"}}]}
```

The problem is that in order to fit in the BsonReader/BsonWriter framework, the change is quite invasive, including

* Adding `writePlaceholder` methods to `BsonWriter`
* Adding `readPlaceholder` methods to `BsonReader`
* Adding a `BsonPlaceholder` subclass to `BsonValue`
* Adding a `PLACEHOLDER` value to the `BsonType` enum
* Adding a `BsonPlaceholderCodec`
* Added `asPlaceholder` and `isPlaceholder` to `BsonValue`
* Adding `doWritePlaceholder` method to `AbstractBsonWriter` and subclasses, including one in `BsonBinaryWriter` that necessarily throws `UnsupportedOperationException` since placeholder is not a real BSON type
* Adding `doReadPlaceholder` method to `AbstractBsonReader` and subclasses, including one in `BsonBinaryReader` that necessarily throws `UnsupportedOperationException` since placeholder is not a real BSON type

It would be hard to justify all these changes, but I thought it would be interesting for people to look at.