### PR TITLE
Add `maxAdaptiveRetries` API

### DIFF
--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -17,6 +17,7 @@
 package com.mongodb;
 
 import com.mongodb.annotations.Alpha;
+import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Reason;
 import com.mongodb.connection.ClusterSettings;
 import com.mongodb.connection.ConnectionPoolSettings;
@@ -264,14 +265,17 @@ import static java.util.Collections.unmodifiableList;
  * <p>SRV configuration:</p>
  * <ul>
  * <li>{@code srvServiceName=string}: The SRV service name. See {@link ClusterSettings#getSrvServiceName()} for details.</li>
- * <li>{@code srvMaxHosts=number}: The maximum number of hosts from the SRV record to connect to.</li>
+ * <li>{@code srvMaxHosts=n}: The maximum number of hosts from the SRV record to connect to.</li>
  * </ul>
  * <p>General configuration:</p>
  * <ul>
- * <li>{@code retryWrites=true|false}. If true the driver will retry supported write operations if they fail due to a network error.
- *  Defaults to true.</li>
- * <li>{@code retryReads=true|false}. If true the driver will retry supported read operations if they fail due to a network error.
- *  Defaults to true.</li>
+ * <li>{@code retryWrites=true|false}: Whether attempts to execute write commands should be retried if they fail due to a retryable error.
+ *  Defaults to true. See also {@code maxAdaptiveRetries}.</li>
+ * <li>{@code retryReads=true|false}: Whether attempts to execute read commands should be retried if they fail due to a retryable error.
+ *  Defaults to true. See also {@code maxAdaptiveRetries}.</li>
+ * <li>{@code maxAdaptiveRetries=n}: This is {@linkplain Beta Beta API}.
+ * The maximum number of retry attempts when encountering a retryable overload error.
+ * See {@link MongoClientSettings.Builder#maxAdaptiveRetries(Integer)} for more information.</li>
  * <li>{@code uuidRepresentation=unspecified|standard|javaLegacy|csharpLegacy|pythonLegacy}.  See
  * {@link MongoClientSettings#getUuidRepresentation()} for documentation of semantics of this parameter.  Defaults to "javaLegacy", but
  * will change to "unspecified" in the next major release.</li>
@@ -308,6 +312,7 @@ public class ConnectionString {
     private WriteConcern writeConcern;
     private Boolean retryWrites;
     private Boolean retryReads;
+    private Integer maxAdaptiveRetries;
     private ReadConcern readConcern;
 
     private Integer minConnectionPoolSize;
@@ -558,6 +563,7 @@ public class ConnectionString {
         GENERAL_OPTIONS_KEYS.add("servermonitoringmode");
         GENERAL_OPTIONS_KEYS.add("retrywrites");
         GENERAL_OPTIONS_KEYS.add("retryreads");
+        GENERAL_OPTIONS_KEYS.add("maxadaptiveretries");
 
         GENERAL_OPTIONS_KEYS.add("appname");
 
@@ -705,6 +711,12 @@ public class ConnectionString {
                     break;
                 case "retryreads":
                     retryReads = parseBoolean(value, "retryreads");
+                    break;
+                case "maxadaptiveretries":
+                    maxAdaptiveRetries = parseInteger(value, "maxadaptiveretries");
+                    if (maxAdaptiveRetries < 0) {
+                        throw new IllegalArgumentException("maxAdaptiveRetries must be >= 0");
+                    }
                     break;
                 case "uuidrepresentation":
                     uuidRepresentation = createUuidRepresentation(value);
@@ -1455,13 +1467,15 @@ public class ConnectionString {
     }
 
     /**
-     * <p>Gets whether writes should be retried if they fail due to a network error</p>
-     *
+     * Gets whether attempts to execute write commands should be retried if they fail due to a retryable error.
+     * See {@link MongoClientSettings.Builder#retryWrites(boolean)} for more information.
+     * <p>
      * The name of this method differs from others in this class so as not to conflict with the now removed
      * getRetryWrites() method, which returned a primitive {@code boolean} value, and didn't allow callers to differentiate
      * between a false value and an unset value.
      *
      * @return the retryWrites value, or null if unset
+     * @see #getMaxAdaptiveRetries()
      * @since 3.9
      * @mongodb.server.release 3.6
      */
@@ -1471,15 +1485,30 @@ public class ConnectionString {
     }
 
     /**
-     * <p>Gets whether reads should be retried if they fail due to a network error</p>
+     * Gets whether attempts to execute read commands should be retried if they fail due to a retryable error.
+     * See {@link MongoClientSettings.Builder#retryReads(boolean)} for more information.
      *
-     * @return the retryWrites value
+     * @return the retryReads value
+     * @see #getMaxAdaptiveRetries()
      * @since 3.11
      * @mongodb.server.release 3.6
      */
     @Nullable
     public Boolean getRetryReads() {
         return retryReads;
+    }
+
+    /**
+     * Gets the maximum number of retry attempts when encountering a retryable overload error.
+     * See {@link MongoClientSettings.Builder#maxAdaptiveRetries(Integer)} for more information.
+     *
+     * @return The {@code maxAdaptiveRetries} value.
+     * @since 5.7
+     */
+    @Beta(Reason.CLIENT)
+    @Nullable
+    public Integer getMaxAdaptiveRetries() {
+        return maxAdaptiveRetries;
     }
 
     /**
@@ -1795,6 +1824,7 @@ public class ConnectionString {
                 && Objects.equals(writeConcern, that.writeConcern)
                 && Objects.equals(retryWrites, that.retryWrites)
                 && Objects.equals(retryReads, that.retryReads)
+                && Objects.equals(maxAdaptiveRetries, that.maxAdaptiveRetries)
                 && Objects.equals(readConcern, that.readConcern)
                 && Objects.equals(minConnectionPoolSize, that.minConnectionPoolSize)
                 && Objects.equals(maxConnectionPoolSize, that.maxConnectionPoolSize)
@@ -1826,7 +1856,7 @@ public class ConnectionString {
     @Override
     public int hashCode() {
         return Objects.hash(credential, isSrvProtocol, hosts, database, collection, directConnection, readPreference,
-                writeConcern, retryWrites, retryReads, readConcern, minConnectionPoolSize, maxConnectionPoolSize, maxWaitTime,
+                writeConcern, retryWrites, retryReads, maxAdaptiveRetries, readConcern, minConnectionPoolSize, maxConnectionPoolSize, maxWaitTime,
                 maxConnectionIdleTime, maxConnectionLifeTime, maxConnecting, connectTimeout, timeout, socketTimeout, sslEnabled,
                 sslInvalidHostnameAllowed, requiredReplicaSetName, serverSelectionTimeout, localThreshold, heartbeatFrequency,
                 serverMonitoringMode, applicationName, compressorList, uuidRepresentation, srvServiceName, srvMaxHosts, proxyHost,

--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -1474,7 +1474,7 @@ public class ConnectionString {
      * getRetryWrites() method, which returned a primitive {@code boolean} value, and didn't allow callers to differentiate
      * between a false value and an unset value.
      *
-     * @return the retryWrites value, or null if unset
+     * @return the {@code retryWrites} value, or {@code null} if unset
      * @see #getMaxAdaptiveRetries()
      * @since 3.9
      * @mongodb.server.release 3.6
@@ -1488,7 +1488,7 @@ public class ConnectionString {
      * Gets whether attempts to execute read commands should be retried if they fail due to a retryable error.
      * See {@link MongoClientSettings.Builder#retryReads(boolean)} for more information.
      *
-     * @return the retryReads value
+     * @return the {@code retryReads} value, or {@code null} if unset
      * @see #getMaxAdaptiveRetries()
      * @since 3.11
      * @mongodb.server.release 3.6
@@ -1502,7 +1502,7 @@ public class ConnectionString {
      * Gets the maximum number of retry attempts when encountering a retryable overload error.
      * See {@link MongoClientSettings.Builder#maxAdaptiveRetries(Integer)} for more information.
      *
-     * @return The {@code maxAdaptiveRetries} value.
+     * @return The {@code maxAdaptiveRetries} value, or {@code null} if unset.
      * @since 5.7
      */
     @Beta(Reason.CLIENT)

--- a/driver-core/src/main/com/mongodb/MongoClientSettings.java
+++ b/driver-core/src/main/com/mongodb/MongoClientSettings.java
@@ -17,6 +17,7 @@
 package com.mongodb;
 
 import com.mongodb.annotations.Alpha;
+import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Immutable;
 import com.mongodb.annotations.NotThreadSafe;
 import com.mongodb.annotations.Reason;
@@ -93,6 +94,8 @@ public final class MongoClientSettings {
     private final WriteConcern writeConcern;
     private final boolean retryWrites;
     private final boolean retryReads;
+    @Nullable
+    private final Integer maxAdaptiveRetries;
     private final ReadConcern readConcern;
     private final MongoCredential credential;
     private final TransportSettings transportSettings;
@@ -214,6 +217,8 @@ public final class MongoClientSettings {
         private WriteConcern writeConcern = WriteConcern.ACKNOWLEDGED;
         private boolean retryWrites = true;
         private boolean retryReads = true;
+        @Nullable
+        private Integer maxAdaptiveRetries;
         private ReadConcern readConcern = ReadConcern.DEFAULT;
         private CodecRegistry codecRegistry = MongoClientSettings.getDefaultCodecRegistry();
         private TransportSettings transportSettings;
@@ -255,6 +260,7 @@ public final class MongoClientSettings {
             writeConcern = settings.getWriteConcern();
             retryWrites = settings.getRetryWrites();
             retryReads = settings.getRetryReads();
+            maxAdaptiveRetries = settings.getMaxAdaptiveRetries();
             readConcern = settings.getReadConcern();
             credential = settings.getCredential();
             uuidRepresentation = settings.getUuidRepresentation();
@@ -313,6 +319,9 @@ public final class MongoClientSettings {
             Boolean retryReadsValue = connectionString.getRetryReads();
             if (retryReadsValue != null) {
                 retryReads = retryReadsValue;
+            }
+            if (connectionString.getMaxAdaptiveRetries() != null) {
+                maxAdaptiveRetries = connectionString.getMaxAdaptiveRetries();
             }
             if (connectionString.getUuidRepresentation() != null) {
                 uuidRepresentation = connectionString.getUuidRepresentation();
@@ -428,13 +437,24 @@ public final class MongoClientSettings {
         }
 
         /**
-         * Sets whether writes should be retried if they fail due to a network error.
+         * Sets whether attempts to execute write commands should be retried if they fail due to a retryable error.
+         * <p>
+         * The errors {@linkplain MongoException#hasErrorLabel(String) having}
+         * the {@value MongoException#RETRYABLE_ERROR_LABEL} label are not the only ones considered retryable here:
+         * unlike applications, which may retry operations, the driver retries commands, which gives it more control
+         * and allows it to safely retry attempts failed due to a broader set of errors
+         * than what applications may {@linkplain MongoException#RETRYABLE_ERROR_LABEL safely retry}.
+         * <p>
+         * For more information on how transactions affect retries,
+         * see the documentation of the {@value MongoException#TRANSIENT_TRANSACTION_ERROR_LABEL},
+         * {@value MongoException#UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL} error labels.
          *
          * <p>Starting with the 3.11.0 release, the default value is true</p>
          *
-         * @param retryWrites sets if writes should be retried if they fail due to a network error.
+         * @param retryWrites sets if write commands should be retried if they fail due to a retryable error.
          * @return this
          * @see #getRetryWrites()
+         * @see #maxAdaptiveRetries(Integer)
          * @mongodb.server.release 3.6
          */
         public Builder retryWrites(final boolean retryWrites) {
@@ -443,16 +463,99 @@ public final class MongoClientSettings {
         }
 
         /**
-         * Sets whether reads should be retried if they fail due to a network error.
+         * Sets whether attempts to execute read commands should be retried if they fail due to a retryable error.
+         * <p>
+         * The errors {@linkplain MongoException#hasErrorLabel(String) having}
+         * the {@value MongoException#RETRYABLE_ERROR_LABEL} label are not the only ones considered retryable here:
+         * unlike applications, which may retry operations, the driver retries commands, which gives it more control
+         * and allows it to safely retry attempts failed due to a broader set of errors
+         * than what applications may {@linkplain MongoException#RETRYABLE_ERROR_LABEL safely retry}.
+         * <p>
+         * For more information on how transactions affect retries,
+         * see the documentation of the {@value MongoException#TRANSIENT_TRANSACTION_ERROR_LABEL},
+         * {@value MongoException#UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL} error labels.
+         * <p>
+         * Default is {@code true}.
          *
-         * @param retryReads sets if reads should be retried if they fail due to a network error.
+         * @param retryReads sets if read commands should be retried if they fail due to a retryable error.
          * @return this
          * @see #getRetryReads()
+         * @see #maxAdaptiveRetries(Integer)
          * @since 3.11
          * @mongodb.server.release 3.6
          */
         public Builder retryReads(final boolean retryReads) {
             this.retryReads = retryReads;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of retry attempts when executing a command and encountering
+         * an error {@linkplain MongoException#hasErrorLabel(String) having}
+         * the {@value MongoException#SYSTEM_OVERLOADED_ERROR_LABEL} and {@value MongoException#RETRYABLE_ERROR_LABEL} labels.
+         * Such errors are referred to as retryable overload errors.
+         * <p>
+         * Default is {@code null}, implies the value 2 and the above retry behavior. The implied value and behavior may change in
+         * the future in a <a href="https://semver.org/spec/v2.0.0.html#summary">minor version</a>.
+         * This means, there is no guarantee that not setting a value is equivalent to setting the value 2.
+         * The value 0 results in not retrying the attempts failed due to retryable overload errors.
+         *
+         * <table>
+         *     <caption>Interactions with {@link #retryWrites(boolean)}/{@link #retryReads(boolean)}</caption>
+         *     <thead>
+         *         <tr>
+         *             <th>Command kind</th>
+         *             <th>Interaction</th>
+         *         </tr>
+         *     </thead>
+         *     <tbody>
+         *         <tr>
+         *             <td style="vertical-align: top;">write</td>
+         *             <td>
+         *                 The attempts failed due to retryable overload errors are retried only if
+         *                 {@link #retryWrites(boolean)} is {@code true}.
+         *             </td>
+         *         </tr>
+         *         <tr>
+         *             <td style="vertical-align: top;">read</td>
+         *             <td>
+         *                 The attempts failed due to retryable overload errors are retried only if
+         *                 {@link #retryReads(boolean)} is {@code true}.
+         *                 <p>
+         *                 Executing a write operation, for example, {@code MongoCluster.bulkWrite},
+         *                 may involve executing not only write commands, but also read commands. In such a situation,
+         *                 just like in other situations, the behavior related to retries depends on
+         *                 the known kind of command, not on the kind of operation.
+         *             </td>
+         *         </tr>
+         *         <tr>
+         *             <td style="vertical-align: top;">unknown</td>
+         *             <td>
+         *                 The attempts failed due to retryable overload errors are retried only if
+         *                 {@link #retryWrites(boolean)} is {@code true} and {@link #retryReads(boolean)} is {@code true}.
+         *                 <p>
+         *                 The command kind is unknown when a command is executed via the {@code MongoDatabase.runCommand} operation.
+         *             </td>
+         *         </tr>
+         *     </tbody>
+         * </table>
+         *
+         * @param maxAdaptiveRetries Sets the maximum number of retry attempts when encountering a retryable overload error.
+         *
+         * @return {@code this}.
+         * @see #getMaxAdaptiveRetries()
+         * @mongodb.driver.manual reference/parameters/#mongodb-parameter-param.overloadAwareServerSelectionEnabled
+         * overloadAwareServerSelectionEnabled: the server-side counterpart, which is configured independently
+         * and affects the server behavior as opposed to the client behavior.
+         * @since 5.7
+         */
+        // TODO-BACKPRESSURE Valentin Document commands that we do not retry now, but should retry according to the spec.
+        @Beta(Reason.CLIENT)
+        public Builder maxAdaptiveRetries(@Nullable final Integer maxAdaptiveRetries) {
+            if (maxAdaptiveRetries != null) {
+                isTrueArgument("maxAdaptiveRetries >= 0", maxAdaptiveRetries >= 0);
+            }
+            this.maxAdaptiveRetries = maxAdaptiveRetries;
             return this;
         }
 
@@ -785,11 +888,14 @@ public final class MongoClientSettings {
     }
 
     /**
-     * Returns true if writes should be retried if they fail due to a network error or other retryable error.
+     * Returns whether attempts to execute write commands should be retried if they fail due to a retryable error.
+     * See {@link Builder#retryWrites(boolean)} for more information.
      *
      * <p>Starting with the 3.11.0 release, the default value is true</p>
      *
      * @return the retryWrites value
+     * @see Builder#retryWrites(boolean)
+     * @see #getMaxAdaptiveRetries()
      * @mongodb.server.release 3.6
      */
     public boolean getRetryWrites() {
@@ -797,14 +903,34 @@ public final class MongoClientSettings {
     }
 
     /**
-     * Returns true if reads should be retried if they fail due to a network error or other retryable error. The default value is true.
+     * Returns whether attempts to execute read commands should be retried if they fail due to a retryable error.
+     * See {@link Builder#retryReads(boolean)} for more information.
+     * <p>
+     * Default is {@code true}.
      *
      * @return the retryReads value
+     * @see Builder#retryReads(boolean)
+     * @see #getMaxAdaptiveRetries()
      * @since 3.11
      * @mongodb.server.release 3.6
      */
     public boolean getRetryReads() {
         return retryReads;
+    }
+
+    /**
+     * Returns the maximum number of retry attempts when encountering a retryable overload error.
+     * See {@link Builder#maxAdaptiveRetries(Integer)} for more information.
+     *
+     * @return The maximum number of retry attempts when encountering a retryable overload error.
+     * @see Builder#maxAdaptiveRetries(Integer)
+     * @since 5.7
+     */
+    @Beta(Reason.CLIENT)
+    @Nullable
+    // TODO-BACKPRESSURE Valentin Use the `maxAdaptiveRetries` setting when retrying.
+    public Integer getMaxAdaptiveRetries() {
+        return maxAdaptiveRetries;
     }
 
     /**
@@ -1080,6 +1206,7 @@ public final class MongoClientSettings {
         MongoClientSettings that = (MongoClientSettings) o;
         return retryWrites == that.retryWrites
                 && retryReads == that.retryReads
+                && Objects.equals(maxAdaptiveRetries, that.maxAdaptiveRetries)
                 && heartbeatSocketTimeoutSetExplicitly == that.heartbeatSocketTimeoutSetExplicitly
                 && heartbeatConnectTimeoutSetExplicitly == that.heartbeatConnectTimeoutSetExplicitly
                 && Objects.equals(readPreference, that.readPreference)
@@ -1109,7 +1236,7 @@ public final class MongoClientSettings {
 
     @Override
     public int hashCode() {
-        return Objects.hash(readPreference, writeConcern, retryWrites, retryReads, readConcern, credential, transportSettings,
+        return Objects.hash(readPreference, writeConcern, retryWrites, retryReads, maxAdaptiveRetries, readConcern, credential, transportSettings,
                 commandListeners, codecRegistry, loggerSettings, clusterSettings, socketSettings,
                 heartbeatSocketSettings, connectionPoolSettings, serverSettings, sslSettings, applicationName, compressorList,
                 uuidRepresentation, serverApi, autoEncryptionSettings, heartbeatSocketTimeoutSetExplicitly,
@@ -1124,6 +1251,7 @@ public final class MongoClientSettings {
                 + ", writeConcern=" + writeConcern
                 + ", retryWrites=" + retryWrites
                 + ", retryReads=" + retryReads
+                + ", maxAdaptiveRetries=" + maxAdaptiveRetries
                 + ", readConcern=" + readConcern
                 + ", credential=" + credential
                 + ", transportSettings=" + transportSettings
@@ -1153,6 +1281,7 @@ public final class MongoClientSettings {
         readPreference = builder.readPreference;
         writeConcern = builder.writeConcern;
         retryWrites = builder.retryWrites;
+        maxAdaptiveRetries = builder.maxAdaptiveRetries;
         retryReads = builder.retryReads;
         readConcern = builder.readConcern;
         credential = builder.credential;

--- a/driver-core/src/main/com/mongodb/MongoClientSettings.java
+++ b/driver-core/src/main/com/mongodb/MongoClientSettings.java
@@ -945,7 +945,7 @@ public final class MongoClientSettings {
     }
 
     /**
-     * The codec registry to use, or null if not set.
+     * The codec registry to use.
      *
      * @return the codec registry
      */

--- a/driver-core/src/main/com/mongodb/MongoException.java
+++ b/driver-core/src/main/com/mongodb/MongoException.java
@@ -36,42 +36,52 @@ public class MongoException extends RuntimeException {
 
     /**
      * An error label indicating that the exception can be treated as a transient transaction error.
+     * See the documentation linked below for more information.
      *
      * @see #hasErrorLabel(String)
+     * @mongodb.driver.manual core/transactions-in-applications/#std-label-transient-transaction-error TransientTransactionError
      * @since 3.8
-     * @mongodb.driver.manual core/transactions-in-applications/#std-label-transient-transaction-error
      */
     public static final String TRANSIENT_TRANSACTION_ERROR_LABEL = "TransientTransactionError";
 
     /**
      * An error label indicating that the exception can be treated as an unknown transaction commit result.
+     * See the documentation linked below for more information.
      *
      * @see #hasErrorLabel(String)
+     * @mongodb.driver.manual core/transactions-in-applications/#std-label-unknown-transaction-commit-result UnknownTransactionCommitResult
      * @since 3.8
-     * @mongodb.driver.manual core/transactions-in-applications/#std-label-unknown-transaction-commit-result
      */
     public static final String UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL = "UnknownTransactionCommitResult";
 
     /**
      * Server is overloaded and shedding load.
-     * If you retry, use exponential backoff because the server has indicated overload.
-     * This label on its own does not mean that the operation can be safely retried.
+     * If an application retries explicitly, it should use exponential backoff because the server has indicated overload.
+     * This label on its own does not mean that the operation can be {@linkplain #RETRYABLE_ERROR_LABEL safely retried}.
      *
      * @see #hasErrorLabel(String)
+     * @see MongoClientSettings.Builder#maxAdaptiveRetries(Integer)
+     * @mongodb.atlas.manual overload-errors/ Overload errors
      * @since 5.7
      * @mongodb.server.release 8.3
      */
-    // TODO-BACKPRESSURE Valentin Add a @mongodb.driver.manual link or something similar, see `content/atlas/source/overload-errors.txt` in https://github.com/10gen/docs-mongodb-internal/pull/17281
     public static final String SYSTEM_OVERLOADED_ERROR_LABEL = "SystemOverloadedError";
 
     /**
-     * The operation was not executed and is safe to retry.
+     * The operation is safe to retry, that is,
+     * retry without rereading the relevant data or considering the semantics of the operation.
+     * <p>
+     * For more information on how transactions affect retries,
+     * see the documentation of the {@value #TRANSIENT_TRANSACTION_ERROR_LABEL}, {@value #UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL}
+     * error labels.
      *
      * @see #hasErrorLabel(String)
+     * @see MongoClientSettings.Builder#retryWrites(boolean)
+     * @see MongoClientSettings.Builder#retryReads(boolean)
+     * @mongodb.atlas.manual overload-errors/ Overload errors
      * @since 5.7
      * @mongodb.server.release 8.3
      */
-    // TODO-BACKPRESSURE Valentin Add a @mongodb.driver.manual link or something similar, see `content/atlas/source/overload-errors.txt` in https://github.com/10gen/docs-mongodb-internal/pull/17281
     public static final String RETRYABLE_ERROR_LABEL = "RetryableError";
 
     private static final long serialVersionUID = -4415279469780082174L;

--- a/driver-core/src/test/unit/com/mongodb/AbstractConnectionStringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/AbstractConnectionStringTest.java
@@ -122,6 +122,9 @@ public abstract class AbstractConnectionStringTest extends TestCase {
             } else if (option.getKey().equalsIgnoreCase("retrywrites")) {
                 boolean expected = option.getValue().asBoolean().getValue();
                 assertEquals(expected, connectionString.getRetryWritesValue().booleanValue());
+            } else if (option.getKey().equalsIgnoreCase("maxadaptiveretries")) {
+                int expected = option.getValue().asInt32().getValue();
+                assertEquals(expected, connectionString.getMaxAdaptiveRetries().intValue());
             } else if (option.getKey().equalsIgnoreCase("replicaset")) {
                 String expected = option.getValue().asString().getValue();
                 assertEquals(expected, connectionString.getRequiredReplicaSetName());

--- a/driver-core/src/test/unit/com/mongodb/ConnectionStringUnitTest.java
+++ b/driver-core/src/test/unit/com/mongodb/ConnectionStringUnitTest.java
@@ -37,7 +37,30 @@ final class ConnectionStringUnitTest {
     @Test
     void defaults() {
         ConnectionString connectionStringDefault = new ConnectionString(DEFAULT_OPTIONS);
-        assertAll(() -> assertNull(connectionStringDefault.getServerMonitoringMode()));
+        assertAll(
+                () -> assertNull(connectionStringDefault.getServerMonitoringMode()),
+                () -> assertNull(connectionStringDefault.getMaxAdaptiveRetries())
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "serverMonitoringMode=stream",
+            "maxAdaptiveRetries=42"
+    })
+    void equalAndHashCode(final String connectionStringOptions) {
+        ConnectionString default1 = new ConnectionString(DEFAULT_OPTIONS);
+        ConnectionString default2 = new ConnectionString(DEFAULT_OPTIONS);
+        String connectionString = DEFAULT_OPTIONS + connectionStringOptions;
+        ConnectionString actual1 = new ConnectionString(connectionString);
+        ConnectionString actual2 = new ConnectionString(connectionString);
+        assertAll(
+                () -> assertEquals(default1, default2),
+                () -> assertEquals(default1.hashCode(), default2.hashCode()),
+                () -> assertEquals(actual1, actual2),
+                () -> assertEquals(actual1.hashCode(), actual2.hashCode()),
+                () -> assertNotEquals(default1, actual1)
+        );
     }
 
     @Test
@@ -68,22 +91,6 @@ final class ConnectionStringUnitTest {
         }
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {DEFAULT_OPTIONS + "serverMonitoringMode=stream"})
-    void equalAndHashCode(final String connectionString) {
-        ConnectionString default1 = new ConnectionString(DEFAULT_OPTIONS);
-        ConnectionString default2 = new ConnectionString(DEFAULT_OPTIONS);
-        ConnectionString actual1 = new ConnectionString(connectionString);
-        ConnectionString actual2 = new ConnectionString(connectionString);
-        assertAll(
-                () -> assertEquals(default1, default2),
-                () -> assertEquals(default1.hashCode(), default2.hashCode()),
-                () -> assertEquals(actual1, actual2),
-                () -> assertEquals(actual1.hashCode(), actual2.hashCode()),
-                () -> assertNotEquals(default1, actual1)
-        );
-    }
-
     @Test
     void serverMonitoringMode() {
         assertAll(
@@ -93,7 +100,6 @@ final class ConnectionStringUnitTest {
                         () -> new ConnectionString(DEFAULT_OPTIONS + "serverMonitoringMode=invalid"))
         );
     }
-
 
     @ParameterizedTest
     @ValueSource(strings = {"mongodb://foo:bar/@hostname/java?", "mongodb://foo:bar?@hostname/java/",
@@ -108,5 +114,19 @@ final class ConnectionStringUnitTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new ConnectionString(input));
         assertFalse(exception.getMessage().contains("bar"));
         assertFalse(exception.getMessage().contains("12345678"));
+    }
+
+    @Test
+    void maxAdaptiveRetries() {
+        assertAll(
+                () -> assertEquals(42,
+                        new ConnectionString(DEFAULT_OPTIONS + "maxAdaptiveRetries=42").getMaxAdaptiveRetries()),
+                () -> assertEquals(0,
+                        new ConnectionString(DEFAULT_OPTIONS + "maxAdaptiveRetries=0").getMaxAdaptiveRetries()),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new ConnectionString(DEFAULT_OPTIONS + "maxAdaptiveRetries=-1")),
+                () -> assertThrows(IllegalArgumentException.class,
+                        () -> new ConnectionString(DEFAULT_OPTIONS + "maxAdaptiveRetries=invalid"))
+        );
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/MongoClientSettingsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/MongoClientSettingsSpecification.groovy
@@ -46,6 +46,7 @@ class MongoClientSettingsSpecification extends Specification {
         settings.getWriteConcern() == WriteConcern.ACKNOWLEDGED
         settings.getRetryWrites()
         settings.getRetryReads()
+        settings.getMaxAdaptiveRetries() == null
         settings.getReadConcern() == ReadConcern.DEFAULT
         settings.getReadPreference() == ReadPreference.primary()
         settings.getCommandListeners().isEmpty()
@@ -79,6 +80,11 @@ class MongoClientSettingsSpecification extends Specification {
 
         when:
         builder.writeConcern(null)
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        builder.maxAdaptiveRetries(-1)
         then:
         thrown(IllegalArgumentException)
 
@@ -135,6 +141,7 @@ class MongoClientSettingsSpecification extends Specification {
                 .writeConcern(WriteConcern.JOURNALED)
                 .retryWrites(true)
                 .retryReads(true)
+                .maxAdaptiveRetries(42)
                 .readConcern(ReadConcern.LOCAL)
                 .applicationName('app1')
                 .addCommandListener(commandListener)
@@ -160,6 +167,7 @@ class MongoClientSettingsSpecification extends Specification {
         settings.getWriteConcern() == WriteConcern.JOURNALED
         settings.getRetryWrites()
         settings.getRetryReads()
+        settings.getMaxAdaptiveRetries() == 42
         settings.getReadConcern() == ReadConcern.LOCAL
         settings.getApplicationName() == 'app1'
         settings.getSocketSettings() == SocketSettings.builder().build()
@@ -200,6 +208,7 @@ class MongoClientSettingsSpecification extends Specification {
                 .writeConcern(WriteConcern.JOURNALED)
                 .retryWrites(true)
                 .retryReads(true)
+                .maxAdaptiveRetries(42)
                 .readConcern(ReadConcern.LOCAL)
                 .applicationName('app1')
                 .addCommandListener(commandListener)
@@ -330,6 +339,7 @@ class MongoClientSettingsSpecification extends Specification {
                 + '&replicaSet=test'
                 + '&retryWrites=true'
                 + '&retryReads=true'
+                + '&maxAdaptiveRetries=42'
                 + '&ssl=true&sslInvalidHostNameAllowed=true'
                 + '&w=majority&wTimeoutMS=2500'
                 + '&readPreference=secondary'
@@ -398,6 +408,7 @@ class MongoClientSettingsSpecification extends Specification {
             .compressorList([MongoCompressor.createZlibCompressor().withProperty(MongoCompressor.LEVEL, 5)])
             .retryWrites(true)
             .retryReads(true)
+            .maxAdaptiveRetries(42)
             .uuidRepresentation(UuidRepresentation.STANDARD)
             .timeout(10000, TimeUnit.MILLISECONDS)
             .build()
@@ -462,6 +473,7 @@ class MongoClientSettingsSpecification extends Specification {
                 .compressorList([MongoCompressor.createZlibCompressor().withProperty(MongoCompressor.LEVEL, 5)])
                 .retryWrites(true)
                 .retryReads(true)
+                .maxAdaptiveRetries(null)
 
         def expectedSettings = builder.build()
         def settingsWithDefaultConnectionStringApplied = builder
@@ -546,6 +558,18 @@ class MongoClientSettingsSpecification extends Specification {
                 .build()
     }
 
+    def 'should allow null, 0 maxAdaptiveRetries'() {
+        when:
+        def settings = MongoClientSettings.builder().maxAdaptiveRetries(null).build()
+        then:
+        settings.getMaxAdaptiveRetries() == null
+
+        when:
+        settings = MongoClientSettings.builder().maxAdaptiveRetries(0).build()
+        then:
+        settings.getMaxAdaptiveRetries() == 0
+    }
+
     def 'should only have the following fields in the builder'() {
         when:
         // A regression test so that if anymore fields are added then the builder(final MongoClientSettings settings) should be updated
@@ -553,7 +577,7 @@ class MongoClientSettingsSpecification extends Specification {
         def expected = ['applicationName', 'autoEncryptionSettings', 'clusterSettingsBuilder', 'codecRegistry', 'commandListeners',
                         'compressorList', 'connectionPoolSettingsBuilder', 'contextProvider', 'credential', 'dnsClient',
                         'heartbeatConnectTimeoutMS', 'heartbeatSocketTimeoutMS', 'inetAddressResolver', 'loggerSettingsBuilder',
-                        'observabilitySettings',
+                        'maxAdaptiveRetries', 'observabilitySettings',
                         'readConcern', 'readPreference', 'retryReads',
                         'retryWrites', 'serverApi', 'serverSettingsBuilder', 'socketSettingsBuilder', 'sslSettingsBuilder',
                         'timeoutMS', 'transportSettings', 'uuidRepresentation',
@@ -572,7 +596,7 @@ class MongoClientSettingsSpecification extends Specification {
                         'applyToSslSettings', 'autoEncryptionSettings', 'build', 'codecRegistry', 'commandListenerList',
                         'compressorList', 'contextProvider', 'credential', 'dnsClient',
                         'heartbeatConnectTimeoutMS',
-                        'heartbeatSocketTimeoutMS', 'inetAddressResolver', 'observabilitySettings', 'readConcern',
+                        'heartbeatSocketTimeoutMS', 'inetAddressResolver', 'maxAdaptiveRetries', 'observabilitySettings', 'readConcern',
                         'readPreference',
                         'retryReads', 'retryWrites',
                         'serverApi', 'timeout', 'transportSettings',

--- a/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/ClientSession.kt
+++ b/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/ClientSession.kt
@@ -200,7 +200,7 @@ public class ClientSession(public val wrapped: reactiveClientSession) : jClientS
         wrapped.startTransaction(transactionOptions)
 
     /**
-     * Commit a transaction in the context of this session. A transaction can only be commmited if one has first been
+     * Commit a transaction in the context of this session. A transaction can only be committed if one has first been
      * started.
      *
      * @return an empty publisher that indicates when the operation has completed

--- a/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/ClientSession.kt
+++ b/driver-kotlin-coroutine/src/main/kotlin/com/mongodb/kotlin/client/coroutine/ClientSession.kt
@@ -184,6 +184,8 @@ public class ClientSession(public val wrapped: reactiveClientSession) : jClientS
     /**
      * Start a transaction in the context of this session with default transaction options. A transaction can not be
      * started if there is already an active transaction on this session.
+     *
+     * @see com.mongodb.MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL
      */
     public fun startTransaction(): Unit = wrapped.startTransaction()
 
@@ -192,6 +194,7 @@ public class ClientSession(public val wrapped: reactiveClientSession) : jClientS
      * started if there is already an active transaction on this session.
      *
      * @param transactionOptions the options to apply to the transaction
+     * @see com.mongodb.MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL
      */
     public fun startTransaction(transactionOptions: TransactionOptions): Unit =
         wrapped.startTransaction(transactionOptions)
@@ -201,6 +204,7 @@ public class ClientSession(public val wrapped: reactiveClientSession) : jClientS
      * started.
      *
      * @return an empty publisher that indicates when the operation has completed
+     * @see com.mongodb.MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL
      */
     public suspend fun commitTransaction() {
         wrapped.commitTransaction().awaitFirstOrNull()

--- a/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/ClientSession.kt
+++ b/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/ClientSession.kt
@@ -66,7 +66,7 @@ public class ClientSession(public val wrapped: JClientSession) : Closeable {
         wrapped.startTransaction(transactionOptions)
 
     /**
-     * Commit a transaction in the context of this session. A transaction can only be commmited if one has first been
+     * Commit a transaction in the context of this session. A transaction can only be committed if one has first been
      * started.
      *
      * @see com.mongodb.MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL

--- a/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/ClientSession.kt
+++ b/driver-kotlin-sync/src/main/kotlin/com/mongodb/kotlin/client/ClientSession.kt
@@ -50,6 +50,8 @@ public class ClientSession(public val wrapped: JClientSession) : Closeable {
     /**
      * Start a transaction in the context of this session with default transaction options. A transaction can not be
      * started if there is already an active transaction on this session.
+     *
+     * @see com.mongodb.MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL
      */
     public fun startTransaction(): Unit = wrapped.startTransaction()
 
@@ -58,6 +60,7 @@ public class ClientSession(public val wrapped: JClientSession) : Closeable {
      * started if there is already an active transaction on this session.
      *
      * @param transactionOptions the options to apply to the transaction
+     * @see com.mongodb.MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL
      */
     public fun startTransaction(transactionOptions: TransactionOptions): Unit =
         wrapped.startTransaction(transactionOptions)
@@ -65,6 +68,8 @@ public class ClientSession(public val wrapped: JClientSession) : Closeable {
     /**
      * Commit a transaction in the context of this session. A transaction can only be commmited if one has first been
      * started.
+     *
+     * @see com.mongodb.MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL
      */
     public fun commitTransaction(): Unit = wrapped.commitTransaction()
 
@@ -82,6 +87,8 @@ public class ClientSession(public val wrapped: JClientSession) : Closeable {
      * @param transactionBody the body of the transaction
      * @param options the transaction options
      * @return the return value of the transaction body
+     * @see com.mongodb.MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL
+     * @see com.mongodb.MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL
      */
     public fun <T : Any> withTransaction(
         transactionBody: () -> T,

--- a/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
@@ -17,6 +17,7 @@
 package com.mongodb;
 
 import com.mongodb.annotations.Alpha;
+import com.mongodb.annotations.Beta;
 import com.mongodb.annotations.Immutable;
 import com.mongodb.annotations.NotThreadSafe;
 import com.mongodb.annotations.Reason;
@@ -442,11 +443,14 @@ public class MongoClientOptions {
     }
 
     /**
-     * Returns true if writes should be retried if they fail due to a network error or other retryable error.
+     * Returns whether attempts to execute write commands should be retried if they fail due to a retryable error.
+     * See {@link MongoClientSettings.Builder#retryWrites(boolean)} for more information.
      *
      * <p>Starting with the 3.11.0 release, the default value is true</p>
      *
      * @return the retryWrites value
+     * @see Builder#retryWrites(boolean)
+     * @see #getMaxAdaptiveRetries()
      * @mongodb.server.release 3.6
      * @since 3.6
      */
@@ -455,14 +459,33 @@ public class MongoClientOptions {
     }
 
     /**
-     * Returns true if reads should be retried if they fail due to a network error or other retryable error.
+     * Returns whether attempts to execute read commands should be retried if they fail due to a retryable error.
+     * See {@link MongoClientSettings.Builder#retryReads(boolean)} for more information.
+     * <p>
+     * Default is {@code true}.
      *
      * @return the retryReads value
+     * @see Builder#retryReads(boolean)
+     * @see #getMaxAdaptiveRetries()
      * @mongodb.server.release 3.6
      * @since 3.11
      */
     public boolean getRetryReads() {
         return wrapped.getRetryReads();
+    }
+
+    /**
+     * Returns the maximum number of retry attempts when encountering a retryable overload error.
+     * See {@link MongoClientSettings.Builder#maxAdaptiveRetries(Integer)} for more information.
+     *
+     * @return The maximum number of retry attempts when encountering a retryable overload error.
+     * @see Builder#maxAdaptiveRetries(Integer)
+     * @since 5.7
+     */
+    @Beta(Reason.CLIENT)
+    @Nullable
+    public Integer getMaxAdaptiveRetries() {
+        return wrapped.getMaxAdaptiveRetries();
     }
 
     /**
@@ -1020,14 +1043,16 @@ public class MongoClientOptions {
         }
 
         /**
-         * Sets whether writes should be retried if they fail due to a network error.
+         * Sets whether attempts to execute write commands should be retried if they fail due to a retryable error.
+         * See {@link MongoClientSettings.Builder#retryWrites(boolean)} for more information.
          *
          * <p>Starting with the 3.11.0 release, the default value is true</p>
          *
-         * @param retryWrites sets if writes should be retried if they fail due to a network error.
+         * @param retryWrites sets if write commands should be retried if they fail due to a retryable error.
          * @return {@code this}
          * @mongodb.server.release 3.6
          * @see #getRetryWrites()
+         * @see #maxAdaptiveRetries(Integer)
          * @since 3.6
          */
         public Builder retryWrites(final boolean retryWrites) {
@@ -1036,16 +1061,35 @@ public class MongoClientOptions {
         }
 
         /**
-         * Sets whether reads should be retried if they fail due to a network error.
+         * Sets whether attempts to execute read commands should be retried if they fail due to a retryable error.
+         * See {@link MongoClientSettings.Builder#retryReads(boolean)} for more information.
+         * <p>
+         * Default is {@code true}.
          *
-         * @param retryReads sets if reads should be retried if they fail due to a network error.
+         * @param retryReads sets if read commands should be retried if they fail due to a retryable error.
          * @return {@code this}
          * @mongodb.server.release 3.6
          * @see #getRetryReads()
+         * @see #maxAdaptiveRetries(Integer)
          * @since 3.11
          */
         public Builder retryReads(final boolean retryReads) {
             wrapped.retryReads(retryReads);
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of retry attempts when encountering a retryable overload error.
+         * See {@link MongoClientSettings.Builder#maxAdaptiveRetries(Integer)} for more information.
+         *
+         * @param maxAdaptiveRetries Sets the maximum number of retry attempts when encountering a retryable overload error.
+         * @return {@code this}.
+         * @see #getMaxAdaptiveRetries()
+         * @since 5.7
+         */
+        @Beta(Reason.CLIENT)
+        public Builder maxAdaptiveRetries(@Nullable final Integer maxAdaptiveRetries) {
+            wrapped.maxAdaptiveRetries(maxAdaptiveRetries);
             return this;
         }
 

--- a/driver-legacy/src/main/com/mongodb/MongoClientURI.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientURI.java
@@ -16,6 +16,7 @@
 
 package com.mongodb;
 
+import com.mongodb.annotations.Beta;
 import com.mongodb.lang.Nullable;
 import org.bson.UuidRepresentation;
 
@@ -147,10 +148,6 @@ import static com.mongodb.assertions.Assertions.notNull;
  *          <li>Used in combination with {@code w}</li>
  *      </ul>
  *  </li>
- *  <li>{@code retryWrites=true|false}. If true the driver will retry supported write operations if they fail due to a network error.
- *  Defaults to false.</li>
- *  <li>{@code retryReads=true|false}. If true the driver will retry supported read operations if they fail due to a network error.
- *  Defaults to false.</li>
  * </ul>
  *
  *
@@ -214,10 +211,13 @@ import static com.mongodb.assertions.Assertions.notNull;
  * </ul>
  * <p>General configuration:</p>
  * <ul>
- * <li>{@code retryWrites=true|false}. If true the driver will retry supported write operations if they fail due to a network error.
- *  Defaults to true.</li>
- * <li>{@code retryReads=true|false}. If true the driver will retry supported read operations if they fail due to a network error.
- *  Defaults to true.</li>
+ * <li>{@code retryWrites=true|false}: Whether attempts to execute write commands should be retried if they fail due to a retryable error.
+ *  Defaults to true. See also {@code maxAdaptiveRetries}.</li>
+ * <li>{@code retryReads=true|false}: Whether attempts to execute read commands should be retried if they fail due to a retryable error.
+ *  Defaults to true. See also {@code maxAdaptiveRetries}.</li>
+ * <li>{@code maxAdaptiveRetries=n}: This is {@linkplain Beta Beta API}.
+ * The maximum number of retry attempts when encountering a retryable overload error.
+ * See {@link MongoClientSettings.Builder#maxAdaptiveRetries(Integer)} for more information.</li>
  * <li>{@code uuidRepresentation=unspecified|standard|javaLegacy|csharpLegacy|pythonLegacy}.  See
  * {@link MongoClientOptions#getUuidRepresentation()} for documentation of semantics of this parameter.  Defaults to "javaLegacy", but
  * will change to "unspecified" in the next major release.</li>
@@ -381,10 +381,13 @@ public class MongoClientURI {
         if (retryWritesValue != null) {
             builder.retryWrites(retryWritesValue);
         }
-
         Boolean retryReads = proxied.getRetryReads();
         if (retryReads != null) {
             builder.retryReads(retryReads);
+        }
+        Integer maxAdaptiveRetries = proxied.getMaxAdaptiveRetries();
+        if (maxAdaptiveRetries != null) {
+            builder.maxAdaptiveRetries(maxAdaptiveRetries);
         }
 
         Integer maxConnectionPoolSize = proxied.getMaxConnectionPoolSize();

--- a/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
@@ -46,6 +46,7 @@ class MongoClientOptionsSpecification extends Specification {
         options.getWriteConcern() == WriteConcern.ACKNOWLEDGED
         options.getRetryWrites()
         options.getRetryReads()
+        options.getMaxAdaptiveRetries() == null
         options.getCodecRegistry() == MongoClientSettings.defaultCodecRegistry
         options.getUuidRepresentation() == UuidRepresentation.UNSPECIFIED
         options.getMinConnectionsPerHost() == 0
@@ -85,6 +86,11 @@ class MongoClientOptionsSpecification extends Specification {
         def builder = new MongoClientOptions.Builder()
 
         when:
+        builder.maxAdaptiveRetries(-1)
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
         builder.dbDecoderFactory(null)
         then:
         thrown(IllegalArgumentException)
@@ -116,6 +122,7 @@ class MongoClientOptionsSpecification extends Specification {
                                         .readPreference(ReadPreference.secondary())
                                         .retryWrites(true)
                                         .retryReads(false)
+                                        .maxAdaptiveRetries(42)
                                         .writeConcern(WriteConcern.JOURNALED)
                                         .readConcern(ReadConcern.MAJORITY)
                                         .minConnectionsPerHost(30)
@@ -162,6 +169,7 @@ class MongoClientOptionsSpecification extends Specification {
         options.getServerSelector() == serverSelector
         options.getRetryWrites()
         !options.getRetryReads()
+        options.getMaxAdaptiveRetries() == 42
         options.getServerSelectionTimeout() == 150
         options.getTimeout() == 10_000
         options.getMaxWaitTime() == 200
@@ -207,6 +215,7 @@ class MongoClientOptionsSpecification extends Specification {
         settings.writeConcern == WriteConcern.JOURNALED
         settings.retryWrites
         !settings.retryReads
+        settings.getMaxAdaptiveRetries() == 42
         settings.autoEncryptionSettings == autoEncryptionSettings
         settings.codecRegistry == codecRegistry
         settings.commandListeners == [commandListener]
@@ -227,6 +236,7 @@ class MongoClientOptionsSpecification extends Specification {
         optionsFromSettings.getServerSelector() == serverSelector
         optionsFromSettings.getRetryWrites()
         !optionsFromSettings.getRetryReads()
+        optionsFromSettings.getMaxAdaptiveRetries() == 42
         optionsFromSettings.getServerSelectionTimeout() == 150
         optionsFromSettings.getServerSelectionTimeout() == 150
         optionsFromSettings.getMaxWaitTime() == 200
@@ -619,6 +629,7 @@ class MongoClientOptionsSpecification extends Specification {
                 .writeConcern(WriteConcern.JOURNALED)
                 .retryWrites(true)
                 .retryReads(true)
+                .maxAdaptiveRetries(42)
                 .uuidRepresentation(UuidRepresentation.STANDARD)
                 .minConnectionsPerHost(30)
                 .connectionsPerHost(500)
@@ -661,6 +672,18 @@ class MongoClientOptionsSpecification extends Specification {
     def 'should allow 0 (infinite) connectionsPerHost'() {
         expect:
         MongoClientOptions.builder().connectionsPerHost(0).build().getConnectionsPerHost() == 0
+    }
+
+    def 'should allow null, 0 maxAdaptiveRetries'() {
+        when:
+        def options = MongoClientOptions.builder().maxAdaptiveRetries(null).build()
+        then:
+        options.getMaxAdaptiveRetries() == null
+
+        when:
+        options = MongoClientOptions.builder().maxAdaptiveRetries(0).build()
+        then:
+        options.getMaxAdaptiveRetries() == 0
     }
 
     private static class MyDBEncoderFactory implements DBEncoderFactory {

--- a/driver-legacy/src/test/unit/com/mongodb/MongoClientURISpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoClientURISpecification.groovy
@@ -131,6 +131,7 @@ class MongoClientURISpecification extends Specification {
                 + 'heartbeatFrequencyMS=20000&'
                 + 'retryWrites=true&'
                 + 'retryReads=true&'
+                + 'maxAdaptiveRetries=42&'
                 + 'uuidRepresentation=csharpLegacy&'
                 + 'appName=app1&'
                 + 'timeoutMS=10000')
@@ -158,6 +159,7 @@ class MongoClientURISpecification extends Specification {
         options.getHeartbeatFrequency() == 20000
         options.getRetryWrites()
         options.getRetryReads()
+        options.getMaxAdaptiveRetries() == 42
         options.getUuidRepresentation() == UuidRepresentation.C_SHARP_LEGACY
         options.getApplicationName() == 'app1'
     }
@@ -178,6 +180,7 @@ class MongoClientURISpecification extends Specification {
         !options.isSslEnabled()
         options.getRetryWrites()
         options.getRetryReads()
+        options.getMaxAdaptiveRetries() == null
         options.getUuidRepresentation() == UuidRepresentation.UNSPECIFIED
     }
 
@@ -188,6 +191,7 @@ class MongoClientURISpecification extends Specification {
                 .readPreference(ReadPreference.secondary())
                 .retryWrites(true)
                 .retryReads(true)
+                .maxAdaptiveRetries(42)
                 .writeConcern(WriteConcern.JOURNALED)
                 .minConnectionsPerHost(30)
                 .connectionsPerHost(500)
@@ -220,6 +224,7 @@ class MongoClientURISpecification extends Specification {
         options.getWriteConcern() == WriteConcern.JOURNALED
         options.getRetryWrites()
         options.getRetryReads()
+        options.getMaxAdaptiveRetries() == 42
         options.getTimeout() == 10_000
         options.getServerSelectionTimeout() == 150
         options.getMaxWaitTime() == 200
@@ -314,24 +319,33 @@ class MongoClientURISpecification extends Specification {
 
     def 'should respect MongoClientOptions builder'() {
         given:
-        def uri = new MongoClientURI('mongodb://localhost/', MongoClientOptions.builder().connectionsPerHost(200))
+        def uri = new MongoClientURI('mongodb://localhost/', MongoClientOptions.builder()
+                .connectionsPerHost(200)
+                .maxAdaptiveRetries(42))
 
         when:
         def options = uri.getOptions()
 
         then:
         options.getConnectionsPerHost() == 200
+        options.getMaxAdaptiveRetries() == 42
     }
 
     def 'should override MongoClientOptions builder'() {
         given:
-        def uri = new MongoClientURI('mongodb://localhost/?maxPoolSize=250', MongoClientOptions.builder().connectionsPerHost(200))
+        def uri = new MongoClientURI('mongodb://localhost/?'
+                + 'maxPoolSize=250'
+                + '&maxAdaptiveRetries=43',
+                MongoClientOptions.builder().
+                        connectionsPerHost(200)
+                        .maxAdaptiveRetries(42))
 
         when:
         def options = uri.getOptions()
 
         then:
         options.getConnectionsPerHost() == 250
+        options.getMaxAdaptiveRetries() == 43
     }
 
     def 'should be equal to another MongoClientURI with the same string values'() {
@@ -371,7 +385,9 @@ class MongoClientURISpecification extends Specification {
                          + 'socketTimeoutMS=5500;'
                          + 'safe=false;w=1;wtimeout=2500;'
                          + 'fsync=true;readPreference=primary;'
-                         + 'ssl=true')                               |  new MongoClientURI('mongodb://localhost/db.coll?minPoolSize=5;'
+                         + 'ssl=true;'
+                         + 'maxAdaptiveRetries=42')                 |  new MongoClientURI('mongodb://localhost/db.coll?'
+                                                                                         + 'minPoolSize=5;'
                                                                                          + 'maxPoolSize=10;'
                                                                                          + 'waitQueueTimeoutMS=150;'
                                                                                          + 'maxIdleTimeMS=200&maxLifeTimeMS=300;'
@@ -379,7 +395,8 @@ class MongoClientURISpecification extends Specification {
                                                                                          + '&replicaSet=test;connectTimeoutMS=2500;'
                                                                                          + 'socketTimeoutMS=5500&safe=false&w=1;'
                                                                                          + 'wtimeout=2500;fsync=true'
-                                                                                         + '&readPreference=primary;ssl=true')
+                                                                                         + '&readPreference=primary;ssl=true;'
+                                                                                         + 'maxAdaptiveRetries=42')
     }
 
     def 'should be not equal to another MongoClientURI with the different string values'() {
@@ -401,12 +418,14 @@ class MongoClientURISpecification extends Specification {
                          + '&readPreferenceTags=dc:ny,rack:1'
                          + '&readPreferenceTags=dc:ny'
                          + '&readPreferenceTags='
-                         + '&maxConnecting=1')                  | new MongoClientURI('mongodb://localhost/'
+                         + '&maxConnecting=1'
+                         + '&maxAdaptiveRetries=42')                 | new MongoClientURI('mongodb://localhost/'
                                                                                        + '?readPreference=secondaryPreferred'
                                                                                        + '&readPreferenceTags=dc:ny'
                                                                                        + '&readPreferenceTags=dc:ny, rack:1'
                                                                                        + '&readPreferenceTags='
-                                                                                       + '&maxConnecting=2')
+                                                                                       + '&maxConnecting=2'
+                                                                                       + '&maxAdaptiveRetries=43')
         new MongoClientURI('mongodb://ross:123@localhost/?'
                          + 'authMechanism=SCRAM-SHA-1')            | new MongoClientURI('mongodb://ross:123@localhost/?'
                                                                                        + 'authMechanism=GSSAPI')
@@ -419,7 +438,8 @@ class MongoClientURISpecification extends Specification {
                                                         + 'minPoolSize=7;maxIdleTimeMS=1000;maxLifeTimeMS=2000;maxConnecting=1;'
                                                         + 'replicaSet=test;'
                                                         + 'connectTimeoutMS=2500;socketTimeoutMS=5500;autoConnectRetry=true;'
-                                                        + 'readPreference=secondaryPreferred;safe=false;w=1;wtimeout=2600')
+                                                        + 'readPreference=secondaryPreferred;safe=false;w=1;wtimeout=2600;'
+                                                        + 'maxAdaptiveRetries=42')
 
         MongoClientOptions.Builder builder = MongoClientOptions.builder()
                                                                .connectionsPerHost(10)
@@ -433,6 +453,7 @@ class MongoClientURISpecification extends Specification {
                                                                .socketTimeout(5500)
                                                                .readPreference(secondaryPreferred())
                                                                .writeConcern(new WriteConcern(1, 2600))
+                                                               .maxAdaptiveRetries(42)
 
         MongoClientOptions options = builder.build()
 

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ClientSession.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ClientSession.java
@@ -83,7 +83,7 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
     void startTransaction(TransactionOptions transactionOptions);
 
     /**
-     * Commit a transaction in the context of this session.  A transaction can only be commmited if one has first been started.
+     * Commit a transaction in the context of this session.  A transaction can only be committed if one has first been started.
      *
      * @return an empty publisher that indicates when the operation has completed
      * @see MongoException#UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ClientSession.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/ClientSession.java
@@ -17,6 +17,7 @@
 
 package com.mongodb.reactivestreams.client;
 
+import com.mongodb.MongoException;
 import com.mongodb.TransactionOptions;
 import org.reactivestreams.Publisher;
 
@@ -65,6 +66,7 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
      * Start a transaction in the context of this session with default transaction options. A transaction can not be started if there is
      * already an active transaction on this session.
      *
+     * @see MongoException#TRANSIENT_TRANSACTION_ERROR_LABEL
      * @mongodb.server.release 4.0
      */
     void startTransaction();
@@ -75,6 +77,7 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
      *
      * @param transactionOptions the options to apply to the transaction
      *
+     * @see MongoException#TRANSIENT_TRANSACTION_ERROR_LABEL
      * @mongodb.server.release 4.0
      */
     void startTransaction(TransactionOptions transactionOptions);
@@ -83,6 +86,7 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
      * Commit a transaction in the context of this session.  A transaction can only be commmited if one has first been started.
      *
      * @return an empty publisher that indicates when the operation has completed
+     * @see MongoException#UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL
      * @mongodb.server.release 4.0
      */
     Publisher<Void> commitTransaction();

--- a/driver-scala/src/main/scala/org/mongodb/scala/ClientSessionImplicits.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/ClientSessionImplicits.scala
@@ -33,7 +33,7 @@ trait ClientSessionImplicits {
     /**
      * Commit a transaction in the context of this session.
      *
-     * A transaction can only be commmited if one has first been started.
+     * A transaction can only be committed if one has first been started.
      */
     def commitTransaction(): SingleObservable[Unit] = clientSession.commitTransaction()
 

--- a/driver-scala/src/main/scala/org/mongodb/scala/package.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/package.scala
@@ -215,18 +215,48 @@ package object scala extends ClientSessionImplicits with ObservableImplicits wit
 
     /**
      * An error label indicating that the exception can be treated as a transient transaction error.
+     * See the documentation linked below for more information.
      *
+     * @see [[https://www.mongodb.com/docs/manual/core/transactions-in-applications/#std-label-transient-transaction-error TransientTransactionError]]
      * @since 2.4
      */
     val TRANSIENT_TRANSACTION_ERROR_LABEL: String = com.mongodb.MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL
 
     /**
      * An error label indicating that the exception can be treated as an unknown transaction commit result.
+     * See the documentation linked below for more information.
      *
+     * @see [[https://www.mongodb.com/docs/manual/core/transactions-in-applications/#std-label-unknown-transaction-commit-result UnknownTransactionCommitResult]]
      * @since 2.4
      */
     val UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL: String =
       com.mongodb.MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL
+
+    /**
+     * Server is overloaded and shedding load.
+     * If an application retries explicitly, it should use exponential backoff because the server has indicated overload.
+     * This label on its own does not mean that the operation can be [[MongoException.RETRYABLE_ERROR_LABEL safely retried]].
+     *
+     * @see [[https://www.mongodb.com/docs/atlas/overload-errors/ Overload errors]]
+     * @since 5.7
+     * @note Requires MongoDB 8.3 or greater
+     */
+    val SYSTEM_OVERLOADED_ERROR_LABEL: String = com.mongodb.MongoException.SYSTEM_OVERLOADED_ERROR_LABEL
+
+    /**
+     * The operation is safe to retry, that is,
+     * retry without rereading the relevant data or considering the semantics of the operation.
+     *
+     * For more information on how transactions affect retries,
+     * see the documentation of the
+     * [[MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL "TransientTransactionError"]],
+     * [[MongoException.UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL "UnknownTransactionCommitResult"]] error labels.
+     *
+     * @see [[https://www.mongodb.com/docs/atlas/overload-errors/ Overload errors]]
+     * @since 5.7
+     * @note Requires MongoDB 8.3 or greater
+     */
+    val RETRYABLE_ERROR_LABEL: String = com.mongodb.MongoException.RETRYABLE_ERROR_LABEL
   }
 
   /**

--- a/driver-sync/src/main/com/mongodb/client/ClientSession.java
+++ b/driver-sync/src/main/com/mongodb/client/ClientSession.java
@@ -94,7 +94,7 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
     void startTransaction(TransactionOptions transactionOptions);
 
     /**
-     * Commit a transaction in the context of this session.  A transaction can only be commmited if one has first been started.
+     * Commit a transaction in the context of this session.  A transaction can only be committed if one has first been started.
      *
      * @see MongoException#UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL
      * @mongodb.server.release 4.0

--- a/driver-sync/src/main/com/mongodb/client/ClientSession.java
+++ b/driver-sync/src/main/com/mongodb/client/ClientSession.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.client;
 
+import com.mongodb.MongoException;
 import com.mongodb.ServerAddress;
 import com.mongodb.TransactionOptions;
 import com.mongodb.internal.observability.micrometer.TransactionSpan;
@@ -76,6 +77,7 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
      * Start a transaction in the context of this session with default transaction options. A transaction can not be started if there is
      * already an active transaction on this session.
      *
+     * @see MongoException#TRANSIENT_TRANSACTION_ERROR_LABEL
      * @mongodb.server.release 4.0
      */
     void startTransaction();
@@ -86,6 +88,7 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
      *
      * @param transactionOptions the options to apply to the transaction
      *
+     * @see MongoException#TRANSIENT_TRANSACTION_ERROR_LABEL
      * @mongodb.server.release 4.0
      */
     void startTransaction(TransactionOptions transactionOptions);
@@ -93,6 +96,7 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
     /**
      * Commit a transaction in the context of this session.  A transaction can only be commmited if one has first been started.
      *
+     * @see MongoException#UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL
      * @mongodb.server.release 4.0
      */
     void commitTransaction();
@@ -110,6 +114,8 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
      * @param <T> the return type of the transaction body
      * @param transactionBody the body of the transaction
      * @return the return value of the transaction body
+     * @see MongoException#TRANSIENT_TRANSACTION_ERROR_LABEL
+     * @see MongoException#UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL
      * @mongodb.server.release 4.0
      * @since 3.11
      */
@@ -122,6 +128,8 @@ public interface ClientSession extends com.mongodb.session.ClientSession {
      * @param transactionBody the body of the transaction
      * @param options         the transaction options
      * @return the return value of the transaction body
+     * @see MongoException#TRANSIENT_TRANSACTION_ERROR_LABEL
+     * @see MongoException#UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL
      * @mongodb.server.release 4.0
      * @since 3.11
      */


### PR DESCRIPTION
### The relevant specification from DRIVERS-3427

Search for `maxAdaptiveRetries` at
- https://github.com/mongodb/specifications/blob/8a8a7c56429c80b51ec62268dcafc5e5e3c477ef/source/client-backpressure/client-backpressure.md
- https://github.com/mongodb/specifications/blob/8a8a7c56429c80b51ec62268dcafc5e5e3c477ef/source/uri-options/uri-options.md

A concrete commit is specified instead of `master` because this is the last commit included in the [DRIVERS-3160 Client Backpressure Support](https://jira.mongodb.org/browse/DRIVERS-3160) epic. Any newer commits are either irrelevant or are included in the [DRIVERS-3337 Client Backpressure Improvements](https://jira.mongodb.org/browse/DRIVERS-3337) epic, which we do not care about for now.

### AI usage

All modifications were done by the author. AI was used only to review the changes locally (Claude Code), and to review the GitHub PR (Copilot).

JAVA-6141