### PR TITLE
JAVA-5829: Add $concatArrays and $setUnion accumulators

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Pull Requests
 Pull requests should generally be made against the master (default) branch and include relevant tests, if applicable. 
 
 Code should compile with the Java 9 compiler and tests should pass under all Java versions which the driver currently
-supports. Currently the Java driver supports a minimum version of Java 8.  Please run './gradlew test' to confirm.   By default, running the
+supports. Currently the Java driver supports a minimum version of Java 8.  Please run `./gradlew test` to confirm.   By default, running the
 tests requires that you start a mongod server on localhost, listening on the default port and configured to run with
 [`enableTestCommands`](https://www.mongodb.com/docs/manual/reference/parameters/#param.enableTestCommands), which may be set with the 
 `--setParameter enableTestCommands=1` command-line parameter.   At minimum, please test against the latest release version of the MongoDB 

--- a/driver-core/src/main/com/mongodb/client/model/Accumulators.java
+++ b/driver-core/src/main/com/mongodb/client/model/Accumulators.java
@@ -364,6 +364,35 @@ public final class Accumulators {
         return accumulatorOperator("$addToSet", fieldName, expression);
     }
 
+    /**
+     * Gets a field name for a $group operation that concatenates arrays from the given expressions into a single array.
+     *
+     * @param fieldName  the field name for the concatenated array
+     * @param expressions the list of array expressions to concatenate
+     * @param <TExpression> the expression type
+     * @return the field
+     * @mongodb.driver.manual reference/operator/aggregation/concatArrays/ $concatArrays
+     * @mongodb.server.release 8.1
+     * @since 5.4
+     */
+    public static <TExpression> BsonField concatArrays(final String fieldName, final List<TExpression> expressions) {
+        return accumulatorOperator("$concatArrays", fieldName, expressions);
+    }
+
+    /**
+     * Gets a field name for a $group operation that computes the union of arrays from the given expressions, removing duplicates.
+     *
+     * @param fieldName  the field name for the union array
+     * @param expressions the list of array expressions to union
+     * @param <TExpression> the expression type
+     * @return the field
+     * @mongodb.driver.manual reference/operator/aggregation/setUnion/ $setUnion
+     * @mongodb.server.release 8.1
+     * @since 5.4
+     */
+    public static <TExpression> BsonField setUnion(final String fieldName, final List<TExpression> expressions) {
+        return accumulatorOperator("$setUnion", fieldName, expressions);
+    }
 
     /**
      * Gets a field name for a $group operation representing the result of merging the fields of the documents.

--- a/driver-kotlin-extensions/src/main/kotlin/com/mongodb/kotlin/client/model/Accumulators.kt
+++ b/driver-kotlin-extensions/src/main/kotlin/com/mongodb/kotlin/client/model/Accumulators.kt
@@ -322,6 +322,34 @@ public object Accumulators {
         Accumulators.addToSet(property.path(), expression)
 
     /**
+     * Gets a field name for a $group operation that concatenates arrays from the given expressions into a single array.
+     *
+     * @param property The data class property computed by the accumulator
+     * @param expressions The list of array expressions to concatenate
+     * @param <TExpression> The expression type
+     * @return The field
+     * @mongodb.driver.manual reference/operator/aggregation/concatArrays/ $concatArrays
+     * @mongodb.server.release 8.1
+     * @since 5.4
+     */
+    public fun <TExpression> concatArrays(property: KProperty<*>, expressions: List<TExpression>): BsonField =
+        Accumulators.concatArrays(property.path(), expressions)
+
+    /**
+     * Gets a field name for a $group operation that computes the union of arrays from the given expressions, removing duplicates.
+     *
+     * @param property The data class property computed by the accumulator
+     * @param expressions The list of array expressions to union
+     * @param <TExpression> The expression type
+     * @return The field
+     * @mongodb.driver.manual reference/operator/aggregation/setUnion/ $setUnion
+     * @mongodb.server.release 8.1
+     * @since 5.4
+     */
+    public fun <TExpression> setUnion(property: KProperty<*>, expressions: List<TExpression>): BsonField =
+        Accumulators.setUnion(property.path(), expressions)
+
+    /**
      * Gets a field name for a $group operation representing the result of merging the fields of the documents. If
      * documents to merge include the same field name, the field, in the resulting document, has the value from the last
      * document merged for the field.

--- a/driver-kotlin-extensions/src/test/kotlin/com/mongodb/kotlin/client/model/AggregatesTest.kt
+++ b/driver-kotlin-extensions/src/test/kotlin/com/mongodb/kotlin/client/model/AggregatesTest.kt
@@ -30,6 +30,8 @@ import com.mongodb.client.model.densify.DensifyRange
 import com.mongodb.kotlin.client.MongoCollection
 import com.mongodb.kotlin.client.model.Accumulators.accumulator
 import com.mongodb.kotlin.client.model.Accumulators.addToSet
+import com.mongodb.kotlin.client.model.Accumulators.concatArrays
+import com.mongodb.kotlin.client.model.Accumulators.setUnion
 import com.mongodb.kotlin.client.model.Accumulators.avg
 import com.mongodb.kotlin.client.model.Accumulators.bottom
 import com.mongodb.kotlin.client.model.Accumulators.bottomN
@@ -283,6 +285,16 @@ class AggregatesTest {
         assertEquals(com.mongodb.client.model.Accumulators.push("age", 1), push(Person::age, 1))
 
         assertEquals(com.mongodb.client.model.Accumulators.addToSet("age", 1), addToSet(Person::age, 1))
+
+        assertEquals(
+            com.mongodb.client.model.Accumulators.concatArrays("results", listOf("\$array1", "\$array2")),
+            concatArrays(Person::results, listOf("\$array1", "\$array2"))
+        )
+
+        assertEquals(
+            com.mongodb.client.model.Accumulators.setUnion("results", listOf("\$expression1", "\$expression2")),
+            setUnion(Person::results, listOf("\$expression1", "\$expression2"))
+        )
 
         assertEquals(com.mongodb.client.model.Accumulators.mergeObjects("age", 1), mergeObjects(Person::age, 1))
 


### PR DESCRIPTION
- Added `$concatArrays` and `$setUnion` methods to Accumulators.java for MongoDB 8.1 aggregation pipelines, producing correct BSON for array concatenation and union. 
- Implemented Kotlin extensions in Accumulators.kt, leveraging KProperty for idiomatic usage. 
- Updated AggregatesTest.kt with tests validating query construction. 
- Fixed formatting in CONTRIBUTING.md for clarity.

**Assistance Required**
Integration tests were omitted due to uncertainty about the appropriate test class. If needed to validate server-side behavior, please specify the target class, and I’ll implement them.