### PR TITLE
Skip QE prefixPreview and suffixPreview tests on server 9.0.0+

### DIFF
--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientEncryptionTextExplicitEncryptionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientEncryptionTextExplicitEncryptionTest.java
@@ -76,6 +76,8 @@ public abstract class AbstractClientEncryptionTextExplicitEncryptionTest {
         assumeTrue("Text explicit encryption tests disabled", hasEncryptionTestsEnabled());
         assumeTrue("Requires newer MongoCrypt version", getMongoCryptVersion().compareTo(REQUIRED_LIB_MONGOCRYPT_VERSION) >= 0);
         assumeTrue(serverVersionAtLeast(8, 2));
+        // TODO-JAVA-6168 update prose tests for post 9.0
+        assumeTrue(!serverVersionAtLeast(9, 0));
         assumeFalse(isStandalone());
 
         MongoNamespace dataKeysNamespace = new MongoNamespace("keyvault.datakeys");
@@ -156,7 +158,7 @@ public abstract class AbstractClientEncryptionTextExplicitEncryptionTest {
     @Test
     @DisplayName("Case 1: can find a document by prefix")
     public void test1CanFindADocumentByPrefix() {
-    EncryptOptions encryptOptions = new EncryptOptions("TextPreview")
+        EncryptOptions encryptOptions = new EncryptOptions("TextPreview")
             .keyId(key1Id)
             .contentionFactor(0L)
             .queryType("prefixPreview")

--- a/driver-sync/src/test/functional/com/mongodb/client/ChangeStreamProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ChangeStreamProseTest.java
@@ -53,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 
@@ -364,6 +365,8 @@ public class ChangeStreamProseTest extends DatabaseTestCase {
     @Test
     public void testNameSpaceTypePresentChangeStreamEvents() {
         assumeTrue(serverVersionAtLeast(8, 1));
+        // TODO-JAVA-6181 temp disabling as failing on latest, while specs are updated
+        assumeFalse(serverVersionAtLeast(9, 0));
         collection.drop();
 
         ChangeStreamIterable<Document> changeStream = database

--- a/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/unified/UnifiedTestModifications.java
@@ -46,6 +46,8 @@ public final class UnifiedTestModifications {
         def.skipNoncompliantReactive("event sensitive tests. We can't guarantee the amount of GetMore commands sent in the reactive driver")
                 .test("change-streams", "change-streams", "Test that comment is set on getMore")
                 .test("change-streams", "change-streams", "Test that comment is not set on getMore - pre 4.4");
+        def.skipJira("https://jira.mongodb.org/browse/JAVA-6181 temp disabling as failing on latest, while specs are updated")
+                .test("change-streams", "change-streams-nsType", "nsType is present when creating timeseries");
         def.modify(IGNORE_EXTRA_EVENTS)
                 .test("change-streams", "change-streams", "Test with document comment")
                 .test("change-streams", "change-streams", "Test with string comment");


### PR DESCRIPTION
Update specifications submodule to pick up maxServerVersion guards for unified spec tests. Skip all text explicit encryption prose tests on server 9.0+ since prefixPreview/suffixPreview are deprecated.

JAVA-6184