### PR TITLE
Fix parameterized test names in CrudProseTest

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/CrudProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/CrudProseTest.java
@@ -238,7 +238,7 @@ public class CrudProseTest {
     }
 
     @DisplayName("6. MongoClient.bulkWrite handles individual WriteErrors across batches")
-    @ParameterizedTest
+    @ParameterizedTest(name = "6. MongoClient.bulkWrite handles individual WriteErrors across batches--ordered:{0}")
     @ValueSource(booleans = {false, true})
     protected void testBulkWriteHandlesWriteErrorsAcrossBatches(final boolean ordered) {
         assumeTrue(serverVersionAtLeast(8, 0));
@@ -380,7 +380,7 @@ public class CrudProseTest {
     }
 
     @DisplayName("12. MongoClient.bulkWrite returns an error if no operations can be added to ops")
-    @ParameterizedTest
+    @ParameterizedTest(name = "12. MongoClient.bulkWrite returns an error if no operations can be added to ops--tooLarge:{0}")
     @ValueSource(strings = {"document", "namespace"})
     protected void testBulkWriteSplitsErrorsForTooLargeOpsOrNsInfo(final String tooLarge) {
         assumeTrue(serverVersionAtLeast(8, 0));
@@ -465,7 +465,8 @@ public class CrudProseTest {
     /**
      * This test is not from the specification.
      */
-    @ParameterizedTest
+    @DisplayName("insertMustGenerateIdAtMostOnce")
+    @ParameterizedTest(name = "insertMustGenerateIdAtMostOnce--documentClass:{0}, expectIdGenerated:{1}")
     @MethodSource("insertMustGenerateIdAtMostOnceArgs")
     protected <TDocument> void insertMustGenerateIdAtMostOnce(
             final Class<TDocument> documentClass,


### PR DESCRIPTION
Previously, for a parameterized test like
CrudProseTest::testBulkWriteHandlesWriteErrorsAcrossBatches, the test cases in the tests results XML output (and therefore the Evergreen UI) appear as 

```
  <testcase name="[1] false" classname="com.mongodb.reactivestreams.client.CrudProseTest""/>
  <testcase name="[2] true" classname="com.mongodb.reactivestreams.client.CrudProseTest"/>
```

Making it quite confusing to figure out which test it actually is.

After this change, they will appear as

```
  <testcase name="6. MongoClient.bulkWrite handles individual WriteErrors across batches--ordered:false" classname="com.mongodb.reactivestreams.client.CrudProseTest"/>
  <testcase name="6. MongoClient.bulkWrite handles individual WriteErrors across batches--ordered:true" classname="com.mongodb.reactivestreams.client.CrudProseTest"/>
```

and in the IDEA UI like

```
 6. MongoClient.bulkWrite handles individual WriteErrors across batches
     --ordered:false 
     --ordered:true
```

and in Gradle output like

```
  6. MongoClient.bulkWrite handles individual WriteErrors across batches

    Test 6. MongoClient.bulkWrite handles individual WriteErrors across batches--ordered:false PASSED
    Test 6. MongoClient.bulkWrite handles individual WriteErrors across batches--ordered:true PASSED
```