### PR TITLE
Fix ByteBufferBsonOutput buffer caching logic.

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/ByteBufferBsonOutput.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ByteBufferBsonOutput.java
@@ -26,7 +26,6 @@ import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.mongodb.assertions.Assertions.assertFalse;
 import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.lang.String.format;

--- a/driver-core/src/main/com/mongodb/internal/connection/ByteBufferBsonOutput.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ByteBufferBsonOutput.java
@@ -176,6 +176,7 @@ public class ByteBufferBsonOutput extends OutputBuffer {
         if (currentByteBuffer == null) {
             currentByteBuffer = getByteBufferAtIndex(curBufferIndex);
         }
+
         if (currentByteBuffer.hasRemaining()) {
             return currentByteBuffer;
         }
@@ -183,11 +184,6 @@ public class ByteBufferBsonOutput extends OutputBuffer {
         curBufferIndex++;
         currentByteBuffer = getByteBufferAtIndex(curBufferIndex);
         return currentByteBuffer;
-    }
-
-    private ByteBuf getNextByteBuffer() {
-        assertFalse(bufferList.get(curBufferIndex).hasRemaining());
-        return getByteBufferAtIndex(++curBufferIndex);
     }
 
     private ByteBuf getByteBufferAtIndex(final int index) {
@@ -459,7 +455,7 @@ public class ByteBufferBsonOutput extends OutputBuffer {
 
             if (c < 0x80) {
                 if (remaining == 0) {
-                    curBuffer = getNextByteBuffer();
+                    curBuffer = getCurrentByteBuffer();
                     curBufferPos = 0;
                     curBufferLimit = curBuffer.limit();
                 }


### PR DESCRIPTION
## Summary
PR #1651 missed changes introduced in PR #1675, leading to incorrect buffer handling in `ByteBufferBsonOutput`.
This PR merges both changes to resolve the issue.

## Changes 
- Replaced `getNextByteBuffer` with `getCurrentByteBuffer` in `writeOnBuffers` to correct buffer state management, because  `getNextByteBuffer` failed to update `currentByteBuffer`, causing encoding errors.

JAVA-5816