### PR TITLE
Add POJO codec benchmark suite

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -1581,6 +1581,22 @@ tasks:
           PROVIDER: "Netty"
       - func: "send-dashboard-data"
 
+  - name: "perf-pojo-task"
+    tags: [ "perf" ]
+    # Benchmark could exceed 1 hour of execution.
+    exec_timeout_secs: 7200
+    commands:
+      - func: "start-mongo-orchestration"
+        vars:
+          VERSION: "v8.0-perf"
+          TOPOLOGY: "server"
+          SSL: "nossl"
+          AUTH: "noauth"
+      - func: "run-perf-tests"
+        vars:
+          PROVIDER: "Pojo"
+      - func: "send-dashboard-data"
+
   - name: "aws-lambda-deployed-task"
     commands:
       - command: ec2.assume_role
@@ -2239,6 +2255,7 @@ buildvariants:
     tasks:
       - name: "perf-task"
       - name: "perf-netty-task"
+      - name: "perf-pojo-task"
 
   - name: plain-auth-test
     display_name: "PLAIN (LDAP) Auth test"

--- a/.evergreen/run-perf-tests.sh
+++ b/.evergreen/run-perf-tests.sh
@@ -19,6 +19,8 @@ export OUTPUT_FILE="${PROJECT_DIRECTORY}/results.json"
 
 if [ "${PROVIDER}" = "Netty" ]; then
     TASK="driver-benchmarks:runNetty"
+elif [ "${PROVIDER}" = "Pojo" ]; then
+    TASK="driver-benchmarks:runPojo"
 else
     TASK="driver-benchmarks:run"
 fi

--- a/.evergreen/run-perf-tests.sh
+++ b/.evergreen/run-perf-tests.sh
@@ -3,18 +3,18 @@
 set -o xtrace
 set -o errexit
 
-rm -rf driver-performance-test-data
-git clone https://github.com/mongodb-labs/driver-performance-test-data.git
-cd driver-performance-test-data
+BENCHMARKING_DATA="${PROJECT_DIRECTORY}/testing/resources/specifications/source/benchmarking/data"
+
+cd "${BENCHMARKING_DATA}"
 tar xf extended_bson.tgz
 tar xf parallel.tgz
 tar xf single_and_multi_document.tgz
-cd ..
+cd "${PROJECT_DIRECTORY}"
 
 RELATIVE_DIR_PATH="$(dirname "${BASH_SOURCE:-$0}")"
 . "${RELATIVE_DIR_PATH}/setup-env.bash"
 
-export TEST_PATH="${PROJECT_DIRECTORY}/driver-performance-test-data/"
+export TEST_PATH="${BENCHMARKING_DATA}/"
 export OUTPUT_FILE="${PROJECT_DIRECTORY}/results.json"
 
 if [ "${PROVIDER}" = "Netty" ]; then

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "specifications"]
 	path = testing/resources/specifications
-	url = https://github.com/mongodb/specifications
+	url = https://github.com/BorisDog/specifications

--- a/driver-benchmarks/build.gradle.kts
+++ b/driver-benchmarks/build.gradle.kts
@@ -62,6 +62,14 @@ tasks.register<JavaExec>("runNetty") {
     jvmArgs = application.applicationDefaultJvmArgs.toList()
 }
 
+tasks.register<JavaExec>("runPojo") {
+    group = "application"
+    description = "Run the POJO benchmark suite."
+    mainClass.set("com.mongodb.benchmark.benchmarks.PojoBenchmarkSuite")
+    classpath = sourceSets["main"].runtimeClasspath
+    jvmArgs = application.applicationDefaultJvmArgs.toList()
+}
+
 tasks.withType<Javadoc>().configureEach {
     enabled = false
 }

--- a/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/PojoBenchmarkSuite.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/PojoBenchmarkSuite.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2016-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.benchmark.benchmarks;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.benchmark.benchmarks.bulk.ClientBulkWriteBenchmark;
+import com.mongodb.benchmark.benchmarks.bulk.CollectionBulkWriteBenchmark;
+import com.mongodb.benchmark.benchmarks.bulk.MixedClientBulkWriteBenchmark;
+import com.mongodb.benchmark.benchmarks.bulk.MixedCollectionBulkWriteBenchmark;
+import com.mongodb.benchmark.benchmarks.pojo.polymorphic.BranchNode;
+import com.mongodb.benchmark.benchmarks.pojo.LargeDoc;
+import com.mongodb.benchmark.benchmarks.pojo.TreeNode;
+import com.mongodb.benchmark.benchmarks.pojo.tweet.Tweet;
+import com.mongodb.benchmark.framework.Benchmark;
+import com.mongodb.benchmark.framework.BenchmarkResult;
+import com.mongodb.benchmark.framework.BenchmarkResultWriter;
+import com.mongodb.benchmark.framework.BenchmarkRunner;
+import com.mongodb.benchmark.framework.EvergreenBenchmarkResultWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class PojoBenchmarkSuite {
+
+    protected static final int NUM_WARMUP_ITERATIONS = 1;
+    protected static final int NUM_ITERATIONS = 100;
+    protected static final int MIN_TIME_SECONDS = 60;
+    protected static final int MAX_TIME_SECONDS = 300;
+
+    protected static final CodecRegistry POJO_CODEC_REGISTRY = fromRegistries(
+            MongoClientSettings.getDefaultCodecRegistry(),
+            fromProviders(PojoCodecProvider.builder().automatic(true).build())
+    );
+
+    protected static final MongoClientSettings MONGO_CLIENT_SETTINGS = MongoClientSettings.builder()
+            .codecRegistry(POJO_CODEC_REGISTRY)
+            .build();
+
+    protected static final Class<TreeNode> TREE_NODE_CLASS = TreeNode.class;
+    protected static final Codec<TreeNode> TREE_NODE_CODEC = POJO_CODEC_REGISTRY.get(TREE_NODE_CLASS);
+
+    protected static final Class<BranchNode> BRANCH_NODE_CLASS = BranchNode.class;
+    protected static final Codec<BranchNode> BRANCH_NODE_CODEC = POJO_CODEC_REGISTRY.get(BRANCH_NODE_CLASS);
+
+    protected static final Class<Tweet> TWEET_CLASS = Tweet.class;
+    protected static final IdRemover<Tweet> TWEET_ID_REMOVER = tweet -> tweet.setId(null);
+
+    protected static final Class<LargeDoc> LARGE_DOC_CLASS = LargeDoc.class;
+    protected static final IdRemover<LargeDoc> LARGE_DOC_ID_REMOVER = doc -> doc.setId(null);
+
+    protected static final List<BenchmarkResultWriter> WRITERS = Arrays.asList(
+            new EvergreenBenchmarkResultWriter());
+
+    public static void main(String[] args) throws Exception {
+        runBenchmarks();
+
+        for (BenchmarkResultWriter writer : WRITERS) {
+            writer.close();
+        }
+    }
+
+    private static void runBenchmarks() throws Exception {
+        runBenchmark(new BsonEncodingBenchmark<>("Deep POJO", "extended_bson/deep_bson.json", TREE_NODE_CODEC));
+        runBenchmark(new BsonDecodingBenchmark<>("Deep POJO", "extended_bson/deep_bson.json", TREE_NODE_CODEC));
+         //TODO
+//        runBenchmark(new BsonEncodingBenchmark<>("Deep POJO Polymorphic", "extended_bson/deep_bson_polymorphic.json", BRANCH_NODE_CODEC));
+//        runBenchmark(new BsonDecodingBenchmark<>("Deep POJO Polymorphic", "extended_bson/deep_bson_polymorphic.json", BRANCH_NODE_CODEC));
+
+        runBenchmark(new FindOneBenchmark<>("single_and_multi_document/tweet.json", TWEET_CLASS)
+                .applyMongoClientSettings(MONGO_CLIENT_SETTINGS));
+        runBenchmark(new FindManyBenchmark<>("single_and_multi_document/tweet.json", TWEET_CLASS)
+                .applyMongoClientSettings(MONGO_CLIENT_SETTINGS));
+
+        runBenchmark(new InsertOneBenchmark<>("POJO Small", "./single_and_multi_document/tweet.json", 10_000,
+                TWEET_CLASS, TWEET_ID_REMOVER).applyMongoClientSettings(MONGO_CLIENT_SETTINGS));
+        runBenchmark(new InsertOneBenchmark<>("POJO Large", "./single_and_multi_document/large_doc.json", 10,
+                LARGE_DOC_CLASS, LARGE_DOC_ID_REMOVER).applyMongoClientSettings(MONGO_CLIENT_SETTINGS));
+
+        runBenchmark(new InsertManyBenchmark<>("POJO Small", "./single_and_multi_document/tweet.json", 10_000,
+                TWEET_CLASS).applyMongoClientSettings(MONGO_CLIENT_SETTINGS));
+        runBenchmark(new InsertManyBenchmark<>("POJO Large", "./single_and_multi_document/large_doc.json", 10,
+                LARGE_DOC_CLASS).applyMongoClientSettings(MONGO_CLIENT_SETTINGS));
+
+        runBenchmark(new CollectionBulkWriteBenchmark<>("POJO Small", "./single_and_multi_document/tweet.json", 10_000,
+                TWEET_CLASS).applyMongoClientSettings(MONGO_CLIENT_SETTINGS));
+        runBenchmark(new CollectionBulkWriteBenchmark<>("POJO Large", "./single_and_multi_document/large_doc.json", 10,
+                LARGE_DOC_CLASS).applyMongoClientSettings(MONGO_CLIENT_SETTINGS));
+
+        runBenchmark(new ClientBulkWriteBenchmark<>("POJO Small", "./single_and_multi_document/tweet.json", 10_000,
+                TWEET_CLASS).applyMongoClientSettings(MONGO_CLIENT_SETTINGS));
+        runBenchmark(new ClientBulkWriteBenchmark<>("POJO Large", "./single_and_multi_document/large_doc.json", 10,
+                LARGE_DOC_CLASS).applyMongoClientSettings(MONGO_CLIENT_SETTINGS));
+
+        runBenchmark(new MixedCollectionBulkWriteBenchmark<>("./single_and_multi_document/tweet.json", 10_000,
+                TWEET_CLASS).applyMongoClientSettings(MONGO_CLIENT_SETTINGS));
+        runBenchmark(new MixedClientBulkWriteBenchmark<>("./single_and_multi_document/tweet.json", 10_000,
+                TWEET_CLASS).applyMongoClientSettings(MONGO_CLIENT_SETTINGS));
+    }
+
+    protected static void runBenchmark(final Benchmark benchmark) throws Exception {
+        long startTime = System.currentTimeMillis();
+        BenchmarkResult benchmarkResult = new BenchmarkRunner(benchmark, NUM_WARMUP_ITERATIONS, NUM_ITERATIONS, MIN_TIME_SECONDS,
+                MAX_TIME_SECONDS).run();
+        long endTime = System.currentTimeMillis();
+        System.out.println(benchmarkResult.getName() + ": " + (endTime - startTime) / 1000.0);
+        for (BenchmarkResultWriter writer : WRITERS) {
+            writer.write(benchmarkResult);
+        }
+    }
+}

--- a/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/LargeDoc.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/LargeDoc.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.benchmark.benchmarks.pojo;
+
+import org.bson.codecs.pojo.annotations.BsonExtraElements;
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.types.ObjectId;
+
+import java.util.Map;
+
+public class LargeDoc {
+    @BsonId
+    private ObjectId id;
+
+    @BsonExtraElements
+    private Map<String, Object> extraFields;
+
+    public LargeDoc() {
+    }
+
+    public ObjectId getId() {
+        return id;
+    }
+
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    public Map<String, Object> getExtraFields() {
+        return extraFields;
+    }
+
+    public void setExtraFields(Map<String, Object> extraFields) {
+        this.extraFields = extraFields;
+    }
+}

--- a/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/TreeNode.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/TreeNode.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.benchmark.benchmarks.pojo;
+
+public class TreeNode {
+    private TreeNode left;
+    private TreeNode right;
+    private String leftValue;
+    private String rightValue;
+
+    public TreeNode() {
+    }
+
+    public TreeNode(TreeNode left, TreeNode right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    public TreeNode(String leftValue, String rightValue) {
+        this.leftValue = leftValue;
+        this.rightValue = rightValue;
+    }
+
+    public TreeNode getLeft() {
+        return left;
+    }
+
+    public void setLeft(TreeNode left) {
+        this.left = left;
+    }
+
+    public TreeNode getRight() {
+        return right;
+    }
+
+    public void setRight(TreeNode right) {
+        this.right = right;
+    }
+
+    public String getLeftValue() {
+        return leftValue;
+    }
+
+    public void setLeftValue(String leftValue) {
+        this.leftValue = leftValue;
+    }
+
+    public String getRightValue() {
+        return rightValue;
+    }
+
+    public void setRightValue(String rightValue) {
+        this.rightValue = rightValue;
+    }
+}

--- a/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/polymorphic/BranchNode.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/polymorphic/BranchNode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.benchmark.benchmarks.pojo.polymorphic;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+@BsonDiscriminator(value = "BranchNode", key = "_t")
+public class BranchNode extends Node {
+    private Node left;
+    private Node right;
+
+    public BranchNode() {
+    }
+
+    public Node getLeft() {
+        return left;
+    }
+
+    public void setLeft(Node left) {
+        this.left = left;
+    }
+
+    public Node getRight() {
+        return right;
+    }
+
+    public void setRight(Node right) {
+        this.right = right;
+    }
+}

--- a/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/polymorphic/LeafNode.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/polymorphic/LeafNode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.benchmark.benchmarks.pojo.polymorphic;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+@BsonDiscriminator(value = "LeafNode", key = "_t")
+public class LeafNode extends Node {
+    private String rightValue;
+    private String leftValue;
+
+    public LeafNode() {
+    }
+
+    public String getRightValue() {
+        return rightValue;
+    }
+
+    public void setRightValue(String rightValue) {
+        this.rightValue = rightValue;
+    }
+
+    public String getLeftValue() {
+        return leftValue;
+    }
+
+    public void setLeftValue(String leftValue) {
+        this.leftValue = leftValue;
+    }
+}

--- a/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/polymorphic/Node.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/polymorphic/Node.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.benchmark.benchmarks.pojo.polymorphic;
+
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+@BsonDiscriminator
+public abstract class Node {
+}

--- a/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/tweet/Tweet.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/tweet/Tweet.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2016-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.benchmark.benchmarks.pojo.tweet;
+
+public class Tweet {
+    private Long id;
+    private String text;
+    private Long inReplyToStatusId;
+    private Integer retweetCount;
+    private String createdAt;
+    private String source;
+    private String inReplyToScreenName;
+    private Boolean truncated;
+    private TweetEntities entities;
+    private Boolean retweeted;
+    private TweetUser user;
+    private Boolean favorited;
+    private Long inReplyToUserId;
+
+    public Tweet() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public Long getInReplyToStatusId() {
+        return inReplyToStatusId;
+    }
+
+    public void setInReplyToStatusId(Long inReplyToStatusId) {
+        this.inReplyToStatusId = inReplyToStatusId;
+    }
+
+    public Integer getRetweetCount() {
+        return retweetCount;
+    }
+
+    public void setRetweetCount(Integer retweetCount) {
+        this.retweetCount = retweetCount;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getInReplyToScreenName() {
+        return inReplyToScreenName;
+    }
+
+    public void setInReplyToScreenName(String inReplyToScreenName) {
+        this.inReplyToScreenName = inReplyToScreenName;
+    }
+
+    public Boolean getTruncated() {
+        return truncated;
+    }
+
+    public void setTruncated(Boolean truncated) {
+        this.truncated = truncated;
+    }
+
+    public TweetEntities getEntities() {
+        return entities;
+    }
+
+    public void setEntities(TweetEntities entities) {
+        this.entities = entities;
+    }
+
+    public Boolean getRetweeted() {
+        return retweeted;
+    }
+
+    public void setRetweeted(Boolean retweeted) {
+        this.retweeted = retweeted;
+    }
+
+    public TweetUser getUser() {
+        return user;
+    }
+
+    public void setUser(TweetUser user) {
+        this.user = user;
+    }
+
+    public Boolean getFavorited() {
+        return favorited;
+    }
+
+    public void setFavorited(Boolean favorited) {
+        this.favorited = favorited;
+    }
+
+    public Long getInReplyToUserId() {
+        return inReplyToUserId;
+    }
+
+    public void setInReplyToUserId(Long inReplyToUserId) {
+        this.inReplyToUserId = inReplyToUserId;
+    }
+}

--- a/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/tweet/TweetEntities.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/tweet/TweetEntities.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.benchmark.benchmarks.pojo.tweet;
+
+import java.util.List;
+
+public class TweetEntities {
+    private List<UserMention> userMentions;
+    private List<String> urls;
+    private List<String> hashtags;
+
+    public TweetEntities() {
+    }
+
+    public List<UserMention> getUserMentions() {
+        return userMentions;
+    }
+
+    public void setUserMentions(List<UserMention> userMentions) {
+        this.userMentions = userMentions;
+    }
+
+    public List<String> getUrls() {
+        return urls;
+    }
+
+    public void setUrls(List<String> urls) {
+        this.urls = urls;
+    }
+
+    public List<String> getHashtags() {
+        return hashtags;
+    }
+
+    public void setHashtags(List<String> hashtags) {
+        this.hashtags = hashtags;
+    }
+}

--- a/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/tweet/TweetUser.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/tweet/TweetUser.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2016-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.benchmark.benchmarks.pojo.tweet;
+
+public class TweetUser {
+    private Long id;
+    private Integer friendsCount;
+    private String profileSidebarFillColor;
+    private String location;
+    private Boolean verified;
+    private Integer favouritesCount;
+    private String profileSidebarBorderColor;
+    private String profileImageUrl;
+    private Boolean geoEnabled;
+    private String createdAt;
+    private String description;
+    private String timeZone;
+    private String url;
+    private String screenName;
+    private String profileBackgroundColor;
+    private Integer listedCount;
+    private String lang;
+    private String profileBackgroundImageUrl;
+    private Integer statusesCount;
+    private String profileTextColor;
+    private Boolean protectedUser;
+    private Boolean showAllInlineMedia;
+    private Boolean profileBackgroundTile;
+    private String name;
+    private Boolean contributorsEnabled;
+    private String profileLinkColor;
+    private Integer followersCount;
+    private Boolean profileUseBackgroundImage;
+    private Integer utcOffset;
+
+    public TweetUser() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Integer getFriendsCount() {
+        return friendsCount;
+    }
+
+    public void setFriendsCount(Integer friendsCount) {
+        this.friendsCount = friendsCount;
+    }
+
+    public String getProfileSidebarFillColor() {
+        return profileSidebarFillColor;
+    }
+
+    public void setProfileSidebarFillColor(String profileSidebarFillColor) {
+        this.profileSidebarFillColor = profileSidebarFillColor;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public Boolean getVerified() {
+        return verified;
+    }
+
+    public void setVerified(Boolean verified) {
+        this.verified = verified;
+    }
+
+    public Integer getFavouritesCount() {
+        return favouritesCount;
+    }
+
+    public void setFavouritesCount(Integer favouritesCount) {
+        this.favouritesCount = favouritesCount;
+    }
+
+    public String getProfileSidebarBorderColor() {
+        return profileSidebarBorderColor;
+    }
+
+    public void setProfileSidebarBorderColor(String profileSidebarBorderColor) {
+        this.profileSidebarBorderColor = profileSidebarBorderColor;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+
+    public void setProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public Boolean getGeoEnabled() {
+        return geoEnabled;
+    }
+
+    public void setGeoEnabled(Boolean geoEnabled) {
+        this.geoEnabled = geoEnabled;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getTimeZone() {
+        return timeZone;
+    }
+
+    public void setTimeZone(String timeZone) {
+        this.timeZone = timeZone;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getScreenName() {
+        return screenName;
+    }
+
+    public void setScreenName(String screenName) {
+        this.screenName = screenName;
+    }
+
+    public String getProfileBackgroundColor() {
+        return profileBackgroundColor;
+    }
+
+    public void setProfileBackgroundColor(String profileBackgroundColor) {
+        this.profileBackgroundColor = profileBackgroundColor;
+    }
+
+    public Integer getListedCount() {
+        return listedCount;
+    }
+
+    public void setListedCount(Integer listedCount) {
+        this.listedCount = listedCount;
+    }
+
+    public String getLang() {
+        return lang;
+    }
+
+    public void setLang(String lang) {
+        this.lang = lang;
+    }
+
+    public String getProfileBackgroundImageUrl() {
+        return profileBackgroundImageUrl;
+    }
+
+    public void setProfileBackgroundImageUrl(String profileBackgroundImageUrl) {
+        this.profileBackgroundImageUrl = profileBackgroundImageUrl;
+    }
+
+    public Integer getStatusesCount() {
+        return statusesCount;
+    }
+
+    public void setStatusesCount(Integer statusesCount) {
+        this.statusesCount = statusesCount;
+    }
+
+    public String getProfileTextColor() {
+        return profileTextColor;
+    }
+
+    public void setProfileTextColor(String profileTextColor) {
+        this.profileTextColor = profileTextColor;
+    }
+
+    public Boolean getProtectedUser() {
+        return protectedUser;
+    }
+
+    public void setProtectedUser(Boolean protectedUser) {
+        this.protectedUser = protectedUser;
+    }
+
+    public Boolean getShowAllInlineMedia() {
+        return showAllInlineMedia;
+    }
+
+    public void setShowAllInlineMedia(Boolean showAllInlineMedia) {
+        this.showAllInlineMedia = showAllInlineMedia;
+    }
+
+    public Boolean getProfileBackgroundTile() {
+        return profileBackgroundTile;
+    }
+
+    public void setProfileBackgroundTile(Boolean profileBackgroundTile) {
+        this.profileBackgroundTile = profileBackgroundTile;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Boolean getContributorsEnabled() {
+        return contributorsEnabled;
+    }
+
+    public void setContributorsEnabled(Boolean contributorsEnabled) {
+        this.contributorsEnabled = contributorsEnabled;
+    }
+
+    public String getProfileLinkColor() {
+        return profileLinkColor;
+    }
+
+    public void setProfileLinkColor(String profileLinkColor) {
+        this.profileLinkColor = profileLinkColor;
+    }
+
+    public Integer getFollowersCount() {
+        return followersCount;
+    }
+
+    public void setFollowersCount(Integer followersCount) {
+        this.followersCount = followersCount;
+    }
+
+    public Boolean getProfileUseBackgroundImage() {
+        return profileUseBackgroundImage;
+    }
+
+    public void setProfileUseBackgroundImage(Boolean profileUseBackgroundImage) {
+        this.profileUseBackgroundImage = profileUseBackgroundImage;
+    }
+
+    public Integer getUtcOffset() {
+        return utcOffset;
+    }
+
+    public void setUtcOffset(Integer utcOffset) {
+        this.utcOffset = utcOffset;
+    }
+}

--- a/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/tweet/UserMention.java
+++ b/driver-benchmarks/src/main/com/mongodb/benchmark/benchmarks/pojo/tweet/UserMention.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.benchmark.benchmarks.pojo.tweet;
+
+import java.util.List;
+
+public class UserMention {
+    private List<Integer> indices;
+    private String screenName;
+    private String name;
+    private Long id;
+
+    public UserMention() {
+    }
+
+    public List<Integer> getIndices() {
+        return indices;
+    }
+
+    public void setIndices(List<Integer> indices) {
+        this.indices = indices;
+    }
+
+    public String getScreenName() {
+        return screenName;
+    }
+
+    public void setScreenName(String screenName) {
+        this.screenName = screenName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}


### PR DESCRIPTION
- Add PojoBenchmarkSuite to measure POJO codec performance and track regressions
- Add Tweet, LargeDoc, TreeNode POJOs to test typical document structures
- Add @BsonExtraElements pattern testing via LargeDoc for dynamic fields
- Add polymorphic Node/BranchNode/LeafNode with @BsonDiscriminator to measure inheritance overhead
- Add benchmarks for encoding/decoding, find, insert, and bulk operations using POJOs

[JAVA-6134](https://jira.mongodb.org/browse/JAVA-6134)