### PR TITLE
Add JavaDoc to NamespaceType.

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/changestream/NamespaceType.java
+++ b/driver-core/src/main/com/mongodb/client/model/changestream/NamespaceType.java
@@ -29,8 +29,17 @@ import com.mongodb.lang.Nullable;
  * @mongodb.server.release 8.1
  */
 public enum NamespaceType {
+    /**
+     * The collection namespace type.
+     */
     COLLECTION("collection"),
+    /**
+     * The timeseries namespace type.
+     */
     TIMESERIES("timeseries"),
+    /**
+     * The view namespace type.
+     */
     VIEW("view"),
     /**
      * The other namespace type.


### PR DESCRIPTION
This PR addresses build warnings introduced by https://github.com/mongodb/mongo-java-driver/pull/1736.

JAVA-5769