### PR TITLE
Ensure local build artifacts are created

### DIFF
--- a/buildSrc/src/main/kotlin/conventions/publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/conventions/publishing.gradle.kts
@@ -122,6 +122,7 @@ tasks.register("publishSnapshots") {
     description = "Publishes snapshots to Sonatype"
 
     if (version.toString().endsWith("-SNAPSHOT")) {
+        dependsOn(tasks.named("publishAllPublicationsToLocalBuildRepository"))
         dependsOn(tasks.named("publishToSonatype"))
     }
 }
@@ -149,6 +150,7 @@ tasks.register("publishArchives") {
         }
     }
     if (gitVersionMatch) {
+        dependsOn(tasks.named("publishAllPublicationsToLocalBuildRepository"))
         dependsOn(tasks.named("publishToSonatype"))
     }
 }


### PR DESCRIPTION
When migrating to the nexus-publish plugin I changed the dependency to just use `publishSonatype` this stopped the local build artifacts being created and tracing artifacts in evergreen relies on them.

JAVA-5904