### PR TITLE
Ensure custom KProperty include the name in the hashcode

### DIFF
--- a/driver-kotlin-extensions/src/main/kotlin/com/mongodb/kotlin/client/model/Properties.kt
+++ b/driver-kotlin-extensions/src/main/kotlin/com/mongodb/kotlin/client/model/Properties.kt
@@ -71,8 +71,7 @@ public fun <T> KProperty<T>.path(): String {
     return if (this is KPropertyPath<*, T>) {
         this.name
     } else {
-        pathCache.computeIfAbsent(this.toString()) {
-
+        pathCache.computeIfAbsent("${this.javaClass.getSimpleName()}@${Integer.toHexString(hashCode())}") {
             // Check serial name - Note kotlinx.serialization.SerialName may not be on the class
             // path
             val serialName =

--- a/driver-kotlin-extensions/src/main/kotlin/com/mongodb/kotlin/client/property/KPropertyPath.kt
+++ b/driver-kotlin-extensions/src/main/kotlin/com/mongodb/kotlin/client/property/KPropertyPath.kt
@@ -20,6 +20,7 @@ package com.mongodb.kotlin.client.property
 
 import com.mongodb.annotations.Sealed
 import com.mongodb.kotlin.client.model.path
+import java.util.Objects
 import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
@@ -84,6 +85,15 @@ public open class KPropertyPath<T, R>(
     override fun callBy(args: Map<KParameter, Any?>): R = unSupportedOperation()
     override fun get(receiver: T): R = unSupportedOperation()
     override fun getDelegate(receiver: T): Any? = unSupportedOperation()
+    override fun hashCode(): Int = Objects.hash(previous, property, name)
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as KPropertyPath<*, *>
+        return Objects.equals(previous, other.previous) &&
+            Objects.equals(property, other.property) &&
+            Objects.equals(name, other.name)
+    }
 
     public companion object {
 
@@ -121,6 +131,13 @@ public open class KPropertyPath<T, R>(
             override fun get(receiver: T): R = unSupportedOperation()
             override fun getDelegate(receiver: T): Any? = unSupportedOperation()
             override fun invoke(p1: T): R = unSupportedOperation()
+            override fun hashCode(): Int = Objects.hash(previous, name)
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (javaClass != other?.javaClass) return false
+                other as CustomProperty<*, *>
+                return Objects.equals(previous, other.previous) && Objects.equals(name, other.name)
+            }
         }
 
         /** Provides "fake" property with custom name. */

--- a/driver-kotlin-extensions/src/test/kotlin/com/mongodb/kotlin/client/model/KPropertiesTest.kt
+++ b/driver-kotlin-extensions/src/test/kotlin/com/mongodb/kotlin/client/model/KPropertiesTest.kt
@@ -139,4 +139,18 @@ class KPropertiesTest {
         assertThrows<UnsupportedOperationException> { property.get(restaurant) }
         assertThrows<UnsupportedOperationException> { property.getDelegate(restaurant) }
     }
+
+    @Test
+    fun testNoCacheCollisions() {
+        for (i in 1.rangeTo(25_000)) {
+            assertEquals("reviews.$i", Restaurant::reviews.pos(i).path())
+            assertEquals("reviews.$[identifier$i]",  Restaurant::reviews.filteredPosOp("identifier$i").path())
+            assertEquals("localeMap.$i", Restaurant::localeMap.keyProjection(i).path())
+
+            val x = i / 2
+            assertEquals("reviews.$[identifier$x].rating", (Restaurant::reviews.filteredPosOp("identifier$x") / Review::score).path())
+            assertEquals("reviews.$x.rating", (Restaurant::reviews.pos(x) / Review::score).path())
+            assertEquals("localeMap.$x.rating", (Restaurant::localeMap.keyProjection(x) / Review::score).path())
+        }
+    }
 }


### PR DESCRIPTION
The `pathCache` utilized the string representation of the `KProperty` instance. The custom implementations didn't include the name (the calculated path value), this can lead to naming collisions in the `pathCache` key.

This commit adds `hashCode` and `equals` methods to ensure the `name` value is included in our custom implementations of `KProperty`. Finally, the cache key is now explicitly created using the same default `Any.toString()` approach to ensure that all implementations of `KProperty` use the same logic to create the cache key.

JAVA-5868