### PR TITLE
Change CSOT exception hierarchy

### DIFF
--- a/driver-core/src/main/com/mongodb/MongoOperationTimeoutException.java
+++ b/driver-core/src/main/com/mongodb/MongoOperationTimeoutException.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  * @since 5.2
  */
 @Alpha(Reason.CLIENT)
-public final class MongoOperationTimeoutException extends MongoTimeoutException {
+public final class MongoOperationTimeoutException extends MongoClientException {
     private static final long serialVersionUID = 1L;
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -427,7 +427,7 @@ abstract class BaseCluster implements Cluster {
                 "Timed out while waiting for a server that matches %s. Client view of cluster state is %s",
                 serverSelector, clusterDescription.getShortDescription());
 
-        MongoTimeoutException exception = operationContext.getTimeoutContext().hasTimeoutMS()
+        MongoClientException exception = operationContext.getTimeoutContext().hasTimeoutMS()
                 ? new MongoOperationTimeoutException(message) : new MongoTimeoutException(message);
 
         logServerSelectionFailed(operationContext, clusterId, exception, serverSelector, clusterDescription);
@@ -590,7 +590,7 @@ abstract class BaseCluster implements Cluster {
             final ServerSelector serverSelector,
             final ClusterDescription clusterDescription) {
         if (STRUCTURED_LOGGER.isRequired(DEBUG, clusterId)) {
-            String failureDescription = failure instanceof MongoTimeoutException
+            String failureDescription = failure instanceof MongoTimeoutException || failure instanceof MongoOperationTimeoutException
                     // This hardcoded message guarantees that the `FAILURE` entry for `MongoTimeoutException` does not include
                     // any information that is specified via other entries, e.g., `SELECTOR` and `TOPOLOGY_DESCRIPTION`.
                     // The logging spec requires us to avoid such duplication of information.

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -16,9 +16,11 @@
 
 package com.mongodb.internal.connection;
 
+import com.mongodb.MongoClientException;
 import com.mongodb.MongoConnectionPoolClearedException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoInterruptedException;
+import com.mongodb.MongoOperationTimeoutException;
 import com.mongodb.MongoServerUnavailableException;
 import com.mongodb.MongoTimeoutException;
 import com.mongodb.annotations.NotThreadSafe;
@@ -256,7 +258,7 @@ final class DefaultConnectionPool implements ConnectionPool {
     private Throwable checkOutFailed(final Throwable t, final OperationContext operationContext, final StartTime checkoutStart) {
         Throwable result = t;
         Reason reason;
-        if (t instanceof MongoTimeoutException) {
+        if (t instanceof MongoTimeoutException || t instanceof MongoOperationTimeoutException) {
             reason = Reason.TIMEOUT;
         } else if (t instanceof MongoOpenConnectionInternalException) {
             reason = Reason.CONNECTION_ERROR;
@@ -334,7 +336,7 @@ final class DefaultConnectionPool implements ConnectionPool {
 
     private PooledConnection getPooledConnection(final Timeout maxWaitTimeout,
                                                  final StartTime startTime,
-                                                 final TimeoutContext timeoutContext) throws MongoTimeoutException {
+                                                 final TimeoutContext timeoutContext) throws MongoClientException {
         try {
             UsageTrackingInternalConnection internalConnection = maxWaitTimeout.call(NANOSECONDS,
                     () -> pool.get(-1L, NANOSECONDS),
@@ -363,9 +365,9 @@ final class DefaultConnectionPool implements ConnectionPool {
         return internalConnection == null ? null : new PooledConnection(internalConnection);
     }
 
-    private MongoTimeoutException createTimeoutException(final StartTime startTime,
-                                                         @Nullable final MongoTimeoutException cause,
-                                                         final TimeoutContext timeoutContext) {
+    private MongoClientException createTimeoutException(final StartTime startTime,
+                                                        @Nullable final MongoTimeoutException cause,
+                                                        final TimeoutContext timeoutContext) {
         long elapsedMs = startTime.elapsed().toMillis();
         int numPinnedToCursor = pinnedStatsManager.getNumPinnedToCursor();
         int numPinnedToTransaction = pinnedStatsManager.getNumPinnedToTransaction();
@@ -425,6 +427,7 @@ final class DefaultConnectionPool implements ConnectionPool {
     void doMaintenance() {
         Predicate<Exception> silentlyComplete = e ->
                 e instanceof MongoInterruptedException || e instanceof MongoTimeoutException
+                        || e instanceof MongoOperationTimeoutException
                         || e instanceof MongoConnectionPoolClearedException || ConcurrentPool.isPoolClosedException(e);
         try {
             pool.prune();

--- a/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LoadBalancedCluster.java
@@ -322,7 +322,7 @@ final class LoadBalancedCluster implements Cluster {
                 + "to multiple hosts");
     }
 
-    private MongoTimeoutException createTimeoutException(final TimeoutContext timeoutContext) {
+    private MongoClientException createTimeoutException(final TimeoutContext timeoutContext) {
         MongoException localSrvResolutionException = srvResolutionException;
         String message;
         if (localSrvResolutionException == null) {
@@ -334,7 +334,7 @@ final class LoadBalancedCluster implements Cluster {
         return createTimeoutException(timeoutContext, message);
     }
 
-    private static MongoTimeoutException createTimeoutException(final TimeoutContext timeoutContext, final String message) {
+    private static MongoClientException createTimeoutException(final TimeoutContext timeoutContext, final String message) {
         return timeoutContext.hasTimeoutMS() ? new MongoOperationTimeoutException(message) : new MongoTimeoutException(message);
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/CommitTransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommitTransactionOperation.java
@@ -21,6 +21,7 @@ import com.mongodb.MongoException;
 import com.mongodb.MongoExecutionTimeoutException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.MongoNodeIsRecoveringException;
+import com.mongodb.MongoOperationTimeoutException;
 import com.mongodb.MongoNotPrimaryException;
 import com.mongodb.MongoSocketException;
 import com.mongodb.MongoTimeoutException;
@@ -103,6 +104,7 @@ public class CommitTransactionOperation extends TransactionOperation {
     private static boolean shouldAddUnknownTransactionCommitResultLabel(final MongoException e) {
 
         if (e instanceof MongoSocketException || e instanceof MongoTimeoutException
+                || e instanceof MongoOperationTimeoutException
                 || e instanceof MongoNotPrimaryException || e instanceof MongoNodeIsRecoveringException
                 || e instanceof MongoExecutionTimeoutException) {
             return true;

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/OperationExecutorImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/OperationExecutorImpl.java
@@ -18,6 +18,7 @@ package com.mongodb.reactivestreams.client.internal;
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoInternalException;
+import com.mongodb.MongoOperationTimeoutException;
 import com.mongodb.MongoQueryException;
 import com.mongodb.MongoSocketException;
 import com.mongodb.MongoTimeoutException;
@@ -203,6 +204,7 @@ public class OperationExecutorImpl implements OperationExecutor {
     private void labelException(@Nullable final ClientSession session, @Nullable final Throwable t) {
         if (session != null && session.hasActiveTransaction()
                 && (t instanceof MongoSocketException || t instanceof MongoTimeoutException
+                || t instanceof MongoOperationTimeoutException
                 || (t instanceof MongoQueryException && ((MongoQueryException) t).getErrorCode() == 91))
                 && !((MongoException) t).hasErrorLabel(UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL)) {
             ((MongoException) t).addLabel(TRANSIENT_TRANSACTION_ERROR_LABEL);

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoClusterImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoClusterImpl.java
@@ -22,6 +22,7 @@ import com.mongodb.ClientSessionOptions;
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoInternalException;
+import com.mongodb.MongoOperationTimeoutException;
 import com.mongodb.MongoQueryException;
 import com.mongodb.MongoSocketException;
 import com.mongodb.MongoTimeoutException;
@@ -535,6 +536,7 @@ final class MongoClusterImpl implements MongoCluster {
 
         private void labelException(final ClientSession session, final MongoException e) {
             if (session.hasActiveTransaction() && (e instanceof MongoSocketException || e instanceof MongoTimeoutException
+                    || e instanceof MongoOperationTimeoutException
                     || e instanceof MongoQueryException && e.getCode() == 91)
                     && !e.hasErrorLabel(UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL)) {
                 e.addLabel(TRANSIENT_TRANSACTION_ERROR_LABEL);


### PR DESCRIPTION
**MongoTimeoutException** is stable public API documented as "waiting for a server or connection to become available," implying the operation was not executed. **MongoOperationTimeoutException** does not provide that guarantee: the operation may have been sent to the server and may have executed. Keeping it as a subclass of **MongoTimeoutException** is therefore semantically incorrect and may mislead consumers that catch **MongoTimeoutException** into assuming no operation was executed.

## Changes:
- Make MongoOperationTimeoutException extend MongoClientException instead of MongoTimeoutException to avoid breaking the semantic guarantee that MongoTimeoutException implies the operation was not executed
- Handle MongoOperationTimeoutException explicitly in instanceof MongoTimeoutException checks to preserve existing behavior for transaction labeling, connection pool events, and logging

## Options considered:

- **extends MongoClientException** (what is proposed in this PR) - sibling to MongoTimeoutException. Both are client-side failures, no shared timeout semantics.                                                                   
- **extends MongoException** - too broad. **MongoException** is the root for everything including server errors. **MongoOperationTimeoutException** is a client-side concern.                                              
-  New intermediate class like **MongoOperationException** - adds a class just for one subclass. Unnecessary abstraction.                                                                                           
- **extends RuntimeException** directly - breaks out of the **MongoException** hierarchy entirely. Users catching **MongoException** would miss it.       


JAVA-5438