### PR TITLE
Simplify RequestMessage class hierarchy

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/CompressedMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CompressedMessage.java
@@ -36,7 +36,7 @@ class CompressedMessage extends RequestMessage {
     }
 
     @Override
-    protected EncodingMetadata encodeMessageBodyWithMetadata(final ByteBufferBsonOutput bsonOutput, final OperationContext operationContext) {
+    protected void encodeMessageBody(final ByteBufferBsonOutput bsonOutput, final OperationContext operationContext) {
         bsonOutput.writeInt32(wrappedOpcode.getValue());
         bsonOutput.writeInt32(getWrappedMessageSize(wrappedMessageBuffers) - MESSAGE_HEADER_LENGTH);
         bsonOutput.writeByte(compressor.getId());
@@ -45,8 +45,6 @@ class CompressedMessage extends RequestMessage {
                 .position(getFirstWrappedMessageBuffer(wrappedMessageBuffers).position() + MESSAGE_HEADER_LENGTH);
 
         compressor.compress(wrappedMessageBuffers, bsonOutput);
-
-        return new EncodingMetadata(0);
     }
 
     private static int getWrappedMessageSize(final List<ByteBuf> wrappedMessageBuffers) {


### PR DESCRIPTION
* Remove EncodingMetadata abstraction and pull the remains into CommandMessage
* Pull the writeDocuments method into CommandMessage and simplify its parameters

JAVA-5944