### PR TITLE
Added nexus-publish plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,4 +17,25 @@
 plugins {
     id("eclipse")
     id("idea")
+    alias(libs.plugins.nexus.publish)
+}
+
+val nexusUsername: Provider<String> = providers.gradleProperty("nexusUsername")
+val nexusPassword: Provider<String> = providers.gradleProperty("nexusPassword")
+
+nexusPublishing {
+    packageGroup = "org.mongodb"
+    repositories {
+        sonatype {
+            username = nexusUsername
+            password = nexusPassword
+
+            snapshotRepositoryUrl.set(uri("https://oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://oss.sonatype.org/service/local/"))
+
+            // central portal URLs
+//            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+//            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        }
+    }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import dev.panuszewski.gradle.pluginMarker
-
 plugins {
     id("java-library")
     `kotlin-dsl`
@@ -26,18 +24,6 @@ repositories {
     gradlePluginPortal()
     mavenCentral()
     google()
-}
-
-// Dependencies needed for the configuration of the plugins
-// Uses `pluginMarker` from the `typesafe-conventions` plugin, see `settings.gradle.kts`
-dependencies {
-    implementation(pluginMarker(libs.plugins.bnd))
-    implementation(pluginMarker(libs.plugins.detekt))
-    implementation(pluginMarker(libs.plugins.dokka))
-    implementation(pluginMarker(libs.plugins.kotlin.gradle))
-    implementation(pluginMarker(libs.plugins.spotbugs))
-    implementation(pluginMarker(libs.plugins.spotless))
-    implementation(pluginMarker(libs.plugins.test.logger))
 }
 
 // Spotless configuration for `buildSrc` code.

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -17,5 +17,5 @@ plugins {
     // Add support for `libs.versions.toml` within `buildSrc`
     // https://github.com/radoslaw-panuszewski/typesafe-conventions-gradle-plugin
     // https://github.com/gradle/gradle/issues/15383
-    id("dev.panuszewski.typesafe-conventions") version "0.4.1"
+    id("dev.panuszewski.typesafe-conventions") version "0.7.3"
 }

--- a/buildSrc/src/main/kotlin/conventions/bnd.gradle.kts
+++ b/buildSrc/src/main/kotlin/conventions/bnd.gradle.kts
@@ -15,7 +15,9 @@
  */
 package conventions
 
+import libs
+
 // Gradle Plugin for developing OSGi bundles with Bnd.
 // https://plugins.gradle.org/plugin/biz.aQute.bnd.builder
 
-plugins { id("biz.aQute.bnd.builder") }
+plugins { alias(libs.plugins.bnd) }

--- a/buildSrc/src/main/kotlin/conventions/detekt.gradle.kts
+++ b/buildSrc/src/main/kotlin/conventions/detekt.gradle.kts
@@ -16,10 +16,11 @@
 package conventions
 
 import io.gitlab.arturbosch.detekt.Detekt
+import libs
 
 // Static code analysis for Kotlin
 // https://plugins.gradle.org/plugin/io.gitlab.arturbosch.detekt
-plugins { id("io.gitlab.arturbosch.detekt") }
+plugins { alias(libs.plugins.detekt) }
 
 detekt {
     allRules = true // fail build on any finding

--- a/buildSrc/src/main/kotlin/conventions/dokka.gradle.kts
+++ b/buildSrc/src/main/kotlin/conventions/dokka.gradle.kts
@@ -15,10 +15,12 @@
  */
 package conventions
 
+import libs
+
 // Dokka, the documentation engine for Kotlin
 // https://plugins.gradle.org/plugin/org.jetbrains.dokka
 plugins {
-    id("org.jetbrains.dokka")
+    alias(libs.plugins.dokka)
     id("conventions.publishing")
 }
 

--- a/buildSrc/src/main/kotlin/conventions/publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/conventions/publishing.gradle.kts
@@ -28,8 +28,6 @@ plugins {
 
 val signingKey: Provider<String> = providers.gradleProperty("signingKey")
 val signingPassword: Provider<String> = providers.gradleProperty("signingPassword")
-val nexusUsername: Provider<String> = providers.gradleProperty("nexusUsername")
-val nexusPassword: Provider<String> = providers.gradleProperty("nexusPassword")
 @Suppress("UNCHECKED_CAST") val gitVersion: Provider<String> = project.findProperty("gitVersion") as Provider<String>
 
 tasks.withType<AbstractPublishToMaven>().configureEach {
@@ -45,25 +43,8 @@ tasks.withType<AbstractPublishToMaven>().configureEach {
 
 val localBuildRepo: Provider<Directory> = rootProject.layout.buildDirectory.dir("repo")
 
-val sonatypeRepositoryReleaseUrl: Provider<String> = provider {
-    if (version.toString().endsWith("SNAPSHOT")) {
-        "https://oss.sonatype.org/content/repositories/snapshots/"
-    } else {
-        "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-    }
-}
-
 publishing {
     repositories {
-        maven {
-            url = uri(sonatypeRepositoryReleaseUrl)
-            if (nexusUsername.isPresent && nexusPassword.isPresent) {
-                credentials {
-                    username = nexusUsername.get()
-                    password = nexusPassword.get()
-                }
-            }
-        }
 
         // publish to local dir, for artifact tracking and testing
         // `./gradlew publishMavenPublicationToLocalBuildRepository`
@@ -141,7 +122,7 @@ tasks.register("publishSnapshots") {
     description = "Publishes snapshots to Sonatype"
 
     if (version.toString().endsWith("-SNAPSHOT")) {
-        dependsOn(tasks.withType<PublishToMavenRepository>())
+        dependsOn(tasks.named("publishToSonatype"))
     }
 }
 
@@ -168,7 +149,7 @@ tasks.register("publishArchives") {
         }
     }
     if (gitVersionMatch) {
-        dependsOn(tasks.withType<PublishToMavenRepository>())
+        dependsOn(tasks.named("publishToSonatype"))
     }
 }
 

--- a/buildSrc/src/main/kotlin/conventions/spotbugs.gradle.kts
+++ b/buildSrc/src/main/kotlin/conventions/spotbugs.gradle.kts
@@ -16,14 +16,14 @@
 package conventions
 
 import com.github.spotbugs.snom.SpotBugsTask
+import libs
 import org.gradle.kotlin.dsl.dependencies
-import project.libs
 
 // Performs quality checks on your project's Java source files using SpotBug
 // https://plugins.gradle.org/plugin/com.github.spotbugs
 plugins {
     id("java-library")
-    id("com.github.spotbugs")
+    alias(libs.plugins.spotbugs)
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/conventions/spotless.gradle.kts
+++ b/buildSrc/src/main/kotlin/conventions/spotless.gradle.kts
@@ -17,10 +17,11 @@ package conventions
 
 import com.diffplug.gradle.spotless.SpotlessApply
 import com.diffplug.gradle.spotless.SpotlessCheck
+import libs
 
 // Spotless - keep your code spotless
 // https://plugins.gradle.org/plugin/com.diffplug.spotless
-plugins { id("com.diffplug.spotless") }
+plugins { alias(libs.plugins.spotless) }
 
 val doesNotHaveACustomLicenseHeader = "/^(?s)(?!.*@custom-license-header).*/"
 

--- a/buildSrc/src/main/kotlin/conventions/testing-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/conventions/testing-base.gradle.kts
@@ -16,6 +16,7 @@
 package conventions
 
 import com.adarshr.gradle.testlogger.theme.ThemeType
+import libs
 import project.DEFAULT_JAVA_VERSION
 
 // Default test configuration for projects
@@ -24,7 +25,7 @@ import project.DEFAULT_JAVA_VERSION
 // https://plugins.gradle.org/plugin/com.adarshr.test-logger
 plugins {
     id("java-library")
-    id("com.adarshr.test-logger")
+    alias(libs.plugins.test.logger)
 }
 
 tasks.withType<Test> {

--- a/buildSrc/src/main/kotlin/project/kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/project/kotlin.gradle.kts
@@ -15,11 +15,12 @@
  */
 package project
 
+import libs
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.gradle)
     id("project.base")
     id("conventions.bnd")
     id("conventions.detekt")

--- a/buildSrc/src/main/kotlin/project/scala.gradle.kts
+++ b/buildSrc/src/main/kotlin/project/scala.gradle.kts
@@ -17,7 +17,6 @@ package project
 
 import ProjectExtensions.configureMavenPublication
 import ProjectExtensions.scalaVersion
-import gradle.kotlin.dsl.accessors._473b9544fb0ec2c6cc860d9af4296ace.java
 
 plugins {
     id("scala")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ plugin-dokka = "1.8.10"
 plugin-download = "5.6.0"
 plugin-graalvm = "0.9.23"
 plugin-optional-base = "7.0.0"
+plugin-nexus-publish = "2.0.0"
 plugin-shadow = "8.3.6"
 plugin-spotbugs = "6.0.15"
 plugin-spotless = "6.14.0"
@@ -207,6 +208,7 @@ download = { id = "de.undercouch.download", version.ref = "plugin-download" }
 graalvm-buildtools = { id = "org.graalvm.buildtools.native", version.ref = "plugin-graalvm" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "plugin-nexus-publish" }
 optional = { id = "nebula.optional-base", version.ref = "plugin-optional-base" }
 shadow = { id = "com.gradleup.shadow", version.ref = "plugin-shadow" }
 spotbugs = { id = "com.github.spotbugs", version.ref = "plugin-spotbugs" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -199,7 +199,7 @@ scala-test-v2-v11 = ["scala-test-flatspec-v2-v11", "scala-test-shouldmatchers-v2
 
 [plugins]
 kotlin-gradle = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-bnd = { id = "biz.aQute.bnd", version.ref = "plugin-bnd" }
+bnd = { id = "biz.aQute.bnd.builder", version.ref = "plugin-bnd" }
 build-config = { id = "com.github.gmazzo.buildconfig", version.ref = "plugin-build-config" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "plugin-detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "plugin-dokka" }


### PR DESCRIPTION
The first commit simplifies use of plugins in buildSrc by upgrading the `dev.panuszewski.typesafe-conventions` plugin to: `0.7.3`.

The second commit introduces the `nexus-publish` to handle publishing to sonatype. Once the migration to central.sonatype.com it should be a case of updating the username and password.

JAVA-5899