### PR TITLE
JAVA-6071

### DIFF
--- a/buildSrc/src/main/kotlin/conventions/testing-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/conventions/testing-base.gradle.kts
@@ -36,6 +36,12 @@ tasks.withType<Test> {
 
     jvmArgs.add("-Dio.netty.leakDetection.level=paranoid")
 
+    // deliberately small stack size to trigger StackOverflowErrors in tests that
+    // silently pass because of the default large stack size on x64 machines
+    // see JAVA-6071 for details
+    jvmArgs.add("-Xss512k")
+
+
     // Pass any `org.mongodb.*` system settings
     systemProperties =
         System.getProperties()

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/AsynchronousTlsChannel.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/AsynchronousTlsChannel.java
@@ -98,8 +98,8 @@ public class AsynchronousTlsChannel implements ExtendedAsynchronousByteChannel {
         new ByteBufferSet(dst),
         0,
         TimeUnit.MILLISECONDS,
-        c -> group.submit(() -> handler.completed((int) c, attach)),
-        e -> group.submit(() -> handler.failed(e, attach)));
+        c -> group.execute(() -> handler.completed((int) c, attach)),
+        e -> group.execute(() -> handler.failed(e, attach)));
   }
 
   @Override
@@ -119,8 +119,8 @@ public class AsynchronousTlsChannel implements ExtendedAsynchronousByteChannel {
         new ByteBufferSet(dst),
         timeout,
         unit,
-        c -> group.submit(() -> handler.completed((int) c, attach)),
-        e -> group.submit(() -> handler.failed(e, attach)));
+        c -> group.execute(() -> handler.completed((int) c, attach)),
+        e -> group.execute(() -> handler.failed(e, attach)));
   }
 
   @Override
@@ -145,8 +145,8 @@ public class AsynchronousTlsChannel implements ExtendedAsynchronousByteChannel {
         bufferSet,
         timeout,
         unit,
-        c -> group.submit(() -> handler.completed(c, attach)),
-        e -> group.submit(() -> handler.failed(e, attach)));
+        c -> group.execute(() -> handler.completed(c, attach)),
+        e -> group.execute(() -> handler.failed(e, attach)));
   }
 
   @Override
@@ -185,8 +185,8 @@ public class AsynchronousTlsChannel implements ExtendedAsynchronousByteChannel {
         new ByteBufferSet(src),
         0,
         TimeUnit.MILLISECONDS,
-        c -> group.submit(() -> handler.completed((int) c, attach)),
-        e -> group.submit(() -> handler.failed(e, attach)));
+        c -> group.execute(() -> handler.completed((int) c, attach)),
+        e -> group.execute(() -> handler.failed(e, attach)));
   }
 
   @Override
@@ -205,8 +205,8 @@ public class AsynchronousTlsChannel implements ExtendedAsynchronousByteChannel {
         new ByteBufferSet(src),
         timeout,
         unit,
-        c -> group.submit(() -> handler.completed((int) c, attach)),
-        e -> group.submit(() -> handler.failed(e, attach)));
+        c -> group.execute(() -> handler.completed((int) c, attach)),
+        e -> group.execute(() -> handler.failed(e, attach)));
   }
 
   @Override
@@ -228,8 +228,8 @@ public class AsynchronousTlsChannel implements ExtendedAsynchronousByteChannel {
         bufferSet,
         timeout,
         unit,
-        c -> group.submit(() -> handler.completed(c, attach)),
-        e -> group.submit(() -> handler.failed(e, attach)));
+        c -> group.execute(() -> handler.completed(c, attach)),
+        e -> group.execute(() -> handler.failed(e, attach)));
   }
 
   @Override
@@ -251,11 +251,11 @@ public class AsynchronousTlsChannel implements ExtendedAsynchronousByteChannel {
   }
 
   private <A> void completeWithZeroInt(A attach, CompletionHandler<Integer, ? super A> handler) {
-    group.submit(() -> handler.completed(0, attach));
+    group.execute(() -> handler.completed(0, attach));
   }
 
   private <A> void completeWithZeroLong(A attach, CompletionHandler<Long, ? super A> handler) {
-    group.submit(() -> handler.completed(0L, attach));
+    group.execute(() -> handler.completed(0L, attach));
   }
 
   /**

--- a/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/AsynchronousTlsChannelGroup.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/tlschannel/async/AsynchronousTlsChannelGroup.java
@@ -43,6 +43,7 @@ import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -65,7 +66,7 @@ import static java.lang.String.format;
  * instance of this class is a singleton-like object that manages a thread pool that makes it
  * possible to run a group of asynchronous channels.
  */
-public class AsynchronousTlsChannelGroup {
+public class AsynchronousTlsChannelGroup implements Executor {
 
     private static final Logger LOGGER = Loggers.getLogger("connection.tls");
 
@@ -224,15 +225,13 @@ public class AsynchronousTlsChannelGroup {
         selectorThread.start();
     }
 
-    void submit(final Runnable r) {
-        executor.submit(() -> {
+    @Override
+    public void execute(final Runnable r) {
+        executor.execute(() -> {
             try {
                 r.run();
             } catch (Throwable e) {
-                // catch Throwable to also catch unexpected StackoverflowErrors and similar,
-                // to avoid silent loss of exceptions in asynchronous code
-                // see JAVA-6071 for an example of such a case
-                LOGGER.error("error in submitted runnable in AsynchronousTlsChannelGroup", e);
+                LOGGER.error(null, e);
             }
         });
     }


### PR DESCRIPTION
JAVA-6071
~~JAVA-5907~~ (this ticket is be addressed in https://github.com/mongodb/mongo-java-driver/pull/1893)

# Problem statement
Original failed [test case ](https://parsley.corp.mongodb.com/test/mongo_java_driver_tests_jdk_secure__version~8.0_os~linux_topology~standalone_auth~auth_ssl~ssl_jdk~jdk17_test_reactive_task_ad430958a6e73fb8498532f4b969da6287049e37_26_01_21_23_52_06/0/05c7cef55e28139ebcc636bf790d4138?bookmarks=0,120&shareLine=0)
The test case only fails on a standalone variant with SSL and `ordered = false`
After adding a try catch to the `submit` in `AsynchronousTlsChannelGroup` executor I was able to catch an error
```
14:23:28.914 [async-channel-group-0-handler-executor] ERROR org.mongodb.driver.connection.tls - error in submitted task
java.lang.StackOverflowError: null
	at com.mongodb.internal.async.AsyncSupplier.lambda$finish$0(AsyncSupplier.java:73)
	at com.mongodb.internal.async.SingleResultCallback$1.completed(SingleResultCallback.java:51)
	at com.mongodb.connection.AsyncCompletionHandler.lambda$asCallback$0(AsyncCompletionHandler.java:52)
	at com.mongodb.internal.async.AsyncSupplier.lambda$finish$0(AsyncSupplier.java:73)
	at com.mongodb.internal.async.AsyncSupplier.lambda$finish$0(AsyncSupplier.java:73)
	at com.mongodb.internal.async.SingleResultCallback$1.completed(SingleResultCallback.java:51)
	at com.mongodb.connection.AsyncCompletionHandler.lambda$asCallback$0(AsyncCompletionHandler.java:52)
	at com.mongodb.internal.async.AsyncSupplier.lambda$finish$0(AsyncSupplier.java:73)
	at com.mongodb.internal.async.AsyncSupplier.lambda$finish$0(AsyncSupplier.java:73)
	at com.mongodb.internal.async.SingleResultCallback$1.completed(SingleResultCallback.java:51)
	at com.mongodb.connection.AsyncCompletionHandler.lambda$asCallback$0(AsyncCompletionHandler.java:52)
	at com.mongodb.internal.async.AsyncSupplier.lambda$finish$0(AsyncSupplier.java:73)
	at com.mongodb.internal.async.AsyncSupplier.lambda$finish$0(AsyncSupplier.java:73)
	at com.mongodb.internal.async.SingleResultCallback$1.completed(SingleResultCallback.java:51)
	at com.mongodb.connection.AsyncCompletionHandler.lambda$asCallback$0(AsyncCompletionHandler.java:52)
	at com.mongodb.internal.async.AsyncSupplier.lambda$finish$0(AsyncSupplier.java:73)
	at com.mongodb.internal.async.AsyncSupplier.lambda$finish$0(AsyncSupplier.java:73)
	at com.mongodb.internal.async.SingleResultCallback$1.completed(SingleResultCallback.java:51)
	at com.mongodb.connection.AsyncCompletionHandler.lambda$asCallback$0(AsyncCompletionHandler.java:52)
	at com.mongodb.internal.async.AsyncSupplier.lambda$finish$0(AsyncSupplier.java:73)
	at com.mongodb.internal.async.AsyncSupplier.lambda$finish$0(AsyncSupplier.java:73)
```

The exception happened because the [maxBatchSize](https://github.com/mongodb/mongo-java-driver/blob/ff7ebe9e325474effbbc21fd60bbe089b5220467/driver-sync/src/test/functional/com/mongodb/client/CrudProseTest.java#L249) is used to generate a huge payload, then once client reads the payload from the server it wraps original callback as handler and handler to callback
1.  Callback to [handler](https://github.com/mongodb/mongo-java-driver/blob/ff7ebe9e325474effbbc21fd60bbe089b5220467/driver-core/src/main/com/mongodb/internal/connection/AsynchronousChannelStream.java#L249)
2. [Handler to callback ](https://github.com/mongodb/mongo-java-driver/blob/ff7ebe9e325474effbbc21fd60bbe089b5220467/driver-core/src/main/com/mongodb/internal/connection/AsynchronousChannelStream.java#L251)

Every time it happens we create a new [BasicCompletionHandler](https://github.com/mongodb/mongo-java-driver/blob/ff7ebe9e325474effbbc21fd60bbe089b5220467/driver-core/src/main/com/mongodb/internal/connection/AsynchronousChannelStream.java#L249C33-L249C55)

Once whole payload is read and client starts to unwind the callback chain it fails occasionally on overflow error 

# The fix 
The fix is to avoid the creation of chained callbacks and only pass a top `this` callback to the chain of reads

# Tests
To test the fix I deliberately used a small stack size locally `Xss=512kb` compared to default 1M
This PR also changes the stack size for all evergreen tests so that we can catch any excessive call stacks during testing 
You also have to run SSL variant locally to reproduce the error 
##