### PR TITLE
Optimize BsonArray Index encoding

### DIFF
--- a/bson/src/test/unit/org/bson/BsonBinaryWriterTest.java
+++ b/bson/src/test/unit/org/bson/BsonBinaryWriterTest.java
@@ -66,7 +66,7 @@ public class BsonBinaryWriterTest {
             writer.writeEndDocument();
             fail();
         } catch (BsonMaximumSizeExceededException e) {
-            assertEquals("Document size of 1037 is larger than maximum of 1024.", e.getMessage());
+            assertEquals("Document size of 12917 is larger than maximum of 12904.", e.getMessage());
         }
     }
 

--- a/bson/src/test/unit/org/bson/BsonBinaryWriterTest.java
+++ b/bson/src/test/unit/org/bson/BsonBinaryWriterTest.java
@@ -201,16 +201,16 @@ public class BsonBinaryWriterTest {
     public void testWriteArrayElements() throws IOException {
         ByteArrayOutputStream expectedOutput = new ByteArrayOutputStream();
         expectedOutput.write(new byte[]{
-                88, 11, 0, 0, //document length
+                -52, 25, 0, 0, //document length
                 4, // array type
                 97, 49, 0, // "a1" name + null terminator
-                79, 11, 0, 0}); // array length
+                -61, 25, 0, 0}); // array length
 
 
         writer.writeStartDocument();
         writer.writeStartArray("a1");
         int arrayIndex = 0;
-        while (arrayIndex < 500) {
+        while (arrayIndex < 1100) {
             writer.writeBoolean(true);
 
             expectedOutput.write(BsonType.BOOLEAN.getValue());


### PR DESCRIPTION
Instead of caching precomputed `String` values, we now cache their corresponding **byte[] representations**. This avoids repeated ASCII string decoding. 

The single contiguous buffer approach provides better cache locality in loops, reduced memory overhead and better performance. 

The array index caching implementation consumes approximately `12 KB of memory in total`:
```
ARRAY_INDEXES_BUFFER: ~3,890 bytes
Numbers 0-9: 10 × (1 byte + null terminator) = 20 bytes
Numbers 10-99: 90 × (2 byte + null terminator) = 270 bytes
Numbers 100-999: 900 × (3 bytes + null terminator) = 3,600 bytes
```

```
ARRAY_INDEXES_OFFSETS: 4,000 bytes
1,000 integers × 4 bytes per int = 4,000 bytes
```

```
ARRAY_INDEXES_LENGTHS: 4,000 bytes
1,000 integers × 4 bytes per int = 4,000 bytes
```

`Array object headers: ~48 bytes`



BsonArrayCodecBenchmark results:


| Metric                        | Before        | After         | Change       |
|------------------------------|---------------|---------------|--------------|
| ops/s                        | 13583.483     | 20046.810     | **+47.5%** |

JAVA-5836