### PR TITLE
[JAVA-6060]  Reduce global state by grouping internal settings

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/InternalMongoClientSettings.java
+++ b/driver-core/src/main/com/mongodb/internal/InternalMongoClientSettings.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.mongodb.internal.connection;
+package com.mongodb.internal;
 
 import com.mongodb.annotations.Immutable;
+import com.mongodb.internal.connection.InternalConnectionPoolSettings;
 
 import java.util.Objects;
 

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterFactory.java
@@ -31,6 +31,7 @@ import com.mongodb.event.ClusterListener;
 import com.mongodb.event.CommandListener;
 import com.mongodb.event.ServerListener;
 import com.mongodb.event.ServerMonitorListener;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.diagnostics.logging.Logger;

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterFactory.java
@@ -60,7 +60,7 @@ public final class DefaultClusterFactory {
 
     public Cluster createCluster(final ClusterSettings originalClusterSettings, final ServerSettings originalServerSettings,
                                  final ConnectionPoolSettings connectionPoolSettings,
-                                 final InternalConnectionPoolSettings internalConnectionPoolSettings,
+                                 final InternalMongoClientSettings internalSettings,
                                  final TimeoutSettings clusterTimeoutSettings,
                                  final StreamFactory streamFactory,
                                  final TimeoutSettings heartbeatTimeoutSettings,
@@ -113,12 +113,12 @@ public final class DefaultClusterFactory {
 
         if (clusterSettings.getMode() == ClusterConnectionMode.LOAD_BALANCED) {
             ClusterableServerFactory serverFactory = new LoadBalancedClusterableServerFactory(serverSettings,
-                    connectionPoolSettings, internalConnectionPoolSettings, streamFactory, credential, loggerSettings, commandListener,
+                    connectionPoolSettings, internalSettings, streamFactory, credential, loggerSettings, commandListener,
                     compressorList, serverApi, clusterOperationContextFactory);
             return new LoadBalancedCluster(clusterId, clusterSettings, serverFactory, clientMetadata, dnsSrvRecordMonitorFactory);
         } else {
             ClusterableServerFactory serverFactory = new DefaultClusterableServerFactory(serverSettings,
-                    connectionPoolSettings, internalConnectionPoolSettings,
+                    connectionPoolSettings, internalSettings,
                     clusterOperationContextFactory, streamFactory, heartBeatOperationContextFactory, heartbeatStreamFactory, credential,
                     loggerSettings, commandListener, compressorList,
                     serverApi, FaasEnvironment.getFaasEnvironment() != FaasEnvironment.UNKNOWN);

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
@@ -27,6 +27,7 @@ import com.mongodb.connection.ServerId;
 import com.mongodb.connection.ServerSettings;
 import com.mongodb.event.CommandListener;
 import com.mongodb.event.ServerListener;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.internal.inject.SameObjectProvider;
 import com.mongodb.lang.Nullable;
 

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalMongoClientSettings.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalMongoClientSettings.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.internal.connection;
+
+import com.mongodb.annotations.Immutable;
+
+import java.util.Objects;
+
+/**
+ * Internal settings for MongoClient that are not part of the public API.
+ * Used for testing and internal configuration purposes.
+ *
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+@Immutable
+public final class InternalMongoClientSettings {
+
+    private static final InternalMongoClientSettings DEFAULTS = builder().build();
+
+    private final InternalConnectionPoolSettings internalConnectionPoolSettings;
+    private final boolean recordEverything;
+
+    private InternalMongoClientSettings(final Builder builder) {
+        this.internalConnectionPoolSettings = builder.internalConnectionPoolSettings != null
+                ? builder.internalConnectionPoolSettings
+                : InternalConnectionPoolSettings.builder().build();
+        this.recordEverything = builder.recordEverything;
+    }
+
+    /**
+     * Gets the default internal settings for production use.
+     *
+     * @return the default settings
+     */
+    public static InternalMongoClientSettings getDefaults() {
+        return DEFAULTS;
+    }
+
+    /**
+     * Creates a new builder for InternalMongoClientSettings.
+     *
+     * @return the builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Gets the internal connection pool settings.
+     *
+     * @return the internal connection pool settings
+     */
+    public InternalConnectionPoolSettings getInternalConnectionPoolSettings() {
+        return internalConnectionPoolSettings;
+    }
+
+    /**
+     * Indicates whether to record all commands including security-sensitive commands
+     * (like authentication commands) to the command listener.
+     * <p>
+     * When disabled (the default for production), security-sensitive commands are not recorded
+     * to the command listener for security reasons. When enabled, all commands are recorded,
+     * which is useful for testing authentication and handshake behavior.
+     * </p>
+     *
+     * @return true if all commands should be recorded
+     */
+    public boolean isRecordEverything() {
+        return recordEverything;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InternalMongoClientSettings that = (InternalMongoClientSettings) o;
+        return recordEverything == that.recordEverything
+                && Objects.equals(internalConnectionPoolSettings, that.internalConnectionPoolSettings);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(internalConnectionPoolSettings, recordEverything);
+    }
+
+    @Override
+    public String toString() {
+        return "InternalMongoClientSettings{"
+                + "internalConnectionPoolSettings=" + internalConnectionPoolSettings
+                + ", recordEverything=" + recordEverything
+                + '}';
+    }
+
+    /**
+     * A builder for InternalMongoClientSettings.
+     */
+    public static final class Builder {
+        private InternalConnectionPoolSettings internalConnectionPoolSettings = InternalConnectionPoolSettings.builder().build();
+        private boolean recordEverything = false;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the internal connection pool settings.
+         *
+         * @param internalConnectionPoolSettings the internal connection pool settings
+         * @return this
+         */
+        public Builder internalConnectionPoolSettings(
+                final InternalConnectionPoolSettings internalConnectionPoolSettings) {
+            this.internalConnectionPoolSettings = internalConnectionPoolSettings;
+            return this;
+        }
+
+        /**
+         * Sets whether to record all commands including security-sensitive commands.
+         * <p>
+         * Default is {@code false} for production use. Set to {@code true} for testing
+         * authentication and handshake behavior.
+         * </p>
+         *
+         * @param recordEverything whether to record all commands
+         * @return this
+         */
+        public Builder recordEverything(final boolean recordEverything) {
+            this.recordEverything = recordEverything;
+            return this;
+        }
+
+        /**
+         * Builds the InternalMongoClientSettings.
+         *
+         * @return the internal settings
+         */
+        public InternalMongoClientSettings build() {
+            return new InternalMongoClientSettings(this);
+        }
+    }
+}
+

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionFactory.java
@@ -40,6 +40,7 @@ class InternalStreamConnectionFactory implements InternalConnectionFactory {
     @Nullable
     private final ServerApi serverApi;
     private final MongoCredentialWithCache credential;
+    private final boolean recordEverything;
 
     InternalStreamConnectionFactory(final ClusterConnectionMode clusterConnectionMode,
                                     final StreamFactory streamFactory,
@@ -49,15 +50,16 @@ class InternalStreamConnectionFactory implements InternalConnectionFactory {
                                     final LoggerSettings loggerSettings, @Nullable final CommandListener commandListener,
                                     @Nullable final ServerApi serverApi) {
         this(clusterConnectionMode, false, streamFactory, credential, clientMetadata, compressorList,
-                loggerSettings, commandListener, serverApi);
+                loggerSettings, commandListener, serverApi, false);
     }
 
     InternalStreamConnectionFactory(final ClusterConnectionMode clusterConnectionMode, final boolean isMonitoringConnection,
                                     final StreamFactory streamFactory,
                                     @Nullable final MongoCredentialWithCache credential,
                                     final ClientMetadata clientMetadata,
-            final List<MongoCompressor> compressorList,
-            final LoggerSettings loggerSettings, @Nullable final CommandListener commandListener, @Nullable final ServerApi serverApi) {
+                                    final List<MongoCompressor> compressorList,
+                                    final LoggerSettings loggerSettings, @Nullable final CommandListener commandListener,
+                                    @Nullable final ServerApi serverApi, final boolean recordEverything) {
         this.clusterConnectionMode = clusterConnectionMode;
         this.isMonitoringConnection = isMonitoringConnection;
         this.streamFactory = notNull("streamFactory", streamFactory);
@@ -67,6 +69,7 @@ class InternalStreamConnectionFactory implements InternalConnectionFactory {
         this.serverApi = serverApi;
         this.clientMetadata = clientMetadata;
         this.credential = credential;
+        this.recordEverything = recordEverything;
     }
 
     @Override
@@ -78,7 +81,7 @@ class InternalStreamConnectionFactory implements InternalConnectionFactory {
                 clusterConnectionMode, authenticator,
                 isMonitoringConnection, serverId, connectionGenerationSupplier,
                 streamFactory, compressorList, loggerSettings, commandListener,
-                connectionInitializer);
+                connectionInitializer, recordEverything);
     }
 
     private Authenticator createAuthenticator(final MongoCredentialWithCache credential) {

--- a/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedClusterableServerFactory.java
@@ -27,6 +27,7 @@ import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.connection.ServerId;
 import com.mongodb.connection.ServerSettings;
 import com.mongodb.event.CommandListener;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.internal.inject.EmptyProvider;
 import com.mongodb.lang.Nullable;
 

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -52,7 +52,7 @@ import com.mongodb.internal.connection.ClientMetadata;
 import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.DefaultClusterFactory;
 import com.mongodb.internal.connection.DefaultInetAddressResolver;
-import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.internal.connection.InternalOperationContextFactory;
 import com.mongodb.internal.connection.MongoCredentialWithCache;
 import com.mongodb.internal.connection.OperationContext;

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -52,7 +52,7 @@ import com.mongodb.internal.connection.ClientMetadata;
 import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.DefaultClusterFactory;
 import com.mongodb.internal.connection.DefaultInetAddressResolver;
-import com.mongodb.internal.connection.InternalConnectionPoolSettings;
+import com.mongodb.internal.connection.InternalMongoClientSettings;
 import com.mongodb.internal.connection.InternalOperationContextFactory;
 import com.mongodb.internal.connection.MongoCredentialWithCache;
 import com.mongodb.internal.connection.OperationContext;
@@ -478,7 +478,7 @@ public final class ClusterFixture {
     private static Cluster createCluster(final MongoCredential credential, final StreamFactory streamFactory) {
         return new DefaultClusterFactory().createCluster(ClusterSettings.builder().hosts(asList(getPrimary())).build(),
                 ServerSettings.builder().build(),
-                ConnectionPoolSettings.builder().maxSize(1).build(), InternalConnectionPoolSettings.builder().build(),
+                ConnectionPoolSettings.builder().maxSize(1).build(), InternalMongoClientSettings.getDefaults(),
                 TIMEOUT_SETTINGS.connectionOnly(), streamFactory, TIMEOUT_SETTINGS.connectionOnly(), streamFactory, credential,
                 LoggerSettings.builder().build(), null, null, null, Collections.emptyList(), getServerApi(), null);
     }
@@ -488,7 +488,7 @@ public final class ClusterFixture {
 
         return new DefaultClusterFactory().createCluster(mongoClientSettings.getClusterSettings(),
                 mongoClientSettings.getServerSettings(), mongoClientSettings.getConnectionPoolSettings(),
-                InternalConnectionPoolSettings.builder().build(), TimeoutSettings.create(mongoClientSettings).connectionOnly(),
+                InternalMongoClientSettings.getDefaults(), TimeoutSettings.create(mongoClientSettings).connectionOnly(),
                 streamFactory, TimeoutSettings.createHeartbeatSettings(mongoClientSettings).connectionOnly(),
                 new SocketStreamFactory(new DefaultInetAddressResolver(), SocketSettings.builder().readTimeout(5, SECONDS).build(),
                         getSslSettings(connectionString)),

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/CommandHelperSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/CommandHelperSpecification.groovy
@@ -43,10 +43,9 @@ class CommandHelperSpecification extends Specification {
     InternalConnection connection
 
     def setup() {
-        InternalStreamConnection.setRecordEverything(true)
-        connection = new InternalStreamConnectionFactory(ClusterConnectionMode.SINGLE,
+        connection = new InternalStreamConnectionFactory(ClusterConnectionMode.SINGLE, false,
                 new NettyStreamFactory(SocketSettings.builder().build(), getSslSettings()),
-                getCredentialWithCache(), CLIENT_METADATA, [], LoggerSettings.builder().build(), null, getServerApi())
+                getCredentialWithCache(), CLIENT_METADATA, [], LoggerSettings.builder().build(), null, getServerApi(), true)
                 .create(new ServerId(new ClusterId(), getPrimary()))
         connection.open(OPERATION_CONTEXT)
     }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
@@ -66,7 +66,7 @@ public class SingleServerClusterTest {
         cluster = new SingleServerCluster(clusterId,
                 clusterSettings,
                 new DefaultClusterableServerFactory(ServerSettings.builder().build(),
-                        ConnectionPoolSettings.builder().maxSize(1).build(), InternalConnectionPoolSettings.builder().build(),
+                        ConnectionPoolSettings.builder().maxSize(1).build(), InternalMongoClientSettings.getDefaults(),
                         OPERATION_CONTEXT_FACTORY, streamFactory, OPERATION_CONTEXT_FACTORY, streamFactory, getCredential(),
                         LoggerSettings.builder().build(), null,
                         Collections.emptyList(), getServerApi(), false), CLIENT_METADATA);

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/SingleServerClusterTest.java
@@ -25,6 +25,7 @@ import com.mongodb.connection.ClusterSettings;
 import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.connection.ServerSettings;
 import com.mongodb.connection.SocketSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.internal.selector.ServerAddressSelector;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import org.bson.BsonDocument;

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/TestCommandListener.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/TestCommandListener.java
@@ -90,7 +90,7 @@ public class TestCommandListener implements CommandListener {
      * type will be lowercase and will omit the terms "command" and "event".
      * For example: {@code "saslContinue succeeded"}.
      *
-     * @see InternalStreamConnection#setRecordEverything(boolean)
+     * @see InternalMongoClientSettings.Builder#recordEverything(boolean)
      * @param listener the test listener
      */
     public TestCommandListener(final TestListener listener) {

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/TestCommandListener.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/TestCommandListener.java
@@ -23,6 +23,7 @@ import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandListener;
 import com.mongodb.event.CommandStartedEvent;
 import com.mongodb.event.CommandSucceededEvent;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoClients.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoClients.java
@@ -17,25 +17,12 @@
 package com.mongodb.reactivestreams.client;
 
 import com.mongodb.ConnectionString;
-import com.mongodb.MongoClientException;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoDriverInformation;
-import com.mongodb.connection.SocketSettings;
-import com.mongodb.internal.TimeoutSettings;
-import com.mongodb.internal.connection.Cluster;
-import com.mongodb.internal.connection.DefaultClusterFactory;
-import com.mongodb.internal.connection.InternalConnectionPoolSettings;
-import com.mongodb.internal.connection.StreamFactory;
-import com.mongodb.internal.connection.StreamFactoryFactory;
+import com.mongodb.internal.connection.InternalMongoClientSettings;
 import com.mongodb.lang.Nullable;
-import com.mongodb.reactivestreams.client.internal.MongoClientImpl;
-import com.mongodb.spi.dns.InetAddressResolver;
+import com.mongodb.reactivestreams.client.internal.InternalMongoClients;
 import org.bson.codecs.configuration.CodecRegistry;
-
-import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.internal.connection.ServerAddressHelper.getInetAddressResolver;
-import static com.mongodb.internal.connection.StreamFactoryHelper.getAsyncStreamFactoryFactory;
-import static com.mongodb.internal.event.EventListenerHelper.getCommandListener;
 
 
 /**
@@ -44,13 +31,15 @@ import static com.mongodb.internal.event.EventListenerHelper.getCommandListener;
  */
 public final class MongoClients {
 
+    private static final InternalMongoClientSettings DEFAULT_INTERNAL_SETTINGS = InternalMongoClientSettings.getDefaults();
+
     /**
      * Creates a new client with the default connection string "mongodb://localhost".
      *
      * @return the client
      */
     public static MongoClient create() {
-        return create(new ConnectionString("mongodb://localhost"));
+        return InternalMongoClients.create(DEFAULT_INTERNAL_SETTINGS);
     }
 
     /**
@@ -60,7 +49,7 @@ public final class MongoClients {
      * @return the client
      */
     public static MongoClient create(final String connectionString) {
-        return create(new ConnectionString(connectionString));
+        return InternalMongoClients.create(connectionString, DEFAULT_INTERNAL_SETTINGS);
     }
 
     /**
@@ -70,7 +59,7 @@ public final class MongoClients {
      * @return the client
      */
     public static MongoClient create(final ConnectionString connectionString) {
-        return create(connectionString, null);
+        return InternalMongoClients.create(connectionString, DEFAULT_INTERNAL_SETTINGS);
     }
 
     /**
@@ -85,7 +74,7 @@ public final class MongoClients {
      */
     public static MongoClient create(final ConnectionString connectionString,
             @Nullable final MongoDriverInformation mongoDriverInformation) {
-        return create(MongoClientSettings.builder().applyConnectionString(connectionString).build(), mongoDriverInformation);
+        return InternalMongoClients.create(connectionString, mongoDriverInformation, DEFAULT_INTERNAL_SETTINGS);
     }
 
     /**
@@ -96,7 +85,7 @@ public final class MongoClients {
      * @since 1.8
      */
     public static MongoClient create(final MongoClientSettings settings) {
-        return create(settings, null);
+        return InternalMongoClients.create(settings, DEFAULT_INTERNAL_SETTINGS);
     }
 
     /**
@@ -110,16 +99,7 @@ public final class MongoClients {
      * @since 1.8
      */
     public static MongoClient create(final MongoClientSettings settings, @Nullable final MongoDriverInformation mongoDriverInformation) {
-        if (settings.getSocketSettings().getProxySettings().isProxyEnabled()) {
-            throw new MongoClientException("Proxy is not supported for reactive clients");
-        }
-        InetAddressResolver inetAddressResolver = getInetAddressResolver(settings);
-        StreamFactoryFactory streamFactoryFactory = getAsyncStreamFactoryFactory(settings, inetAddressResolver);
-        StreamFactory streamFactory = getStreamFactory(streamFactoryFactory, settings, false);
-        StreamFactory heartbeatStreamFactory = getStreamFactory(streamFactoryFactory, settings, true);
-        MongoDriverInformation wrappedMongoDriverInformation = wrapMongoDriverInformation(mongoDriverInformation);
-        Cluster cluster = createCluster(settings, wrappedMongoDriverInformation, streamFactory, heartbeatStreamFactory);
-        return new MongoClientImpl(settings, wrappedMongoDriverInformation, cluster, streamFactoryFactory);
+        return InternalMongoClients.create(settings, mongoDriverInformation, DEFAULT_INTERNAL_SETTINGS);
     }
 
     /**
@@ -133,30 +113,6 @@ public final class MongoClients {
         return MongoClientSettings.getDefaultCodecRegistry();
     }
 
-    private static Cluster createCluster(final MongoClientSettings settings,
-                                         @Nullable final MongoDriverInformation mongoDriverInformation,
-                                         final StreamFactory streamFactory, final StreamFactory heartbeatStreamFactory) {
-        notNull("settings", settings);
-        return new DefaultClusterFactory().createCluster(settings.getClusterSettings(), settings.getServerSettings(),
-                settings.getConnectionPoolSettings(), InternalConnectionPoolSettings.builder().prestartAsyncWorkManager(true).build(),
-                TimeoutSettings.create(settings), streamFactory, TimeoutSettings.createHeartbeatSettings(settings), heartbeatStreamFactory,
-                settings.getCredential(), settings.getLoggerSettings(), getCommandListener(settings.getCommandListeners()),
-                settings.getApplicationName(), mongoDriverInformation, settings.getCompressorList(), settings.getServerApi(),
-                settings.getDnsClient());
-    }
-
-    private static MongoDriverInformation wrapMongoDriverInformation(@Nullable final MongoDriverInformation mongoDriverInformation) {
-        return (mongoDriverInformation == null ? MongoDriverInformation.builder() : MongoDriverInformation.builder(mongoDriverInformation))
-                .driverName("reactive-streams").build();
-    }
-
-    private static StreamFactory getStreamFactory(
-            final StreamFactoryFactory streamFactoryFactory, final MongoClientSettings settings,
-            final boolean isHeartbeat) {
-        SocketSettings socketSettings = isHeartbeat
-                ? settings.getHeartbeatSocketSettings() : settings.getSocketSettings();
-        return streamFactoryFactory.create(socketSettings, settings.getSslSettings());
-    }
 
     private MongoClients() {
     }

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoClients.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoClients.java
@@ -19,7 +19,7 @@ package com.mongodb.reactivestreams.client;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoDriverInformation;
-import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.internal.InternalMongoClients;
 import org.bson.codecs.configuration.CodecRegistry;

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/InternalMongoClients.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/InternalMongoClients.java
@@ -24,7 +24,7 @@ import com.mongodb.connection.SocketSettings;
 import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.DefaultClusterFactory;
-import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.internal.connection.StreamFactory;
 import com.mongodb.internal.connection.StreamFactoryFactory;
 import com.mongodb.lang.Nullable;

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/InternalMongoClients.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/InternalMongoClients.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.internal;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientException;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoDriverInformation;
+import com.mongodb.connection.SocketSettings;
+import com.mongodb.internal.TimeoutSettings;
+import com.mongodb.internal.connection.Cluster;
+import com.mongodb.internal.connection.DefaultClusterFactory;
+import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.connection.StreamFactory;
+import com.mongodb.internal.connection.StreamFactoryFactory;
+import com.mongodb.lang.Nullable;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.spi.dns.InetAddressResolver;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.connection.ServerAddressHelper.getInetAddressResolver;
+import static com.mongodb.internal.connection.StreamFactoryHelper.getAsyncStreamFactoryFactory;
+import static com.mongodb.internal.event.EventListenerHelper.getCommandListener;
+
+/**
+ * Internal factory for MongoClient instances.
+ *
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+public final class InternalMongoClients {
+
+    private InternalMongoClients() {
+    }
+
+    /**
+     * Creates a new client with the default connection string "mongodb://localhost" and the given internal settings.
+     *
+     * @param internalSettings the internal settings
+     * @return the client
+     */
+    public static MongoClient create(final InternalMongoClientSettings internalSettings) {
+        return create(new ConnectionString("mongodb://localhost"), internalSettings);
+    }
+
+    /**
+     * Creates a new client with the given connection string and internal settings.
+     *
+     * @param connectionString the connection string
+     * @param internalSettings the internal settings
+     * @return the client
+     */
+    public static MongoClient create(final String connectionString,
+                                     final InternalMongoClientSettings internalSettings) {
+        return create(new ConnectionString(connectionString), internalSettings);
+    }
+
+    /**
+     * Creates a new client with the given connection string and internal settings.
+     *
+     * @param connectionString the connection string
+     * @param internalSettings the internal settings
+     * @return the client
+     */
+    public static MongoClient create(final ConnectionString connectionString,
+                                     final InternalMongoClientSettings internalSettings) {
+        return create(connectionString, null, internalSettings);
+    }
+
+    /**
+     * Creates a new client with the given connection string, driver information and internal settings.
+     *
+     * @param connectionString       the connection string
+     * @param mongoDriverInformation any driver information to associate with the MongoClient
+     * @param internalSettings       the internal settings
+     * @return the client
+     */
+    public static MongoClient create(final ConnectionString connectionString,
+                                     @Nullable final MongoDriverInformation mongoDriverInformation,
+                                     final InternalMongoClientSettings internalSettings) {
+        return create(MongoClientSettings.builder().applyConnectionString(connectionString).build(),
+                mongoDriverInformation, internalSettings);
+    }
+
+    /**
+     * Creates a new client with the given client settings and internal settings.
+     *
+     * @param settings         the public settings
+     * @param internalSettings the internal settings
+     * @return the client
+     */
+    public static MongoClient create(final MongoClientSettings settings,
+                                     final InternalMongoClientSettings internalSettings) {
+        return create(settings, null, internalSettings);
+    }
+
+    /**
+     * Creates a new client with the given client settings, driver information and internal settings.
+     *
+     * @param settings               the public settings
+     * @param mongoDriverInformation any driver information to associate with the MongoClient
+     * @param internalSettings       the internal settings
+     * @return the client
+     */
+    public static MongoClient create(final MongoClientSettings settings,
+                                     @Nullable final MongoDriverInformation mongoDriverInformation,
+                                     final InternalMongoClientSettings internalSettings) {
+        notNull("settings", settings);
+        notNull("internalSettings", internalSettings);
+
+        if (settings.getSocketSettings().getProxySettings().isProxyEnabled()) {
+            throw new MongoClientException("Proxy is not supported for reactive clients");
+        }
+        InetAddressResolver inetAddressResolver = getInetAddressResolver(settings);
+        StreamFactoryFactory streamFactoryFactory = getAsyncStreamFactoryFactory(settings, inetAddressResolver);
+        StreamFactory streamFactory = getStreamFactory(streamFactoryFactory, settings, false);
+        StreamFactory heartbeatStreamFactory = getStreamFactory(streamFactoryFactory, settings, true);
+        MongoDriverInformation wrappedMongoDriverInformation = wrapMongoDriverInformation(mongoDriverInformation);
+        Cluster cluster = createCluster(settings, wrappedMongoDriverInformation, streamFactory, heartbeatStreamFactory, internalSettings);
+        return new MongoClientImpl(settings, wrappedMongoDriverInformation, cluster, streamFactoryFactory);
+    }
+
+    private static Cluster createCluster(final MongoClientSettings settings,
+                                         @Nullable final MongoDriverInformation mongoDriverInformation,
+                                         final StreamFactory streamFactory,
+                                         final StreamFactory heartbeatStreamFactory,
+                                         final InternalMongoClientSettings internalSettings) {
+        notNull("settings", settings);
+        return new DefaultClusterFactory().createCluster(settings.getClusterSettings(), settings.getServerSettings(),
+                settings.getConnectionPoolSettings(), internalSettings,
+                TimeoutSettings.create(settings), streamFactory, TimeoutSettings.createHeartbeatSettings(settings), heartbeatStreamFactory,
+                settings.getCredential(), settings.getLoggerSettings(), getCommandListener(settings.getCommandListeners()),
+                settings.getApplicationName(), mongoDriverInformation, settings.getCompressorList(), settings.getServerApi(),
+                settings.getDnsClient());
+    }
+
+    private static MongoDriverInformation wrapMongoDriverInformation(@Nullable final MongoDriverInformation mongoDriverInformation) {
+        return (mongoDriverInformation == null ? MongoDriverInformation.builder() : MongoDriverInformation.builder(mongoDriverInformation))
+                .driverName("reactive-streams").build();
+    }
+
+    private static StreamFactory getStreamFactory(
+            final StreamFactoryFactory streamFactoryFactory, final MongoClientSettings settings,
+            final boolean isHeartbeat) {
+        SocketSettings socketSettings = isHeartbeat
+                ? settings.getHeartbeatSocketSettings() : settings.getSocketSettings();
+        return streamFactoryFactory.create(socketSettings, settings.getSslSettings());
+    }
+}
+

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/AbstractClientMetadataProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/AbstractClientMetadataProseTest.java
@@ -20,7 +20,9 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.AbstractClientMetadataProseTest;
 import com.mongodb.client.MongoClient;
+import com.mongodb.internal.connection.InternalMongoClientSettings;
 import com.mongodb.lang.Nullable;
+import com.mongodb.reactivestreams.client.internal.InternalMongoClients;
 import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
 
 /**
@@ -29,6 +31,7 @@ import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
 class ClientMetadataProseTest extends AbstractClientMetadataProseTest {
 
     protected MongoClient createMongoClient(@Nullable final MongoDriverInformation mongoDriverInformation, final MongoClientSettings mongoClientSettings) {
-        return new SyncMongoClient(mongoClientSettings, mongoDriverInformation);
+        return new SyncMongoClient(InternalMongoClients.create(mongoClientSettings, mongoDriverInformation,
+                InternalMongoClientSettings.builder().recordEverything(true).build()));
     }
 }

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/AbstractClientMetadataProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/AbstractClientMetadataProseTest.java
@@ -20,7 +20,7 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.AbstractClientMetadataProseTest;
 import com.mongodb.client.MongoClient;
-import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.lang.Nullable;
 import com.mongodb.reactivestreams.client.internal.InternalMongoClients;
 import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideOperationTimeoutProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideOperationTimeoutProseTest.java
@@ -28,7 +28,7 @@ import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandStartedEvent;
-import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.reactivestreams.client.gridfs.GridFSBucket;
 import com.mongodb.reactivestreams.client.gridfs.GridFSBuckets;
 import com.mongodb.reactivestreams.client.internal.InternalMongoClients;

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideOperationTimeoutProseTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideOperationTimeoutProseTest.java
@@ -28,8 +28,10 @@ import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.internal.connection.InternalMongoClientSettings;
 import com.mongodb.reactivestreams.client.gridfs.GridFSBucket;
 import com.mongodb.reactivestreams.client.gridfs.GridFSBuckets;
+import com.mongodb.reactivestreams.client.internal.InternalMongoClients;
 import com.mongodb.reactivestreams.client.syncadapter.SyncGridFSBucket;
 import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
 import org.bson.BsonDocument;
@@ -77,6 +79,15 @@ public final class ClientSideOperationTimeoutProseTest extends AbstractClientSid
     protected com.mongodb.client.MongoClient createMongoClient(final MongoClientSettings mongoClientSettings) {
         SyncMongoClient client = new SyncMongoClient(mongoClientSettings);
         wrapped = client.getWrapped();
+        return client;
+    }
+
+    @Override
+    protected com.mongodb.client.MongoClient createMongoClientWithInternalSettings(final MongoClientSettings mongoClientSettings,
+                                                                                   final InternalMongoClientSettings internalSettings) {
+        MongoClient reactiveClient = InternalMongoClients.create(mongoClientSettings, null, internalSettings);
+        SyncMongoClient client = new SyncMongoClient(reactiveClient);
+        wrapped = reactiveClient;
         return client;
     }
 

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoClient.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/syncadapter/SyncMongoClient.java
@@ -158,6 +158,17 @@ public class SyncMongoClient implements MongoClient {
         this.delegate = new SyncMongoCluster(wrapped);
     }
 
+    /**
+     * Wraps an existing reactive MongoClient as a sync client adapter.
+     *
+     * @param reactiveMongoClient the reactive MongoClient to wrap
+     */
+    public SyncMongoClient(final com.mongodb.reactivestreams.client.MongoClient reactiveMongoClient) {
+        this.connectionPoolCounter = new ConnectionPoolCounter();
+        this.wrapped = reactiveMongoClient;
+        this.delegate = new SyncMongoCluster(wrapped);
+    }
+
     public com.mongodb.reactivestreams.client.MongoClient getWrapped() {
         return wrapped;
     }

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/InternalMongoClientsTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/InternalMongoClientsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.internal;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.internal.connection.InternalMongoClientSettings;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for reactive {@link InternalMongoClients}.
+ * See sync InternalMongoClientsTest for comprehensive InternalMongoClientSettings tests.
+ */
+class InternalMongoClientsTest {
+
+    @Test
+    void testCreateMethodsValidateNullSettings() {
+        // Verify that null MongoClientSettings is rejected
+        assertThrows(IllegalArgumentException.class, () ->
+                InternalMongoClients.create((MongoClientSettings) null, InternalMongoClientSettings.getDefaults()));
+
+        // Verify that null InternalMongoClientSettings is rejected
+        MongoClientSettings settings = MongoClientSettings.builder().build();
+        assertThrows(IllegalArgumentException.class, () ->
+                InternalMongoClients.create(settings, null));
+    }
+
+    @Test
+    void testInternalSettingsArePreserved() {
+        // Verify that InternalMongoClientSettings can be built with recordEverything for reactive clients
+        InternalMongoClientSettings internalSettings = InternalMongoClientSettings.builder()
+                .recordEverything(true)
+                .build();
+        assertNotNull(internalSettings);
+    }
+}
+

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/InternalMongoClientsTest.java
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/InternalMongoClientsTest.java
@@ -17,7 +17,7 @@
 package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.MongoClientSettings;
-import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/driver-sync/src/main/com/mongodb/client/MongoClients.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoClients.java
@@ -20,7 +20,7 @@ import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.internal.InternalMongoClients;
-import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.lang.Nullable;
 
 

--- a/driver-sync/src/main/com/mongodb/client/internal/Clusters.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Clusters.java
@@ -21,7 +21,7 @@ import com.mongodb.connection.SocketSettings;
 import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.DefaultClusterFactory;
-import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.internal.connection.StreamFactory;
 import com.mongodb.internal.connection.StreamFactoryFactory;
 import com.mongodb.lang.Nullable;

--- a/driver-sync/src/main/com/mongodb/client/internal/Clusters.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Clusters.java
@@ -21,7 +21,7 @@ import com.mongodb.connection.SocketSettings;
 import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.DefaultClusterFactory;
-import com.mongodb.internal.connection.InternalConnectionPoolSettings;
+import com.mongodb.internal.connection.InternalMongoClientSettings;
 import com.mongodb.internal.connection.StreamFactory;
 import com.mongodb.internal.connection.StreamFactoryFactory;
 import com.mongodb.lang.Nullable;
@@ -35,17 +35,42 @@ public final class Clusters {
         //NOP
     }
 
+    /**
+     * Creates a cluster with the given settings and default internal settings.
+     *
+     * @param settings the client settings
+     * @param mongoDriverInformation driver information
+     * @param streamFactoryFactory the stream factory
+     * @return the cluster
+     */
     public static Cluster createCluster(final MongoClientSettings settings,
                                         @Nullable final MongoDriverInformation mongoDriverInformation,
                                         final StreamFactoryFactory streamFactoryFactory) {
+        return createCluster(settings, mongoDriverInformation, streamFactoryFactory, InternalMongoClientSettings.getDefaults());
+    }
+
+    /**
+     * Creates a cluster with the given settings and internal settings.
+     *
+     * @param settings the client settings
+     * @param mongoDriverInformation driver information
+     * @param streamFactoryFactory the stream factory
+     * @param internalSettings the internal settings
+     * @return the cluster
+     */
+    public static Cluster createCluster(final MongoClientSettings settings,
+                                        @Nullable final MongoDriverInformation mongoDriverInformation,
+                                        final StreamFactoryFactory streamFactoryFactory,
+                                        final InternalMongoClientSettings internalSettings) {
         assertNotNull(streamFactoryFactory);
         assertNotNull(settings);
+        assertNotNull(internalSettings);
 
         StreamFactory streamFactory = getStreamFactory(streamFactoryFactory, settings, false);
         StreamFactory heartbeatStreamFactory = getStreamFactory(streamFactoryFactory, settings, true);
 
         return new DefaultClusterFactory().createCluster(settings.getClusterSettings(), settings.getServerSettings(),
-                settings.getConnectionPoolSettings(), InternalConnectionPoolSettings.builder().build(),
+                settings.getConnectionPoolSettings(), internalSettings,
                 TimeoutSettings.create(settings), streamFactory,
                 TimeoutSettings.createHeartbeatSettings(settings), heartbeatStreamFactory,
                 settings.getCredential(), settings.getLoggerSettings(), getCommandListener(settings.getCommandListeners()),

--- a/driver-sync/src/main/com/mongodb/client/internal/InternalMongoClients.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/InternalMongoClients.java
@@ -21,7 +21,7 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.MongoClient;
 import com.mongodb.internal.connection.Cluster;
-import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.internal.connection.StreamFactoryFactory;
 import com.mongodb.lang.Nullable;
 

--- a/driver-sync/src/main/com/mongodb/client/internal/InternalMongoClients.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/InternalMongoClients.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.internal;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoDriverInformation;
+import com.mongodb.client.MongoClient;
+import com.mongodb.internal.connection.Cluster;
+import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.connection.StreamFactoryFactory;
+import com.mongodb.lang.Nullable;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.connection.ServerAddressHelper.getInetAddressResolver;
+import static com.mongodb.internal.connection.StreamFactoryHelper.getSyncStreamFactoryFactory;
+
+/**
+ * Internal factory for MongoClient instances.
+ *
+ * <p>This class is not part of the public API and may be removed or changed at any time</p>
+ */
+public final class InternalMongoClients {
+
+    private InternalMongoClients() {
+    }
+
+    /**
+     * Creates a new client with the default connection string "mongodb://localhost" and the given internal settings.
+     *
+     * @param internalSettings the internal settings
+     * @return the client
+     */
+    public static MongoClient create(final InternalMongoClientSettings internalSettings) {
+        return create(new ConnectionString("mongodb://localhost"), internalSettings);
+    }
+
+    /**
+     * Creates a new client with the given connection string and internal settings.
+     *
+     * @param connectionString the connection string
+     * @param internalSettings the internal settings
+     * @return the client
+     */
+    public static MongoClient create(final String connectionString,
+                                     final InternalMongoClientSettings internalSettings) {
+        return create(new ConnectionString(connectionString), internalSettings);
+    }
+
+    /**
+     * Creates a new client with the given connection string and internal settings.
+     *
+     * @param connectionString the connection string
+     * @param internalSettings the internal settings
+     * @return the client
+     */
+    public static MongoClient create(final ConnectionString connectionString,
+                                     final InternalMongoClientSettings internalSettings) {
+        return create(connectionString, null, internalSettings);
+    }
+
+    /**
+     * Creates a new client with the given connection string, driver information and internal settings.
+     *
+     * @param connectionString       the connection string
+     * @param mongoDriverInformation any driver information to associate with the MongoClient
+     * @param internalSettings       the internal settings
+     * @return the client
+     */
+    public static MongoClient create(final ConnectionString connectionString,
+                                     @Nullable final MongoDriverInformation mongoDriverInformation,
+                                     final InternalMongoClientSettings internalSettings) {
+        return create(MongoClientSettings.builder().applyConnectionString(connectionString).build(),
+                mongoDriverInformation, internalSettings);
+    }
+
+    /**
+     * Creates a new client with the given client settings and internal settings.
+     *
+     * @param settings         the public settings
+     * @param internalSettings the internal settings
+     * @return the client
+     */
+    public static MongoClient create(final MongoClientSettings settings,
+                                     final InternalMongoClientSettings internalSettings) {
+        return create(settings, null, internalSettings);
+    }
+
+    /**
+     * Creates a new client with the given client settings, driver information and internal settings.
+     *
+     * @param settings               the public settings
+     * @param mongoDriverInformation any driver information to associate with the MongoClient
+     * @param internalSettings       the internal settings
+     * @return the client
+     */
+    public static MongoClient create(final MongoClientSettings settings,
+                                     @Nullable final MongoDriverInformation mongoDriverInformation,
+                                     final InternalMongoClientSettings internalSettings) {
+        notNull("settings", settings);
+        notNull("internalSettings", internalSettings);
+
+        MongoDriverInformation.Builder builder = mongoDriverInformation == null ? MongoDriverInformation.builder()
+                : MongoDriverInformation.builder(mongoDriverInformation);
+
+        MongoDriverInformation driverInfo = builder.driverName("sync").build();
+
+        StreamFactoryFactory syncStreamFactoryFactory = getSyncStreamFactoryFactory(
+                settings.getTransportSettings(),
+                getInetAddressResolver(settings));
+
+        Cluster cluster = Clusters.createCluster(
+                settings,
+                driverInfo,
+                syncStreamFactoryFactory,
+                internalSettings);
+
+        return new MongoClientImpl(cluster, settings, driverInfo, syncStreamFactoryFactory);
+    }
+}
+

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoClientImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoClientImpl.java
@@ -36,15 +36,10 @@ import com.mongodb.client.model.bulk.ClientBulkWriteOptions;
 import com.mongodb.client.model.bulk.ClientBulkWriteResult;
 import com.mongodb.client.model.bulk.ClientNamespacedWriteModel;
 import com.mongodb.connection.ClusterDescription;
-import com.mongodb.connection.SocketSettings;
 import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.VisibleForTesting;
 import com.mongodb.internal.connection.ClientMetadata;
 import com.mongodb.internal.connection.Cluster;
-import com.mongodb.internal.connection.DefaultClusterFactory;
-import com.mongodb.internal.connection.InternalConnectionPoolSettings;
-import com.mongodb.internal.connection.StreamFactory;
-import com.mongodb.internal.connection.StreamFactoryFactory;
 import com.mongodb.internal.diagnostics.logging.Logger;
 import com.mongodb.internal.diagnostics.logging.Loggers;
 import com.mongodb.internal.session.ServerSessionPool;
@@ -61,7 +56,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.client.internal.Crypts.createCrypt;
-import static com.mongodb.internal.event.EventListenerHelper.getCommandListener;
 import static java.lang.String.format;
 import static org.bson.codecs.configuration.CodecRegistries.withUuidRepresentation;
 
@@ -308,27 +302,6 @@ public final class MongoClientImpl implements MongoClient {
             final List<? extends ClientNamespacedWriteModel> clientWriteModels,
             final ClientBulkWriteOptions options) throws ClientBulkWriteException {
         return delegate.bulkWrite(clientSession, clientWriteModels, options);
-    }
-
-    private static Cluster createCluster(final MongoClientSettings settings,
-                                         @Nullable final MongoDriverInformation mongoDriverInformation,
-                                         final StreamFactory streamFactory, final StreamFactory heartbeatStreamFactory) {
-        notNull("settings", settings);
-        return new DefaultClusterFactory().createCluster(settings.getClusterSettings(), settings.getServerSettings(),
-                settings.getConnectionPoolSettings(), InternalConnectionPoolSettings.builder().build(),
-                TimeoutSettings.create(settings), streamFactory,
-                TimeoutSettings.createHeartbeatSettings(settings), heartbeatStreamFactory,
-                settings.getCredential(), settings.getLoggerSettings(), getCommandListener(settings.getCommandListeners()),
-                settings.getApplicationName(), mongoDriverInformation, settings.getCompressorList(), settings.getServerApi(),
-                settings.getDnsClient());
-    }
-
-    private static StreamFactory getStreamFactory(
-            final StreamFactoryFactory streamFactoryFactory,
-            final MongoClientSettings settings,
-            final boolean isHeartbeat) {
-        SocketSettings socketSettings = isHeartbeat ? settings.getHeartbeatSocketSettings() : settings.getSocketSettings();
-        return streamFactoryFactory.create(socketSettings, settings.getSslSettings());
     }
 
     public Cluster getCluster() {

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientMetadataProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientMetadataProseTest.java
@@ -20,12 +20,10 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoDriverInformation;
 import com.mongodb.event.CommandStartedEvent;
 import com.mongodb.internal.client.DriverInformation;
-import com.mongodb.internal.connection.InternalStreamConnection;
 import com.mongodb.internal.connection.TestCommandListener;
 import com.mongodb.internal.connection.TestConnectionPoolListener;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonDocument;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -65,12 +63,6 @@ public abstract class AbstractClientMetadataProseTest {
 
         commandListener = new TestCommandListener();
         connectionPoolListener = new TestConnectionPoolListener();
-        InternalStreamConnection.setRecordEverything(true);
-    }
-
-    @AfterEach
-    public void tearDown() {
-        InternalStreamConnection.setRecordEverything(false);
     }
 
     @DisplayName("Test 1: Test that the driver updates metadata")

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideOperationsTimeoutProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideOperationsTimeoutProseTest.java
@@ -47,7 +47,7 @@ import com.mongodb.event.CommandSucceededEvent;
 import com.mongodb.event.ConnectionClosedEvent;
 import com.mongodb.event.ConnectionCreatedEvent;
 import com.mongodb.event.ConnectionReadyEvent;
-import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.internal.connection.ServerHelper;
 import com.mongodb.internal.connection.TestCommandListener;
 import com.mongodb.internal.connection.TestConnectionPoolListener;

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientMetadataProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientMetadataProseTest.java
@@ -19,7 +19,7 @@ package com.mongodb.client;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.internal.InternalMongoClients;
-import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.lang.Nullable;
 
 public class ClientMetadataProseTest extends AbstractClientMetadataProseTest {

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientMetadataProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientMetadataProseTest.java
@@ -18,6 +18,8 @@ package com.mongodb.client;
 
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoDriverInformation;
+import com.mongodb.client.internal.InternalMongoClients;
+import com.mongodb.internal.connection.InternalMongoClientSettings;
 import com.mongodb.lang.Nullable;
 
 public class ClientMetadataProseTest extends AbstractClientMetadataProseTest {
@@ -25,6 +27,7 @@ public class ClientMetadataProseTest extends AbstractClientMetadataProseTest {
     @Override
     protected MongoClient createMongoClient(@Nullable final MongoDriverInformation mongoDriverInformation,
                                             final MongoClientSettings mongoClientSettings) {
-        return MongoClients.create(mongoClientSettings, mongoDriverInformation);
+        return InternalMongoClients.create(mongoClientSettings, mongoDriverInformation,
+                InternalMongoClientSettings.builder().recordEverything(true).build());
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideOperationTimeoutProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideOperationTimeoutProseTest.java
@@ -20,7 +20,7 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.gridfs.GridFSBucket;
 import com.mongodb.client.gridfs.GridFSBuckets;
 import com.mongodb.client.internal.InternalMongoClients;
-import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 
 
 /**

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideOperationTimeoutProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideOperationTimeoutProseTest.java
@@ -19,6 +19,8 @@ package com.mongodb.client;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.gridfs.GridFSBucket;
 import com.mongodb.client.gridfs.GridFSBuckets;
+import com.mongodb.client.internal.InternalMongoClients;
+import com.mongodb.internal.connection.InternalMongoClientSettings;
 
 
 /**
@@ -29,6 +31,12 @@ public final class ClientSideOperationTimeoutProseTest extends AbstractClientSid
     @Override
     protected MongoClient createMongoClient(final MongoClientSettings mongoClientSettings) {
         return MongoClients.create(mongoClientSettings);
+    }
+
+    @Override
+    protected MongoClient createMongoClientWithInternalSettings(final MongoClientSettings mongoClientSettings,
+                                                                final InternalMongoClientSettings internalSettings) {
+        return InternalMongoClients.create(mongoClientSettings, internalSettings);
     }
 
     @Override

--- a/driver-sync/src/test/functional/com/mongodb/internal/connection/OidcAuthenticationProseTests.java
+++ b/driver-sync/src/test/functional/com/mongodb/internal/connection/OidcAuthenticationProseTests.java
@@ -33,6 +33,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.TestListener;
 import com.mongodb.client.internal.InternalMongoClients;
 import com.mongodb.event.CommandListener;
+import com.mongodb.internal.InternalMongoClientSettings;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;

--- a/driver-sync/src/test/functional/com/mongodb/internal/connection/OidcAuthenticationProseTests.java
+++ b/driver-sync/src/test/functional/com/mongodb/internal/connection/OidcAuthenticationProseTests.java
@@ -29,9 +29,9 @@ import com.mongodb.client.ClientSession;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.Fixture;
 import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.TestListener;
+import com.mongodb.client.internal.InternalMongoClients;
 import com.mongodb.event.CommandListener;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
@@ -40,7 +40,6 @@ import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.bson.Document;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -141,19 +140,14 @@ public class OidcAuthenticationProseTests {
     }
 
     protected MongoClient createMongoClient(final MongoClientSettings settings) {
-        return MongoClients.create(settings);
+        return InternalMongoClients.create(settings,
+                InternalMongoClientSettings.builder().recordEverything(true).build());
     }
 
     @BeforeEach
     public void beforeEach() {
         assumeTrue(oidcTestsEnabled());
-        InternalStreamConnection.setRecordEverything(true);
         this.appName = this.getClass().getSimpleName() + "-" + new Random().nextInt(Integer.MAX_VALUE);
-    }
-
-    @AfterEach
-    public void afterEach() {
-        InternalStreamConnection.setRecordEverything(false);
     }
 
     @Test

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/InternalMongoClientsTest.java
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/InternalMongoClientsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.internal;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.internal.connection.InternalConnectionPoolSettings;
+import com.mongodb.internal.connection.InternalMongoClientSettings;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link InternalMongoClients}.
+ *
+ * <p>These tests demonstrate how to use InternalMongoClients to create MongoClient instances
+ * with custom internal settings, avoiding the need for global mutable state in tests.</p>
+ */
+class InternalMongoClientsTest {
+
+    @Test
+    void testCreateWithDefaultInternalSettings() {
+        // Tests can now create clients with explicit internal settings
+        InternalMongoClientSettings internalSettings = InternalMongoClientSettings.builder().build();
+
+        assertNotNull(internalSettings.getInternalConnectionPoolSettings(),
+                "Default internal settings should have connection pool settings");
+        assertFalse(internalSettings.isRecordEverything(),
+                "Default internal settings should have log recordEverything set to false");
+    }
+
+    @Test
+    void testCreateWithCustomInternalConnectionPoolSettings() {
+        // Demonstrates setting custom internal connection pool settings
+        InternalConnectionPoolSettings poolSettings = InternalConnectionPoolSettings.builder()
+                .prestartAsyncWorkManager(false)
+                .build();
+
+        InternalMongoClientSettings internalSettings = InternalMongoClientSettings.builder()
+                .internalConnectionPoolSettings(poolSettings)
+                .build();
+
+        assertEquals(poolSettings, internalSettings.getInternalConnectionPoolSettings(),
+                "Custom connection pool settings should be preserved");
+    }
+
+    @Test
+    void testCreateWithCustomLogRecordingSettings() {
+        InternalMongoClientSettings internalSettings = InternalMongoClientSettings.builder()
+                .recordEverything(true)
+                .build();
+
+        assertTrue(internalSettings.isRecordEverything());
+    }
+
+    @Test
+    void testGetDefaultsReturnsSameInstance() {
+        InternalMongoClientSettings defaults1 = InternalMongoClientSettings.getDefaults();
+        InternalMongoClientSettings defaults2 = InternalMongoClientSettings.getDefaults();
+        assertSame(defaults1, defaults2, "getDefaults() should return the same instances");
+    }
+
+    @Test
+    void testCreateMethodsValidateNullSettings() {
+        // Verify that null MongoClientSettings is rejected
+        assertThrows(IllegalArgumentException.class, () ->
+                InternalMongoClients.create((MongoClientSettings) null, InternalMongoClientSettings.getDefaults()));
+
+        // Verify that null InternalMongoClientSettings is rejected
+        MongoClientSettings settings = MongoClientSettings.builder().build();
+        assertThrows(IllegalArgumentException.class, () ->
+                InternalMongoClients.create(settings, null));
+    }
+}

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/InternalMongoClientsTest.java
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/InternalMongoClientsTest.java
@@ -75,7 +75,7 @@ class InternalMongoClientsTest {
     void testGetDefaultsReturnsSameInstance() {
         InternalMongoClientSettings defaults1 = InternalMongoClientSettings.getDefaults();
         InternalMongoClientSettings defaults2 = InternalMongoClientSettings.getDefaults();
-        assertSame(defaults1, defaults2, "getDefaults() should return the same instances");
+        assertSame(defaults1, defaults2, "getDefaults() should return the same instance");
     }
 
     @Test

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/InternalMongoClientsTest.java
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/InternalMongoClientsTest.java
@@ -18,7 +18,7 @@ package com.mongodb.client.internal;
 
 import com.mongodb.MongoClientSettings;
 import com.mongodb.internal.connection.InternalConnectionPoolSettings;
-import com.mongodb.internal.connection.InternalMongoClientSettings;
+import com.mongodb.internal.InternalMongoClientSettings;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
- Replace static `recordEverything` with instance-based `InternalMongoClientSettings` configuration.
- Moved `InternalConnectionPoolSettings` under `InternalMongoClientSettings`

Fixes [JAVA-6060 ](https://jira.mongodb.org/browse/JAVA-6060)