### PR TITLE
Enable test of nsType with a collection view

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedCrudHelper.java
@@ -1381,10 +1381,10 @@ final class UnifiedCrudHelper extends UnifiedHelper {
         // In Java driver there is a separate method for creating a view, but in the unified test CRUD format
         // views and collections are both created with the createCollection operation. We use the createView
         // method if the requisite arguments are present.
-        if (arguments.containsKey("viewOn") && arguments.containsKey("pipeline")) {
+        if (arguments.containsKey("viewOn")) {
             String viewOn = arguments.getString("viewOn").getValue();
             List<BsonDocument> pipeline =
-                    arguments.getArray("pipeline").stream().map(BsonValue::asDocument).collect(toList());
+                    arguments.getArray("pipeline", new BsonArray()).stream().map(BsonValue::asDocument).collect(toList());
 
             for (Map.Entry<String, BsonValue> cur : arguments.entrySet()) {
                 switch (cur.getKey()) {

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -63,9 +63,6 @@ public final class UnifiedTestModifications {
                 .test("change-streams", "change-streams-errors", "Change Stream should error when an invalid aggregation stage is passed in")
                 .test("change-streams", "change-streams-errors", "The watch helper must not throw a custom exception when executed against a single server topology, but instead depend on a server error");
 
-        def.skipJira("https://jira.mongodb.org/browse/JAVA-5769")
-                .test("change-streams", "change-streams-nsType", "nsType is present when creating views");
-
         // client-side-operation-timeout (CSOT)
 
         def.skipNoncompliantReactive("No good way to fulfill tryNext() requirement with a Publisher<T>")


### PR DESCRIPTION
The reason this test fails is due to a unified test runner bug, in which a view is created only when a pipeline is specified.

JAVA-5769