### PR TITLE
Fix `com.mongodb.client.FailPoint.enable`

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
@@ -24,6 +24,7 @@ import org.bson.conversions.Bson;
 
 import java.util.Collections;
 
+import static com.mongodb.assertions.Assertions.assertFalse;
 import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
 
 public final class FailPoint implements AutoCloseable {
@@ -48,27 +49,10 @@ public final class FailPoint implements AutoCloseable {
                         .hosts(Collections.singletonList(serverAddress)))
                 .build();
         MongoClient client = MongoClients.create(clientSettings);
-        Throwable enableException = null;
-        try {
-            return enable(configureFailPointDoc, client);
-        } catch (Throwable e) {
-            enableException = e;
-            throw e;
-        } finally {
-            if (enableException != null) {
-                try {
-                    disableAndClose(configureFailPointDoc, client);
-                } catch (Throwable closeException) {
-                    enableException.addSuppressed(closeException);
-                }
-            }
+        try (Guard guard = new Guard(configureFailPointDoc, client)) {
+            client.getDatabase("admin").runCommand(configureFailPointDoc);
+            return guard.intoFailPoint();
         }
-    }
-
-    private static FailPoint enable(final BsonDocument configureFailPointDoc, final MongoClient client) {
-        FailPoint result = new FailPoint(configureFailPointDoc, client);
-        client.getDatabase("admin").runCommand(configureFailPointDoc);
-        return result;
     }
 
     @Override
@@ -83,6 +67,39 @@ public final class FailPoint implements AutoCloseable {
                     .append("mode", new BsonString("off")));
         } finally {
             client.close();
+        }
+    }
+
+    private static final class Guard implements AutoCloseable {
+        private final BsonDocument failPointDocument;
+        private final MongoClient client;
+        private boolean consumed;
+
+        Guard(final BsonDocument failPointDocument, final MongoClient client) {
+            this.failPointDocument = failPointDocument;
+            this.client = client;
+            consumed = false;
+        }
+
+        /**
+         * May be invoked at most once.
+         *
+         * @see #close()
+         */
+        FailPoint intoFailPoint() {
+            assertFalse(consumed);
+            consumed = true;
+            return new FailPoint(failPointDocument, client);
+        }
+
+        /**
+         * Invokes {@link #disableAndClose(BsonDocument, MongoClient)} unless {@link #intoFailPoint()} was invoked.
+         */
+        @Override
+        public void close() {
+            if (!consumed) {
+                disableAndClose(failPointDocument, client);
+            }
         }
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
@@ -61,12 +61,10 @@ public final class FailPoint implements AutoCloseable {
     }
 
     private static void disableAndClose(final BsonDocument failPointDocument, final MongoClient client) {
-        try {
+        try (MongoClient ignored = client) {
             client.getDatabase("admin").runCommand(new BsonDocument()
                     .append("configureFailPoint", failPointDocument.getString("configureFailPoint"))
                     .append("mode", new BsonString("off")));
-        } finally {
-            client.close();
         }
     }
 
@@ -88,8 +86,9 @@ public final class FailPoint implements AutoCloseable {
          */
         FailPoint intoFailPoint() {
             assertFalse(consumed);
+            FailPoint result = new FailPoint(failPointDocument, client);
             consumed = true;
-            return new FailPoint(failPointDocument, client);
+            return result;
         }
 
         /**

--- a/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
@@ -48,7 +48,22 @@ public final class FailPoint implements AutoCloseable {
                         .hosts(Collections.singletonList(serverAddress)))
                 .build();
         MongoClient client = MongoClients.create(clientSettings);
-        return enable(configureFailPointDoc, client);
+        RuntimeException enableException = null;
+        try {
+            return enable(configureFailPointDoc, client);
+        } catch (RuntimeException e) {
+            enableException = e;
+            throw e;
+        } finally {
+            if (enableException != null) {
+                try {
+                    disableAndClose(configureFailPointDoc, client);
+                } catch (RuntimeException closeException) {
+                    enableException.addSuppressed(closeException);
+                }
+            }
+        }
+
     }
 
     private static FailPoint enable(final BsonDocument configureFailPointDoc, final MongoClient client) {
@@ -59,6 +74,10 @@ public final class FailPoint implements AutoCloseable {
 
     @Override
     public void close() {
+        disableAndClose(failPointDocument, client);
+    }
+
+    private static void disableAndClose(final BsonDocument failPointDocument, final MongoClient client) {
         try {
             client.getDatabase("admin").runCommand(new BsonDocument()
                     .append("configureFailPoint", failPointDocument.getString("configureFailPoint"))

--- a/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
@@ -48,17 +48,17 @@ public final class FailPoint implements AutoCloseable {
                         .hosts(Collections.singletonList(serverAddress)))
                 .build();
         MongoClient client = MongoClients.create(clientSettings);
-        RuntimeException enableException = null;
+        Throwable enableException = null;
         try {
             return enable(configureFailPointDoc, client);
-        } catch (RuntimeException e) {
+        } catch (Throwable e) {
             enableException = e;
             throw e;
         } finally {
             if (enableException != null) {
                 try {
                     disableAndClose(configureFailPointDoc, client);
-                } catch (RuntimeException closeException) {
+                } catch (Throwable closeException) {
                     enableException.addSuppressed(closeException);
                 }
             }

--- a/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
@@ -63,7 +63,6 @@ public final class FailPoint implements AutoCloseable {
                 }
             }
         }
-
     }
 
     private static FailPoint enable(final BsonDocument configureFailPointDoc, final MongoClient client) {


### PR DESCRIPTION
Given the `FailPoint` API, when `enable` completes abruptly, it must not be the case that the fail point is left enabled.