### PR TITLE
Fix warnings

### DIFF
--- a/driver-scala/build.gradle.kts
+++ b/driver-scala/build.gradle.kts
@@ -26,6 +26,7 @@ val scalaVersion: String = project.scalaVersion()
 dependencies {
     api(project(path = ":bson-scala", configuration = "default"))
     api(project(path = ":driver-reactive-streams", configuration = "default"))
+    compileOnly(libs.findbugs.jsr)
 
     testImplementation(project(path = ":driver-sync", configuration = "default"))
     testImplementation(project(path = ":bson", configuration = "testArtifacts"))


### PR DESCRIPTION
`[Warn] : While parsing annotations in .../mongo-java-driver/driver-core/build/libs/mongodb-driver-core-5.5.0-SNAPSHOT.jar(com/mongodb/lang/Nullable.class), could not find MAYBE in enum <none>.
This is likely due to an implementation restriction: an annotation argument cannot refer to a member of the annotated class (scala/bug#7014).`