### PR TITLE
Remove skip for GridFS download timeout test

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -104,10 +104,6 @@ public final class UnifiedTestModifications {
                 .test("client-side-operations-timeout", "timeoutMS behaves correctly for tailable awaitData cursors",
                         "apply maxAwaitTimeMS if less than remaining timeout");
 
-        def.skipJira("https://jira.mongodb.org/browse/JAVA-5839")
-                .test("client-side-operations-timeout", "timeoutMS behaves correctly for GridFS download operations",
-                        "timeoutMS applied to entire download, not individual parts");
-
         def.skipJira("https://jira.mongodb.org/browse/JAVA-5491")
                 .when(() -> !serverVersionLessThan(8, 3))
                 .test("client-side-operations-timeout", "operations ignore deprecated timeout options if timeoutMS is set",


### PR DESCRIPTION
Remove JAVA-5839 skip entry for "timeoutMS applied to entire download, not individual parts" test so it runs in CI

JAVA-5839