### PR TITLE
Add support for server selection's deprioritized servers to all topologies.

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -68,7 +68,6 @@ import static com.mongodb.connection.ServerDescription.MIN_DRIVER_SERVER_VERSION
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
 import static com.mongodb.internal.Locks.withInterruptibleLock;
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
-import static com.mongodb.internal.VisibleForTesting.AccessModifier.PROTECTED;
 import static com.mongodb.internal.connection.EventHelper.wouldDescriptionsGenerateEquivalentEvents;
 import static com.mongodb.internal.event.EventListenerHelper.singleClusterListener;
 import static com.mongodb.internal.logging.LogMessage.Component.SERVER_SELECTION;
@@ -237,8 +236,7 @@ public abstract class BaseCluster implements Cluster {
         return isClosed;
     }
 
-    @VisibleForTesting(otherwise = PROTECTED)
-    public void updateDescription(final ClusterDescription newDescription) {
+    protected void updateDescription(final ClusterDescription newDescription) {
         withLock(() -> {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(format("Updating cluster description to  %s", newDescription.getShortDescription()));

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -68,6 +68,7 @@ import static com.mongodb.connection.ServerDescription.MIN_DRIVER_SERVER_VERSION
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
 import static com.mongodb.internal.Locks.withInterruptibleLock;
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
+import static com.mongodb.internal.VisibleForTesting.AccessModifier.PROTECTED;
 import static com.mongodb.internal.connection.EventHelper.wouldDescriptionsGenerateEquivalentEvents;
 import static com.mongodb.internal.event.EventListenerHelper.singleClusterListener;
 import static com.mongodb.internal.logging.LogMessage.Component.SERVER_SELECTION;
@@ -94,7 +95,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.stream.Collectors.toList;
 
-abstract class BaseCluster implements Cluster {
+@VisibleForTesting(otherwise = PRIVATE)
+public abstract class BaseCluster implements Cluster {
     private static final Logger LOGGER = Loggers.getLogger("cluster");
     private static final StructuredLogger STRUCTURED_LOGGER = new StructuredLogger("cluster");
 
@@ -112,10 +114,11 @@ abstract class BaseCluster implements Cluster {
     private volatile boolean isClosed;
     private volatile ClusterDescription description;
 
-    BaseCluster(final ClusterId clusterId,
-                final ClusterSettings settings,
-                final ClusterableServerFactory serverFactory,
-                final ClientMetadata clientMetadata) {
+    @VisibleForTesting(otherwise = PRIVATE)
+    protected BaseCluster(final ClusterId clusterId,
+                          final ClusterSettings settings,
+                          final ClusterableServerFactory serverFactory,
+                          final ClientMetadata clientMetadata) {
         this.clusterId = notNull("clusterId", clusterId);
         this.settings = notNull("settings", settings);
         this.serverFactory = notNull("serverFactory", serverFactory);
@@ -234,7 +237,8 @@ abstract class BaseCluster implements Cluster {
         return isClosed;
     }
 
-    protected void updateDescription(final ClusterDescription newDescription) {
+    @VisibleForTesting(otherwise = PROTECTED)
+    public void updateDescription(final ClusterDescription newDescription) {
         withLock(() -> {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(format("Updating cluster description to  %s", newDescription.getShortDescription()));
@@ -361,8 +365,7 @@ abstract class BaseCluster implements Cluster {
             final ClusterSettings settings) {
         List<ServerSelector> selectors = Stream.of(
                 getRaceConditionPreFilteringSelector(serversSnapshot),
-                serverSelector,
-                serverDeprioritization.getServerSelector(),
+                serverDeprioritization.applyDeprioritization(serverSelector),
                 settings.getServerSelector(), // may be null
                 new LatencyMinimizingServerSelector(settings.getLocalThreshold(MILLISECONDS), MILLISECONDS),
                 AtMostTwoRandomServerSelector.instance(),

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -163,7 +163,7 @@ public abstract class BaseCluster implements Cluster {
             if (serverTuple != null) {
                 ServerAddress serverAddress = serverTuple.getServerDescription().getAddress();
                 logServerSelectionSucceeded(operationContext, clusterId, serverAddress, serverSelector, currentDescription);
-                serverDeprioritization.updateCandidate(serverAddress);
+                serverDeprioritization.updateCandidate(serverAddress, currentDescription.getType());
                 return serverTuple;
             }
             computedServerSelectionTimeout.onExpired(() ->
@@ -306,7 +306,7 @@ public abstract class BaseCluster implements Cluster {
                 if (serverTuple != null) {
                     ServerAddress serverAddress = serverTuple.getServerDescription().getAddress();
                     logServerSelectionSucceeded(operationContext, clusterId, serverAddress, request.originalSelector, description);
-                    serverDeprioritization.updateCandidate(serverAddress);
+                    serverDeprioritization.updateCandidate(serverAddress, description.getType());
                     request.onResult(serverTuple, null);
                     return true;
                 }

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -67,7 +67,6 @@ import static com.mongodb.connection.ServerDescription.MAX_DRIVER_WIRE_VERSION;
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_SERVER_VERSION;
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
 import static com.mongodb.internal.Locks.withInterruptibleLock;
-import static com.mongodb.internal.VisibleForTesting.AccessModifier.PACKAGE;
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PROTECTED;
 import static com.mongodb.internal.connection.EventHelper.wouldDescriptionsGenerateEquivalentEvents;
@@ -115,8 +114,7 @@ public abstract class BaseCluster implements Cluster {
     private volatile boolean isClosed;
     private volatile ClusterDescription description;
 
-    @VisibleForTesting(otherwise = PACKAGE)
-    protected BaseCluster(final ClusterId clusterId,
+    BaseCluster(final ClusterId clusterId,
                           final ClusterSettings settings,
                           final ClusterableServerFactory serverFactory,
                           final ClientMetadata clientMetadata) {

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -68,7 +68,6 @@ import static com.mongodb.connection.ServerDescription.MIN_DRIVER_SERVER_VERSION
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
 import static com.mongodb.internal.Locks.withInterruptibleLock;
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
-import static com.mongodb.internal.VisibleForTesting.AccessModifier.PROTECTED;
 import static com.mongodb.internal.connection.EventHelper.wouldDescriptionsGenerateEquivalentEvents;
 import static com.mongodb.internal.event.EventListenerHelper.singleClusterListener;
 import static com.mongodb.internal.logging.LogMessage.Component.SERVER_SELECTION;
@@ -95,8 +94,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.stream.Collectors.toList;
 
-@VisibleForTesting(otherwise = PROTECTED)
-public abstract class BaseCluster implements Cluster {
+abstract class BaseCluster implements Cluster {
     private static final Logger LOGGER = Loggers.getLogger("cluster");
     private static final StructuredLogger STRUCTURED_LOGGER = new StructuredLogger("cluster");
 

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -69,6 +69,7 @@ import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
 import static com.mongodb.internal.Locks.withInterruptibleLock;
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PACKAGE;
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
+import static com.mongodb.internal.VisibleForTesting.AccessModifier.PROTECTED;
 import static com.mongodb.internal.connection.EventHelper.wouldDescriptionsGenerateEquivalentEvents;
 import static com.mongodb.internal.event.EventListenerHelper.singleClusterListener;
 import static com.mongodb.internal.logging.LogMessage.Component.SERVER_SELECTION;
@@ -95,7 +96,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.stream.Collectors.toList;
 
-@VisibleForTesting(otherwise = PRIVATE)
+@VisibleForTesting(otherwise = PROTECTED)
 public abstract class BaseCluster implements Cluster {
     private static final Logger LOGGER = Loggers.getLogger("cluster");
     private static final StructuredLogger STRUCTURED_LOGGER = new StructuredLogger("cluster");

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -67,6 +67,7 @@ import static com.mongodb.connection.ServerDescription.MAX_DRIVER_WIRE_VERSION;
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_SERVER_VERSION;
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
 import static com.mongodb.internal.Locks.withInterruptibleLock;
+import static com.mongodb.internal.VisibleForTesting.AccessModifier.PACKAGE;
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
 import static com.mongodb.internal.connection.EventHelper.wouldDescriptionsGenerateEquivalentEvents;
 import static com.mongodb.internal.event.EventListenerHelper.singleClusterListener;
@@ -113,7 +114,7 @@ public abstract class BaseCluster implements Cluster {
     private volatile boolean isClosed;
     private volatile ClusterDescription description;
 
-    @VisibleForTesting(otherwise = PRIVATE)
+    @VisibleForTesting(otherwise = PACKAGE)
     protected BaseCluster(final ClusterId clusterId,
                           final ClusterSettings settings,
                           final ClusterableServerFactory serverFactory,

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -364,7 +364,7 @@ public abstract class BaseCluster implements Cluster {
             final ClusterSettings settings) {
         List<ServerSelector> selectors = Stream.of(
                 getRaceConditionPreFilteringSelector(serversSnapshot),
-                serverDeprioritization.applyDeprioritization(serverSelector),
+                serverDeprioritization.apply(serverSelector),
                 settings.getServerSelector(), // may be null
                 new LatencyMinimizingServerSelector(settings.getLocalThreshold(MILLISECONDS), MILLISECONDS),
                 AtMostTwoRandomServerSelector.instance(),

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -112,6 +112,12 @@ public class OperationContext {
                 operationName, tracingSpan);
     }
 
+    //TODO-JAVA
+    public OperationContext withServerDeprioritization(final ServerDeprioritization serverDeprioritization) {
+        return new OperationContext(id, requestContext, sessionContext, timeoutContext, serverDeprioritization, tracingManager, serverApi,
+                operationName, tracingSpan);
+    }
+
     public long getId() {
         return id;
     }
@@ -228,7 +234,7 @@ public class OperationContext {
         private ServerAddress candidate;
         private final Set<ServerAddress> deprioritized;
 
-        private ServerDeprioritization() {
+        public ServerDeprioritization() {
             candidate = null;
             deprioritized = new HashSet<>();
         }

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -116,8 +116,8 @@ public class OperationContext {
 
     // TODO-JAVA-6058: This method enables overriding the ServerDeprioritization state.
     //  It is a temporary solution to handle cases where deprioritization state persists across operations.
-    public OperationContext withServerDeprioritization(final ServerDeprioritization serverDeprioritization) {
-        return new OperationContext(id, requestContext, sessionContext, timeoutContext, serverDeprioritization, tracingManager, serverApi,
+    public OperationContext withNewServerDeprioritization() {
+        return new OperationContext(id, requestContext, sessionContext, timeoutContext, new ServerDeprioritization(), tracingManager, serverApi,
                 operationName, tracingSpan);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -250,6 +250,7 @@ public class OperationContext {
                 return;
             }
 
+            // As per spec: sharded clusters deprioritize on any error, other topologies only on overload
             boolean isSystemOverloadedError = failure instanceof MongoException
                     && ((MongoException) failure).hasErrorLabel(SYSTEM_OVERLOADED_ERROR_LABEL);
             if (clusterType == ClusterType.SHARDED || isSystemOverloadedError) {

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -250,7 +250,8 @@ public class OperationContext {
                 return;
             }
 
-            boolean isSystemOverloadedError = failure instanceof MongoException && ((MongoException) failure).hasErrorLabel("SystemOverloadedError");
+            boolean isSystemOverloadedError = failure instanceof MongoException 
+                    && ((MongoException) failure).hasErrorLabel(MongoException.SYSTEM_OVERLOADED_ERROR_LABEL);
             if (clusterType == ClusterType.SHARDED || isSystemOverloadedError) {
                 deprioritized.add(candidate);
             }

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -77,7 +77,7 @@ public class OperationContext {
                 null);
     }
 
-    public static OperationContext simpleOperationContext(
+    static OperationContext simpleOperationContext(
             final TimeoutSettings timeoutSettings, @Nullable final ServerApi serverApi) {
         return new OperationContext(
                 IgnorableRequestContext.INSTANCE,
@@ -160,8 +160,7 @@ public class OperationContext {
         this.tracingSpan = tracingSpan;
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.AccessModifier.PRIVATE)
-    public OperationContext(final long id,
+    private OperationContext(final long id,
             final RequestContext requestContext,
             final SessionContext sessionContext,
             final TimeoutContext timeoutContext,
@@ -181,26 +180,6 @@ public class OperationContext {
         this.operationName = operationName;
         this.tracingSpan = tracingSpan;
     }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.AccessModifier.PRIVATE)
-    public OperationContext(final long id,
-            final RequestContext requestContext,
-            final SessionContext sessionContext,
-            final TimeoutContext timeoutContext,
-            final TracingManager tracingManager,
-            @Nullable final ServerApi serverApi,
-            @Nullable final String operationName) {
-        this.id = id;
-        this.serverDeprioritization = new ServerDeprioritization();
-        this.requestContext = requestContext;
-        this.sessionContext = sessionContext;
-        this.timeoutContext = timeoutContext;
-        this.tracingManager = tracingManager;
-        this.serverApi = serverApi;
-        this.operationName = operationName;
-        this.tracingSpan = null;
-    }
-
 
     /**
      * @return The same {@link ServerDeprioritization} if called on the same {@link OperationContext}.

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -284,6 +284,7 @@ public class OperationContext {
                         new ClusterDescription(
                                 clusterDescription.getConnectionMode(),
                                 clusterDescription.getType(),
+                                clusterDescription.getSrvResolutionException(),
                                 nonDeprioritizedServerDescriptions,
                                 clusterDescription.getClusterSettings(),
                                 clusterDescription.getServerSettings()));

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -237,8 +237,7 @@ public class OperationContext {
         private ServerAddress candidate;
         private final Set<ServerAddress> deprioritized;
 
-        @VisibleForTesting(otherwise = PRIVATE)
-        public ServerDeprioritization() {
+        private ServerDeprioritization() {
             candidate = null;
             deprioritized = new HashSet<>();
         }

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -114,8 +114,10 @@ public class OperationContext {
                 operationName, tracingSpan);
     }
 
-    // TODO-JAVA-6058: This method enables overriding the ServerDeprioritization state.
-    //  It is a temporary solution to handle cases where deprioritization state persists across operations.
+    /**
+     * TODO-JAVA-6058: This method enables overriding the ServerDeprioritization state.
+     * It is a temporary solution to handle cases where deprioritization state persists across operations.
+     */
     public OperationContext withNewServerDeprioritization() {
         return new OperationContext(id, requestContext, sessionContext, timeoutContext, new ServerDeprioritization(), tracingManager, serverApi,
                 operationName, tracingSpan);

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.mongodb.MongoException.SYSTEM_OVERLOADED_ERROR_LABEL;
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PACKAGE;
 import static java.util.stream.Collectors.toList;
 
@@ -253,7 +254,7 @@ public class OperationContext {
             }
 
             boolean isSystemOverloadedError = failure instanceof MongoException 
-                    && ((MongoException) failure).hasErrorLabel(MongoException.SYSTEM_OVERLOADED_ERROR_LABEL);
+                    && ((MongoException) failure).hasErrorLabel(SYSTEM_OVERLOADED_ERROR_LABEL);
             if (clusterType == ClusterType.SHARDED || isSystemOverloadedError) {
                 deprioritized.add(candidate);
             }

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -17,11 +17,13 @@ package com.mongodb.internal.connection;
 
 import com.mongodb.Function;
 import com.mongodb.MongoConnectionPoolClearedException;
+import com.mongodb.MongoException;
 import com.mongodb.ReadConcern;
 import com.mongodb.RequestContext;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerApi;
 import com.mongodb.connection.ClusterDescription;
+import com.mongodb.connection.ClusterType;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.internal.IgnorableRequestContext;
 import com.mongodb.internal.TimeoutContext;
@@ -215,6 +217,7 @@ public class OperationContext {
     public static final class ServerDeprioritization {
         @Nullable
         private ServerAddress candidate;
+        private ClusterType clusterType;
         private final Set<ServerAddress> deprioritized;
 
         private ServerDeprioritization() {
@@ -236,8 +239,9 @@ public class OperationContext {
         }
 
         @VisibleForTesting(otherwise = PACKAGE)
-        public void updateCandidate(final ServerAddress serverAddress) {
-            candidate = serverAddress;
+        public void updateCandidate(final ServerAddress serverAddress, final ClusterType clusterType) {
+            this.candidate = serverAddress;
+            this.clusterType = clusterType;
         }
 
         public void onAttemptFailure(final Throwable failure) {
@@ -245,7 +249,11 @@ public class OperationContext {
                 candidate = null;
                 return;
             }
-            deprioritized.add(candidate);
+
+            boolean isSystemOverloadedError = failure instanceof MongoException && ((MongoException) failure).hasErrorLabel("SystemOverloadedError");
+            if (clusterType == ClusterType.SHARDED || isSystemOverloadedError) {
+                deprioritized.add(candidate);
+            }
         }
 
         /**

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -217,6 +217,7 @@ public class OperationContext {
     public static final class ServerDeprioritization {
         @Nullable
         private ServerAddress candidate;
+        @Nullable
         private ClusterType clusterType;
         private final Set<ServerAddress> deprioritized;
 

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -264,18 +264,18 @@ public class OperationContext {
             public List<ServerDescription> select(final ClusterDescription clusterDescription) {
                 List<ServerDescription> serverDescriptions = clusterDescription.getServerDescriptions();
 
-                // TODO-JAVA-5908: Evaluate whether the early-return optimization a meaningful performance impact on server selection.
+                // TODO-JAVA-5908: Evaluate whether using the early-return optimization has a meaningful performance impact on server selection.
                 if (serverDescriptions.size() == 1 || deprioritized.isEmpty()) {
                     return wrappedSelector.select(clusterDescription);
                 }
 
-                // TODO-JAVA-5908: Evaluate whether using a loop instead of Stream a meaningful performance impact on server selection.
+                // TODO-JAVA-5908: Evaluate whether using a loop instead of Stream has a meaningful performance impact on server selection.
                 List<ServerDescription> nonDeprioritizedServerDescriptions = serverDescriptions
                         .stream()
                         .filter(serverDescription -> !deprioritized.contains(serverDescription.getAddress()))
                         .collect(toList());
 
-                // TODO-JAVA-5908: Evaluate whether the early-return optimization a meaningful performance impact on server selection.
+                // TODO-JAVA-5908: Evaluate whether the early-return optimization has a meaningful performance impact on server selection.
                 if (nonDeprioritizedServerDescriptions.isEmpty()) {
                     return wrappedSelector.select(clusterDescription);
                 }

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -244,10 +244,12 @@ public class OperationContext {
         }
 
         /**
-         * The returned {@link ServerSelector} wraps the provided selector and attempts server selection in two passes:
+         * The returned {@link ServerSelector} wraps the provided selector and attempts
+         * {@linkplain ServerSelector#select(ClusterDescription) server selection} in two passes:
          * <ol>
-         *   <li>First pass: calls the wrapped selector with only non-deprioritized {@link ServerDescription}s</li>
-         *   <li>Second pass: if the first pass returns no servers, calls the wrapped selector again with all servers (including deprioritized ones)</li>
+         *   <li>First pass: selects using the wrapped selector with only non-deprioritized {@link ServerDescription}s.</li>
+         *   <li>Second pass: if the first pass selects no {@link ServerDescription}s,
+         *   selects using the wrapped selector again with all {@link ServerDescription}s, including deprioritized ones.</li>
          * </ol>
          */
         ServerSelector applyDeprioritization(final ServerSelector wrappedSelector) {

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -252,7 +252,7 @@ public class OperationContext {
          *   selects using the wrapped selector again with all {@link ServerDescription}s, including deprioritized ones.</li>
          * </ol>
          */
-        ServerSelector applyDeprioritization(final ServerSelector wrappedSelector) {
+        ServerSelector apply(final ServerSelector wrappedSelector) {
             return new DeprioritizingSelector(wrappedSelector);
         }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -28,7 +28,6 @@ import com.mongodb.connection.ServerDescription;
 import com.mongodb.internal.IgnorableRequestContext;
 import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.TimeoutSettings;
-import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.observability.micrometer.Span;
 import com.mongodb.internal.observability.micrometer.TracingManager;
 import com.mongodb.internal.session.SessionContext;
@@ -42,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.mongodb.MongoException.SYSTEM_OVERLOADED_ERROR_LABEL;
-import static com.mongodb.internal.VisibleForTesting.AccessModifier.PACKAGE;
 import static java.util.stream.Collectors.toList;
 
 /**

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -241,8 +241,7 @@ public class OperationContext {
             return new DeprioritizingSelector(wrappedSelector);
         }
 
-        @VisibleForTesting(otherwise = PACKAGE)
-        public void updateCandidate(final ServerAddress serverAddress, final ClusterType clusterType) {
+        void updateCandidate(final ServerAddress serverAddress, final ClusterType clusterType) {
             this.candidate = serverAddress;
             this.clusterType = clusterType;
         }
@@ -253,7 +252,7 @@ public class OperationContext {
                 return;
             }
 
-            boolean isSystemOverloadedError = failure instanceof MongoException 
+            boolean isSystemOverloadedError = failure instanceof MongoException
                     && ((MongoException) failure).hasErrorLabel(SYSTEM_OVERLOADED_ERROR_LABEL);
             if (clusterType == ClusterType.SHARDED || isSystemOverloadedError) {
                 deprioritized.add(candidate);

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -285,21 +285,26 @@ public class OperationContext {
             public List<ServerDescription> select(final ClusterDescription clusterDescription) {
                 List<ServerDescription> serverDescriptions = clusterDescription.getServerDescriptions();
 
+                // TODO-JAVA-5908: Evaluate whether the early-return optimization a meaningful performance impact on server selection.
                 if (serverDescriptions.size() == 1 || deprioritized.isEmpty()) {
                     return wrappedSelector.select(clusterDescription);
                 }
 
+                // TODO-JAVA-5908: Evaluate whether using a loop instead of Stream a meaningful performance impact on server selection.
                 List<ServerDescription> nonDeprioritizedServerDescriptions = serverDescriptions
                         .stream()
                         .filter(serverDescription -> !deprioritized.contains(serverDescription.getAddress()))
                         .collect(toList());
 
+                // TODO-JAVA-5908: Evaluate whether the early-return optimization a meaningful performance impact on server selection.
                 if (nonDeprioritizedServerDescriptions.isEmpty()) {
                     return wrappedSelector.select(clusterDescription);
                 }
 
                 List<ServerDescription> selected = wrappedSelector.select(
-                        new ClusterDescription(clusterDescription.getConnectionMode(), clusterDescription.getType(),
+                        new ClusterDescription(
+                                clusterDescription.getConnectionMode(),
+                                clusterDescription.getType(),
                                 nonDeprioritizedServerDescriptions,
                                 clusterDescription.getClusterSettings(),
                                 clusterDescription.getServerSettings()));

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -275,7 +275,7 @@ public class OperationContext {
                         .filter(serverDescription -> !deprioritized.contains(serverDescription.getAddress()))
                         .collect(toList());
 
-                // TODO-JAVA-5908: Evaluate whether the early-return optimization has a meaningful performance impact on server selection.
+                // TODO-JAVA-5908: Evaluate whether using the early-return optimization has a meaningful performance impact on server selection.
                 if (nonDeprioritizedServerDescriptions.isEmpty()) {
                     return wrappedSelector.select(clusterDescription);
                 }

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -40,7 +40,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.mongodb.internal.VisibleForTesting.AccessModifier.PACKAGE;
-import static com.mongodb.internal.VisibleForTesting.AccessModifier.PRIVATE;
 import static java.util.stream.Collectors.toList;
 
 /**

--- a/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/OperationContext.java
@@ -224,6 +224,7 @@ public class OperationContext {
         private ServerDeprioritization() {
             candidate = null;
             deprioritized = new HashSet<>();
+            clusterType = null;
         }
 
         /**

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncChangeStreamBatchCursor.java
@@ -73,7 +73,9 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncAggregateResponseBat
         this.wrapped = new AtomicReference<>(assertNotNull(wrapped));
         this.binding = binding;
         binding.retain();
-        this.initialOperationContext = operationContext.withOverride(TimeoutContext::withMaxTimeAsMaxAwaitTimeOverride);
+        this.initialOperationContext = operationContext
+                .withOverride(TimeoutContext::withMaxTimeAsMaxAwaitTimeOverride)
+                .withNewServerDeprioritization();
         this.resumeToken = resumeToken;
         this.maxWireVersion = maxWireVersion;
         isClosed = new AtomicBoolean();

--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursor.java
@@ -85,7 +85,10 @@ final class ChangeStreamBatchCursor<T> implements AggregateResponseBatchCursor<T
                             final int maxWireVersion) {
         this.changeStreamOperation = changeStreamOperation;
         this.binding = binding.retain();
-        this.initialOperationContext = operationContext.withOverride(TimeoutContext::withMaxTimeAsMaxAwaitTimeOverride);
+        this.initialOperationContext = operationContext
+                .withOverride(TimeoutContext::withMaxTimeAsMaxAwaitTimeOverride)
+                //TODO-JAVA
+                .withServerDeprioritization(new OperationContext.ServerDeprioritization());
         this.wrapped = wrapped;
         this.resumeToken = resumeToken;
         this.maxWireVersion = maxWireVersion;

--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursor.java
@@ -87,7 +87,8 @@ final class ChangeStreamBatchCursor<T> implements AggregateResponseBatchCursor<T
         this.binding = binding.retain();
         this.initialOperationContext = operationContext
                 .withOverride(TimeoutContext::withMaxTimeAsMaxAwaitTimeOverride)
-                //TODO-JAVA
+                //TODO-JAVA-6058. Temporary workaround to reset any server deprioritization
+                // state from the previous find operation.
                 .withServerDeprioritization(new OperationContext.ServerDeprioritization());
         this.wrapped = wrapped;
         this.resumeToken = resumeToken;

--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursor.java
@@ -87,7 +87,7 @@ final class ChangeStreamBatchCursor<T> implements AggregateResponseBatchCursor<T
         this.binding = binding.retain();
         this.initialOperationContext = operationContext
                 .withOverride(TimeoutContext::withMaxTimeAsMaxAwaitTimeOverride)
-                .withServerDeprioritization(new OperationContext.ServerDeprioritization());
+                .withNewServerDeprioritization();
         this.wrapped = wrapped;
         this.resumeToken = resumeToken;
         this.maxWireVersion = maxWireVersion;

--- a/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ChangeStreamBatchCursor.java
@@ -87,8 +87,6 @@ final class ChangeStreamBatchCursor<T> implements AggregateResponseBatchCursor<T
         this.binding = binding.retain();
         this.initialOperationContext = operationContext
                 .withOverride(TimeoutContext::withMaxTimeAsMaxAwaitTimeOverride)
-                //TODO-JAVA-6058. Temporary workaround to reset any server deprioritization
-                // state from the previous find operation.
                 .withServerDeprioritization(new OperationContext.ServerDeprioritization());
         this.wrapped = wrapped;
         this.resumeToken = resumeToken;

--- a/driver-core/src/main/com/mongodb/selector/CompositeServerSelector.java
+++ b/driver-core/src/main/com/mongodb/selector/CompositeServerSelector.java
@@ -72,9 +72,6 @@ public final class CompositeServerSelector implements ServerSelector {
         List<ServerDescription> choices = null;
         for (ServerSelector cur : serverSelectors) {
             choices = cur.select(curClusterDescription);
-            if (choices.isEmpty()) {
-                return choices;
-            }
             curClusterDescription = new ClusterDescription(clusterDescription.getConnectionMode(), clusterDescription.getType(), choices,
                                                                   clusterDescription.getClusterSettings(),
                                                                   clusterDescription.getServerSettings());

--- a/driver-core/src/main/com/mongodb/selector/CompositeServerSelector.java
+++ b/driver-core/src/main/com/mongodb/selector/CompositeServerSelector.java
@@ -72,6 +72,9 @@ public final class CompositeServerSelector implements ServerSelector {
         List<ServerDescription> choices = null;
         for (ServerSelector cur : serverSelectors) {
             choices = cur.select(curClusterDescription);
+            if (choices.isEmpty()) {
+                return choices;
+            }
             curClusterDescription = new ClusterDescription(clusterDescription.getConnectionMode(), clusterDescription.getType(), choices,
                                                                   clusterDescription.getClusterSettings(),
                                                                   clusterDescription.getServerSettings());

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -376,7 +376,9 @@ public final class ClusterFixture {
     }
 
     public static ReadWriteBinding getBinding(final TimeoutSettings timeoutSettings) {
-        return getBinding(getCluster(), ReadPreference.primary(), createNewOperationContext(timeoutSettings));
+        return getBinding(getCluster(),
+                ReadPreference.primary(),
+                createOperationContext().withTimeoutContext(new TimeoutContext(timeoutSettings)));
     }
 
     public static ReadWriteBinding getBinding(final OperationContext operationContext) {
@@ -385,10 +387,6 @@ public final class ClusterFixture {
 
     public static ReadWriteBinding getBinding(final ReadPreference readPreference) {
         return getBinding(getCluster(), readPreference, createOperationContext());
-    }
-
-    public static OperationContext createNewOperationContext(final TimeoutSettings timeoutSettings) {
-        return createOperationContext().withTimeoutContext(new TimeoutContext(timeoutSettings));
     }
 
     private static ReadWriteBinding getBinding(final Cluster cluster,
@@ -425,7 +423,7 @@ public final class ClusterFixture {
     }
 
     public static AsyncReadWriteBinding getAsyncBinding(final TimeoutSettings timeoutSettings) {
-        return getAsyncBinding(createNewOperationContext(timeoutSettings));
+        return getAsyncBinding(createOperationContext().withTimeoutContext(new TimeoutContext(timeoutSettings)));
     }
 
     public static AsyncReadWriteBinding getAsyncBinding(final OperationContext operationContext) {

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -193,12 +193,12 @@ public final class ClusterFixture {
         if (serverVersion == null) {
             serverVersion = getVersion(new CommandReadOperation<>("admin",
                     new BsonDocument("buildInfo", new BsonInt32(1)), new BsonDocumentCodec())
-                    .execute(new ClusterBinding(getCluster(), ReadPreference.nearest()), getOperationContext()));
+                    .execute(new ClusterBinding(getCluster(), ReadPreference.nearest()), createOperationContext()));
         }
         return serverVersion;
     }
 
-    public static OperationContext getOperationContext() {
+    public static OperationContext createOperationContext() {
         return new OperationContext(
                 IgnorableRequestContext.INSTANCE,
                 new ReadConcernAwareNoOpSessionContext(ReadConcern.DEFAULT),
@@ -257,7 +257,7 @@ public final class ClusterFixture {
     public static Document getServerStatus() {
         return new CommandReadOperation<>("admin", new BsonDocument("serverStatus", new BsonInt32(1)),
                 new DocumentCodec())
-                .execute(getBinding(), getOperationContext());
+                .execute(getBinding(), createOperationContext());
     }
 
     public static boolean supportsFsync() {
@@ -272,7 +272,7 @@ public final class ClusterFixture {
         public void run() {
             if (cluster != null) {
                 try {
-                    new DropDatabaseOperation(getDefaultDatabaseName(), WriteConcern.ACKNOWLEDGED).execute(getBinding(), getOperationContext());
+                    new DropDatabaseOperation(getDefaultDatabaseName(), WriteConcern.ACKNOWLEDGED).execute(getBinding(), createOperationContext());
                 } catch (MongoCommandException e) {
                     // if we do not have permission to drop the database, assume it is cleaned up in some other way
                     if (!e.getMessage().contains("Command dropDatabase requires authentication")) {
@@ -324,7 +324,7 @@ public final class ClusterFixture {
         try {
             BsonDocument helloResult = new CommandReadOperation<>("admin",
                     new BsonDocument(LEGACY_HELLO, new BsonInt32(1)), new BsonDocumentCodec())
-                    .execute(new ClusterBinding(cluster, ReadPreference.nearest()), getOperationContext());
+                    .execute(new ClusterBinding(cluster, ReadPreference.nearest()), createOperationContext());
             if (helloResult.containsKey("setName")) {
                 connectionString = new ConnectionString(DEFAULT_URI + "/?replicaSet="
                         + helloResult.getString("setName").getValue());
@@ -384,11 +384,11 @@ public final class ClusterFixture {
     }
 
     public static ReadWriteBinding getBinding(final ReadPreference readPreference) {
-        return getBinding(getCluster(), readPreference, getOperationContext());
+        return getBinding(getCluster(), readPreference, createOperationContext());
     }
 
     public static OperationContext createNewOperationContext(final TimeoutSettings timeoutSettings) {
-        return getOperationContext().withTimeoutContext(new TimeoutContext(timeoutSettings));
+        return createOperationContext().withTimeoutContext(new TimeoutContext(timeoutSettings));
     }
 
     private static ReadWriteBinding getBinding(final Cluster cluster,
@@ -405,7 +405,7 @@ public final class ClusterFixture {
     }
 
     public static SingleConnectionBinding getSingleConnectionBinding() {
-        return new SingleConnectionBinding(getCluster(), ReadPreference.primary(), getOperationContext());
+        return new SingleConnectionBinding(getCluster(), ReadPreference.primary(), createOperationContext());
     }
 
     public static AsyncSingleConnectionBinding getAsyncSingleConnectionBinding() {
@@ -413,7 +413,7 @@ public final class ClusterFixture {
     }
 
     public static AsyncSingleConnectionBinding getAsyncSingleConnectionBinding(final Cluster cluster) {
-        return new AsyncSingleConnectionBinding(cluster,  ReadPreference.primary(), getOperationContext());
+        return new AsyncSingleConnectionBinding(cluster,  ReadPreference.primary(), createOperationContext());
     }
 
     public static AsyncReadWriteBinding getAsyncBinding(final Cluster cluster) {
@@ -421,7 +421,7 @@ public final class ClusterFixture {
     }
 
     public static AsyncReadWriteBinding getAsyncBinding() {
-        return getAsyncBinding(getAsyncCluster(), ReadPreference.primary(), getOperationContext());
+        return getAsyncBinding(getAsyncCluster(), ReadPreference.primary(), createOperationContext());
     }
 
     public static AsyncReadWriteBinding getAsyncBinding(final TimeoutSettings timeoutSettings) {
@@ -433,7 +433,7 @@ public final class ClusterFixture {
     }
 
     public static AsyncReadWriteBinding getAsyncBinding(final ReadPreference readPreference) {
-        return getAsyncBinding(getAsyncCluster(), readPreference, getOperationContext());
+        return getAsyncBinding(getAsyncCluster(), readPreference, createOperationContext());
     }
 
     public static AsyncReadWriteBinding getAsyncBinding(
@@ -607,7 +607,7 @@ public final class ClusterFixture {
         if (serverParameters == null) {
             serverParameters = new CommandReadOperation<>("admin",
                     new BsonDocument("getParameter", new BsonString("*")), new BsonDocumentCodec())
-                    .execute(getBinding(), getOperationContext());
+                    .execute(getBinding(), createOperationContext());
         }
         return serverParameters;
     }
@@ -675,7 +675,7 @@ public final class ClusterFixture {
         if (!isSharded()) {
             try {
                 new CommandReadOperation<>("admin", failPointDocument, new BsonDocumentCodec())
-                        .execute(getBinding(), getOperationContext());
+                        .execute(getBinding(), createOperationContext());
             } catch (MongoCommandException e) {
                 if (e.getErrorCode() == COMMAND_NOT_FOUND_ERROR_CODE) {
                     failsPointsSupported = false;
@@ -691,7 +691,7 @@ public final class ClusterFixture {
                     .append("mode", new BsonString("off"));
             try {
                 new CommandReadOperation<>("admin", failPointDocument, new BsonDocumentCodec())
-                        .execute(getBinding(), getOperationContext());
+                        .execute(getBinding(), createOperationContext());
             } catch (MongoCommandException e) {
                 // ignore
             }
@@ -705,7 +705,7 @@ public final class ClusterFixture {
 
     @SuppressWarnings("overloads")
     public static <T> T executeSync(final WriteOperation<T> op, final ReadWriteBinding binding) {
-        return op.execute(binding, applySessionContext(getOperationContext(), binding.getReadPreference()));
+        return op.execute(binding, applySessionContext(createOperationContext(), binding.getReadPreference()));
     }
 
     @SuppressWarnings("overloads")
@@ -715,7 +715,7 @@ public final class ClusterFixture {
 
     @SuppressWarnings("overloads")
     public static <T> T executeSync(final ReadOperation<T, ?> op, final ReadWriteBinding binding) {
-        return op.execute(binding, getOperationContext());
+        return op.execute(binding, createOperationContext());
     }
 
     @SuppressWarnings("overloads")
@@ -731,7 +731,7 @@ public final class ClusterFixture {
     @SuppressWarnings("overloads")
     public static <T> T executeAsync(final WriteOperation<T> op, final AsyncReadWriteBinding binding) throws Throwable {
         FutureResultCallback<T> futureResultCallback = new FutureResultCallback<>();
-        op.executeAsync(binding, applySessionContext(getOperationContext(), binding.getReadPreference()), futureResultCallback);
+        op.executeAsync(binding, applySessionContext(createOperationContext(), binding.getReadPreference()), futureResultCallback);
         return futureResultCallback.get(TIMEOUT, SECONDS);
     }
 
@@ -743,7 +743,7 @@ public final class ClusterFixture {
     @SuppressWarnings("overloads")
     public static <T> T executeAsync(final ReadOperation<?, T> op, final AsyncReadBinding binding) throws Throwable {
         FutureResultCallback<T> futureResultCallback = new FutureResultCallback<>();
-        op.executeAsync(binding, getOperationContext(), futureResultCallback);
+        op.executeAsync(binding, createOperationContext(), futureResultCallback);
         return futureResultCallback.get(TIMEOUT, SECONDS);
     }
 
@@ -813,19 +813,19 @@ public final class ClusterFixture {
 
     public static AsyncConnectionSource getWriteConnectionSource(final AsyncReadWriteBinding binding) throws Throwable {
         FutureResultCallback<AsyncConnectionSource> futureResultCallback = new FutureResultCallback<>();
-        binding.getWriteConnectionSource(getOperationContext(), futureResultCallback);
+        binding.getWriteConnectionSource(createOperationContext(), futureResultCallback);
         return futureResultCallback.get(TIMEOUT, SECONDS);
     }
 
     public static AsyncConnectionSource getReadConnectionSource(final AsyncReadWriteBinding binding) throws Throwable {
         FutureResultCallback<AsyncConnectionSource> futureResultCallback = new FutureResultCallback<>();
-        binding.getReadConnectionSource(getOperationContext(), futureResultCallback);
+        binding.getReadConnectionSource(createOperationContext(), futureResultCallback);
         return futureResultCallback.get(TIMEOUT, SECONDS);
     }
 
     public static AsyncConnection getConnection(final AsyncConnectionSource source) throws Throwable {
         FutureResultCallback<AsyncConnection> futureResultCallback = new FutureResultCallback<>();
-        source.getConnection(getOperationContext(), futureResultCallback);
+        source.getConnection(createOperationContext(), futureResultCallback);
         return futureResultCallback.get(TIMEOUT, SECONDS);
     }
 
@@ -868,7 +868,7 @@ public final class ClusterFixture {
         return operationContext.withSessionContext(simpleSessionContext);
     }
 
-    public static OperationContext getOperationContext(final ReadPreference readPreference) {
-        return applySessionContext(getOperationContext(), readPreference);
+    public static OperationContext createOperationContext(final ReadPreference readPreference) {
+        return applySessionContext(createOperationContext(), readPreference);
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
@@ -61,7 +61,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.TIMEOUT
 import static com.mongodb.ClusterFixture.checkReferenceCountReachesTarget
 import static com.mongodb.ClusterFixture.executeAsync
@@ -108,7 +108,7 @@ class OperationFunctionalSpecification extends Specification {
 
     void acknowledgeWrite(final SingleConnectionBinding binding) {
         new MixedBulkWriteOperation(getNamespace(), [new InsertRequest(new BsonDocument())], true,
-                ACKNOWLEDGED, false).execute(binding, OPERATION_CONTEXT)
+                ACKNOWLEDGED, false).execute(binding, getOperationContext())
         binding.release()
     }
 
@@ -279,7 +279,7 @@ class OperationFunctionalSpecification extends Specification {
                           BsonDocument expectedCommand=null, Boolean checkSecondaryOk=false,
                           ReadPreference readPreference=ReadPreference.primary(), Boolean retryable = false,
                           ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false) {
-        def operationContext = OPERATION_CONTEXT
+        def operationContext = getOperationContext()
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> activeTransaction
                     getReadConcern() >> readConcern
@@ -353,7 +353,7 @@ class OperationFunctionalSpecification extends Specification {
                            Boolean checkCommand = true, BsonDocument expectedCommand = null, Boolean checkSecondaryOk = false,
                            ReadPreference readPreference = ReadPreference.primary(), Boolean retryable = false,
                            ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false) {
-        def operationContext = OPERATION_CONTEXT
+        def operationContext = getOperationContext()
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> activeTransaction
                     getReadConcern() >> readConcern
@@ -447,7 +447,7 @@ class OperationFunctionalSpecification extends Specification {
             }
         }
 
-        def operationContext = OPERATION_CONTEXT.withSessionContext(
+        def operationContext = getOperationContext().withSessionContext(
                 Stub(SessionContext) {
                     hasSession() >> true
                     hasActiveTransaction() >> false
@@ -488,7 +488,7 @@ class OperationFunctionalSpecification extends Specification {
             }
         }
 
-        def operationContext = OPERATION_CONTEXT.withSessionContext(
+        def operationContext = getOperationContext().withSessionContext(
                 Stub(SessionContext) {
                     hasSession() >> true
                     hasActiveTransaction() >> false

--- a/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
@@ -61,7 +61,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.TIMEOUT
 import static com.mongodb.ClusterFixture.checkReferenceCountReachesTarget
 import static com.mongodb.ClusterFixture.executeAsync
@@ -108,7 +108,7 @@ class OperationFunctionalSpecification extends Specification {
 
     void acknowledgeWrite(final SingleConnectionBinding binding) {
         new MixedBulkWriteOperation(getNamespace(), [new InsertRequest(new BsonDocument())], true,
-                ACKNOWLEDGED, false).execute(binding, getOperationContext())
+                ACKNOWLEDGED, false).execute(binding, createOperationContext())
         binding.release()
     }
 
@@ -279,7 +279,7 @@ class OperationFunctionalSpecification extends Specification {
                           BsonDocument expectedCommand=null, Boolean checkSecondaryOk=false,
                           ReadPreference readPreference=ReadPreference.primary(), Boolean retryable = false,
                           ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false) {
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> activeTransaction
                     getReadConcern() >> readConcern
@@ -353,7 +353,7 @@ class OperationFunctionalSpecification extends Specification {
                            Boolean checkCommand = true, BsonDocument expectedCommand = null, Boolean checkSecondaryOk = false,
                            ReadPreference readPreference = ReadPreference.primary(), Boolean retryable = false,
                            ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false) {
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> activeTransaction
                     getReadConcern() >> readConcern
@@ -447,7 +447,7 @@ class OperationFunctionalSpecification extends Specification {
             }
         }
 
-        def operationContext = getOperationContext().withSessionContext(
+        def operationContext = createOperationContext().withSessionContext(
                 Stub(SessionContext) {
                     hasSession() >> true
                     hasActiveTransaction() >> false
@@ -488,7 +488,7 @@ class OperationFunctionalSpecification extends Specification {
             }
         }
 
-        def operationContext = getOperationContext().withSessionContext(
+        def operationContext = createOperationContext().withSessionContext(
                 Stub(SessionContext) {
                     hasSession() >> true
                     hasActiveTransaction() >> false

--- a/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.client.test;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
@@ -72,7 +73,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.executeAsync;
 import static com.mongodb.ClusterFixture.getBinding;
 import static java.lang.String.format;
@@ -93,7 +93,7 @@ public final class CollectionHelper<T> {
 
     public T hello() {
         return new CommandReadOperation<>("admin", BsonDocument.parse("{isMaster: 1}"), codec)
-                .execute(getBinding(), getOperationContext());
+                .execute(getBinding(), ClusterFixture.createOperationContext());
     }
 
     public static void drop(final MongoNamespace namespace) {
@@ -106,7 +106,7 @@ public final class CollectionHelper<T> {
         boolean success = false;
         while (!success) {
             try {
-                new DropCollectionOperation(namespace, writeConcern).execute(getBinding(), getOperationContext());
+                new DropCollectionOperation(namespace, writeConcern).execute(getBinding(), ClusterFixture.createOperationContext());
                 success = true;
             } catch (MongoWriteConcernException e) {
                 LOGGER.info("Retrying drop collection after a write concern error: " + e);
@@ -131,7 +131,7 @@ public final class CollectionHelper<T> {
             return;
         }
         try {
-            new DropDatabaseOperation(name, writeConcern).execute(getBinding(), getOperationContext());
+            new DropDatabaseOperation(name, writeConcern).execute(getBinding(), ClusterFixture.createOperationContext());
         } catch (MongoCommandException e) {
             if (!e.getErrorMessage().contains("ns not found")) {
                 throw e;
@@ -141,7 +141,7 @@ public final class CollectionHelper<T> {
 
     public static BsonDocument getCurrentClusterTime() {
         return new CommandReadOperation<BsonDocument>("admin", new BsonDocument("ping", new BsonInt32(1)), new BsonDocumentCodec())
-                .execute(getBinding(), getOperationContext()).getDocument("$clusterTime", null);
+                .execute(getBinding(), ClusterFixture.createOperationContext()).getDocument("$clusterTime", null);
     }
 
     public MongoNamespace getNamespace() {
@@ -235,7 +235,7 @@ public final class CollectionHelper<T> {
         boolean success = false;
         while (!success) {
             try {
-                operation.execute(getBinding(), getOperationContext());
+                operation.execute(getBinding(), ClusterFixture.createOperationContext());
                 success = true;
             } catch (MongoCommandException e) {
                 if ("Interrupted".equals(e.getErrorCodeName())) {
@@ -254,7 +254,7 @@ public final class CollectionHelper<T> {
                     .append("cursors", new BsonArray(singletonList(new BsonInt64(serverCursor.getId()))));
             try {
                 new CommandReadOperation<>(namespace.getDatabaseName(), command, new BsonDocumentCodec())
-                        .execute(getBinding(), getOperationContext());
+                        .execute(getBinding(), ClusterFixture.createOperationContext());
             } catch (Exception e) {
                 // Ignore any exceptions killing old cursors
             }
@@ -286,7 +286,7 @@ public final class CollectionHelper<T> {
         for (BsonDocument document : documents) {
             insertRequests.add(new InsertRequest(document));
         }
-        new MixedBulkWriteOperation(namespace, insertRequests, true, writeConcern, false).execute(binding, getOperationContext());
+        new MixedBulkWriteOperation(namespace, insertRequests, true, writeConcern, false).execute(binding, ClusterFixture.createOperationContext());
     }
 
     public void insertDocuments(final Document... documents) {
@@ -329,7 +329,7 @@ public final class CollectionHelper<T> {
     public Optional<T> listSearchIndex(final String indexName) {
         ListSearchIndexesOperation<T> listSearchIndexesOperation =
                 new ListSearchIndexesOperation<>(namespace, codec, indexName, null, null, null, null, true);
-        BatchCursor<T> cursor = listSearchIndexesOperation.execute(getBinding(), getOperationContext());
+        BatchCursor<T> cursor = listSearchIndexesOperation.execute(getBinding(), ClusterFixture.createOperationContext());
 
         List<T> results = new ArrayList<>();
         while (cursor.hasNext()) {
@@ -342,13 +342,13 @@ public final class CollectionHelper<T> {
     public void createSearchIndex(final SearchIndexRequest searchIndexModel) {
         CreateSearchIndexesOperation searchIndexesOperation =
                 new CreateSearchIndexesOperation(namespace, singletonList(searchIndexModel));
-        searchIndexesOperation.execute(getBinding(), getOperationContext());
+        searchIndexesOperation.execute(getBinding(), ClusterFixture.createOperationContext());
     }
 
     public <D> List<D> find(final Codec<D> codec) {
         BatchCursor<D> cursor = new FindOperation<>(namespace, codec)
                 .sort(new BsonDocument("_id", new BsonInt32(1)))
-                .execute(getBinding(), getOperationContext());
+                .execute(getBinding(), ClusterFixture.createOperationContext());
         List<D> results = new ArrayList<>();
         while (cursor.hasNext()) {
             results.addAll(cursor.next());
@@ -367,7 +367,7 @@ public final class CollectionHelper<T> {
                                                                     WriteRequest.Type.UPDATE)
                                                   .upsert(isUpsert)),
                                     true, WriteConcern.ACKNOWLEDGED, false)
-                .execute(getBinding(), getOperationContext());
+                .execute(getBinding(), ClusterFixture.createOperationContext());
     }
 
     public void replaceOne(final Bson filter, final Bson update, final boolean isUpsert) {
@@ -377,7 +377,7 @@ public final class CollectionHelper<T> {
                         WriteRequest.Type.REPLACE)
                         .upsert(isUpsert)),
                                     true, WriteConcern.ACKNOWLEDGED, false)
-                .execute(getBinding(), getOperationContext());
+                .execute(getBinding(), ClusterFixture.createOperationContext());
     }
 
     public void deleteOne(final Bson filter) {
@@ -392,7 +392,7 @@ public final class CollectionHelper<T> {
         new MixedBulkWriteOperation(namespace,
                 singletonList(new DeleteRequest(filter.toBsonDocument(Document.class, registry)).multi(multi)),
                 true, WriteConcern.ACKNOWLEDGED, false)
-                .execute(getBinding(), getOperationContext());
+                .execute(getBinding(), ClusterFixture.createOperationContext());
     }
 
     public List<T> find(final Bson filter) {
@@ -417,7 +417,7 @@ public final class CollectionHelper<T> {
             bsonDocumentPipeline.add(cur.toBsonDocument(Document.class, registry));
         }
         BatchCursor<D> cursor = new AggregateOperation<>(namespace, bsonDocumentPipeline, decoder, level)
-                .execute(getBinding(), getOperationContext());
+                .execute(getBinding(), ClusterFixture.createOperationContext());
         List<D> results = new ArrayList<>();
         while (cursor.hasNext()) {
             results.addAll(cursor.next());
@@ -452,7 +452,7 @@ public final class CollectionHelper<T> {
 
     public <D> List<D> find(final BsonDocument filter, final BsonDocument sort, final BsonDocument projection, final Decoder<D> decoder) {
         BatchCursor<D> cursor = new FindOperation<>(namespace, decoder).filter(filter).sort(sort)
-                .projection(projection).execute(getBinding(), getOperationContext());
+                .projection(projection).execute(getBinding(), ClusterFixture.createOperationContext());
         List<D> results = new ArrayList<>();
         while (cursor.hasNext()) {
             results.addAll(cursor.next());
@@ -465,7 +465,7 @@ public final class CollectionHelper<T> {
     }
 
     public long count(final ReadBinding binding) {
-        return new CountDocumentsOperation(namespace).execute(binding, getOperationContext());
+        return new CountDocumentsOperation(namespace).execute(binding, ClusterFixture.createOperationContext());
     }
 
     public long count(final AsyncReadWriteBinding binding) throws Throwable {
@@ -474,7 +474,7 @@ public final class CollectionHelper<T> {
 
     public long count(final Bson filter) {
         return new CountDocumentsOperation(namespace)
-                .filter(toBsonDocument(filter)).execute(getBinding(), getOperationContext());
+                .filter(toBsonDocument(filter)).execute(getBinding(), ClusterFixture.createOperationContext());
     }
 
     public BsonDocument wrap(final Document document) {
@@ -487,36 +487,36 @@ public final class CollectionHelper<T> {
 
     public void createIndex(final BsonDocument key) {
         new CreateIndexesOperation(namespace, singletonList(new IndexRequest(key)), WriteConcern.ACKNOWLEDGED)
-                .execute(getBinding(), getOperationContext());
+                .execute(getBinding(), ClusterFixture.createOperationContext());
     }
 
     public void createIndex(final Document key) {
         new CreateIndexesOperation(namespace, singletonList(new IndexRequest(wrap(key))), WriteConcern.ACKNOWLEDGED)
-                .execute(getBinding(), getOperationContext());
+                .execute(getBinding(), ClusterFixture.createOperationContext());
     }
 
     public void createUniqueIndex(final Document key) {
         new CreateIndexesOperation(namespace, singletonList(new IndexRequest(wrap(key)).unique(true)),
                                    WriteConcern.ACKNOWLEDGED)
-                .execute(getBinding(), getOperationContext());
+                .execute(getBinding(), ClusterFixture.createOperationContext());
     }
 
     public void createIndex(final Document key, final String defaultLanguage) {
         new CreateIndexesOperation(namespace,
                 singletonList(new IndexRequest(wrap(key)).defaultLanguage(defaultLanguage)), WriteConcern.ACKNOWLEDGED).execute(
-                getBinding(), getOperationContext());
+                getBinding(), ClusterFixture.createOperationContext());
     }
 
     public void createIndex(final Bson key) {
         new CreateIndexesOperation(namespace,
                 singletonList(new IndexRequest(key.toBsonDocument(Document.class, registry))), WriteConcern.ACKNOWLEDGED).execute(
-                getBinding(), getOperationContext());
+                getBinding(), ClusterFixture.createOperationContext());
     }
 
     public List<BsonDocument> listIndexes(){
         List<BsonDocument> indexes = new ArrayList<>();
         BatchCursor<BsonDocument> cursor = new ListIndexesOperation<>(namespace, new BsonDocumentCodec())
-                .execute(getBinding(), getOperationContext());
+                .execute(getBinding(), ClusterFixture.createOperationContext());
         while (cursor.hasNext()) {
             indexes.addAll(cursor.next());
         }
@@ -526,7 +526,7 @@ public final class CollectionHelper<T> {
     public static void killAllSessions() {
         try {
             new CommandReadOperation<>("admin",
-                    new BsonDocument("killAllSessions", new BsonArray()), new BsonDocumentCodec()).execute(getBinding(), getOperationContext());
+                    new BsonDocument("killAllSessions", new BsonArray()), new BsonDocumentCodec()).execute(getBinding(), ClusterFixture.createOperationContext());
         } catch (MongoCommandException e) {
             // ignore exception caused by killing the implicit session that the killAllSessions command itself is running in
         }
@@ -537,7 +537,7 @@ public final class CollectionHelper<T> {
             new CommandReadOperation<>("admin",
                                        new BsonDocument("renameCollection", new BsonString(getNamespace().getFullName()))
                                                .append("to", new BsonString(newNamespace.getFullName())), new BsonDocumentCodec()).execute(
-                    getBinding(), getOperationContext());
+                    getBinding(), ClusterFixture.createOperationContext());
         } catch (MongoCommandException e) {
             // do nothing
         }
@@ -549,11 +549,11 @@ public final class CollectionHelper<T> {
 
     public void runAdminCommand(final BsonDocument command) {
         new CommandReadOperation<>("admin", command, new BsonDocumentCodec())
-                .execute(getBinding(), getOperationContext());
+                .execute(getBinding(), ClusterFixture.createOperationContext());
     }
 
     public void runAdminCommand(final BsonDocument command, final ReadPreference readPreference) {
         new CommandReadOperation<>("admin", command, new BsonDocumentCodec())
-                .execute(getBinding(readPreference), getOperationContext());
+                .execute(getBinding(readPreference), ClusterFixture.createOperationContext());
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/connection/ConnectionSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/ConnectionSpecification.groovy
@@ -23,7 +23,7 @@ import org.bson.BsonInt32
 import org.bson.codecs.BsonDocumentCodec
 
 import static com.mongodb.ClusterFixture.LEGACY_HELLO
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.connection.ConnectionDescription.getDefaultMaxMessageSize
 import static com.mongodb.connection.ConnectionDescription.getDefaultMaxWriteBatchSize
@@ -32,8 +32,8 @@ class ConnectionSpecification extends OperationFunctionalSpecification {
 
     def 'should have id'() {
         when:
-        def source = getBinding().getReadConnectionSource(OPERATION_CONTEXT)
-        def connection = source.getConnection(OPERATION_CONTEXT)
+        def source = getBinding().getReadConnectionSource(getOperationContext())
+        def connection = source.getConnection(getOperationContext())
 
         then:
         connection.getDescription().getConnectionId() != null
@@ -50,8 +50,8 @@ class ConnectionSpecification extends OperationFunctionalSpecification {
                                                              new BsonInt32(getDefaultMaxMessageSize())).intValue()
         def expectedMaxBatchCount = commandResult.getNumber('maxWriteBatchSize',
                                                             new BsonInt32(getDefaultMaxWriteBatchSize())).intValue()
-        def source = getBinding().getReadConnectionSource(OPERATION_CONTEXT)
-        def connection = source.getConnection(OPERATION_CONTEXT)
+        def source = getBinding().getReadConnectionSource(getOperationContext())
+        def connection = source.getConnection(getOperationContext())
 
         then:
         connection.description.serverAddress == source.getServerDescription().getAddress()
@@ -66,6 +66,6 @@ class ConnectionSpecification extends OperationFunctionalSpecification {
     }
    private static BsonDocument getHelloResult() {
         new CommandReadOperation<BsonDocument>('admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)),
-                new BsonDocumentCodec()).execute(getBinding(), OPERATION_CONTEXT)
+                new BsonDocumentCodec()).execute(getBinding(), getOperationContext())
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/connection/ConnectionSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/ConnectionSpecification.groovy
@@ -23,7 +23,7 @@ import org.bson.BsonInt32
 import org.bson.codecs.BsonDocumentCodec
 
 import static com.mongodb.ClusterFixture.LEGACY_HELLO
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.connection.ConnectionDescription.getDefaultMaxMessageSize
 import static com.mongodb.connection.ConnectionDescription.getDefaultMaxWriteBatchSize
@@ -32,8 +32,8 @@ class ConnectionSpecification extends OperationFunctionalSpecification {
 
     def 'should have id'() {
         when:
-        def source = getBinding().getReadConnectionSource(getOperationContext())
-        def connection = source.getConnection(getOperationContext())
+        def source = getBinding().getReadConnectionSource(createOperationContext())
+        def connection = source.getConnection(createOperationContext())
 
         then:
         connection.getDescription().getConnectionId() != null
@@ -50,8 +50,8 @@ class ConnectionSpecification extends OperationFunctionalSpecification {
                                                              new BsonInt32(getDefaultMaxMessageSize())).intValue()
         def expectedMaxBatchCount = commandResult.getNumber('maxWriteBatchSize',
                                                             new BsonInt32(getDefaultMaxWriteBatchSize())).intValue()
-        def source = getBinding().getReadConnectionSource(getOperationContext())
-        def connection = source.getConnection(getOperationContext())
+        def source = getBinding().getReadConnectionSource(createOperationContext())
+        def connection = source.getConnection(createOperationContext())
 
         then:
         connection.description.serverAddress == source.getServerDescription().getAddress()
@@ -66,6 +66,6 @@ class ConnectionSpecification extends OperationFunctionalSpecification {
     }
    private static BsonDocument getHelloResult() {
         new CommandReadOperation<BsonDocument>('admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)),
-                new BsonDocumentCodec()).execute(getBinding(), getOperationContext())
+                new BsonDocumentCodec()).execute(getBinding(), createOperationContext())
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/connection/ConnectionSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/ConnectionSpecification.groovy
@@ -17,6 +17,7 @@
 package com.mongodb.connection
 
 import com.mongodb.OperationFunctionalSpecification
+import com.mongodb.internal.connection.OperationContext
 import com.mongodb.internal.operation.CommandReadOperation
 import org.bson.BsonDocument
 import org.bson.BsonInt32
@@ -32,8 +33,9 @@ class ConnectionSpecification extends OperationFunctionalSpecification {
 
     def 'should have id'() {
         when:
-        def source = getBinding().getReadConnectionSource(createOperationContext())
-        def connection = source.getConnection(createOperationContext())
+        def operationContext = createOperationContext()
+        def source = getBinding().getReadConnectionSource(operationContext)
+        def connection = source.getConnection(operationContext)
 
         then:
         connection.getDescription().getConnectionId() != null
@@ -45,13 +47,14 @@ class ConnectionSpecification extends OperationFunctionalSpecification {
 
     def 'should have description'() {
         when:
-        def commandResult = getHelloResult()
+        def operationContext = createOperationContext()
+        def commandResult = getHelloResult(operationContext)
         def expectedMaxMessageSize = commandResult.getNumber('maxMessageSizeBytes',
                                                              new BsonInt32(getDefaultMaxMessageSize())).intValue()
         def expectedMaxBatchCount = commandResult.getNumber('maxWriteBatchSize',
                                                             new BsonInt32(getDefaultMaxWriteBatchSize())).intValue()
-        def source = getBinding().getReadConnectionSource(createOperationContext())
-        def connection = source.getConnection(createOperationContext())
+        def source = getBinding().getReadConnectionSource(operationContext)
+        def connection = source.getConnection(operationContext)
 
         then:
         connection.description.serverAddress == source.getServerDescription().getAddress()
@@ -64,8 +67,8 @@ class ConnectionSpecification extends OperationFunctionalSpecification {
         connection?.release()
         source?.release()
     }
-   private static BsonDocument getHelloResult() {
+   private static BsonDocument getHelloResult(OperationContext operationContext) {
         new CommandReadOperation<BsonDocument>('admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)),
-                new BsonDocumentCodec()).execute(getBinding(), createOperationContext())
+                new BsonDocumentCodec()).execute(getBinding(), operationContext)
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/connection/netty/NettyStreamSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/netty/NettyStreamSpecification.groovy
@@ -18,7 +18,7 @@ import com.mongodb.spock.Slow
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.getSslSettings
 
 class NettyStreamSpecification extends Specification {
@@ -43,7 +43,7 @@ class NettyStreamSpecification extends Specification {
         def stream = factory.create(new ServerAddress())
 
         when:
-        stream.open(OPERATION_CONTEXT)
+        stream.open(getOperationContext())
 
         then:
         !stream.isClosed()
@@ -69,7 +69,7 @@ class NettyStreamSpecification extends Specification {
         def stream = factory.create(new ServerAddress())
 
         when:
-        stream.open(OPERATION_CONTEXT)
+        stream.open(getOperationContext())
 
         then:
         thrown(MongoSocketOpenException)
@@ -96,7 +96,7 @@ class NettyStreamSpecification extends Specification {
         def callback = new CallbackErrorHolder()
 
         when:
-        stream.openAsync(OPERATION_CONTEXT, callback)
+        stream.openAsync(getOperationContext(), callback)
 
         then:
         callback.getError().is(exception)

--- a/driver-core/src/test/functional/com/mongodb/connection/netty/NettyStreamSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/netty/NettyStreamSpecification.groovy
@@ -18,7 +18,7 @@ import com.mongodb.spock.Slow
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getSslSettings
 
 class NettyStreamSpecification extends Specification {
@@ -43,7 +43,7 @@ class NettyStreamSpecification extends Specification {
         def stream = factory.create(new ServerAddress())
 
         when:
-        stream.open(getOperationContext())
+        stream.open(createOperationContext())
 
         then:
         !stream.isClosed()
@@ -69,7 +69,7 @@ class NettyStreamSpecification extends Specification {
         def stream = factory.create(new ServerAddress())
 
         when:
-        stream.open(getOperationContext())
+        stream.open(createOperationContext())
 
         then:
         thrown(MongoSocketOpenException)
@@ -96,7 +96,7 @@ class NettyStreamSpecification extends Specification {
         def callback = new CallbackErrorHolder()
 
         when:
-        stream.openAsync(getOperationContext(), callback)
+        stream.openAsync(createOperationContext(), callback)
 
         then:
         callback.getError().is(exception)

--- a/driver-core/src/test/functional/com/mongodb/internal/binding/AsyncSessionBindingSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/binding/AsyncSessionBindingSpecification.groovy
@@ -16,10 +16,9 @@
 
 package com.mongodb.internal.binding
 
+import com.mongodb.ClusterFixture
 import com.mongodb.internal.async.SingleResultCallback
 import spock.lang.Specification
-
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
 
 class AsyncSessionBindingSpecification extends Specification {
 
@@ -27,6 +26,7 @@ class AsyncSessionBindingSpecification extends Specification {
         given:
         def wrapped = Mock(AsyncReadWriteBinding)
         def binding = new AsyncSessionBinding(wrapped)
+        def operationContext = ClusterFixture.getOperationContext()
 
         when:
         binding.getCount()
@@ -52,17 +52,18 @@ class AsyncSessionBindingSpecification extends Specification {
         then:
         1 * wrapped.release()
 
-        when:
-        binding.getReadConnectionSource(OPERATION_CONTEXT, Stub(SingleResultCallback))
-
-        then:
-        1 * wrapped.getReadConnectionSource(OPERATION_CONTEXT, _)
 
         when:
-        binding.getWriteConnectionSource(OPERATION_CONTEXT, Stub(SingleResultCallback))
+        binding.getReadConnectionSource(operationContext, Stub(SingleResultCallback))
 
         then:
-        1 * wrapped.getWriteConnectionSource(OPERATION_CONTEXT, _)
+        1 * wrapped.getReadConnectionSource(operationContext, _)
+
+        when:
+        binding.getWriteConnectionSource(operationContext, Stub(SingleResultCallback))
+
+        then:
+        1 * wrapped.getWriteConnectionSource(operationContext, _)
     }
 
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/binding/AsyncSessionBindingSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/binding/AsyncSessionBindingSpecification.groovy
@@ -26,7 +26,7 @@ class AsyncSessionBindingSpecification extends Specification {
         given:
         def wrapped = Mock(AsyncReadWriteBinding)
         def binding = new AsyncSessionBinding(wrapped)
-        def operationContext = ClusterFixture.getOperationContext()
+        def operationContext = ClusterFixture.createOperationContext()
 
         when:
         binding.getCount()

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncSocketChannelStreamSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncSocketChannelStreamSpecification.groovy
@@ -13,7 +13,7 @@ import com.mongodb.spock.Slow
 
 import java.util.concurrent.CountDownLatch
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.getSslSettings
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
@@ -40,7 +40,7 @@ class AsyncSocketChannelStreamSpecification extends Specification {
         def stream = factory.create(new ServerAddress('host1'))
 
         when:
-        stream.open(OPERATION_CONTEXT)
+        stream.open(getOperationContext())
 
         then:
         !stream.isClosed()
@@ -66,7 +66,7 @@ class AsyncSocketChannelStreamSpecification extends Specification {
         def stream = factory.create(new ServerAddress())
 
         when:
-        stream.open(OPERATION_CONTEXT)
+        stream.open(getOperationContext())
 
         then:
         thrown(MongoSocketOpenException)
@@ -90,7 +90,7 @@ class AsyncSocketChannelStreamSpecification extends Specification {
         def callback = new CallbackErrorHolder()
 
         when:
-        stream.openAsync(OPERATION_CONTEXT, callback)
+        stream.openAsync(getOperationContext(), callback)
 
         then:
         callback.getError().is(exception)

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncSocketChannelStreamSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncSocketChannelStreamSpecification.groovy
@@ -13,7 +13,7 @@ import com.mongodb.spock.Slow
 
 import java.util.concurrent.CountDownLatch
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getSslSettings
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
@@ -40,7 +40,7 @@ class AsyncSocketChannelStreamSpecification extends Specification {
         def stream = factory.create(new ServerAddress('host1'))
 
         when:
-        stream.open(getOperationContext())
+        stream.open(createOperationContext())
 
         then:
         !stream.isClosed()
@@ -66,7 +66,7 @@ class AsyncSocketChannelStreamSpecification extends Specification {
         def stream = factory.create(new ServerAddress())
 
         when:
-        stream.open(getOperationContext())
+        stream.open(createOperationContext())
 
         then:
         thrown(MongoSocketOpenException)
@@ -90,7 +90,7 @@ class AsyncSocketChannelStreamSpecification extends Specification {
         def callback = new CallbackErrorHolder()
 
         when:
-        stream.openAsync(getOperationContext(), callback)
+        stream.openAsync(createOperationContext(), callback)
 
         then:
         callback.getError().is(exception)

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncStreamTimeoutsSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncStreamTimeoutsSpecification.groovy
@@ -30,7 +30,7 @@ import com.mongodb.spock.Slow
 
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getServerApi
 import static com.mongodb.ClusterFixture.getSslSettings
@@ -49,7 +49,7 @@ class AsyncStreamTimeoutsSpecification extends OperationFunctionalSpecification 
                 .create(new ServerId(new ClusterId(), new ServerAddress(new InetSocketAddress('192.168.255.255', 27017))))
 
         when:
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
 
         then:
         thrown(MongoSocketOpenException)
@@ -63,7 +63,7 @@ class AsyncStreamTimeoutsSpecification extends OperationFunctionalSpecification 
                 new ServerAddress(new InetSocketAddress('192.168.255.255', 27017))))
 
         when:
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
 
         then:
         thrown(MongoSocketOpenException)

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncStreamTimeoutsSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/AsyncStreamTimeoutsSpecification.groovy
@@ -30,7 +30,7 @@ import com.mongodb.spock.Slow
 
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getServerApi
 import static com.mongodb.ClusterFixture.getSslSettings
@@ -49,7 +49,7 @@ class AsyncStreamTimeoutsSpecification extends OperationFunctionalSpecification 
                 .create(new ServerId(new ClusterId(), new ServerAddress(new InetSocketAddress('192.168.255.255', 27017))))
 
         when:
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
 
         then:
         thrown(MongoSocketOpenException)
@@ -63,7 +63,7 @@ class AsyncStreamTimeoutsSpecification extends OperationFunctionalSpecification 
                 new ServerAddress(new InetSocketAddress('192.168.255.255', 27017))))
 
         when:
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
 
         then:
         thrown(MongoSocketOpenException)

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/AwsAuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/AwsAuthenticationSpecification.groovy
@@ -19,7 +19,7 @@ import spock.lang.Specification
 import java.util.function.Supplier
 
 import static com.mongodb.AuthenticationMechanism.MONGODB_AWS
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.getClusterConnectionMode
 import static com.mongodb.ClusterFixture.getConnectionString
 import static com.mongodb.ClusterFixture.getCredential
@@ -52,7 +52,7 @@ class AwsAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, OPERATION_CONTEXT)
+                getClusterConnectionMode(), null, connection, getOperationContext())
 
         then:
         thrown(MongoCommandException)
@@ -71,7 +71,7 @@ class AwsAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, OPERATION_CONTEXT)
+                getClusterConnectionMode(), null, connection, getOperationContext())
 
         then:
         true
@@ -101,7 +101,7 @@ class AwsAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, OPERATION_CONTEXT)
+                getClusterConnectionMode(), null, connection, getOperationContext())
 
         then:
         true
@@ -160,10 +160,10 @@ class AwsAuthenticationSpecification extends Specification {
     private static void openConnection(final InternalConnection connection, final boolean async) {
         if (async) {
             FutureResultCallback<Void> futureResultCallback = new FutureResultCallback<Void>()
-            connection.openAsync(OPERATION_CONTEXT, futureResultCallback)
+            connection.openAsync(getOperationContext(), futureResultCallback)
             futureResultCallback.get(ClusterFixture.TIMEOUT, SECONDS)
         } else {
-            connection.open(OPERATION_CONTEXT)
+            connection.open(getOperationContext())
         }
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/AwsAuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/AwsAuthenticationSpecification.groovy
@@ -19,7 +19,7 @@ import spock.lang.Specification
 import java.util.function.Supplier
 
 import static com.mongodb.AuthenticationMechanism.MONGODB_AWS
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getClusterConnectionMode
 import static com.mongodb.ClusterFixture.getConnectionString
 import static com.mongodb.ClusterFixture.getCredential
@@ -52,7 +52,7 @@ class AwsAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, getOperationContext())
+                getClusterConnectionMode(), null, connection, createOperationContext())
 
         then:
         thrown(MongoCommandException)
@@ -71,7 +71,7 @@ class AwsAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, getOperationContext())
+                getClusterConnectionMode(), null, connection, createOperationContext())
 
         then:
         true
@@ -101,7 +101,7 @@ class AwsAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, getOperationContext())
+                getClusterConnectionMode(), null, connection, createOperationContext())
 
         then:
         true
@@ -160,10 +160,10 @@ class AwsAuthenticationSpecification extends Specification {
     private static void openConnection(final InternalConnection connection, final boolean async) {
         if (async) {
             FutureResultCallback<Void> futureResultCallback = new FutureResultCallback<Void>()
-            connection.openAsync(getOperationContext(), futureResultCallback)
+            connection.openAsync(createOperationContext(), futureResultCallback)
             futureResultCallback.get(ClusterFixture.TIMEOUT, SECONDS)
         } else {
-            connection.open(getOperationContext())
+            connection.open(createOperationContext())
         }
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/CommandHelperSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/CommandHelperSpecification.groovy
@@ -31,7 +31,7 @@ import java.util.concurrent.CountDownLatch
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA
 import static com.mongodb.ClusterFixture.LEGACY_HELLO
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.getClusterConnectionMode
 import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getPrimary
@@ -48,7 +48,7 @@ class CommandHelperSpecification extends Specification {
                 new NettyStreamFactory(SocketSettings.builder().build(), getSslSettings()),
                 getCredentialWithCache(), CLIENT_METADATA, [], LoggerSettings.builder().build(), null, getServerApi())
                 .create(new ServerId(new ClusterId(), getPrimary()))
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
     }
 
     def cleanup() {
@@ -62,7 +62,7 @@ class CommandHelperSpecification extends Specification {
         Throwable receivedException = null
         def latch1 = new CountDownLatch(1)
         executeCommandAsync('admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)), getClusterConnectionMode(),
-                getServerApi(), connection, OPERATION_CONTEXT)
+                getServerApi(), connection, getOperationContext())
                 { document, exception -> receivedDocument = document; receivedException = exception; latch1.countDown() }
         latch1.await()
 
@@ -74,7 +74,7 @@ class CommandHelperSpecification extends Specification {
         when:
         def latch2 = new CountDownLatch(1)
         executeCommandAsync('admin', new BsonDocument('non-existent-command', new BsonInt32(1)), getClusterConnectionMode(),
-                getServerApi(), connection, OPERATION_CONTEXT)
+                getServerApi(), connection, getOperationContext())
                 { document, exception -> receivedDocument = document; receivedException = exception; latch2.countDown() }
         latch2.await()
 

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/CommandHelperSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/CommandHelperSpecification.groovy
@@ -31,7 +31,7 @@ import java.util.concurrent.CountDownLatch
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA
 import static com.mongodb.ClusterFixture.LEGACY_HELLO
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getClusterConnectionMode
 import static com.mongodb.ClusterFixture.getCredentialWithCache
 import static com.mongodb.ClusterFixture.getPrimary
@@ -48,7 +48,7 @@ class CommandHelperSpecification extends Specification {
                 new NettyStreamFactory(SocketSettings.builder().build(), getSslSettings()),
                 getCredentialWithCache(), CLIENT_METADATA, [], LoggerSettings.builder().build(), null, getServerApi())
                 .create(new ServerId(new ClusterId(), getPrimary()))
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
     }
 
     def cleanup() {
@@ -62,7 +62,7 @@ class CommandHelperSpecification extends Specification {
         Throwable receivedException = null
         def latch1 = new CountDownLatch(1)
         executeCommandAsync('admin', new BsonDocument(LEGACY_HELLO, new BsonInt32(1)), getClusterConnectionMode(),
-                getServerApi(), connection, getOperationContext())
+                getServerApi(), connection, createOperationContext())
                 { document, exception -> receivedDocument = document; receivedException = exception; latch1.countDown() }
         latch1.await()
 
@@ -74,7 +74,7 @@ class CommandHelperSpecification extends Specification {
         when:
         def latch2 = new CountDownLatch(1)
         executeCommandAsync('admin', new BsonDocument('non-existent-command', new BsonInt32(1)), getClusterConnectionMode(),
-                getServerApi(), connection, getOperationContext())
+                getServerApi(), connection, createOperationContext())
                 { document, exception -> receivedDocument = document; receivedException = exception; latch2.countDown() }
         latch2.await()
 

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
@@ -60,7 +60,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_FACTORY;
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.ClusterFixture.createOperationContext;
@@ -173,7 +173,7 @@ public class DefaultConnectionPoolTest {
 
         String expectedExceptionMessage = "The server at 127.0.0.1:27017 is no longer available";
         MongoServerUnavailableException exception;
-        exception = assertThrows(MongoServerUnavailableException.class, () -> provider.get(OPERATION_CONTEXT));
+        exception = assertThrows(MongoServerUnavailableException.class, () -> provider.get(getOperationContext()));
         assertEquals(expectedExceptionMessage, exception.getMessage());
         SupplyingCallback<InternalConnection> supplyingCallback = new SupplyingCallback<>();
         provider.getAsync(createOperationContext(TIMEOUT_SETTINGS.withMaxWaitTimeMS(50)), supplyingCallback);
@@ -194,10 +194,10 @@ public class DefaultConnectionPoolTest {
         provider.ready();
 
         // when
-        provider.get(OPERATION_CONTEXT).close();
+        provider.get(getOperationContext()).close();
         sleep(100);
         provider.doMaintenance();
-        provider.get(OPERATION_CONTEXT);
+        provider.get(getOperationContext());
 
         // then
         assertTrue(connectionFactory.getNumCreatedConnections() >= 2);  // should really be two, but it's racy
@@ -215,7 +215,7 @@ public class DefaultConnectionPoolTest {
         provider.ready();
 
         // when
-        InternalConnection connection = provider.get(OPERATION_CONTEXT);
+        InternalConnection connection = provider.get(getOperationContext());
         sleep(50);
         connection.close();
 
@@ -236,10 +236,10 @@ public class DefaultConnectionPoolTest {
         provider.ready();
 
         // when
-        provider.get(OPERATION_CONTEXT).close();
+        provider.get(getOperationContext()).close();
         sleep(100);
         provider.doMaintenance();
-        provider.get(OPERATION_CONTEXT);
+        provider.get(getOperationContext());
 
         // then
         assertTrue(connectionFactory.getNumCreatedConnections() >= 2);  // should really be two, but it's racy
@@ -258,10 +258,10 @@ public class DefaultConnectionPoolTest {
         provider.ready();
 
         // when
-        provider.get(OPERATION_CONTEXT).close();
+        provider.get(getOperationContext()).close();
         sleep(50);
         provider.doMaintenance();
-        provider.get(OPERATION_CONTEXT);
+        provider.get(getOperationContext());
 
         // then
         assertTrue(connectionFactory.getCreatedConnections().get(0).isClosed());
@@ -280,10 +280,10 @@ public class DefaultConnectionPoolTest {
         provider.ready();
 
         // when
-        provider.get(OPERATION_CONTEXT).close();
+        provider.get(getOperationContext()).close();
         sleep(50);
         provider.doMaintenance();
-        InternalConnection secondConnection = provider.get(OPERATION_CONTEXT);
+        InternalConnection secondConnection = provider.get(getOperationContext());
 
         // then
         assertNotNull(secondConnection);
@@ -302,7 +302,7 @@ public class DefaultConnectionPoolTest {
                         .build(),
                 mockSdamProvider(), OPERATION_CONTEXT_FACTORY);
         provider.ready();
-        provider.get(OPERATION_CONTEXT).close();
+        provider.get(getOperationContext()).close();
 
 
         // when
@@ -322,7 +322,7 @@ public class DefaultConnectionPoolTest {
         List<InternalConnection> connections = new ArrayList<>();
         try {
             for (int i = 0; i < 2 * defaultMaxSize; i++) {
-                connections.add(provider.get(OPERATION_CONTEXT));
+                connections.add(provider.get(getOperationContext()));
             }
         } finally {
             connections.forEach(connection -> {

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.connection;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.MongoConnectionPoolClearedException;
 import com.mongodb.MongoServerUnavailableException;
 import com.mongodb.ServerAddress;
@@ -60,7 +61,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_FACTORY;
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.ClusterFixture.createOperationContext;
@@ -173,7 +173,7 @@ public class DefaultConnectionPoolTest {
 
         String expectedExceptionMessage = "The server at 127.0.0.1:27017 is no longer available";
         MongoServerUnavailableException exception;
-        exception = assertThrows(MongoServerUnavailableException.class, () -> provider.get(getOperationContext()));
+        exception = assertThrows(MongoServerUnavailableException.class, () -> provider.get(ClusterFixture.createOperationContext()));
         assertEquals(expectedExceptionMessage, exception.getMessage());
         SupplyingCallback<InternalConnection> supplyingCallback = new SupplyingCallback<>();
         provider.getAsync(createOperationContext(TIMEOUT_SETTINGS.withMaxWaitTimeMS(50)), supplyingCallback);
@@ -194,10 +194,10 @@ public class DefaultConnectionPoolTest {
         provider.ready();
 
         // when
-        provider.get(getOperationContext()).close();
+        provider.get(ClusterFixture.createOperationContext()).close();
         sleep(100);
         provider.doMaintenance();
-        provider.get(getOperationContext());
+        provider.get(ClusterFixture.createOperationContext());
 
         // then
         assertTrue(connectionFactory.getNumCreatedConnections() >= 2);  // should really be two, but it's racy
@@ -215,7 +215,7 @@ public class DefaultConnectionPoolTest {
         provider.ready();
 
         // when
-        InternalConnection connection = provider.get(getOperationContext());
+        InternalConnection connection = provider.get(ClusterFixture.createOperationContext());
         sleep(50);
         connection.close();
 
@@ -236,10 +236,10 @@ public class DefaultConnectionPoolTest {
         provider.ready();
 
         // when
-        provider.get(getOperationContext()).close();
+        provider.get(ClusterFixture.createOperationContext()).close();
         sleep(100);
         provider.doMaintenance();
-        provider.get(getOperationContext());
+        provider.get(ClusterFixture.createOperationContext());
 
         // then
         assertTrue(connectionFactory.getNumCreatedConnections() >= 2);  // should really be two, but it's racy
@@ -258,10 +258,10 @@ public class DefaultConnectionPoolTest {
         provider.ready();
 
         // when
-        provider.get(getOperationContext()).close();
+        provider.get(ClusterFixture.createOperationContext()).close();
         sleep(50);
         provider.doMaintenance();
-        provider.get(getOperationContext());
+        provider.get(ClusterFixture.createOperationContext());
 
         // then
         assertTrue(connectionFactory.getCreatedConnections().get(0).isClosed());
@@ -280,10 +280,10 @@ public class DefaultConnectionPoolTest {
         provider.ready();
 
         // when
-        provider.get(getOperationContext()).close();
+        provider.get(ClusterFixture.createOperationContext()).close();
         sleep(50);
         provider.doMaintenance();
-        InternalConnection secondConnection = provider.get(getOperationContext());
+        InternalConnection secondConnection = provider.get(ClusterFixture.createOperationContext());
 
         // then
         assertNotNull(secondConnection);
@@ -302,7 +302,7 @@ public class DefaultConnectionPoolTest {
                         .build(),
                 mockSdamProvider(), OPERATION_CONTEXT_FACTORY);
         provider.ready();
-        provider.get(getOperationContext()).close();
+        provider.get(ClusterFixture.createOperationContext()).close();
 
 
         // when
@@ -322,7 +322,7 @@ public class DefaultConnectionPoolTest {
         List<InternalConnection> connections = new ArrayList<>();
         try {
             for (int i = 0; i < 2 * defaultMaxSize; i++) {
-                connections.add(provider.get(getOperationContext()));
+                connections.add(provider.get(ClusterFixture.createOperationContext()));
             }
         } finally {
             connections.forEach(connection -> {

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/GSSAPIAuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/GSSAPIAuthenticationSpecification.groovy
@@ -36,7 +36,7 @@ import javax.security.auth.Subject
 import javax.security.auth.login.LoginContext
 
 import static com.mongodb.AuthenticationMechanism.GSSAPI
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.getClusterConnectionMode
 import static com.mongodb.ClusterFixture.getConnectionString
 import static com.mongodb.ClusterFixture.getCredential
@@ -58,7 +58,7 @@ class GSSAPIAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, OPERATION_CONTEXT)
+                getClusterConnectionMode(), null, connection, getOperationContext())
 
         then:
         thrown(MongoCommandException)
@@ -77,7 +77,7 @@ class GSSAPIAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, OPERATION_CONTEXT)
+                getClusterConnectionMode(), null, connection, getOperationContext())
 
         then:
         true
@@ -99,7 +99,7 @@ class GSSAPIAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, OPERATION_CONTEXT)
+                getClusterConnectionMode(), null, connection, getOperationContext())
 
         then:
         thrown(MongoSecurityException)
@@ -131,7 +131,7 @@ class GSSAPIAuthenticationSpecification extends Specification {
         def connection = createConnection(async, getMongoCredential(subject))
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, OPERATION_CONTEXT)
+                getClusterConnectionMode(), null, connection, getOperationContext())
 
         then:
         true
@@ -175,7 +175,7 @@ class GSSAPIAuthenticationSpecification extends Specification {
         def connection = createConnection(async, getMongoCredential(saslClientProperties))
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, OPERATION_CONTEXT)
+                getClusterConnectionMode(), null, connection, getOperationContext())
 
         then:
         true
@@ -219,10 +219,10 @@ class GSSAPIAuthenticationSpecification extends Specification {
     private static void openConnection(final InternalConnection connection, final boolean async) {
         if (async) {
             FutureResultCallback<Void> futureResultCallback = new FutureResultCallback<Void>()
-            connection.openAsync(OPERATION_CONTEXT, futureResultCallback)
+            connection.openAsync(getOperationContext(), futureResultCallback)
             futureResultCallback.get(ClusterFixture.TIMEOUT, SECONDS)
         } else {
-            connection.open(OPERATION_CONTEXT)
+            connection.open(getOperationContext())
         }
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/GSSAPIAuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/GSSAPIAuthenticationSpecification.groovy
@@ -36,7 +36,7 @@ import javax.security.auth.Subject
 import javax.security.auth.login.LoginContext
 
 import static com.mongodb.AuthenticationMechanism.GSSAPI
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getClusterConnectionMode
 import static com.mongodb.ClusterFixture.getConnectionString
 import static com.mongodb.ClusterFixture.getCredential
@@ -58,7 +58,7 @@ class GSSAPIAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, getOperationContext())
+                getClusterConnectionMode(), null, connection, createOperationContext())
 
         then:
         thrown(MongoCommandException)
@@ -77,7 +77,7 @@ class GSSAPIAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, getOperationContext())
+                getClusterConnectionMode(), null, connection, createOperationContext())
 
         then:
         true
@@ -99,7 +99,7 @@ class GSSAPIAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, getOperationContext())
+                getClusterConnectionMode(), null, connection, createOperationContext())
 
         then:
         thrown(MongoSecurityException)
@@ -131,7 +131,7 @@ class GSSAPIAuthenticationSpecification extends Specification {
         def connection = createConnection(async, getMongoCredential(subject))
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, getOperationContext())
+                getClusterConnectionMode(), null, connection, createOperationContext())
 
         then:
         true
@@ -175,7 +175,7 @@ class GSSAPIAuthenticationSpecification extends Specification {
         def connection = createConnection(async, getMongoCredential(saslClientProperties))
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, getOperationContext())
+                getClusterConnectionMode(), null, connection, createOperationContext())
 
         then:
         true
@@ -219,10 +219,10 @@ class GSSAPIAuthenticationSpecification extends Specification {
     private static void openConnection(final InternalConnection connection, final boolean async) {
         if (async) {
             FutureResultCallback<Void> futureResultCallback = new FutureResultCallback<Void>()
-            connection.openAsync(getOperationContext(), futureResultCallback)
+            connection.openAsync(createOperationContext(), futureResultCallback)
             futureResultCallback.get(ClusterFixture.TIMEOUT, SECONDS)
         } else {
-            connection.open(getOperationContext())
+            connection.open(createOperationContext())
         }
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/GSSAPIAuthenticatorSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/GSSAPIAuthenticatorSpecification.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 import javax.security.auth.login.LoginContext
 
 import static com.mongodb.AuthenticationMechanism.GSSAPI
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.getLoginContextName
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getServerApi
@@ -57,7 +57,7 @@ class GSSAPIAuthenticatorSpecification extends Specification {
                 .create(new ServerId(new ClusterId(), getPrimary()))
 
         when:
-        internalConnection.open(OPERATION_CONTEXT)
+        internalConnection.open(getOperationContext())
 
         then:
         1 * subjectProvider.getSubject() >> subject

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/GSSAPIAuthenticatorSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/GSSAPIAuthenticatorSpecification.groovy
@@ -30,7 +30,7 @@ import spock.lang.Specification
 import javax.security.auth.login.LoginContext
 
 import static com.mongodb.AuthenticationMechanism.GSSAPI
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getLoginContextName
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getServerApi
@@ -57,7 +57,7 @@ class GSSAPIAuthenticatorSpecification extends Specification {
                 .create(new ServerId(new ClusterId(), getPrimary()))
 
         when:
-        internalConnection.open(getOperationContext())
+        internalConnection.open(createOperationContext())
 
         then:
         1 * subjectProvider.getSubject() >> subject

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/PlainAuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/PlainAuthenticationSpecification.groovy
@@ -32,7 +32,7 @@ import spock.lang.IgnoreIf
 import spock.lang.Specification
 
 import static com.mongodb.AuthenticationMechanism.PLAIN
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.getClusterConnectionMode
 import static com.mongodb.ClusterFixture.getConnectionString
 import static com.mongodb.ClusterFixture.getCredential
@@ -52,7 +52,7 @@ class PlainAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, OPERATION_CONTEXT)
+                getClusterConnectionMode(), null, connection, getOperationContext())
 
         then:
         thrown(MongoCommandException)
@@ -71,7 +71,7 @@ class PlainAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, OPERATION_CONTEXT)
+                getClusterConnectionMode(), null, connection, getOperationContext())
 
         then:
         true
@@ -90,7 +90,7 @@ class PlainAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, OPERATION_CONTEXT)
+                getClusterConnectionMode(), null, connection, getOperationContext())
 
         then:
         thrown(MongoSecurityException)
@@ -123,10 +123,10 @@ class PlainAuthenticationSpecification extends Specification {
     private static void openConnection(final InternalConnection connection, final boolean async) {
         if (async) {
             FutureResultCallback<Void> futureResultCallback = new FutureResultCallback<Void>()
-            connection.openAsync(OPERATION_CONTEXT, futureResultCallback)
+            connection.openAsync(getOperationContext(), futureResultCallback)
             futureResultCallback.get(ClusterFixture.TIMEOUT, SECONDS)
         } else {
-            connection.open(OPERATION_CONTEXT)
+            connection.open(getOperationContext())
         }
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/PlainAuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/PlainAuthenticationSpecification.groovy
@@ -32,7 +32,7 @@ import spock.lang.IgnoreIf
 import spock.lang.Specification
 
 import static com.mongodb.AuthenticationMechanism.PLAIN
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getClusterConnectionMode
 import static com.mongodb.ClusterFixture.getConnectionString
 import static com.mongodb.ClusterFixture.getCredential
@@ -52,7 +52,7 @@ class PlainAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, getOperationContext())
+                getClusterConnectionMode(), null, connection, createOperationContext())
 
         then:
         thrown(MongoCommandException)
@@ -71,7 +71,7 @@ class PlainAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, getOperationContext())
+                getClusterConnectionMode(), null, connection, createOperationContext())
 
         then:
         true
@@ -90,7 +90,7 @@ class PlainAuthenticationSpecification extends Specification {
         when:
         openConnection(connection, async)
         executeCommand(getConnectionString().getDatabase(), new BsonDocument('count', new BsonString('test')),
-                getClusterConnectionMode(), null, connection, getOperationContext())
+                getClusterConnectionMode(), null, connection, createOperationContext())
 
         then:
         thrown(MongoSecurityException)
@@ -123,10 +123,10 @@ class PlainAuthenticationSpecification extends Specification {
     private static void openConnection(final InternalConnection connection, final boolean async) {
         if (async) {
             FutureResultCallback<Void> futureResultCallback = new FutureResultCallback<Void>()
-            connection.openAsync(getOperationContext(), futureResultCallback)
+            connection.openAsync(createOperationContext(), futureResultCallback)
             futureResultCallback.get(ClusterFixture.TIMEOUT, SECONDS)
         } else {
-            connection.open(getOperationContext())
+            connection.open(createOperationContext())
         }
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/PlainAuthenticatorTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/PlainAuthenticatorTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA;
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getClusterConnectionMode;
 import static com.mongodb.ClusterFixture.getServerApi;
 import static com.mongodb.ClusterFixture.getSslSettings;
@@ -69,14 +69,14 @@ public class PlainAuthenticatorTest {
     public void testSuccessfulAuthentication() {
         PlainAuthenticator authenticator = new PlainAuthenticator(getCredentialWithCache(userName, source, password.toCharArray()),
                 getClusterConnectionMode(), getServerApi());
-        authenticator.authenticate(internalConnection, connectionDescription, OPERATION_CONTEXT);
+        authenticator.authenticate(internalConnection, connectionDescription, getOperationContext());
     }
 
     @Test(expected = MongoSecurityException.class)
     public void testUnsuccessfulAuthentication() {
         PlainAuthenticator authenticator = new PlainAuthenticator(getCredentialWithCache(userName, source, "wrong".toCharArray()),
                 getClusterConnectionMode(), getServerApi());
-        authenticator.authenticate(internalConnection, connectionDescription, OPERATION_CONTEXT);
+        authenticator.authenticate(internalConnection, connectionDescription, getOperationContext());
     }
 
     private static MongoCredentialWithCache getCredentialWithCache(final String userName, final String source, final char[] password) {

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/PlainAuthenticatorTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/PlainAuthenticatorTest.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.connection;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.LoggerSettings;
 import com.mongodb.MongoCredential;
 import com.mongodb.MongoSecurityException;
@@ -33,7 +34,6 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA;
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getClusterConnectionMode;
 import static com.mongodb.ClusterFixture.getServerApi;
 import static com.mongodb.ClusterFixture.getSslSettings;
@@ -69,14 +69,14 @@ public class PlainAuthenticatorTest {
     public void testSuccessfulAuthentication() {
         PlainAuthenticator authenticator = new PlainAuthenticator(getCredentialWithCache(userName, source, password.toCharArray()),
                 getClusterConnectionMode(), getServerApi());
-        authenticator.authenticate(internalConnection, connectionDescription, getOperationContext());
+        authenticator.authenticate(internalConnection, connectionDescription, ClusterFixture.createOperationContext());
     }
 
     @Test(expected = MongoSecurityException.class)
     public void testUnsuccessfulAuthentication() {
         PlainAuthenticator authenticator = new PlainAuthenticator(getCredentialWithCache(userName, source, "wrong".toCharArray()),
                 getClusterConnectionMode(), getServerApi());
-        authenticator.authenticate(internalConnection, connectionDescription, getOperationContext());
+        authenticator.authenticate(internalConnection, connectionDescription, ClusterFixture.createOperationContext());
     }
 
     private static MongoCredentialWithCache getCredentialWithCache(final String userName, final String source, final char[] password) {

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/ScramSha256AuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/ScramSha256AuthenticationSpecification.groovy
@@ -33,7 +33,7 @@ import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.createAsyncCluster
 import static com.mongodb.ClusterFixture.createCluster
 import static com.mongodb.ClusterFixture.getBinding
@@ -105,7 +105,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         when:
         new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
-                .execute(new ClusterBinding(cluster, ReadPreference.primary()), OPERATION_CONTEXT)
+                .execute(new ClusterBinding(cluster, ReadPreference.primary()), getOperationContext())
 
         then:
         noExceptionThrown()
@@ -128,7 +128,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         def binding = new AsyncClusterBinding(cluster, ReadPreference.primary())
         new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
-                .executeAsync(binding, OPERATION_CONTEXT, callback)
+                .executeAsync(binding, getOperationContext(), callback)
         callback.get()
 
         then:
@@ -148,7 +148,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         when:
         new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
-                .execute(new ClusterBinding(cluster, ReadPreference.primary()), OPERATION_CONTEXT)
+                .execute(new ClusterBinding(cluster, ReadPreference.primary()), getOperationContext())
 
         then:
         thrown(MongoSecurityException)
@@ -168,7 +168,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         when:
         new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
-                .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary()), OPERATION_CONTEXT,
+                .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary()), getOperationContext(),
                         callback)
         callback.get()
 
@@ -189,7 +189,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         when:
         new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
-                .execute(new ClusterBinding(cluster, ReadPreference.primary()), OPERATION_CONTEXT)
+                .execute(new ClusterBinding(cluster, ReadPreference.primary()), getOperationContext())
 
         then:
         noExceptionThrown()
@@ -209,7 +209,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         when:
         new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
-                .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary()), OPERATION_CONTEXT,
+                .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary()), getOperationContext(),
                         callback)
         callback.get()
 

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/ScramSha256AuthenticationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/ScramSha256AuthenticationSpecification.groovy
@@ -33,7 +33,7 @@ import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.createAsyncCluster
 import static com.mongodb.ClusterFixture.createCluster
 import static com.mongodb.ClusterFixture.getBinding
@@ -88,12 +88,12 @@ class ScramSha256AuthenticationSpecification extends Specification {
         def binding = getBinding()
         new CommandReadOperation<>('admin',
                 new BsonDocumentWrapper<Document>(createUserCommand, new DocumentCodec()), new DocumentCodec())
-                .execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                .execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
     }
 
     def dropUser(final String userName) {
         def binding = getBinding()
-        def operationContext = ClusterFixture.getOperationContext(binding.getReadPreference())
+        def operationContext = ClusterFixture.createOperationContext(binding.getReadPreference())
         new CommandReadOperation<>('admin', new BsonDocument('dropUser', new BsonString(userName)),
                 new BsonDocumentCodec()).execute(binding, operationContext)
     }
@@ -105,7 +105,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         when:
         new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
-                .execute(new ClusterBinding(cluster, ReadPreference.primary()), getOperationContext())
+                .execute(new ClusterBinding(cluster, ReadPreference.primary()), createOperationContext())
 
         then:
         noExceptionThrown()
@@ -128,7 +128,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         def binding = new AsyncClusterBinding(cluster, ReadPreference.primary())
         new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
-                .executeAsync(binding, getOperationContext(), callback)
+                .executeAsync(binding, createOperationContext(), callback)
         callback.get()
 
         then:
@@ -148,7 +148,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         when:
         new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
-                .execute(new ClusterBinding(cluster, ReadPreference.primary()), getOperationContext())
+                .execute(new ClusterBinding(cluster, ReadPreference.primary()), createOperationContext())
 
         then:
         thrown(MongoSecurityException)
@@ -168,7 +168,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         when:
         new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
-                .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary()), getOperationContext(),
+                .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary()), createOperationContext(),
                         callback)
         callback.get()
 
@@ -189,7 +189,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         when:
         new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
-                .execute(new ClusterBinding(cluster, ReadPreference.primary()), getOperationContext())
+                .execute(new ClusterBinding(cluster, ReadPreference.primary()), createOperationContext())
 
         then:
         noExceptionThrown()
@@ -209,7 +209,7 @@ class ScramSha256AuthenticationSpecification extends Specification {
         when:
         new CommandReadOperation<Document>('admin',
                 new BsonDocumentWrapper<Document>(new Document('dbstats', 1), new DocumentCodec()), new DocumentCodec())
-                .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary()), getOperationContext(),
+                .executeAsync(new AsyncClusterBinding(cluster, ReadPreference.primary()), createOperationContext(),
                         callback)
         callback.get()
 

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/ServerHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/ServerHelper.java
@@ -23,7 +23,7 @@ import com.mongodb.connection.ServerDescription;
 import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.selector.ServerAddressSelector;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getAsyncCluster;
 import static com.mongodb.ClusterFixture.getCluster;
 import static com.mongodb.assertions.Assertions.fail;
@@ -54,7 +54,7 @@ public final class ServerHelper {
 
     public static void waitForLastRelease(final ServerAddress address, final Cluster cluster) {
         ConcurrentPool<UsageTrackingInternalConnection> pool = connectionPool(
-                cluster.selectServer(new ServerAddressSelector(address), OPERATION_CONTEXT).getServer());
+                cluster.selectServer(new ServerAddressSelector(address), getOperationContext()).getServer());
         long startTime = System.currentTimeMillis();
         while (pool.getInUseCount() > 0) {
             try {
@@ -70,7 +70,7 @@ public final class ServerHelper {
     }
 
     private static ConcurrentPool<UsageTrackingInternalConnection> getConnectionPool(final ServerAddress address, final Cluster cluster) {
-        return connectionPool(cluster.selectServer(new ServerAddressSelector(address), OPERATION_CONTEXT).getServer());
+        return connectionPool(cluster.selectServer(new ServerAddressSelector(address), getOperationContext()).getServer());
     }
 
     private static void checkPool(final ServerAddress address, final Cluster cluster) {

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/ServerHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/ServerHelper.java
@@ -23,7 +23,6 @@ import com.mongodb.connection.ServerDescription;
 import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.selector.ServerAddressSelector;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getAsyncCluster;
 import static com.mongodb.ClusterFixture.getCluster;
 import static com.mongodb.assertions.Assertions.fail;
@@ -54,7 +53,7 @@ public final class ServerHelper {
 
     public static void waitForLastRelease(final ServerAddress address, final Cluster cluster) {
         ConcurrentPool<UsageTrackingInternalConnection> pool = connectionPool(
-                cluster.selectServer(new ServerAddressSelector(address), getOperationContext()).getServer());
+                cluster.selectServer(new ServerAddressSelector(address), ClusterFixture.createOperationContext()).getServer());
         long startTime = System.currentTimeMillis();
         while (pool.getInUseCount() > 0) {
             try {
@@ -70,7 +69,7 @@ public final class ServerHelper {
     }
 
     private static ConcurrentPool<UsageTrackingInternalConnection> getConnectionPool(final ServerAddress address, final Cluster cluster) {
-        return connectionPool(cluster.selectServer(new ServerAddressSelector(address), getOperationContext()).getServer());
+        return connectionPool(cluster.selectServer(new ServerAddressSelector(address), ClusterFixture.createOperationContext()).getServer());
     }
 
     private static void checkPool(final ServerAddress address, final Cluster cluster) {

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA;
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_FACTORY;
 import static com.mongodb.ClusterFixture.getCredential;
 import static com.mongodb.ClusterFixture.getDefaultDatabaseName;
@@ -93,7 +93,7 @@ public class SingleServerClusterTest {
         setUpCluster(getPrimary());
 
         // when
-        ServerTuple serverTuple = cluster.selectServer(clusterDescription -> getPrimaries(clusterDescription), OPERATION_CONTEXT);
+        ServerTuple serverTuple = cluster.selectServer(clusterDescription -> getPrimaries(clusterDescription), getOperationContext());
 
         // then
         assertTrue(serverTuple.getServerDescription().isOk());
@@ -102,7 +102,7 @@ public class SingleServerClusterTest {
     @Test
     public void shouldSuccessfullyQueryASecondaryWithPrimaryReadPreference() {
         // given
-        OperationContext operationContext = OPERATION_CONTEXT;
+        OperationContext operationContext = getOperationContext();
         ServerAddress secondary = getSecondary();
         setUpCluster(secondary);
         String collectionName = getClass().getName();

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.connection;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.LoggerSettings;
 import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
@@ -37,7 +38,6 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA;
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_FACTORY;
 import static com.mongodb.ClusterFixture.getCredential;
 import static com.mongodb.ClusterFixture.getDefaultDatabaseName;
@@ -93,7 +93,7 @@ public class SingleServerClusterTest {
         setUpCluster(getPrimary());
 
         // when
-        ServerTuple serverTuple = cluster.selectServer(clusterDescription -> getPrimaries(clusterDescription), getOperationContext());
+        ServerTuple serverTuple = cluster.selectServer(clusterDescription -> getPrimaries(clusterDescription), ClusterFixture.createOperationContext());
 
         // then
         assertTrue(serverTuple.getServerDescription().isOk());
@@ -102,7 +102,7 @@ public class SingleServerClusterTest {
     @Test
     public void shouldSuccessfullyQueryASecondaryWithPrimaryReadPreference() {
         // given
-        OperationContext operationContext = getOperationContext();
+        OperationContext operationContext = ClusterFixture.createOperationContext();
         ServerAddress secondary = getSecondary();
         setUpCluster(secondary);
         String collectionName = getClass().getName();

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SocketStreamHelperSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SocketStreamHelperSpecification.groovy
@@ -33,7 +33,7 @@ import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import java.lang.reflect.Method
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getPrimary
@@ -87,7 +87,7 @@ class SocketStreamHelperSpecification extends Specification {
 
         when:
         SocketStreamHelper.initialize(
-                OPERATION_CONTEXT.withTimeoutContext(new TimeoutContext(
+                getOperationContext().withTimeoutContext(new TimeoutContext(
                                 new TimeoutSettings(
                                         1,
                                         100,
@@ -110,7 +110,8 @@ class SocketStreamHelperSpecification extends Specification {
         Socket socket = SocketFactory.default.createSocket()
 
         when:
-        SocketStreamHelper.initialize(OPERATION_CONTEXT, socket, getSocketAddresses(getPrimary(), new DefaultInetAddressResolver()).get(0),
+        SocketStreamHelper.initialize(getOperationContext(), socket, getSocketAddresses(getPrimary(),
+                new DefaultInetAddressResolver()).get(0),
                 SocketSettings.builder().build(), SslSettings.builder().build())
 
         then:
@@ -126,7 +127,8 @@ class SocketStreamHelperSpecification extends Specification {
         SSLSocket socket = SSLSocketFactory.default.createSocket()
 
         when:
-        SocketStreamHelper.initialize(OPERATION_CONTEXT, socket, getSocketAddresses(getPrimary(), new DefaultInetAddressResolver()).get(0),
+        SocketStreamHelper.initialize(getOperationContext(), socket, getSocketAddresses(getPrimary(),
+                new DefaultInetAddressResolver()).get(0),
                 SocketSettings.builder().build(), sslSettings)
 
         then:
@@ -147,7 +149,8 @@ class SocketStreamHelperSpecification extends Specification {
         SSLSocket socket = SSLSocketFactory.default.createSocket()
 
         when:
-        SocketStreamHelper.initialize(OPERATION_CONTEXT, socket, getSocketAddresses(getPrimary(), new DefaultInetAddressResolver()).get(0),
+        SocketStreamHelper.initialize(getOperationContext(), socket, getSocketAddresses(getPrimary(),
+                new DefaultInetAddressResolver()).get(0),
                 SocketSettings.builder().build(), sslSettings)
 
         then:
@@ -166,7 +169,8 @@ class SocketStreamHelperSpecification extends Specification {
         Socket socket = SocketFactory.default.createSocket()
 
         when:
-        SocketStreamHelper.initialize(OPERATION_CONTEXT, socket, getSocketAddresses(getPrimary(), new DefaultInetAddressResolver()).get(0),
+        SocketStreamHelper.initialize(getOperationContext(), socket, getSocketAddresses(getPrimary(),
+                new DefaultInetAddressResolver()).get(0),
                 SocketSettings.builder().build(), SslSettings.builder().enabled(true).build())
 
         then:

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SocketStreamHelperSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SocketStreamHelperSpecification.groovy
@@ -33,7 +33,6 @@ import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
 import java.lang.reflect.Method
 
-import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getPrimary
@@ -87,7 +86,7 @@ class SocketStreamHelperSpecification extends Specification {
 
         when:
         SocketStreamHelper.initialize(
-                getOperationContext().withTimeoutContext(new TimeoutContext(
+                createOperationContext().withTimeoutContext(new TimeoutContext(
                                 new TimeoutSettings(
                                         1,
                                         100,
@@ -110,7 +109,7 @@ class SocketStreamHelperSpecification extends Specification {
         Socket socket = SocketFactory.default.createSocket()
 
         when:
-        SocketStreamHelper.initialize(getOperationContext(), socket, getSocketAddresses(getPrimary(),
+        SocketStreamHelper.initialize(createOperationContext(), socket, getSocketAddresses(getPrimary(),
                 new DefaultInetAddressResolver()).get(0),
                 SocketSettings.builder().build(), SslSettings.builder().build())
 
@@ -127,7 +126,7 @@ class SocketStreamHelperSpecification extends Specification {
         SSLSocket socket = SSLSocketFactory.default.createSocket()
 
         when:
-        SocketStreamHelper.initialize(getOperationContext(), socket, getSocketAddresses(getPrimary(),
+        SocketStreamHelper.initialize(createOperationContext(), socket, getSocketAddresses(getPrimary(),
                 new DefaultInetAddressResolver()).get(0),
                 SocketSettings.builder().build(), sslSettings)
 
@@ -149,7 +148,7 @@ class SocketStreamHelperSpecification extends Specification {
         SSLSocket socket = SSLSocketFactory.default.createSocket()
 
         when:
-        SocketStreamHelper.initialize(getOperationContext(), socket, getSocketAddresses(getPrimary(),
+        SocketStreamHelper.initialize(createOperationContext(), socket, getSocketAddresses(getPrimary(),
                 new DefaultInetAddressResolver()).get(0),
                 SocketSettings.builder().build(), sslSettings)
 
@@ -169,7 +168,7 @@ class SocketStreamHelperSpecification extends Specification {
         Socket socket = SocketFactory.default.createSocket()
 
         when:
-        SocketStreamHelper.initialize(getOperationContext(), socket, getSocketAddresses(getPrimary(),
+        SocketStreamHelper.initialize(createOperationContext(), socket, getSocketAddresses(getPrimary(),
                 new DefaultInetAddressResolver()).get(0),
                 SocketSettings.builder().build(), SslSettings.builder().enabled(true).build())
 

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/StreamSocketAddressSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/StreamSocketAddressSpecification.groovy
@@ -13,7 +13,7 @@ import com.mongodb.spock.Slow
 import javax.net.SocketFactory
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.getSslSettings
 
 class StreamSocketAddressSpecification extends Specification {
@@ -44,7 +44,7 @@ class StreamSocketAddressSpecification extends Specification {
         def socketStream = new SocketStream(serverAddress, null, socketSettings, sslSettings, socketFactory, bufferProvider)
 
         when:
-        socketStream.open(OPERATION_CONTEXT)
+        socketStream.open(getOperationContext())
 
         then:
         !socket0.isConnected()
@@ -83,7 +83,7 @@ class StreamSocketAddressSpecification extends Specification {
         def socketStream = new SocketStream(serverAddress, inetAddressResolver, socketSettings, sslSettings, socketFactory, bufferProvider)
 
         when:
-        socketStream.open(OPERATION_CONTEXT)
+        socketStream.open(getOperationContext())
 
         then:
         thrown(MongoSocketOpenException)

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/StreamSocketAddressSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/StreamSocketAddressSpecification.groovy
@@ -13,7 +13,7 @@ import com.mongodb.spock.Slow
 import javax.net.SocketFactory
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getSslSettings
 
 class StreamSocketAddressSpecification extends Specification {
@@ -44,7 +44,7 @@ class StreamSocketAddressSpecification extends Specification {
         def socketStream = new SocketStream(serverAddress, null, socketSettings, sslSettings, socketFactory, bufferProvider)
 
         when:
-        socketStream.open(getOperationContext())
+        socketStream.open(createOperationContext())
 
         then:
         !socket0.isConnected()
@@ -83,7 +83,7 @@ class StreamSocketAddressSpecification extends Specification {
         def socketStream = new SocketStream(serverAddress, inetAddressResolver, socketSettings, sslSettings, socketFactory, bufferProvider)
 
         when:
-        socketStream.open(getOperationContext())
+        socketStream.open(createOperationContext())
 
         then:
         thrown(MongoSocketOpenException)

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/TlsChannelStreamFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/TlsChannelStreamFunctionalTest.java
@@ -184,11 +184,11 @@ class TlsChannelStreamFunctionalTest {
                             .build());
 
             Stream stream = streamFactory.create(getPrimaryServerDescription().getAddress());
-            stream.open(ClusterFixture.OPERATION_CONTEXT);
+            stream.open(ClusterFixture.getOperationContext());
             ByteBuf wrap = new ByteBufNIO(ByteBuffer.wrap(new byte[]{1, 3, 4}));
 
             //when
-            stream.write(Collections.singletonList(wrap), ClusterFixture.OPERATION_CONTEXT);
+            stream.write(Collections.singletonList(wrap), ClusterFixture.getOperationContext());
 
             //then
             SECONDS.sleep(5);

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/TlsChannelStreamFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/TlsChannelStreamFunctionalTest.java
@@ -184,11 +184,11 @@ class TlsChannelStreamFunctionalTest {
                             .build());
 
             Stream stream = streamFactory.create(getPrimaryServerDescription().getAddress());
-            stream.open(ClusterFixture.getOperationContext());
+            stream.open(ClusterFixture.createOperationContext());
             ByteBuf wrap = new ByteBufNIO(ByteBuffer.wrap(new byte[]{1, 3, 4}));
 
             //when
-            stream.write(Collections.singletonList(wrap), ClusterFixture.getOperationContext());
+            stream.write(Collections.singletonList(wrap), ClusterFixture.createOperationContext());
 
             //then
             SECONDS.sleep(5);

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateOperationSpecification.groovy
@@ -52,7 +52,6 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
 import static com.mongodb.ClusterFixture.collectCursorResults
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getAsyncCluster
@@ -381,7 +380,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add read concern to command'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
         def binding = Stub(ReadBinding)
         def source = Stub(ConnectionSource)
         def connection = Mock(Connection)
@@ -423,7 +422,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add read concern to command asynchronously'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
         def binding = Stub(AsyncReadBinding)
         def source = Stub(AsyncConnectionSource)
         def connection = Mock(AsyncConnection)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateOperationSpecification.groovy
@@ -355,7 +355,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
 
         def binding = ClusterFixture.getBinding()
         new CommandReadOperation<>(getDatabaseName(), new BsonDocument('profile', new BsonInt32(2)),
-                new BsonDocumentCodec()).execute(binding, getOperationContext(binding.getReadPreference()))
+                new BsonDocumentCodec()).execute(binding, createOperationContext(binding.getReadPreference()))
         def expectedComment = 'this is a comment'
         def operation = new AggregateOperation<Document>(getNamespace(), [], new DocumentCodec())
                 .comment(new BsonString(expectedComment))
@@ -371,7 +371,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         cleanup:
         binding = ClusterFixture.getBinding()
         new CommandReadOperation<>(getDatabaseName(), new BsonDocument('profile', new BsonInt32(0)),
-                new BsonDocumentCodec()).execute(binding, getOperationContext(binding.getReadPreference()))
+                new BsonDocumentCodec()).execute(binding, createOperationContext(binding.getReadPreference()))
         profileCollectionHelper.drop()
 
         where:

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateOperationSpecification.groovy
@@ -56,7 +56,7 @@ import static com.mongodb.ClusterFixture.collectCursorResults
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getAsyncCluster
 import static com.mongodb.ClusterFixture.getCluster
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.isStandalone
 import static com.mongodb.ExplainVerbosity.QUERY_PLANNER
@@ -231,7 +231,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
 
         def binding = ClusterFixture.getBinding(ClusterFixture.getCluster())
         new CreateViewOperation(getDatabaseName(), viewName, getCollectionName(), [], WriteConcern.ACKNOWLEDGED)
-                .execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                .execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
 
         when:
         AggregateOperation operation = new AggregateOperation<Document>(viewNamespace, [], new DocumentCodec())
@@ -245,7 +245,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         cleanup:
         binding = ClusterFixture.getBinding(ClusterFixture.getCluster())
         new DropCollectionOperation(viewNamespace, WriteConcern.ACKNOWLEDGED)
-                .execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                .execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
 
         where:
         async << [true, false]
@@ -272,7 +272,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
                 .allowDiskUse(allowDiskUse)
 
         def binding = ClusterFixture.getBinding()
-        def cursor = operation.execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
 
         then:
         cursor.next()*.getString('name') == ['Pete', 'Sam', 'Pete']
@@ -287,7 +287,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
                 .batchSize(batchSize)
 
         def binding = ClusterFixture.getBinding()
-        def cursor = operation.execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
 
         then:
         cursor.next()*.getString('name') == ['Pete', 'Sam', 'Pete']
@@ -380,7 +380,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add read concern to command'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
         def binding = Stub(ReadBinding)
         def source = Stub(ConnectionSource)
         def connection = Mock(Connection)
@@ -422,7 +422,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add read concern to command asynchronously'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
         def binding = Stub(AsyncReadBinding)
         def source = Stub(AsyncConnectionSource)
         def connection = Mock(AsyncConnection)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateToCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AggregateToCollectionOperationSpecification.groovy
@@ -278,7 +278,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         def profileCollectionHelper = getCollectionHelper(new MongoNamespace(getDatabaseName(), 'system.profile'))
         def binding = getBinding()
         new CommandReadOperation<>(getDatabaseName(), new BsonDocument('profile', new BsonInt32(2)),
-                new BsonDocumentCodec()).execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                new BsonDocumentCodec()).execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
         def expectedComment = 'this is a comment'
         AggregateToCollectionOperation operation = createOperation(getNamespace(),
                 [Aggregates.out('outputCollection').toBsonDocument(BsonDocument, registry)], ACKNOWLEDGED)
@@ -293,7 +293,7 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
 
         cleanup:
         new CommandReadOperation<>(getDatabaseName(), new BsonDocument('profile', new BsonInt32(0)),
-                new BsonDocumentCodec()).execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                new BsonDocumentCodec()).execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
         profileCollectionHelper.drop()
 
         where:

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncCommandBatchCursorFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncCommandBatchCursorFunctionalTest.java
@@ -55,7 +55,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.checkReferenceCountReachesTarget;
 import static com.mongodb.ClusterFixture.getAsyncBinding;
 import static com.mongodb.ClusterFixture.getConnection;
@@ -111,7 +111,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void shouldExhaustCursorAsyncWithMultipleBatches() {
         // given
         BsonDocument commandResult = executeFindCommand(0, 3); // Fetch in batches of size 3
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
        // when
@@ -133,7 +133,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void shouldExhaustCursorAsyncWithClosedCursor() {
         // given
         BsonDocument commandResult = executeFindCommand(0, 3);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         cursor.close();
@@ -156,7 +156,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         getCollectionHelper().deleteMany(Filters.empty());
 
         BsonDocument commandResult = executeFindCommand(0, 3); // No documents to fetch
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         // when
@@ -175,7 +175,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(2);
         AsyncCommandCursor<Document> coreCursor =
                 new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 coreCursor);
 
         assertNotNull(coreCursor.getServerCursor());
@@ -187,7 +187,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(5);
         AsyncCommandCursor<Document> coreCursor =
                 new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 coreCursor);
 
         cursor.close();
@@ -202,7 +202,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should throw an Exception when going off the end")
     void shouldThrowAnExceptionWhenGoingOffTheEnd() {
         BsonDocument commandResult = executeFindCommand(2, 1);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         cursorNext();
@@ -216,7 +216,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test normal exhaustion")
     void testNormalExhaustion() {
         BsonDocument commandResult = executeFindCommand();
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(10, cursorFlatten().size());
@@ -227,7 +227,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test limit exhaustion")
     void testLimitExhaustion(final int limit, final int batchSize, final int expectedTotal) {
         BsonDocument commandResult = executeFindCommand(limit, batchSize);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new AsyncCommandCursor<>(commandResult, batchSize, DOCUMENT_DECODER, null, connectionSource, connection));
 
 
@@ -246,7 +246,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, awaitData);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, getOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertFalse(cursor.isClosed());
@@ -269,7 +269,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -304,7 +304,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(5, 10);
         AsyncCommandCursor<Document> coreCursor =
                 new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 coreCursor);
 
         assertNotNull(cursorNext());
@@ -319,7 +319,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(5, 3);
         AsyncCommandCursor<Document> coreCursor =
                 new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 coreCursor);
 
         ServerCursor serverCursor = coreCursor.getServerCursor();
@@ -341,7 +341,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(5, 10);
         AsyncCommandCursor<Document> coreCursor =
                 new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 coreCursor);
 
         assertDoesNotThrow(() -> checkReferenceCountReachesTarget(connectionSource, 1));
@@ -354,7 +354,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void shouldReleaseConnectionSourceIfLimitIsReachedOnGetMore() {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 3);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursorNext());
@@ -367,7 +367,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test limit with get more")
     void testLimitWithGetMore() {
         BsonDocument commandResult = executeFindCommand(5, 2);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursorNext());
@@ -390,7 +390,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         );
 
         BsonDocument commandResult = executeFindCommand(300, 0);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(300, cursorFlatten().size());
@@ -400,7 +400,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should respect batch size")
     void shouldRespectBatchSize() {
         BsonDocument commandResult = executeFindCommand(2);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(2, cursor.getBatchSize());
@@ -419,7 +419,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(2);
         AsyncCommandCursor<Document> coreCursor =
                 new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 coreCursor);
 
         ServerCursor serverCursor = coreCursor.getServerCursor();
@@ -428,7 +428,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         this.<BsonDocument>block(cb -> localConnection.commandAsync(getNamespace().getDatabaseName(),
                 new BsonDocument("killCursors", new BsonString(getNamespace().getCollectionName()))
                         .append("cursors", new BsonArray(singletonList(new BsonInt64(serverCursor.getId())))),
-                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), OPERATION_CONTEXT, cb));
+                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), getOperationContext(), cb));
         localConnection.release();
 
         cursorNext();
@@ -494,7 +494,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument results = block(cb -> connection.commandAsync(getDatabaseName(), findCommand,
                 NoOpFieldNameValidator.INSTANCE, readPreference, CommandResultDocumentCodec.create(DOCUMENT_DECODER, FIRST_BATCH),
-                OPERATION_CONTEXT, cb));
+                getOperationContext(), cb));
 
         assertNotNull(results);
         return results;

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncCommandBatchCursorFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/AsyncCommandBatchCursorFunctionalTest.java
@@ -17,6 +17,7 @@
 package com.mongodb.internal.operation;
 
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.MongoCursorNotFoundException;
 import com.mongodb.MongoQueryException;
 import com.mongodb.ReadPreference;
@@ -55,7 +56,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.checkReferenceCountReachesTarget;
 import static com.mongodb.ClusterFixture.getAsyncBinding;
 import static com.mongodb.ClusterFixture.getConnection;
@@ -111,7 +111,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void shouldExhaustCursorAsyncWithMultipleBatches() {
         // given
         BsonDocument commandResult = executeFindCommand(0, 3); // Fetch in batches of size 3
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
        // when
@@ -133,7 +133,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void shouldExhaustCursorAsyncWithClosedCursor() {
         // given
         BsonDocument commandResult = executeFindCommand(0, 3);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         cursor.close();
@@ -156,7 +156,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         getCollectionHelper().deleteMany(Filters.empty());
 
         BsonDocument commandResult = executeFindCommand(0, 3); // No documents to fetch
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         // when
@@ -175,7 +175,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(2);
         AsyncCommandCursor<Document> coreCursor =
                 new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 coreCursor);
 
         assertNotNull(coreCursor.getServerCursor());
@@ -187,7 +187,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(5);
         AsyncCommandCursor<Document> coreCursor =
                 new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 coreCursor);
 
         cursor.close();
@@ -202,7 +202,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should throw an Exception when going off the end")
     void shouldThrowAnExceptionWhenGoingOffTheEnd() {
         BsonDocument commandResult = executeFindCommand(2, 1);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         cursorNext();
@@ -216,7 +216,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test normal exhaustion")
     void testNormalExhaustion() {
         BsonDocument commandResult = executeFindCommand();
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(10, cursorFlatten().size());
@@ -227,7 +227,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test limit exhaustion")
     void testLimitExhaustion(final int limit, final int batchSize, final int expectedTotal) {
         BsonDocument commandResult = executeFindCommand(limit, batchSize);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new AsyncCommandCursor<>(commandResult, batchSize, DOCUMENT_DECODER, null, connectionSource, connection));
 
 
@@ -246,7 +246,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, awaitData);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, ClusterFixture.createOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertFalse(cursor.isClosed());
@@ -269,7 +269,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -304,7 +304,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(5, 10);
         AsyncCommandCursor<Document> coreCursor =
                 new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 coreCursor);
 
         assertNotNull(cursorNext());
@@ -319,7 +319,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(5, 3);
         AsyncCommandCursor<Document> coreCursor =
                 new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 coreCursor);
 
         ServerCursor serverCursor = coreCursor.getServerCursor();
@@ -341,7 +341,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(5, 10);
         AsyncCommandCursor<Document> coreCursor =
                 new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 coreCursor);
 
         assertDoesNotThrow(() -> checkReferenceCountReachesTarget(connectionSource, 1));
@@ -354,7 +354,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     void shouldReleaseConnectionSourceIfLimitIsReachedOnGetMore() {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 3);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursorNext());
@@ -367,7 +367,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test limit with get more")
     void testLimitWithGetMore() {
         BsonDocument commandResult = executeFindCommand(5, 2);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursorNext());
@@ -390,7 +390,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         );
 
         BsonDocument commandResult = executeFindCommand(300, 0);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(300, cursorFlatten().size());
@@ -400,7 +400,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should respect batch size")
     void shouldRespectBatchSize() {
         BsonDocument commandResult = executeFindCommand(2);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(2, cursor.getBatchSize());
@@ -419,7 +419,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument commandResult = executeFindCommand(2);
         AsyncCommandCursor<Document> coreCursor =
                 new AsyncCommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection);
-        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new AsyncCommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 coreCursor);
 
         ServerCursor serverCursor = coreCursor.getServerCursor();
@@ -428,7 +428,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
         this.<BsonDocument>block(cb -> localConnection.commandAsync(getNamespace().getDatabaseName(),
                 new BsonDocument("killCursors", new BsonString(getNamespace().getCollectionName()))
                         .append("cursors", new BsonArray(singletonList(new BsonInt64(serverCursor.getId())))),
-                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), getOperationContext(), cb));
+                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), ClusterFixture.createOperationContext(), cb));
         localConnection.release();
 
         cursorNext();
@@ -494,7 +494,7 @@ public class AsyncCommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument results = block(cb -> connection.commandAsync(getDatabaseName(), findCommand,
                 NoOpFieldNameValidator.INSTANCE, readPreference, CommandResultDocumentCodec.create(DOCUMENT_DECODER, FIRST_BATCH),
-                getOperationContext(), cb));
+                ClusterFixture.createOperationContext(), cb));
 
         assertNotNull(results);
         return results;

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
@@ -53,7 +53,7 @@ import org.bson.codecs.DocumentCodec
 import org.bson.codecs.ValueCodecProvider
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.getAsyncCluster
 import static com.mongodb.ClusterFixture.getCluster
 import static com.mongodb.ClusterFixture.isStandalone
@@ -635,7 +635,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
     def 'should set the startAtOperationTime on the sync cursor'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(
+        def operationContext = getOperationContext().withSessionContext(
                 Stub(SessionContext) {
                     getReadConcern() >> ReadConcern.DEFAULT
                     getOperationTime() >> new BsonTimestamp()
@@ -690,7 +690,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
     def 'should set the startAtOperationTime on the async cursor'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(
+        def operationContext = getOperationContext().withSessionContext(
                 Stub(SessionContext) {
                     getReadConcern() >> ReadConcern.DEFAULT
                     getOperationTime() >> new BsonTimestamp()

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ChangeStreamOperationSpecification.groovy
@@ -53,7 +53,7 @@ import org.bson.codecs.DocumentCodec
 import org.bson.codecs.ValueCodecProvider
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getAsyncCluster
 import static com.mongodb.ClusterFixture.getCluster
 import static com.mongodb.ClusterFixture.isStandalone
@@ -635,7 +635,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
     def 'should set the startAtOperationTime on the sync cursor'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(
+        def operationContext = createOperationContext().withSessionContext(
                 Stub(SessionContext) {
                     getReadConcern() >> ReadConcern.DEFAULT
                     getOperationTime() >> new BsonTimestamp()
@@ -690,7 +690,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
     def 'should set the startAtOperationTime on the async cursor'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(
+        def operationContext = createOperationContext().withSessionContext(
                 Stub(SessionContext) {
                     getReadConcern() >> ReadConcern.DEFAULT
                     getOperationTime() >> new BsonTimestamp()

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CommandBatchCursorFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CommandBatchCursorFunctionalTest.java
@@ -55,7 +55,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.checkReferenceCountReachesTarget;
 import static com.mongodb.ClusterFixture.getBinding;
 import static com.mongodb.ClusterFixture.getReferenceCountAfterTimeout;
@@ -87,8 +87,8 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
                 .collect(Collectors.toList());
         getCollectionHelper().insertDocuments(documents);
 
-        connectionSource = getBinding().getWriteConnectionSource(ClusterFixture.OPERATION_CONTEXT);
-        connection = connectionSource.getConnection(ClusterFixture.OPERATION_CONTEXT);
+        connectionSource = getBinding().getWriteConnectionSource(ClusterFixture.getOperationContext());
+        connection = connectionSource.getConnection(ClusterFixture.getOperationContext());
     }
 
     @AfterEach
@@ -109,7 +109,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldExhaustCursorWithMultipleBatches() {
         // given
         BsonDocument commandResult = executeFindCommand(0, 3); // Fetch in batches of size 3
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         // when
@@ -127,7 +127,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldExhaustCursorWithClosedCursor() {
         // given
         BsonDocument commandResult = executeFindCommand(0, 3);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
         cursor.close();
 
@@ -143,7 +143,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         getCollectionHelper().deleteMany(Filters.empty());
 
         BsonDocument commandResult = executeFindCommand(0, 3); // No documents to fetch
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         // when
@@ -157,7 +157,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("server cursor should not be null")
     void theServerCursorShouldNotBeNull() {
         BsonDocument commandResult = executeFindCommand(2);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursor.getServerCursor());
@@ -167,7 +167,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test server address should not be null")
     void theServerAddressShouldNotNull() {
         BsonDocument commandResult = executeFindCommand();
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursor.getServerAddress());
@@ -177,7 +177,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should get Exceptions for operations on the cursor after closing")
     void shouldGetExceptionsForOperationsOnTheCursorAfterClosing() {
         BsonDocument commandResult = executeFindCommand();
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         cursor.close();
@@ -192,7 +192,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should throw an Exception when going off the end")
     void shouldThrowAnExceptionWhenGoingOffTheEnd() {
         BsonDocument commandResult = executeFindCommand(1);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         cursor.next();
@@ -204,7 +204,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test cursor remove")
     void testCursorRemove() {
         BsonDocument commandResult = executeFindCommand();
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertThrows(UnsupportedOperationException.class, () -> cursor.remove());
@@ -214,7 +214,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test normal exhaustion")
     void testNormalExhaustion() {
         BsonDocument commandResult = executeFindCommand();
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(10, cursorFlatten().size());
@@ -225,7 +225,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test limit exhaustion")
     void testLimitExhaustion(final int limit, final int batchSize, final int expectedTotal) {
         BsonDocument commandResult = executeFindCommand(limit, batchSize);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(expectedTotal, cursorFlatten().size());
@@ -244,7 +244,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, awaitData);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, getOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertTrue(cursor.hasNext());
@@ -267,7 +267,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         List<Document> nextBatch = cursor.tryNext();
@@ -293,7 +293,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertTrue(cursor.hasNext());
@@ -320,7 +320,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         long maxTimeMS = 500;
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, getOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         List<Document> nextBatch = cursor.tryNext();
@@ -344,7 +344,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -377,7 +377,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldKillCursorIfLimitIsReachedOnInitialQuery() {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 10);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursor.next());
@@ -390,7 +390,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldKillCursorIfLimitIsReachedOnGetMore() {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 3);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         ServerCursor serverCursor = cursor.getServerCursor();
@@ -409,7 +409,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldReleaseConnectionSourceIfLimitIsReachedOnInitialQuery() {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 10);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNull(cursor.getServerCursor());
@@ -422,7 +422,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldReleaseConnectionSourceIfLimitIsReachedOnGetMore() {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 3);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursor.next());
@@ -435,7 +435,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test limit with get more")
     void testLimitWithGetMore() {
         BsonDocument commandResult = executeFindCommand(5, 2);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursor.next());
@@ -456,7 +456,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         );
 
         BsonDocument commandResult = executeFindCommand(300, 0);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(300, cursorFlatten().size());
@@ -466,7 +466,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should respect batch size")
     void shouldRespectBatchSize() {
         BsonDocument commandResult = executeFindCommand(2);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(2, cursor.getBatchSize());
@@ -483,16 +483,16 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should throw cursor not found exception")
     void shouldThrowCursorNotFoundException() {
         BsonDocument commandResult = executeFindCommand(2);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         ServerCursor serverCursor = cursor.getServerCursor();
         assertNotNull(serverCursor);
-        Connection localConnection = connectionSource.getConnection(OPERATION_CONTEXT);
+        Connection localConnection = connectionSource.getConnection(getOperationContext());
         localConnection.command(getNamespace().getDatabaseName(),
                 new BsonDocument("killCursors", new BsonString(getNamespace().getCollectionName()))
                         .append("cursors", new BsonArray(singletonList(new BsonInt64(serverCursor.getId())))),
-                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), OPERATION_CONTEXT);
+                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), getOperationContext());
         localConnection.release();
 
         cursor.next();
@@ -506,7 +506,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should report available documents")
     void shouldReportAvailableDocuments() {
         BsonDocument commandResult = executeFindCommand(3);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, OPERATION_CONTEXT,
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(3, cursor.available());
@@ -584,7 +584,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument results = connection.command(getDatabaseName(), findCommand,
                 NoOpFieldNameValidator.INSTANCE, readPreference,
                 CommandResultDocumentCodec.create(DOCUMENT_DECODER, FIRST_BATCH),
-                OPERATION_CONTEXT);
+                getOperationContext());
 
         assertNotNull(results);
         return results;

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CommandBatchCursorFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CommandBatchCursorFunctionalTest.java
@@ -27,6 +27,7 @@ import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.OperationTest;
 import com.mongodb.internal.binding.ConnectionSource;
 import com.mongodb.internal.connection.Connection;
+import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
@@ -86,8 +87,9 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
                 .collect(Collectors.toList());
         getCollectionHelper().insertDocuments(documents);
 
-        connectionSource = getBinding().getWriteConnectionSource(ClusterFixture.createOperationContext());
-        connection = connectionSource.getConnection(ClusterFixture.createOperationContext());
+        OperationContext operationContext = ClusterFixture.createOperationContext();
+        connectionSource = getBinding().getWriteConnectionSource(operationContext);
+        connection = connectionSource.getConnection(operationContext);
     }
 
     @AfterEach

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CommandBatchCursorFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CommandBatchCursorFunctionalTest.java
@@ -55,7 +55,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.checkReferenceCountReachesTarget;
 import static com.mongodb.ClusterFixture.getBinding;
 import static com.mongodb.ClusterFixture.getReferenceCountAfterTimeout;
@@ -87,8 +86,8 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
                 .collect(Collectors.toList());
         getCollectionHelper().insertDocuments(documents);
 
-        connectionSource = getBinding().getWriteConnectionSource(ClusterFixture.getOperationContext());
-        connection = connectionSource.getConnection(ClusterFixture.getOperationContext());
+        connectionSource = getBinding().getWriteConnectionSource(ClusterFixture.createOperationContext());
+        connection = connectionSource.getConnection(ClusterFixture.createOperationContext());
     }
 
     @AfterEach
@@ -109,7 +108,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldExhaustCursorWithMultipleBatches() {
         // given
         BsonDocument commandResult = executeFindCommand(0, 3); // Fetch in batches of size 3
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         // when
@@ -127,7 +126,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldExhaustCursorWithClosedCursor() {
         // given
         BsonDocument commandResult = executeFindCommand(0, 3);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
         cursor.close();
 
@@ -143,7 +142,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         getCollectionHelper().deleteMany(Filters.empty());
 
         BsonDocument commandResult = executeFindCommand(0, 3); // No documents to fetch
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         // when
@@ -157,7 +156,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("server cursor should not be null")
     void theServerCursorShouldNotBeNull() {
         BsonDocument commandResult = executeFindCommand(2);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursor.getServerCursor());
@@ -167,7 +166,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test server address should not be null")
     void theServerAddressShouldNotNull() {
         BsonDocument commandResult = executeFindCommand();
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursor.getServerAddress());
@@ -177,7 +176,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should get Exceptions for operations on the cursor after closing")
     void shouldGetExceptionsForOperationsOnTheCursorAfterClosing() {
         BsonDocument commandResult = executeFindCommand();
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         cursor.close();
@@ -192,7 +191,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should throw an Exception when going off the end")
     void shouldThrowAnExceptionWhenGoingOffTheEnd() {
         BsonDocument commandResult = executeFindCommand(1);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         cursor.next();
@@ -204,7 +203,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test cursor remove")
     void testCursorRemove() {
         BsonDocument commandResult = executeFindCommand();
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertThrows(UnsupportedOperationException.class, () -> cursor.remove());
@@ -214,7 +213,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test normal exhaustion")
     void testNormalExhaustion() {
         BsonDocument commandResult = executeFindCommand();
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(10, cursorFlatten().size());
@@ -225,7 +224,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test limit exhaustion")
     void testLimitExhaustion(final int limit, final int batchSize, final int expectedTotal) {
         BsonDocument commandResult = executeFindCommand(limit, batchSize);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(expectedTotal, cursorFlatten().size());
@@ -244,7 +243,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, awaitData);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertTrue(cursor.hasNext());
@@ -267,7 +266,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         List<Document> nextBatch = cursor.tryNext();
@@ -293,7 +292,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertTrue(cursor.hasNext());
@@ -320,7 +319,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         long maxTimeMS = 500;
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, maxTimeMS, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         List<Document> nextBatch = cursor.tryNext();
@@ -344,7 +343,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
 
         BsonDocument commandResult = executeFindCommand(new BsonDocument("ts",
                 new BsonDocument("$gte", new BsonTimestamp(5, 0))), 0, 2, true, true);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -377,7 +376,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldKillCursorIfLimitIsReachedOnInitialQuery() {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 10);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursor.next());
@@ -390,7 +389,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldKillCursorIfLimitIsReachedOnGetMore() {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 3);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         ServerCursor serverCursor = cursor.getServerCursor();
@@ -409,7 +408,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldReleaseConnectionSourceIfLimitIsReachedOnInitialQuery() {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 10);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNull(cursor.getServerCursor());
@@ -422,7 +421,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     void shouldReleaseConnectionSourceIfLimitIsReachedOnGetMore() {
         assumeFalse(isSharded());
         BsonDocument commandResult = executeFindCommand(5, 3);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 3, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursor.next());
@@ -435,7 +434,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("test limit with get more")
     void testLimitWithGetMore() {
         BsonDocument commandResult = executeFindCommand(5, 2);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertNotNull(cursor.next());
@@ -456,7 +455,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         );
 
         BsonDocument commandResult = executeFindCommand(300, 0);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 0, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(300, cursorFlatten().size());
@@ -466,7 +465,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should respect batch size")
     void shouldRespectBatchSize() {
         BsonDocument commandResult = executeFindCommand(2);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(2, cursor.getBatchSize());
@@ -483,16 +482,16 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should throw cursor not found exception")
     void shouldThrowCursorNotFoundException() {
         BsonDocument commandResult = executeFindCommand(2);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         ServerCursor serverCursor = cursor.getServerCursor();
         assertNotNull(serverCursor);
-        Connection localConnection = connectionSource.getConnection(getOperationContext());
+        Connection localConnection = connectionSource.getConnection(ClusterFixture.createOperationContext());
         localConnection.command(getNamespace().getDatabaseName(),
                 new BsonDocument("killCursors", new BsonString(getNamespace().getCollectionName()))
                         .append("cursors", new BsonArray(singletonList(new BsonInt64(serverCursor.getId())))),
-                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), getOperationContext());
+                NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), ClusterFixture.createOperationContext());
         localConnection.release();
 
         cursor.next();
@@ -506,7 +505,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
     @DisplayName("should report available documents")
     void shouldReportAvailableDocuments() {
         BsonDocument commandResult = executeFindCommand(3);
-        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, getOperationContext(),
+        cursor = new CommandBatchCursor<>(TimeoutMode.CURSOR_LIFETIME, 0, ClusterFixture.createOperationContext(),
                 new CommandCursor<>(commandResult, 2, DOCUMENT_DECODER, null, connectionSource, connection));
 
         assertEquals(3, cursor.available());
@@ -584,7 +583,7 @@ public class CommandBatchCursorFunctionalTest extends OperationTest {
         BsonDocument results = connection.command(getDatabaseName(), findCommand,
                 NoOpFieldNameValidator.INSTANCE, readPreference,
                 CommandResultDocumentCodec.create(DOCUMENT_DECODER, FIRST_BATCH),
-                getOperationContext());
+                ClusterFixture.createOperationContext());
 
         assertNotNull(results);
         return results;

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CountDocumentsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CountDocumentsOperationSpecification.groovy
@@ -46,7 +46,7 @@ import org.bson.BsonTimestamp
 import org.bson.Document
 import org.bson.codecs.DocumentCodec
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.connection.ServerType.STANDALONE
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand
@@ -259,7 +259,7 @@ class CountDocumentsOperationSpecification extends OperationFunctionalSpecificat
 
     def 'should add read concern to command'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
         def binding = Stub(ReadBinding)
         def source = Stub(ConnectionSource)
         def connection = Mock(Connection)
@@ -297,7 +297,7 @@ class CountDocumentsOperationSpecification extends OperationFunctionalSpecificat
 
     def 'should add read concern to command asynchronously'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
         def binding = Stub(AsyncReadBinding)
         def source = Stub(AsyncConnectionSource)
         def connection = Mock(AsyncConnection)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CountDocumentsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CountDocumentsOperationSpecification.groovy
@@ -46,7 +46,7 @@ import org.bson.BsonTimestamp
 import org.bson.Document
 import org.bson.codecs.DocumentCodec
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.connection.ServerType.STANDALONE
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand
@@ -156,7 +156,7 @@ class CountDocumentsOperationSpecification extends OperationFunctionalSpecificat
 
         def binding = ClusterFixture.getBinding()
         new CreateIndexesOperation(getNamespace(), [new IndexRequest(indexDefinition).sparse(true)], null)
-                .execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                .execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
         def operation = new CountDocumentsOperation(getNamespace()).hint(indexDefinition)
 
         when:
@@ -259,7 +259,7 @@ class CountDocumentsOperationSpecification extends OperationFunctionalSpecificat
 
     def 'should add read concern to command'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
         def binding = Stub(ReadBinding)
         def source = Stub(ConnectionSource)
         def connection = Mock(Connection)
@@ -297,7 +297,7 @@ class CountDocumentsOperationSpecification extends OperationFunctionalSpecificat
 
     def 'should add read concern to command asynchronously'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
         def binding = Stub(AsyncReadBinding)
         def source = Stub(AsyncConnectionSource)
         def connection = Mock(AsyncConnection)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CreateCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CreateCollectionOperationSpecification.groovy
@@ -113,7 +113,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         then:
         def binding = ClusterFixture.getBinding()
         new ListCollectionsOperation(getDatabaseName(), new BsonDocumentCodec())
-                .execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                .execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
                 .next()
                 .find { it -> it.getString('name').value == getCollectionName() }
                 .getDocument('options').getDocument('storageEngine') == operation.storageEngineOptions
@@ -134,7 +134,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         then:
         def binding = ClusterFixture.getBinding()
         new ListCollectionsOperation(getDatabaseName(), new BsonDocumentCodec())
-                .execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                .execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
                 .next()
                 .find { it -> it.getString('name').value == getCollectionName() }
                 .getDocument('options').getDocument('storageEngine') == operation.storageEngineOptions
@@ -255,7 +255,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         def binding = getBinding()
         new ListCollectionsOperation(databaseName, new BsonDocumentCodec()).filter(new BsonDocument('name',
                 new BsonString(collectionName))).execute(binding,
-                ClusterFixture.getOperationContext(binding.getReadPreference())).tryNext()?.head()
+                ClusterFixture.createOperationContext(binding.getReadPreference())).tryNext()?.head()
     }
 
     def collectionNameExists(String collectionName) {
@@ -268,13 +268,13 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
             def binding = getBinding()
             return new CommandReadOperation<>(getDatabaseName(),
                     new BsonDocument('collStats', new BsonString(getCollectionName())),
-                    new BsonDocumentCodec()).execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                    new BsonDocumentCodec()).execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
         }
         def binding = ClusterFixture.getBinding()
         BatchCursor<BsonDocument> cursor = new AggregateOperation(
                 getNamespace(),
                 singletonList(new BsonDocument('$collStats', new BsonDocument('storageStats', new BsonDocument()))),
-                new BsonDocumentCodec()).execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                new BsonDocumentCodec()).execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
         try {
             return cursor.next().first().getDocument('storageStats')
         } finally {

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CreateIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CreateIndexesOperationSpecification.groovy
@@ -494,7 +494,7 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
 
         def binding = ClusterFixture.getBinding()
         def cursor = new ListIndexesOperation(getNamespace(), new DocumentCodec())
-                .execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                .execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
         while (cursor.hasNext()) {
             indexes.addAll(cursor.next())
         }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CreateViewOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CreateViewOperationSpecification.groovy
@@ -29,6 +29,7 @@ import org.bson.BsonString
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 
@@ -123,7 +124,7 @@ class CreateViewOperationSpecification extends OperationFunctionalSpecification 
     def getCollectionInfo(String collectionName) {
         def binding = getBinding()
         new ListCollectionsOperation(databaseName, new BsonDocumentCodec()).filter(new BsonDocument('name',
-                new BsonString(collectionName))).execute(binding, getOperationContext(binding.getReadPreference())).tryNext()?.head()
+                new BsonString(collectionName))).execute(binding, createOperationContext(binding.getReadPreference())).tryNext()?.head()
     }
 
     def collectionNameExists(String collectionName) {

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/CreateViewOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/CreateViewOperationSpecification.groovy
@@ -30,7 +30,6 @@ import org.bson.codecs.BsonDocumentCodec
 import spock.lang.IgnoreIf
 
 import static com.mongodb.ClusterFixture.getBinding
-import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 
 class CreateViewOperationSpecification extends OperationFunctionalSpecification {

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DistinctOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DistinctOperationSpecification.groovy
@@ -51,7 +51,7 @@ import org.bson.codecs.StringCodec
 import org.bson.codecs.ValueCodecProvider
 import org.bson.types.ObjectId
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.connection.ServerType.STANDALONE
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand
@@ -227,7 +227,7 @@ class DistinctOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add read concern to command'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
         def binding = Stub(ReadBinding)
         def source = Stub(ConnectionSource)
         def connection = Mock(Connection)
@@ -266,7 +266,7 @@ class DistinctOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add read concern to command asynchronously'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
         def binding = Stub(AsyncReadBinding)
         def source = Stub(AsyncConnectionSource)
         def connection = Mock(AsyncConnection)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DistinctOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DistinctOperationSpecification.groovy
@@ -51,7 +51,7 @@ import org.bson.codecs.StringCodec
 import org.bson.codecs.ValueCodecProvider
 import org.bson.types.ObjectId
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.connection.ServerType.STANDALONE
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand
@@ -227,7 +227,7 @@ class DistinctOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add read concern to command'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
         def binding = Stub(ReadBinding)
         def source = Stub(ConnectionSource)
         def connection = Mock(Connection)
@@ -266,7 +266,7 @@ class DistinctOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add read concern to command asynchronously'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
         def binding = Stub(AsyncReadBinding)
         def source = Stub(AsyncConnectionSource)
         def connection = Mock(AsyncConnection)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DropCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DropCollectionOperationSpecification.groovy
@@ -39,7 +39,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
         when:
         def binding = getBinding()
         new DropCollectionOperation(getNamespace(), WriteConcern.ACKNOWLEDGED)
-                .execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                .execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
 
         then:
         !collectionNameExists(getCollectionName())
@@ -64,7 +64,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
 
         when:
         new DropCollectionOperation(namespace, WriteConcern.ACKNOWLEDGED)
-                .execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                .execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
 
         then:
         !collectionNameExists('nonExistingCollection')
@@ -91,7 +91,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
 
         when:
         def binding = getBinding()
-        async ? executeAsync(operation) : operation.execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+        async ? executeAsync(operation) : operation.execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
 
         then:
         def ex = thrown(MongoWriteConcernException)
@@ -104,7 +104,7 @@ class DropCollectionOperationSpecification extends OperationFunctionalSpecificat
 
     def collectionNameExists(String collectionName) {
         def cursor = new ListCollectionsOperation(databaseName, new DocumentCodec())
-                .execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                .execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
         if (!cursor.hasNext()) {
             return false
         }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DropDatabaseOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DropDatabaseOperationSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb.internal.operation
 
-
 import com.mongodb.MongoWriteConcernException
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.WriteConcern
@@ -25,6 +24,7 @@ import org.bson.Document
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.configureFailPoint
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
@@ -79,7 +79,7 @@ class DropDatabaseOperationSpecification extends OperationFunctionalSpecificatio
 
         def binding = getBinding()
         when:
-        async ? executeAsync(operation) : operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        async ? executeAsync(operation) : operation.execute(binding, createOperationContext(binding.getReadPreference()))
 
         then:
         def ex = thrown(MongoWriteConcernException)
@@ -92,7 +92,7 @@ class DropDatabaseOperationSpecification extends OperationFunctionalSpecificatio
 
     def databaseNameExists(String databaseName) {
         new ListDatabasesOperation(new DocumentCodec()).execute(binding,
-                getOperationContext(binding.getReadPreference())).next()*.name.contains(databaseName)
+                createOperationContext(binding.getReadPreference())).next()*.name.contains(databaseName)
     }
 
 }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DropDatabaseOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DropDatabaseOperationSpecification.groovy
@@ -28,7 +28,6 @@ import spock.lang.IgnoreIf
 import static com.mongodb.ClusterFixture.configureFailPoint
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
-import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/DropIndexOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/DropIndexOperationSpecification.groovy
@@ -159,7 +159,7 @@ class DropIndexOperationSpecification extends OperationFunctionalSpecification {
         def indexes = []
         def binding = getBinding()
         def cursor = new ListIndexesOperation(getNamespace(), new DocumentCodec())
-                .execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                .execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
         while (cursor.hasNext()) {
             indexes.addAll(cursor.next())
         }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindOperationSpecification.groovy
@@ -54,7 +54,6 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.executeSync
 import static com.mongodb.ClusterFixture.getAsyncCluster
@@ -482,7 +481,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add read concern to command'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
         def binding = Stub(ReadBinding)
         def source = Stub(ConnectionSource)
         def connection = Mock(Connection)
@@ -522,7 +521,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add read concern to command asynchronously'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
         def binding = Stub(AsyncReadBinding)
         def source = Stub(AsyncConnectionSource)
         def connection = Mock(AsyncConnection)
@@ -562,7 +561,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add allowDiskUse to command if the server version >= 3.2'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
         def binding = Stub(ReadBinding)
         def source = Stub(ConnectionSource)
         def connection = Mock(Connection)
@@ -602,7 +601,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add allowDiskUse to command if the server version >= 3.2 asynchronously'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
         def binding = Stub(AsyncReadBinding)
         def source = Stub(AsyncConnectionSource)
         def connection = Mock(AsyncConnection)
@@ -646,7 +645,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         def (cursorType, long maxAwaitTimeMS, long maxTimeMSForCursor) = cursorDetails
         def timeoutSettings = ClusterFixture.TIMEOUT_SETTINGS_WITH_INFINITE_TIMEOUT.withMaxAwaitTimeMS(maxAwaitTimeMS)
         def timeoutContext = new TimeoutContext(timeoutSettings)
-        def operationContext = OPERATION_CONTEXT.withTimeoutContext(timeoutContext)
+        def operationContext = getOperationContext().withTimeoutContext(timeoutContext)
 
         collectionHelper.create(getCollectionName(), new CreateCollectionOptions().capped(true).sizeInBytes(1000))
         def operation = new FindOperation<BsonDocument>(namespace, new BsonDocumentCodec())

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindOperationSpecification.groovy
@@ -59,7 +59,7 @@ import static com.mongodb.ClusterFixture.executeSync
 import static com.mongodb.ClusterFixture.getAsyncCluster
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.getCluster
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionLessThan
 import static com.mongodb.CursorType.NonTailable
@@ -481,7 +481,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add read concern to command'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
         def binding = Stub(ReadBinding)
         def source = Stub(ConnectionSource)
         def connection = Mock(Connection)
@@ -521,7 +521,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add read concern to command asynchronously'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
         def binding = Stub(AsyncReadBinding)
         def source = Stub(AsyncConnectionSource)
         def connection = Mock(AsyncConnection)
@@ -561,7 +561,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add allowDiskUse to command if the server version >= 3.2'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
         def binding = Stub(ReadBinding)
         def source = Stub(ConnectionSource)
         def connection = Mock(Connection)
@@ -601,7 +601,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should add allowDiskUse to command if the server version >= 3.2 asynchronously'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
         def binding = Stub(AsyncReadBinding)
         def source = Stub(AsyncConnectionSource)
         def connection = Mock(AsyncConnection)
@@ -645,7 +645,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         def (cursorType, long maxAwaitTimeMS, long maxTimeMSForCursor) = cursorDetails
         def timeoutSettings = ClusterFixture.TIMEOUT_SETTINGS_WITH_INFINITE_TIMEOUT.withMaxAwaitTimeMS(maxAwaitTimeMS)
         def timeoutContext = new TimeoutContext(timeoutSettings)
-        def operationContext = getOperationContext().withTimeoutContext(timeoutContext)
+        def operationContext = createOperationContext().withTimeoutContext(timeoutContext)
 
         collectionHelper.create(getCollectionName(), new CreateCollectionOptions().capped(true).sizeInBytes(1000))
         def operation = new FindOperation<BsonDocument>(namespace, new BsonDocumentCodec())

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/FindOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/FindOperationSpecification.groovy
@@ -389,7 +389,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
 
         def binding = getBinding()
         new CommandReadOperation<>(getDatabaseName(), new BsonDocument('profile', new BsonInt32(2)),
-                new BsonDocumentCodec()).execute(binding, getOperationContext(binding.getReadPreference()))
+                new BsonDocumentCodec()).execute(binding, createOperationContext(binding.getReadPreference()))
         def expectedComment = 'this is a comment'
         def operation = new FindOperation<Document>(getNamespace(), new DocumentCodec())
                 .comment(new BsonString(expectedComment))
@@ -404,7 +404,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         cleanup:
         new CommandReadOperation<>(getDatabaseName(), new BsonDocument('profile', new BsonInt32(0)),
                 new BsonDocumentCodec())
-                .execute(binding, getOperationContext(binding.getReadPreference()))
+                .execute(binding, createOperationContext(binding.getReadPreference()))
         profileCollectionHelper.drop()
 
         where:

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ListCollectionsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ListCollectionsOperationSpecification.groovy
@@ -46,7 +46,6 @@ import org.bson.codecs.DocumentCodec
 
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
-import static com.mongodb.ClusterFixture.getOperationContext
 import static org.junit.jupiter.api.Assertions.assertEquals
 
 class ListCollectionsOperationSpecification extends OperationFunctionalSpecification {
@@ -398,7 +397,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should use the readPreference to set secondaryOk'() {
         given:
-        def operationContext = ClusterFixture.getOperationContext()
+        def operationContext = ClusterFixture.createOperationContext()
         def connection = Mock(Connection)
         def connectionSource = Stub(ConnectionSource) {
             getConnection(_) >> connection
@@ -427,7 +426,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
     def 'should use the readPreference to set secondaryOk in async'() {
         given:
-        def operationContext = ClusterFixture.getOperationContext()
+        def operationContext = ClusterFixture.createOperationContext()
         def connection = Mock(AsyncConnection)
         def connectionSource = Stub(AsyncConnectionSource) {
             getConnection(_, _) >> { it[1].onResult(connection, null) }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ListCollectionsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ListCollectionsOperationSpecification.groovy
@@ -44,6 +44,7 @@ import org.bson.Document
 import org.bson.codecs.Decoder
 import org.bson.codecs.DocumentCodec
 
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static org.junit.jupiter.api.Assertions.assertEquals
@@ -59,7 +60,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
         def binding = getBinding()
         when:
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
 
         then:
         !cursor.hasNext()
@@ -97,7 +98,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
         def binding = getBinding()
         when:
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
         def collections = cursor.next()
         def names = collections*.get('name')
 
@@ -120,7 +121,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
         def binding = getBinding()
         when:
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference())
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference())
         )
         def collections = cursor.next()
         def names = collections*.get('name')
@@ -142,7 +143,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
         def binding = getBinding()
         when:
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
         def collections = cursor.next()
         def names = collections*.get('name')
 
@@ -160,7 +161,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
         def binding = getBinding()
         when:
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
         def collection = cursor.next()[0]
 
         then:
@@ -177,7 +178,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
         def binding = getBinding()
         when:
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
         def collection = cursor.next()[0]
 
         then:
@@ -194,7 +195,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
         def binding = getBinding()
         when:
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
         def collection = cursor.next()[0]
 
         then:
@@ -226,14 +227,14 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         def binding = getBinding()
         given:
         new DropDatabaseOperation(databaseName, WriteConcern.ACKNOWLEDGED)
-                .execute(binding, getOperationContext(binding.getReadPreference()))
+                .execute(binding, createOperationContext(binding.getReadPreference()))
         addSeveralIndexes()
         def operation = new ListCollectionsOperation(databaseName, new DocumentCodec()).batchSize(2)
 
 
         when:
         binding = getBinding()
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
 
         then:
         cursor.hasNext()
@@ -246,13 +247,13 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         def binding = getBinding()
         given:
         new DropDatabaseOperation(databaseName, WriteConcern.ACKNOWLEDGED)
-                .execute(binding, getOperationContext(binding.getReadPreference()))
+                .execute(binding, createOperationContext(binding.getReadPreference()))
         addSeveralIndexes()
         def operation = new ListCollectionsOperation(databaseName, new DocumentCodec()).batchSize(2)
 
         when:
         binding = getBinding()
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
         def list = cursorToListWithNext(cursor)
 
         then:
@@ -271,14 +272,14 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         def binding = getBinding()
         given:
         new DropDatabaseOperation(databaseName, WriteConcern.ACKNOWLEDGED)
-                .execute(binding, getOperationContext(binding.getReadPreference()))
+                .execute(binding, createOperationContext(binding.getReadPreference()))
         addSeveralIndexes()
         def operation = new ListCollectionsOperation(databaseName, new DocumentCodec()).batchSize(2)
 
 
         when:
         binding = getBinding()
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
 
         then:
         cursor.hasNext()
@@ -297,13 +298,13 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         given:
         def binding = getBinding()
         new DropDatabaseOperation(databaseName, WriteConcern.ACKNOWLEDGED)
-                .execute(binding, getOperationContext(binding.getReadPreference()))
+                .execute(binding, createOperationContext(binding.getReadPreference()))
         addSeveralIndexes()
         def operation = new ListCollectionsOperation(databaseName, new DocumentCodec()).batchSize(2)
 
         when:
         binding = getBinding()
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
         def list = cursorToListWithTryNext(cursor)
 
         then:
@@ -317,7 +318,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         given:
         def binding = getBinding()
         new DropDatabaseOperation(databaseName, WriteConcern.ACKNOWLEDGED)
-                .execute(binding, getOperationContext(binding.getReadPreference()))
+                .execute(binding, createOperationContext(binding.getReadPreference()))
         addSeveralIndexes()
         def operation = new ListCollectionsOperation(databaseName, new DocumentCodec()).batchSize(2)
 
@@ -343,7 +344,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
         when:
         def binding = getBinding()
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
         def collections = cursor.next()
 
         then:

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ListDatabasesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ListDatabasesOperationSpecification.groovy
@@ -33,7 +33,7 @@ import org.bson.Document
 import org.bson.codecs.Decoder
 import org.bson.codecs.DocumentCodec
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 
 class ListDatabasesOperationSpecification extends OperationFunctionalSpecification {
     def codec = new DocumentCodec()
@@ -82,7 +82,7 @@ class ListDatabasesOperationSpecification extends OperationFunctionalSpecificati
         def operation = new ListDatabasesOperation(helper.decoder)
 
         when:
-        operation.execute(readBinding, OPERATION_CONTEXT)
+        operation.execute(readBinding, getOperationContext())
 
         then:
         _ * connection.getDescription() >> helper.connectionDescription
@@ -107,7 +107,7 @@ class ListDatabasesOperationSpecification extends OperationFunctionalSpecificati
         def operation = new ListDatabasesOperation(helper.decoder)
 
         when:
-        operation.executeAsync(readBinding, OPERATION_CONTEXT, Stub(SingleResultCallback))
+        operation.executeAsync(readBinding, getOperationContext(), Stub(SingleResultCallback))
 
         then:
         _ * connection.getDescription() >> helper.connectionDescription

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ListDatabasesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ListDatabasesOperationSpecification.groovy
@@ -33,7 +33,7 @@ import org.bson.Document
 import org.bson.codecs.Decoder
 import org.bson.codecs.DocumentCodec
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 
 class ListDatabasesOperationSpecification extends OperationFunctionalSpecification {
     def codec = new DocumentCodec()
@@ -82,7 +82,7 @@ class ListDatabasesOperationSpecification extends OperationFunctionalSpecificati
         def operation = new ListDatabasesOperation(helper.decoder)
 
         when:
-        operation.execute(readBinding, getOperationContext())
+        operation.execute(readBinding, createOperationContext())
 
         then:
         _ * connection.getDescription() >> helper.connectionDescription
@@ -107,7 +107,7 @@ class ListDatabasesOperationSpecification extends OperationFunctionalSpecificati
         def operation = new ListDatabasesOperation(helper.decoder)
 
         when:
-        operation.executeAsync(readBinding, getOperationContext(), Stub(SingleResultCallback))
+        operation.executeAsync(readBinding, createOperationContext(), Stub(SingleResultCallback))
 
         then:
         _ * connection.getDescription() >> helper.connectionDescription

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ListIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ListIndexesOperationSpecification.groovy
@@ -16,7 +16,7 @@
 
 package com.mongodb.internal.operation
 
-
+import com.mongodb.ClusterFixture
 import com.mongodb.MongoNamespace
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.ReadPreference
@@ -44,7 +44,6 @@ import org.bson.codecs.Decoder
 import org.bson.codecs.DocumentCodec
 import org.junit.jupiter.api.Assertions
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.getOperationContext
@@ -226,6 +225,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
     def 'should use the readPreference to set secondaryOk'() {
         given:
         def connection = Mock(Connection)
+        def operationContext = ClusterFixture.getOperationContext()
         def connectionSource = Stub(ConnectionSource) {
             getConnection(_) >> connection
             getReadPreference() >> readPreference
@@ -237,12 +237,12 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
         def operation = new ListIndexesOperation(helper.namespace, helper.decoder)
 
         when: '3.6.0'
-        operation.execute(readBinding, OPERATION_CONTEXT)
+        operation.execute(readBinding, operationContext)
 
         then:
         _ * connection.getDescription() >> helper.threeSixConnectionDescription
         1 * connection.command(_, _, _, readPreference, _, _) >> {
-            Assertions.assertEquals(((OperationContext) it[5]).getId(), OPERATION_CONTEXT.getId())
+            Assertions.assertEquals(((OperationContext) it[5]).getId(), operationContext.getId())
             helper.commandResult
         }
         1 * connection.release()
@@ -265,7 +265,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
         def operation = new ListIndexesOperation(helper.namespace, helper.decoder)
 
         when: '3.6.0'
-        operation.executeAsync(readBinding, OPERATION_CONTEXT, Stub(SingleResultCallback))
+        operation.executeAsync(readBinding, getOperationContext(), Stub(SingleResultCallback))
 
         then:
         _ * connection.getDescription() >> helper.threeSixConnectionDescription

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ListIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ListIndexesOperationSpecification.groovy
@@ -57,7 +57,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
         def binding = getBinding()
         when:
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
 
         then:
         !cursor.hasNext()
@@ -86,7 +86,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
         def binding = getBinding()
         when:
-        BatchCursor<Document> indexes = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        BatchCursor<Document> indexes = operation.execute(binding, createOperationContext(binding.getReadPreference()))
 
         then:
         def firstBatch = indexes.next()
@@ -121,11 +121,11 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
         def binding = getBinding()
         new CreateIndexesOperation(namespace,
                 [new IndexRequest(new BsonDocument('unique', new BsonInt32(1))).unique(true)], null).execute(binding,
-                getOperationContext(binding.getReadPreference()))
+                createOperationContext(binding.getReadPreference()))
 
         when:
         binding = getBinding()
-        BatchCursor cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        BatchCursor cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
 
         then:
         def indexes = cursor.next()
@@ -145,7 +145,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
         def binding = getBinding()
         new CreateIndexesOperation(namespace,
                 [new IndexRequest(new BsonDocument('unique', new BsonInt32(1))).unique(true)], null).execute(binding,
-                getOperationContext(binding.getReadPreference()))
+                createOperationContext(binding.getReadPreference()))
 
         when:
         def cursor = executeAsync(operation)
@@ -171,7 +171,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
         def binding = getBinding()
         when:
-        def cursor = operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        def cursor = operation.execute(binding, createOperationContext(binding.getReadPreference()))
         def collections = cursor.next()
 
         then:

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/ListIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/ListIndexesOperationSpecification.groovy
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Assertions
 
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 
 class ListIndexesOperationSpecification extends OperationFunctionalSpecification {
 
@@ -225,7 +225,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
     def 'should use the readPreference to set secondaryOk'() {
         given:
         def connection = Mock(Connection)
-        def operationContext = ClusterFixture.getOperationContext()
+        def operationContext = ClusterFixture.createOperationContext()
         def connectionSource = Stub(ConnectionSource) {
             getConnection(_) >> connection
             getReadPreference() >> readPreference
@@ -265,7 +265,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
         def operation = new ListIndexesOperation(helper.namespace, helper.decoder)
 
         when: '3.6.0'
-        operation.executeAsync(readBinding, getOperationContext(), Stub(SingleResultCallback))
+        operation.executeAsync(readBinding, createOperationContext(), Stub(SingleResultCallback))
 
         then:
         _ * connection.getDescription() >> helper.threeSixConnectionDescription

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceToCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceToCollectionOperationSpecification.groovy
@@ -64,7 +64,7 @@ class MapReduceToCollectionOperationSpecification extends OperationFunctionalSpe
 
     def cleanup() {
         def binding = getBinding()
-        def operationContext = ClusterFixture.getOperationContext(binding.getReadPreference())
+        def operationContext = ClusterFixture.createOperationContext(binding.getReadPreference())
         new DropCollectionOperation(mapReduceInputNamespace, WriteConcern.ACKNOWLEDGED)
                 .execute(binding, operationContext)
         new DropCollectionOperation(mapReduceOutputNamespace, WriteConcern.ACKNOWLEDGED)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceWithInlineResultsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceWithInlineResultsOperationSpecification.groovy
@@ -46,7 +46,7 @@ import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.connection.ServerType.STANDALONE
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand
@@ -217,7 +217,7 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
 
     def 'should add read concern to command'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
         def binding = Stub(ReadBinding)
         def source = Stub(ConnectionSource)
         def connection = Mock(Connection)
@@ -264,7 +264,7 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
 
     def 'should add read concern to command asynchronously'() {
         given:
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
         def binding = Stub(AsyncReadBinding)
         def source = Stub(AsyncConnectionSource)
         def connection = Mock(AsyncConnection)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceWithInlineResultsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MapReduceWithInlineResultsOperationSpecification.groovy
@@ -46,7 +46,7 @@ import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.connection.ServerType.STANDALONE
 import static com.mongodb.internal.operation.OperationReadConcernHelper.appendReadConcernToCommand
@@ -217,7 +217,7 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
 
     def 'should add read concern to command'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
         def binding = Stub(ReadBinding)
         def source = Stub(ConnectionSource)
         def connection = Mock(Connection)
@@ -264,7 +264,7 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
 
     def 'should add read concern to command asynchronously'() {
         given:
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
         def binding = Stub(AsyncReadBinding)
         def source = Stub(AsyncConnectionSource)
         def connection = Mock(AsyncConnection)

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/RenameCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/RenameCollectionOperationSpecification.groovy
@@ -28,7 +28,6 @@ import spock.lang.IgnoreIf
 
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
-import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
 

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/RenameCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/RenameCollectionOperationSpecification.groovy
@@ -26,6 +26,7 @@ import org.bson.Document
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
@@ -37,7 +38,7 @@ class RenameCollectionOperationSpecification extends OperationFunctionalSpecific
     def cleanup() {
         def binding = getBinding()
         new DropCollectionOperation(new MongoNamespace(getDatabaseName(), 'newCollection'),
-                WriteConcern.ACKNOWLEDGED).execute(binding, getOperationContext(binding.getReadPreference()))
+                WriteConcern.ACKNOWLEDGED).execute(binding, createOperationContext(binding.getReadPreference()))
     }
 
     def 'should return rename a collection'() {
@@ -86,7 +87,7 @@ class RenameCollectionOperationSpecification extends OperationFunctionalSpecific
 
         def binding = getBinding()
         when:
-        async ? executeAsync(operation) : operation.execute(binding, getOperationContext(binding.getReadPreference()))
+        async ? executeAsync(operation) : operation.execute(binding, createOperationContext(binding.getReadPreference()))
 
         then:
         def ex = thrown(MongoWriteConcernException)
@@ -100,7 +101,7 @@ class RenameCollectionOperationSpecification extends OperationFunctionalSpecific
     def collectionNameExists(String collectionName) {
         def binding = getBinding()
         def cursor = new ListCollectionsOperation(databaseName, new DocumentCodec()).execute(binding,
-                getOperationContext(binding.getReadPreference()))
+                createOperationContext(binding.getReadPreference()))
         if (!cursor.hasNext()) {
             return false
         }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/TestOperationHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/TestOperationHelper.java
@@ -31,7 +31,7 @@ import org.bson.BsonInt64;
 import org.bson.BsonString;
 import org.bson.codecs.BsonDocumentCodec;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 
 final class TestOperationHelper {
 
@@ -56,7 +56,7 @@ final class TestOperationHelper {
                 connection.command(namespace.getDatabaseName(),
                         new BsonDocument("getMore", new BsonInt64(serverCursor.getId()))
                                 .append("collection", new BsonString(namespace.getCollectionName())),
-                        NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), OPERATION_CONTEXT));
+                        NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), getOperationContext()));
     }
 
     static void makeAdditionalGetMoreCall(final MongoNamespace namespace, final ServerCursor serverCursor,
@@ -66,7 +66,7 @@ final class TestOperationHelper {
             connection.commandAsync(namespace.getDatabaseName(),
                     new BsonDocument("getMore", new BsonInt64(serverCursor.getId()))
                             .append("collection", new BsonString(namespace.getCollectionName())),
-                    NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), OPERATION_CONTEXT, callback);
+                    NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), getOperationContext(), callback);
             callback.get();
         });
     }

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/TestOperationHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/TestOperationHelper.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.operation;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoCursorNotFoundException;
 import com.mongodb.MongoNamespace;
@@ -30,8 +31,6 @@ import org.bson.BsonDocument;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
 import org.bson.codecs.BsonDocumentCodec;
-
-import static com.mongodb.ClusterFixture.getOperationContext;
 
 final class TestOperationHelper {
 
@@ -56,7 +55,7 @@ final class TestOperationHelper {
                 connection.command(namespace.getDatabaseName(),
                         new BsonDocument("getMore", new BsonInt64(serverCursor.getId()))
                                 .append("collection", new BsonString(namespace.getCollectionName())),
-                        NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), getOperationContext()));
+                        NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), ClusterFixture.createOperationContext()));
     }
 
     static void makeAdditionalGetMoreCall(final MongoNamespace namespace, final ServerCursor serverCursor,
@@ -66,7 +65,7 @@ final class TestOperationHelper {
             connection.commandAsync(namespace.getDatabaseName(),
                     new BsonDocument("getMore", new BsonInt64(serverCursor.getId()))
                             .append("collection", new BsonString(namespace.getCollectionName())),
-                    NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), getOperationContext(), callback);
+                    NoOpFieldNameValidator.INSTANCE, ReadPreference.primary(), new BsonDocumentCodec(), ClusterFixture.createOperationContext(), callback);
             callback.get();
         });
     }

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -104,12 +104,10 @@ public class ServerSelectionSelectionTest {
         // skip this test because the driver prohibits maxStaleness or tagSets with mode of primary at a much lower level
         assumeTrue(!description.endsWith("/max-staleness/tests/ReplicaSetWithPrimary/MaxStalenessWithModePrimary.json"));
         ServerTuple serverTuple;
-        BaseCluster cluster = null;
-        try {
-            ServerSelector serverSelector = getServerSelector();
-            OperationContext operationContext = createOperationContext();
-            Cluster.ServersSnapshot serversSnapshot = createServersSnapshot(clusterDescription);
-            cluster = createTestCluster(clusterDescription, serversSnapshot);
+        ServerSelector serverSelector = getServerSelector();
+        OperationContext operationContext = createOperationContext();
+        Cluster.ServersSnapshot serversSnapshot = createServersSnapshot(clusterDescription);
+        try (BaseCluster cluster = createTestCluster(clusterDescription, serversSnapshot);) {
             serverTuple = cluster.selectServer(serverSelector, operationContext);
             if (error) {
                 fail("Should have thrown exception");
@@ -125,10 +123,6 @@ public class ServerSelectionSelectionTest {
                     JsonWriterSettings.builder()
                             .indent(true).build()), inLatencyWindowServers.isEmpty());
             return;
-        } finally {
-            if (cluster != null) {
-                cluster.close();
-            }
         }
         List<ServerDescription> inLatencyWindowServers = buildServerDescriptions(definition.getArray("in_latency_window"));
         assertNotNull(serverTuple);
@@ -338,7 +332,7 @@ public class ServerSelectionSelectionTest {
     private static class TestCluster extends BaseCluster {
         private final ServersSnapshot serversSnapshot;
 
-        public TestCluster(final ClusterDescription clusterDescription, final ServersSnapshot serversSnapshot) {
+        TestCluster(final ClusterDescription clusterDescription, final ServersSnapshot serversSnapshot) {
             super(new ClusterId(), clusterDescription.getClusterSettings(), new TestClusterableServerFactory(),
                     ClusterFixture.CLIENT_METADATA);
             this.serversSnapshot = serversSnapshot;

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -341,8 +341,7 @@ public class ServerSelectionSelectionTest {
 
         @Override
         protected void connect() {
-            // We do not expect this to be called during server selection.
-            Assertions.fail();
+            // NOOP: this method may be invoked in test cases where no server is expected to be selected.
         }
 
         @Override

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -24,6 +24,7 @@ import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.mongodb.Tag;
 import com.mongodb.TagSet;
+import com.mongodb.assertions.Assertions;
 import com.mongodb.event.ServerDescriptionChangedEvent;
 import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.connection.BaseCluster;
@@ -346,8 +347,7 @@ public class ServerSelectionSelectionTest {
 
         @Override
         public void onChange(final ServerDescriptionChangedEvent event) {
-            // We do not expect this to be called during server selection.
-            fail();
+            Assertions.fail();
         }
     }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -106,6 +106,8 @@ public class ServerSelectionSelectionTest {
         ServerSelector serverSelector = getServerSelector();
         OperationContext operationContext = createOperationContext();
         Cluster.ServersSnapshot serversSnapshot = createServersSnapshot(clusterDescription);
+        List<ServerDescription> inLatencyWindowServers = buildServerDescriptions(definition.getArray("in_latency_window", new BsonArray()));
+
         try (BaseCluster cluster = createTestCluster(clusterDescription, serversSnapshot);) {
             serverTuple = cluster.selectServer(serverSelector, operationContext);
             if (error) {
@@ -117,13 +119,11 @@ public class ServerSelectionSelectionTest {
             }
             return;
         } catch (MongoTimeoutException mongoTimeoutException) {
-            List<ServerDescription> inLatencyWindowServers = buildServerDescriptions(definition.getArray("in_latency_window"));
             assertTrue("Expected emtpy but was " + inLatencyWindowServers.size() + " " + definition.toJson(
                     JsonWriterSettings.builder()
                             .indent(true).build()), inLatencyWindowServers.isEmpty());
             return;
         }
-        List<ServerDescription> inLatencyWindowServers = buildServerDescriptions(definition.getArray("in_latency_window"));
         assertNotNull(serverTuple);
         assertTrue(inLatencyWindowServers.stream().anyMatch(s -> s.equals(serverTuple.getServerDescription())));
     }

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -18,6 +18,7 @@ package com.mongodb.connection;
 
 import com.mongodb.ClusterFixture;
 import com.mongodb.MongoConfigurationException;
+import com.mongodb.MongoException;
 import com.mongodb.MongoTimeoutException;
 import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
@@ -298,7 +299,7 @@ public class ServerSelectionSelectionTest {
         OperationContext.ServerDeprioritization serverDeprioritization = operationContext.getServerDeprioritization();
         for (ServerAddress address : extractDeprioritizedServerAddresses(definition)) {
             serverDeprioritization.updateCandidate(address);
-            serverDeprioritization.onAttemptFailure(new MongoConfigurationException("test"));
+            serverDeprioritization.onAttemptFailure(new MongoException("test"));
         }
         return operationContext;
     }

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -82,7 +82,6 @@ public class ServerSelectionSelectionTest {
     private final ClusterDescription clusterDescription;
     private final boolean error;
 
-    private static final long SERVER_SELECTION_TIMEOUT_MS = 200;
     private static final Set<String> TOPOLOGY_DESCRIPTION_FIELDS = new HashSet<>(Arrays.asList("type", "servers"));
     private static final Set<String> SERVER_DESCRIPTION_FIELDS = new HashSet<>(Arrays.asList(
             "address", "type", "tags", "avg_rtt_ms", "lastWrite", "lastUpdateTime", "maxWireVersion"));
@@ -295,7 +294,7 @@ public class ServerSelectionSelectionTest {
     private OperationContext createOperationContext() {
         OperationContext operationContext =
                 OperationContext.simpleOperationContext(
-                        new TimeoutContext(TIMEOUT_SETTINGS.withServerSelectionTimeoutMS(SERVER_SELECTION_TIMEOUT_MS)));
+                        new TimeoutContext(TIMEOUT_SETTINGS.withServerSelectionTimeoutMS(0)));
         OperationContext.ServerDeprioritization serverDeprioritization = operationContext.getServerDeprioritization();
         for (ServerAddress address : extractDeprioritizedServerAddresses(definition)) {
             serverDeprioritization.updateCandidate(address);

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -80,7 +80,6 @@ public class ServerSelectionSelectionTest {
     private final BsonDocument definition;
     private final ClusterDescription clusterDescription;
     private final boolean error;
-    private final List<ServerAddress> deprioritizedServerAddresses;
 
     private static final long SERVER_SELECTION_TIMEOUT_MS = 200;
     private static final Set<String> TOPOLOGY_DESCRIPTION_FIELDS = new HashSet<>(Arrays.asList("type", "servers"));
@@ -97,7 +96,6 @@ public class ServerSelectionSelectionTest {
         this.error = definition.getBoolean("error", BsonBoolean.FALSE).getValue();
         this.clusterDescription = buildClusterDescription(definition.getDocument("topology_description"),
                 ServerSettings.builder().heartbeatFrequency(heartbeatFrequencyMS, TimeUnit.MILLISECONDS).build());
-        this.deprioritizedServerAddresses = extractDeprioritizedServerAddresses(definition);
     }
 
     @Test
@@ -299,7 +297,7 @@ public class ServerSelectionSelectionTest {
                 OperationContext.simpleOperationContext(
                         new TimeoutContext(TIMEOUT_SETTINGS.withServerSelectionTimeoutMS(SERVER_SELECTION_TIMEOUT_MS)));
         OperationContext.ServerDeprioritization serverDeprioritization = operationContext.getServerDeprioritization();
-        for (ServerAddress address : deprioritizedServerAddresses) {
+        for (ServerAddress address : extractDeprioritizedServerAddresses(definition)) {
             serverDeprioritization.updateCandidate(address);
             serverDeprioritization.onAttemptFailure(new MongoConfigurationException("test"));
         }

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -126,7 +126,7 @@ public class ServerSelectionSelectionTest {
         }
         List<ServerDescription> inLatencyWindowServers = buildServerDescriptions(definition.getArray("in_latency_window"));
         assertNotNull(serverTuple);
-        assertTrue(inLatencyWindowServers.stream().anyMatch(s -> s.getAddress().equals(serverTuple.getServerDescription().getAddress())));
+        assertTrue(inLatencyWindowServers.stream().anyMatch(s -> s.equals(serverTuple.getServerDescription())));
     }
 
     @Parameterized.Parameters(name = "{0}")

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -65,6 +65,7 @@ import java.util.stream.Collectors;
 
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
+import static java.lang.String.format;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
@@ -111,21 +112,21 @@ public class ServerSelectionSelectionTest {
         try (BaseCluster cluster = createTestCluster(clusterDescription, serversSnapshot)) {
             serverTuple = cluster.selectServer(serverSelector, operationContext);
             if (error) {
-                fail("Should have thrown exception");
+                fail(format("Should have thrown exception"));
             }
         } catch (MongoConfigurationException e) {
             if (!error) {
-                fail("Should not have thrown exception: " + e);
+                fail(format("Should not have thrown exception: %s", e));
             }
             return;
         } catch (MongoTimeoutException mongoTimeoutException) {
-            assertTrue("Expected emtpy but was " + inLatencyWindowServers.size() + " " + definition.toJson(
-                    JsonWriterSettings.builder()
-                            .indent(true).build()), inLatencyWindowServers.isEmpty());
+            assertTrue(format("Expected empty but was %s", inLatencyWindowServers.size()),
+                    inLatencyWindowServers.isEmpty());
             return;
         }
-        assertNotNull(serverTuple);
-        assertTrue(inLatencyWindowServers.stream().anyMatch(s -> s.equals(serverTuple.getServerDescription())));
+        assertNotNull(format("Server tuple should not be null"), serverTuple);
+        assertTrue(format("Selected server should be in latency window"),
+                inLatencyWindowServers.stream().anyMatch(s -> s.equals(serverTuple.getServerDescription())));
     }
 
     @Parameterized.Parameters(name = "{0}")
@@ -353,5 +354,10 @@ public class ServerSelectionSelectionTest {
             // We do not expect this to be called during server selection.
             fail();
         }
+    }
+
+    private String format(final String messageFormat, final Object... args) {
+        String message = String.format(messageFormat, args);
+        return message + "\nTest Definition:\n" + definition.toJson(JsonWriterSettings.builder().indent(true).build());
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -302,7 +302,7 @@ public class ServerSelectionSelectionTest {
             // The spec defines deprioritized_servers as a pre-populated list to feed into the selection mechanism - not as "simulate the
             // failure that caused deprioritization." Thus, SystemOverloadedError used unconditionally regardless of the cluster type.
             MongoException error = new MongoException("test");
-            error.addLabel("SystemOverloadedError");
+            error.addLabel(MongoException.SYSTEM_OVERLOADED_ERROR_LABEL);
             serverDeprioritization.onAttemptFailure(error);
         }
         return operationContext;

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -109,7 +109,7 @@ public class ServerSelectionSelectionTest {
         Cluster.ServersSnapshot serversSnapshot = createServersSnapshot(clusterDescription);
         List<ServerDescription> inLatencyWindowServers = buildServerDescriptions(definition.getArray("in_latency_window", new BsonArray()));
 
-        try (BaseCluster cluster = createTestCluster(clusterDescription, serversSnapshot)) {
+        try (BaseCluster cluster = new TestCluster(clusterDescription, serversSnapshot)) {
             serverTuple = cluster.selectServer(serverSelector, operationContext);
             if (error) {
                 fail(format("Should have thrown exception"));
@@ -316,11 +316,7 @@ public class ServerSelectionSelectionTest {
         return serverMap::get;
     }
 
-    private BaseCluster createTestCluster(final ClusterDescription clusterDescription, final Cluster.ServersSnapshot serversSnapshot) {
-        return new TestCluster(clusterDescription, serversSnapshot);
-    }
-
-    private static void validateTestDescriptionFields(final Set<String> actualFields, final Set<String> knownFields) {
+        private static void validateTestDescriptionFields(final Set<String> actualFields, final Set<String> knownFields) {
         Set<String> unknownFields = new HashSet<>(actualFields);
         unknownFields.removeAll(knownFields);
         if (!unknownFields.isEmpty()) {

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -126,7 +126,7 @@ public class ServerSelectionSelectionTest {
             return;
         }
         assertNotNull(format("Server tuple should not be null"), serverTuple);
-        assertTrue(format("Selected server should be in latency window"),
+        assertTrue(format("Selected server should be in latency window. Selected server: %s", serverTuple.getServerDescription()),
                 inLatencyWindowServers.stream().anyMatch(s -> s.equals(serverTuple.getServerDescription())));
     }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -68,7 +68,7 @@ import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
@@ -102,7 +102,7 @@ public class ServerSelectionSelectionTest {
     @Test
     public void shouldPassAllOutcomes() {
         // skip this test because the driver prohibits maxStaleness or tagSets with mode of primary at a much lower level
-        assumeTrue(!description.endsWith("/max-staleness/tests/ReplicaSetWithPrimary/MaxStalenessWithModePrimary.json"));
+        assumeFalse(description.endsWith("/max-staleness/tests/ReplicaSetWithPrimary/MaxStalenessWithModePrimary.json"));
         ServerTuple serverTuple;
         ServerSelector serverSelector = getServerSelector();
         OperationContext operationContext = createOperationContext();

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -108,7 +108,7 @@ public class ServerSelectionSelectionTest {
         Cluster.ServersSnapshot serversSnapshot = createServersSnapshot(clusterDescription);
         List<ServerDescription> inLatencyWindowServers = buildServerDescriptions(definition.getArray("in_latency_window", new BsonArray()));
 
-        try (BaseCluster cluster = createTestCluster(clusterDescription, serversSnapshot);) {
+        try (BaseCluster cluster = createTestCluster(clusterDescription, serversSnapshot)) {
             serverTuple = cluster.selectServer(serverSelector, operationContext);
             if (error) {
                 fail("Should have thrown exception");

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -71,7 +71,9 @@ import static org.junit.Assume.assumeFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
-// See https://github.com/mongodb/specifications/tree/master/source/server-selection/tests
+/**
+ * See <a href="https://github.com/mongodb/specifications/tree/master/source/server-selection/tests/server_selection">Server Selection Tests</a>.
+ */
 @RunWith(Parameterized.class)
 public class ServerSelectionSelectionTest {
     private final String description;

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -46,7 +46,6 @@ import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.json.JsonWriterSettings;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import util.JsonPoweredTestHelper;
@@ -69,7 +68,7 @@ import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 // See https://github.com/mongodb/specifications/tree/master/source/server-selection/tests
@@ -352,7 +351,7 @@ public class ServerSelectionSelectionTest {
         @Override
         public void onChange(final ServerDescriptionChangedEvent event) {
             // We do not expect this to be called during server selection.
-            Assertions.fail();
+            fail();
         }
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -16,17 +16,27 @@
 
 package com.mongodb.connection;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.MongoConfigurationException;
+import com.mongodb.MongoTimeoutException;
 import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.mongodb.Tag;
 import com.mongodb.TagSet;
-import com.mongodb.internal.selector.LatencyMinimizingServerSelector;
+import com.mongodb.event.ServerDescriptionChangedEvent;
+import com.mongodb.internal.TimeoutContext;
+import com.mongodb.internal.connection.BaseCluster;
+import com.mongodb.internal.connection.Cluster;
+import com.mongodb.internal.connection.OperationContext;
+import com.mongodb.internal.connection.Server;
+import com.mongodb.internal.connection.ServerTuple;
+import com.mongodb.internal.connection.TestClusterableServerFactory;
+import com.mongodb.internal.mockito.MongoMockito;
 import com.mongodb.internal.selector.ReadPreferenceServerSelector;
 import com.mongodb.internal.selector.WritableServerSelector;
+import com.mongodb.internal.time.Timeout;
 import com.mongodb.lang.NonNull;
 import com.mongodb.lang.Nullable;
-import com.mongodb.selector.CompositeServerSelector;
 import com.mongodb.selector.ServerSelector;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
@@ -34,22 +44,32 @@ import org.bson.BsonDocument;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
 import org.bson.BsonValue;
+import org.bson.json.JsonWriterSettings;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import util.JsonPoweredTestHelper;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
+import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
+import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
 
 // See https://github.com/mongodb/specifications/tree/master/source/server-selection/tests
 @RunWith(Parameterized.class)
@@ -59,6 +79,14 @@ public class ServerSelectionSelectionTest {
     private final ClusterDescription clusterDescription;
     private final long heartbeatFrequencyMS;
     private final boolean error;
+    private final List<ServerAddress> deprioritizedServerAddresses;
+
+    private static final long SERVER_SELECTION_TIMEOUT_MS = 200;
+    private static final Set<String> TOPOLOGY_DESCRIPTION_FIELDS = new HashSet<>(Arrays.asList("type", "servers"));
+    private static final Set<String> SERVER_DESCRIPTION_FIELDS = new HashSet<>(Arrays.asList(
+            "address", "type", "tags", "avg_rtt_ms", "lastWrite", "lastUpdateTime", "maxWireVersion"));
+    private static final Set<String> READ_PREFERENCE_FIELDS = new HashSet<>(
+            Arrays.asList("mode", "tag_sets", "maxStalenessSeconds"));
 
     public ServerSelectionSelectionTest(final String description, final BsonDocument definition) {
         this.description = description;
@@ -67,20 +95,21 @@ public class ServerSelectionSelectionTest {
         this.error = definition.getBoolean("error", BsonBoolean.FALSE).getValue();
         this.clusterDescription = buildClusterDescription(definition.getDocument("topology_description"),
                 ServerSettings.builder().heartbeatFrequency(heartbeatFrequencyMS, TimeUnit.MILLISECONDS).build());
+        this.deprioritizedServerAddresses = extractDeprioritizedServerAddresses(definition);
     }
 
     @Test
     public void shouldPassAllOutcomes() {
         // skip this test because the driver prohibits maxStaleness or tagSets with mode of primary at a much lower level
-        assumeFalse(description.endsWith("/max-staleness/tests/ReplicaSetWithPrimary/MaxStalenessWithModePrimary.json"));
-        assumeFalse(description.contains("Deprioritized")); // TODO JAVA-6021 deprioritized server selection"
-
-        ServerSelector serverSelector = null;
-        List<ServerDescription> suitableServers = buildServerDescriptions(definition.getArray("suitable_servers", new BsonArray()));
-        List<ServerDescription> selectedServers = null;
+        assumeTrue(!description.endsWith("/max-staleness/tests/ReplicaSetWithPrimary/MaxStalenessWithModePrimary.json"));
+        ServerTuple serverTuple;
+        BaseCluster cluster = null;
         try {
-            serverSelector = getServerSelector();
-            selectedServers = serverSelector.select(clusterDescription);
+            ServerSelector serverSelector = getServerSelector();
+            OperationContext operationContext = createOperationContext();
+            Cluster.ServersSnapshot serversSnapshot = createServersSnapshot(clusterDescription);
+            cluster = createTestCluster(clusterDescription, serversSnapshot);
+            serverTuple = cluster.selectServer(serverSelector, operationContext);
             if (error) {
                 fail("Should have thrown exception");
             }
@@ -89,21 +118,29 @@ public class ServerSelectionSelectionTest {
                 fail("Should not have thrown exception: " + e);
             }
             return;
+        } catch (MongoTimeoutException mongoTimeoutException) {
+            List<ServerDescription> inLatencyWindowServers = buildServerDescriptions(definition.getArray("in_latency_window"));
+            assertTrue("Expected emtpy but was " + inLatencyWindowServers.size() + " " + definition.toJson(
+                    JsonWriterSettings.builder()
+                            .indent(true).build()), inLatencyWindowServers.isEmpty());
+            return;
+        } finally {
+            if (cluster != null) {
+                cluster.close();
+            }
         }
-        assertServers(selectedServers, suitableServers);
-
-        ServerSelector latencyBasedServerSelector = new CompositeServerSelector(asList(serverSelector,
-                new LatencyMinimizingServerSelector(15, TimeUnit.MILLISECONDS)));
         List<ServerDescription> inLatencyWindowServers = buildServerDescriptions(definition.getArray("in_latency_window"));
-        List<ServerDescription> latencyBasedSelectedServers = latencyBasedServerSelector.select(clusterDescription);
-        assertServers(latencyBasedSelectedServers, inLatencyWindowServers);
+        assertNotNull(serverTuple);
+        assertTrue(inLatencyWindowServers.stream().anyMatch(s -> s.getAddress().equals(serverTuple.getServerDescription().getAddress())));
     }
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         List<Object[]> data = new ArrayList<>();
+        //source/server-selection/tests/server_selection/ReplicaSetNoPrimary/read/DeprioritizedPrimary.json
         for (BsonDocument testDocument : JsonPoweredTestHelper.getSpecTestDocuments("server-selection/tests/server_selection")) {
-            data.add(new Object[]{testDocument.getString("resourcePath").getValue(), testDocument});
+            String resourcePath = testDocument.getString("resourcePath").getValue();
+            data.add(new Object[]{resourcePath, testDocument});
         }
         for (BsonDocument testDocument : JsonPoweredTestHelper.getSpecTestDocuments("max-staleness/tests")) {
             data.add(new Object[]{testDocument.getString("resourcePath").getValue(), testDocument});
@@ -112,11 +149,12 @@ public class ServerSelectionSelectionTest {
     }
 
     public static ClusterDescription buildClusterDescription(final BsonDocument topologyDescription,
-            @Nullable final ServerSettings serverSettings) {
+                                                             @Nullable final ServerSettings serverSettings) {
+        validateTestDescriptionFields(topologyDescription.keySet(), TOPOLOGY_DESCRIPTION_FIELDS);
         ClusterType clusterType = getClusterType(topologyDescription.getString("type").getValue());
         ClusterConnectionMode connectionMode = getClusterConnectionMode(clusterType);
         List<ServerDescription> servers = buildServerDescriptions(topologyDescription.getArray("servers"));
-        return new ClusterDescription(connectionMode, clusterType, servers, null,
+        return new ClusterDescription(connectionMode, clusterType, servers, ClusterSettings.builder().build(),
                 serverSettings == null ? ServerSettings.builder().build() : serverSettings);
     }
 
@@ -153,6 +191,7 @@ public class ServerSelectionSelectionTest {
     }
 
     private static ServerDescription buildServerDescription(final BsonDocument serverDescription) {
+        validateTestDescriptionFields(serverDescription.keySet(), SERVER_DESCRIPTION_FIELDS);
         ServerDescription.Builder builder = ServerDescription.builder();
         builder.address(new ServerAddress(serverDescription.getString("address").getValue()));
         ServerType serverType = getServerType(serverDescription.getString("type").getValue());
@@ -175,6 +214,8 @@ public class ServerSelectionSelectionTest {
         }
         if (serverDescription.containsKey("maxWireVersion")) {
             builder.maxWireVersion(serverDescription.getNumber("maxWireVersion").intValue());
+        } else {
+            builder.maxWireVersion(MIN_DRIVER_WIRE_VERSION);
         }
         return builder.build();
     }
@@ -229,6 +270,7 @@ public class ServerSelectionSelectionTest {
             return new WritableServerSelector();
         } else {
             BsonDocument readPreferenceDefinition = definition.getDocument("read_preference");
+            validateTestDescriptionFields(readPreferenceDefinition.keySet(), READ_PREFERENCE_FIELDS);
             ReadPreference readPreference;
             if (readPreferenceDefinition.getString("mode").getValue().equals("Primary")) {
                 readPreference = ReadPreference.valueOf("Primary");
@@ -244,8 +286,69 @@ public class ServerSelectionSelectionTest {
         }
     }
 
-    private void assertServers(final List<ServerDescription> actual, final List<ServerDescription> expected) {
-        assertEquals(expected.size(), actual.size());
-        assertTrue(actual.containsAll(expected));
+    private static List<ServerAddress> extractDeprioritizedServerAddresses(final BsonDocument definition) {
+        if (!definition.containsKey("deprioritized_servers")) {
+            return Collections.emptyList();
+        }
+        return definition.getArray("deprioritized_servers")
+                .stream()
+                .map(BsonValue::asDocument)
+                .map(ServerSelectionSelectionTest::buildServerDescription)
+                .map(ServerDescription::getAddress)
+                .collect(Collectors.toList());
+    }
+
+    private OperationContext createOperationContext() {
+        OperationContext operationContext =
+                OperationContext.simpleOperationContext(new TimeoutContext(TIMEOUT_SETTINGS.withServerSelectionTimeoutMS(SERVER_SELECTION_TIMEOUT_MS)));
+        OperationContext.ServerDeprioritization serverDeprioritization = operationContext.getServerDeprioritization();
+        for (ServerAddress address : deprioritizedServerAddresses) {
+            serverDeprioritization.updateCandidate(address);
+            serverDeprioritization.onAttemptFailure(new MongoConfigurationException("test"));
+        }
+        return operationContext;
+    }
+
+    private static Cluster.ServersSnapshot createServersSnapshot(
+            final ClusterDescription clusterDescription) {
+        Map<ServerAddress, Server> serverMap = new HashMap<>();
+        for (ServerDescription desc : clusterDescription.getServerDescriptions()) {
+            serverMap.put(desc.getAddress(), MongoMockito.mock(Server.class, server -> {
+                // Operation count selector should select any server since they all have 0 operation count.
+                when(server.operationCount()).thenReturn(0);
+            }));
+        }
+        return serverMap::get;
+    }
+
+    private BaseCluster createTestCluster(final ClusterDescription clusterDescription, final Cluster.ServersSnapshot serversSnapshot) {
+        BaseCluster baseCluster = new BaseCluster(
+                new ClusterId(),
+                clusterDescription.getClusterSettings(),
+                new TestClusterableServerFactory(),
+                ClusterFixture.CLIENT_METADATA) {
+            @Override
+            protected void connect() {
+            }
+
+            @Override
+            public ServersSnapshot getServersSnapshot(final Timeout serverSelectionTimeout, final TimeoutContext timeoutContext) {
+                return serversSnapshot;
+            }
+
+            @Override
+            public void onChange(final ServerDescriptionChangedEvent event) {
+            }
+        };
+        baseCluster.updateDescription(clusterDescription);
+        return baseCluster;
+    }
+
+    private static void validateTestDescriptionFields(final Set<String> actualFields, final Set<String> knownFields) {
+        Set<String> unknownFields = new HashSet<>(actualFields);
+        unknownFields.removeAll(knownFields);
+        if (!unknownFields.isEmpty()) {
+            throw new UnsupportedOperationException("Unknown fields: " + unknownFields);
+        }
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -132,7 +132,6 @@ public class ServerSelectionSelectionTest {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         List<Object[]> data = new ArrayList<>();
-        //source/server-selection/tests/server_selection/ReplicaSetNoPrimary/read/DeprioritizedPrimary.json
         for (BsonDocument testDocument : JsonPoweredTestHelper.getSpecTestDocuments("server-selection/tests/server_selection")) {
             String resourcePath = testDocument.getString("resourcePath").getValue();
             data.add(new Object[]{resourcePath, testDocument});

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -78,7 +78,6 @@ public class ServerSelectionSelectionTest {
     private final String description;
     private final BsonDocument definition;
     private final ClusterDescription clusterDescription;
-    private final long heartbeatFrequencyMS;
     private final boolean error;
     private final List<ServerAddress> deprioritizedServerAddresses;
 
@@ -92,7 +91,8 @@ public class ServerSelectionSelectionTest {
     public ServerSelectionSelectionTest(final String description, final BsonDocument definition) {
         this.description = description;
         this.definition = definition;
-        this.heartbeatFrequencyMS = definition.getNumber("heartbeatFrequencyMS", new BsonInt64(10000)).longValue();
+
+        long heartbeatFrequencyMS = definition.getNumber("heartbeatFrequencyMS", new BsonInt64(10000)).longValue();
         this.error = definition.getBoolean("error", BsonBoolean.FALSE).getValue();
         this.clusterDescription = buildClusterDescription(definition.getDocument("topology_description"),
                 ServerSettings.builder().heartbeatFrequency(heartbeatFrequencyMS, TimeUnit.MILLISECONDS).build());

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -310,7 +310,7 @@ public class ServerSelectionSelectionTest {
         Map<ServerAddress, Server> serverMap = new HashMap<>();
         for (ServerDescription desc : clusterDescription.getServerDescriptions()) {
             serverMap.put(desc.getAddress(), MongoMockito.mock(Server.class, server -> {
-                // Operation count selector should select any server since they all have 0 operation count.
+                // `MinimumOperationCountServerSelector` should select any server since they all have 0 operation count.
                 when(server.operationCount()).thenReturn(0);
             }));
         }

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerSelectionSelectionTest.java
@@ -67,11 +67,10 @@ import java.util.stream.Collectors;
 
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.connection.ServerDescription.MIN_DRIVER_WIRE_VERSION;
-import static java.lang.String.format;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 /**
@@ -299,8 +298,12 @@ public class ServerSelectionSelectionTest {
                         new TimeoutContext(TIMEOUT_SETTINGS.withServerSelectionTimeoutMS(0)));
         OperationContext.ServerDeprioritization serverDeprioritization = operationContext.getServerDeprioritization();
         for (ServerAddress address : extractDeprioritizedServerAddresses(definition)) {
-            serverDeprioritization.updateCandidate(address);
-            serverDeprioritization.onAttemptFailure(new MongoException("test"));
+            serverDeprioritization.updateCandidate(address, clusterDescription.getType());
+            // The spec defines deprioritized_servers as a pre-populated list to feed into the selection mechanism - not as "simulate the
+            // failure that caused deprioritization." Thus, SystemOverloadedError used unconditionally regardless of the cluster type.
+            MongoException error = new MongoException("test");
+            error.addLabel("SystemOverloadedError");
+            serverDeprioritization.onAttemptFailure(error);
         }
         return operationContext;
     }
@@ -317,7 +320,7 @@ public class ServerSelectionSelectionTest {
         return serverMap::get;
     }
 
-        private static void validateTestDescriptionFields(final Set<String> actualFields, final Set<String> knownFields) {
+    private static void validateTestDescriptionFields(final Set<String> actualFields, final Set<String> knownFields) {
         Set<String> unknownFields = new HashSet<>(actualFields);
         unknownFields.removeAll(knownFields);
         if (!unknownFields.isEmpty()) {

--- a/driver-core/src/test/unit/com/mongodb/internal/binding/SingleServerBindingSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/binding/SingleServerBindingSpecification.groovy
@@ -26,7 +26,7 @@ import com.mongodb.internal.connection.Server
 import com.mongodb.internal.connection.ServerTuple
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 
 class SingleServerBindingSpecification extends Specification {
 
@@ -68,7 +68,7 @@ class SingleServerBindingSpecification extends Specification {
         binding.count == 1
 
         when:
-        def source = binding.getReadConnectionSource(OPERATION_CONTEXT)
+        def source = binding.getReadConnectionSource(getOperationContext())
 
         then:
         source.count == 1
@@ -96,7 +96,7 @@ class SingleServerBindingSpecification extends Specification {
         binding.count == 1
 
         when:
-        source = binding.getWriteConnectionSource(OPERATION_CONTEXT)
+        source = binding.getWriteConnectionSource(getOperationContext())
 
         then:
         source.count == 1

--- a/driver-core/src/test/unit/com/mongodb/internal/binding/SingleServerBindingSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/binding/SingleServerBindingSpecification.groovy
@@ -26,7 +26,7 @@ import com.mongodb.internal.connection.Server
 import com.mongodb.internal.connection.ServerTuple
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 
 class SingleServerBindingSpecification extends Specification {
 
@@ -68,7 +68,7 @@ class SingleServerBindingSpecification extends Specification {
         binding.count == 1
 
         when:
-        def source = binding.getReadConnectionSource(getOperationContext())
+        def source = binding.getReadConnectionSource(createOperationContext())
 
         then:
         source.count == 1
@@ -96,7 +96,7 @@ class SingleServerBindingSpecification extends Specification {
         binding.count == 1
 
         when:
-        source = binding.getWriteConnectionSource(getOperationContext())
+        source = binding.getWriteConnectionSource(createOperationContext())
 
         then:
         source.count == 1

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
@@ -77,7 +77,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_FACTORY;
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.assertions.Assertions.assertFalse;
@@ -542,7 +542,7 @@ public abstract class AbstractConnectionPoolTest {
 
     private static void executeAdminCommand(final BsonDocument command) {
         new CommandReadOperation<>("admin", command, new BsonDocumentCodec())
-                .execute(ClusterFixture.getBinding(), OPERATION_CONTEXT);
+                .execute(ClusterFixture.getBinding(), getOperationContext());
     }
 
     private void setFailPoint() {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
@@ -77,7 +77,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_FACTORY;
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.assertions.Assertions.assertFalse;
@@ -542,7 +541,7 @@ public abstract class AbstractConnectionPoolTest {
 
     private static void executeAdminCommand(final BsonDocument command) {
         new CommandReadOperation<>("admin", command, new BsonDocumentCodec())
-                .execute(ClusterFixture.getBinding(), getOperationContext());
+                .execute(ClusterFixture.getBinding(), ClusterFixture.createOperationContext());
     }
 
     private void setFailPoint() {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractServerDiscoveryAndMonitoringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractServerDiscoveryAndMonitoringTest.java
@@ -43,7 +43,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA;
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.connection.ServerConnectionState.CONNECTING;
 import static com.mongodb.internal.connection.DescriptionHelper.createServerDescription;
@@ -82,7 +82,7 @@ public class AbstractServerDiscoveryAndMonitoringTest {
     }
 
     protected void applyApplicationError(final BsonDocument applicationError) {
-        Timeout serverSelectionTimeout = OPERATION_CONTEXT.getTimeoutContext().computeServerSelectionTimeout();
+        Timeout serverSelectionTimeout = getOperationContext().getTimeoutContext().computeServerSelectionTimeout();
         ServerAddress serverAddress = new ServerAddress(applicationError.getString("address").getValue());
         TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS);
         int errorGeneration = applicationError.getNumber("generation",
@@ -98,7 +98,7 @@ public class AbstractServerDiscoveryAndMonitoringTest {
         switch (type) {
             case "command":
                 exception = getCommandFailureException(applicationError.getDocument("response"), serverAddress,
-                        OPERATION_CONTEXT.getTimeoutContext());
+                        getOperationContext().getTimeoutContext());
                 break;
             case "network":
                 exception = new MongoSocketReadException("Read error", serverAddress, new IOException());

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractServerDiscoveryAndMonitoringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractServerDiscoveryAndMonitoringTest.java
@@ -82,7 +82,8 @@ public class AbstractServerDiscoveryAndMonitoringTest {
     }
 
     protected void applyApplicationError(final BsonDocument applicationError) {
-        Timeout serverSelectionTimeout = ClusterFixture.createOperationContext().getTimeoutContext().computeServerSelectionTimeout();
+        OperationContext operationContext = ClusterFixture.createOperationContext();
+        Timeout serverSelectionTimeout = operationContext.getTimeoutContext().computeServerSelectionTimeout();
         ServerAddress serverAddress = new ServerAddress(applicationError.getString("address").getValue());
         TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS);
         int errorGeneration = applicationError.getNumber("generation",
@@ -98,7 +99,7 @@ public class AbstractServerDiscoveryAndMonitoringTest {
         switch (type) {
             case "command":
                 exception = getCommandFailureException(applicationError.getDocument("response"), serverAddress,
-                        ClusterFixture.createOperationContext().getTimeoutContext());
+                        operationContext.getTimeoutContext());
                 break;
             case "network":
                 exception = new MongoSocketReadException("Read error", serverAddress, new IOException());

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractServerDiscoveryAndMonitoringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractServerDiscoveryAndMonitoringTest.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.connection;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoSocketReadException;
 import com.mongodb.MongoSocketReadTimeoutException;
@@ -43,7 +44,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA;
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.connection.ServerConnectionState.CONNECTING;
 import static com.mongodb.internal.connection.DescriptionHelper.createServerDescription;
@@ -82,7 +82,7 @@ public class AbstractServerDiscoveryAndMonitoringTest {
     }
 
     protected void applyApplicationError(final BsonDocument applicationError) {
-        Timeout serverSelectionTimeout = getOperationContext().getTimeoutContext().computeServerSelectionTimeout();
+        Timeout serverSelectionTimeout = ClusterFixture.createOperationContext().getTimeoutContext().computeServerSelectionTimeout();
         ServerAddress serverAddress = new ServerAddress(applicationError.getString("address").getValue());
         TimeoutContext timeoutContext = new TimeoutContext(TIMEOUT_SETTINGS);
         int errorGeneration = applicationError.getNumber("generation",
@@ -98,7 +98,7 @@ public class AbstractServerDiscoveryAndMonitoringTest {
         switch (type) {
             case "command":
                 exception = getCommandFailureException(applicationError.getDocument("response"), serverAddress,
-                        getOperationContext().getTimeoutContext());
+                        ClusterFixture.createOperationContext().getTimeoutContext());
                 break;
             case "network":
                 exception = new MongoSocketReadException("Read error", serverAddress, new IOException());

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterSpecification.groovy
@@ -42,7 +42,7 @@ import spock.lang.Specification
 import java.util.concurrent.CountDownLatch
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
@@ -135,7 +135,7 @@ class BaseClusterSpecification extends Specification {
         factory.sendNotification(thirdServer, REPLICA_SET_PRIMARY, allServers)
 
         expect:
-        cluster.selectServer(new ReadPreferenceServerSelector(ReadPreference.secondary()), OPERATION_CONTEXT)
+        cluster.selectServer(new ReadPreferenceServerSelector(ReadPreference.secondary()), getOperationContext())
                 .serverDescription.address == firstServer
     }
 
@@ -171,7 +171,7 @@ class BaseClusterSpecification extends Specification {
         factory.sendNotification(thirdServer, 1, REPLICA_SET_PRIMARY, allServers)
 
         expect:
-        cluster.selectServer(new ReadPreferenceServerSelector(ReadPreference.nearest()), OPERATION_CONTEXT)
+        cluster.selectServer(new ReadPreferenceServerSelector(ReadPreference.nearest()), getOperationContext())
                 .serverDescription.address == firstServer
     }
 
@@ -189,7 +189,7 @@ class BaseClusterSpecification extends Specification {
         factory.sendNotification(thirdServer, 1, REPLICA_SET_PRIMARY, allServers)
 
         expect: // firstServer is the only secondary within the latency threshold
-        cluster.selectServer(new ReadPreferenceServerSelector(ReadPreference.secondary()), OPERATION_CONTEXT)
+        cluster.selectServer(new ReadPreferenceServerSelector(ReadPreference.secondary()), getOperationContext())
                 .serverDescription.address == firstServer
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterSpecification.groovy
@@ -42,7 +42,6 @@ import spock.lang.Specification
 import java.util.concurrent.CountDownLatch
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA
-import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
@@ -135,7 +134,7 @@ class BaseClusterSpecification extends Specification {
         factory.sendNotification(thirdServer, REPLICA_SET_PRIMARY, allServers)
 
         expect:
-        cluster.selectServer(new ReadPreferenceServerSelector(ReadPreference.secondary()), getOperationContext())
+        cluster.selectServer(new ReadPreferenceServerSelector(ReadPreference.secondary()), createOperationContext())
                 .serverDescription.address == firstServer
     }
 
@@ -171,7 +170,7 @@ class BaseClusterSpecification extends Specification {
         factory.sendNotification(thirdServer, 1, REPLICA_SET_PRIMARY, allServers)
 
         expect:
-        cluster.selectServer(new ReadPreferenceServerSelector(ReadPreference.nearest()), getOperationContext())
+        cluster.selectServer(new ReadPreferenceServerSelector(ReadPreference.nearest()), createOperationContext())
                 .serverDescription.address == firstServer
     }
 
@@ -189,7 +188,7 @@ class BaseClusterSpecification extends Specification {
         factory.sendNotification(thirdServer, 1, REPLICA_SET_PRIMARY, allServers)
 
         expect: // firstServer is the only secondary within the latency threshold
-        cluster.selectServer(new ReadPreferenceServerSelector(ReadPreference.secondary()), getOperationContext())
+        cluster.selectServer(new ReadPreferenceServerSelector(ReadPreference.secondary()), createOperationContext())
                 .serverDescription.address == firstServer
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterTest.java
@@ -48,7 +48,7 @@ final class BaseClusterTest {
                 new ServerAddressSelector(serverAddressA),
                 clusterDescriptionAB,
                 serversSnapshotB,
-                ClusterFixture.OPERATION_CONTEXT.getServerDeprioritization(),
+                ClusterFixture.getOperationContext().getServerDeprioritization(),
                 ClusterSettings.builder().build()));
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/BaseClusterTest.java
@@ -48,7 +48,7 @@ final class BaseClusterTest {
                 new ServerAddressSelector(serverAddressA),
                 clusterDescriptionAB,
                 serversSnapshotB,
-                ClusterFixture.getOperationContext().getServerDeprioritization(),
+                ClusterFixture.createOperationContext().getServerDeprioritization(),
                 ClusterSettings.builder().build()));
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultConnectionPoolSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultConnectionPoolSpecification.groovy
@@ -41,7 +41,6 @@ import java.util.concurrent.CountDownLatch
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_FACTORY
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.createOperationContext
@@ -78,7 +77,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         pool.ready()
 
         expect:
-        pool.get(getOperationContext()) != null
+        pool.get(createOperationContext()) != null
     }
 
     def 'should reuse released connection'() throws InterruptedException {
@@ -86,7 +85,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                 builder().maxSize(1).build(), mockSdamProvider(), OPERATION_CONTEXT_FACTORY)
         pool.ready()
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
 
         when:
         pool.get(operationContext).close()
@@ -103,7 +102,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         pool.ready()
 
         when:
-        pool.get(getOperationContext()).close()
+        pool.get(createOperationContext()).close()
 
         then:
         !connectionFactory.getCreatedConnections().get(0).isClosed()
@@ -221,7 +220,7 @@ class DefaultConnectionPoolSpecification extends Specification {
 
         when:
         pool.ready()
-        pool.get(getOperationContext())
+        pool.get(createOperationContext())
 
         then:
         1 * listener.connectionCreated { it.connectionId.serverId == SERVER_ID }
@@ -240,7 +239,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         connectionDescription.getConnectionId() >> id
         connection.getDescription() >> connectionDescription
         connection.opened() >> false
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
 
         when: 'connection pool is created'
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory, settings, mockSdamProvider(), OPERATION_CONTEXT_FACTORY)
@@ -353,7 +352,7 @@ class DefaultConnectionPoolSpecification extends Specification {
 
         when:
         pool.ready()
-        pool.get(getOperationContext()).close()
+        pool.get(createOperationContext()).close()
         //not cool - but we have no way of waiting for connection to become idle
         Thread.sleep(500)
         pool.close();
@@ -388,7 +387,7 @@ class DefaultConnectionPoolSpecification extends Specification {
 
     def 'should log connection checkout failed with Reason.CONNECTION_ERROR if fails to open a connection'() {
         given:
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
         def listener = Mock(ConnectionPoolListener)
         def connection = Mock(InternalConnection)
         connection.getDescription() >> new ConnectionDescription(SERVER_ID)
@@ -438,7 +437,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory, builder().maxSize(10)
                 .addConnectionPoolListener(listener).build(), mockSdamProvider(), OPERATION_CONTEXT_FACTORY)
         pool.ready()
-        def connection = pool.get(getOperationContext())
+        def connection = pool.get(createOperationContext())
         connection.close()
 
         when:
@@ -466,7 +465,7 @@ class DefaultConnectionPoolSpecification extends Specification {
 
     def 'should fire connection pool events on check out and check in'() {
         given:
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
         def listener = Mock(ConnectionPoolListener)
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory, builder().maxSize(1)
                 .addConnectionPoolListener(listener).build(), mockSdamProvider(), OPERATION_CONTEXT_FACTORY)
@@ -497,7 +496,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         connection.close()
 
         when:
-        connection = pool.get(getOperationContext())
+        connection = pool.get(createOperationContext())
 
         then:
         1 * listener.connectionCheckedOut { it.connectionId.serverId == SERVER_ID }
@@ -511,7 +510,7 @@ class DefaultConnectionPoolSpecification extends Specification {
 
     def 'should fire connection checkout failed with Reason.CONNECTION_ERROR if fails to open a connection'() {
         given:
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
         def listener = Mock(ConnectionPoolListener)
         def connection = Mock(InternalConnection)
         connection.getDescription() >> new ConnectionDescription(SERVER_ID)
@@ -569,7 +568,7 @@ class DefaultConnectionPoolSpecification extends Specification {
 
         when:
         try {
-            pool.get(getOperationContext())
+            pool.get(createOperationContext())
         } catch (MongoConnectionPoolClearedException e) {
             caught = e
         }
@@ -584,7 +583,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         CompletableFuture<Throwable> caught = new CompletableFuture<>()
 
         when:
-        pool.getAsync(getOperationContext()) { InternalConnection result, Throwable t ->
+        pool.getAsync(createOperationContext()) { InternalConnection result, Throwable t ->
             if (t != null) {
                 caught.complete(t)
             }
@@ -604,7 +603,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         when:
         pool.invalidate(cause)
         try {
-            pool.get(getOperationContext())
+            pool.get(createOperationContext())
         } catch (MongoConnectionPoolClearedException e) {
             caught = e
         }
@@ -635,7 +634,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory, builder().maxSize(1)
                 .addConnectionPoolListener(listener).build(), mockSdamProvider(), OPERATION_CONTEXT_FACTORY)
         pool.ready()
-        def connection = pool.get(getOperationContext())
+        def connection = pool.get(createOperationContext())
         pool.close()
 
         when:
@@ -679,7 +678,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         pool.ready()
 
         when:
-        def connection = pool.get(getOperationContext())
+        def connection = pool.get(createOperationContext())
         def connectionLatch = selectConnectionAsync(pool)
         connection.close()
 
@@ -689,7 +688,7 @@ class DefaultConnectionPoolSpecification extends Specification {
 
     def 'when getting a connection asynchronously should send MongoTimeoutException to callback after timeout period'() {
         given:
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                 builder().maxSize(1).maxWaitTime(5, MILLISECONDS).build(), mockSdamProvider(), OPERATION_CONTEXT_FACTORY)
         pool.ready()
@@ -727,7 +726,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         selectConnectionAsync(pool).get()
     }
 
-    def selectConnectionAsync(DefaultConnectionPool pool, operationContext = getOperationContext()) {
+    def selectConnectionAsync(DefaultConnectionPool pool, operationContext = createOperationContext()) {
         def serverLatch = new ConnectionLatch()
         pool.getAsync(operationContext) { InternalConnection result, Throwable e ->
             serverLatch.connection = result

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerConnectionSpecification.groovy
@@ -16,7 +16,7 @@
 
 package com.mongodb.internal.connection
 
-
+import com.mongodb.ClusterFixture
 import com.mongodb.ReadPreference
 import com.mongodb.connection.ClusterConnectionMode
 import com.mongodb.internal.async.SingleResultCallback
@@ -27,7 +27,6 @@ import org.bson.BsonInt32
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
 import static com.mongodb.CustomMatchers.compare
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback
 import static com.mongodb.internal.connection.MessageHelper.LEGACY_HELLO_LOWER
@@ -43,14 +42,16 @@ class DefaultServerConnectionSpecification extends Specification {
         def codec = new BsonDocumentCodec()
         def executor = Mock(ProtocolExecutor)
         def connection = new DefaultServerConnection(internalConnection, executor, ClusterConnectionMode.MULTIPLE)
+        def operationContext = ClusterFixture.getOperationContext()
+
 
         when:
-        connection.commandAsync('test', command, validator, ReadPreference.primary(), codec, OPERATION_CONTEXT, callback)
+        connection.commandAsync('test', command, validator, ReadPreference.primary(), codec, operationContext, callback)
 
         then:
         1 * executor.executeAsync({
             compare(new CommandProtocolImpl('test', command, validator, ReadPreference.primary(), codec, true,
-                    MessageSequences.EmptyMessageSequences.INSTANCE, ClusterConnectionMode.MULTIPLE, OPERATION_CONTEXT), it)
-        }, internalConnection, OPERATION_CONTEXT.getSessionContext(), callback)
+                    MessageSequences.EmptyMessageSequences.INSTANCE, ClusterConnectionMode.MULTIPLE, operationContext), it)
+        }, internalConnection, operationContext.getSessionContext(), callback)
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerConnectionSpecification.groovy
@@ -42,7 +42,7 @@ class DefaultServerConnectionSpecification extends Specification {
         def codec = new BsonDocumentCodec()
         def executor = Mock(ProtocolExecutor)
         def connection = new DefaultServerConnection(internalConnection, executor, ClusterConnectionMode.MULTIPLE)
-        def operationContext = ClusterFixture.getOperationContext()
+        def operationContext = ClusterFixture.createOperationContext()
 
 
         when:

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
@@ -54,7 +54,7 @@ import spock.lang.Specification
 import java.util.concurrent.CountDownLatch
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.MongoCredential.createCredential
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
@@ -74,7 +74,7 @@ class DefaultServerSpecification extends Specification {
                 Mock(SdamServerDescriptionManager), Mock(ServerListener), Mock(CommandListener), new ClusterClock(), false)
 
         when:
-        def receivedConnection = server.getConnection(OPERATION_CONTEXT)
+        def receivedConnection = server.getConnection(getOperationContext())
 
         then:
         receivedConnection
@@ -100,7 +100,7 @@ class DefaultServerSpecification extends Specification {
 
         when:
         def callback = new SupplyingCallback<AsyncConnection>()
-        server.getConnectionAsync(OPERATION_CONTEXT, callback)
+        server.getConnectionAsync(getOperationContext(), callback)
 
         then:
         callback.get() == connection
@@ -117,7 +117,7 @@ class DefaultServerSpecification extends Specification {
         server.close()
 
         when:
-        server.getConnection(OPERATION_CONTEXT)
+        server.getConnection(getOperationContext())
 
         then:
         def ex = thrown(MongoServerUnavailableException)
@@ -127,7 +127,7 @@ class DefaultServerSpecification extends Specification {
         def latch = new CountDownLatch(1)
         def receivedConnection = null
         def receivedThrowable = null
-        server.getConnectionAsync(OPERATION_CONTEXT) {
+        server.getConnectionAsync(getOperationContext()) {
             result, throwable ->
                 receivedConnection = result; receivedThrowable = throwable; latch.countDown()
         }
@@ -210,7 +210,7 @@ class DefaultServerSpecification extends Specification {
         given:
         def connectionPool = Mock(ConnectionPool)
         def serverMonitor = Mock(ServerMonitor)
-        connectionPool.get(OPERATION_CONTEXT) >> { throw exceptionToThrow }
+        connectionPool.get(getOperationContext()) >> { throw exceptionToThrow }
 
         def server = defaultServer(connectionPool, serverMonitor)
         server.close()
@@ -242,7 +242,7 @@ class DefaultServerSpecification extends Specification {
         def server = defaultServer(connectionPool, serverMonitor)
 
         when:
-        server.getConnection(OPERATION_CONTEXT)
+        server.getConnection(getOperationContext())
 
         then:
         def e = thrown(MongoException)
@@ -267,7 +267,7 @@ class DefaultServerSpecification extends Specification {
         def server = defaultServer(connectionPool, serverMonitor)
 
         when:
-        server.getConnection(OPERATION_CONTEXT)
+        server.getConnection(getOperationContext())
 
         then:
         def e = thrown(MongoSecurityException)
@@ -292,7 +292,7 @@ class DefaultServerSpecification extends Specification {
         def latch = new CountDownLatch(1)
         def receivedConnection = null
         def receivedThrowable = null
-        server.getConnectionAsync(OPERATION_CONTEXT) {
+        server.getConnectionAsync(getOperationContext()) {
             result, throwable ->
                 receivedConnection = result; receivedThrowable = throwable; latch.countDown()
         }
@@ -325,7 +325,7 @@ class DefaultServerSpecification extends Specification {
         def latch = new CountDownLatch(1)
         def receivedConnection = null
         def receivedThrowable = null
-        server.getConnectionAsync(OPERATION_CONTEXT) {
+        server.getConnectionAsync(getOperationContext()) {
             result, throwable ->
                 receivedConnection = result; receivedThrowable = throwable; latch.countDown()
         }
@@ -350,7 +350,7 @@ class DefaultServerSpecification extends Specification {
         clusterClock.advance(clusterClockClusterTime)
         def server = new DefaultServer(serverId, SINGLE, Mock(ConnectionPool), new TestConnectionFactory(), Mock(ServerMonitor),
                 Mock(SdamServerDescriptionManager), Mock(ServerListener), Mock(CommandListener), clusterClock, false)
-        def testConnection = (TestConnection) server.getConnection(OPERATION_CONTEXT)
+        def testConnection = (TestConnection) server.getConnection(getOperationContext())
         def sessionContext = new TestSessionContext(initialClusterTime)
         def response = BsonDocument.parse(
                 '''{
@@ -361,7 +361,7 @@ class DefaultServerSpecification extends Specification {
                           ''')
         def protocol = new TestCommandProtocol(response)
         testConnection.enqueueProtocol(protocol)
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
 
         when:
         if (async) {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
@@ -210,7 +210,6 @@ class DefaultServerSpecification extends Specification {
         given:
         def connectionPool = Mock(ConnectionPool)
         def serverMonitor = Mock(ServerMonitor)
-        connectionPool.get(createOperationContext()) >> { throw exceptionToThrow }
 
         def server = defaultServer(connectionPool, serverMonitor)
         server.close()

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
@@ -54,7 +54,7 @@ import spock.lang.Specification
 import java.util.concurrent.CountDownLatch
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.MongoCredential.createCredential
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
@@ -74,7 +74,7 @@ class DefaultServerSpecification extends Specification {
                 Mock(SdamServerDescriptionManager), Mock(ServerListener), Mock(CommandListener), new ClusterClock(), false)
 
         when:
-        def receivedConnection = server.getConnection(getOperationContext())
+        def receivedConnection = server.getConnection(createOperationContext())
 
         then:
         receivedConnection
@@ -100,7 +100,7 @@ class DefaultServerSpecification extends Specification {
 
         when:
         def callback = new SupplyingCallback<AsyncConnection>()
-        server.getConnectionAsync(getOperationContext(), callback)
+        server.getConnectionAsync(createOperationContext(), callback)
 
         then:
         callback.get() == connection
@@ -117,7 +117,7 @@ class DefaultServerSpecification extends Specification {
         server.close()
 
         when:
-        server.getConnection(getOperationContext())
+        server.getConnection(createOperationContext())
 
         then:
         def ex = thrown(MongoServerUnavailableException)
@@ -127,7 +127,7 @@ class DefaultServerSpecification extends Specification {
         def latch = new CountDownLatch(1)
         def receivedConnection = null
         def receivedThrowable = null
-        server.getConnectionAsync(getOperationContext()) {
+        server.getConnectionAsync(createOperationContext()) {
             result, throwable ->
                 receivedConnection = result; receivedThrowable = throwable; latch.countDown()
         }
@@ -210,7 +210,7 @@ class DefaultServerSpecification extends Specification {
         given:
         def connectionPool = Mock(ConnectionPool)
         def serverMonitor = Mock(ServerMonitor)
-        connectionPool.get(getOperationContext()) >> { throw exceptionToThrow }
+        connectionPool.get(createOperationContext()) >> { throw exceptionToThrow }
 
         def server = defaultServer(connectionPool, serverMonitor)
         server.close()
@@ -242,7 +242,7 @@ class DefaultServerSpecification extends Specification {
         def server = defaultServer(connectionPool, serverMonitor)
 
         when:
-        server.getConnection(getOperationContext())
+        server.getConnection(createOperationContext())
 
         then:
         def e = thrown(MongoException)
@@ -267,7 +267,7 @@ class DefaultServerSpecification extends Specification {
         def server = defaultServer(connectionPool, serverMonitor)
 
         when:
-        server.getConnection(getOperationContext())
+        server.getConnection(createOperationContext())
 
         then:
         def e = thrown(MongoSecurityException)
@@ -292,7 +292,7 @@ class DefaultServerSpecification extends Specification {
         def latch = new CountDownLatch(1)
         def receivedConnection = null
         def receivedThrowable = null
-        server.getConnectionAsync(getOperationContext()) {
+        server.getConnectionAsync(createOperationContext()) {
             result, throwable ->
                 receivedConnection = result; receivedThrowable = throwable; latch.countDown()
         }
@@ -325,7 +325,7 @@ class DefaultServerSpecification extends Specification {
         def latch = new CountDownLatch(1)
         def receivedConnection = null
         def receivedThrowable = null
-        server.getConnectionAsync(getOperationContext()) {
+        server.getConnectionAsync(createOperationContext()) {
             result, throwable ->
                 receivedConnection = result; receivedThrowable = throwable; latch.countDown()
         }
@@ -350,7 +350,7 @@ class DefaultServerSpecification extends Specification {
         clusterClock.advance(clusterClockClusterTime)
         def server = new DefaultServer(serverId, SINGLE, Mock(ConnectionPool), new TestConnectionFactory(), Mock(ServerMonitor),
                 Mock(SdamServerDescriptionManager), Mock(ServerListener), Mock(CommandListener), clusterClock, false)
-        def testConnection = (TestConnection) server.getConnection(getOperationContext())
+        def testConnection = (TestConnection) server.getConnection(createOperationContext())
         def sessionContext = new TestSessionContext(initialClusterTime)
         def response = BsonDocument.parse(
                 '''{
@@ -361,7 +361,7 @@ class DefaultServerSpecification extends Specification {
                           ''')
         def protocol = new TestCommandProtocol(response)
         testConnection.enqueueProtocol(protocol)
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
 
         when:
         if (async) {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
@@ -58,7 +58,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_INFINITE_TIMEOUT
 import static com.mongodb.ReadPreference.primary
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
@@ -114,7 +114,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
     def getOpenedConnection() {
         def connection = getConnection()
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
         connection
     }
 
@@ -132,7 +132,7 @@ class InternalStreamConnectionSpecification extends Specification {
                 .lastUpdateTimeNanos(connection.getInitialServerDescription().getLastUpdateTime(NANOSECONDS))
                 .build()
         when:
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
 
         then:
         connection.opened()
@@ -159,7 +159,7 @@ class InternalStreamConnectionSpecification extends Specification {
                 .build()
 
         when:
-        connection.openAsync(OPERATION_CONTEXT, futureResultCallback)
+        connection.openAsync(getOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -177,7 +177,7 @@ class InternalStreamConnectionSpecification extends Specification {
                 failedInitializer)
 
         when:
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
 
         then:
         thrown MongoInternalException
@@ -195,7 +195,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
         when:
         def futureResultCallback = new FutureResultCallback<Void>()
-        connection.openAsync(OPERATION_CONTEXT, futureResultCallback)
+        connection.openAsync(getOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -212,14 +212,14 @@ class InternalStreamConnectionSpecification extends Specification {
         def (buffers2, messageId2) = helper.hello()
 
         when:
-        connection.sendMessage(buffers1, messageId1, OPERATION_CONTEXT)
+        connection.sendMessage(buffers1, messageId1, getOperationContext())
 
         then:
         connection.isClosed()
         thrown MongoSocketWriteException
 
         when:
-        connection.sendMessage(buffers2, messageId2, OPERATION_CONTEXT)
+        connection.sendMessage(buffers2, messageId2, getOperationContext())
 
         then:
         thrown MongoSocketClosedException
@@ -243,7 +243,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.sendMessageAsync(buffers1, messageId1, OPERATION_CONTEXT, sndCallbck1)
+        connection.sendMessageAsync(buffers1, messageId1, getOperationContext(), sndCallbck1)
         sndCallbck1.get(10, SECONDS)
 
         then:
@@ -251,7 +251,7 @@ class InternalStreamConnectionSpecification extends Specification {
         connection.isClosed()
 
         when:
-        connection.sendMessageAsync(buffers2, messageId2, OPERATION_CONTEXT, sndCallbck2)
+        connection.sendMessageAsync(buffers2, messageId2, getOperationContext(), sndCallbck2)
         sndCallbck2.get(10, SECONDS)
 
         then:
@@ -267,16 +267,16 @@ class InternalStreamConnectionSpecification extends Specification {
         def (buffers2, messageId2) = helper.hello()
 
         when:
-        connection.sendMessage(buffers1, messageId1, OPERATION_CONTEXT)
-        connection.sendMessage(buffers2, messageId2, OPERATION_CONTEXT)
-        connection.receiveMessage(messageId1, OPERATION_CONTEXT)
+        connection.sendMessage(buffers1, messageId1, getOperationContext())
+        connection.sendMessage(buffers2, messageId2, getOperationContext())
+        connection.receiveMessage(messageId1, getOperationContext())
 
         then:
         connection.isClosed()
         thrown MongoSocketReadException
 
         when:
-        connection.receiveMessage(messageId2, OPERATION_CONTEXT)
+        connection.receiveMessage(messageId2, getOperationContext())
 
         then:
         thrown MongoSocketClosedException
@@ -289,7 +289,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.receiveMessage(1, OPERATION_CONTEXT)
+        connection.receiveMessage(1, getOperationContext())
 
         then:
         thrown(MongoInternalException)
@@ -306,7 +306,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def callback = new FutureResultCallback()
 
         when:
-        connection.receiveMessageAsync(1, OPERATION_CONTEXT, callback)
+        connection.receiveMessageAsync(1, getOperationContext(), callback)
         callback.get()
 
         then:
@@ -321,7 +321,7 @@ class InternalStreamConnectionSpecification extends Specification {
         Thread.currentThread().interrupt()
 
         when:
-        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, OPERATION_CONTEXT)
+        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, getOperationContext())
 
         then:
         Thread.interrupted()
@@ -335,7 +335,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, OPERATION_CONTEXT)
+        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, getOperationContext())
 
         then:
         !Thread.interrupted()
@@ -350,7 +350,7 @@ class InternalStreamConnectionSpecification extends Specification {
         Thread.currentThread().interrupt()
 
         when:
-        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, OPERATION_CONTEXT)
+        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, getOperationContext())
 
         then:
         Thread.interrupted()
@@ -365,7 +365,7 @@ class InternalStreamConnectionSpecification extends Specification {
         Thread.currentThread().interrupt()
 
         when:
-        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, OPERATION_CONTEXT)
+        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, getOperationContext())
 
         then:
         Thread.interrupted()
@@ -379,7 +379,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, OPERATION_CONTEXT)
+        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, getOperationContext())
 
         then:
         thrown(MongoSocketWriteException)
@@ -393,7 +393,7 @@ class InternalStreamConnectionSpecification extends Specification {
         Thread.currentThread().interrupt()
 
         when:
-        connection.receiveMessage(1, OPERATION_CONTEXT)
+        connection.receiveMessage(1, getOperationContext())
 
         then:
         Thread.interrupted()
@@ -407,7 +407,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.receiveMessage(1, OPERATION_CONTEXT)
+        connection.receiveMessage(1, getOperationContext())
 
         then:
         !Thread.interrupted()
@@ -422,7 +422,7 @@ class InternalStreamConnectionSpecification extends Specification {
         Thread.currentThread().interrupt()
 
         when:
-        connection.receiveMessage(1, OPERATION_CONTEXT)
+        connection.receiveMessage(1, getOperationContext())
 
         then:
         Thread.interrupted()
@@ -437,7 +437,7 @@ class InternalStreamConnectionSpecification extends Specification {
         Thread.currentThread().interrupt()
 
         when:
-        connection.receiveMessage(1, OPERATION_CONTEXT)
+        connection.receiveMessage(1, getOperationContext())
 
         then:
         Thread.interrupted()
@@ -451,7 +451,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.receiveMessage(1, OPERATION_CONTEXT)
+        connection.receiveMessage(1, getOperationContext())
 
         then:
         thrown(MongoSocketReadException)
@@ -464,7 +464,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.receiveMessage(1, OPERATION_CONTEXT.withTimeoutContext(
+        connection.receiveMessage(1, getOperationContext().withTimeoutContext(
                 new TimeoutContext(TIMEOUT_SETTINGS_WITH_INFINITE_TIMEOUT)))
 
         then:
@@ -482,7 +482,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.receiveMessage(1, OPERATION_CONTEXT.withTimeoutContext(
+        connection.receiveMessage(1, getOperationContext().withTimeoutContext(
                 new TimeoutContext(TIMEOUT_SETTINGS_WITH_INFINITE_TIMEOUT)))
 
         then:
@@ -502,7 +502,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
         def connection = getOpenedConnection()
         def callback = new FutureResultCallback()
-        def operationContext = OPERATION_CONTEXT.withTimeoutContext(
+        def operationContext = getOperationContext().withTimeoutContext(
                 new TimeoutContext(TIMEOUT_SETTINGS_WITH_INFINITE_TIMEOUT))
         when:
         connection.receiveMessageAsync(1, operationContext, callback)
@@ -525,7 +525,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
         def connection = getOpenedConnection()
         def callback = new FutureResultCallback()
-        def operationContext = OPERATION_CONTEXT.withTimeoutContext(
+        def operationContext = getOperationContext().withTimeoutContext(
                 new TimeoutContext(TIMEOUT_SETTINGS_WITH_INFINITE_TIMEOUT))
         when:
         connection.receiveMessageAsync(1, operationContext, callback)
@@ -563,10 +563,10 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.sendMessageAsync(buffers1, messageId1, OPERATION_CONTEXT, sndCallbck1)
-        connection.sendMessageAsync(buffers2, messageId2, OPERATION_CONTEXT, sndCallbck2)
-        connection.receiveMessageAsync(messageId1, OPERATION_CONTEXT, rcvdCallbck1)
-        connection.receiveMessageAsync(messageId2, OPERATION_CONTEXT, rcvdCallbck2)
+        connection.sendMessageAsync(buffers1, messageId1, getOperationContext(), sndCallbck1)
+        connection.sendMessageAsync(buffers2, messageId2, getOperationContext(), sndCallbck2)
+        connection.receiveMessageAsync(messageId1, getOperationContext(), rcvdCallbck1)
+        connection.receiveMessageAsync(messageId2, getOperationContext(), rcvdCallbck2)
         rcvdCallbck1.get(1, SECONDS)
 
         then:
@@ -588,14 +588,14 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.receiveMessage(1, OPERATION_CONTEXT)
+        connection.receiveMessage(1, getOperationContext())
 
         then:
         connection.isClosed()
         thrown MongoSocketReadException
 
         when:
-        connection.receiveMessage(1, OPERATION_CONTEXT)
+        connection.receiveMessage(1, getOperationContext())
 
         then:
         thrown MongoSocketClosedException
@@ -620,9 +620,9 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.sendMessageAsync(buffers1, messageId1, OPERATION_CONTEXT, sndCallbck1)
-        connection.sendMessageAsync(buffers2, messageId2, OPERATION_CONTEXT, sndCallbck2)
-        connection.receiveMessageAsync(messageId1, OPERATION_CONTEXT, rcvdCallbck1)
+        connection.sendMessageAsync(buffers1, messageId1, getOperationContext(), sndCallbck1)
+        connection.sendMessageAsync(buffers2, messageId2, getOperationContext(), sndCallbck2)
+        connection.receiveMessageAsync(messageId1, getOperationContext(), rcvdCallbck1)
         rcvdCallbck1.get(1, SECONDS)
 
         then:
@@ -630,7 +630,7 @@ class InternalStreamConnectionSpecification extends Specification {
         connection.isClosed()
 
         when:
-        connection.receiveMessageAsync(messageId2, OPERATION_CONTEXT, rcvdCallbck2)
+        connection.receiveMessageAsync(messageId2, getOperationContext(), rcvdCallbck2)
         rcvdCallbck2.get(1, SECONDS)
 
         then:
@@ -649,7 +649,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(_, _) >> helper.reply(response)
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
 
         then:
         thrown(MongoCommandException)
@@ -677,7 +677,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT, callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
         callback.get()
 
         then:
@@ -705,7 +705,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def callbacks = []
         (1..numberOfOperations).each { n ->
             def (buffers, messageId, sndCallbck, rcvdCallbck) = messages.pop()
-            connection.sendMessageAsync(buffers, messageId, OPERATION_CONTEXT, sndCallbck)
+            connection.sendMessageAsync(buffers, messageId, getOperationContext(), sndCallbck)
             callbacks.add(sndCallbck)
         }
         streamLatch.countDown()
@@ -730,7 +730,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(90, _) >> helper.defaultReply()
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
 
         then:
         commandListener.eventsWereDelivered([
@@ -753,7 +753,7 @@ class InternalStreamConnectionSpecification extends Specification {
         when:
         connection.sendAndReceive(commandMessage, {
             BsonReader reader, DecoderContext decoderContext -> throw new CodecConfigurationException('')
-        }, OPERATION_CONTEXT)
+        }, getOperationContext())
 
         then:
         thrown(CodecConfigurationException)
@@ -783,7 +783,7 @@ class InternalStreamConnectionSpecification extends Specification {
             1 * advanceClusterTime(BsonDocument.parse(response).getDocument('$clusterTime'))
             getReadConcern() >> ReadConcern.DEFAULT
         }
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
 
         when:
         connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), operationContext)
@@ -819,7 +819,7 @@ class InternalStreamConnectionSpecification extends Specification {
             1 * advanceClusterTime(BsonDocument.parse(response).getDocument('$clusterTime'))
             getReadConcern() >> ReadConcern.DEFAULT
         }
-        def operationContext = OPERATION_CONTEXT.withSessionContext(sessionContext)
+        def operationContext = getOperationContext().withSessionContext(sessionContext)
 
         when:
         connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), operationContext, callback)
@@ -839,7 +839,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.write(_, _) >> { throw new MongoSocketWriteException('Failed to write', serverAddress, new IOException()) }
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
 
         then:
         def e = thrown(MongoSocketWriteException)
@@ -859,7 +859,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(16, _) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
 
         then:
         def e = thrown(MongoSocketReadException)
@@ -880,7 +880,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(90, _) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
 
         then:
         def e = thrown(MongoSocketException)
@@ -902,7 +902,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(_, _) >> helper.reply(response)
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
 
         then:
         def e = thrown(MongoCommandException)
@@ -923,7 +923,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(90, _) >> helper.defaultReply()
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
 
         then:
         commandListener.eventsWereDelivered([
@@ -959,7 +959,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(_, _) >> helper.reply('{ok : 0, errmsg : "failed"}')
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
 
         then:
         thrown(MongoCommandException)
@@ -1005,7 +1005,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT, callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
         callback.get()
 
         then:
@@ -1038,7 +1038,7 @@ class InternalStreamConnectionSpecification extends Specification {
         when:
         connection.sendAndReceiveAsync(commandMessage, {
             BsonReader reader, DecoderContext decoderContext -> throw new CodecConfigurationException('')
-        }, OPERATION_CONTEXT, callback)
+        }, getOperationContext(), callback)
         callback.get()
 
         then:
@@ -1065,7 +1065,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT, callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
         callback.get()
 
         then:
@@ -1093,7 +1093,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT, callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
         callback.get()
 
         then:
@@ -1124,7 +1124,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT, callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
         callback.get()
 
         then:
@@ -1156,7 +1156,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT, callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
         callback.get()
 
         then:
@@ -1187,7 +1187,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), OPERATION_CONTEXT, callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
         callback.get()
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/InternalStreamConnectionSpecification.groovy
@@ -58,7 +58,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS_WITH_INFINITE_TIMEOUT
 import static com.mongodb.ReadPreference.primary
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
@@ -114,7 +114,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
     def getOpenedConnection() {
         def connection = getConnection()
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
         connection
     }
 
@@ -132,7 +132,7 @@ class InternalStreamConnectionSpecification extends Specification {
                 .lastUpdateTimeNanos(connection.getInitialServerDescription().getLastUpdateTime(NANOSECONDS))
                 .build()
         when:
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
 
         then:
         connection.opened()
@@ -159,7 +159,7 @@ class InternalStreamConnectionSpecification extends Specification {
                 .build()
 
         when:
-        connection.openAsync(getOperationContext(), futureResultCallback)
+        connection.openAsync(createOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -177,7 +177,7 @@ class InternalStreamConnectionSpecification extends Specification {
                 failedInitializer)
 
         when:
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
 
         then:
         thrown MongoInternalException
@@ -195,7 +195,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
         when:
         def futureResultCallback = new FutureResultCallback<Void>()
-        connection.openAsync(getOperationContext(), futureResultCallback)
+        connection.openAsync(createOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -212,14 +212,14 @@ class InternalStreamConnectionSpecification extends Specification {
         def (buffers2, messageId2) = helper.hello()
 
         when:
-        connection.sendMessage(buffers1, messageId1, getOperationContext())
+        connection.sendMessage(buffers1, messageId1, createOperationContext())
 
         then:
         connection.isClosed()
         thrown MongoSocketWriteException
 
         when:
-        connection.sendMessage(buffers2, messageId2, getOperationContext())
+        connection.sendMessage(buffers2, messageId2, createOperationContext())
 
         then:
         thrown MongoSocketClosedException
@@ -243,7 +243,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.sendMessageAsync(buffers1, messageId1, getOperationContext(), sndCallbck1)
+        connection.sendMessageAsync(buffers1, messageId1, createOperationContext(), sndCallbck1)
         sndCallbck1.get(10, SECONDS)
 
         then:
@@ -251,7 +251,7 @@ class InternalStreamConnectionSpecification extends Specification {
         connection.isClosed()
 
         when:
-        connection.sendMessageAsync(buffers2, messageId2, getOperationContext(), sndCallbck2)
+        connection.sendMessageAsync(buffers2, messageId2, createOperationContext(), sndCallbck2)
         sndCallbck2.get(10, SECONDS)
 
         then:
@@ -267,16 +267,16 @@ class InternalStreamConnectionSpecification extends Specification {
         def (buffers2, messageId2) = helper.hello()
 
         when:
-        connection.sendMessage(buffers1, messageId1, getOperationContext())
-        connection.sendMessage(buffers2, messageId2, getOperationContext())
-        connection.receiveMessage(messageId1, getOperationContext())
+        connection.sendMessage(buffers1, messageId1, createOperationContext())
+        connection.sendMessage(buffers2, messageId2, createOperationContext())
+        connection.receiveMessage(messageId1, createOperationContext())
 
         then:
         connection.isClosed()
         thrown MongoSocketReadException
 
         when:
-        connection.receiveMessage(messageId2, getOperationContext())
+        connection.receiveMessage(messageId2, createOperationContext())
 
         then:
         thrown MongoSocketClosedException
@@ -289,7 +289,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.receiveMessage(1, getOperationContext())
+        connection.receiveMessage(1, createOperationContext())
 
         then:
         thrown(MongoInternalException)
@@ -306,7 +306,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def callback = new FutureResultCallback()
 
         when:
-        connection.receiveMessageAsync(1, getOperationContext(), callback)
+        connection.receiveMessageAsync(1, createOperationContext(), callback)
         callback.get()
 
         then:
@@ -321,7 +321,7 @@ class InternalStreamConnectionSpecification extends Specification {
         Thread.currentThread().interrupt()
 
         when:
-        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, getOperationContext())
+        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, createOperationContext())
 
         then:
         Thread.interrupted()
@@ -335,7 +335,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, getOperationContext())
+        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, createOperationContext())
 
         then:
         !Thread.interrupted()
@@ -350,7 +350,7 @@ class InternalStreamConnectionSpecification extends Specification {
         Thread.currentThread().interrupt()
 
         when:
-        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, getOperationContext())
+        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, createOperationContext())
 
         then:
         Thread.interrupted()
@@ -365,7 +365,7 @@ class InternalStreamConnectionSpecification extends Specification {
         Thread.currentThread().interrupt()
 
         when:
-        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, getOperationContext())
+        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, createOperationContext())
 
         then:
         Thread.interrupted()
@@ -379,7 +379,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, getOperationContext())
+        connection.sendMessage([new ByteBufNIO(ByteBuffer.allocate(1))], 1, createOperationContext())
 
         then:
         thrown(MongoSocketWriteException)
@@ -393,7 +393,7 @@ class InternalStreamConnectionSpecification extends Specification {
         Thread.currentThread().interrupt()
 
         when:
-        connection.receiveMessage(1, getOperationContext())
+        connection.receiveMessage(1, createOperationContext())
 
         then:
         Thread.interrupted()
@@ -407,7 +407,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.receiveMessage(1, getOperationContext())
+        connection.receiveMessage(1, createOperationContext())
 
         then:
         !Thread.interrupted()
@@ -422,7 +422,7 @@ class InternalStreamConnectionSpecification extends Specification {
         Thread.currentThread().interrupt()
 
         when:
-        connection.receiveMessage(1, getOperationContext())
+        connection.receiveMessage(1, createOperationContext())
 
         then:
         Thread.interrupted()
@@ -437,7 +437,7 @@ class InternalStreamConnectionSpecification extends Specification {
         Thread.currentThread().interrupt()
 
         when:
-        connection.receiveMessage(1, getOperationContext())
+        connection.receiveMessage(1, createOperationContext())
 
         then:
         Thread.interrupted()
@@ -451,7 +451,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.receiveMessage(1, getOperationContext())
+        connection.receiveMessage(1, createOperationContext())
 
         then:
         thrown(MongoSocketReadException)
@@ -464,7 +464,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.receiveMessage(1, getOperationContext().withTimeoutContext(
+        connection.receiveMessage(1, createOperationContext().withTimeoutContext(
                 new TimeoutContext(TIMEOUT_SETTINGS_WITH_INFINITE_TIMEOUT)))
 
         then:
@@ -482,7 +482,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.receiveMessage(1, getOperationContext().withTimeoutContext(
+        connection.receiveMessage(1, createOperationContext().withTimeoutContext(
                 new TimeoutContext(TIMEOUT_SETTINGS_WITH_INFINITE_TIMEOUT)))
 
         then:
@@ -502,7 +502,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
         def connection = getOpenedConnection()
         def callback = new FutureResultCallback()
-        def operationContext = getOperationContext().withTimeoutContext(
+        def operationContext = createOperationContext().withTimeoutContext(
                 new TimeoutContext(TIMEOUT_SETTINGS_WITH_INFINITE_TIMEOUT))
         when:
         connection.receiveMessageAsync(1, operationContext, callback)
@@ -525,7 +525,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
         def connection = getOpenedConnection()
         def callback = new FutureResultCallback()
-        def operationContext = getOperationContext().withTimeoutContext(
+        def operationContext = createOperationContext().withTimeoutContext(
                 new TimeoutContext(TIMEOUT_SETTINGS_WITH_INFINITE_TIMEOUT))
         when:
         connection.receiveMessageAsync(1, operationContext, callback)
@@ -563,10 +563,10 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.sendMessageAsync(buffers1, messageId1, getOperationContext(), sndCallbck1)
-        connection.sendMessageAsync(buffers2, messageId2, getOperationContext(), sndCallbck2)
-        connection.receiveMessageAsync(messageId1, getOperationContext(), rcvdCallbck1)
-        connection.receiveMessageAsync(messageId2, getOperationContext(), rcvdCallbck2)
+        connection.sendMessageAsync(buffers1, messageId1, createOperationContext(), sndCallbck1)
+        connection.sendMessageAsync(buffers2, messageId2, createOperationContext(), sndCallbck2)
+        connection.receiveMessageAsync(messageId1, createOperationContext(), rcvdCallbck1)
+        connection.receiveMessageAsync(messageId2, createOperationContext(), rcvdCallbck2)
         rcvdCallbck1.get(1, SECONDS)
 
         then:
@@ -588,14 +588,14 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.receiveMessage(1, getOperationContext())
+        connection.receiveMessage(1, createOperationContext())
 
         then:
         connection.isClosed()
         thrown MongoSocketReadException
 
         when:
-        connection.receiveMessage(1, getOperationContext())
+        connection.receiveMessage(1, createOperationContext())
 
         then:
         thrown MongoSocketClosedException
@@ -620,9 +620,9 @@ class InternalStreamConnectionSpecification extends Specification {
         def connection = getOpenedConnection()
 
         when:
-        connection.sendMessageAsync(buffers1, messageId1, getOperationContext(), sndCallbck1)
-        connection.sendMessageAsync(buffers2, messageId2, getOperationContext(), sndCallbck2)
-        connection.receiveMessageAsync(messageId1, getOperationContext(), rcvdCallbck1)
+        connection.sendMessageAsync(buffers1, messageId1, createOperationContext(), sndCallbck1)
+        connection.sendMessageAsync(buffers2, messageId2, createOperationContext(), sndCallbck2)
+        connection.receiveMessageAsync(messageId1, createOperationContext(), rcvdCallbck1)
         rcvdCallbck1.get(1, SECONDS)
 
         then:
@@ -630,7 +630,7 @@ class InternalStreamConnectionSpecification extends Specification {
         connection.isClosed()
 
         when:
-        connection.receiveMessageAsync(messageId2, getOperationContext(), rcvdCallbck2)
+        connection.receiveMessageAsync(messageId2, createOperationContext(), rcvdCallbck2)
         rcvdCallbck2.get(1, SECONDS)
 
         then:
@@ -649,7 +649,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(_, _) >> helper.reply(response)
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), createOperationContext())
 
         then:
         thrown(MongoCommandException)
@@ -677,7 +677,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), createOperationContext(), callback)
         callback.get()
 
         then:
@@ -705,7 +705,7 @@ class InternalStreamConnectionSpecification extends Specification {
         def callbacks = []
         (1..numberOfOperations).each { n ->
             def (buffers, messageId, sndCallbck, rcvdCallbck) = messages.pop()
-            connection.sendMessageAsync(buffers, messageId, getOperationContext(), sndCallbck)
+            connection.sendMessageAsync(buffers, messageId, createOperationContext(), sndCallbck)
             callbacks.add(sndCallbck)
         }
         streamLatch.countDown()
@@ -730,7 +730,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(90, _) >> helper.defaultReply()
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), createOperationContext())
 
         then:
         commandListener.eventsWereDelivered([
@@ -753,7 +753,7 @@ class InternalStreamConnectionSpecification extends Specification {
         when:
         connection.sendAndReceive(commandMessage, {
             BsonReader reader, DecoderContext decoderContext -> throw new CodecConfigurationException('')
-        }, getOperationContext())
+        }, createOperationContext())
 
         then:
         thrown(CodecConfigurationException)
@@ -783,7 +783,7 @@ class InternalStreamConnectionSpecification extends Specification {
             1 * advanceClusterTime(BsonDocument.parse(response).getDocument('$clusterTime'))
             getReadConcern() >> ReadConcern.DEFAULT
         }
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
 
         when:
         connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), operationContext)
@@ -819,7 +819,7 @@ class InternalStreamConnectionSpecification extends Specification {
             1 * advanceClusterTime(BsonDocument.parse(response).getDocument('$clusterTime'))
             getReadConcern() >> ReadConcern.DEFAULT
         }
-        def operationContext = getOperationContext().withSessionContext(sessionContext)
+        def operationContext = createOperationContext().withSessionContext(sessionContext)
 
         when:
         connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), operationContext, callback)
@@ -839,7 +839,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.write(_, _) >> { throw new MongoSocketWriteException('Failed to write', serverAddress, new IOException()) }
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), createOperationContext())
 
         then:
         def e = thrown(MongoSocketWriteException)
@@ -859,7 +859,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(16, _) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), createOperationContext())
 
         then:
         def e = thrown(MongoSocketReadException)
@@ -880,7 +880,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(90, _) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), createOperationContext())
 
         then:
         def e = thrown(MongoSocketException)
@@ -902,7 +902,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(_, _) >> helper.reply(response)
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), createOperationContext())
 
         then:
         def e = thrown(MongoCommandException)
@@ -923,7 +923,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(90, _) >> helper.defaultReply()
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), createOperationContext())
 
         then:
         commandListener.eventsWereDelivered([
@@ -959,7 +959,7 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.read(_, _) >> helper.reply('{ok : 0, errmsg : "failed"}')
 
         when:
-        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), getOperationContext())
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec(), createOperationContext())
 
         then:
         thrown(MongoCommandException)
@@ -1005,7 +1005,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), createOperationContext(), callback)
         callback.get()
 
         then:
@@ -1038,7 +1038,7 @@ class InternalStreamConnectionSpecification extends Specification {
         when:
         connection.sendAndReceiveAsync(commandMessage, {
             BsonReader reader, DecoderContext decoderContext -> throw new CodecConfigurationException('')
-        }, getOperationContext(), callback)
+        }, createOperationContext(), callback)
         callback.get()
 
         then:
@@ -1065,7 +1065,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), createOperationContext(), callback)
         callback.get()
 
         then:
@@ -1093,7 +1093,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), createOperationContext(), callback)
         callback.get()
 
         then:
@@ -1124,7 +1124,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), createOperationContext(), callback)
         callback.get()
 
         then:
@@ -1156,7 +1156,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), createOperationContext(), callback)
         callback.get()
 
         then:
@@ -1187,7 +1187,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), getOperationContext(), callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), createOperationContext(), callback)
         callback.get()
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/JMXConnectionPoolListenerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/JMXConnectionPoolListenerSpecification.groovy
@@ -29,7 +29,7 @@ import spock.lang.Unroll
 import javax.management.ObjectName
 import java.lang.management.ManagementFactory
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_FACTORY
 
 class JMXConnectionPoolListenerSpecification extends Specification {
@@ -50,8 +50,8 @@ class JMXConnectionPoolListenerSpecification extends Specification {
         provider.ready()
 
         when:
-        provider.get(OPERATION_CONTEXT)
-        provider.get(OPERATION_CONTEXT).close()
+        provider.get(getOperationContext())
+        provider.get(getOperationContext()).close()
 
         then:
         with(jmxListener.getMBean(SERVER_ID)) {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/JMXConnectionPoolListenerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/JMXConnectionPoolListenerSpecification.groovy
@@ -29,7 +29,7 @@ import spock.lang.Unroll
 import javax.management.ObjectName
 import java.lang.management.ManagementFactory
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.OPERATION_CONTEXT_FACTORY
 
 class JMXConnectionPoolListenerSpecification extends Specification {
@@ -50,8 +50,8 @@ class JMXConnectionPoolListenerSpecification extends Specification {
         provider.ready()
 
         when:
-        provider.get(getOperationContext())
-        provider.get(getOperationContext()).close()
+        provider.get(createOperationContext())
+        provider.get(createOperationContext()).close()
 
         then:
         with(jmxListener.getMBean(SERVER_ID)) {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoadBalancedClusterTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoadBalancedClusterTest.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA;
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.ClusterFixture.createOperationContext;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -96,14 +96,14 @@ public class LoadBalancedClusterTest {
                 mock(DnsSrvRecordMonitorFactory.class));
 
         // when
-        ServerTuple serverTuple = cluster.selectServer(mock(ServerSelector.class), OPERATION_CONTEXT);
+        ServerTuple serverTuple = cluster.selectServer(mock(ServerSelector.class), getOperationContext());
 
         // then
         assertServerTupleExpectations(serverAddress, expectedServer, serverTuple);
 
         // when
         FutureResultCallback<ServerTuple> callback = new FutureResultCallback<>();
-        cluster.selectServerAsync(mock(ServerSelector.class), OPERATION_CONTEXT, callback);
+        cluster.selectServerAsync(mock(ServerSelector.class), getOperationContext(), callback);
         serverTuple = callback.get();
 
         // then
@@ -131,7 +131,7 @@ public class LoadBalancedClusterTest {
         cluster = new LoadBalancedCluster(new ClusterId(), clusterSettings, serverFactory, CLIENT_METADATA, dnsSrvRecordMonitorFactory);
 
         // when
-        ServerTuple serverTuple = cluster.selectServer(mock(ServerSelector.class), OPERATION_CONTEXT);
+        ServerTuple serverTuple = cluster.selectServer(mock(ServerSelector.class), getOperationContext());
 
         // then
         assertServerTupleExpectations(resolvedServerAddress, expectedServer, serverTuple);
@@ -159,7 +159,7 @@ public class LoadBalancedClusterTest {
 
         // when
         FutureResultCallback<ServerTuple> callback = new FutureResultCallback<>();
-        cluster.selectServerAsync(mock(ServerSelector.class), OPERATION_CONTEXT, callback);
+        cluster.selectServerAsync(mock(ServerSelector.class), getOperationContext(), callback);
         ServerTuple serverTuple = callback.get();
 
         // then
@@ -185,7 +185,7 @@ public class LoadBalancedClusterTest {
         cluster = new LoadBalancedCluster(new ClusterId(), clusterSettings, serverFactory, CLIENT_METADATA, dnsSrvRecordMonitorFactory);
 
         MongoClientException exception = assertThrows(MongoClientException.class, () -> cluster.selectServer(mock(ServerSelector.class),
-                OPERATION_CONTEXT));
+                getOperationContext()));
         assertEquals("In load balancing mode, the host must resolve to a single SRV record, but instead it resolved to multiple hosts",
                 exception.getMessage());
     }
@@ -209,7 +209,7 @@ public class LoadBalancedClusterTest {
         cluster = new LoadBalancedCluster(new ClusterId(), clusterSettings, serverFactory, CLIENT_METADATA, dnsSrvRecordMonitorFactory);
 
         FutureResultCallback<ServerTuple> callback = new FutureResultCallback<>();
-        cluster.selectServerAsync(mock(ServerSelector.class), OPERATION_CONTEXT, callback);
+        cluster.selectServerAsync(mock(ServerSelector.class), getOperationContext(), callback);
 
         MongoClientException exception = assertThrows(MongoClientException.class, callback::get);
         assertEquals("In load balancing mode, the host must resolve to a single SRV record, but instead it resolved to multiple hosts",

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoadBalancedClusterTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoadBalancedClusterTest.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.connection;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoConfigurationException;
 import com.mongodb.MongoException;
@@ -52,7 +53,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA;
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.ClusterFixture.createOperationContext;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -96,14 +96,14 @@ public class LoadBalancedClusterTest {
                 mock(DnsSrvRecordMonitorFactory.class));
 
         // when
-        ServerTuple serverTuple = cluster.selectServer(mock(ServerSelector.class), getOperationContext());
+        ServerTuple serverTuple = cluster.selectServer(mock(ServerSelector.class), ClusterFixture.createOperationContext());
 
         // then
         assertServerTupleExpectations(serverAddress, expectedServer, serverTuple);
 
         // when
         FutureResultCallback<ServerTuple> callback = new FutureResultCallback<>();
-        cluster.selectServerAsync(mock(ServerSelector.class), getOperationContext(), callback);
+        cluster.selectServerAsync(mock(ServerSelector.class), ClusterFixture.createOperationContext(), callback);
         serverTuple = callback.get();
 
         // then
@@ -131,7 +131,7 @@ public class LoadBalancedClusterTest {
         cluster = new LoadBalancedCluster(new ClusterId(), clusterSettings, serverFactory, CLIENT_METADATA, dnsSrvRecordMonitorFactory);
 
         // when
-        ServerTuple serverTuple = cluster.selectServer(mock(ServerSelector.class), getOperationContext());
+        ServerTuple serverTuple = cluster.selectServer(mock(ServerSelector.class), ClusterFixture.createOperationContext());
 
         // then
         assertServerTupleExpectations(resolvedServerAddress, expectedServer, serverTuple);
@@ -159,7 +159,7 @@ public class LoadBalancedClusterTest {
 
         // when
         FutureResultCallback<ServerTuple> callback = new FutureResultCallback<>();
-        cluster.selectServerAsync(mock(ServerSelector.class), getOperationContext(), callback);
+        cluster.selectServerAsync(mock(ServerSelector.class), ClusterFixture.createOperationContext(), callback);
         ServerTuple serverTuple = callback.get();
 
         // then
@@ -185,7 +185,7 @@ public class LoadBalancedClusterTest {
         cluster = new LoadBalancedCluster(new ClusterId(), clusterSettings, serverFactory, CLIENT_METADATA, dnsSrvRecordMonitorFactory);
 
         MongoClientException exception = assertThrows(MongoClientException.class, () -> cluster.selectServer(mock(ServerSelector.class),
-                getOperationContext()));
+                ClusterFixture.createOperationContext()));
         assertEquals("In load balancing mode, the host must resolve to a single SRV record, but instead it resolved to multiple hosts",
                 exception.getMessage());
     }
@@ -209,7 +209,7 @@ public class LoadBalancedClusterTest {
         cluster = new LoadBalancedCluster(new ClusterId(), clusterSettings, serverFactory, CLIENT_METADATA, dnsSrvRecordMonitorFactory);
 
         FutureResultCallback<ServerTuple> callback = new FutureResultCallback<>();
-        cluster.selectServerAsync(mock(ServerSelector.class), getOperationContext(), callback);
+        cluster.selectServerAsync(mock(ServerSelector.class), ClusterFixture.createOperationContext(), callback);
 
         MongoClientException exception = assertThrows(MongoClientException.class, callback::get);
         assertEquals("In load balancing mode, the host must resolve to a single SRV record, but instead it resolved to multiple hosts",

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
@@ -39,7 +39,7 @@ import org.bson.BsonInt32
 import org.bson.BsonString
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.internal.operation.ServerVersionHelper.LATEST_WIRE_VERSION
@@ -63,7 +63,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def logger = Stub(Logger) {
             isDebugEnabled() >> debugLoggingEnabled
         }
-        def operationContext = OPERATION_CONTEXT
+        def operationContext = getOperationContext()
         def sender = new LoggingCommandEventSender([] as Set, [] as Set, connectionDescription, commandListener,
                 operationContext, message, message.getCommandDocument(bsonOutput),
                 new StructuredLogger(logger), LoggerSettings.builder().build())
@@ -109,7 +109,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def logger = Mock(Logger) {
             isDebugEnabled() >> true
         }
-        def operationContext = OPERATION_CONTEXT
+        def operationContext = getOperationContext()
         def sender = new LoggingCommandEventSender([] as Set, [] as Set, connectionDescription, commandListener,
                 operationContext, message, message.getCommandDocument(bsonOutput), new StructuredLogger(logger),
                 LoggerSettings.builder().build())
@@ -166,7 +166,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def logger = Mock(Logger) {
             isDebugEnabled() >> true
         }
-        def operationContext = OPERATION_CONTEXT
+        def operationContext = getOperationContext()
 
         def sender = new LoggingCommandEventSender([] as Set, [] as Set, connectionDescription, null, operationContext,
                 message, message.getCommandDocument(bsonOutput), new StructuredLogger(logger), LoggerSettings.builder().build())
@@ -200,7 +200,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def logger = Mock(Logger) {
             isDebugEnabled() >> true
         }
-        def operationContext = OPERATION_CONTEXT
+        def operationContext = getOperationContext()
         def sender = new LoggingCommandEventSender(['createUser'] as Set, [] as Set, connectionDescription, null,
                 operationContext, message, message.getCommandDocument(bsonOutput), new StructuredLogger(logger),
                 LoggerSettings.builder().build())

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
@@ -39,7 +39,7 @@ import org.bson.BsonInt32
 import org.bson.BsonString
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.internal.operation.ServerVersionHelper.LATEST_WIRE_VERSION
@@ -63,7 +63,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def logger = Stub(Logger) {
             isDebugEnabled() >> debugLoggingEnabled
         }
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
         def sender = new LoggingCommandEventSender([] as Set, [] as Set, connectionDescription, commandListener,
                 operationContext, message, message.getCommandDocument(bsonOutput),
                 new StructuredLogger(logger), LoggerSettings.builder().build())
@@ -109,7 +109,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def logger = Mock(Logger) {
             isDebugEnabled() >> true
         }
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
         def sender = new LoggingCommandEventSender([] as Set, [] as Set, connectionDescription, commandListener,
                 operationContext, message, message.getCommandDocument(bsonOutput), new StructuredLogger(logger),
                 LoggerSettings.builder().build())
@@ -166,7 +166,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def logger = Mock(Logger) {
             isDebugEnabled() >> true
         }
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
 
         def sender = new LoggingCommandEventSender([] as Set, [] as Set, connectionDescription, null, operationContext,
                 message, message.getCommandDocument(bsonOutput), new StructuredLogger(logger), LoggerSettings.builder().build())
@@ -200,7 +200,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
         def logger = Mock(Logger) {
             isDebugEnabled() >> true
         }
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
         def sender = new LoggingCommandEventSender(['createUser'] as Set, [] as Set, connectionDescription, null,
                 operationContext, message, message.getCommandDocument(bsonOutput), new StructuredLogger(logger),
                 LoggerSettings.builder().build())

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/MultiServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/MultiServerClusterSpecification.groovy
@@ -29,7 +29,7 @@ import org.bson.types.ObjectId
 import spock.lang.Specification
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
 import static com.mongodb.connection.ClusterType.REPLICA_SET
 import static com.mongodb.connection.ClusterType.SHARDED
@@ -96,8 +96,8 @@ class MultiServerClusterSpecification extends Specification {
 
         when:
         cluster.getServersSnapshot(
-                OPERATION_CONTEXT.getTimeoutContext().computeServerSelectionTimeout(),
-                OPERATION_CONTEXT.getTimeoutContext())
+                getOperationContext().getTimeoutContext().computeServerSelectionTimeout(),
+                getOperationContext().getTimeoutContext())
 
         then:
         thrown(IllegalStateException)
@@ -386,7 +386,7 @@ class MultiServerClusterSpecification extends Specification {
         cluster.close()
 
         when:
-        cluster.selectServer(new WritableServerSelector(), OPERATION_CONTEXT)
+        cluster.selectServer(new WritableServerSelector(), getOperationContext())
 
         then:
         thrown(IllegalStateException)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/MultiServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/MultiServerClusterSpecification.groovy
@@ -93,11 +93,12 @@ class MultiServerClusterSpecification extends Specification {
         def cluster = new MultiServerCluster(CLUSTER_ID, ClusterSettings.builder().hosts(Arrays.asList(firstServer)).mode(MULTIPLE).build(),
                 factory, CLIENT_METADATA)
         cluster.close()
+        def operationContext = createOperationContext()
 
         when:
         cluster.getServersSnapshot(
-                createOperationContext().getTimeoutContext().computeServerSelectionTimeout(),
-                createOperationContext().getTimeoutContext())
+                operationContext.getTimeoutContext().computeServerSelectionTimeout(),
+                operationContext.getTimeoutContext())
 
         then:
         thrown(IllegalStateException)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/MultiServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/MultiServerClusterSpecification.groovy
@@ -29,7 +29,7 @@ import org.bson.types.ObjectId
 import spock.lang.Specification
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
 import static com.mongodb.connection.ClusterType.REPLICA_SET
 import static com.mongodb.connection.ClusterType.SHARDED
@@ -96,8 +96,8 @@ class MultiServerClusterSpecification extends Specification {
 
         when:
         cluster.getServersSnapshot(
-                getOperationContext().getTimeoutContext().computeServerSelectionTimeout(),
-                getOperationContext().getTimeoutContext())
+                createOperationContext().getTimeoutContext().computeServerSelectionTimeout(),
+                createOperationContext().getTimeoutContext())
 
         then:
         thrown(IllegalStateException)
@@ -386,7 +386,7 @@ class MultiServerClusterSpecification extends Specification {
         cluster.close()
 
         when:
-        cluster.selectServer(new WritableServerSelector(), getOperationContext())
+        cluster.selectServer(new WritableServerSelector(), createOperationContext())
 
         then:
         thrown(IllegalStateException)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/PlainAuthenticatorUnitTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/PlainAuthenticatorUnitTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getServerApi;
 import static com.mongodb.internal.connection.MessageHelper.getApiVersionField;
 import static com.mongodb.internal.connection.MessageHelper.getDbField;
@@ -54,7 +54,7 @@ public class PlainAuthenticatorUnitTest {
     public void testSuccessfulAuthentication() {
         enqueueSuccessfulReply();
 
-        subject.authenticate(connection, connectionDescription, OPERATION_CONTEXT);
+        subject.authenticate(connection, connectionDescription, getOperationContext());
 
         validateMessages();
     }
@@ -64,7 +64,7 @@ public class PlainAuthenticatorUnitTest {
         enqueueSuccessfulReply();
 
         FutureResultCallback<Void> futureCallback = new FutureResultCallback<>();
-        subject.authenticateAsync(connection, connectionDescription, OPERATION_CONTEXT, futureCallback);
+        subject.authenticateAsync(connection, connectionDescription, getOperationContext(), futureCallback);
         futureCallback.get();
 
         validateMessages();

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/PlainAuthenticatorUnitTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/PlainAuthenticatorUnitTest.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.connection;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.async.FutureResultCallback;
@@ -30,7 +31,6 @@ import org.junit.Test;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getServerApi;
 import static com.mongodb.internal.connection.MessageHelper.getApiVersionField;
 import static com.mongodb.internal.connection.MessageHelper.getDbField;
@@ -54,7 +54,7 @@ public class PlainAuthenticatorUnitTest {
     public void testSuccessfulAuthentication() {
         enqueueSuccessfulReply();
 
-        subject.authenticate(connection, connectionDescription, getOperationContext());
+        subject.authenticate(connection, connectionDescription, ClusterFixture.createOperationContext());
 
         validateMessages();
     }
@@ -64,7 +64,7 @@ public class PlainAuthenticatorUnitTest {
         enqueueSuccessfulReply();
 
         FutureResultCallback<Void> futureCallback = new FutureResultCallback<>();
-        subject.authenticateAsync(connection, connectionDescription, getOperationContext(), futureCallback);
+        subject.authenticateAsync(connection, connectionDescription, ClusterFixture.createOperationContext(), futureCallback);
         futureCallback.get();
 
         validateMessages();

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
@@ -25,6 +25,7 @@ import com.mongodb.connection.ServerConnectionState;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.connection.ServerId;
 import com.mongodb.internal.connection.OperationContext.ServerDeprioritization;
+import com.mongodb.internal.mockito.MongoMockito;
 import com.mongodb.selector.ServerSelector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -48,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.of;
+import static org.mockito.ArgumentMatchers.any;
 
 final class ServerDeprioritizationTest {
     private static final ServerDescription SERVER_A = serverDescription("a");
@@ -167,9 +170,9 @@ final class ServerDeprioritizationTest {
                         })
             );
         assertAll(
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selectorSupplier.get()).select(SHARDED_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selectorSupplier.get()).select(REPLICA_SET_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selectorSupplier.get()).select(UNKNOWN_CLUSTER))
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(selectorSupplier.get()).select(SHARDED_CLUSTER)),
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(selectorSupplier.get()).select(REPLICA_SET_CLUSTER)),
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(selectorSupplier.get()).select(UNKNOWN_CLUSTER))
         );
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
@@ -80,6 +80,7 @@ final class ServerDeprioritizationTest {
                 of(Named.of(generateArgumentName(ALL_SERVERS), ALL_SERVERS))
         );
     }
+
     @ParameterizedTest
     @MethodSource
     void selectNoneDeprioritized(final List<ServerDescription> selectorResult) {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
@@ -155,26 +155,21 @@ final class ServerDeprioritizationTest {
     @MethodSource("selectSomeDeprioritized")
     void selectWithRetryWhenWrappedReturnsEmpty(final List<ServerDescription> selectorResult) {
         deprioritize(SERVER_B);
-        Supplier<ServerSelector> selector = () -> new ServerSelector() {
-            private boolean firstCall = true;
-
-            @Override
-            public List<ServerDescription> select(final ClusterDescription clusterDescription) {
-                List<ServerDescription> servers = clusterDescription.getServerDescriptions();
-                if (firstCall) {
-                    firstCall = false;
-                    assertEquals(asList(SERVER_A, SERVER_C), servers);
-                    return emptyList();
-                }
-                assertEquals(ALL_SERVERS, servers);
-                return selectorResult;
-            }
-        };
-
+        Supplier<ServerSelector> selectorSupplier = () -> MongoMockito.mock(ServerSelector.class, tuner ->
+                Mockito.when(tuner.select(any(ClusterDescription.class)))
+                        .thenAnswer(invocation -> {
+                            assertEquals(asList(SERVER_A, SERVER_C), invocation.<ClusterDescription>getArgument(0).getServerDescriptions());
+                            return emptyList();
+                        })
+                        .thenAnswer(invocation -> {
+                            assertEquals(ALL_SERVERS, invocation.<ClusterDescription>getArgument(0).getServerDescriptions());
+                            return selectorResult;
+                        })
+            );
         assertAll(
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector.get()).select(SHARDED_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector.get()).select(REPLICA_SET_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector.get()).select(UNKNOWN_CLUSTER))
+                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selectorSupplier.get()).select(SHARDED_CLUSTER)),
+                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selectorSupplier.get()).select(REPLICA_SET_CLUSTER)),
+                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selectorSupplier.get()).select(UNKNOWN_CLUSTER))
         );
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
@@ -210,18 +210,19 @@ final class ServerDeprioritizationTest {
     @ParameterizedTest
     @EnumSource(value = ClusterType.class, names = "SHARDED", mode = EnumSource.Mode.EXCLUDE)
     void onAttemptFailureIgnoresIfNonShardedWithoutOverloadError(final ClusterType clusterType) {
+        ClusterDescription cluster = multipleModeClusterDescription(clusterType);
         ServerSelector selector = createAssertingSelector(ALL_SERVERS, singletonList(SERVER_A));
 
         assertAll(() -> {
                     serverDeprioritization.updateCandidate(SERVER_B.getAddress(), clusterType);
                     serverDeprioritization.onAttemptFailure(new RuntimeException());
-                    assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(selector).select(SHARDED_CLUSTER),
+                    assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(selector).select(cluster),
                             "Expected no deprioritization for " + clusterType + " with RuntimeException");
                 }, () -> {
                     serverDeprioritization = createOperationContext(TIMEOUT_SETTINGS).getServerDeprioritization();
                     serverDeprioritization.updateCandidate(SERVER_B.getAddress(), clusterType);
                     serverDeprioritization.onAttemptFailure(new MongoException(1, "error"));
-                    assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(selector).select(SHARDED_CLUSTER),
+                    assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(selector).select(cluster),
                             "Expected no deprioritization for " + clusterType + " with no SystemOverloadedError MongoException");
                 }
         );

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
@@ -16,6 +16,7 @@
 package com.mongodb.internal.connection;
 
 import com.mongodb.MongoConnectionPoolClearedException;
+import com.mongodb.MongoException;
 import com.mongodb.ServerAddress;
 import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.connection.ClusterDescription;
@@ -32,11 +33,11 @@ import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.util.List;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -59,10 +60,8 @@ final class ServerDeprioritizationTest {
     private static final List<ServerDescription> ALL_SERVERS = unmodifiableList(asList(SERVER_A, SERVER_B, SERVER_C));
     private static final ClusterDescription REPLICA_SET_CLUSTER = multipleModeClusterDescription(ClusterType.REPLICA_SET);
     private static final ClusterDescription SHARDED_CLUSTER = multipleModeClusterDescription(ClusterType.SHARDED);
-    private static final ClusterDescription LOAD_BALANCED_CLUSTER = singleModeClusterDescription(ClusterType.LOAD_BALANCED);
-    private static final ClusterDescription STANDALONE_CLUSTER = singleModeClusterDescription(ClusterType.STANDALONE);
     private static final ClusterDescription UNKNOWN_CLUSTER = multipleModeClusterDescription(ClusterType.UNKNOWN);
-
+    private static final List<ClusterDescription> CLUSTERS = asList(SHARDED_CLUSTER, REPLICA_SET_CLUSTER, UNKNOWN_CLUSTER);
     private ServerDeprioritization serverDeprioritization;
 
     @BeforeEach
@@ -71,94 +70,116 @@ final class ServerDeprioritizationTest {
     }
 
     private static Stream<Arguments> selectNoneDeprioritized() {
-        return Stream.of(
-                of(Named.of(generateArgumentName(emptyList()), emptyList())),
-                of(Named.of(generateArgumentName(singletonList(SERVER_A)), singletonList(SERVER_A))),
-                of(Named.of(generateArgumentName(singletonList(SERVER_B)), singletonList(SERVER_B))),
-                of(Named.of(generateArgumentName(singletonList(SERVER_C)), singletonList(SERVER_C))),
-                of(Named.of(generateArgumentName(asList(SERVER_A, SERVER_B)), asList(SERVER_A, SERVER_B))),
-                of(Named.of(generateArgumentName(asList(SERVER_B, SERVER_A)), asList(SERVER_B, SERVER_A))),
-                of(Named.of(generateArgumentName(asList(SERVER_A, SERVER_C)), asList(SERVER_A, SERVER_C))),
-                of(Named.of(generateArgumentName(asList(SERVER_C, SERVER_A)), asList(SERVER_C, SERVER_A))),
-                of(Named.of(generateArgumentName(ALL_SERVERS), ALL_SERVERS))
-        );
+        return CLUSTERS.stream().flatMap(clusterDescription ->
+                Stream.of(
+                        namedArguments(clusterDescription),
+                        namedArguments(clusterDescription, SERVER_A),
+                        namedArguments(clusterDescription, SERVER_B),
+                        namedArguments(clusterDescription, SERVER_C),
+                        namedArguments(clusterDescription, SERVER_A, SERVER_B),
+                        namedArguments(clusterDescription, SERVER_B, SERVER_A),
+                        namedArguments(clusterDescription, SERVER_A, SERVER_C),
+                        namedArguments(clusterDescription, SERVER_C, SERVER_A),
+                        namedArguments(clusterDescription, SERVER_A, SERVER_B, SERVER_C)
+                ));
     }
 
     @ParameterizedTest
     @MethodSource
-    void selectNoneDeprioritized(final List<ServerDescription> selectorResult) {
+    void selectNoneDeprioritized(final ClusterDescription clusterDescription, final List<ServerDescription> selectorResult) {
         ServerSelector wrappedSelector = createAssertingSelector(ALL_SERVERS, selectorResult);
-        assertAll(
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(wrappedSelector).select(SHARDED_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(wrappedSelector).select(REPLICA_SET_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(wrappedSelector).select(UNKNOWN_CLUSTER))
-        );
+        assertEquals(selectorResult, serverDeprioritization.apply(wrappedSelector).select(clusterDescription));
     }
 
-    @Test
-    void selectNoneDeprioritizedSingleServerCluster() {
+    @ParameterizedTest
+    @EnumSource(value = ClusterType.class, names = {"STANDALONE", "LOAD_BALANCED"})
+    void selectNoneDeprioritizedSingleServerCluster(final ClusterType clusterType) {
+        ClusterDescription cluster = singleModeClusterDescription(clusterType);
         ServerSelector wrappedSelector = createAssertingSelector(singletonList(SERVER_A), singletonList(SERVER_A));
         ServerSelector emptyListWrappedSelector = createAssertingSelector(singletonList(SERVER_A), emptyList());
         assertAll(
-                () -> assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(wrappedSelector).select(STANDALONE_CLUSTER)),
-                () -> assertEquals(emptyList(), serverDeprioritization.apply(emptyListWrappedSelector).select(STANDALONE_CLUSTER)),
-                () -> assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(wrappedSelector).select(LOAD_BALANCED_CLUSTER)),
-                () -> assertEquals(emptyList(), serverDeprioritization.apply(emptyListWrappedSelector).select(LOAD_BALANCED_CLUSTER))
+                () -> assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(wrappedSelector).select(cluster)),
+                () -> assertEquals(emptyList(), serverDeprioritization.apply(emptyListWrappedSelector).select(cluster))
         );
     }
 
-   private static Stream<Arguments> selectSomeDeprioritized() {
+    private static Stream<Arguments> deprioritizableClusters() {
         return Stream.of(
-                of(Named.of(generateArgumentName(singletonList(SERVER_A)), singletonList(SERVER_A))),
-                of(Named.of(generateArgumentName(singletonList(SERVER_C)), singletonList(SERVER_C))),
-                of(Named.of(generateArgumentName(asList(SERVER_A, SERVER_C)), asList(SERVER_A, SERVER_C))),
-                of(Named.of(generateArgumentName(asList(SERVER_C, SERVER_A)), asList(SERVER_C, SERVER_A)))
+                of(SHARDED_CLUSTER, new RuntimeException()),
+                of(SHARDED_CLUSTER, new MongoException(0, "test")),
+                of(REPLICA_SET_CLUSTER, createSystemOverloadedError()),
+                of(UNKNOWN_CLUSTER, createSystemOverloadedError())
         );
+    }
+
+    private static Stream<Arguments> selectSomeDeprioritized() {
+        return deprioritizableClusters().flatMap(args -> {
+            ClusterDescription clusterDescription = (ClusterDescription) args.get()[0];
+            Throwable exception = (Throwable) args.get()[1];
+            return Stream.of(
+                    namedArguments(clusterDescription, exception, SERVER_A),
+                    namedArguments(clusterDescription, exception, SERVER_C),
+                    namedArguments(clusterDescription, exception, SERVER_A, SERVER_C),
+                    namedArguments(clusterDescription, exception, SERVER_C, SERVER_A)
+            );
+        });
     }
 
     @ParameterizedTest
     @MethodSource
-    void selectSomeDeprioritized(final List<ServerDescription> selectorResult) {
-        deprioritize(SERVER_B);
+    void selectSomeDeprioritized(final ClusterDescription clusterDescription, final Throwable exception,
+                                 final List<ServerDescription> selectorResult) {
+        deprioritize(clusterDescription.getType(), exception, SERVER_B);
         List<ServerDescription> expectedWrappedSelectorFilteredInput = asList(SERVER_A, SERVER_C);
-        ServerSelector selector = createAssertingSelector(expectedWrappedSelectorFilteredInput, selectorResult);
-        assertAll(
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector).select(SHARDED_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector).select(REPLICA_SET_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector).select(UNKNOWN_CLUSTER))
-        );
+        ServerSelector wrappedSelector = createAssertingSelector(expectedWrappedSelectorFilteredInput, selectorResult);
+        assertEquals(selectorResult, serverDeprioritization.apply(wrappedSelector).select(clusterDescription));
+    }
+
+    private static Stream<Arguments> selectAllDeprioritized() {
+        return deprioritizableClusters().flatMap(args -> {
+            ClusterDescription clusterDescription = (ClusterDescription) args.get()[0];
+            Throwable exception = (Throwable) args.get()[1];
+            return Stream.of(
+                    namedArguments(clusterDescription, exception),
+                    namedArguments(clusterDescription, exception, SERVER_A),
+                    namedArguments(clusterDescription, exception, SERVER_B),
+                    namedArguments(clusterDescription, exception, SERVER_C),
+                    namedArguments(clusterDescription, exception, SERVER_A, SERVER_B),
+                    namedArguments(clusterDescription, exception, SERVER_B, SERVER_A),
+                    namedArguments(clusterDescription, exception, SERVER_A, SERVER_C),
+                    namedArguments(clusterDescription, exception, SERVER_C, SERVER_A),
+                    namedArguments(clusterDescription, exception, SERVER_A, SERVER_B, SERVER_C)
+            );
+        });
     }
 
     @ParameterizedTest
-    @MethodSource("selectNoneDeprioritized")
-    void selectAllDeprioritized(final List<ServerDescription> selectorResult) {
-        deprioritize(SERVER_A);
-        deprioritize(SERVER_B);
-        deprioritize(SERVER_C);
+    @MethodSource
+    void selectAllDeprioritized(final ClusterDescription clusterDescription, final Throwable exception,
+                                final List<ServerDescription> selectorResult) {
+        deprioritize(clusterDescription.getType(), exception, SERVER_A);
+        deprioritize(clusterDescription.getType(), exception, SERVER_B);
+        deprioritize(clusterDescription.getType(), exception, SERVER_C);
         ServerSelector selector = createAssertingSelector(ALL_SERVERS, selectorResult);
-        assertAll(
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector).select(SHARDED_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector).select(REPLICA_SET_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector).select(UNKNOWN_CLUSTER))
-        );
+        assertEquals(selectorResult, serverDeprioritization.apply(selector).select(clusterDescription));
     }
 
-    @Test
-    void selectAllDeprioritizedSingleServerCluster() {
-        deprioritize(SERVER_A);
+    @ParameterizedTest
+    @EnumSource(value = ClusterType.class, names = {"STANDALONE", "LOAD_BALANCED"})
+    void selectAllDeprioritizedSingleServerCluster(final ClusterType clusterType) {
+        ClusterDescription cluster = singleModeClusterDescription(clusterType);
+        deprioritize(clusterType, createSystemOverloadedError(), SERVER_A);
         ServerSelector selector = createAssertingSelector(singletonList(SERVER_A), singletonList(SERVER_A));
-        assertAll(
-                () -> assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(selector).select(STANDALONE_CLUSTER)),
-                () -> assertEquals(singletonList(SERVER_A),
-                        serverDeprioritization.apply(selector).select(LOAD_BALANCED_CLUSTER))
-        );
+        assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(selector).select(cluster));
     }
 
     @ParameterizedTest
     @MethodSource("selectSomeDeprioritized")
-    void selectWithRetryWhenWrappedReturnsEmpty(final List<ServerDescription> selectorResult) {
-        deprioritize(SERVER_B);
-        Supplier<ServerSelector> selectorSupplier = () -> MongoMockito.mock(ServerSelector.class, tuner ->
+    void selectWithRetryWhenWrappedReturnsEmpty(final ClusterDescription clusterDescription,
+                                                final Throwable exception,
+                                                final List<ServerDescription> selectorResult) {
+        deprioritize(clusterDescription.getType(), exception, SERVER_B);
+        ServerSelector selector = MongoMockito.mock(ServerSelector.class, tuner ->
                 Mockito.when(tuner.select(any(ClusterDescription.class)))
                         .thenAnswer(invocation -> {
                             assertEquals(asList(SERVER_A, SERVER_C), invocation.<ClusterDescription>getArgument(0).getServerDescriptions());
@@ -168,17 +189,13 @@ final class ServerDeprioritizationTest {
                             assertEquals(ALL_SERVERS, invocation.<ClusterDescription>getArgument(0).getServerDescriptions());
                             return selectorResult;
                         })
-            );
-        assertAll(
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(selectorSupplier.get()).select(SHARDED_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(selectorSupplier.get()).select(REPLICA_SET_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.apply(selectorSupplier.get()).select(UNKNOWN_CLUSTER))
         );
+        assertEquals(selectorResult, serverDeprioritization.apply(selector).select(clusterDescription));
     }
 
     @Test
     void onAttemptFailureIgnoresIfPoolClearedException() {
-        serverDeprioritization.updateCandidate(SERVER_A.getAddress());
+        serverDeprioritization.updateCandidate(SERVER_A.getAddress(), ClusterType.SHARDED);
         serverDeprioritization.onAttemptFailure(
                 new MongoConnectionPoolClearedException(new ServerId(new ClusterId(), new ServerAddress()), null));
         ServerSelector selector = createAssertingSelector(ALL_SERVERS, ALL_SERVERS);
@@ -190,10 +207,30 @@ final class ServerDeprioritizationTest {
         assertDoesNotThrow(() -> serverDeprioritization.onAttemptFailure(new RuntimeException()));
     }
 
-    private void deprioritize(final ServerDescription... serverDescriptions) {
+    @ParameterizedTest
+    @EnumSource(value = ClusterType.class, names = "SHARDED", mode = EnumSource.Mode.EXCLUDE)
+    void onAttemptFailureIgnoresIfNonShardedWithoutOverloadError(final ClusterType clusterType) {
+        ServerSelector selector = createAssertingSelector(ALL_SERVERS, singletonList(SERVER_A));
+
+        assertAll(() -> {
+                    serverDeprioritization.updateCandidate(SERVER_B.getAddress(), clusterType);
+                    serverDeprioritization.onAttemptFailure(new RuntimeException());
+                    assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(selector).select(SHARDED_CLUSTER),
+                            "Expected no deprioritization for " + clusterType + " with RuntimeException");
+                }, () -> {
+                    serverDeprioritization = createOperationContext(TIMEOUT_SETTINGS).getServerDeprioritization();
+                    serverDeprioritization.updateCandidate(SERVER_B.getAddress(), clusterType);
+                    serverDeprioritization.onAttemptFailure(new MongoException(1, "error"));
+                    assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(selector).select(SHARDED_CLUSTER),
+                            "Expected no deprioritization for " + clusterType + " with no SystemOverloadedError MongoException");
+                }
+        );
+    }
+
+    private void deprioritize(final ClusterType clusterType, final Throwable exception, final ServerDescription... serverDescriptions) {
         for (ServerDescription serverDescription : serverDescriptions) {
-            serverDeprioritization.updateCandidate(serverDescription.getAddress());
-            serverDeprioritization.onAttemptFailure(new RuntimeException());
+            serverDeprioritization.updateCandidate(serverDescription.getAddress(), clusterType);
+            serverDeprioritization.onAttemptFailure(exception);
         }
     }
 
@@ -222,10 +259,31 @@ final class ServerDeprioritizationTest {
         return new ClusterDescription(ClusterConnectionMode.SINGLE, clusterType, singletonList(SERVER_A));
     }
 
+    private static MongoException createSystemOverloadedError() {
+        MongoException e = new MongoException(6, "overloaded");
+        e.addLabel("SystemOverloadedError");
+        return e;
+    }
+
+    private static Arguments namedArguments(final ClusterDescription clusterDescription, final ServerDescription... serverDescriptions) {
+        return of(Named.of(generateArgumentName(clusterDescription), clusterDescription),
+                Named.of(generateArgumentName(asList(serverDescriptions)), asList(serverDescriptions)));
+    }
+
+    private static Arguments namedArguments(final ClusterDescription clusterDescription, final Throwable exception, final ServerDescription... serverDescriptions) {
+        return of(Named.of(generateArgumentName(clusterDescription), clusterDescription),
+                exception,
+                Named.of(generateArgumentName(asList(serverDescriptions)), asList(serverDescriptions)));
+    }
+
     private static String generateArgumentName(final List<ServerDescription> servers) {
         return "[" + servers.stream()
                 .map(ServerDescription::getAddress)
                 .map(ServerAddress::getHost)
                 .collect(Collectors.joining(", ")) + "]";
+    }
+
+    private static String generateArgumentName(final ClusterDescription clusterDescription) {
+        return "[" + clusterDescription.getType() + ", " + generateArgumentName(clusterDescription.getServerDescriptions()) + "]";
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
@@ -183,8 +183,8 @@ final class ServerDeprioritizationTest {
         serverDeprioritization.updateCandidate(SERVER_A.getAddress());
         serverDeprioritization.onAttemptFailure(
                 new MongoConnectionPoolClearedException(new ServerId(new ClusterId(), new ServerAddress()), null));
-        ServerSelector selector = createAssertingSelector(ALL_SERVERS, singletonList(SERVER_A));
-        assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(selector).select(SHARDED_CLUSTER));
+        ServerSelector selector = createAssertingSelector(ALL_SERVERS, ALL_SERVERS);
+        assertEquals(ALL_SERVERS, serverDeprioritization.apply(selector).select(SHARDED_CLUSTER));
     }
 
     @Test

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDeprioritizationTest.java
@@ -85,9 +85,9 @@ final class ServerDeprioritizationTest {
     void selectNoneDeprioritized(final List<ServerDescription> selectorResult) {
         ServerSelector wrappedSelector = createAssertingSelector(ALL_SERVERS, selectorResult);
         assertAll(
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(wrappedSelector).select(SHARDED_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(wrappedSelector).select(REPLICA_SET_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(wrappedSelector).select(UNKNOWN_CLUSTER))
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(wrappedSelector).select(SHARDED_CLUSTER)),
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(wrappedSelector).select(REPLICA_SET_CLUSTER)),
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(wrappedSelector).select(UNKNOWN_CLUSTER))
         );
     }
 
@@ -96,10 +96,10 @@ final class ServerDeprioritizationTest {
         ServerSelector wrappedSelector = createAssertingSelector(singletonList(SERVER_A), singletonList(SERVER_A));
         ServerSelector emptyListWrappedSelector = createAssertingSelector(singletonList(SERVER_A), emptyList());
         assertAll(
-                () -> assertEquals(singletonList(SERVER_A), serverDeprioritization.applyDeprioritization(wrappedSelector).select(STANDALONE_CLUSTER)),
-                () -> assertEquals(emptyList(), serverDeprioritization.applyDeprioritization(emptyListWrappedSelector).select(STANDALONE_CLUSTER)),
-                () -> assertEquals(singletonList(SERVER_A), serverDeprioritization.applyDeprioritization(wrappedSelector).select(LOAD_BALANCED_CLUSTER)),
-                () -> assertEquals(emptyList(), serverDeprioritization.applyDeprioritization(emptyListWrappedSelector).select(LOAD_BALANCED_CLUSTER))
+                () -> assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(wrappedSelector).select(STANDALONE_CLUSTER)),
+                () -> assertEquals(emptyList(), serverDeprioritization.apply(emptyListWrappedSelector).select(STANDALONE_CLUSTER)),
+                () -> assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(wrappedSelector).select(LOAD_BALANCED_CLUSTER)),
+                () -> assertEquals(emptyList(), serverDeprioritization.apply(emptyListWrappedSelector).select(LOAD_BALANCED_CLUSTER))
         );
     }
 
@@ -119,9 +119,9 @@ final class ServerDeprioritizationTest {
         List<ServerDescription> expectedWrappedSelectorFilteredInput = asList(SERVER_A, SERVER_C);
         ServerSelector selector = createAssertingSelector(expectedWrappedSelectorFilteredInput, selectorResult);
         assertAll(
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selector).select(SHARDED_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selector).select(REPLICA_SET_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selector).select(UNKNOWN_CLUSTER))
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector).select(SHARDED_CLUSTER)),
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector).select(REPLICA_SET_CLUSTER)),
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector).select(UNKNOWN_CLUSTER))
         );
     }
 
@@ -133,9 +133,9 @@ final class ServerDeprioritizationTest {
         deprioritize(SERVER_C);
         ServerSelector selector = createAssertingSelector(ALL_SERVERS, selectorResult);
         assertAll(
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selector).select(SHARDED_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selector).select(REPLICA_SET_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selector).select(UNKNOWN_CLUSTER))
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector).select(SHARDED_CLUSTER)),
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector).select(REPLICA_SET_CLUSTER)),
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector).select(UNKNOWN_CLUSTER))
         );
     }
 
@@ -144,9 +144,9 @@ final class ServerDeprioritizationTest {
         deprioritize(SERVER_A);
         ServerSelector selector = createAssertingSelector(singletonList(SERVER_A), singletonList(SERVER_A));
         assertAll(
-                () -> assertEquals(singletonList(SERVER_A), serverDeprioritization.applyDeprioritization(selector).select(STANDALONE_CLUSTER)),
+                () -> assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(selector).select(STANDALONE_CLUSTER)),
                 () -> assertEquals(singletonList(SERVER_A),
-                        serverDeprioritization.applyDeprioritization(selector).select(LOAD_BALANCED_CLUSTER))
+                        serverDeprioritization.apply(selector).select(LOAD_BALANCED_CLUSTER))
         );
     }
 
@@ -171,9 +171,9 @@ final class ServerDeprioritizationTest {
         };
 
         assertAll(
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selector.get()).select(SHARDED_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selector.get()).select(REPLICA_SET_CLUSTER)),
-                () -> assertEquals(selectorResult, serverDeprioritization.applyDeprioritization(selector.get()).select(UNKNOWN_CLUSTER))
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector.get()).select(SHARDED_CLUSTER)),
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector.get()).select(REPLICA_SET_CLUSTER)),
+                () -> assertEquals(selectorResult, serverDeprioritization.apply(selector.get()).select(UNKNOWN_CLUSTER))
         );
     }
 
@@ -183,7 +183,7 @@ final class ServerDeprioritizationTest {
         serverDeprioritization.onAttemptFailure(
                 new MongoConnectionPoolClearedException(new ServerId(new ClusterId(), new ServerAddress()), null));
         ServerSelector selector = createAssertingSelector(ALL_SERVERS, singletonList(SERVER_A));
-        assertEquals(singletonList(SERVER_A), serverDeprioritization.applyDeprioritization(selector).select(SHARDED_CLUSTER));
+        assertEquals(singletonList(SERVER_A), serverDeprioritization.apply(selector).select(SHARDED_CLUSTER));
     }
 
     @Test

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringTest.java
@@ -32,7 +32,7 @@ import org.junit.runners.Parameterized;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getClusterDescription;
 import static com.mongodb.internal.connection.ClusterDescriptionHelper.getPrimaries;
 import static com.mongodb.internal.event.EventListenerHelper.NO_OP_CLUSTER_LISTENER;
@@ -154,9 +154,9 @@ public class ServerDiscoveryAndMonitoringTest extends AbstractServerDiscoveryAnd
 
         if (expectedServerDescriptionDocument.isDocument("pool")) {
             int expectedGeneration = expectedServerDescriptionDocument.getDocument("pool").getNumber("generation").intValue();
-            Timeout serverSelectionTimeout = OPERATION_CONTEXT.getTimeoutContext().computeServerSelectionTimeout();
+            Timeout serverSelectionTimeout = getOperationContext().getTimeoutContext().computeServerSelectionTimeout();
             DefaultServer server = (DefaultServer) getCluster()
-                    .getServersSnapshot(serverSelectionTimeout, OPERATION_CONTEXT.getTimeoutContext())
+                    .getServersSnapshot(serverSelectionTimeout, getOperationContext().getTimeoutContext())
                     .getServer(new ServerAddress(serverName));
             assertEquals(expectedGeneration, server.getConnectionPool().getGeneration());
         }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringTest.java
@@ -154,9 +154,10 @@ public class ServerDiscoveryAndMonitoringTest extends AbstractServerDiscoveryAnd
 
         if (expectedServerDescriptionDocument.isDocument("pool")) {
             int expectedGeneration = expectedServerDescriptionDocument.getDocument("pool").getNumber("generation").intValue();
-            Timeout serverSelectionTimeout = ClusterFixture.createOperationContext().getTimeoutContext().computeServerSelectionTimeout();
+            OperationContext operationContext = ClusterFixture.createOperationContext();
+            Timeout serverSelectionTimeout = operationContext.getTimeoutContext().computeServerSelectionTimeout();
             DefaultServer server = (DefaultServer) getCluster()
-                    .getServersSnapshot(serverSelectionTimeout, ClusterFixture.createOperationContext().getTimeoutContext())
+                    .getServersSnapshot(serverSelectionTimeout, operationContext.getTimeoutContext())
                     .getServer(new ServerAddress(serverName));
             assertEquals(expectedGeneration, server.getConnectionPool().getGeneration());
         }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerDiscoveryAndMonitoringTest.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.connection;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.ServerAddress;
 import com.mongodb.connection.ClusterType;
 import com.mongodb.connection.ServerDescription;
@@ -32,7 +33,6 @@ import org.junit.runners.Parameterized;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getClusterDescription;
 import static com.mongodb.internal.connection.ClusterDescriptionHelper.getPrimaries;
 import static com.mongodb.internal.event.EventListenerHelper.NO_OP_CLUSTER_LISTENER;
@@ -154,9 +154,9 @@ public class ServerDiscoveryAndMonitoringTest extends AbstractServerDiscoveryAnd
 
         if (expectedServerDescriptionDocument.isDocument("pool")) {
             int expectedGeneration = expectedServerDescriptionDocument.getDocument("pool").getNumber("generation").intValue();
-            Timeout serverSelectionTimeout = getOperationContext().getTimeoutContext().computeServerSelectionTimeout();
+            Timeout serverSelectionTimeout = ClusterFixture.createOperationContext().getTimeoutContext().computeServerSelectionTimeout();
             DefaultServer server = (DefaultServer) getCluster()
-                    .getServersSnapshot(serverSelectionTimeout, getOperationContext().getTimeoutContext())
+                    .getServersSnapshot(serverSelectionTimeout, ClusterFixture.createOperationContext().getTimeoutContext())
                     .getServer(new ServerAddress(serverName));
             assertEquals(expectedGeneration, server.getConnectionPool().getGeneration());
         }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerSelectionSelectionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerSelectionSelectionTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.mongodb.connection;
+package com.mongodb.internal.connection;
 
 import com.mongodb.ClusterFixture;
 import com.mongodb.MongoConfigurationException;
@@ -25,14 +25,17 @@ import com.mongodb.ServerAddress;
 import com.mongodb.Tag;
 import com.mongodb.TagSet;
 import com.mongodb.assertions.Assertions;
+import com.mongodb.connection.ClusterConnectionMode;
+import com.mongodb.connection.ClusterDescription;
+import com.mongodb.connection.ClusterId;
+import com.mongodb.connection.ClusterSettings;
+import com.mongodb.connection.ClusterType;
+import com.mongodb.connection.ServerConnectionState;
+import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.ServerSettings;
+import com.mongodb.connection.ServerType;
 import com.mongodb.event.ServerDescriptionChangedEvent;
 import com.mongodb.internal.TimeoutContext;
-import com.mongodb.internal.connection.BaseCluster;
-import com.mongodb.internal.connection.Cluster;
-import com.mongodb.internal.connection.OperationContext;
-import com.mongodb.internal.connection.Server;
-import com.mongodb.internal.connection.ServerTuple;
-import com.mongodb.internal.connection.TestClusterableServerFactory;
 import com.mongodb.internal.mockito.MongoMockito;
 import com.mongodb.internal.selector.ReadPreferenceServerSelector;
 import com.mongodb.internal.selector.WritableServerSelector;

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ServerSelectionWithinLatencyWindowTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ServerSelectionWithinLatencyWindowTest.java
@@ -43,7 +43,7 @@ import java.util.stream.IntStream;
 
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS;
 import static com.mongodb.ClusterFixture.createOperationContext;
-import static com.mongodb.connection.ServerSelectionSelectionTest.buildClusterDescription;
+import static com.mongodb.internal.connection.ServerSelectionSelectionTest.buildClusterDescription;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertEquals;

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/SingleServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/SingleServerClusterSpecification.groovy
@@ -29,7 +29,7 @@ import com.mongodb.internal.selector.WritableServerSelector
 import spock.lang.Specification
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.connection.ClusterType.REPLICA_SET
 import static com.mongodb.connection.ClusterType.UNKNOWN
@@ -78,10 +78,10 @@ class SingleServerClusterSpecification extends Specification {
         sendNotification(firstServer, STANDALONE)
 
         then:
-        cluster.getServersSnapshot(OPERATION_CONTEXT
+        cluster.getServersSnapshot(getOperationContext()
                         .getTimeoutContext()
                         .computeServerSelectionTimeout(),
-                OPERATION_CONTEXT.getTimeoutContext()).getServer(firstServer) == factory.getServer(firstServer)
+                getOperationContext().getTimeoutContext()).getServer(firstServer) == factory.getServer(firstServer)
 
         cleanup:
         cluster?.close()
@@ -95,8 +95,8 @@ class SingleServerClusterSpecification extends Specification {
         cluster.close()
 
         when:
-        cluster.getServersSnapshot(OPERATION_CONTEXT.getTimeoutContext().computeServerSelectionTimeout(),
-                OPERATION_CONTEXT.getTimeoutContext())
+        cluster.getServersSnapshot(getOperationContext().getTimeoutContext().computeServerSelectionTimeout(),
+                getOperationContext().getTimeoutContext())
 
         then:
         thrown(IllegalStateException)
@@ -146,7 +146,7 @@ class SingleServerClusterSpecification extends Specification {
         sendNotification(firstServer, getBuilder(firstServer).minWireVersion(1000).maxWireVersion(1000).build())
 
         when:
-        cluster.selectServer(new WritableServerSelector(), OPERATION_CONTEXT)
+        cluster.selectServer(new WritableServerSelector(), getOperationContext())
 
         then:
         thrown(MongoIncompatibleDriverException)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/SingleServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/SingleServerClusterSpecification.groovy
@@ -29,7 +29,7 @@ import com.mongodb.internal.selector.WritableServerSelector
 import spock.lang.Specification
 
 import static com.mongodb.ClusterFixture.CLIENT_METADATA
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 import static com.mongodb.connection.ClusterType.REPLICA_SET
 import static com.mongodb.connection.ClusterType.UNKNOWN
@@ -78,10 +78,10 @@ class SingleServerClusterSpecification extends Specification {
         sendNotification(firstServer, STANDALONE)
 
         then:
-        cluster.getServersSnapshot(getOperationContext()
+        cluster.getServersSnapshot(createOperationContext()
                         .getTimeoutContext()
                         .computeServerSelectionTimeout(),
-                getOperationContext().getTimeoutContext()).getServer(firstServer) == factory.getServer(firstServer)
+                createOperationContext().getTimeoutContext()).getServer(firstServer) == factory.getServer(firstServer)
 
         cleanup:
         cluster?.close()
@@ -95,8 +95,8 @@ class SingleServerClusterSpecification extends Specification {
         cluster.close()
 
         when:
-        cluster.getServersSnapshot(getOperationContext().getTimeoutContext().computeServerSelectionTimeout(),
-                getOperationContext().getTimeoutContext())
+        cluster.getServersSnapshot(createOperationContext().getTimeoutContext().computeServerSelectionTimeout(),
+                createOperationContext().getTimeoutContext())
 
         then:
         thrown(IllegalStateException)
@@ -146,7 +146,7 @@ class SingleServerClusterSpecification extends Specification {
         sendNotification(firstServer, getBuilder(firstServer).minWireVersion(1000).maxWireVersion(1000).build())
 
         when:
-        cluster.selectServer(new WritableServerSelector(), getOperationContext())
+        cluster.selectServer(new WritableServerSelector(), createOperationContext())
 
         then:
         thrown(MongoIncompatibleDriverException)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/SingleServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/SingleServerClusterSpecification.groovy
@@ -78,10 +78,9 @@ class SingleServerClusterSpecification extends Specification {
         sendNotification(firstServer, STANDALONE)
 
         then:
-        cluster.getServersSnapshot(createOperationContext()
-                        .getTimeoutContext()
-                        .computeServerSelectionTimeout(),
-                createOperationContext().getTimeoutContext()).getServer(firstServer) == factory.getServer(firstServer)
+        def operationContext = createOperationContext()
+        cluster.getServersSnapshot(operationContext.getTimeoutContext().computeServerSelectionTimeout(),
+                operationContext.getTimeoutContext()).getServer(firstServer) == factory.getServer(firstServer)
 
         cleanup:
         cluster?.close()
@@ -95,8 +94,9 @@ class SingleServerClusterSpecification extends Specification {
         cluster.close()
 
         when:
-        cluster.getServersSnapshot(createOperationContext().getTimeoutContext().computeServerSelectionTimeout(),
-                createOperationContext().getTimeoutContext())
+        def operationContext = createOperationContext()
+        cluster.getServersSnapshot(operationContext.getTimeoutContext().computeServerSelectionTimeout(),
+                operationContext.getTimeoutContext())
 
         then:
         thrown(IllegalStateException)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/UsageTrackingConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/UsageTrackingConnectionSpecification.groovy
@@ -26,7 +26,7 @@ import org.bson.BsonInt32
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ReadPreference.primary
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 
@@ -49,7 +49,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         connection.openedAt == Long.MAX_VALUE
 
         when:
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
 
         then:
         connection.openedAt <= System.currentTimeMillis()
@@ -65,7 +65,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         connection.openedAt == Long.MAX_VALUE
 
         when:
-        connection.openAsync(OPERATION_CONTEXT, futureResultCallback)
+        connection.openAsync(getOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -80,7 +80,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         connection.lastUsedAt == Long.MAX_VALUE
 
         when:
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
 
         then:
         connection.lastUsedAt <= System.currentTimeMillis()
@@ -96,7 +96,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         connection.lastUsedAt == Long.MAX_VALUE
 
         when:
-        connection.openAsync(OPERATION_CONTEXT, futureResultCallback)
+        connection.openAsync(getOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -106,11 +106,11 @@ class UsageTrackingConnectionSpecification extends Specification {
     def 'lastUsedAt should be set on sendMessage'() {
         given:
         def connection = createConnection()
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
         def openedLastUsedAt = connection.lastUsedAt
 
         when:
-        connection.sendMessage([], 1, OPERATION_CONTEXT)
+        connection.sendMessage([], 1, getOperationContext())
 
         then:
         connection.lastUsedAt >= openedLastUsedAt
@@ -121,12 +121,12 @@ class UsageTrackingConnectionSpecification extends Specification {
     def 'lastUsedAt should be set on sendMessage asynchronously'() {
         given:
         def connection = createConnection()
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
         def openedLastUsedAt = connection.lastUsedAt
         def futureResultCallback = new FutureResultCallback<Void>()
 
         when:
-        connection.sendMessageAsync([], 1, OPERATION_CONTEXT, futureResultCallback)
+        connection.sendMessageAsync([], 1, getOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -137,10 +137,10 @@ class UsageTrackingConnectionSpecification extends Specification {
     def 'lastUsedAt should be set on receiveMessage'() {
         given:
         def connection = createConnection()
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
         def openedLastUsedAt = connection.lastUsedAt
         when:
-        connection.receiveMessage(1, OPERATION_CONTEXT)
+        connection.receiveMessage(1, getOperationContext())
 
         then:
         connection.lastUsedAt >= openedLastUsedAt
@@ -150,12 +150,12 @@ class UsageTrackingConnectionSpecification extends Specification {
     def 'lastUsedAt should be set on receiveMessage asynchronously'() {
         given:
         def connection = createConnection()
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
         def openedLastUsedAt = connection.lastUsedAt
         def futureResultCallback = new FutureResultCallback<Void>()
 
         when:
-        connection.receiveMessageAsync(1, OPERATION_CONTEXT, futureResultCallback)
+        connection.receiveMessageAsync(1, getOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -166,13 +166,13 @@ class UsageTrackingConnectionSpecification extends Specification {
     def 'lastUsedAt should be set on sendAndReceive'() {
         given:
         def connection = createConnection()
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
         def openedLastUsedAt = connection.lastUsedAt
 
         when:
         connection.sendAndReceive(new CommandMessage('test',
                 new BsonDocument('ping', new BsonInt32(1)), NoOpFieldNameValidator.INSTANCE, primary(),
-                MessageSettings.builder().build(), SINGLE, null), new BsonDocumentCodec(),  OPERATION_CONTEXT)
+                MessageSettings.builder().build(), SINGLE, null), new BsonDocumentCodec(),  getOperationContext())
 
         then:
         connection.lastUsedAt >= openedLastUsedAt
@@ -182,7 +182,7 @@ class UsageTrackingConnectionSpecification extends Specification {
     def 'lastUsedAt should be set on sendAndReceive asynchronously'() {
         given:
         def connection = createConnection()
-        connection.open(OPERATION_CONTEXT)
+        connection.open(getOperationContext())
         def openedLastUsedAt = connection.lastUsedAt
         def futureResultCallback = new FutureResultCallback<Void>()
 
@@ -190,7 +190,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         connection.sendAndReceiveAsync(new CommandMessage('test',
                 new BsonDocument('ping', new BsonInt32(1)), NoOpFieldNameValidator.INSTANCE, primary(),
                 MessageSettings.builder().build(), SINGLE, null),
-                new BsonDocumentCodec(), OPERATION_CONTEXT, futureResultCallback)
+                new BsonDocumentCodec(), getOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/UsageTrackingConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/UsageTrackingConnectionSpecification.groovy
@@ -26,7 +26,7 @@ import org.bson.BsonInt32
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ReadPreference.primary
 import static com.mongodb.connection.ClusterConnectionMode.SINGLE
 
@@ -49,7 +49,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         connection.openedAt == Long.MAX_VALUE
 
         when:
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
 
         then:
         connection.openedAt <= System.currentTimeMillis()
@@ -65,7 +65,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         connection.openedAt == Long.MAX_VALUE
 
         when:
-        connection.openAsync(getOperationContext(), futureResultCallback)
+        connection.openAsync(createOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -80,7 +80,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         connection.lastUsedAt == Long.MAX_VALUE
 
         when:
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
 
         then:
         connection.lastUsedAt <= System.currentTimeMillis()
@@ -96,7 +96,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         connection.lastUsedAt == Long.MAX_VALUE
 
         when:
-        connection.openAsync(getOperationContext(), futureResultCallback)
+        connection.openAsync(createOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -106,11 +106,11 @@ class UsageTrackingConnectionSpecification extends Specification {
     def 'lastUsedAt should be set on sendMessage'() {
         given:
         def connection = createConnection()
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
         def openedLastUsedAt = connection.lastUsedAt
 
         when:
-        connection.sendMessage([], 1, getOperationContext())
+        connection.sendMessage([], 1, createOperationContext())
 
         then:
         connection.lastUsedAt >= openedLastUsedAt
@@ -121,12 +121,12 @@ class UsageTrackingConnectionSpecification extends Specification {
     def 'lastUsedAt should be set on sendMessage asynchronously'() {
         given:
         def connection = createConnection()
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
         def openedLastUsedAt = connection.lastUsedAt
         def futureResultCallback = new FutureResultCallback<Void>()
 
         when:
-        connection.sendMessageAsync([], 1, getOperationContext(), futureResultCallback)
+        connection.sendMessageAsync([], 1, createOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -137,10 +137,10 @@ class UsageTrackingConnectionSpecification extends Specification {
     def 'lastUsedAt should be set on receiveMessage'() {
         given:
         def connection = createConnection()
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
         def openedLastUsedAt = connection.lastUsedAt
         when:
-        connection.receiveMessage(1, getOperationContext())
+        connection.receiveMessage(1, createOperationContext())
 
         then:
         connection.lastUsedAt >= openedLastUsedAt
@@ -150,12 +150,12 @@ class UsageTrackingConnectionSpecification extends Specification {
     def 'lastUsedAt should be set on receiveMessage asynchronously'() {
         given:
         def connection = createConnection()
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
         def openedLastUsedAt = connection.lastUsedAt
         def futureResultCallback = new FutureResultCallback<Void>()
 
         when:
-        connection.receiveMessageAsync(1, getOperationContext(), futureResultCallback)
+        connection.receiveMessageAsync(1, createOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:
@@ -166,13 +166,13 @@ class UsageTrackingConnectionSpecification extends Specification {
     def 'lastUsedAt should be set on sendAndReceive'() {
         given:
         def connection = createConnection()
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
         def openedLastUsedAt = connection.lastUsedAt
 
         when:
         connection.sendAndReceive(new CommandMessage('test',
                 new BsonDocument('ping', new BsonInt32(1)), NoOpFieldNameValidator.INSTANCE, primary(),
-                MessageSettings.builder().build(), SINGLE, null), new BsonDocumentCodec(),  getOperationContext())
+                MessageSettings.builder().build(), SINGLE, null), new BsonDocumentCodec(),  createOperationContext())
 
         then:
         connection.lastUsedAt >= openedLastUsedAt
@@ -182,7 +182,7 @@ class UsageTrackingConnectionSpecification extends Specification {
     def 'lastUsedAt should be set on sendAndReceive asynchronously'() {
         given:
         def connection = createConnection()
-        connection.open(getOperationContext())
+        connection.open(createOperationContext())
         def openedLastUsedAt = connection.lastUsedAt
         def futureResultCallback = new FutureResultCallback<Void>()
 
@@ -190,7 +190,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         connection.sendAndReceiveAsync(new CommandMessage('test',
                 new BsonDocument('ping', new BsonInt32(1)), NoOpFieldNameValidator.INSTANCE, primary(),
                 MessageSettings.builder().build(), SINGLE, null),
-                new BsonDocumentCodec(), getOperationContext(), futureResultCallback)
+                new BsonDocumentCodec(), createOperationContext(), futureResultCallback)
         futureResultCallback.get()
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorNoUserNameTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorNoUserNameTest.java
@@ -32,7 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getServerApi;
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE;
 import static com.mongodb.internal.connection.MessageHelper.buildSuccessfulReply;
@@ -58,7 +58,7 @@ public class X509AuthenticatorNoUserNameTest {
         enqueueSuccessfulAuthenticationReply();
 
         new X509Authenticator(getCredentialWithCache(), MULTIPLE, getServerApi())
-                .authenticate(connection, connectionDescriptionThreeSix, OPERATION_CONTEXT);
+                .authenticate(connection, connectionDescriptionThreeSix, getOperationContext());
 
         validateMessages();
     }
@@ -69,7 +69,7 @@ public class X509AuthenticatorNoUserNameTest {
 
         FutureResultCallback<Void> futureCallback = new FutureResultCallback<>();
         new X509Authenticator(getCredentialWithCache(), MULTIPLE, getServerApi()).authenticateAsync(connection,
-                connectionDescriptionThreeSix, OPERATION_CONTEXT, futureCallback);
+                connectionDescriptionThreeSix, getOperationContext(), futureCallback);
 
         futureCallback.get();
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorNoUserNameTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorNoUserNameTest.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.connection;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.async.FutureResultCallback;
@@ -32,7 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getServerApi;
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE;
 import static com.mongodb.internal.connection.MessageHelper.buildSuccessfulReply;
@@ -58,7 +58,7 @@ public class X509AuthenticatorNoUserNameTest {
         enqueueSuccessfulAuthenticationReply();
 
         new X509Authenticator(getCredentialWithCache(), MULTIPLE, getServerApi())
-                .authenticate(connection, connectionDescriptionThreeSix, getOperationContext());
+                .authenticate(connection, connectionDescriptionThreeSix, ClusterFixture.createOperationContext());
 
         validateMessages();
     }
@@ -69,7 +69,7 @@ public class X509AuthenticatorNoUserNameTest {
 
         FutureResultCallback<Void> futureCallback = new FutureResultCallback<>();
         new X509Authenticator(getCredentialWithCache(), MULTIPLE, getServerApi()).authenticateAsync(connection,
-                connectionDescriptionThreeSix, getOperationContext(), futureCallback);
+                connectionDescriptionThreeSix, ClusterFixture.createOperationContext(), futureCallback);
 
         futureCallback.get();
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorUnitTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorUnitTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getServerApi;
 import static com.mongodb.internal.connection.MessageHelper.buildSuccessfulReply;
 import static com.mongodb.internal.connection.MessageHelper.getApiVersionField;
@@ -58,7 +58,7 @@ public class X509AuthenticatorUnitTest {
         enqueueFailedAuthenticationReply();
 
         try {
-            subject.authenticate(connection, connectionDescription, OPERATION_CONTEXT);
+            subject.authenticate(connection, connectionDescription, getOperationContext());
             fail();
         } catch (MongoSecurityException e) {
             // all good
@@ -70,7 +70,7 @@ public class X509AuthenticatorUnitTest {
         enqueueFailedAuthenticationReply();
 
         FutureResultCallback<Void> futureCallback = new FutureResultCallback<>();
-        subject.authenticateAsync(connection, connectionDescription, OPERATION_CONTEXT, futureCallback);
+        subject.authenticateAsync(connection, connectionDescription, getOperationContext(), futureCallback);
 
         try {
             futureCallback.get();
@@ -92,7 +92,7 @@ public class X509AuthenticatorUnitTest {
     public void testSuccessfulAuthentication() {
         enqueueSuccessfulAuthenticationReply();
 
-        subject.authenticate(connection, connectionDescription, OPERATION_CONTEXT);
+        subject.authenticate(connection, connectionDescription, getOperationContext());
 
         validateMessages();
     }
@@ -102,7 +102,7 @@ public class X509AuthenticatorUnitTest {
         enqueueSuccessfulAuthenticationReply();
 
         FutureResultCallback<Void> futureCallback = new FutureResultCallback<>();
-        subject.authenticateAsync(connection, connectionDescription, OPERATION_CONTEXT, futureCallback);
+        subject.authenticateAsync(connection, connectionDescription, getOperationContext(), futureCallback);
 
         futureCallback.get();
 
@@ -117,7 +117,7 @@ public class X509AuthenticatorUnitTest {
                 + "user: \"CN=client,OU=kerneluser,O=10Gen,L=New York City,ST=New York,C=US\", "
                 + "mechanism: \"MONGODB-X509\", db: \"$external\"}");
         subject.setSpeculativeAuthenticateResponse(BsonDocument.parse(speculativeAuthenticateResponse));
-        subject.authenticate(connection, connectionDescription, OPERATION_CONTEXT);
+        subject.authenticate(connection, connectionDescription, getOperationContext());
 
         assertEquals(connection.getSent().size(), 0);
         assertEquals(expectedSpeculativeAuthenticateCommand, subject.createSpeculativeAuthenticateCommand(connection));

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorUnitTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorUnitTest.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.connection;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.MongoCredential;
 import com.mongodb.MongoSecurityException;
 import com.mongodb.ServerAddress;
@@ -31,7 +32,6 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getServerApi;
 import static com.mongodb.internal.connection.MessageHelper.buildSuccessfulReply;
 import static com.mongodb.internal.connection.MessageHelper.getApiVersionField;
@@ -58,7 +58,7 @@ public class X509AuthenticatorUnitTest {
         enqueueFailedAuthenticationReply();
 
         try {
-            subject.authenticate(connection, connectionDescription, getOperationContext());
+            subject.authenticate(connection, connectionDescription, ClusterFixture.createOperationContext());
             fail();
         } catch (MongoSecurityException e) {
             // all good
@@ -70,7 +70,7 @@ public class X509AuthenticatorUnitTest {
         enqueueFailedAuthenticationReply();
 
         FutureResultCallback<Void> futureCallback = new FutureResultCallback<>();
-        subject.authenticateAsync(connection, connectionDescription, getOperationContext(), futureCallback);
+        subject.authenticateAsync(connection, connectionDescription, ClusterFixture.createOperationContext(), futureCallback);
 
         try {
             futureCallback.get();
@@ -92,7 +92,7 @@ public class X509AuthenticatorUnitTest {
     public void testSuccessfulAuthentication() {
         enqueueSuccessfulAuthenticationReply();
 
-        subject.authenticate(connection, connectionDescription, getOperationContext());
+        subject.authenticate(connection, connectionDescription, ClusterFixture.createOperationContext());
 
         validateMessages();
     }
@@ -102,7 +102,7 @@ public class X509AuthenticatorUnitTest {
         enqueueSuccessfulAuthenticationReply();
 
         FutureResultCallback<Void> futureCallback = new FutureResultCallback<>();
-        subject.authenticateAsync(connection, connectionDescription, getOperationContext(), futureCallback);
+        subject.authenticateAsync(connection, connectionDescription, ClusterFixture.createOperationContext(), futureCallback);
 
         futureCallback.get();
 
@@ -117,7 +117,7 @@ public class X509AuthenticatorUnitTest {
                 + "user: \"CN=client,OU=kerneluser,O=10Gen,L=New York City,ST=New York,C=US\", "
                 + "mechanism: \"MONGODB-X509\", db: \"$external\"}");
         subject.setSpeculativeAuthenticateResponse(BsonDocument.parse(speculativeAuthenticateResponse));
-        subject.authenticate(connection, connectionDescription, getOperationContext());
+        subject.authenticate(connection, connectionDescription, ClusterFixture.createOperationContext());
 
         assertEquals(connection.getSent().size(), 0);
         assertEquals(expectedSpeculativeAuthenticateCommand, subject.createSpeculativeAuthenticateCommand(connection));

--- a/driver-core/src/test/unit/com/mongodb/internal/mockito/InsufficientStubbingDetectorDemoTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/mockito/InsufficientStubbingDetectorDemoTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.internal.stubbing.answers.ThrowsException;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -40,33 +40,33 @@ final class InsufficientStubbingDetectorDemoTest {
     @Test
     void mockObjectWithDefaultAnswer() {
         ReadBinding binding = Mockito.mock(ReadBinding.class);
-        assertThrows(NullPointerException.class, () -> operation.execute(binding, OPERATION_CONTEXT));
+        assertThrows(NullPointerException.class, () -> operation.execute(binding, getOperationContext()));
     }
 
     @Test
     void mockObjectWithThrowsException() {
         ReadBinding binding = Mockito.mock(ReadBinding.class,
                 new ThrowsException(new AssertionError("Insufficient stubbing for " + ReadBinding.class)));
-        assertThrows(AssertionError.class, () -> operation.execute(binding, OPERATION_CONTEXT));
+        assertThrows(AssertionError.class, () -> operation.execute(binding, getOperationContext()));
     }
 
     @Test
     void mockObjectWithInsufficientStubbingDetector() {
         ReadBinding binding = MongoMockito.mock(ReadBinding.class);
-        assertThrows(AssertionError.class, () -> operation.execute(binding, OPERATION_CONTEXT));
+        assertThrows(AssertionError.class, () -> operation.execute(binding, getOperationContext()));
     }
 
     @Test
     void stubbingWithThrowsException() {
         ReadBinding binding = Mockito.mock(ReadBinding.class,
                 new ThrowsException(new AssertionError("Unfortunately, you cannot do stubbing")));
-        assertThrows(AssertionError.class, () -> when(binding.getReadConnectionSource(OPERATION_CONTEXT)).thenReturn(null));
+        assertThrows(AssertionError.class, () -> when(binding.getReadConnectionSource(getOperationContext())).thenReturn(null));
     }
 
     @Test
     void stubbingWithInsufficientStubbingDetector() {
         MongoMockito.mock(ReadBinding.class, bindingMock ->
-                when(bindingMock.getReadConnectionSource(OPERATION_CONTEXT)).thenReturn(null)
+                when(bindingMock.getReadConnectionSource(getOperationContext())).thenReturn(null)
         );
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/mockito/InsufficientStubbingDetectorDemoTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/mockito/InsufficientStubbingDetectorDemoTest.java
@@ -15,6 +15,7 @@
  */
 package com.mongodb.internal.mockito;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.internal.binding.ReadBinding;
 import com.mongodb.internal.operation.ListCollectionsOperation;
 import org.bson.BsonDocument;
@@ -24,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.internal.stubbing.answers.ThrowsException;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -40,33 +40,33 @@ final class InsufficientStubbingDetectorDemoTest {
     @Test
     void mockObjectWithDefaultAnswer() {
         ReadBinding binding = Mockito.mock(ReadBinding.class);
-        assertThrows(NullPointerException.class, () -> operation.execute(binding, getOperationContext()));
+        assertThrows(NullPointerException.class, () -> operation.execute(binding, ClusterFixture.createOperationContext()));
     }
 
     @Test
     void mockObjectWithThrowsException() {
         ReadBinding binding = Mockito.mock(ReadBinding.class,
                 new ThrowsException(new AssertionError("Insufficient stubbing for " + ReadBinding.class)));
-        assertThrows(AssertionError.class, () -> operation.execute(binding, getOperationContext()));
+        assertThrows(AssertionError.class, () -> operation.execute(binding, ClusterFixture.createOperationContext()));
     }
 
     @Test
     void mockObjectWithInsufficientStubbingDetector() {
         ReadBinding binding = MongoMockito.mock(ReadBinding.class);
-        assertThrows(AssertionError.class, () -> operation.execute(binding, getOperationContext()));
+        assertThrows(AssertionError.class, () -> operation.execute(binding, ClusterFixture.createOperationContext()));
     }
 
     @Test
     void stubbingWithThrowsException() {
         ReadBinding binding = Mockito.mock(ReadBinding.class,
                 new ThrowsException(new AssertionError("Unfortunately, you cannot do stubbing")));
-        assertThrows(AssertionError.class, () -> when(binding.getReadConnectionSource(getOperationContext())).thenReturn(null));
+        assertThrows(AssertionError.class, () -> when(binding.getReadConnectionSource(ClusterFixture.createOperationContext())).thenReturn(null));
     }
 
     @Test
     void stubbingWithInsufficientStubbingDetector() {
         MongoMockito.mock(ReadBinding.class, bindingMock ->
-                when(bindingMock.getReadConnectionSource(getOperationContext())).thenReturn(null)
+                when(bindingMock.getReadConnectionSource(ClusterFixture.createOperationContext())).thenReturn(null)
         );
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncOperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncOperationHelperSpecification.groovy
@@ -36,7 +36,7 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.Decoder
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ReadPreference.primary
 import static com.mongodb.internal.operation.AsyncOperationHelper.CommandReadTransformerAsync
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync
@@ -74,7 +74,7 @@ class AsyncOperationHelperSpecification extends Specification {
             _ * getDescription() >> connectionDescription
         }
 
-        def operationContext = OPERATION_CONTEXT.withSessionContext(
+        def operationContext = getOperationContext().withSessionContext(
                 Stub(SessionContext) {
                     hasSession() >> true
                     hasActiveTransaction() >> false
@@ -116,7 +116,7 @@ class AsyncOperationHelperSpecification extends Specification {
         def connectionDescription = Stub(ConnectionDescription)
 
         when:
-        executeCommandAsync(asyncWriteBinding, OPERATION_CONTEXT, dbName, command, connection, { t, conn -> t }, callback)
+        executeCommandAsync(asyncWriteBinding, getOperationContext(), dbName, command, connection, { t, conn -> t }, callback)
 
         then:
         _ * connection.getDescription() >> connectionDescription
@@ -143,7 +143,7 @@ class AsyncOperationHelperSpecification extends Specification {
         def connectionDescription = Stub(ConnectionDescription)
 
         when:
-        executeRetryableReadAsync(asyncReadBinding, OPERATION_CONTEXT, dbName, commandCreator, decoder, function, false, callback)
+        executeRetryableReadAsync(asyncReadBinding, getOperationContext(), dbName, commandCreator, decoder, function, false, callback)
 
         then:
         _ * connection.getDescription() >> connectionDescription

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncOperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/AsyncOperationHelperSpecification.groovy
@@ -36,7 +36,7 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.Decoder
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ReadPreference.primary
 import static com.mongodb.internal.operation.AsyncOperationHelper.CommandReadTransformerAsync
 import static com.mongodb.internal.operation.AsyncOperationHelper.executeCommandAsync
@@ -74,7 +74,7 @@ class AsyncOperationHelperSpecification extends Specification {
             _ * getDescription() >> connectionDescription
         }
 
-        def operationContext = getOperationContext().withSessionContext(
+        def operationContext = createOperationContext().withSessionContext(
                 Stub(SessionContext) {
                     hasSession() >> true
                     hasActiveTransaction() >> false
@@ -116,7 +116,7 @@ class AsyncOperationHelperSpecification extends Specification {
         def connectionDescription = Stub(ConnectionDescription)
 
         when:
-        executeCommandAsync(asyncWriteBinding, getOperationContext(), dbName, command, connection, { t, conn -> t }, callback)
+        executeCommandAsync(asyncWriteBinding, createOperationContext(), dbName, command, connection, { t, conn -> t }, callback)
 
         then:
         _ * connection.getDescription() >> connectionDescription
@@ -143,7 +143,7 @@ class AsyncOperationHelperSpecification extends Specification {
         def connectionDescription = Stub(ConnectionDescription)
 
         when:
-        executeRetryableReadAsync(asyncReadBinding, getOperationContext(), dbName, commandCreator, decoder, function, false, callback)
+        executeRetryableReadAsync(asyncReadBinding, createOperationContext(), dbName, commandCreator, decoder, function, false, callback)
 
         then:
         _ * connection.getDescription() >> connectionDescription

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/ClientBulkWriteOperationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/ClientBulkWriteOperationTest.java
@@ -124,7 +124,7 @@ class ClientBulkWriteOperationTest {
                 false,
                 getDefaultCodecRegistry());
         //when
-        ClientBulkWriteResult result = op.execute(binding, ClusterFixture.OPERATION_CONTEXT);
+        ClientBulkWriteResult result = op.execute(binding, ClusterFixture.getOperationContext());
 
         //then
         assertEquals(
@@ -176,7 +176,7 @@ class ClientBulkWriteOperationTest {
                 false,
                 getDefaultCodecRegistry());
         //when
-        ClientBulkWriteResult result = op.execute(binding, ClusterFixture.OPERATION_CONTEXT);
+        ClientBulkWriteResult result = op.execute(binding, ClusterFixture.getOperationContext());
 
         //then
         assertEquals(1, result.getInsertedCount());

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/ClientBulkWriteOperationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/ClientBulkWriteOperationTest.java
@@ -124,7 +124,7 @@ class ClientBulkWriteOperationTest {
                 false,
                 getDefaultCodecRegistry());
         //when
-        ClientBulkWriteResult result = op.execute(binding, ClusterFixture.getOperationContext());
+        ClientBulkWriteResult result = op.execute(binding, ClusterFixture.createOperationContext());
 
         //then
         assertEquals(
@@ -176,7 +176,7 @@ class ClientBulkWriteOperationTest {
                 false,
                 getDefaultCodecRegistry());
         //when
-        ClientBulkWriteResult result = op.execute(binding, ClusterFixture.getOperationContext());
+        ClientBulkWriteResult result = op.execute(binding, ClusterFixture.createOperationContext());
 
         //then
         assertEquals(1, result.getInsertedCount());

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/CommitTransactionOperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/CommitTransactionOperationUnitSpecification.groovy
@@ -27,7 +27,7 @@ import com.mongodb.internal.binding.WriteBinding
 import com.mongodb.internal.connection.OperationContext
 import com.mongodb.internal.session.SessionContext
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 
 class CommitTransactionOperationUnitSpecification extends OperationUnitSpecification {
     def 'should add UnknownTransactionCommitResult error label to MongoTimeoutException'() {
@@ -42,7 +42,7 @@ class CommitTransactionOperationUnitSpecification extends OperationUnitSpecifica
         def operation = new CommitTransactionOperation(WriteConcern.ACKNOWLEDGED)
 
         when:
-        operation.execute(writeBinding, OPERATION_CONTEXT.withSessionContext(sessionContext))
+        operation.execute(writeBinding, getOperationContext().withSessionContext(sessionContext))
 
         then:
         def e = thrown(MongoTimeoutException)
@@ -64,7 +64,7 @@ class CommitTransactionOperationUnitSpecification extends OperationUnitSpecifica
         def callback = new FutureResultCallback()
 
         when:
-        operation.executeAsync(writeBinding, OPERATION_CONTEXT.withSessionContext(sessionContext), callback)
+        operation.executeAsync(writeBinding, getOperationContext().withSessionContext(sessionContext), callback)
         callback.get()
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/CommitTransactionOperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/CommitTransactionOperationUnitSpecification.groovy
@@ -27,7 +27,7 @@ import com.mongodb.internal.binding.WriteBinding
 import com.mongodb.internal.connection.OperationContext
 import com.mongodb.internal.session.SessionContext
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 
 class CommitTransactionOperationUnitSpecification extends OperationUnitSpecification {
     def 'should add UnknownTransactionCommitResult error label to MongoTimeoutException'() {
@@ -42,7 +42,7 @@ class CommitTransactionOperationUnitSpecification extends OperationUnitSpecifica
         def operation = new CommitTransactionOperation(WriteConcern.ACKNOWLEDGED)
 
         when:
-        operation.execute(writeBinding, getOperationContext().withSessionContext(sessionContext))
+        operation.execute(writeBinding, createOperationContext().withSessionContext(sessionContext))
 
         then:
         def e = thrown(MongoTimeoutException)
@@ -64,7 +64,7 @@ class CommitTransactionOperationUnitSpecification extends OperationUnitSpecifica
         def callback = new FutureResultCallback()
 
         when:
-        operation.executeAsync(writeBinding, getOperationContext().withSessionContext(sessionContext), callback)
+        operation.executeAsync(writeBinding, createOperationContext().withSessionContext(sessionContext), callback)
         callback.get()
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/CursorResourceManagerTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/CursorResourceManagerTest.java
@@ -24,7 +24,7 @@ import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.internal.mockito.MongoMockito;
 import org.junit.jupiter.api.Test;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.when;
 
@@ -50,12 +50,12 @@ final class CursorResourceManagerTest {
         cursorResourceManager.tryStartOperation();
         try {
             assertDoesNotThrow(() -> {
-                cursorResourceManager.close(OPERATION_CONTEXT);
-                cursorResourceManager.close(OPERATION_CONTEXT);
+                cursorResourceManager.close(getOperationContext());
+                cursorResourceManager.close(getOperationContext());
                 cursorResourceManager.setServerCursor(null);
             });
         } finally {
-            cursorResourceManager.endOperation(OPERATION_CONTEXT);
+            cursorResourceManager.endOperation(getOperationContext());
         }
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/CursorResourceManagerTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/CursorResourceManagerTest.java
@@ -15,6 +15,7 @@
  */
 package com.mongodb.internal.operation;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ServerCursor;
 import com.mongodb.internal.binding.AsyncConnectionSource;
@@ -24,7 +25,6 @@ import com.mongodb.internal.connection.OperationContext;
 import com.mongodb.internal.mockito.MongoMockito;
 import org.junit.jupiter.api.Test;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.when;
 
@@ -50,12 +50,12 @@ final class CursorResourceManagerTest {
         cursorResourceManager.tryStartOperation();
         try {
             assertDoesNotThrow(() -> {
-                cursorResourceManager.close(getOperationContext());
-                cursorResourceManager.close(getOperationContext());
+                cursorResourceManager.close(ClusterFixture.createOperationContext());
+                cursorResourceManager.close(ClusterFixture.createOperationContext());
                 cursorResourceManager.setServerCursor(null);
             });
         } finally {
-            cursorResourceManager.endOperation(getOperationContext());
+            cursorResourceManager.endOperation(ClusterFixture.createOperationContext());
         }
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/ListCollectionsOperationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/ListCollectionsOperationTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.internal.mockito.MongoMockito.mock;
 import static java.util.Collections.emptyList;
@@ -99,7 +99,7 @@ final class ListCollectionsOperationTest {
     }
 
     private BsonDocument executeOperationAndCaptureCommand() {
-        operation.execute(mocks.readBinding(), OPERATION_CONTEXT);
+        operation.execute(mocks.readBinding(), getOperationContext());
         ArgumentCaptor<BsonDocument> commandCaptor = forClass(BsonDocument.class);
         verify(mocks.connection()).command(any(), commandCaptor.capture(), any(), any(), any(), any());
         return commandCaptor.getValue();

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/ListCollectionsOperationTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/ListCollectionsOperationTest.java
@@ -15,6 +15,7 @@
  */
 package com.mongodb.internal.operation;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
@@ -39,7 +40,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.internal.mockito.MongoMockito.mock;
 import static java.util.Collections.emptyList;
@@ -99,7 +99,7 @@ final class ListCollectionsOperationTest {
     }
 
     private BsonDocument executeOperationAndCaptureCommand() {
-        operation.execute(mocks.readBinding(), getOperationContext());
+        operation.execute(mocks.readBinding(), ClusterFixture.createOperationContext());
         ArgumentCaptor<BsonDocument> commandCaptor = forClass(BsonDocument.class);
         verify(mocks.connection()).command(any(), commandCaptor.capture(), any(), any(), any(), any());
         return commandCaptor.getValue();

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/OperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/OperationHelperSpecification.groovy
@@ -32,7 +32,7 @@ import org.bson.BsonArray
 import org.bson.BsonDocument
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.UNACKNOWLEDGED
 import static com.mongodb.connection.ServerConnectionState.CONNECTED
@@ -108,8 +108,8 @@ class OperationHelperSpecification extends Specification {
         }
 
         expect:
-        canRetryRead(retryableServerDescription, OPERATION_CONTEXT.withSessionContext(noTransactionSessionContext))
-        !canRetryRead(retryableServerDescription, OPERATION_CONTEXT.withSessionContext(activeTransactionSessionContext))
+        canRetryRead(retryableServerDescription, getOperationContext().withSessionContext(noTransactionSessionContext))
+        !canRetryRead(retryableServerDescription, getOperationContext().withSessionContext(activeTransactionSessionContext))
     }
 
 

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/OperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/OperationHelperSpecification.groovy
@@ -32,7 +32,7 @@ import org.bson.BsonArray
 import org.bson.BsonDocument
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.UNACKNOWLEDGED
 import static com.mongodb.connection.ServerConnectionState.CONNECTED
@@ -108,8 +108,8 @@ class OperationHelperSpecification extends Specification {
         }
 
         expect:
-        canRetryRead(retryableServerDescription, getOperationContext().withSessionContext(noTransactionSessionContext))
-        !canRetryRead(retryableServerDescription, getOperationContext().withSessionContext(activeTransactionSessionContext))
+        canRetryRead(retryableServerDescription, createOperationContext().withSessionContext(noTransactionSessionContext))
+        !canRetryRead(retryableServerDescription, createOperationContext().withSessionContext(activeTransactionSessionContext))
     }
 
 

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/OperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/OperationUnitSpecification.groovy
@@ -41,7 +41,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 
 class OperationUnitSpecification extends Specification {
 
@@ -97,7 +97,7 @@ class OperationUnitSpecification extends Specification {
     def testSyncOperation(operation, List<Integer> serverVersion, result, Boolean checkCommand=true,
                           BsonDocument expectedCommand=null,
                           Boolean checkSecondaryOk=false, ReadPreference readPreference=ReadPreference.primary()) {
-        def operationContext = OPERATION_CONTEXT
+        def operationContext = getOperationContext()
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> false
                     getReadConcern() >> ReadConcern.DEFAULT
@@ -151,7 +151,7 @@ class OperationUnitSpecification extends Specification {
                            Boolean checkCommand=true, BsonDocument expectedCommand=null,
                            Boolean checkSecondaryOk=false, ReadPreference readPreference=ReadPreference.primary()) {
 
-        def operationContext = OPERATION_CONTEXT
+        def operationContext = getOperationContext()
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> false
                     getReadConcern() >> ReadConcern.DEFAULT

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/OperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/OperationUnitSpecification.groovy
@@ -41,7 +41,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 
 class OperationUnitSpecification extends Specification {
 
@@ -97,7 +97,7 @@ class OperationUnitSpecification extends Specification {
     def testSyncOperation(operation, List<Integer> serverVersion, result, Boolean checkCommand=true,
                           BsonDocument expectedCommand=null,
                           Boolean checkSecondaryOk=false, ReadPreference readPreference=ReadPreference.primary()) {
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> false
                     getReadConcern() >> ReadConcern.DEFAULT
@@ -151,7 +151,7 @@ class OperationUnitSpecification extends Specification {
                            Boolean checkCommand=true, BsonDocument expectedCommand=null,
                            Boolean checkSecondaryOk=false, ReadPreference readPreference=ReadPreference.primary()) {
 
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> false
                     getReadConcern() >> ReadConcern.DEFAULT

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/SyncOperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/SyncOperationHelperSpecification.groovy
@@ -34,7 +34,7 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.Decoder
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ReadPreference.primary
 import static com.mongodb.internal.operation.OperationUnitSpecification.getMaxWireVersionForServerVersion
 import static com.mongodb.internal.operation.SyncOperationHelper.CommandReadTransformer
@@ -61,7 +61,7 @@ class SyncOperationHelperSpecification extends Specification {
         def connectionDescription = Stub(ConnectionDescription)
 
         when:
-        executeCommand(writeBinding, OPERATION_CONTEXT, dbName, command, decoder, function)
+        executeCommand(writeBinding, getOperationContext(), dbName, command, decoder, function)
 
         then:
         _ * connection.getDescription() >> connectionDescription
@@ -71,7 +71,7 @@ class SyncOperationHelperSpecification extends Specification {
 
     def 'should retry with retryable exception'() {
         given:
-        def operationContext = OPERATION_CONTEXT
+        def operationContext = getOperationContext()
                 .withSessionContext(Stub(SessionContext) {
                     hasSession() >> true
                     hasActiveTransaction() >> false
@@ -132,7 +132,7 @@ class SyncOperationHelperSpecification extends Specification {
         def connectionDescription = Stub(ConnectionDescription)
 
         when:
-        executeRetryableRead(readBinding, OPERATION_CONTEXT, dbName, commandCreator, decoder, function, false)
+        executeRetryableRead(readBinding, getOperationContext(), dbName, commandCreator, decoder, function, false)
 
         then:
         _ * connection.getDescription() >> connectionDescription

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/SyncOperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/SyncOperationHelperSpecification.groovy
@@ -34,7 +34,7 @@ import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.Decoder
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ReadPreference.primary
 import static com.mongodb.internal.operation.OperationUnitSpecification.getMaxWireVersionForServerVersion
 import static com.mongodb.internal.operation.SyncOperationHelper.CommandReadTransformer
@@ -61,7 +61,7 @@ class SyncOperationHelperSpecification extends Specification {
         def connectionDescription = Stub(ConnectionDescription)
 
         when:
-        executeCommand(writeBinding, getOperationContext(), dbName, command, decoder, function)
+        executeCommand(writeBinding, createOperationContext(), dbName, command, decoder, function)
 
         then:
         _ * connection.getDescription() >> connectionDescription
@@ -71,7 +71,7 @@ class SyncOperationHelperSpecification extends Specification {
 
     def 'should retry with retryable exception'() {
         given:
-        def operationContext = getOperationContext()
+        def operationContext = createOperationContext()
                 .withSessionContext(Stub(SessionContext) {
                     hasSession() >> true
                     hasActiveTransaction() >> false
@@ -132,7 +132,7 @@ class SyncOperationHelperSpecification extends Specification {
         def connectionDescription = Stub(ConnectionDescription)
 
         when:
-        executeRetryableRead(readBinding, getOperationContext(), dbName, commandCreator, decoder, function, false)
+        executeRetryableRead(readBinding, createOperationContext(), dbName, commandCreator, decoder, function, false)
 
         then:
         _ * connection.getDescription() >> connectionDescription

--- a/driver-core/src/test/unit/com/mongodb/internal/session/BaseClientSessionImplTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/session/BaseClientSessionImplTest.java
@@ -20,7 +20,7 @@ import com.mongodb.ClientSessionOptions;
 import com.mongodb.session.ClientSession;
 import org.junit.jupiter.api.Test;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -28,7 +28,7 @@ class BaseClientSessionImplTest {
 
     @Test
     void shouldNotCheckoutServerSessionIfNeverRequested() {
-        ServerSessionPool serverSessionPool = new ServerSessionPool(getCluster(), OPERATION_CONTEXT);
+        ServerSessionPool serverSessionPool = new ServerSessionPool(getCluster(), getOperationContext());
         ClientSession clientSession = new BaseClientSessionImpl(serverSessionPool, new Object(), ClientSessionOptions.builder().build());
 
         assertEquals(0, serverSessionPool.getInUseCount());
@@ -40,7 +40,7 @@ class BaseClientSessionImplTest {
 
     @Test
     void shouldDelayServerSessionCheckoutUntilRequested() {
-        ServerSessionPool serverSessionPool = new ServerSessionPool(getCluster(), OPERATION_CONTEXT);
+        ServerSessionPool serverSessionPool = new ServerSessionPool(getCluster(), getOperationContext());
         ClientSession clientSession = new BaseClientSessionImpl(serverSessionPool, new Object(), ClientSessionOptions.builder().build());
 
         assertEquals(0, serverSessionPool.getInUseCount());

--- a/driver-core/src/test/unit/com/mongodb/internal/session/BaseClientSessionImplTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/session/BaseClientSessionImplTest.java
@@ -17,10 +17,10 @@
 package com.mongodb.internal.session;
 
 import com.mongodb.ClientSessionOptions;
+import com.mongodb.ClusterFixture;
 import com.mongodb.session.ClientSession;
 import org.junit.jupiter.api.Test;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.getCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -28,7 +28,7 @@ class BaseClientSessionImplTest {
 
     @Test
     void shouldNotCheckoutServerSessionIfNeverRequested() {
-        ServerSessionPool serverSessionPool = new ServerSessionPool(getCluster(), getOperationContext());
+        ServerSessionPool serverSessionPool = new ServerSessionPool(getCluster(), ClusterFixture.createOperationContext());
         ClientSession clientSession = new BaseClientSessionImpl(serverSessionPool, new Object(), ClientSessionOptions.builder().build());
 
         assertEquals(0, serverSessionPool.getInUseCount());
@@ -40,7 +40,7 @@ class BaseClientSessionImplTest {
 
     @Test
     void shouldDelayServerSessionCheckoutUntilRequested() {
-        ServerSessionPool serverSessionPool = new ServerSessionPool(getCluster(), getOperationContext());
+        ServerSessionPool serverSessionPool = new ServerSessionPool(getCluster(), ClusterFixture.createOperationContext());
         ClientSession clientSession = new BaseClientSessionImpl(serverSessionPool, new Object(), ClientSessionOptions.builder().build());
 
         assertEquals(0, serverSessionPool.getInUseCount());

--- a/driver-core/src/test/unit/com/mongodb/internal/session/ServerSessionPoolSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/session/ServerSessionPoolSpecification.groovy
@@ -32,7 +32,7 @@ import org.bson.BsonDocument
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.getServerApi
 import static com.mongodb.ReadPreference.primaryPreferred
@@ -120,7 +120,7 @@ class ServerSessionPoolSpecification extends Specification {
             millis() >>> [0, MINUTES.toMillis(29) + 1,
             ]
         }
-        def pool = new ServerSessionPool(cluster, OPERATION_CONTEXT, clock)
+        def pool = new ServerSessionPool(cluster, getOperationContext(), clock)
         def sessionOne = pool.get()
 
         when:
@@ -146,7 +146,7 @@ class ServerSessionPoolSpecification extends Specification {
         def clock = Stub(ServerSessionPool.Clock) {
             millis() >>> [0, 0, 0]
         }
-        def pool = new ServerSessionPool(cluster, OPERATION_CONTEXT, clock)
+        def pool = new ServerSessionPool(cluster, getOperationContext(), clock)
         def session = pool.get()
 
         when:
@@ -165,7 +165,7 @@ class ServerSessionPoolSpecification extends Specification {
         def clock = Stub(ServerSessionPool.Clock) {
             millis() >> 42
         }
-        def pool = new ServerSessionPool(cluster, OPERATION_CONTEXT, clock)
+        def pool = new ServerSessionPool(cluster, getOperationContext(), clock)
 
         when:
         def session = pool.get() as ServerSessionPool.ServerSessionImpl
@@ -187,7 +187,7 @@ class ServerSessionPoolSpecification extends Specification {
         def clock = Stub(ServerSessionPool.Clock) {
             millis() >> 42
         }
-        def pool = new ServerSessionPool(cluster, OPERATION_CONTEXT, clock)
+        def pool = new ServerSessionPool(cluster, getOperationContext(), clock)
 
         when:
         def session = pool.get() as ServerSessionPool.ServerSessionImpl

--- a/driver-core/src/test/unit/com/mongodb/internal/session/ServerSessionPoolSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/session/ServerSessionPoolSpecification.groovy
@@ -32,7 +32,7 @@ import org.bson.BsonDocument
 import org.bson.codecs.BsonDocumentCodec
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 import static com.mongodb.ClusterFixture.TIMEOUT_SETTINGS
 import static com.mongodb.ClusterFixture.getServerApi
 import static com.mongodb.ReadPreference.primaryPreferred
@@ -120,7 +120,7 @@ class ServerSessionPoolSpecification extends Specification {
             millis() >>> [0, MINUTES.toMillis(29) + 1,
             ]
         }
-        def pool = new ServerSessionPool(cluster, getOperationContext(), clock)
+        def pool = new ServerSessionPool(cluster, createOperationContext(), clock)
         def sessionOne = pool.get()
 
         when:
@@ -146,7 +146,7 @@ class ServerSessionPoolSpecification extends Specification {
         def clock = Stub(ServerSessionPool.Clock) {
             millis() >>> [0, 0, 0]
         }
-        def pool = new ServerSessionPool(cluster, getOperationContext(), clock)
+        def pool = new ServerSessionPool(cluster, createOperationContext(), clock)
         def session = pool.get()
 
         when:
@@ -165,7 +165,7 @@ class ServerSessionPoolSpecification extends Specification {
         def clock = Stub(ServerSessionPool.Clock) {
             millis() >> 42
         }
-        def pool = new ServerSessionPool(cluster, getOperationContext(), clock)
+        def pool = new ServerSessionPool(cluster, createOperationContext(), clock)
 
         when:
         def session = pool.get() as ServerSessionPool.ServerSessionImpl
@@ -187,7 +187,7 @@ class ServerSessionPoolSpecification extends Specification {
         def clock = Stub(ServerSessionPool.Clock) {
             millis() >> 42
         }
-        def pool = new ServerSessionPool(cluster, getOperationContext(), clock)
+        def pool = new ServerSessionPool(cluster, createOperationContext(), clock)
 
         when:
         def session = pool.get() as ServerSessionPool.ServerSessionImpl

--- a/driver-legacy/src/test/functional/com/mongodb/DBTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import java.util.Locale;
 import java.util.UUID;
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.getBinding;
@@ -345,7 +345,7 @@ public class DBTest extends DatabaseTestCase {
 
     BsonDocument getCollectionInfo(final String collectionName) {
         return new ListCollectionsOperation<>(getDefaultDatabaseName(), new BsonDocumentCodec())
-                .filter(new BsonDocument("name", new BsonString(collectionName))).execute(getBinding(), OPERATION_CONTEXT).next().get(0);
+                .filter(new BsonDocument("name", new BsonString(collectionName))).execute(getBinding(), getOperationContext()).next().get(0);
     }
 
     private boolean isCapped(final DBCollection collection) {

--- a/driver-legacy/src/test/functional/com/mongodb/DBTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import java.util.Locale;
 import java.util.UUID;
 
-import static com.mongodb.ClusterFixture.getOperationContext;
 import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint;
 import static com.mongodb.ClusterFixture.getBinding;
@@ -345,7 +344,7 @@ public class DBTest extends DatabaseTestCase {
 
     BsonDocument getCollectionInfo(final String collectionName) {
         return new ListCollectionsOperation<>(getDefaultDatabaseName(), new BsonDocumentCodec())
-                .filter(new BsonDocument("name", new BsonString(collectionName))).execute(getBinding(), getOperationContext()).next().get(0);
+                .filter(new BsonDocument("name", new BsonString(collectionName))).execute(getBinding(), ClusterFixture.createOperationContext()).next().get(0);
     }
 
     private boolean isCapped(final DBCollection collection) {

--- a/driver-legacy/src/test/functional/com/mongodb/LegacyMixedBulkWriteOperationSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/LegacyMixedBulkWriteOperationSpecification.groovy
@@ -184,7 +184,7 @@ class LegacyMixedBulkWriteOperationSpecification extends OperationFunctionalSpec
         def insert = new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))
         def binding = getBinding()
         createBulkWriteOperationForInsert(getNamespace(), true, ACKNOWLEDGED, false, asList(insert))
-                .execute(binding, ClusterFixture.getOperationContext(binding.getReadPreference()))
+                .execute(binding, ClusterFixture.createOperationContext(binding.getReadPreference()))
 
         def replacement = new UpdateRequest(new BsonDocument('_id', new BsonInt32(1)),
                 new BsonDocument('_id', new BsonInt32(1)).append('x', new BsonInt32(1)), REPLACE)

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/RetryableReadsProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/RetryableReadsProseTest.java
@@ -16,57 +16,14 @@
 
 package com.mongodb.reactivestreams.client;
 
-import com.mongodb.client.MongoCursor;
-import com.mongodb.client.RetryableWritesProseTest;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.AbstractRetryableReadsProseTest;
+import com.mongodb.client.MongoClient;
 import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
-import org.bson.Document;
-import org.junit.jupiter.api.Test;
 
-import static com.mongodb.client.model.Filters.eq;
-
-/**
- * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#prose-tests">
- * Prose Tests</a>.
- */
-final class RetryableReadsProseTest {
-    /**
-     * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#1-poolclearederror-retryability-test">
-     * 1. PoolClearedError Retryability Test</a>.
-     */
-    @Test
-    void poolClearedExceptionMustBeRetryable() throws Exception {
-        RetryableWritesProseTest.poolClearedExceptionMustBeRetryable(
-                SyncMongoClient::new,
-                mongoCollection -> mongoCollection.find(eq(0)).iterator().hasNext(), "find", false);
-    }
-
-    /**
-     * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#21-retryable-reads-are-retried-on-a-different-mongos-when-one-is-available">
-     * 2.1 Retryable Reads Are Retried on a Different mongos When One is Available</a>.
-     */
-    @Test
-    void retriesOnDifferentMongosWhenAvailable() {
-        RetryableWritesProseTest.retriesOnDifferentMongosWhenAvailable(
-                SyncMongoClient::new,
-                mongoCollection -> {
-                    try (MongoCursor<Document> cursor = mongoCollection.find().iterator()) {
-                        return cursor.hasNext();
-                    }
-                }, "find", false);
-    }
-
-    /**
-     * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#22-retryable-reads-are-retried-on-the-same-mongos-when-no-others-are-available">
-     * 2.2 Retryable Reads Are Retried on the Same mongos When No Others are Available</a>.
-     */
-    @Test
-    void retriesOnSameMongosWhenAnotherNotAvailable() {
-        RetryableWritesProseTest.retriesOnSameMongosWhenAnotherNotAvailable(
-                SyncMongoClient::new,
-                mongoCollection -> {
-                    try (MongoCursor<Document> cursor = mongoCollection.find().iterator()) {
-                        return cursor.hasNext();
-                    }
-                }, "find", false);
+final class RetryableReadsProseTest extends AbstractRetryableReadsProseTest {
+    @Override
+    protected MongoClient createClient(final MongoClientSettings settings) {
+        return new SyncMongoClient(settings);
     }
 }

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ClientSessionBindingSpecification.groovy
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ClientSessionBindingSpecification.groovy
@@ -16,6 +16,7 @@
 
 package com.mongodb.reactivestreams.client.internal
 
+import com.mongodb.ClusterFixture
 import com.mongodb.ReadPreference
 import com.mongodb.ServerAddress
 import com.mongodb.async.FutureResultCallback
@@ -31,32 +32,34 @@ import com.mongodb.internal.connection.ServerTuple
 import com.mongodb.reactivestreams.client.ClientSession
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
+import static com.mongodb.ClusterFixture.getOperationContext
 
 class ClientSessionBindingSpecification extends Specification {
 
     def 'should return the session context from the connection source'() {
         given:
         def session = Stub(ClientSession)
+        def operationContext = ClusterFixture.getOperationContext()
         def wrappedBinding = Mock(AsyncClusterAwareReadWriteBinding);
         wrappedBinding.retain() >> wrappedBinding
         def binding = new ClientSessionBinding(session, false, wrappedBinding)
 
         when:
         def futureResultCallback = new FutureResultCallback<AsyncConnectionSource>()
-        binding.getReadConnectionSource(OPERATION_CONTEXT, futureResultCallback)
+
+        binding.getReadConnectionSource(operationContext, futureResultCallback)
 
         then:
-        1 * wrappedBinding.getReadConnectionSource(OPERATION_CONTEXT, _) >> {
+        1 * wrappedBinding.getReadConnectionSource(operationContext, _) >> {
             it[1].onResult(Stub(AsyncConnectionSource), null)
         }
 
         when:
         futureResultCallback = new FutureResultCallback<AsyncConnectionSource>()
-        binding.getWriteConnectionSource(OPERATION_CONTEXT, futureResultCallback)
+        binding.getWriteConnectionSource(operationContext, futureResultCallback)
 
         then:
-        1 * wrappedBinding.getWriteConnectionSource(OPERATION_CONTEXT, _) >> {
+        1 * wrappedBinding.getWriteConnectionSource(operationContext, _) >> {
             it[1].onResult(Stub(AsyncConnectionSource), null)
         }
     }
@@ -87,10 +90,10 @@ class ClientSessionBindingSpecification extends Specification {
         def wrappedBinding = createStubBinding()
         def binding = new ClientSessionBinding(session, true, wrappedBinding)
         def futureResultCallback = new FutureResultCallback<AsyncConnectionSource>()
-        binding.getReadConnectionSource(OPERATION_CONTEXT, futureResultCallback)
+        binding.getReadConnectionSource(getOperationContext(), futureResultCallback)
         def readConnectionSource = futureResultCallback.get()
         futureResultCallback = new FutureResultCallback<AsyncConnectionSource>()
-        binding.getWriteConnectionSource(OPERATION_CONTEXT, futureResultCallback)
+        binding.getWriteConnectionSource(getOperationContext(), futureResultCallback)
         def writeConnectionSource = futureResultCallback.get()
 
         when:

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ClientSessionBindingSpecification.groovy
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/ClientSessionBindingSpecification.groovy
@@ -32,14 +32,14 @@ import com.mongodb.internal.connection.ServerTuple
 import com.mongodb.reactivestreams.client.ClientSession
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.getOperationContext
+import static com.mongodb.ClusterFixture.createOperationContext
 
 class ClientSessionBindingSpecification extends Specification {
 
     def 'should return the session context from the connection source'() {
         given:
         def session = Stub(ClientSession)
-        def operationContext = ClusterFixture.getOperationContext()
+        def operationContext = ClusterFixture.createOperationContext()
         def wrappedBinding = Mock(AsyncClusterAwareReadWriteBinding);
         wrappedBinding.retain() >> wrappedBinding
         def binding = new ClientSessionBinding(session, false, wrappedBinding)
@@ -90,10 +90,10 @@ class ClientSessionBindingSpecification extends Specification {
         def wrappedBinding = createStubBinding()
         def binding = new ClientSessionBinding(session, true, wrappedBinding)
         def futureResultCallback = new FutureResultCallback<AsyncConnectionSource>()
-        binding.getReadConnectionSource(getOperationContext(), futureResultCallback)
+        binding.getReadConnectionSource(createOperationContext(), futureResultCallback)
         def readConnectionSource = futureResultCallback.get()
         futureResultCallback = new FutureResultCallback<AsyncConnectionSource>()
-        binding.getWriteConnectionSource(getOperationContext(), futureResultCallback)
+        binding.getWriteConnectionSource(createOperationContext(), futureResultCallback)
         def writeConnectionSource = futureResultCallback.get()
 
         when:

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
@@ -134,7 +134,7 @@ public abstract class AbstractRetryableReadsProseTest {
             commandListener.reset();
 
             //when
-            collection.insertOne(new Document());
+            collection.find().first();
 
             //then
             List<CommandFailedEvent> commandFailedEvents = commandListener.getCommandFailedEvents();

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.test.CollectionHelper;
+import com.mongodb.connection.ClusterDescription;
 import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandSucceededEvent;
 import com.mongodb.internal.connection.TestClusterListener;
@@ -136,7 +137,7 @@ public abstract class AbstractRetryableReadsProseTest {
                      .applyToClusterSettings(builder -> builder.addClusterListener(clusterListener))
                      .build())) {
 
-            waitForPrimaryDiscovery();
+            waitForClusterDiscovery();
 
             MongoCollection<Document> collection = client.getDatabase(getDefaultDatabaseName())
                     .getCollection(COLLECTION_NAME);
@@ -188,7 +189,7 @@ public abstract class AbstractRetryableReadsProseTest {
                      .applyToClusterSettings(builder -> builder.addClusterListener(clusterListener))
                      .build())) {
 
-            waitForPrimaryDiscovery();
+            waitForClusterDiscovery();
 
             MongoCollection<Document> collection = client.getDatabase(getDefaultDatabaseName())
                     .getCollection(COLLECTION_NAME);
@@ -211,9 +212,21 @@ public abstract class AbstractRetryableReadsProseTest {
         }
     }
 
-    private void waitForPrimaryDiscovery() throws InterruptedException, TimeoutException {
+    private void waitForClusterDiscovery() throws InterruptedException, TimeoutException {
         clusterListener.waitForClusterDescriptionChangedEvents(
-                event -> event.getNewDescription().hasReadableServer(ReadPreference.primary()),
+                event -> {
+                    ClusterDescription desc = event.getNewDescription();
+                    // We need both primary and secondary to be discovered (not UNKNOWN) before running the test.
+                    //
+                    // 1. The failpoint is set on the primary. If the primary is not yet discovered,
+                    //    primaryPreferred may route the find to a secondary, and the failpoint never fires.
+                    //
+                    // 2. When the primary is deprioritized on retry, primaryPreferred falls back to a secondary.
+                    //    If the secondaries are still UNKNOWN at that point, the fallback yields no selectable servers,
+                    //    causing the deprioritized primary to be selected again.
+                    return desc.hasReadableServer(ReadPreference.primary())
+                            && desc.hasReadableServer(ReadPreference.secondary());
+                },
                 1, Duration.ofSeconds(10));
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
@@ -216,7 +216,7 @@ public abstract class AbstractRetryableReadsProseTest {
         clusterListener.waitForClusterDescriptionChangedEvents(
                 event -> {
                     ClusterDescription desc = event.getNewDescription();
-                    // We need both primary and secondary to be discovered (not UNKNOWN) before running the test.
+                    // We need both primary and secondary to be discovered (not UNKNOWN) before running the deprioritization tests.
                     //
                     // 1. The failpoint is set on the primary. If the primary is not yet discovered,
                     //    primaryPreferred may route the find to a secondary, and the failpoint never fires.

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
@@ -53,7 +53,7 @@ public abstract class AbstractRetryableReadsProseTest {
 
     private static final String COLLECTION_NAME = "test";
 
-    protected abstract MongoClient createClient(final MongoClientSettings settings);
+    protected abstract MongoClient createClient(MongoClientSettings settings);
 
     @AfterEach
     void afterEach() {

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.ReadPreference;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.test.CollectionHelper;
+import com.mongodb.event.CommandFailedEvent;
+import com.mongodb.event.CommandSucceededEvent;
+import com.mongodb.internal.connection.TestCommandListener;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.MongoException.RETRYABLE_ERROR_LABEL;
+import static com.mongodb.MongoException.SYSTEM_OVERLOADED_ERROR_LABEL;
+import static com.mongodb.client.Fixture.getDefaultDatabaseName;
+import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
+import static com.mongodb.client.Fixture.getPrimary;
+import static com.mongodb.client.model.Filters.eq;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#prose-tests">
+ * Prose Tests</a>.
+ */
+public abstract class AbstractRetryableReadsProseTest {
+
+    private static final String COLLECTION_NAME = "test";
+
+    protected abstract MongoClient createClient(MongoClientSettings settings);
+
+    @AfterEach
+    void afterEach() {
+        CollectionHelper.dropDatabase(getDefaultDatabaseName());
+    }
+
+    /**
+     * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#1-poolclearederror-retryability-test">
+     * 1. PoolClearedError Retryability Test</a>.
+     */
+    @Test
+    void poolClearedExceptionMustBeRetryable() throws Exception {
+        RetryableWritesProseTest.poolClearedExceptionMustBeRetryable(this::createClient,
+                mongoCollection -> mongoCollection.find(eq(0)).iterator().hasNext(), "find", false);
+    }
+
+    /**
+     * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#21-retryable-reads-are-retried-on-a-different-mongos-when-one-is-available">
+     * 2.1 Retryable Reads Are Retried on a Different mongos When One is Available</a>.
+     */
+    @Test
+    void retriesOnDifferentMongosWhenAvailable() {
+        RetryableWritesProseTest.retriesOnDifferentMongosWhenAvailable(this::createClient,
+            mongoCollection -> {
+                try (MongoCursor<Document> cursor = mongoCollection.find().iterator()) {
+                    return cursor.hasNext();
+                }
+            }, "find", false);
+    }
+
+    /**
+     * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#22-retryable-reads-are-retried-on-the-same-mongos-when-no-others-are-available">
+     * 2.2 Retryable Reads Are Retried on the Same mongos When No Others are Available</a>.
+     */
+    @Test
+    void retriesOnSameMongosWhenAnotherNotAvailable() {
+        RetryableWritesProseTest.retriesOnSameMongosWhenAnotherNotAvailable(this::createClient,
+                mongoCollection -> {
+                    try (MongoCursor<Document> cursor = mongoCollection.find().iterator()) {
+                        return cursor.hasNext();
+                    }
+                }, "find", false);
+    }
+
+    /**
+     * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#31-retryable-reads-caused-by-overload-errors-are-retried-on-a-different-replicaset-server-when-one-is-available">
+     * 3.1 Retryable Reads Caused by Overload Errors Are Retried on a Different Replicaset Server When One is Available</a>.
+     */
+    //TODO-JAVA-6141 add overloadRetargeting into tests.
+    @Test
+    void overloadErrorRetriedOnDifferentReplicaSetServer() throws InterruptedException {
+        //given
+        assumeTrue(serverVersionAtLeast(4, 4));
+        assumeTrue(isDiscoverableReplicaSet());
+        ServerAddress primaryServerAddress = getPrimary();
+        TestCommandListener commandListener = new TestCommandListener(asList("commandFailedEvent", "commandSucceededEvent"), emptyList());
+        BsonDocument configureFailPoint = BsonDocument.parse(
+                "{\n"
+                        + "    configureFailPoint: \"failCommand\",\n"
+                        + "    mode: { times: 1 },\n"
+                        + "    data: {\n"
+                        + "        failCommands: [\"find\"],\n"
+                        + "        errorLabels: ['" + RETRYABLE_ERROR_LABEL + "', '" + SYSTEM_OVERLOADED_ERROR_LABEL + "'],\n"
+                        + "        errorCode: 6\n"
+                        + "    }\n"
+                        + "}\n");
+
+        try (FailPoint ignored = FailPoint.enable(configureFailPoint, primaryServerAddress);
+             MongoClient client = createClient(getMongoClientSettingsBuilder()
+                     .retryReads(true)
+                     .readPreference(ReadPreference.primaryPreferred())
+                     .addCommandListener(commandListener)
+                     .build())) {
+
+            MongoCollection<Document> collection = client.getDatabase(getDefaultDatabaseName())
+                    .getCollection(COLLECTION_NAME);
+            commandListener.reset();
+
+            //when
+            collection.find().first();
+
+            //then
+            List<CommandFailedEvent> commandFailedEvents = commandListener.getCommandFailedEvents();
+            assertEquals(1, commandFailedEvents.size());
+            List<CommandSucceededEvent> commandSucceededEvents = commandListener.getCommandSucceededEvents();
+            assertEquals(1, commandSucceededEvents.size());
+
+            ServerAddress failedServer = commandFailedEvents.get(0).getConnectionDescription().getServerAddress();
+            ServerAddress succeededServer = commandSucceededEvents.get(0).getConnectionDescription().getServerAddress();
+
+            assertFalse(failedServer.equals(succeededServer),
+                    format("Expected retry on different server but both were %s", failedServer));
+        }
+    }
+
+    /**
+     * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#32-retryable-reads-caused-by-non-overload-errors-are-retried-on-the-same-replicaset-server">
+     * 3.2 Retryable Reads Caused by Non-Overload Errors Are Retried on the Same Replicaset Server</a>.
+     */
+    //TODO-JAVA-6141 add overloadRetargeting into tests.
+    @Test
+    void nonOverloadErrorRetriedOnSameReplicaSetServer() throws InterruptedException {
+        //given
+        assumeTrue(serverVersionAtLeast(4, 4));
+        assumeTrue(isDiscoverableReplicaSet());
+        ServerAddress primaryServerAddress = getPrimary();
+        TestCommandListener commandListener = new TestCommandListener(asList("commandFailedEvent", "commandSucceededEvent"), emptyList());
+        BsonDocument configureFailPoint = BsonDocument.parse(
+                "{\n"
+                        + "    configureFailPoint: \"failCommand\",\n"
+                        + "    mode: { times: 1 },\n"
+                        + "    data: {\n"
+                        + "        failCommands: [\"find\"],\n"
+                        + "        errorLabels: ['" + RETRYABLE_ERROR_LABEL + "'],\n"
+                        + "        errorCode: 6\n"
+                        + "    }\n"
+                        + "}\n");
+
+        try (FailPoint ignored = FailPoint.enable(configureFailPoint, primaryServerAddress);
+             MongoClient client = createClient(getMongoClientSettingsBuilder()
+                     .retryReads(true)
+                     .readPreference(ReadPreference.primaryPreferred())
+                     .addCommandListener(commandListener)
+                     .build())) {
+
+            MongoCollection<Document> collection = client.getDatabase(getDefaultDatabaseName())
+                    .getCollection(COLLECTION_NAME);
+            commandListener.reset();
+
+            //when
+            collection.find().first();
+
+            //then
+            List<CommandFailedEvent> commandFailedEvents = commandListener.getCommandFailedEvents();
+            assertEquals(1, commandFailedEvents.size());
+            List<CommandSucceededEvent> commandSucceededEvents = commandListener.getCommandSucceededEvents();
+            assertEquals(1, commandSucceededEvents.size());
+
+            ServerAddress failedServer = commandFailedEvents.get(0).getConnectionDescription().getServerAddress();
+            ServerAddress succeededServer = commandSucceededEvents.get(0).getConnectionDescription().getServerAddress();
+
+            assertEquals(failedServer, succeededServer,
+                    format("Expected retry on same server but got %s and %s", failedServer, succeededServer));
+        }
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
@@ -22,13 +22,16 @@ import com.mongodb.ServerAddress;
 import com.mongodb.client.test.CollectionHelper;
 import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandSucceededEvent;
+import com.mongodb.internal.connection.TestClusterListener;
 import com.mongodb.internal.connection.TestCommandListener;
 import org.bson.BsonDocument;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
@@ -53,11 +56,17 @@ public abstract class AbstractRetryableReadsProseTest {
 
     private static final String COLLECTION_NAME = "test";
 
+    private final TestCommandListener commandListener =
+            new TestCommandListener(asList("commandFailedEvent", "commandSucceededEvent"), emptyList());
+    private final TestClusterListener clusterListener = new TestClusterListener();
+
     protected abstract MongoClient createClient(MongoClientSettings settings);
 
     @AfterEach
     void afterEach() {
         CollectionHelper.dropDatabase(getDefaultDatabaseName());
+        commandListener.reset();
+        clusterListener.clearClusterDescriptionChangedEvents();
     }
 
     /**
@@ -104,12 +113,10 @@ public abstract class AbstractRetryableReadsProseTest {
      */
     //TODO-BACKPRESSURE Slav Babanin JAVA-6167 add overloadRetargeting into tests.
     @Test
-    void overloadErrorRetriedOnDifferentReplicaSetServer() throws InterruptedException {
+    void overloadErrorRetriedOnDifferentReplicaSetServer() throws InterruptedException, TimeoutException {
         //given
         assumeTrue(serverVersionAtLeast(4, 4));
         assumeTrue(isDiscoverableReplicaSet());
-        ServerAddress primaryServerAddress = getPrimary();
-        TestCommandListener commandListener = new TestCommandListener(asList("commandFailedEvent", "commandSucceededEvent"), emptyList());
         BsonDocument configureFailPoint = BsonDocument.parse(
                 "{\n"
                         + "    configureFailPoint: \"failCommand\",\n"
@@ -121,12 +128,15 @@ public abstract class AbstractRetryableReadsProseTest {
                         + "    }\n"
                         + "}\n");
 
-        try (FailPoint ignored = FailPoint.enable(configureFailPoint, primaryServerAddress);
+        try (FailPoint ignored = FailPoint.enable(configureFailPoint, getPrimary());
              MongoClient client = createClient(getMongoClientSettingsBuilder()
                      .retryReads(true)
                      .readPreference(ReadPreference.primaryPreferred())
                      .addCommandListener(commandListener)
+                     .applyToClusterSettings(builder -> builder.addClusterListener(clusterListener))
                      .build())) {
+
+            waitForPrimaryDiscovery();
 
             MongoCollection<Document> collection = client.getDatabase(getDefaultDatabaseName())
                     .getCollection(COLLECTION_NAME);
@@ -155,12 +165,10 @@ public abstract class AbstractRetryableReadsProseTest {
      */
     //TODO-BACKPRESSURE Slav Babanin JAVA-6167 add overloadRetargeting into tests.
     @Test
-    void nonOverloadErrorRetriedOnSameReplicaSetServer() throws InterruptedException {
+    void nonOverloadErrorRetriedOnSameReplicaSetServer() throws InterruptedException, TimeoutException {
         //given
         assumeTrue(serverVersionAtLeast(4, 4));
         assumeTrue(isDiscoverableReplicaSet());
-        ServerAddress primaryServerAddress = getPrimary();
-        TestCommandListener commandListener = new TestCommandListener(asList("commandFailedEvent", "commandSucceededEvent"), emptyList());
         BsonDocument configureFailPoint = BsonDocument.parse(
                 "{\n"
                         + "    configureFailPoint: \"failCommand\",\n"
@@ -172,12 +180,15 @@ public abstract class AbstractRetryableReadsProseTest {
                         + "    }\n"
                         + "}\n");
 
-        try (FailPoint ignored = FailPoint.enable(configureFailPoint, primaryServerAddress);
+        try (FailPoint ignored = FailPoint.enable(configureFailPoint, getPrimary());
              MongoClient client = createClient(getMongoClientSettingsBuilder()
                      .retryReads(true)
                      .readPreference(ReadPreference.primaryPreferred())
                      .addCommandListener(commandListener)
+                     .applyToClusterSettings(builder -> builder.addClusterListener(clusterListener))
                      .build())) {
+
+            waitForPrimaryDiscovery();
 
             MongoCollection<Document> collection = client.getDatabase(getDefaultDatabaseName())
                     .getCollection(COLLECTION_NAME);
@@ -198,5 +209,11 @@ public abstract class AbstractRetryableReadsProseTest {
             assertEquals(failedServer, succeededServer,
                     format("Expected retry on same server but got %s and %s", failedServer, succeededServer));
         }
+    }
+
+    private void waitForPrimaryDiscovery() throws InterruptedException, TimeoutException {
+        clusterListener.waitForClusterDescriptionChangedEvents(
+                event -> event.getNewDescription().hasReadableServer(ReadPreference.primary()),
+                1, Duration.ofSeconds(10));
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
@@ -115,12 +115,11 @@ public abstract class AbstractRetryableReadsProseTest {
                         + "    configureFailPoint: \"failCommand\",\n"
                         + "    mode: { times: 1 },\n"
                         + "    data: {\n"
-                        + "        failCommands: [\"insert\"],\n"
+                        + "        failCommands: [\"find\"],\n"
                         + "        errorLabels: ['" + RETRYABLE_ERROR_LABEL + "', '" + SYSTEM_OVERLOADED_ERROR_LABEL + "'],\n"
                         + "        errorCode: 6\n"
                         + "    }\n"
                         + "}\n");
-
 
         try (FailPoint ignored = FailPoint.enable(configureFailPoint, primaryServerAddress);
              MongoClient client = createClient(getMongoClientSettingsBuilder()

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractRetryableReadsProseTest.java
@@ -42,7 +42,7 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -53,7 +53,7 @@ public abstract class AbstractRetryableReadsProseTest {
 
     private static final String COLLECTION_NAME = "test";
 
-    protected abstract MongoClient createClient(MongoClientSettings settings);
+    protected abstract MongoClient createClient(final MongoClientSettings settings);
 
     @AfterEach
     void afterEach() {
@@ -102,7 +102,7 @@ public abstract class AbstractRetryableReadsProseTest {
      * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#31-retryable-reads-caused-by-overload-errors-are-retried-on-a-different-replicaset-server-when-one-is-available">
      * 3.1 Retryable Reads Caused by Overload Errors Are Retried on a Different Replicaset Server When One is Available</a>.
      */
-    //TODO-JAVA-6141 add overloadRetargeting into tests.
+    //TODO-BACKPRESSURE Slav Babanin JAVA-6167 add overloadRetargeting into tests.
     @Test
     void overloadErrorRetriedOnDifferentReplicaSetServer() throws InterruptedException {
         //given
@@ -115,11 +115,12 @@ public abstract class AbstractRetryableReadsProseTest {
                         + "    configureFailPoint: \"failCommand\",\n"
                         + "    mode: { times: 1 },\n"
                         + "    data: {\n"
-                        + "        failCommands: [\"find\"],\n"
+                        + "        failCommands: [\"insert\"],\n"
                         + "        errorLabels: ['" + RETRYABLE_ERROR_LABEL + "', '" + SYSTEM_OVERLOADED_ERROR_LABEL + "'],\n"
                         + "        errorCode: 6\n"
                         + "    }\n"
                         + "}\n");
+
 
         try (FailPoint ignored = FailPoint.enable(configureFailPoint, primaryServerAddress);
              MongoClient client = createClient(getMongoClientSettingsBuilder()
@@ -133,7 +134,7 @@ public abstract class AbstractRetryableReadsProseTest {
             commandListener.reset();
 
             //when
-            collection.find().first();
+            collection.insertOne(new Document());
 
             //then
             List<CommandFailedEvent> commandFailedEvents = commandListener.getCommandFailedEvents();
@@ -144,7 +145,7 @@ public abstract class AbstractRetryableReadsProseTest {
             ServerAddress failedServer = commandFailedEvents.get(0).getConnectionDescription().getServerAddress();
             ServerAddress succeededServer = commandSucceededEvents.get(0).getConnectionDescription().getServerAddress();
 
-            assertFalse(failedServer.equals(succeededServer),
+            assertNotEquals(failedServer, succeededServer,
                     format("Expected retry on different server but both were %s", failedServer));
         }
     }
@@ -153,7 +154,7 @@ public abstract class AbstractRetryableReadsProseTest {
      * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#32-retryable-reads-caused-by-non-overload-errors-are-retried-on-the-same-replicaset-server">
      * 3.2 Retryable Reads Caused by Non-Overload Errors Are Retried on the Same Replicaset Server</a>.
      */
-    //TODO-JAVA-6141 add overloadRetargeting into tests.
+    //TODO-BACKPRESSURE Slav Babanin JAVA-6167 add overloadRetargeting into tests.
     @Test
     void nonOverloadErrorRetriedOnSameReplicaSetServer() throws InterruptedException {
         //given

--- a/driver-sync/src/test/functional/com/mongodb/client/RetryableReadsProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/RetryableReadsProseTest.java
@@ -16,51 +16,11 @@
 
 package com.mongodb.client;
 
-import org.bson.Document;
-import org.junit.jupiter.api.Test;
+import com.mongodb.MongoClientSettings;
 
-import static com.mongodb.client.model.Filters.eq;
-
-/**
- * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#prose-tests">
- * Prose Tests</a>.
- */
-final class RetryableReadsProseTest {
-    /**
-     * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#1-poolclearederror-retryability-test">
-     * 1. PoolClearedError Retryability Test</a>.
-     */
-    @Test
-    void poolClearedExceptionMustBeRetryable() throws Exception {
-        RetryableWritesProseTest.poolClearedExceptionMustBeRetryable(MongoClients::create,
-                mongoCollection -> mongoCollection.find(eq(0)).iterator().hasNext(), "find", false);
-    }
-
-    /**
-     * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#21-retryable-reads-are-retried-on-a-different-mongos-when-one-is-available">
-     * 2.1 Retryable Reads Are Retried on a Different mongos When One is Available</a>.
-     */
-    @Test
-    void retriesOnDifferentMongosWhenAvailable() {
-        RetryableWritesProseTest.retriesOnDifferentMongosWhenAvailable(MongoClients::create,
-            mongoCollection -> {
-                try (MongoCursor<Document> cursor = mongoCollection.find().iterator()) {
-                    return cursor.hasNext();
-                }
-            }, "find", false);
-    }
-
-    /**
-     * <a href="https://github.com/mongodb/specifications/blob/master/source/retryable-reads/tests/README.md#22-retryable-reads-are-retried-on-the-same-mongos-when-no-others-are-available">
-     * 2.2 Retryable Reads Are Retried on the Same mongos When No Others are Available</a>.
-     */
-    @Test
-    void retriesOnSameMongosWhenAnotherNotAvailable() {
-        RetryableWritesProseTest.retriesOnSameMongosWhenAnotherNotAvailable(MongoClients::create,
-                mongoCollection -> {
-                    try (MongoCursor<Document> cursor = mongoCollection.find().iterator()) {
-                        return cursor.hasNext();
-                    }
-                }, "find", false);
+final class RetryableReadsProseTest extends AbstractRetryableReadsProseTest {
+    @Override
+    protected MongoClient createClient(final MongoClientSettings settings) {
+        return MongoClients.create(settings);
     }
 }

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ClientSessionBindingSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ClientSessionBindingSpecification.groovy
@@ -16,7 +16,7 @@
 
 package com.mongodb.client.internal
 
-
+import com.mongodb.ClusterFixture
 import com.mongodb.ReadPreference
 import com.mongodb.client.ClientSession
 import com.mongodb.internal.binding.ClusterBinding
@@ -25,29 +25,28 @@ import com.mongodb.internal.binding.ReadWriteBinding
 import com.mongodb.internal.connection.Cluster
 import spock.lang.Specification
 
-import static com.mongodb.ClusterFixture.OPERATION_CONTEXT
-
 class ClientSessionBindingSpecification extends Specification {
 
     def 'should call underlying wrapped binding'() {
         given:
         def session = Stub(ClientSession)
+        def operationContext = ClusterFixture.getOperationContext()
         def wrappedBinding = Mock(ClusterBinding);
         def binding = new ClientSessionBinding(session, false, wrappedBinding)
 
         when:
-        binding.getReadConnectionSource(OPERATION_CONTEXT)
+        binding.getReadConnectionSource(operationContext)
 
         then:
-        1 * wrappedBinding.getReadConnectionSource(OPERATION_CONTEXT) >> {
+        1 * wrappedBinding.getReadConnectionSource(operationContext) >> {
             Stub(ConnectionSource)
         }
 
         when:
-        binding.getWriteConnectionSource(OPERATION_CONTEXT)
+        binding.getWriteConnectionSource(operationContext)
 
         then:
-        1 * wrappedBinding.getWriteConnectionSource(OPERATION_CONTEXT) >> {
+        1 * wrappedBinding.getWriteConnectionSource(operationContext) >> {
             Stub(ConnectionSource)
         }
     }
@@ -77,8 +76,9 @@ class ClientSessionBindingSpecification extends Specification {
         def session = Mock(ClientSession)
         def wrappedBinding = createStubBinding()
         def binding = new ClientSessionBinding(session, true, wrappedBinding)
-        def readConnectionSource = binding.getReadConnectionSource(OPERATION_CONTEXT)
-        def writeConnectionSource = binding.getWriteConnectionSource(OPERATION_CONTEXT)
+        def operationContext = ClusterFixture.getOperationContext()
+        def readConnectionSource = binding.getReadConnectionSource(operationContext)
+        def writeConnectionSource = binding.getWriteConnectionSource(operationContext)
 
         when:
         binding.release()

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ClientSessionBindingSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ClientSessionBindingSpecification.groovy
@@ -30,7 +30,7 @@ class ClientSessionBindingSpecification extends Specification {
     def 'should call underlying wrapped binding'() {
         given:
         def session = Stub(ClientSession)
-        def operationContext = ClusterFixture.getOperationContext()
+        def operationContext = ClusterFixture.createOperationContext()
         def wrappedBinding = Mock(ClusterBinding);
         def binding = new ClientSessionBinding(session, false, wrappedBinding)
 
@@ -76,7 +76,7 @@ class ClientSessionBindingSpecification extends Specification {
         def session = Mock(ClientSession)
         def wrappedBinding = createStubBinding()
         def binding = new ClientSessionBinding(session, true, wrappedBinding)
-        def operationContext = ClusterFixture.getOperationContext()
+        def operationContext = ClusterFixture.createOperationContext()
         def readConnectionSource = binding.getReadConnectionSource(operationContext)
         def writeConnectionSource = binding.getWriteConnectionSource(operationContext)
 

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/CryptConnectionSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/CryptConnectionSpecification.groovy
@@ -61,7 +61,7 @@ class CryptConnectionSpecification extends Specification {
         def cryptConnection = new CryptConnection(wrappedConnection, crypt)
         def codec = new DocumentCodec()
         def timeoutContext = Mock(TimeoutContext)
-        def operationContext = ClusterFixture.OPERATION_CONTEXT.withTimeoutContext(timeoutContext)
+        def operationContext = ClusterFixture.getOperationContext().withTimeoutContext(timeoutContext)
         def operationTimeout = Mock(Timeout)
         timeoutContext.getTimeout() >> operationTimeout
 
@@ -127,7 +127,7 @@ class CryptConnectionSpecification extends Specification {
         def encryptedResponse = toRaw(new BsonDocument('ok', new BsonInt32(1)))
         def decryptedResponse = encryptedResponse
         def timeoutContext = Mock(TimeoutContext)
-        def operationContext = ClusterFixture.OPERATION_CONTEXT.withTimeoutContext(timeoutContext)
+        def operationContext = ClusterFixture.getOperationContext().withTimeoutContext(timeoutContext)
         def operationTimeout = Mock(Timeout)
         timeoutContext.getTimeout() >> operationTimeout
 
@@ -183,7 +183,7 @@ class CryptConnectionSpecification extends Specification {
         def encryptedResponse = toRaw(new BsonDocument('ok', new BsonInt32(1)))
         def decryptedResponse = encryptedResponse
         def timeoutContext = Mock(TimeoutContext)
-        def operationContext = ClusterFixture.OPERATION_CONTEXT.withTimeoutContext(timeoutContext)
+        def operationContext = ClusterFixture.getOperationContext().withTimeoutContext(timeoutContext)
         def operationTimeout = Mock(Timeout)
         timeoutContext.getTimeout() >> operationTimeout
 

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/CryptConnectionSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/CryptConnectionSpecification.groovy
@@ -61,7 +61,7 @@ class CryptConnectionSpecification extends Specification {
         def cryptConnection = new CryptConnection(wrappedConnection, crypt)
         def codec = new DocumentCodec()
         def timeoutContext = Mock(TimeoutContext)
-        def operationContext = ClusterFixture.getOperationContext().withTimeoutContext(timeoutContext)
+        def operationContext = ClusterFixture.createOperationContext().withTimeoutContext(timeoutContext)
         def operationTimeout = Mock(Timeout)
         timeoutContext.getTimeout() >> operationTimeout
 
@@ -127,7 +127,7 @@ class CryptConnectionSpecification extends Specification {
         def encryptedResponse = toRaw(new BsonDocument('ok', new BsonInt32(1)))
         def decryptedResponse = encryptedResponse
         def timeoutContext = Mock(TimeoutContext)
-        def operationContext = ClusterFixture.getOperationContext().withTimeoutContext(timeoutContext)
+        def operationContext = ClusterFixture.createOperationContext().withTimeoutContext(timeoutContext)
         def operationTimeout = Mock(Timeout)
         timeoutContext.getTimeout() >> operationTimeout
 
@@ -183,7 +183,7 @@ class CryptConnectionSpecification extends Specification {
         def encryptedResponse = toRaw(new BsonDocument('ok', new BsonInt32(1)))
         def decryptedResponse = encryptedResponse
         def timeoutContext = Mock(TimeoutContext)
-        def operationContext = ClusterFixture.getOperationContext().withTimeoutContext(timeoutContext)
+        def operationContext = ClusterFixture.createOperationContext().withTimeoutContext(timeoutContext)
         def operationTimeout = Mock(Timeout)
         timeoutContext.getTimeout() >> operationTimeout
 


### PR DESCRIPTION
Relevant specification changes:

- [DRIVERS-3344 - Add support for server selection's deprioritized servers to all topologies (#1865)](https://github.com/mongodb/specifications/commit/3e577e879b60d3850ed617ea8f91eeec14c106e3)
- [DRIVERS-3380 Filter deprioritized candidates by address only (#1886)](https://github.com/mongodb/specifications/commit/9e2acc6c9f77977cdbc0705cd8e236ed4d1b6551)
- [DRIVERS-3404 - Server selection deprioritization only for overload errors on replica sets (#1900)](https://github.com/mongodb/specifications/commit/9a101dec57a95ebca1593c022fcf79cfff725577) (the change has been added on April 15, 2026 to this PR)
- [DRIVERS-3406 test deprioritized selection with tag sets (#1903)](https://github.com/mongodb/specifications/commit/19ed647f6d6ca2de231e21de25bd1279f6d0bd14) - the change has not yet been addressed in this PR, because it was introduced after creation of the PR.

The change will be as part of a subsequent PR as it concerns API surface:
- [DRIVERS-3427: Finalize client backpressure implementation for phase 1 rollout (#1919)](https://github.com/mongodb/specifications/commit/1b15cd299011172f941893cbe3c9d4737cb2ee5d) - the part in `client-backpressure.md` about `enableOverloadRetargeting`, and all the prose test changes in `source/retryable-reads/tests/README.md`. 

JAVA-6021, 
JAVA-6074,
JAVA-6105
JAVA-6114

- [x]  Has AI-assistance been used?
- Prose test refactoring to abstract class was performed by Claude Opus 4.6
- Code review was done by Claude Opus 4.6 based on @rozza Claude skill: https://github.com/rozza/ai-skills/tree/main/driver-code-review
<details> 
<summary> Code review result </summary>
JAVA-6105

Correctness & Architecture

**[praise]** The gating logic in `onAttemptFailure` is clean and minimal -- one boolean, one `if`. No over-engineering.

**[praise]** Passing `ClusterType` to `updateCandidate` rather than storing it in the deprioritized set keeps the data structure simple (`Set<ServerAddress>`).

**[nit]** `OperationContext.java:220` -- `clusterType` field is uninitialized (defaults to `null`). If `onAttemptFailure` is called before `updateCandidate`, `clusterType == ClusterType.SHARDED` is false and `candidate` is null so it returns early. Safe, but an explicit initialization `private ClusterType clusterType = ClusterType.UNKNOWN` would make the intent clearer.

**[important]** `ServerSelectionSelectionTest.java` -- The comment "Thus, SystemOverloadedError used unconditionally regardless of the cluster type" is correct but the `static import` of `format` was removed and replaced with... nothing. The `format` method is now called as an instance method `format()` on the test class itself (line 115/119 in the existing code). That's from the existing `format` helper at the bottom of the class. No issue, just noting the import change is valid.

### Performance & Concurrency

**[praise]** No performance concerns. The `instanceof` + `hasErrorLabel` check in `onAttemptFailure` is on the error path only -- not a hot path.

**[praise]** No concurrency changes. `ServerDeprioritization` is explicitly documented as not needing thread safety.

### Code Quality & Tests

**[praise]** `deprioritizableClusters()` pattern in `ServerDeprioritizationTest` is elegant -- it encodes the valid (clusterType, error) pairs that trigger deprioritization, and all test method sources derive from it. Single source of truth.

**[praise]** `onAttemptFailureIgnoresIfNonShardedWithoutOverloadError` tests both `RuntimeException` and `MongoException` without `SystemOverloadedError`, covering both branches of the conditional.

[This suggestion was adopted in the PR]**[nit]** `ServerDeprioritizationTest` line 108: `of(SHARDED_CLUSTER, new RuntimeException())` -- `RuntimeException` is used as "any error" for sharded. This works but a `MongoException` might be more realistic since server errors are always `MongoException` in practice. Not wrong, just a style choice. Using `RuntimeException` actually makes the test stronger -- it proves sharded deprioritizes on *any* `Throwable`, not just `MongoException`.

**[nit]** `AbstractRetryableReadsProseTest` -- Tests 1, 2.1, 2.2 delegate to `RetryableWritesProseTest` static methods (pre-existing pattern). Tests 3.1, 3.2 are inline. This inconsistency is acceptable since the new tests don't share logic with writes, but worth noting.

**[suggestion]** `AbstractRetryableReadsProseTest` line 54 -- `COLLECTION_NAME = "test"` is a private constant used only in 3.1/3.2. The older tests (1, 2.1, 2.2) use their own collection names inside `RetryableWritesProseTest`. After `@AfterEach` drops the database anyway, the collection name doesn't matter much. Fine as-is.

### Final Verdict: **Approve**

No blocking issues. The implementation is clean, minimal, well-tested, and aligned with the spec. The parameterized test structure in `ServerDeprioritizationTest` is a good pattern.
</details>
