### PR TITLE
JAVA-6171 upgrade libcrypt to 1.17.3

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryption25LookupProseTests.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryption25LookupProseTests.java
@@ -19,13 +19,13 @@ package com.mongodb.client;
 import com.mongodb.AutoEncryptionSettings;
 import com.mongodb.ClientEncryptionSettings;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.ValidationOptions;
 import com.mongodb.client.vault.ClientEncryption;
 import com.mongodb.client.vault.ClientEncryptions;
-import com.mongodb.crypt.capi.MongoCryptException;
 import com.mongodb.fixture.EncryptionFixture;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
@@ -216,8 +216,8 @@ public class ClientSideEncryption25LookupProseTests {
                 + "]").stream().map(stage -> stage.asDocument()).collect(Collectors.toList());
 
         assertCause(
-                MongoCryptException.class,
-                "not supported",
+                MongoCommandException.class,
+                "Cannot specify both encryptionInformation and csfleEncryptionSchemas",
                 () -> client.getDatabase("db").getCollection("csfle").aggregate(pipeline).first());
     }
 

--- a/mongodb-crypt/build.gradle.kts
+++ b/mongodb-crypt/build.gradle.kts
@@ -54,7 +54,7 @@ val jnaLibsPath: String = System.getProperty("jnaLibsPath", "${jnaResourcesDir}$
 val jnaResources: String = System.getProperty("jna.library.path", jnaLibsPath)
 
 // Download jnaLibs that match the git tag or revision to jnaResourcesBuildDir
-val downloadRevision = "1.15.1"
+val downloadRevision = "1.17.3"
 val binariesArchiveName = "libmongocrypt-java.tar.gz"
 
 /**


### PR DESCRIPTION
[JAVA-6171](https://jira.mongodb.org/browse/JAVA-6171) upgraded libcrypt version to latest 1.17.3
The [test ](https://github.com/mongodb/mongo-java-driver/pull/1947/changes#diff-6caee6d987ddb756a56f33ea764a7a5c94803af0dd8447d8db9f3c994eed0fcb) case has been changed 
# Old expectation (libmongocrypt < 1.17.0):
  libmongocrypt refused to build the command at all. It threw a client-side MongoCryptException with the message "not supported" before reaching the server
Since [1.17.0](https://github.com/mongodb/libmongocrypt/releases/tag/1.17.0) library introduced a new feature, according to release notes
> Support mixing QE and unencrypted JSON schemas.

# The change 
Our CSFLE collection has an actual encryption schema (not just a plain JSON-schema validator), so the server still rejects the mixed request but now it's a server-side MongoCommandException