### PR TITLE
Auto close the repository on publish

### DIFF
--- a/.evergreen/publish.sh
+++ b/.evergreen/publish.sh
@@ -18,7 +18,7 @@ export ORG_GRADLE_PROJECT_signingKey="${SIGNING_KEY}"
 export ORG_GRADLE_PROJECT_signingPassword=${SIGNING_PASSWORD}
 
 if [ "$RELEASE" == "true" ]; then
-  TASK="publishArchives"
+  TASK="publishArchives closeSonatypeStagingRepository"
 else
   TASK="publishSnapshots"
 fi


### PR DESCRIPTION
Appears finding the repository for local
checking fails due to ip restrictions.
See: gradle-nexus/publish-plugin#379

JAVA-5881