### PR TITLE
Added option to configure DEK cache lifetime

### DIFF
--- a/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
+++ b/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
@@ -515,7 +515,7 @@ public final class AutoEncryptionSettings {
      * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently {@code 60000 ms}.
      * Set to {@code 0} to disable key expiration.</p>
      *
-     * @param timeUnit the time unit, which may not be null
+     * @param timeUnit the time unit, which must not be null
      * @return the cache expiration time or null if not set.
      * @since 5.5
      */

--- a/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
+++ b/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
@@ -512,7 +512,7 @@ public final class AutoEncryptionSettings {
     /**
      * Returns the cache expiration time for data encryption keys.
      *
-     * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently {@code 60000}.
+     * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently {@code 60000 ms}.
      * Set to {@code 0} to disable key expiration.</p>
      *
      * @param timeUnit the time unit, which may not be null

--- a/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
+++ b/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
@@ -243,7 +243,7 @@ public final class AutoEncryptionSettings {
 
         /**
          * The cache expiration time for data encryption keys.
-         * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently 60000. Set to 0 to disable key expiration.</p>
+         * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently 60000 ms. Set to 0 to disable key expiration.</p>
          *
          * @param keyExpiration the cache expiration time in milliseconds or null to use libmongocrypt's default.
          * @param timeUnit the time unit

--- a/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
+++ b/driver-core/src/main/com/mongodb/AutoEncryptionSettings.java
@@ -24,8 +24,10 @@ import javax.net.ssl.SSLContext;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static com.mongodb.assertions.Assertions.assertTrue;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.Collections.unmodifiableMap;
 
@@ -73,6 +75,8 @@ public final class AutoEncryptionSettings {
     private final boolean bypassAutoEncryption;
     private final Map<String, BsonDocument> encryptedFieldsMap;
     private final boolean bypassQueryAnalysis;
+    @Nullable
+    private final Long keyExpirationMS;
 
     /**
      * A builder for {@code AutoEncryptionSettings} so that {@code AutoEncryptionSettings} can be immutable, and to support easier
@@ -90,6 +94,7 @@ public final class AutoEncryptionSettings {
         private boolean bypassAutoEncryption;
         private Map<String, BsonDocument> encryptedFieldsMap = Collections.emptyMap();
         private boolean bypassQueryAnalysis;
+        @Nullable private Long keyExpirationMS;
 
         /**
          * Sets the key vault settings.
@@ -233,6 +238,22 @@ public final class AutoEncryptionSettings {
          */
         public Builder bypassQueryAnalysis(final boolean bypassQueryAnalysis) {
             this.bypassQueryAnalysis = bypassQueryAnalysis;
+            return this;
+        }
+
+        /**
+         * The cache expiration time for data encryption keys.
+         * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently 60000. Set to 0 to disable key expiration.</p>
+         *
+         * @param keyExpiration the cache expiration time in milliseconds or null to use libmongocrypt's default.
+         * @param timeUnit the time unit
+         * @return this
+         * @see #getKeyExpiration(TimeUnit)
+         * @since 5.5
+         */
+        public Builder keyExpiration(@Nullable final Long keyExpiration, final TimeUnit timeUnit) {
+            assertTrue(keyExpiration == null || keyExpiration >= 0, "keyExpiration must be >= 0 or null");
+            this.keyExpirationMS = keyExpiration == null ? null : TimeUnit.MILLISECONDS.convert(keyExpiration, timeUnit);
             return this;
         }
 
@@ -488,6 +509,21 @@ public final class AutoEncryptionSettings {
         return bypassQueryAnalysis;
     }
 
+    /**
+     * Returns the cache expiration time for data encryption keys.
+     *
+     * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently {@code 60000}.
+     * Set to {@code 0} to disable key expiration.</p>
+     *
+     * @param timeUnit the time unit, which may not be null
+     * @return the cache expiration time or null if not set.
+     * @since 5.5
+     */
+    @Nullable
+    public Long getKeyExpiration(final TimeUnit timeUnit) {
+        return keyExpirationMS == null ? null : timeUnit.convert(keyExpirationMS, TimeUnit.MILLISECONDS);
+    }
+
     private AutoEncryptionSettings(final Builder builder) {
         this.keyVaultMongoClientSettings = builder.keyVaultMongoClientSettings;
         this.keyVaultNamespace = notNull("keyVaultNamespace", builder.keyVaultNamespace);
@@ -499,6 +535,7 @@ public final class AutoEncryptionSettings {
         this.bypassAutoEncryption = builder.bypassAutoEncryption;
         this.encryptedFieldsMap = builder.encryptedFieldsMap;
         this.bypassQueryAnalysis = builder.bypassQueryAnalysis;
+        this.keyExpirationMS = builder.keyExpirationMS;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/ClientEncryptionSettings.java
+++ b/driver-core/src/main/com/mongodb/ClientEncryptionSettings.java
@@ -333,7 +333,7 @@ public final class ClientEncryptionSettings {
     /**
      * Returns the cache expiration time for data encryption keys.
      *
-     * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently {@code 60000}.
+     * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently {@code 60000 ms}.
      * Set to {@code 0} to disable key expiration.</p>
      *
      * @param timeUnit the time unit, which may not be null

--- a/driver-core/src/main/com/mongodb/ClientEncryptionSettings.java
+++ b/driver-core/src/main/com/mongodb/ClientEncryptionSettings.java
@@ -138,7 +138,7 @@ public final class ClientEncryptionSettings {
 
         /**
          * The cache expiration time for data encryption keys.
-         * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently 60000. Set to 0 to disable key expiration.</p>
+         * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently 60000 ms. Set to 0 to disable key expiration.</p>
          *
          * @param keyExpiration the cache expiration time in milliseconds or null to use libmongocrypt's default.
          * @param timeUnit the time unit

--- a/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
@@ -53,7 +53,8 @@ import static java.util.Collections.singletonList;
 public final class MongoCryptHelper {
 
     public static MongoCryptOptions createMongoCryptOptions(final ClientEncryptionSettings settings) {
-        return createMongoCryptOptions(settings.getKmsProviders(), false, emptyList(), emptyMap(), null, null);
+        return createMongoCryptOptions(settings.getKmsProviders(), false, emptyList(), emptyMap(), null, null,
+                settings.getKeyExpiration(TimeUnit.MILLISECONDS));
     }
 
     public static MongoCryptOptions createMongoCryptOptions(final AutoEncryptionSettings settings) {
@@ -63,7 +64,8 @@ public final class MongoCryptHelper {
                 settings.isBypassAutoEncryption() ? emptyList() :  singletonList("$SYSTEM"),
                 settings.getExtraOptions(),
                 settings.getSchemaMap(),
-                settings.getEncryptedFieldsMap());
+                settings.getEncryptedFieldsMap(),
+                settings.getKeyExpiration(TimeUnit.MILLISECONDS));
     }
 
     public static void validateRewrapManyDataKeyOptions(final RewrapManyDataKeyOptions options) {
@@ -78,7 +80,8 @@ public final class MongoCryptHelper {
             final List<String> searchPaths,
             @Nullable final Map<String, Object> extraOptions,
             @Nullable final Map<String, BsonDocument> localSchemaMap,
-            @Nullable final Map<String, BsonDocument> encryptedFieldsMap) {
+            @Nullable final Map<String, BsonDocument> encryptedFieldsMap,
+            @Nullable final Long keyExpirationMS) {
         MongoCryptOptions.Builder mongoCryptOptionsBuilder = MongoCryptOptions.builder();
         mongoCryptOptionsBuilder.kmsProviderOptions(getKmsProvidersAsBsonDocument(kmsProviders));
         mongoCryptOptionsBuilder.bypassQueryAnalysis(bypassQueryAnalysis);
@@ -87,6 +90,7 @@ public final class MongoCryptHelper {
         mongoCryptOptionsBuilder.localSchemaMap(localSchemaMap);
         mongoCryptOptionsBuilder.encryptedFieldsMap(encryptedFieldsMap);
         mongoCryptOptionsBuilder.needsKmsCredentialsStateEnabled(true);
+        mongoCryptOptionsBuilder.keyExpirationMS(keyExpirationMS);
         return mongoCryptOptionsBuilder.build();
     }
     public static BsonDocument fetchCredentials(final Map<String, Map<String, Object>> kmsProviders,

--- a/driver-core/src/test/functional/com/mongodb/internal/capi/MongoCryptHelperTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/capi/MongoCryptHelperTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.internal.capi.MongoCryptHelper.isMongocryptdSpawningDisabled;
 import static com.mongodb.internal.capi.MongoCryptHelper.validateRewrapManyDataKeyOptions;
@@ -94,6 +95,11 @@ public class MongoCryptHelperTest {
 
         assertMongoCryptOptions(mongoCryptOptionsBuilder.build(), mongoCryptOptions);
 
+        // Ensure can set key expiration
+        autoEncryptionSettingsBuilder.keyExpiration(10L, TimeUnit.SECONDS);
+        mongoCryptOptions = MongoCryptHelper.createMongoCryptOptions(autoEncryptionSettingsBuilder.build());
+        assertMongoCryptOptions(mongoCryptOptionsBuilder.keyExpirationMS(10_000L).build(), mongoCryptOptions);
+
         // Ensure search Paths is empty when bypassAutoEncryption is true
         autoEncryptionSettingsBuilder.bypassAutoEncryption(true);
         mongoCryptOptions = MongoCryptHelper.createMongoCryptOptions(autoEncryptionSettingsBuilder.build());
@@ -143,5 +149,6 @@ public class MongoCryptHelperTest {
         assertEquals(expected.getSearchPaths(), actual.getSearchPaths(), "SearchPaths not equal");
         assertEquals(expected.isBypassQueryAnalysis(), actual.isBypassQueryAnalysis(), "isBypassQueryAnalysis not equal");
         assertEquals(expected.isNeedsKmsCredentialsStateEnabled(), actual.isNeedsKmsCredentialsStateEnabled(), "isNeedsKmsCredentialsStateEnabled not equal");
+        assertEquals(expected.getKeyExpirationMS(), actual.getKeyExpirationMS(), "keyExpirationMS not equal");
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionTest.java
@@ -135,7 +135,6 @@ public abstract class AbstractClientSideEncryptionTest {
                 description.equals("timeoutMS applied to listCollections to get collection schema"));
         assumeFalse("runOn requirements not satisfied", skipTest);
         assumeFalse("Skipping count tests", filename.startsWith("count."));
-        assumeFalse("https://jira.mongodb.org/browse/JAVA-5297", description.equals("Insert with deterministic encryption, then find it"));
 
         assumeFalse(definition.getString("skipReason", new BsonString("")).getValue(), definition.containsKey("skipReason"));
 
@@ -185,6 +184,8 @@ public abstract class AbstractClientSideEncryptionTest {
         BsonDocument kmsProviders = cryptOptions.getDocument("kmsProviders", new BsonDocument());
         boolean bypassAutoEncryption = cryptOptions.getBoolean("bypassAutoEncryption", BsonBoolean.FALSE).getValue();
         boolean bypassQueryAnalysis = cryptOptions.getBoolean("bypassQueryAnalysis", BsonBoolean.FALSE).getValue();
+        Long keyExpirationMS = cryptOptions.containsKey("keyExpirationMS")
+                ? cryptOptions.getNumber("keyExpirationMS").longValue() : null;
 
         Map<String, BsonDocument> namespaceToSchemaMap = new HashMap<>();
 
@@ -285,6 +286,7 @@ public abstract class AbstractClientSideEncryptionTest {
                     .bypassQueryAnalysis(bypassQueryAnalysis)
                     .bypassAutoEncryption(bypassAutoEncryption)
                     .extraOptions(extraOptions)
+                    .keyExpiration(keyExpirationMS, TimeUnit.MILLISECONDS)
                     .build());
         }
         createMongoClient(mongoClientSettingsBuilder.build());

--- a/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
@@ -1198,6 +1198,15 @@ public class JsonPoweredCrudTestHelper {
         }
     }
 
+    BsonDocument wait(final BsonDocument options, final BsonDocument rawArguments, @Nullable final ClientSession clientSession) {
+        try {
+            Thread.sleep(rawArguments.getNumber("ms").longValue());
+            return new BsonDocument();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     Collation getCollation(final BsonDocument bsonCollation) {
         Collation.Builder builder = Collation.builder();
         if (bsonCollation.containsKey("locale")) {

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/Entities.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/Entities.java
@@ -754,6 +754,9 @@ public final class Entities {
                 case "kmsProviders":
                     builder.kmsProviders(createKmsProvidersMap(entry.getValue().asDocument()));
                     break;
+                case "keyExpirationMS":
+                    builder.keyExpiration(entry.getValue().asNumber().longValue(), TimeUnit.MILLISECONDS);
+                    break;
                 default:
                     throw new UnsupportedOperationException("Unsupported client encryption option: " + entry.getKey());
             }

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedClientEncryptionHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedClientEncryptionHelper.java
@@ -166,9 +166,10 @@ public final class UnifiedClientEncryptionHelper {
             }
 
             if (explicitPropertySupplier == null) {
-                throw new UnsupportedOperationException("Non-placeholder value is not supported for: " + key + " :: " + kmsProviderOptions.toJson());
+                kmsProviderMap.put(key, kmsProviderOptions.get(key));
+            } else {
+                kmsProviderMap.put(key, explicitPropertySupplier.get());
             }
-            kmsProviderMap.put(key, explicitPropertySupplier.get());
         }
     }
 

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTest.java
@@ -109,7 +109,7 @@ public abstract class UnifiedTest {
     private static final Set<String> PRESTART_POOL_ASYNC_WORK_MANAGER_FILE_DESCRIPTIONS = Collections.singleton(
             "wait queue timeout errors include details about checked out connections");
 
-    private static final String MAX_SUPPORTED_SCHEMA_VERSION = "1.21";
+    private static final String MAX_SUPPORTED_SCHEMA_VERSION = "1.22";
     private static final List<Integer> MAX_SUPPORTED_SCHEMA_VERSION_COMPONENTS = Arrays.stream(MAX_SUPPORTED_SCHEMA_VERSION.split("\\."))
             .map(Integer::parseInt)
             .collect(Collectors.toList());
@@ -265,6 +265,7 @@ public abstract class UnifiedTest {
         skips(fileDescription, testDescription);
 
         assumeTrue(isSupportedSchemaVersion(schemaVersion), format("Unsupported schema version %s", schemaVersion));
+
         if (runOnRequirements != null) {
             assumeTrue(runOnRequirementsMet(runOnRequirements, getMongoClientSettings(), getServerVersion()),
                     "Run-on requirements not met");

--- a/mongodb-crypt/src/main/com/mongodb/internal/crypt/capi/CAPI.java
+++ b/mongodb-crypt/src/main/com/mongodb/internal/crypt/capi/CAPI.java
@@ -487,6 +487,17 @@ public class CAPI {
     mongocrypt_setopt_bypass_query_analysis (mongocrypt_t crypt);
 
     /**
+     * Set the expiration time for the data encryption key cache. Defaults to 60 seconds if not set.
+     *
+     * @param crypt The @ref mongocrypt_t object to update
+     * @param cache_expiration_ms if 0 the cache never expires
+     * @return A boolean indicating success. If false, an error status is set.
+     * @since 5.4
+     */
+    public static native boolean
+    mongocrypt_setopt_key_expiration (mongocrypt_t crypt, long cache_expiration_ms);
+
+    /**
      * Opt-into enabling sending multiple collection info documents.
      *
      * @param crypt The @ref mongocrypt_t object to update

--- a/mongodb-crypt/src/main/com/mongodb/internal/crypt/capi/MongoCryptImpl.java
+++ b/mongodb-crypt/src/main/com/mongodb/internal/crypt/capi/MongoCryptImpl.java
@@ -67,6 +67,7 @@ import static com.mongodb.internal.crypt.capi.CAPI.mongocrypt_setopt_crypto_hook
 import static com.mongodb.internal.crypt.capi.CAPI.mongocrypt_setopt_crypto_hooks;
 import static com.mongodb.internal.crypt.capi.CAPI.mongocrypt_setopt_enable_multiple_collinfo;
 import static com.mongodb.internal.crypt.capi.CAPI.mongocrypt_setopt_encrypted_field_config_map;
+import static com.mongodb.internal.crypt.capi.CAPI.mongocrypt_setopt_key_expiration;
 import static com.mongodb.internal.crypt.capi.CAPI.mongocrypt_setopt_kms_provider_aws;
 import static com.mongodb.internal.crypt.capi.CAPI.mongocrypt_setopt_kms_provider_local;
 import static com.mongodb.internal.crypt.capi.CAPI.mongocrypt_setopt_kms_providers;
@@ -192,6 +193,11 @@ class MongoCryptImpl implements MongoCrypt {
 
         if (options.isBypassQueryAnalysis()) {
             mongocrypt_setopt_bypass_query_analysis(wrapped);
+        }
+
+        Long keyExpirationMS = options.getKeyExpirationMS();
+        if (keyExpirationMS != null) {
+            configure(() -> mongocrypt_setopt_key_expiration(wrapped, keyExpirationMS));
         }
 
         if (options.getEncryptedFieldsMap() != null) {

--- a/mongodb-crypt/src/main/com/mongodb/internal/crypt/capi/MongoCryptOptions.java
+++ b/mongodb-crypt/src/main/com/mongodb/internal/crypt/capi/MongoCryptOptions.java
@@ -139,7 +139,7 @@ public final class MongoCryptOptions {
     /**
      * Returns the cache expiration time for data encryption keys.
      *
-     * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently {@code 60000}.
+     * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently {@code 60000 ms}.
      * Set to {@code 0} to disable key expiration.</p>
      *
      * @return the cache expiration time or null if not set.

--- a/mongodb-crypt/src/main/com/mongodb/internal/crypt/capi/MongoCryptOptions.java
+++ b/mongodb-crypt/src/main/com/mongodb/internal/crypt/capi/MongoCryptOptions.java
@@ -39,6 +39,7 @@ public final class MongoCryptOptions {
     private final BsonDocument extraOptions;
     private final boolean bypassQueryAnalysis;
     private final List<String> searchPaths;
+    private final Long keyExpirationMS;
 
 
     /**
@@ -136,6 +137,19 @@ public final class MongoCryptOptions {
     }
 
     /**
+     * Returns the cache expiration time for data encryption keys.
+     *
+     * <p>Defaults to {@code null} which defers to libmongocrypt's default which is currently {@code 60000}.
+     * Set to {@code 0} to disable key expiration.</p>
+     *
+     * @return the cache expiration time or null if not set.
+     * @since 5.5
+     */
+    public Long getKeyExpirationMS() {
+        return keyExpirationMS;
+    }
+
+    /**
      * The builder for the options
      */
     public static final class Builder {
@@ -148,6 +162,7 @@ public final class MongoCryptOptions {
         private boolean bypassQueryAnalysis;
         private BsonDocument extraOptions = new BsonDocument();
         private List<String> searchPaths = emptyList();
+        private Long keyExpirationMS = null;
 
         private Builder() {
         }
@@ -259,6 +274,18 @@ public final class MongoCryptOptions {
         }
 
         /**
+         * The cache expiration time for data encryption keys.
+         *
+         * @param keyExpirationMS the cache expiration time in milliseconds or null to use libmongocrypt's default.
+         * @return this
+         * @since 5.5
+         */
+        public Builder keyExpirationMS(final Long keyExpirationMS) {
+            this.keyExpirationMS = keyExpirationMS;
+            return this;
+        }
+
+        /**
          * Build the options.
          *
          * @return the options
@@ -281,5 +308,6 @@ public final class MongoCryptOptions {
         this.bypassQueryAnalysis = builder.bypassQueryAnalysis;
         this.extraOptions = builder.extraOptions;
         this.searchPaths = builder.searchPaths;
+        this.keyExpirationMS = builder.keyExpirationMS;
     }
 }


### PR DESCRIPTION
Added the `AutoEncryptionSettings.Builder#keyExpiration` method and `ClientEncryptionSettings.Builder#keyExpiration` method to configure the cache expiration time for data encryption keys.

JAVA-5547