### PR TITLE
Improve error message clarity in MongoCommandException.

### DIFF
--- a/driver-core/src/main/com/mongodb/ClientBulkWriteException.java
+++ b/driver-core/src/main/com/mongodb/ClientBulkWriteException.java
@@ -88,7 +88,7 @@ public final class ClientBulkWriteException extends MongoServerException {
             @Nullable final Map<Integer, WriteError> writeErrors,
             @Nullable final ClientBulkWriteResult partialResult,
             final ServerAddress serverAddress) {
-        return "Client-level bulk write operation error on server " + serverAddress + "."
+        return "Client-level bulk write operation error on MongoDB server " + serverAddress + "."
                 + (error == null ? "" : " Top-level error: " + error + ".")
                 + (writeErrors == null || writeErrors.isEmpty() ? "" : " Write errors: " + writeErrors + ".")
                 + (writeConcernErrors == null || writeConcernErrors.isEmpty() ? "" : " Write concern errors: " + writeConcernErrors + ".")

--- a/driver-core/src/main/com/mongodb/MongoBulkWriteException.java
+++ b/driver-core/src/main/com/mongodb/MongoBulkWriteException.java
@@ -53,7 +53,7 @@ public class MongoBulkWriteException extends MongoServerException {
     public MongoBulkWriteException(final BulkWriteResult writeResult, final List<BulkWriteError> writeErrors,
                                    @Nullable final WriteConcernError writeConcernError, final ServerAddress serverAddress,
                                    final Set<String> errorLabels) {
-        super("Bulk write operation error on server " + serverAddress + ". "
+        super("Bulk write operation error on MongoDB server " + serverAddress + ". "
                 + (writeErrors.isEmpty() ? "" : "Write errors: " + writeErrors + ". ")
                 + (writeConcernError == null ? "" : "Write concern error: " + writeConcernError + ". "), serverAddress);
         this.writeResult = writeResult;

--- a/driver-core/src/main/com/mongodb/MongoCommandException.java
+++ b/driver-core/src/main/com/mongodb/MongoCommandException.java
@@ -48,7 +48,7 @@ public class MongoCommandException extends MongoServerException {
      */
     public MongoCommandException(final BsonDocument response, final ServerAddress address) {
         super(extractErrorCode(response), extractErrorCodeName(response),
-              format("Command failed with error %s: '%s' on server %s. The full response is %s", extractErrorCodeAndName(response),
+              format("Command execution failed on MongoDB server with error %s: '%s' on server %s. The full response is %s", extractErrorCodeAndName(response),
                      extractErrorMessage(response), address, getResponseAsJson(response)), address);
         this.response = response;
         addLabels(extractErrorLabelsAsBson(response));

--- a/driver-core/src/main/com/mongodb/MongoWriteException.java
+++ b/driver-core/src/main/com/mongodb/MongoWriteException.java
@@ -50,7 +50,7 @@ public class MongoWriteException extends MongoServerException {
      * @since 5.0
      */
     public MongoWriteException(final WriteError error, final ServerAddress serverAddress, final Collection<String> errorLabels) {
-        super(error.getCode(), "Write operation error on server " + serverAddress + ". Write error: " + error + ".", serverAddress);
+        super(error.getCode(), "Write operation error on MongoDB server " + serverAddress + ". Write error: " + error + ".", serverAddress);
         this.error = error;
         addLabels(errorLabels);
     }

--- a/driver-core/src/test/unit/com/mongodb/MongoCommandExceptionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/MongoCommandExceptionSpecification.groovy
@@ -56,11 +56,12 @@ class MongoCommandExceptionSpecification extends Specification {
         new MongoCommandException(new BsonDocument('ok', BsonBoolean.FALSE).append('code', new BsonInt32(26))
                 .append('codeName', new BsonString('TimeoutError')).append('errmsg', new BsonString('the error message')),
                 new ServerAddress())
-                .getMessage() == 'Command execution failed on MongoDB server with error 26 (TimeoutError): \'the error message\' on server 127.0.0.1:27017. ' +
-                'The full response is {"ok": false, "code": 26, "codeName": "TimeoutError", "errmsg": "the error message"}'
+                .getMessage() == 'Command execution failed on MongoDB server with error 26 (TimeoutError): \'the error message\' ' +
+                'on server 127.0.0.1:27017. The full response is {"ok": false, "code": 26, "codeName": "TimeoutError", ' +
+                '"errmsg": "the error message"}'
         new MongoCommandException(new BsonDocument('ok', BsonBoolean.FALSE).append('code', new BsonInt32(26))
                 .append('errmsg', new BsonString('the error message')), new ServerAddress())
-                .getMessage() == 'Command execution failed on MongoDB server with error 26: \'the error message\' on server 127.0.0.1:27017. ' +
-                'The full response is {"ok": false, "code": 26, "errmsg": "the error message"}'
+                .getMessage() == 'Command execution failed on MongoDB server with error 26: \'the error message\' ' +
+                'on server 127.0.0.1:27017. The full response is {"ok": false, "code": 26, "errmsg": "the error message"}'
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/MongoCommandExceptionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/MongoCommandExceptionSpecification.groovy
@@ -56,11 +56,11 @@ class MongoCommandExceptionSpecification extends Specification {
         new MongoCommandException(new BsonDocument('ok', BsonBoolean.FALSE).append('code', new BsonInt32(26))
                 .append('codeName', new BsonString('TimeoutError')).append('errmsg', new BsonString('the error message')),
                 new ServerAddress())
-                .getMessage() == 'Command failed with error 26 (TimeoutError): \'the error message\' on server 127.0.0.1:27017. ' +
+                .getMessage() == 'Command execution failed on MongoDB server with error 26 (TimeoutError): \'the error message\' on server 127.0.0.1:27017. ' +
                 'The full response is {"ok": false, "code": 26, "codeName": "TimeoutError", "errmsg": "the error message"}'
         new MongoCommandException(new BsonDocument('ok', BsonBoolean.FALSE).append('code', new BsonInt32(26))
                 .append('errmsg', new BsonString('the error message')), new ServerAddress())
-                .getMessage() == 'Command failed with error 26: \'the error message\' on server 127.0.0.1:27017. ' +
+                .getMessage() == 'Command execution failed on MongoDB server with error 26: \'the error message\' on server 127.0.0.1:27017. ' +
                 'The full response is {"ok": false, "code": 26, "errmsg": "the error message"}'
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/MongoWriteExceptionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/MongoWriteExceptionTest.java
@@ -32,7 +32,7 @@ public class MongoWriteExceptionTest {
         WriteError writeError = new WriteError(11000, "Duplicate key", new BsonDocument("x", new BsonInt32(1)));
         MongoWriteException e = new MongoWriteException(writeError, new ServerAddress("host1"), Collections.emptySet());
 
-        assertEquals("Write operation error on server host1:27017. Write error: WriteError{code=11000, message='Duplicate key', "
+        assertEquals("Write operation error on MongoDB server host1:27017. Write error: WriteError{code=11000, message='Duplicate key', "
                 + "details={\"x\": 1}}.",
                 e.getMessage());
         assertEquals(writeError.getCode(), e.getCode());

--- a/driver-legacy/src/main/com/mongodb/BulkWriteException.java
+++ b/driver-legacy/src/main/com/mongodb/BulkWriteException.java
@@ -46,7 +46,7 @@ public class BulkWriteException extends MongoServerException {
      */
     BulkWriteException(final BulkWriteResult writeResult, final List<BulkWriteError> writeErrors,
                        @Nullable final WriteConcernError writeConcernError, final ServerAddress serverAddress) {
-        super("Bulk write operation error on server " + serverAddress + ". "
+        super("Bulk write operation error on MongoDB server " + serverAddress + ". "
               + (writeErrors.isEmpty() ? "" : "Write errors: " + writeErrors + ". ")
               + (writeConcernError == null ? "" : "Write concern error: " + writeConcernError + ". "), serverAddress);
         this.writeResult = writeResult;

--- a/driver-sync/src/test/functional/com/mongodb/internal/connection/OidcAuthenticationProseTests.java
+++ b/driver-sync/src/test/functional/com/mongodb/internal/connection/OidcAuthenticationProseTests.java
@@ -406,7 +406,7 @@ public class OidcAuthenticationProseTests {
         MongoClientSettings clientSettings = createSettings(callback);
         try (MongoClient mongoClient = createMongoClient(clientSettings)) {
             assertCause(MongoCommandException.class,
-                    "Command failed with error 18 (AuthenticationFailed):",
+                    "Command execution failed on MongoDB server with error 18 (AuthenticationFailed):",
                     () -> performFind(mongoClient));
         }
     }
@@ -424,7 +424,7 @@ public class OidcAuthenticationProseTests {
         try (MongoClient mongoClient = createMongoClient(clientSettings)) {
             failCommand(20, 1, "saslStart");
             assertCause(MongoCommandException.class,
-                    "Command failed with error 20",
+                    "Command execution failed on MongoDB server with error 20",
                     () -> performFind(mongoClient));
 
             assertEquals(Arrays.asList(
@@ -471,7 +471,7 @@ public class OidcAuthenticationProseTests {
             performFind(mongoClient);
             failCommand(391, 1, "find");
             assertCause(MongoCommandException.class,
-                    "Command failed with error 18",
+                    "Command execution failed on MongoDB server with error 18",
                     () -> performFind(mongoClient));
         }
         assertEquals(2, wrappedCallback.invocations.get());
@@ -492,7 +492,7 @@ public class OidcAuthenticationProseTests {
             performInsert(mongoClient);
             failCommand(391, 1, "insert");
             assertCause(MongoCommandException.class,
-                    "Command failed with error 18",
+                    "Command execution failed on MongoDB server with error 18",
                     () -> performInsert(mongoClient));
         }
         assertEquals(2, wrappedCallback.invocations.get());
@@ -740,7 +740,7 @@ public class OidcAuthenticationProseTests {
         TestCommandListener commandListener = new TestCommandListener(listener);
         assertFindFails(createHumanSettings(createHumanCallback(), commandListener),
                 MongoCommandException.class,
-                "Command failed with error 18");
+                "Command execution failed on MongoDB server with error 18");
         assertEquals(Arrays.asList(
                 "isMaster started",
                 "isMaster succeeded",
@@ -833,7 +833,7 @@ public class OidcAuthenticationProseTests {
             assertEquals(1, callback1.getInvocations());
             failCommand(391, 1, "find");
             assertCause(MongoCommandException.class,
-                    "Command failed with error 18",
+                    "Command execution failed on MongoDB server with error 18",
                     () -> performFind(mongoClient));
             assertEquals(3, callback1.getInvocations());
         }


### PR DESCRIPTION
## Description
This PR improves the clarity of error messages when a Command fails on a server.

Error messages now explicitly indicate that the exception originated from the server, not the driver, reducing ambiguity when diagnosing failures.

JAVA-5905