### PR TITLE
Add onlyConnectOriginalUrl connection string option to skip replica set topology discovery

### DIFF
--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -304,6 +304,7 @@ public class ConnectionString {
     private String srvServiceName;
     private Boolean directConnection;
     private Boolean loadBalanced;
+    private Boolean onlyConnectOriginalUrl;
     private ReadPreference readPreference;
     private WriteConcern writeConcern;
     private Boolean retryWrites;
@@ -569,6 +570,8 @@ public class ConnectionString {
         GENERAL_OPTIONS_KEYS.add("srvmaxhosts");
         GENERAL_OPTIONS_KEYS.add("srvservicename");
 
+        GENERAL_OPTIONS_KEYS.add("onlyconnectoriginalurl");
+
         COMPRESSOR_KEYS.add("compressors");
         COMPRESSOR_KEYS.add("zlibcompressionlevel");
 
@@ -723,6 +726,9 @@ public class ConnectionString {
                     break;
                 case "srvservicename":
                     srvServiceName = value;
+                    break;
+                case "onlyconnectoriginalurl":
+                    onlyConnectOriginalUrl = parseBoolean(value, "onlyconnectoriginalurl");
                     break;
                 default:
                     break;
@@ -1404,6 +1410,19 @@ public class ConnectionString {
     @Nullable
     public Boolean isLoadBalanced() {
         return loadBalanced;
+    }
+
+    /**
+     * Gets the value of the {@code onlyConnectOriginalUrl} property from the connection string.
+     * When true, the driver will only connect to the servers specified in the original connection string
+     * and will not add or remove servers based on replica set topology discovery.
+     *
+     * @return true if only the original URL hosts should be connected, or null if unset
+     * @since 5.7
+     */
+    @Nullable
+    public Boolean getOnlyConnectOriginalUrl() {
+        return onlyConnectOriginalUrl;
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/ClusterSettings.java
+++ b/driver-core/src/main/com/mongodb/connection/ClusterSettings.java
@@ -58,6 +58,7 @@ public final class ClusterSettings {
     private final long localThresholdMS;
     private final long serverSelectionTimeoutMS;
     private final List<ClusterListener> clusterListeners;
+    private final boolean onlyConnectOriginalUrl;
 
     /**
      * Get a builder for this class.
@@ -96,6 +97,7 @@ public final class ClusterSettings {
         private long serverSelectionTimeoutMS = MILLISECONDS.convert(30, TimeUnit.SECONDS);
         private long localThresholdMS = MILLISECONDS.convert(15, MILLISECONDS);
         private List<ClusterListener> clusterListeners = new ArrayList<>();
+        private boolean onlyConnectOriginalUrl = false;
 
         private Builder() {
         }
@@ -122,6 +124,7 @@ public final class ClusterSettings {
             serverSelectionTimeoutMS = clusterSettings.serverSelectionTimeoutMS;
             clusterListeners = new ArrayList<>(clusterSettings.clusterListeners);
             serverSelector = clusterSettings.serverSelector;
+            onlyConnectOriginalUrl = clusterSettings.onlyConnectOriginalUrl;
             return this;
         }
 
@@ -315,6 +318,19 @@ public final class ClusterSettings {
         }
 
         /**
+         * Sets whether to only connect to the servers specified in the original connection string,
+         * skipping replica set topology discovery (no new hosts added or removed).
+         *
+         * @param onlyConnectOriginalUrl true to disable topology-based host management
+         * @return this
+         * @since 5.7
+         */
+        public Builder onlyConnectOriginalUrl(final boolean onlyConnectOriginalUrl) {
+            this.onlyConnectOriginalUrl = onlyConnectOriginalUrl;
+            return this;
+        }
+
+        /**
          * Takes the settings from the given {@code ConnectionString} and applies them to the builder
          *
          * @param connectionString the connection string containing details of how to connect to MongoDB
@@ -363,6 +379,10 @@ public final class ClusterSettings {
             Integer localThreshold = connectionString.getLocalThreshold();
             if (localThreshold != null) {
                 localThreshold(localThreshold, MILLISECONDS);
+            }
+            Boolean onlyConnectOriginalUrl = connectionString.getOnlyConnectOriginalUrl();
+            if (onlyConnectOriginalUrl != null) {
+                onlyConnectOriginalUrl(onlyConnectOriginalUrl);
             }
             return this;
         }
@@ -540,6 +560,17 @@ public final class ClusterSettings {
         return clusterListeners;
     }
 
+    /**
+     * Gets whether the driver should only connect to the servers specified in the original connection string,
+     * skipping replica set topology discovery.
+     *
+     * @return true if only the original URL hosts should be connected
+     * @since 5.7
+     */
+    public boolean isOnlyConnectOriginalUrl() {
+        return onlyConnectOriginalUrl;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -551,6 +582,7 @@ public final class ClusterSettings {
         ClusterSettings that = (ClusterSettings) o;
         return localThresholdMS == that.localThresholdMS
                 && serverSelectionTimeoutMS == that.serverSelectionTimeoutMS
+                && onlyConnectOriginalUrl == that.onlyConnectOriginalUrl
                 && Objects.equals(srvHost, that.srvHost)
                 && Objects.equals(srvMaxHosts, that.srvMaxHosts)
                 && srvServiceName.equals(that.srvServiceName)
@@ -565,7 +597,7 @@ public final class ClusterSettings {
     @Override
     public int hashCode() {
         return Objects.hash(srvHost, srvMaxHosts, srvServiceName, hosts, mode, requiredClusterType, requiredReplicaSetName, serverSelector,
-                localThresholdMS, serverSelectionTimeoutMS, clusterListeners);
+                localThresholdMS, serverSelectionTimeoutMS, clusterListeners, onlyConnectOriginalUrl);
     }
 
     @Override
@@ -582,6 +614,7 @@ public final class ClusterSettings {
                + ", clusterListeners='" + clusterListeners + '\''
                + ", serverSelectionTimeout='" + serverSelectionTimeoutMS + " ms" + '\''
                + ", localThreshold='" + localThresholdMS + " ms" + '\''
+               + ", onlyConnectOriginalUrl=" + onlyConnectOriginalUrl
                + '}';
     }
 
@@ -659,5 +692,6 @@ public final class ClusterSettings {
         serverSelector = builder.serverSelector;
         serverSelectionTimeoutMS = builder.serverSelectionTimeoutMS;
         clusterListeners = unmodifiableList(builder.clusterListeners);
+        onlyConnectOriginalUrl = builder.onlyConnectOriginalUrl;
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
@@ -254,6 +254,11 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
             return true;
         }
 
+        // When onlyConnectOriginalUrl is true, skip topology-based host management (no adding/removing hosts)
+        if (getSettings().isOnlyConnectOriginalUrl()) {
+            return true;
+        }
+
         ensureServers(newDescription);
 
         if (newDescription.getCanonicalAddress() != null

--- a/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
@@ -536,6 +536,7 @@ class ConnectionStringSpecification extends Specification {
         connectionString.getCompressorList() == []
         connectionString.getRetryWritesValue() == null
         connectionString.getRetryReads() == null
+        connectionString.getOnlyConnectOriginalUrl() == null
     }
 
     @Unroll
@@ -844,5 +845,25 @@ class ConnectionStringSpecification extends Specification {
 
         then:
         connectionString.getRequiredReplicaSetName() == 'java'
+    }
+
+    def 'should parse onlyConnectOriginalUrl option correctly'() {
+        when:
+        def connectionString = new ConnectionString('mongodb://localhost:27017,localhost:27018/?onlyConnectOriginalUrl=true')
+
+        then:
+        connectionString.getOnlyConnectOriginalUrl() == true
+
+        when:
+        connectionString = new ConnectionString('mongodb://localhost:27017/?onlyConnectOriginalUrl=false')
+
+        then:
+        connectionString.getOnlyConnectOriginalUrl() == false
+
+        when:
+        connectionString = new ConnectionString('mongodb://localhost:27017/')
+
+        then:
+        connectionString.getOnlyConnectOriginalUrl() == null
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/connection/ClusterSettingsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ClusterSettingsSpecification.groovy
@@ -43,6 +43,7 @@ class ClusterSettingsSpecification extends Specification {
         settings.clusterListeners == []
         settings.srvMaxHosts == null
         settings.srvServiceName == 'mongodb'
+        settings.onlyConnectOriginalUrl == false
     }
 
     def 'should set all properties'() {
@@ -519,6 +520,53 @@ class ClusterSettingsSpecification extends Specification {
 
        then:
        thrown(IllegalArgumentException)
+    }
+
+    def 'should support onlyConnectOriginalUrl via builder'() {
+        when:
+        def settings = ClusterSettings.builder()
+                .hosts([new ServerAddress('localhost:27017'), new ServerAddress('localhost:27018')])
+                .mode(ClusterConnectionMode.MULTIPLE)
+                .onlyConnectOriginalUrl(true)
+                .build()
+
+        then:
+        settings.onlyConnectOriginalUrl == true
+
+        when:
+        def copy = ClusterSettings.builder().applySettings(settings).build()
+
+        then:
+        copy.onlyConnectOriginalUrl == true
+        copy == settings
+    }
+
+    def 'should read onlyConnectOriginalUrl from connection string'() {
+        when:
+        def settings = ClusterSettings.builder()
+                .applyConnectionString(new ConnectionString(
+                        'mongodb://localhost:27017,localhost:27018/?onlyConnectOriginalUrl=true'))
+                .build()
+
+        then:
+        settings.onlyConnectOriginalUrl == true
+
+        when:
+        settings = ClusterSettings.builder()
+                .applyConnectionString(new ConnectionString(
+                        'mongodb://localhost:27017,localhost:27018/?onlyConnectOriginalUrl=false'))
+                .build()
+
+        then:
+        settings.onlyConnectOriginalUrl == false
+
+        when:
+        settings = ClusterSettings.builder()
+                .applyConnectionString(new ConnectionString('mongodb://localhost:27017,localhost:27018/'))
+                .build()
+
+        then:
+        settings.onlyConnectOriginalUrl == false
     }
 
     static class ServerAddressSubclass extends ServerAddress {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/MultiServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/MultiServerClusterSpecification.groovy
@@ -523,4 +523,106 @@ class MultiServerClusterSpecification extends Specification {
     def sendNotification(ServerAddress serverAddress, ServerType serverType) {
         factory.sendNotification(serverAddress, serverType, [firstServer, secondServer, thirdServer])
     }
+
+    // ---- onlyConnectOriginalUrl tests ----
+
+    def 'should not add new hosts when onlyConnectOriginalUrl is true and primary reports additional members'() {
+        given:
+        def cluster = new MultiServerCluster(CLUSTER_ID,
+                ClusterSettings.builder()
+                        .mode(MULTIPLE)
+                        .hosts([firstServer])
+                        .onlyConnectOriginalUrl(true)
+                        .build(),
+                factory, CLIENT_METADATA)
+
+        when:
+        // Primary reports firstServer, secondServer, thirdServer in its host list
+        factory.sendNotification(firstServer, REPLICA_SET_PRIMARY, [firstServer, secondServer, thirdServer])
+
+        then:
+        // Only firstServer should remain — no new hosts added
+        getAll(cluster.getCurrentDescription()) == factory.getDescriptions(firstServer)
+    }
+
+    def 'should not remove hosts when onlyConnectOriginalUrl is true and primary reports reduced member list'() {
+        given:
+        def cluster = new MultiServerCluster(CLUSTER_ID,
+                ClusterSettings.builder()
+                        .mode(MULTIPLE)
+                        .hosts([firstServer, secondServer, thirdServer])
+                        .onlyConnectOriginalUrl(true)
+                        .build(),
+                factory, CLIENT_METADATA)
+        factory.sendNotification(firstServer, REPLICA_SET_PRIMARY, [firstServer, secondServer, thirdServer])
+        factory.sendNotification(secondServer, REPLICA_SET_SECONDARY, [firstServer, secondServer, thirdServer])
+        factory.sendNotification(thirdServer, REPLICA_SET_SECONDARY, [firstServer, secondServer, thirdServer])
+
+        when:
+        // Primary now only reports firstServer and secondServer — thirdServer should NOT be removed
+        factory.sendNotification(firstServer, REPLICA_SET_PRIMARY, [firstServer, secondServer])
+
+        then:
+        getAll(cluster.getCurrentDescription()) == factory.getDescriptions(firstServer, secondServer, thirdServer)
+        !factory.getServer(thirdServer).isClosed()
+    }
+
+    def 'should still remove a server of wrong type when onlyConnectOriginalUrl is true'() {
+        given:
+        def cluster = new MultiServerCluster(CLUSTER_ID,
+                ClusterSettings.builder()
+                        .requiredClusterType(REPLICA_SET)
+                        .hosts([firstServer, secondServer])
+                        .onlyConnectOriginalUrl(true)
+                        .build(),
+                factory, CLIENT_METADATA)
+
+        when:
+        // secondServer is a shard router — must still be removed (wrong type check happens before the guard)
+        sendNotificationOnlyConnectOriginalUrl(secondServer, SHARD_ROUTER)
+
+        then:
+        cluster.getCurrentDescription().type == REPLICA_SET
+        getAll(cluster.getCurrentDescription()) == factory.getDescriptions(firstServer)
+    }
+
+    def 'should still reject a member from the wrong replica set when onlyConnectOriginalUrl is true'() {
+        given:
+        def cluster = new MultiServerCluster(CLUSTER_ID,
+                ClusterSettings.builder()
+                        .mode(MULTIPLE)
+                        .hosts([firstServer])
+                        .requiredReplicaSetName('test1')
+                        .onlyConnectOriginalUrl(true)
+                        .build(),
+                factory, CLIENT_METADATA)
+
+        when:
+        factory.sendNotification(firstServer, REPLICA_SET_PRIMARY, [firstServer, secondServer, thirdServer], 'test2')
+
+        then:
+        // wrong setName — firstServer must be removed regardless of onlyConnectOriginalUrl
+        getAll(cluster.getCurrentDescription()) == [] as Set
+    }
+
+    def 'should add hosts normally when onlyConnectOriginalUrl is false'() {
+        given:
+        def cluster = new MultiServerCluster(CLUSTER_ID,
+                ClusterSettings.builder()
+                        .mode(MULTIPLE)
+                        .hosts([firstServer])
+                        .onlyConnectOriginalUrl(false)
+                        .build(),
+                factory, CLIENT_METADATA)
+
+        when:
+        factory.sendNotification(firstServer, REPLICA_SET_PRIMARY, [firstServer, secondServer, thirdServer])
+
+        then:
+        getAll(cluster.getCurrentDescription()) == factory.getDescriptions(firstServer, secondServer, thirdServer)
+    }
+
+    def sendNotificationOnlyConnectOriginalUrl(ServerAddress serverAddress, ServerType serverType) {
+        factory.sendNotification(serverAddress, serverType, [firstServer, secondServer])
+    }
 }


### PR DESCRIPTION
Resolves JAVA-6128

## Motivation

When connecting to a replica set, the Java driver automatically discovers and manages cluster topology by adding and removing hosts based on information reported by primary members (via `ensureServers()`). This behavior is not always desirable.

Common scenarios where users need to disable auto-discovery:
- Certain replica set nodes are known to be unreachable from the client network
- The client should only connect to the explicitly specified seed list, without expanding to other members

## Changes

Add a new boolean connection string option `onlyConnectOriginalUrl` (default: `false`).

When set to `true`, `AbstractMultiServerCluster` will:
- Still perform necessary validity checks (server type check, replica set ghost check, set name matching)
- Skip the `ensureServers()` call in `handleReplicaSetMemberChanged`, so no new hosts are added and no existing hosts are removed based on topology discovery — similar to the behavior of `handleShardRouterChanged`

**Example usage:**
mongodb://host1:27017,host2:27018/?replicaSet=myRS&onlyConnectOriginalUrl=true

## Files Changed

- `ConnectionString.java` — parse and expose the new option
- `ClusterSettings.java` — store the flag via builder/getter and apply from connection string
- `AbstractMultiServerCluster.java` — apply guard logic in `handleReplicaSetMemberChanged`

## Testing

Added unit tests covering:
- Primary reports additional members → no new hosts added
- Primary reports reduced member list → no existing hosts removed
- Wrong server type → server still removed (safety checks take priority)
- Wrong replica set name → server still rejected
- `onlyConnectOriginalUrl=false` → original behavior unchanged

![20260313160733](https://github.com/user-attachments/assets/3d9ccd6d-4df5-4c38-8b32-844fb790518f)
