### PR TITLE
Enhance buffer handling to reduce direct list access.

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/ByteBufferBsonOutput.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ByteBufferBsonOutput.java
@@ -43,6 +43,7 @@ public class ByteBufferBsonOutput extends OutputBuffer {
     private int curBufferIndex = 0;
     private int position = 0;
     private boolean closed;
+    private ByteBuf currentByteBuffer;
 
     /**
      * Construct an instance that uses the given buffer provider to allocate byte buffers as needs as it grows.
@@ -91,13 +92,15 @@ public class ByteBufferBsonOutput extends OutputBuffer {
     }
 
     private ByteBuf getCurrentByteBuffer() {
-        ByteBuf curByteBuffer = getByteBufferAtIndex(curBufferIndex);
-        if (curByteBuffer.hasRemaining()) {
-            return curByteBuffer;
+        if (currentByteBuffer == null) {
+            currentByteBuffer = getByteBufferAtIndex(curBufferIndex);
+        }
+        if (currentByteBuffer.hasRemaining()) {
+            return currentByteBuffer;
         }
 
-        curBufferIndex++;
-        return getByteBufferAtIndex(curBufferIndex);
+        currentByteBuffer = getByteBufferAtIndex(++curBufferIndex);
+        return currentByteBuffer;
     }
 
     private ByteBuf getByteBufferAtIndex(final int index) {
@@ -181,6 +184,10 @@ public class ByteBufferBsonOutput extends OutputBuffer {
 
         bufferList.get(bufferPositionPair.bufferIndex).position(bufferPositionPair.position);
 
+        if (bufferPositionPair.bufferIndex + 1 < bufferList.size()) {
+            currentByteBuffer = null;
+        }
+
         while (bufferList.size() > bufferPositionPair.bufferIndex + 1) {
             ByteBuf buffer = bufferList.remove(bufferList.size() - 1);
             buffer.release();
@@ -243,10 +250,13 @@ public class ByteBufferBsonOutput extends OutputBuffer {
      */
     private void merge(final ByteBufferBsonOutput branch) {
         assertTrue(branch instanceof ByteBufferBsonOutput.Branch);
-        branch.bufferList.forEach(ByteBuf::retain);
+        for (ByteBuf byteBuf : branch.bufferList) {
+            byteBuf.retain();
+        }
         bufferList.addAll(branch.bufferList);
         curBufferIndex += branch.curBufferIndex + 1;
         position += branch.position;
+        currentByteBuffer = null;
     }
 
     public static final class Branch extends ByteBufferBsonOutput {

--- a/driver-core/src/main/com/mongodb/internal/connection/ByteBufferBsonOutput.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ByteBufferBsonOutput.java
@@ -99,7 +99,8 @@ public class ByteBufferBsonOutput extends OutputBuffer {
             return currentByteBuffer;
         }
 
-        currentByteBuffer = getByteBufferAtIndex(++curBufferIndex);
+        curBufferIndex++;
+        currentByteBuffer = getByteBufferAtIndex(curBufferIndex);
         return currentByteBuffer;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/ByteBufferBsonOutput.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ByteBufferBsonOutput.java
@@ -250,9 +250,7 @@ public class ByteBufferBsonOutput extends OutputBuffer {
      */
     private void merge(final ByteBufferBsonOutput branch) {
         assertTrue(branch instanceof ByteBufferBsonOutput.Branch);
-        for (ByteBuf byteBuf : branch.bufferList) {
-            byteBuf.retain();
-        }
+        branch.bufferList.forEach(ByteBuf::retain);
         bufferList.addAll(branch.bufferList);
         curBufferIndex += branch.curBufferIndex + 1;
         position += branch.position;

--- a/driver-core/src/main/com/mongodb/internal/connection/ByteBufferBsonOutput.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ByteBufferBsonOutput.java
@@ -294,6 +294,7 @@ public class ByteBufferBsonOutput extends OutputBuffer {
             for (final ByteBuf cur : bufferList) {
                 cur.release();
             }
+            currentByteBuffer = null;
             bufferList.clear();
             closed = true;
         }


### PR DESCRIPTION
## Summary
The PR improves buffer handling by introducing a `currentByteBuffer` field to cache the current `ByteBuf`, reducing direct list access which is costly because of bounds checking. Additionally, caching `currentByteBuffer` helps with JIT (Just-In-Time) inlining based on compilation profiling. By making the buffer access more predictable and, the JIT compiler can better inline the `getCurrentByteBuffer` method, leading to improved runtime performance.


Test Name | Base Mean | Compare Mean | Perf Diff Percent | Z-Score
-- | -- | -- | -- | --
Deep BSON Encoding | 62.2417 | 71.5916 | 15.02% | 6.7074
Flat BSON Encoding | 133.9693 | 172.8321 | 29.01% | 10.3677
Full BSON Encoding | 139.8435 | 172.5080 | 23.36% | 20.1526
Large doc Client BulkWrite insert | 56.1605 | 62.9421 | 13.57% | 12.0393
Large doc Collection BulkWrite insert | 62.0188 | 72.3853 | 16.71% | 17.0376
Large doc bulk insert | 60.6105 | 70.3881 | 16.13% | 15.0138
Large doc insertOne | 63.2810 | 73.0264 | 15.40% | 11.1243



Perf analyzer results: [Link](https://performance-analyzer.server-tig.prod.corp.mongodb.com/perf-analyzer-viz/?comparison_id=67fca2e92cfb6af8afd08492&selected_tab=data-table&determination_filter=Improved&percent_filter=0%7C%7C100&z_filter=0%7C%7C10&filter_type=Default)

[JAVA-5846](https://jira.mongodb.org/browse/JAVA-5846)