### PR TITLE
Fix type parameters not being passed to fallback property codec

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/FallbackPropertyCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/pojo/FallbackPropertyCodecProvider.java
@@ -20,6 +20,8 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecRegistry;
 
 import java.lang.reflect.Type;
+import java.util.List;
+import java.util.stream.Collectors;
 
 final class FallbackPropertyCodecProvider implements PropertyCodecProvider {
     private final CodecRegistry codecRegistry;
@@ -37,6 +39,10 @@ final class FallbackPropertyCodecProvider implements PropertyCodecProvider {
         if (clazz == pojoCodec.getEncoderClass()) {
             return (Codec<S>) pojoCodec;
         }
-        return codecRegistry.get(type.getType(), type.getTypeParameters().stream().<Type>map(TypeWithTypeParameters::getType).toList());
+        List<Type> types = type.getTypeParameters().stream().<Type>map(TypeWithTypeParameters::getType).collect(Collectors.toList());
+        if (!types.isEmpty()) {
+            return codecRegistry.get(type.getType(), types);
+        }
+        return codecRegistry.get(type.getType());
     }
 }

--- a/bson/src/main/org/bson/codecs/pojo/FallbackPropertyCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/pojo/FallbackPropertyCodecProvider.java
@@ -19,6 +19,8 @@ package org.bson.codecs.pojo;
 import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecRegistry;
 
+import java.lang.reflect.Type;
+
 final class FallbackPropertyCodecProvider implements PropertyCodecProvider {
     private final CodecRegistry codecRegistry;
     private final PojoCodec<?> pojoCodec;
@@ -35,6 +37,6 @@ final class FallbackPropertyCodecProvider implements PropertyCodecProvider {
         if (clazz == pojoCodec.getEncoderClass()) {
             return (Codec<S>) pojoCodec;
         }
-        return codecRegistry.get(type.getType());
+        return codecRegistry.get(type.getType(), type.getTypeParameters().stream().<Type>map(TypeWithTypeParameters::getType).toList());
     }
 }

--- a/bson/src/test/unit/org/bson/codecs/pojo/PojoCodecCyclicalLookupTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/PojoCodecCyclicalLookupTest.java
@@ -31,6 +31,7 @@ import org.bson.codecs.pojo.entities.SimpleGenericsModel;
 import org.bson.codecs.pojo.entities.SimpleModel;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -136,9 +137,19 @@ public class PojoCodecCyclicalLookupTest extends PojoTestCase {
 
         @Override
         public <T> Codec<T> get(final Class<T> clazz) {
+            return get(clazz, this);
+        }
+
+        @Override
+        public <T> Codec<T> get(final Class<T> clazz, final List<Type> typeArguments) {
+            return get(clazz, typeArguments, this);
+        }
+
+        @Override
+        public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
             incrementCount(clazz);
             for (CodecProvider provider : codecProviders) {
-                Codec<T> codec = provider.get(clazz, this);
+                Codec<T> codec = provider.get(clazz, registry);
                 if (codec != null) {
                     return codec;
                 }
@@ -146,10 +157,11 @@ public class PojoCodecCyclicalLookupTest extends PojoTestCase {
             return null;
         }
 
-        public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
+        @Override
+        public <T> Codec<T> get(final Class<T> clazz, final List<Type> typeArguments, final CodecRegistry registry) {
             incrementCount(clazz);
             for (CodecProvider provider : codecProviders) {
-                Codec<T> codec = provider.get(clazz, registry);
+                Codec<T> codec = provider.get(clazz, typeArguments, registry);
                 if (codec != null) {
                     return codec;
                 }


### PR DESCRIPTION
For some reason, type parameters weren't passed to fallback property codec, which caused an exception when trying to access them. Now, this issue is fixed.