### PR TITLE
Remove internal use of MongoNamespace.COMMAND_COLLECTION_NAME

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/CommandHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandHelper.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.connection;
 
-import com.mongodb.MongoNamespace;
 import com.mongodb.MongoServerException;
 import com.mongodb.ServerApi;
 import com.mongodb.connection.ClusterConnectionMode;
@@ -31,7 +30,6 @@ import org.bson.codecs.BsonDocumentCodec;
 
 import java.util.Locale;
 
-import static com.mongodb.MongoNamespace.COMMAND_COLLECTION_NAME;
 import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.assertNotNull;
 
@@ -107,7 +105,7 @@ public final class CommandHelper {
                                                     final InternalConnection internalConnection,
                                                     final ClusterConnectionMode clusterConnectionMode,
                                                     @Nullable final ServerApi serverApi) {
-        return new CommandMessage(new MongoNamespace(database, COMMAND_COLLECTION_NAME), command, NoOpFieldNameValidator.INSTANCE, primary(),
+        return new CommandMessage(database, command, NoOpFieldNameValidator.INSTANCE, primary(),
                 MessageSettings
                         .builder()
                          // Note: server version will be 0.0 at this point when called from InternalConnectionInitializer,

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
@@ -408,9 +408,7 @@ public final class CommandMessage extends RequestMessage {
     }
 
     /**
-     * Gets the collection name, which may be null for some message types
-     *
-     * Gets the database name, which may be null for some message types
+     * Gets the database name
      *
      * @return the database name
      */

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
@@ -83,6 +83,7 @@ public final class CommandMessage extends RequestMessage {
     private final boolean exhaustAllowed;
     private final MessageSequences sequences;
     private final boolean responseExpected;
+    private final String database;
     /**
      * {@code null} iff either {@link #sequences} is not of the {@link DualMessageSequences} type,
      * or it is of that type, but it has not been {@linkplain #encodeMessageBodyWithMetadata(ByteBufferBsonOutput, OperationContext) encoded}.
@@ -119,7 +120,8 @@ public final class CommandMessage extends RequestMessage {
                    final boolean responseExpected, final boolean exhaustAllowed,
                    final MessageSequences sequences,
                    final ClusterConnectionMode clusterConnectionMode, @Nullable final ServerApi serverApi) {
-        super(database, getOpCode(settings, clusterConnectionMode, serverApi), settings);
+        super(getOpCode(settings, clusterConnectionMode, serverApi), settings);
+        this.database = database;
         this.command = command;
         this.commandFieldNameValidator = commandFieldNameValidator;
         this.readPreference = readPreference;
@@ -403,6 +405,15 @@ public final class CommandMessage extends RequestMessage {
 
     private static boolean isServerVersionKnown(final MessageSettings settings) {
         return settings.getMaxWireVersion() != UNKNOWN_WIRE_VERSION;
+    }
+
+    /**
+     * Gets the collection name, which may be null for some message types
+     *
+     * @return the collection name
+     */
+    public String getDatabase() {
+        return database;
     }
 
     @FunctionalInterface

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
@@ -77,7 +77,6 @@ public final class CommandMessage extends RequestMessage {
      */
     private static final byte PAYLOAD_TYPE_1_DOCUMENT_SEQUENCE = 1;
 
-    private final MongoNamespace namespace;
     private final BsonDocument command;
     private final FieldNameValidator commandFieldNameValidator;
     private final ReadPreference readPreference;
@@ -93,35 +92,34 @@ public final class CommandMessage extends RequestMessage {
     private final ClusterConnectionMode clusterConnectionMode;
     private final ServerApi serverApi;
 
-    CommandMessage(final MongoNamespace namespace, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
+    CommandMessage(final String database, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
                    final ReadPreference readPreference, final MessageSettings settings, final ClusterConnectionMode clusterConnectionMode,
                    @Nullable final ServerApi serverApi) {
-        this(namespace, command, commandFieldNameValidator, readPreference, settings, true, EmptyMessageSequences.INSTANCE,
+        this(database, command, commandFieldNameValidator, readPreference, settings, true, EmptyMessageSequences.INSTANCE,
                 clusterConnectionMode, serverApi);
     }
 
-    CommandMessage(final MongoNamespace namespace, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
+    CommandMessage(final String database, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
                    final ReadPreference readPreference, final MessageSettings settings, final boolean exhaustAllowed,
                    final ClusterConnectionMode clusterConnectionMode, @Nullable final ServerApi serverApi) {
-        this(namespace, command, commandFieldNameValidator, readPreference, settings, true, exhaustAllowed, EmptyMessageSequences.INSTANCE,
+        this(database, command, commandFieldNameValidator, readPreference, settings, true, exhaustAllowed, EmptyMessageSequences.INSTANCE,
                 clusterConnectionMode, serverApi);
     }
 
-    CommandMessage(final MongoNamespace namespace, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
+    CommandMessage(final String database, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
                    final ReadPreference readPreference, final MessageSettings settings, final boolean responseExpected,
                    final MessageSequences sequences,
                    final ClusterConnectionMode clusterConnectionMode, @Nullable final ServerApi serverApi) {
-        this(namespace, command, commandFieldNameValidator, readPreference, settings, responseExpected, false,
+        this(database, command, commandFieldNameValidator, readPreference, settings, responseExpected, false,
                 sequences, clusterConnectionMode, serverApi);
     }
 
-    CommandMessage(final MongoNamespace namespace, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
+    CommandMessage(final String database, final BsonDocument command, final FieldNameValidator commandFieldNameValidator,
                    final ReadPreference readPreference, final MessageSettings settings,
                    final boolean responseExpected, final boolean exhaustAllowed,
                    final MessageSequences sequences,
                    final ClusterConnectionMode clusterConnectionMode, @Nullable final ServerApi serverApi) {
-        super(namespace.getFullName(), getOpCode(settings, clusterConnectionMode, serverApi), settings);
-        this.namespace = namespace;
+        super(database, getOpCode(settings, clusterConnectionMode, serverApi), settings);
         this.command = command;
         this.commandFieldNameValidator = commandFieldNameValidator;
         this.readPreference = readPreference;
@@ -222,10 +220,6 @@ public final class CommandMessage extends RequestMessage {
         }
     }
 
-    MongoNamespace getNamespace() {
-        return namespace;
-    }
-
     @Override
     protected EncodingMetadata encodeMessageBodyWithMetadata(final ByteBufferBsonOutput bsonOutput, final OperationContext operationContext) {
         int commandStartPosition = useOpMsg() ? writeOpMsg(bsonOutput, operationContext) : writeOpQuery(bsonOutput);
@@ -281,7 +275,7 @@ public final class CommandMessage extends RequestMessage {
 
     private int writeOpQuery(final ByteBufferBsonOutput bsonOutput) {
         bsonOutput.writeInt32(0);
-        bsonOutput.writeCString(namespace.getFullName());
+        bsonOutput.writeCString(new MongoNamespace(getDatabase(), "$cmd").getFullName());
         bsonOutput.writeInt32(0);
         bsonOutput.writeInt32(-1);
 
@@ -328,7 +322,7 @@ public final class CommandMessage extends RequestMessage {
                    extraElements.add(new BsonElement("maxTimeMS", new BsonInt64(maxTimeMS)))
            );
         }
-        extraElements.add(new BsonElement("$db", new BsonString(new MongoNamespace(getCollectionName()).getDatabaseName())));
+        extraElements.add(new BsonElement("$db", new BsonString(getDatabase())));
         if (sessionContext.getClusterTime() != null) {
             extraElements.add(new BsonElement("$clusterTime", sessionContext.getClusterTime()));
         }

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
@@ -410,7 +410,9 @@ public final class CommandMessage extends RequestMessage {
     /**
      * Gets the collection name, which may be null for some message types
      *
-     * @return the collection name
+     * Gets the database name, which may be null for some message types
+     *
+     * @return the database name
      */
     public String getDatabase() {
         return database;

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandProtocolImpl.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandProtocolImpl.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.connection;
 
-import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
 import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.internal.async.SingleResultCallback;
@@ -30,7 +29,7 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.connection.ProtocolHelper.getMessageSettings;
 
 class CommandProtocolImpl<T> implements CommandProtocol<T> {
-    private final MongoNamespace namespace;
+    private final String database;
     private final BsonDocument command;
     private final MessageSequences sequences;
     private final ReadPreference readPreference;
@@ -44,7 +43,7 @@ class CommandProtocolImpl<T> implements CommandProtocol<T> {
             @Nullable final ReadPreference readPreference, final Decoder<T> commandResultDecoder, final boolean responseExpected,
             final MessageSequences sequences, final ClusterConnectionMode clusterConnectionMode, final OperationContext operationContext) {
         notNull("database", database);
-        this.namespace = new MongoNamespace(notNull("database", database), MongoNamespace.COMMAND_COLLECTION_NAME);
+        this.database = notNull("database", database);
         this.command = notNull("command", command);
         this.commandFieldNameValidator = notNull("commandFieldNameValidator", commandFieldNameValidator);
         this.readPreference = readPreference;
@@ -79,13 +78,13 @@ class CommandProtocolImpl<T> implements CommandProtocol<T> {
 
     @Override
     public CommandProtocolImpl<T> withSessionContext(final SessionContext sessionContext) {
-        return new CommandProtocolImpl<>(namespace.getDatabaseName(), command, commandFieldNameValidator, readPreference,
+        return new CommandProtocolImpl<>(database, command, commandFieldNameValidator, readPreference,
                 commandResultDecoder, responseExpected, sequences, clusterConnectionMode,
                 operationContext.withSessionContext(sessionContext));
     }
 
     private CommandMessage getCommandMessage(final InternalConnection connection) {
-        return new CommandMessage(namespace, command, commandFieldNameValidator, readPreference,
+        return new CommandMessage(database, command, commandFieldNameValidator, readPreference,
                     getMessageSettings(connection.getDescription(), connection.getInitialServerDescription()), responseExpected,
                 sequences, clusterConnectionMode, operationContext.getServerApi());
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServerMonitor.java
@@ -17,7 +17,6 @@
 package com.mongodb.internal.connection;
 
 import com.mongodb.MongoInterruptedException;
-import com.mongodb.MongoNamespace;
 import com.mongodb.MongoSocketException;
 import com.mongodb.ServerApi;
 import com.mongodb.annotations.ThreadSafe;
@@ -51,7 +50,6 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static com.mongodb.MongoNamespace.COMMAND_COLLECTION_NAME;
 import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.fail;
@@ -381,7 +379,7 @@ class DefaultServerMonitor implements ServerMonitor {
 
         private CommandMessage createCommandMessage(final BsonDocument command, final InternalConnection connection,
                 final ServerDescription currentServerDescription) {
-            return new CommandMessage(new MongoNamespace("admin", COMMAND_COLLECTION_NAME), command,
+            return new CommandMessage("admin", command,
                     NoOpFieldNameValidator.INSTANCE, primary(),
                     MessageSettings.builder()
                             .maxWireVersion(connection.getDescription().getMaxWireVersion())

--- a/driver-core/src/main/com/mongodb/internal/connection/LoggingCommandEventSender.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoggingCommandEventSender.java
@@ -102,7 +102,7 @@ class LoggingCommandEventSender implements CommandEventSender {
 
             logEventMessage(messagePrefix, "Command started", null, entries -> {
                         entries.add(new Entry(COMMAND_NAME, commandName));
-                        entries.add(new Entry(DATABASE_NAME, message.getNamespace().getDatabaseName()));
+                        entries.add(new Entry(DATABASE_NAME, message.getDatabase()));
                     },
                     entries -> entries.add(new Entry(COMMAND_CONTENT, command)));
         }
@@ -111,7 +111,7 @@ class LoggingCommandEventSender implements CommandEventSender {
             BsonDocument commandDocumentForEvent = redactionRequired
                     ? new BsonDocument() : commandDocument;
 
-            sendCommandStartedEvent(message, message.getNamespace().getDatabaseName(), commandName, commandDocumentForEvent, description,
+            sendCommandStartedEvent(message, message.getDatabase(), commandName, commandDocumentForEvent, description,
                     assertNotNull(commandListener), operationContext);
         }
         // the buffer underlying the command document may be released after the started event, so set to null to ensure it's not used
@@ -134,14 +134,14 @@ class LoggingCommandEventSender implements CommandEventSender {
             logEventMessage(messagePrefix, "Command failed", commandEventException,
                     entries -> {
                         entries.add(new Entry(COMMAND_NAME, commandName));
-                        entries.add(new Entry(DATABASE_NAME, message.getNamespace().getDatabaseName()));
+                        entries.add(new Entry(DATABASE_NAME, message.getDatabase()));
                         entries.add(new Entry(DURATION_MS, elapsedTimeNanos / NANOS_PER_MILLI));
                     },
                     entries -> entries.add(new Entry(COMMAND_CONTENT, null)));
         }
 
         if (eventRequired()) {
-            sendCommandFailedEvent(message, commandName, message.getNamespace().getDatabaseName(), description, elapsedTimeNanos,
+            sendCommandFailedEvent(message, commandName, message.getDatabase(), description, elapsedTimeNanos,
                     commandEventException, commandListener, operationContext);
         }
     }
@@ -170,7 +170,7 @@ class LoggingCommandEventSender implements CommandEventSender {
             logEventMessage("Command succeeded", null,
                     entries -> {
                         entries.add(new Entry(COMMAND_NAME, commandName));
-                        entries.add(new Entry(DATABASE_NAME, message.getNamespace().getDatabaseName()));
+                        entries.add(new Entry(DATABASE_NAME, message.getDatabase()));
                         entries.add(new Entry(DURATION_MS, elapsedTimeNanos / NANOS_PER_MILLI));
                     },
                     entries -> entries.add(new Entry(REPLY, replyString)), format);
@@ -178,7 +178,7 @@ class LoggingCommandEventSender implements CommandEventSender {
 
         if (eventRequired()) {
             BsonDocument responseDocumentForEvent = redactionRequired ? new BsonDocument() : reply;
-            sendCommandSucceededEvent(message, commandName, message.getNamespace().getDatabaseName(), responseDocumentForEvent,
+            sendCommandSucceededEvent(message, commandName, message.getDatabase(), responseDocumentForEvent,
                     description, elapsedTimeNanos, commandListener, operationContext);
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/RequestMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/RequestMessage.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.connection;
 
-import com.mongodb.lang.Nullable;
 import org.bson.BsonBinaryWriter;
 import org.bson.BsonDocument;
 import org.bson.FieldNameValidator;
@@ -38,7 +37,6 @@ abstract class RequestMessage {
 
     static final int MESSAGE_PROLOGUE_LENGTH = 16;
 
-    private final String database;
     private final MessageSettings settings;
     private final int id;
     private final OpCode opCode;
@@ -64,18 +62,11 @@ abstract class RequestMessage {
         return REQUEST_ID.get();
     }
 
+    RequestMessage(final OpCode opCode, final MessageSettings settings) {
+        this(opCode, REQUEST_ID.getAndIncrement(), settings);
+    }
+
     RequestMessage(final OpCode opCode, final int requestId, final MessageSettings settings) {
-        this(null, opCode, requestId, settings);
-    }
-
-
-    RequestMessage(final String database, final OpCode opCode, final MessageSettings settings) {
-        this(database, opCode, REQUEST_ID.getAndIncrement(), settings);
-    }
-
-    private RequestMessage(@Nullable final String database, final OpCode opCode, final int requestId,
-                           final MessageSettings settings) {
-        this.database = database;
         this.settings = settings;
         id = requestId;
         this.opCode = opCode;
@@ -158,14 +149,5 @@ abstract class RequestMessage {
         int documentStart = bsonOutput.getPosition();
         encodeUsingRegistry(writer, document);
         return bsonOutput.getPosition() - documentStart;
-    }
-
-    /**
-     * Gets the collection name, which may be null for some message types
-     *
-     * @return the collection name
-     */
-    protected String getDatabase() {
-        return database;
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/RequestMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/RequestMessage.java
@@ -38,7 +38,7 @@ abstract class RequestMessage {
 
     static final int MESSAGE_PROLOGUE_LENGTH = 16;
 
-    private final String collectionName;
+    private final String database;
     private final MessageSettings settings;
     private final int id;
     private final OpCode opCode;
@@ -69,13 +69,13 @@ abstract class RequestMessage {
     }
 
 
-    RequestMessage(final String collectionName, final OpCode opCode, final MessageSettings settings) {
-        this(collectionName, opCode, REQUEST_ID.getAndIncrement(), settings);
+    RequestMessage(final String database, final OpCode opCode, final MessageSettings settings) {
+        this(database, opCode, REQUEST_ID.getAndIncrement(), settings);
     }
 
-    private RequestMessage(@Nullable final String collectionName, final OpCode opCode, final int requestId,
+    private RequestMessage(@Nullable final String database, final OpCode opCode, final int requestId,
                            final MessageSettings settings) {
-        this.collectionName = collectionName;
+        this.database = database;
         this.settings = settings;
         id = requestId;
         this.opCode = opCode;
@@ -165,7 +165,7 @@ abstract class RequestMessage {
      *
      * @return the collection name
      */
-    protected String getCollectionName() {
-        return collectionName;
+    protected String getDatabase() {
+        return database;
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageSpecification.groovy
@@ -56,7 +56,7 @@ class CommandMessageSpecification extends Specification {
 
     def 'should encode command message with OP_MSG when server version is >= 3.6'() {
         given:
-        def message = new CommandMessage(namespace, command, fieldNameValidator, readPreference,
+        def message = new CommandMessage(namespace.getDatabaseName(), command, fieldNameValidator, readPreference,
                 MessageSettings.builder()
                         .maxWireVersion(LATEST_WIRE_VERSION)
                         .serverType(serverType as ServerType)
@@ -152,8 +152,8 @@ class CommandMessageSpecification extends Specification {
 
     def 'should get command document'() {
         given:
-        def message = new CommandMessage(namespace, originalCommandDocument, fieldNameValidator, ReadPreference.primary(),
-                MessageSettings.builder().maxWireVersion(maxWireVersion).build(), true,
+        def message = new CommandMessage(namespace.getDatabaseName(), originalCommandDocument, fieldNameValidator,
+                ReadPreference.primary(), MessageSettings.builder().maxWireVersion(maxWireVersion).build(), true,
                 payload == null ? MessageSequences.EmptyMessageSequences.INSTANCE : payload,
                 ClusterConnectionMode.MULTIPLE, null)
         def output = new ByteBufferBsonOutput(new SimpleBufferProvider())
@@ -200,8 +200,8 @@ class CommandMessageSpecification extends Specification {
                                                      new BsonDocument('_id', new BsonInt32(4)).append('b', new BsonBinary(new byte[441])),
                                                      new BsonDocument('_id', new BsonInt32(5)).append('c', new BsonBinary(new byte[451]))]
                 .withIndex().collect { doc, i -> new WriteRequestWithIndex(new InsertRequest(doc), i) }, true, fieldNameValidator)
-        def message = new CommandMessage(namespace, insertCommand, fieldNameValidator, ReadPreference.primary(), messageSettings,
-                false, payload, ClusterConnectionMode.MULTIPLE, null)
+        def message = new CommandMessage(namespace.getDatabaseName(), insertCommand, fieldNameValidator, ReadPreference.primary(),
+                messageSettings, false, payload, ClusterConnectionMode.MULTIPLE, null)
         def output = new ByteBufferBsonOutput(new SimpleBufferProvider())
         def sessionContext = Stub(SessionContext) {
             getReadConcern() >> ReadConcern.DEFAULT
@@ -224,8 +224,8 @@ class CommandMessageSpecification extends Specification {
 
         when:
         payload = payload.getNextSplit()
-        message = new CommandMessage(namespace, insertCommand, fieldNameValidator, ReadPreference.primary(), messageSettings,
-                false, payload, ClusterConnectionMode.MULTIPLE, null)
+        message = new CommandMessage(namespace.getDatabaseName(), insertCommand, fieldNameValidator, ReadPreference.primary(),
+                messageSettings, false, payload, ClusterConnectionMode.MULTIPLE, null)
         output.truncateToPosition(0)
         message.encode(output, new OperationContext(IgnorableRequestContext.INSTANCE, sessionContext, Stub(TimeoutContext), null))
         byteBuf = new ByteBufNIO(ByteBuffer.wrap(output.toByteArray()))
@@ -242,8 +242,8 @@ class CommandMessageSpecification extends Specification {
 
         when:
         payload = payload.getNextSplit()
-        message = new CommandMessage(namespace, insertCommand, fieldNameValidator, ReadPreference.primary(), messageSettings,
-                false, payload, ClusterConnectionMode.MULTIPLE, null)
+        message = new CommandMessage(namespace.getDatabaseName(), insertCommand, fieldNameValidator, ReadPreference.primary(),
+                messageSettings, false, payload, ClusterConnectionMode.MULTIPLE, null)
         output.truncateToPosition(0)
         message.encode(output, new OperationContext(IgnorableRequestContext.INSTANCE, sessionContext, Stub(TimeoutContext), null))
         byteBuf = new ByteBufNIO(ByteBuffer.wrap(output.toByteArray()))
@@ -260,8 +260,8 @@ class CommandMessageSpecification extends Specification {
 
         when:
         payload = payload.getNextSplit()
-        message = new CommandMessage(namespace, insertCommand, fieldNameValidator, ReadPreference.primary(), messageSettings,
-                false, payload, ClusterConnectionMode.MULTIPLE, null)
+        message = new CommandMessage(namespace.getDatabaseName(), insertCommand, fieldNameValidator, ReadPreference.primary(),
+                messageSettings, false, payload, ClusterConnectionMode.MULTIPLE, null)
         output.truncateToPosition(0)
         message.encode(output, new OperationContext(IgnorableRequestContext.INSTANCE,
                 sessionContext,
@@ -290,8 +290,8 @@ class CommandMessageSpecification extends Specification {
                                                      new BsonDocument('b', new BsonBinary(new byte[450])),
                                                      new BsonDocument('c', new BsonBinary(new byte[450]))]
                 .withIndex().collect { doc, i -> new WriteRequestWithIndex(new InsertRequest(doc), i) }, true, fieldNameValidator)
-        def message = new CommandMessage(namespace, command, fieldNameValidator, ReadPreference.primary(), messageSettings,
-                false, payload, ClusterConnectionMode.MULTIPLE, null)
+        def message = new CommandMessage(namespace.getDatabaseName(), command, fieldNameValidator, ReadPreference.primary(),
+                messageSettings, false, payload, ClusterConnectionMode.MULTIPLE, null)
         def output = new ByteBufferBsonOutput(new SimpleBufferProvider())
         def sessionContext = Stub(SessionContext) {
             getReadConcern() >> ReadConcern.DEFAULT
@@ -315,7 +315,7 @@ class CommandMessageSpecification extends Specification {
 
         when:
         payload = payload.getNextSplit()
-        message = new CommandMessage(namespace, command, fieldNameValidator, ReadPreference.primary(), messageSettings,
+        message = new CommandMessage(namespace.getDatabaseName(), command, fieldNameValidator, ReadPreference.primary(), messageSettings,
                 false, payload, ClusterConnectionMode.MULTIPLE, null)
         output.truncateToPosition(0)
         message.encode(output, new OperationContext(IgnorableRequestContext.INSTANCE, sessionContext,
@@ -341,8 +341,8 @@ class CommandMessageSpecification extends Specification {
                 .maxWireVersion(LATEST_WIRE_VERSION).build()
         def payload = new SplittablePayload(INSERT, [new BsonDocument('a', new BsonBinary(new byte[900]))]
                 .withIndex().collect { doc, i -> new WriteRequestWithIndex(new InsertRequest(doc), i) }, true, fieldNameValidator)
-        def message = new CommandMessage(namespace, command, fieldNameValidator, ReadPreference.primary(), messageSettings,
-                false, payload, ClusterConnectionMode.MULTIPLE, null)
+        def message = new CommandMessage(namespace.getDatabaseName(), command, fieldNameValidator, ReadPreference.primary(),
+                messageSettings, false, payload, ClusterConnectionMode.MULTIPLE, null)
         def output = new ByteBufferBsonOutput(new SimpleBufferProvider())
         def sessionContext = Stub(SessionContext) {
             getReadConcern() >> ReadConcern.DEFAULT

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/CommandMessageTest.java
@@ -66,7 +66,7 @@ class CommandMessageTest {
     @Test
     void encodeShouldThrowTimeoutExceptionWhenTimeoutContextIsCalled() {
         //given
-        CommandMessage commandMessage = new CommandMessage(NAMESPACE, COMMAND, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
+        CommandMessage commandMessage = new CommandMessage(NAMESPACE.getDatabaseName(), COMMAND, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 MessageSettings.builder()
                         .maxWireVersion(LATEST_WIRE_VERSION)
                         .serverType(ServerType.REPLICA_SET_SECONDARY)
@@ -93,7 +93,7 @@ class CommandMessageTest {
     @Test
     void encodeShouldNotAddExtraElementsFromTimeoutContextWhenConnectedToMongoCrypt() {
         //given
-        CommandMessage commandMessage = new CommandMessage(NAMESPACE, COMMAND, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
+        CommandMessage commandMessage = new CommandMessage(NAMESPACE.getDatabaseName(), COMMAND, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 MessageSettings.builder()
                         .maxWireVersion(LATEST_WIRE_VERSION)
                         .serverType(ServerType.REPLICA_SET_SECONDARY)
@@ -156,7 +156,7 @@ class CommandMessageTest {
                         new BsonDocument("insert", new BsonInt32(0)).append("document", documents.get(1)))))
                 .append("nsInfo", new BsonArray(singletonList(new BsonDocument("ns", new BsonString(ns.toString())))));
         CommandMessage commandMessage = new CommandMessage(
-                ns, command, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
+                ns.getDatabaseName(), command, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 MessageSettings.builder().maxWireVersion(LATEST_WIRE_VERSION).build(), true, opsAndNsInfo, ClusterConnectionMode.MULTIPLE, null);
         try (ByteBufferBsonOutput output = new ByteBufferBsonOutput(new SimpleBufferProvider())) {
             commandMessage.encode(

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
@@ -19,7 +19,6 @@ package com.mongodb.internal.connection
 import com.mongodb.MongoCommandException
 import com.mongodb.MongoInternalException
 import com.mongodb.MongoInterruptedException
-import com.mongodb.MongoNamespace
 import com.mongodb.MongoOperationTimeoutException
 import com.mongodb.MongoSocketClosedException
 import com.mongodb.MongoSocketException
@@ -77,7 +76,7 @@ import static java.util.concurrent.TimeUnit.SECONDS
 class InternalStreamConnectionSpecification extends Specification {
     private static final ServerId SERVER_ID = new ServerId(new ClusterId(), new ServerAddress())
 
-    def cmdNamespace = new MongoNamespace('admin.$cmd')
+    def database = 'admin'
     def fieldNameValidator = NoOpFieldNameValidator.INSTANCE
     def helper = new StreamHelper()
     def serverAddress = new ServerAddress()
@@ -642,7 +641,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         def response = '{ok : 0, errmsg : "failed"}'
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -661,7 +660,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         def callback = new FutureResultCallback()
         def response = '{ok : 0, errmsg : "failed"}'
@@ -724,7 +723,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, _) >> helper.defaultMessageHeader(commandMessage.getId())
@@ -745,7 +744,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, _) >> helper.defaultMessageHeader(commandMessage.getId())
@@ -769,7 +768,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         def response = '''{
                             ok : 1,
@@ -797,7 +796,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         def callback = new FutureResultCallback()
         def response = '''{
@@ -834,7 +833,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.write(_, _) >> { throw new MongoSocketWriteException('Failed to write', serverAddress, new IOException()) }
@@ -854,7 +853,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, _) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
@@ -874,7 +873,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, _) >> helper.defaultMessageHeader(commandMessage.getId())
@@ -895,7 +894,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         def response = '{ok : 0, errmsg : "failed"}'
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -917,7 +916,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def securitySensitiveCommandName = securitySensitiveCommand.keySet().iterator().next()
         def connection = getOpenedConnection()
-        def commandMessage = new CommandMessage(cmdNamespace, securitySensitiveCommand, fieldNameValidator, primary(), messageSettings,
+        def commandMessage = new CommandMessage(database, securitySensitiveCommand, fieldNameValidator, primary(), messageSettings,
                 MULTIPLE, null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, _) >> helper.defaultMessageHeader(commandMessage.getId())
@@ -953,7 +952,7 @@ class InternalStreamConnectionSpecification extends Specification {
     def 'should send failed event with redacted exception in failed security-sensitive commands'() {
         given:
         def connection = getOpenedConnection()
-        def commandMessage = new CommandMessage(cmdNamespace, securitySensitiveCommand, fieldNameValidator, primary(), messageSettings,
+        def commandMessage = new CommandMessage(database, securitySensitiveCommand, fieldNameValidator, primary(), messageSettings,
                 MULTIPLE, null)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16, _) >> helper.defaultMessageHeader(commandMessage.getId())
@@ -990,7 +989,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         def callback = new FutureResultCallback()
 
@@ -1021,7 +1020,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         def callback = new FutureResultCallback()
 
@@ -1056,7 +1055,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         def callback = new FutureResultCallback()
 
@@ -1081,7 +1080,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         def callback = new FutureResultCallback()
 
@@ -1109,7 +1108,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         def callback = new FutureResultCallback()
 
@@ -1140,7 +1139,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new CommandMessage(cmdNamespace, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
+        def commandMessage = new CommandMessage(database, pingCommandDocument, fieldNameValidator, primary(), messageSettings, MULTIPLE,
                 null)
         def callback = new FutureResultCallback()
         def response = '{ok : 0, errmsg : "failed"}'
@@ -1172,7 +1171,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def securitySensitiveCommandName = securitySensitiveCommand.keySet().iterator().next()
         def connection = getOpenedConnection()
-        def commandMessage = new CommandMessage(cmdNamespace, securitySensitiveCommand, fieldNameValidator, primary(), messageSettings,
+        def commandMessage = new CommandMessage(database, securitySensitiveCommand, fieldNameValidator, primary(), messageSettings,
                 MULTIPLE, null)
         def callback = new FutureResultCallback()
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
@@ -18,7 +18,6 @@ package com.mongodb.internal.connection
 
 import com.mongodb.LoggerSettings
 import com.mongodb.MongoInternalException
-import com.mongodb.MongoNamespace
 import com.mongodb.ReadPreference
 import com.mongodb.ServerAddress
 import com.mongodb.connection.ClusterId
@@ -50,13 +49,13 @@ class LoggingCommandEventSenderSpecification extends Specification {
     def 'should send events'() {
         given:
         def connectionDescription = new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress()))
-        def namespace = new MongoNamespace('test.driver')
-            def messageSettings = MessageSettings.builder().maxWireVersion(LATEST_WIRE_VERSION).build()
+        def database = 'test'
+        def messageSettings = MessageSettings.builder().maxWireVersion(LATEST_WIRE_VERSION).build()
         def commandListener = new TestCommandListener()
         def commandDocument = new BsonDocument('ping', new BsonInt32(1))
         def replyDocument = new BsonDocument('ok', new BsonInt32(1))
         def failureException = new MongoInternalException('failure!')
-        def message = new CommandMessage(namespace, commandDocument,
+        def message = new CommandMessage(database, commandDocument,
                 NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), messageSettings, MULTIPLE, null)
         def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
         message.encode(bsonOutput, new OperationContext(IgnorableRequestContext.INSTANCE, NoOpSessionContext.INSTANCE,
@@ -77,14 +76,14 @@ class LoggingCommandEventSenderSpecification extends Specification {
         then:
         commandListener.eventsWereDelivered([
                 new CommandStartedEvent(null, operationContext.id, message.getId(), connectionDescription,
-                        namespace.databaseName, commandDocument.getFirstKey(),
-                        commandDocument.append('$db', new BsonString(namespace.databaseName))),
+                        database, commandDocument.getFirstKey(),
+                        commandDocument.append('$db', new BsonString(database))),
                 new CommandSucceededEvent(null, operationContext.id, message.getId(), connectionDescription,
-                        namespace.databaseName, commandDocument.getFirstKey(), new BsonDocument(), 1),
+                        database, commandDocument.getFirstKey(), new BsonDocument(), 1),
                 new CommandSucceededEvent(null, operationContext.id, message.getId(), connectionDescription,
-                        namespace.databaseName, commandDocument.getFirstKey(), replyDocument, 1),
+                        database, commandDocument.getFirstKey(), replyDocument, 1),
                 new CommandFailedEvent(null, operationContext.id, message.getId(), connectionDescription,
-                        namespace.databaseName, commandDocument.getFirstKey(), 1, failureException)
+                        database, commandDocument.getFirstKey(), 1, failureException)
         ])
 
         where:
@@ -96,12 +95,12 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def serverId = new ServerId(new ClusterId(), new ServerAddress())
         def connectionDescription = new ConnectionDescription(serverId)
                 .withConnectionId(new ConnectionId(serverId, 42, 1000))
-        def namespace = new MongoNamespace('test.driver')
+        def database = 'test'
         def messageSettings = MessageSettings.builder().maxWireVersion(LATEST_WIRE_VERSION).build()
         def commandDocument = new BsonDocument('ping', new BsonInt32(1))
         def replyDocument = new BsonDocument('ok', new BsonInt32(42))
         def failureException = new MongoInternalException('failure!')
-        def message = new CommandMessage(namespace, commandDocument, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
+        def message = new CommandMessage(database, commandDocument, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 messageSettings, MULTIPLE, null)
         def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
         message.encode(bsonOutput, new OperationContext(IgnorableRequestContext.INSTANCE, NoOpSessionContext.INSTANCE,
@@ -155,10 +154,10 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def serverId = new ServerId(new ClusterId(), new ServerAddress())
         def connectionDescription = new ConnectionDescription(serverId)
                 .withConnectionId(new ConnectionId(serverId, 42, 1000))
-        def namespace = new MongoNamespace('test.driver')
+        def database = 'test'
         def messageSettings = MessageSettings.builder().maxWireVersion(LATEST_WIRE_VERSION).build()
         def commandDocument = new BsonDocument('fake', new BsonBinary(new byte[2048]))
-        def message = new CommandMessage(namespace, commandDocument, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
+        def message = new CommandMessage(database, commandDocument, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 messageSettings, SINGLE, null)
         def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
         message.encode(bsonOutput, new OperationContext(IgnorableRequestContext.INSTANCE, NoOpSessionContext.INSTANCE,
@@ -189,10 +188,10 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def serverId = new ServerId(new ClusterId(), new ServerAddress())
         def connectionDescription = new ConnectionDescription(serverId)
                 .withConnectionId(new ConnectionId(serverId, 42, 1000))
-        def namespace = new MongoNamespace('test.driver')
+        def database = 'test'
         def messageSettings = MessageSettings.builder().maxWireVersion(LATEST_WIRE_VERSION).build()
         def commandDocument = new BsonDocument('createUser', new BsonString('private'))
-        def message = new CommandMessage(namespace, commandDocument, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
+        def message = new CommandMessage(database, commandDocument, NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 messageSettings, SINGLE, null)
         def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
         message.encode(bsonOutput, new OperationContext(IgnorableRequestContext.INSTANCE, NoOpSessionContext.INSTANCE,

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/StreamHelper.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/StreamHelper.groovy
@@ -17,7 +17,6 @@
 package com.mongodb.internal.connection
 
 import com.mongodb.ClusterFixture
-import com.mongodb.MongoNamespace
 import com.mongodb.ReadPreference
 import com.mongodb.async.FutureResultCallback
 import com.mongodb.internal.IgnorableRequestContext
@@ -37,7 +36,6 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.security.SecureRandom
 
-import static com.mongodb.MongoNamespace.COMMAND_COLLECTION_NAME
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.internal.connection.MessageHelper.LEGACY_HELLO
 
@@ -166,7 +164,7 @@ class StreamHelper {
     }
 
     static hello() {
-        CommandMessage command = new CommandMessage(new MongoNamespace('admin', COMMAND_COLLECTION_NAME),
+        CommandMessage command = new CommandMessage('admin',
                 new BsonDocument(LEGACY_HELLO, new BsonInt32(1)), NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(),
                 MessageSettings.builder().build(), SINGLE, null)
         ByteBufferBsonOutput outputBuffer = new ByteBufferBsonOutput(new SimpleBufferProvider())

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/UsageTrackingConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/UsageTrackingConnectionSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.connection
 
-import com.mongodb.MongoNamespace
 import com.mongodb.ServerAddress
 import com.mongodb.async.FutureResultCallback
 import com.mongodb.connection.ClusterId
@@ -171,7 +170,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         def openedLastUsedAt = connection.lastUsedAt
 
         when:
-        connection.sendAndReceive(new CommandMessage(new MongoNamespace('test.coll'),
+        connection.sendAndReceive(new CommandMessage('test',
                 new BsonDocument('ping', new BsonInt32(1)), NoOpFieldNameValidator.INSTANCE, primary(),
                 MessageSettings.builder().build(), SINGLE, null), new BsonDocumentCodec(),  OPERATION_CONTEXT)
 
@@ -188,7 +187,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         def futureResultCallback = new FutureResultCallback<Void>()
 
         when:
-        connection.sendAndReceiveAsync(new CommandMessage(new MongoNamespace('test.coll'),
+        connection.sendAndReceiveAsync(new CommandMessage('test',
                 new BsonDocument('ping', new BsonInt32(1)), NoOpFieldNameValidator.INSTANCE, primary(),
                 MessageSettings.builder().build(), SINGLE, null),
                 new BsonDocumentCodec(), OPERATION_CONTEXT, futureResultCallback)

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoOperationPublisher.java
@@ -175,7 +175,7 @@ public final class MongoOperationPublisher<T> {
     }
 
     <D> MongoOperationPublisher<D> withDatabaseAndDocumentClass(final String name, final Class<D> documentClass) {
-        return withNamespaceAndDocumentClass(new MongoNamespace(notNull("name", name), "ignored"),
+        return withNamespaceAndDocumentClass(new MongoNamespace(notNull("name", name), "_ignored"),
                                              notNull("documentClass", documentClass));
     }
 

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoOperationPublisherTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoOperationPublisherTest.java
@@ -66,7 +66,7 @@ public class MongoOperationPublisherTest {
 
     @Test
     public void withDatabase() {
-        assertEquals(new MongoNamespace("c.ignored"), DEFAULT_MOP.withDatabase("c").getNamespace());
+        assertEquals(new MongoNamespace("c._ignored"), DEFAULT_MOP.withDatabase("c").getNamespace());
     }
 
     @Test
@@ -79,7 +79,7 @@ public class MongoOperationPublisherTest {
     public void withDatabaseAndDocumentClass() {
         MongoOperationPublisher<BsonDocument> alternative = DEFAULT_MOP.withDatabaseAndDocumentClass("c", BsonDocument.class);
         assertEquals(BsonDocument.class, alternative.getDocumentClass());
-        assertEquals(new MongoNamespace("c.ignored"), alternative.getNamespace());
+        assertEquals(new MongoNamespace("c._ignored"), alternative.getNamespace());
     }
 
     @Test

--- a/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
@@ -69,7 +69,7 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
             final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
             final List<? extends Bson> pipeline, final AggregationLevel aggregationLevel, final boolean retryReads,
             final TimeoutSettings timeoutSettings) {
-        this(clientSession, new MongoNamespace(databaseName, "ignored"), documentClass, resultClass, codecRegistry, readPreference,
+        this(clientSession, new MongoNamespace(databaseName, "_ignored"), documentClass, resultClass, codecRegistry, readPreference,
                 readConcern, writeConcern, executor, pipeline, aggregationLevel, retryReads, timeoutSettings);
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ChangeStreamIterableImpl.java
@@ -73,7 +73,7 @@ public class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeS
             final CodecRegistry codecRegistry, final ReadPreference readPreference, final ReadConcern readConcern,
             final OperationExecutor executor, final List<? extends Bson> pipeline, final Class<TResult> resultClass,
             final ChangeStreamLevel changeStreamLevel, final boolean retryReads, final TimeoutSettings timeoutSettings) {
-        this(clientSession, new MongoNamespace(databaseName, "ignored"), codecRegistry, readPreference, readConcern, executor, pipeline,
+        this(clientSession, new MongoNamespace(databaseName, "_ignored"), codecRegistry, readPreference, readConcern, executor, pipeline,
                 resultClass, changeStreamLevel, retryReads, timeoutSettings);
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
@@ -46,7 +46,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static com.mongodb.MongoNamespace.COMMAND_COLLECTION_NAME;
 import static com.mongodb.MongoNamespace.checkDatabaseNameValidity;
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -88,7 +87,7 @@ public class MongoDatabaseImpl implements MongoDatabase {
         this.autoEncryptionSettings = autoEncryptionSettings;
         this.timeoutSettings = timeoutSettings;
         this.executor = notNull("executor", executor);
-        this.operations = new Operations<>(new MongoNamespace(name, COMMAND_COLLECTION_NAME), BsonDocument.class, readPreference,
+        this.operations = new Operations<>(new MongoNamespace(name, "_ignored"), BsonDocument.class, readPreference,
                 codecRegistry, readConcern, writeConcern, retryWrites, retryReads, timeoutSettings);
     }
 

--- a/driver-sync/src/test/unit/com/mongodb/client/MongoClientSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/MongoClientSpecification.groovy
@@ -124,7 +124,7 @@ class MongoClientSpecification extends Specification {
     def 'should create ChangeStreamIterable correctly'() {
         given:
         def executor = new TestOperationExecutor([])
-        def namespace = new MongoNamespace('admin', 'ignored')
+        def namespace = new MongoNamespace('admin', '_ignored')
         def settings = MongoClientSettings.builder()
                 .readPreference(secondary())
                 .readConcern(ReadConcern.MAJORITY)

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoClusterSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoClusterSpecification.groovy
@@ -186,7 +186,7 @@ class MongoClusterSpecification extends Specification {
     def 'should create ChangeStreamIterable correctly'() {
         given:
         def executor = new TestOperationExecutor([])
-        def namespace = new MongoNamespace('admin', 'ignored')
+        def namespace = new MongoNamespace('admin', '_ignored')
         def settings = MongoClientSettings.builder()
                 .readPreference(secondary())
                 .readConcern(ReadConcern.MAJORITY)

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoDatabaseSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoDatabaseSpecification.groovy
@@ -382,7 +382,7 @@ class MongoDatabaseSpecification extends Specification {
     def 'should create ChangeStreamIterable correctly'() {
         given:
         def executor = new TestOperationExecutor([])
-        def namespace = new MongoNamespace(name, 'ignored')
+        def namespace = new MongoNamespace(name, '_ignored')
         def database = new MongoDatabaseImpl(name, codecRegistry, readPreference, writeConcern, false, false,
                 readConcern,  JAVA_LEGACY, null, TIMEOUT_SETTINGS, executor)
         def watchMethod = database.&watch


### PR DESCRIPTION
This removes a remnant of the pre-OP_MSG wire protocol, which required a synthetic collection name for most commands.  It's no longer needed, except for the last remaining bit where the driver uses OP_QUERY for the first message in the connection handshake.

JAVA-5939