### PR TITLE
Fix Netty reference leak.

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -132,4 +132,9 @@ echo "Running tests with Java ${JAVA_VERSION}"
           ${MULTI_MONGOS_URI_SYSTEM_PROPERTY} ${API_VERSION} ${GRADLE_EXTRA_VARS} \
           ${JAVA_SYSPROP_ASYNC_TRANSPORT}  ${JAVA_SYSPROP_NETTY_SSL_PROVIDER} \
           -Dorg.mongodb.test.fle.on.demand.credential.test.failure.enabled=true \
-          --stacktrace --info --continue ${TESTS}
+          --stacktrace --info --continue ${TESTS} | tee -a logs.txt
+
+if grep -q 'LEAK:' logs.txt ; then
+    echo "Netty Leak detected, please inspect build log"
+    exit 1
+fi

--- a/buildSrc/src/main/kotlin/conventions/testing-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/conventions/testing-base.gradle.kts
@@ -34,6 +34,8 @@ tasks.withType<Test> {
 
     useJUnitPlatform()
 
+    jvmArgs.add("-Dio.netty.leakDetection.level=paranoid")
+
     // Pass any `org.mongodb.*` system settings
     systemProperties =
         System.getProperties()

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -19,6 +19,7 @@ package com.mongodb.internal.connection;
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoIncompatibleDriverException;
+import com.mongodb.MongoInternalException;
 import com.mongodb.MongoInterruptedException;
 import com.mongodb.MongoOperationTimeoutException;
 import com.mongodb.MongoTimeoutException;
@@ -188,7 +189,9 @@ abstract class BaseCluster implements Cluster {
     @Override
     public void selectServerAsync(final ServerSelector serverSelector, final OperationContext operationContext,
             final SingleResultCallback<ServerTuple> callback) {
-        isTrue("open", !isClosed());
+        if (isClosed()) {
+            callback.onResult(null, new MongoClientException("Cluster was closed during server selection."));
+        }
 
         Timeout computedServerSelectionTimeout = operationContext.getTimeoutContext().computeServerSelectionTimeout();
         ServerSelectionRequest request = new ServerSelectionRequest(

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnection.java
@@ -46,6 +46,7 @@ import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.async.AsyncSupplier;
 import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.internal.connection.netty.NettyByteBuf;
 import com.mongodb.internal.diagnostics.logging.Logger;
 import com.mongodb.internal.diagnostics.logging.Loggers;
 import com.mongodb.internal.logging.StructuredLogger;
@@ -355,7 +356,7 @@ public class InternalStreamConnection implements InternalConnection {
     public void close() {
         // All but the first call is a no-op
         if (!isClosed.getAndSet(true) && (stream != null)) {
-                stream.close();
+            stream.close();
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/netty/NettyByteBuf.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/netty/NettyByteBuf.java
@@ -256,7 +256,7 @@ public final class NettyByteBuf implements ByteBuf {
 
     @Override
     public ByteBuf duplicate() {
-        return new NettyByteBuf(proxied.duplicate().retain(), isWriting);
+        return new NettyByteBuf(proxied.retainedDuplicate(), isWriting);
     }
 
     @Override

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ByteBufferBsonOutputTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ByteBufferBsonOutputTest.java
@@ -495,6 +495,7 @@ final class ByteBufferBsonOutputTest {
     @ParameterizedTest(name = "should get byte buffers as little endian. Parameters: useBranch={0}, bufferProvider={1}")
     @MethodSource("bufferProvidersWithBranches")
     void shouldGetByteBuffersAsLittleEndian(final boolean useBranch, final BufferProvider bufferProvider) {
+        List<ByteBuf> byteBuffers = new ArrayList<>();
         try (ByteBufferBsonOutput out = new ByteBufferBsonOutput(bufferProvider)) {
             byte[] v = {1, 0, 0, 0};
             if (useBranch) {
@@ -504,7 +505,11 @@ final class ByteBufferBsonOutputTest {
             } else {
                 out.writeBytes(v);
             }
-            assertEquals(1, out.getByteBuffers().get(0).getInt());
+
+           byteBuffers = out.getByteBuffers();
+            assertEquals(1,byteBuffers.get(0).getInt());
+        } finally {
+            byteBuffers.forEach(ByteBuf::release);
         }
     }
 
@@ -1017,6 +1022,7 @@ final class ByteBufferBsonOutputTest {
             final int expectedLastBufferPosition,
             final BufferProvider bufferProvider) {
 
+        List<ByteBuf> buffers = new ArrayList<>();
         try (ByteBufferBsonOutput output =
                      new ByteBufferBsonOutput(size -> bufferProvider.getBuffer(Integer.BYTES))) {
 
@@ -1028,12 +1034,14 @@ final class ByteBufferBsonOutputTest {
 
             //then
             //getByteBuffers returns ByteBuffers with limit() set to position, position set to 0.
-            List<ByteBuf> buffers = output.getByteBuffers();
+            buffers = output.getByteBuffers();
             assertEquals(expectedBuffers.size(), buffers.size(), "Number of buffers mismatch");
             assertBufferContents(expectedBuffers, buffers);
 
             assertEquals(expectedLastBufferPosition, buffers.get(buffers.size() - 1).limit());
             assertEquals(expectedOutputPosition, output.getPosition());
+        } finally {
+            buffers.forEach(ByteBuf::release);
         }
     }
 
@@ -1049,6 +1057,7 @@ final class ByteBufferBsonOutputTest {
             final int expectedLastBufferPosition,
             final BufferProvider bufferProvider) {
 
+        List<ByteBuf> buffers = new ArrayList<>();
         try (ByteBufferBsonOutput output =
                      new ByteBufferBsonOutput(size -> bufferProvider.getBuffer(Long.BYTES))) {
 
@@ -1060,12 +1069,14 @@ final class ByteBufferBsonOutputTest {
 
             //then
             //getByteBuffers returns ByteBuffers with limit() set to position, position set to 0.
-            List<ByteBuf> buffers = output.getByteBuffers();
+            buffers = output.getByteBuffers();
             assertEquals(expectedBuffers.size(), buffers.size(), "Number of buffers mismatch");
             assertBufferContents(expectedBuffers, buffers);
 
             assertEquals(expectedLastBufferPosition, buffers.get(buffers.size() - 1).limit());
             assertEquals(expectedOutputPosition, output.getPosition());
+        } finally {
+            buffers.forEach(ByteBuf::release);
         }
     }
 
@@ -1081,6 +1092,7 @@ final class ByteBufferBsonOutputTest {
             final int expectedLastBufferPosition,
             final BufferProvider bufferProvider) {
 
+        List<ByteBuf> buffers = new ArrayList<>();
         try (ByteBufferBsonOutput output =
                      new ByteBufferBsonOutput(size -> bufferProvider.getBuffer(Long.BYTES))) {
 
@@ -1092,12 +1104,14 @@ final class ByteBufferBsonOutputTest {
 
             //then
             //getByteBuffers returns ByteBuffers with limit() set to position, position set to 0.
-            List<ByteBuf> buffers = output.getByteBuffers();
+            buffers = output.getByteBuffers();
             assertEquals(expectedBuffers.size(), buffers.size(), "Number of buffers mismatch");
             assertBufferContents(expectedBuffers, buffers);
 
             assertEquals(expectedLastBufferPosition, buffers.get(buffers.size() - 1).limit());
             assertEquals(expectedOutputPosition, output.getPosition());
+        } finally {
+            buffers.forEach(ByteBuf::release);
         }
     }
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/OperationExecutorImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/OperationExecutorImpl.java
@@ -47,6 +47,7 @@ import java.util.Objects;
 import static com.mongodb.MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL;
 import static com.mongodb.MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL;
 import static com.mongodb.ReadPreference.primary;
+import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.TimeoutContext.createTimeoutContext;
 import static com.mongodb.reactivestreams.client.internal.MongoOperationPublisher.sinkToCallback;
@@ -73,6 +74,7 @@ public class OperationExecutorImpl implements OperationExecutor {
     @Override
     public <T> Mono<T> execute(final AsyncReadOperation<T> operation, final ReadPreference readPreference, final ReadConcern readConcern,
             @Nullable final ClientSession session) {
+        isTrue("open", !mongoClient.getCluster().isClosed());
         notNull("operation", operation);
         notNull("readPreference", readPreference);
         notNull("readConcern", readConcern);
@@ -109,6 +111,7 @@ public class OperationExecutorImpl implements OperationExecutor {
     @Override
     public <T> Mono<T> execute(final AsyncWriteOperation<T> operation, final ReadConcern readConcern,
             @Nullable final ClientSession session) {
+        isTrue("open", !mongoClient.getCluster().isClosed());
         notNull("operation", operation);
         notNull("readConcern", readConcern);
 


### PR DESCRIPTION
Fixes netty byte buffer releases in edge case scenarios:

- Ensure async select server uses a callback if the cluster had been closed
- Ensure that handleReadResponse checks to see if the cluster had been closed before retaining incoming buffers
- Ensure closing the netty stream releases all references

Test fixes
- Ensure tests run using paranoid leak detection
- Fail the testsuite if a leak is detected.
- Fixed releasing buffers in the ByteBufferBsonOutputTest.

JAVA-5901