### PR TITLE
Add Kotlin Extensions to BOM

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
         api(project(":bson-kotlinx"))
         api(project(":driver-kotlin-coroutine"))
         api(project(":driver-kotlin-sync"))
+        api(project(":driver-kotlin-extensions"))
 
         api(project(":bson-scala"))
         api(project(":driver-scala"))


### PR DESCRIPTION
Snapshot build POM:
https://oss.sonatype.org/content/repositories/snapshots/org/mongodb/mongodb-driver-bom/5.5.0-SNAPSHOT/mongodb-driver-bom-5.5.0-20250331.210512-14.pom

JAVA-5825