### PR TITLE
Fix validation in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: "Ensure current snapshot version matches release version"
         run: |
-          grep -q "version='${{ env.RELEASE_VERSION_WITHOUT_SUFFIX }}-SNAPSHOT'" gradle.properties
+          grep -q "version=${{ env.RELEASE_VERSION_WITHOUT_SUFFIX }}-SNAPSHOT" gradle.properties
           if [[ $? != 0 ]]; then
             echo '❌ Release failed: version in gradle.properties is not a snapshot for release version ${{ inputs.version }}' >> $GITHUB_STEP_SUMMARY
             exit 1


### PR DESCRIPTION
The changes have been tested in a forked repository.

Commits on main: [View commits](https://github.com/vbabanin/mongo-java-driver/commits/main)
5.5.x branch was created by GitHub Actions: [View branches](https://github.com/vbabanin/mongo-java-driver/branches)

Successful execution of the 5.5.0 GitHub Action: [View run](https://github.com/vbabanin/mongo-java-driver/actions/runs/14805885730)

Validation failures occurred as expected, since `release.yml` enforces version alignment with `5.6.0-SNAPSHOT` after  bumping to 5.6.0-SNAPSHOT. Tested the following versions:
5.5.7: [View run](https://github.com/vbabanin/mongo-java-driver/actions/runs/14805891719)
5.7.0: [View run](https://github.com/vbabanin/mongo-java-driver/actions/runs/14805899578)

JAVA-5867