### PR TITLE
Properly handle exceptions in threads created by MongoClient

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -519,39 +519,44 @@ abstract class BaseCluster implements Cluster {
         }
 
         public void run() {
-            while (!isClosed) {
-                CountDownLatch currentPhase = phase.get();
-                ClusterDescription curDescription = description;
+            try {
+                while (!isClosed) {
+                    CountDownLatch currentPhase = phase.get();
+                    ClusterDescription curDescription = description;
 
-                Timeout timeout = Timeout.infinite();
-                boolean someWaitersNotSatisfied = false;
-                for (Iterator<ServerSelectionRequest> iter = waitQueue.iterator(); iter.hasNext();) {
-                    ServerSelectionRequest currentRequest = iter.next();
-                    if (handleServerSelectionRequest(currentRequest, currentPhase, curDescription)) {
-                        iter.remove();
-                    } else {
-                        someWaitersNotSatisfied = true;
-                        timeout = Timeout.earliest(
-                                timeout,
-                                currentRequest.getTimeout(),
-                                startMinWaitHeartbeatTimeout());
+                    Timeout timeout = Timeout.infinite();
+                    boolean someWaitersNotSatisfied = false;
+                    for (Iterator<ServerSelectionRequest> iter = waitQueue.iterator(); iter.hasNext();) {
+                        ServerSelectionRequest currentRequest = iter.next();
+                        if (handleServerSelectionRequest(currentRequest, currentPhase, curDescription)) {
+                            iter.remove();
+                        } else {
+                            someWaitersNotSatisfied = true;
+                            timeout = Timeout.earliest(
+                                    timeout,
+                                    currentRequest.getTimeout(),
+                                    startMinWaitHeartbeatTimeout());
+                        }
+                    }
+
+                    if (someWaitersNotSatisfied) {
+                        connect();
+                    }
+
+                    try {
+                        timeout.awaitOn(currentPhase, () -> "ignored");
+                    } catch (MongoInterruptedException closed) {
+                        // The cluster has been closed and the while loop will exit.
                     }
                 }
-
-                if (someWaitersNotSatisfied) {
-                    connect();
+                // Notify all remaining waiters that a shutdown is in progress
+                for (Iterator<ServerSelectionRequest> iter = waitQueue.iterator(); iter.hasNext();) {
+                    iter.next().onResult(null, new MongoClientException("Shutdown in progress"));
+                    iter.remove();
                 }
-
-                try {
-                    timeout.awaitOn(currentPhase, () -> "ignored");
-                } catch (MongoInterruptedException closed) {
-                    // The cluster has been closed and the while loop will exit.
-                }
-            }
-            // Notify all remaining waiters that a shutdown is in progress
-            for (Iterator<ServerSelectionRequest> iter = waitQueue.iterator(); iter.hasNext();) {
-                iter.next().onResult(null, new MongoClientException("Shutdown in progress"));
-                iter.remove();
+            } catch (Throwable t) {
+                LOGGER.error(this + " stopped working. You may want to recreate the MongoClient", t);
+                throw t;
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -1369,7 +1369,7 @@ final class DefaultConnectionPool implements ConnectionPool {
             try {
                 runnable.run();
             } catch (Throwable t) {
-                LOGGER.error("The pool is not going to work correctly from now on. You may want to recreate the MongoClient", t);
+                LOGGER.error(this + "stopped working. You may want to recreate the MongoClient", t);
                 throw t;
             }
         }

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -1369,7 +1369,7 @@ final class DefaultConnectionPool implements ConnectionPool {
             try {
                 runnable.run();
             } catch (Throwable t) {
-                LOGGER.error(this + "stopped working. You may want to recreate the MongoClient", t);
+                LOGGER.error(this + " stopped working. You may want to recreate the MongoClient", t);
                 throw t;
             }
         }

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
@@ -261,7 +261,7 @@ class DefaultServerMonitor implements ServerMonitor {
 
                 // Get existing connection
                 return doHeartbeat(currentServerDescription, shouldStreamResponses);
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 roundTripTimeSampler.reset();
                 InternalConnection localConnection = withLock(lock, () -> {
                     InternalConnection result = connection;

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
@@ -231,8 +231,9 @@ class DefaultServerMonitor implements ServerMonitor {
                 }
             } catch (InterruptedException | MongoInterruptedException closed) {
                 // stop the monitor
-            } catch (RuntimeException e) {
-                LOGGER.error(format("Server monitor for %s exiting with exception", serverId), e);
+            } catch (Throwable t) {
+                LOGGER.error(format("%s for %s stopped working. You may want to recreate the MongoClient", this, serverId), t);
+                throw t;
             } finally {
                 if (connection != null) {
                     connection.close();
@@ -532,7 +533,7 @@ class DefaultServerMonitor implements ServerMonitor {
                         } else {
                             pingServer(connection);
                         }
-                    } catch (Throwable t) {
+                    } catch (Exception t) {
                         if (connection != null) {
                             connection.close();
                             connection = null;
@@ -542,7 +543,11 @@ class DefaultServerMonitor implements ServerMonitor {
                 }
             } catch (InterruptedException closed) {
                 // stop the monitor
-            } finally {
+            } catch (Throwable t) {
+                LOGGER.error(format("%s for %s stopped working. You may want to recreate the MongoClient", this, serverId), t);
+                throw t;
+            }
+            finally {
                 if (connection != null) {
                     connection.close();
                 }

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
@@ -546,8 +546,7 @@ class DefaultServerMonitor implements ServerMonitor {
             } catch (Throwable t) {
                 LOGGER.error(format("%s for %s stopped working. You may want to recreate the MongoClient", this, serverId), t);
                 throw t;
-            }
-            finally {
+            } finally {
                 if (connection != null) {
                     connection.close();
                 }

--- a/driver-core/src/main/com/mongodb/internal/connection/TlsChannelStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/TlsChannelStreamFactoryFactory.java
@@ -162,6 +162,9 @@ public class TlsChannelStreamFactoryFactory implements StreamFactoryFactory {
                             LOGGER.warn("Exception in selector loop", e);
                         }
                     }
+                } catch (Throwable t) {
+                    LOGGER.error(this + " stopped working. You may want to recreate the MongoClient", t);
+                    throw t;
                 } finally {
                     try {
                         selector.close();

--- a/driver-legacy/src/main/com/mongodb/MongoClient.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClient.java
@@ -881,7 +881,7 @@ public class MongoClient implements Closeable {
                     binding.release();
                 }
             }
-        }  catch (Throwable t) {
+        } catch (Throwable t) {
             LOGGER.error(this + " stopped cleaning cursors. You may want to recreate the MongoClient", t);
             throw t;
         }


### PR DESCRIPTION
Hello dear mongo-java-driver maintainers,
Please allow me to contribute this bugfix. The problem with Throwable in this line is that
it catches errors (OutOfMemoryError in particular) and doesn't let JVM crash leaving it
in zombie state - unable to recover, unable to exit.

JAVA-5913