### PR TITLE
Make `RetryState.isLastAttempt` private, and simplify the code

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
@@ -360,7 +360,6 @@ public final class RetryState {
     private boolean isLastAttempt(final Throwable attemptException) {
         boolean lastIteration = loopState.isLastIteration();
         boolean operationTimeout = retryUntilTimeoutThrowsException && attemptException instanceof MongoOperationTimeoutException;
-        assertFalse(lastIteration && operationTimeout);
         return lastIteration || operationTimeout || attempt() == attempts - 1;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
@@ -360,7 +360,6 @@ public final class RetryState {
     private boolean isLastAttempt(final Throwable attemptException) {
         boolean operationTimeout = retryUntilTimeoutThrowsException && attemptException instanceof MongoOperationTimeoutException;
         boolean attemptLimit = attempt() == attempts - 1;
-        assertFalse(operationTimeout && attemptLimit);
         return loopState.isLastIteration() || operationTimeout || attemptLimit;
     }
 

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
@@ -358,9 +358,10 @@ public final class RetryState {
      * @see #attempt()
      */
     private boolean isLastAttempt(final Throwable attemptException) {
-        boolean lastIteration = loopState.isLastIteration();
         boolean operationTimeout = retryUntilTimeoutThrowsException && attemptException instanceof MongoOperationTimeoutException;
-        return lastIteration || operationTimeout || attempt() == attempts - 1;
+        boolean attemptLimit = attempt() == attempts - 1;
+        assertFalse(operationTimeout && attemptLimit);
+        return loopState.isLastIteration() || operationTimeout || attemptLimit;
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
@@ -132,7 +132,7 @@ public final class RetryState {
      * per attempt and only if all the following is true:
      * <ul>
      *     <li>{@code onAttemptFailureOperator} completed normally;</li>
-     *     <li>the most recent attempt is not the {@linkplain #isLastAttempt() last} one.</li>
+     *     <li>the most recent attempt is not known to be the {@linkplain #isLastAttempt(Throwable) last} one.</li>
      * </ul>
      * The {@code retryPredicate} accepts this {@link RetryState} and the exception from the most recent attempt,
      * and may mutate the exception. The {@linkplain RetryState} advances to represent the state of a new attempt
@@ -140,7 +140,7 @@ public final class RetryState {
      * @throws RuntimeException Iff any of the following is true:
      * <ul>
      *     <li>the {@code onAttemptFailureOperator} completed abruptly;</li>
-     *     <li>the most recent attempt is the {@linkplain #isLastAttempt() last} one;</li>
+     *     <li>the most recent attempt is known to be the {@linkplain #isLastAttempt(Throwable) last} one;</li>
      *     <li>the {@code retryPredicate} completed abruptly;</li>
      *     <li>the {@code retryPredicate} is {@code false}.</li>
      * </ul>
@@ -187,24 +187,10 @@ public final class RetryState {
         }
         assertTrue(!isFirstAttempt() || previouslyChosenException == null);
         Throwable newlyChosenException = callOnAttemptFailureOperator(previouslyChosenException, attemptException, onlyRuntimeExceptions, onAttemptFailureOperator);
-
-        /*
-         * A MongoOperationTimeoutException indicates that the operation timed out, either during command execution or server selection.
-         * The timeout for server selection is determined by the computedServerSelectionMS = min(serverSelectionTimeoutMS, timeoutMS).
-         *
-         * It is important to check if the exception is an instance of MongoOperationTimeoutException to detect a timeout.
-         */
-        if (isLastAttempt() || attemptException instanceof MongoOperationTimeoutException) {
+        if (isLastAttempt(attemptException)) {
             previouslyChosenException = newlyChosenException;
-            /*
-             * The function of isLastIteration() is to indicate if retrying has
-             * been explicitly halted. Such a stop is not interpreted as
-             * a timeout exception but as a deliberate cessation of retry attempts.
-             */
-            if (retryUntilTimeoutThrowsException && !loopState.isLastIteration()) {
-                previouslyChosenException = createMongoTimeoutException(
-                        "Retry attempt exceeded the timeout limit.",
-                        previouslyChosenException);
+            if (attemptException instanceof MongoOperationTimeoutException) {
+                previouslyChosenException = createMongoTimeoutException("Retry attempt exceeded the timeout limit.", previouslyChosenException);
             }
             throw previouslyChosenException;
         } else {
@@ -365,27 +351,23 @@ public final class RetryState {
      * An attempt is known to be the last one iff any of the following applies:
      * <ul>
      *   <li>{@link #breakAndThrowIfRetryAnd(Supplier)} / {@link #breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)} / {@link #markAsLastAttempt()} was called.</li>
-     *   <li>A timeout is set and has been reached.</li>
+     *   <li>A timeout is set and has been reached, as indicated by {@code attemptException}.</li>
      *   <li>No timeout is set, and the number of attempts is limited, and the current attempt is the last one.</li>
      * </ul>
      *
      * @see #attempt()
      */
-    public boolean isLastAttempt() {
-        if (loopState.isLastIteration()) {
-            return true;
-        }
-        if (retryUntilTimeoutThrowsException) {
-            return false;
-        }
-        return attempt() == attempts - 1;
+    private boolean isLastAttempt(final Throwable attemptException) {
+        boolean lastIteration = loopState.isLastIteration();
+        boolean operationTimeout = retryUntilTimeoutThrowsException && attemptException instanceof MongoOperationTimeoutException;
+        assertFalse(lastIteration && operationTimeout);
+        return lastIteration || operationTimeout || attempt() == attempts - 1;
     }
 
     /**
      * A 0-based attempt number.
      *
      * @see #isFirstAttempt()
-     * @see #isLastAttempt()
      */
     public int attempt() {
         return loopState.iteration();

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryingAsyncCallbackSupplier.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryingAsyncCallbackSupplier.java
@@ -69,7 +69,7 @@ public final class RetryingAsyncCallbackSupplier<R> implements AsyncCallbackSupp
      * per attempt and only if all the following is true:
      * <ul>
      *     <li>{@code onAttemptFailureOperator} completed normally;</li>
-     *     <li>the most recent attempt is not the {@linkplain RetryState#isLastAttempt() last} one.</li>
+     *     <li>the most recent attempt is not known to be the last one.</li>
      * </ul>
      * The {@code retryPredicate} accepts this {@link RetryState} and the exception from the most recent attempt,
      * and may mutate the exception. The {@linkplain RetryState} advances to represent the state of a new attempt

--- a/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
@@ -148,8 +148,8 @@ final class RetryStateTest {
 
     @ParameterizedTest
     @MethodSource({"infiniteTimeout", "noTimeout"})
-    void breakAndThrowIfRetryAndTrue() {
-        RetryState retryState = new RetryState(TIMEOUT_CONTEXT_NO_GLOBAL_TIMEOUT);
+    void breakAndThrowIfRetryAndTrue(final TimeoutContext timeoutContext) {
+        RetryState retryState = new RetryState(timeoutContext);
         advance(retryState);
         assertThrows(RuntimeException.class, () -> retryState.breakAndThrowIfRetryAnd(() -> true));
         RuntimeException attemptException = new RuntimeException();

--- a/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
@@ -21,6 +21,7 @@ import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.function.LoopState.AttachmentKey;
 import com.mongodb.internal.operation.retry.AttachmentKeys;
+import com.mongodb.lang.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,11 +29,15 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.function.BiPredicate;
+import java.util.function.BinaryOperator;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -73,41 +78,36 @@ final class RetryStateTest {
     @ParameterizedTest
     @MethodSource({"infiniteTimeout", "noTimeout"})
     void unlimitedAttemptsAndAdvance(final TimeoutContext timeoutContext) {
+        RuntimeException attemptException = new RuntimeException();
         RetryState retryState = new RetryState(timeoutContext);
         assertAll(
                 () -> assertTrue(retryState.isFirstAttempt()),
-                () -> assertEquals(0, retryState.attempt()),
-                () -> assertFalse(retryState.isLastAttempt())
+                () -> assertEquals(0, retryState.attempt())
         );
-        advance(retryState);
+        retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> true);
         assertAll(
                 () -> assertFalse(retryState.isFirstAttempt()),
-                () -> assertEquals(1, retryState.attempt()),
-                () -> assertFalse(retryState.isLastAttempt())
+                () -> assertEquals(1, retryState.attempt())
         );
         retryState.markAsLastAttempt();
         assertAll(
                 () -> assertFalse(retryState.isFirstAttempt()),
                 () -> assertEquals(1, retryState.attempt()),
-                () -> assertTrue(retryState.isLastAttempt())
+                () -> assertAdvanceOrThrow(attemptException, retryState, attemptException)
         );
     }
 
     @Test
     void limitedAttemptsAndAdvance() {
         RetryState retryState = RetryState.withNonRetryableState();
-        RuntimeException attemptException = new RuntimeException() {
-        };
+        RuntimeException attemptException = new RuntimeException();
         assertAll(
                 () -> assertTrue(retryState.isFirstAttempt()),
                 () -> assertEquals(0, retryState.attempt()),
-                () -> assertTrue(retryState.isLastAttempt()),
-                () -> assertThrows(attemptException.getClass(), () ->
-                        retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> true)),
+                () -> assertAdvanceOrThrow(attemptException, retryState, attemptException),
                 // when there is only one attempt, it is both the first and the last one
                 () -> assertTrue(retryState.isFirstAttempt()),
-                () -> assertEquals(0, retryState.attempt()),
-                () -> assertTrue(retryState.isLastAttempt())
+                () -> assertEquals(0, retryState.attempt())
         );
     }
 
@@ -116,11 +116,8 @@ final class RetryStateTest {
     void markAsLastAttemptAdvanceWithRuntimeException(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
         retryState.markAsLastAttempt();
-        assertTrue(retryState.isLastAttempt());
-        RuntimeException attemptException = new RuntimeException() {
-        };
-        assertThrows(attemptException.getClass(),
-                () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> fail()));
+        RuntimeException attemptException = new RuntimeException();
+        assertAdvanceOrThrow(attemptException, retryState, attemptException, (rs, e) -> fail());
     }
 
     @ParameterizedTest(name = "should advance with non-retryable error when marked as last attempt and : ''{0}''")
@@ -128,11 +125,8 @@ final class RetryStateTest {
     void markAsLastAttemptAdvanceWithError(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
         retryState.markAsLastAttempt();
-        assertTrue(retryState.isLastAttempt());
-        Error attemptException = new Error() {
-        };
-        assertThrows(attemptException.getClass(),
-                () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> fail()));
+        Error attemptException = new Error();
+        assertAdvanceOrThrow(attemptException, retryState, attemptException, (rs, e) -> fail());
     }
 
     @ParameterizedTest
@@ -140,7 +134,7 @@ final class RetryStateTest {
     void breakAndThrowIfRetryAndFirstAttempt(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
         retryState.breakAndThrowIfRetryAnd(Assertions::fail);
-        assertFalse(retryState.isLastAttempt());
+        assertAdvanceOrThrow(null, retryState, new RuntimeException());
     }
 
     @ParameterizedTest
@@ -149,7 +143,7 @@ final class RetryStateTest {
         RetryState retryState = new RetryState(timeoutContext);
         advance(retryState);
         retryState.breakAndThrowIfRetryAnd(() -> false);
-        assertFalse(retryState.isLastAttempt());
+        assertAdvanceOrThrow(null, retryState, new RuntimeException());
     }
 
     @ParameterizedTest
@@ -158,17 +152,18 @@ final class RetryStateTest {
         RetryState retryState = new RetryState(TIMEOUT_CONTEXT_NO_GLOBAL_TIMEOUT);
         advance(retryState);
         assertThrows(RuntimeException.class, () -> retryState.breakAndThrowIfRetryAnd(() -> true));
-        assertTrue(retryState.isLastAttempt());
+        RuntimeException attemptException = new RuntimeException();
+        assertAdvanceOrThrow(attemptException, retryState, attemptException);
     }
 
     @Test
     void breakAndThrowIfRetryAndTrueWithExpiredTimeout() {
         TimeoutContext tContextMock = mock(TimeoutContext.class);
-
         RetryState retryState = new RetryState(tContextMock);
         advance(retryState);
         assertThrows(RuntimeException.class, () -> retryState.breakAndThrowIfRetryAnd(() -> true));
-        assertTrue(retryState.isLastAttempt());
+        RuntimeException attemptException = new RuntimeException();
+        assertAdvanceOrThrow(attemptException, retryState, attemptException);
     }
 
     @ParameterizedTest
@@ -176,12 +171,13 @@ final class RetryStateTest {
     void breakAndThrowIfRetryIfPredicateThrows(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
         advance(retryState);
-        RuntimeException e = new RuntimeException() {
-        };
-        assertThrows(e.getClass(), () -> retryState.breakAndThrowIfRetryAnd(() -> {
-            throw e;
-        }));
-        assertFalse(retryState.isLastAttempt());
+        RuntimeException exception = new RuntimeException();
+        assertEquals(
+                exception,
+                assertThrows(exception.getClass(), () -> retryState.breakAndThrowIfRetryAnd(() -> {
+                    throw exception;
+                })));
+        assertAdvanceOrThrow(null, retryState, exception);
     }
 
     @ParameterizedTest
@@ -191,7 +187,7 @@ final class RetryStateTest {
         SupplyingCallback<?> callback = new SupplyingCallback<>();
         assertFalse(retryState.breakAndCompleteIfRetryAnd(Assertions::fail, callback));
         assertFalse(callback.completed());
-        assertFalse(retryState.isLastAttempt());
+        assertAdvanceOrThrow(null, retryState, new RuntimeException());
     }
 
     @ParameterizedTest
@@ -202,7 +198,7 @@ final class RetryStateTest {
         SupplyingCallback<?> callback = new SupplyingCallback<>();
         assertFalse(retryState.breakAndCompleteIfRetryAnd(() -> false, callback));
         assertFalse(callback.completed());
-        assertFalse(retryState.isLastAttempt());
+        assertAdvanceOrThrow(null, retryState, new RuntimeException());
     }
 
     @ParameterizedTest
@@ -213,7 +209,8 @@ final class RetryStateTest {
         SupplyingCallback<?> callback = new SupplyingCallback<>();
         assertTrue(retryState.breakAndCompleteIfRetryAnd(() -> true, callback));
         assertThrows(RuntimeException.class, callback::get);
-        assertTrue(retryState.isLastAttempt());
+        RuntimeException attemptException = new RuntimeException();
+        assertAdvanceOrThrow(attemptException, retryState, attemptException);
     }
 
     @ParameterizedTest
@@ -221,23 +218,23 @@ final class RetryStateTest {
     void breakAndCompleteIfRetryAndPredicateThrows(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
         advance(retryState);
-        Error e = new Error() {
-        };
+        Error exception = new Error();
         SupplyingCallback<?> callback = new SupplyingCallback<>();
         assertTrue(retryState.breakAndCompleteIfRetryAnd(() -> {
-            throw e;
+            throw exception;
         }, callback));
-        assertThrows(e.getClass(), callback::get);
-        assertFalse(retryState.isLastAttempt());
+        assertEquals(
+                exception,
+                assertThrows(exception.getClass(), callback::get));
+        assertAdvanceOrThrow(null, retryState, exception);
     }
 
     @ParameterizedTest
     @MethodSource({"infiniteTimeout", "noTimeout"})
     void advanceOrThrowPredicateFalse(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
-        RuntimeException attemptException = new RuntimeException() {
-        };
-        assertThrows(attemptException.getClass(), () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> false));
+        RuntimeException attemptException = new RuntimeException();
+        assertAdvanceOrThrow(attemptException, retryState, attemptException, (rs, e) -> false);
     }
 
     @ParameterizedTest
@@ -247,34 +244,30 @@ final class RetryStateTest {
         RetryState retryState = new RetryState(timeoutContext);
 
         MongoOperationTimeoutException expectedTimeoutException = TimeoutContext.createMongoTimeoutException("Server selection failed");
-        MongoOperationTimeoutException actualTimeoutException =
-                assertThrows(expectedTimeoutException.getClass(), () -> retryState.advanceOrThrow(expectedTimeoutException,
-                        (e1, e2) -> expectedTimeoutException,
-                        (rs, e) -> false));
-
-        Assertions.assertEquals(actualTimeoutException, expectedTimeoutException);
+        assertAdvanceOrThrow(expectedTimeoutException, retryState, expectedTimeoutException,
+                (e1, e2) -> expectedTimeoutException,
+                (rs, e) -> false);
     }
 
     @Test
     @DisplayName("should throw timeout exception from retry, when transformer swallows original timeout exception")
     void advanceThrowTimeoutExceptionWhenTransformerSwallowOriginalTimeoutException() {
         RetryState retryState = new RetryState(TIMEOUT_CONTEXT_INFINITE_GLOBAL_TIMEOUT);
-        RuntimeException previousAttemptException = new RuntimeException() {
-        };
-        MongoOperationTimeoutException expectedTimeoutException = TimeoutContext.createMongoTimeoutException("Server selection failed");
+        RuntimeException previousAttemptException = new RuntimeException();
+        MongoOperationTimeoutException unexpectedTimeoutException = TimeoutContext.createMongoTimeoutException("Server selection failed");
 
         retryState.advanceOrThrow(previousAttemptException,
                 (e1, e2) -> previousAttemptException,
                 (rs, e) -> true);
 
         MongoOperationTimeoutException actualTimeoutException =
-                assertThrows(expectedTimeoutException.getClass(), () -> retryState.advanceOrThrow(expectedTimeoutException,
+                assertThrows(unexpectedTimeoutException.getClass(), () -> retryState.advanceOrThrow(unexpectedTimeoutException,
                         (e1, e2) -> previousAttemptException,
                         (rs, e) -> false));
 
-        Assertions.assertNotEquals(actualTimeoutException, expectedTimeoutException);
-        Assertions.assertEquals(EXPECTED_TIMEOUT_MESSAGE, actualTimeoutException.getMessage());
-        Assertions.assertEquals(previousAttemptException, actualTimeoutException.getCause(),
+        assertNotEquals(unexpectedTimeoutException, actualTimeoutException);
+        assertEquals(EXPECTED_TIMEOUT_MESSAGE, actualTimeoutException.getMessage());
+        assertEquals(previousAttemptException, actualTimeoutException.getCause(),
                 "Retry timeout exception should have a cause if transformer returned non-timeout exception.");
     }
 
@@ -283,8 +276,7 @@ final class RetryStateTest {
     @DisplayName("should throw original timeout exception from retry, when transformer returns original timeout exception")
     void advanceThrowOriginalTimeoutExceptionWhenTransformerReturnsOriginalTimeoutException() {
         RetryState retryState = new RetryState(TIMEOUT_CONTEXT_INFINITE_GLOBAL_TIMEOUT);
-        RuntimeException previousAttemptException = new RuntimeException() {
-        };
+        RuntimeException previousAttemptException = new RuntimeException();
         MongoOperationTimeoutException expectedTimeoutException = TimeoutContext
                 .createMongoTimeoutException("Server selection failed");
 
@@ -292,44 +284,37 @@ final class RetryStateTest {
                 (e1, e2) -> previousAttemptException,
                 (rs, e) -> true);
 
-        MongoOperationTimeoutException actualTimeoutException =
-                assertThrows(expectedTimeoutException.getClass(), () -> retryState.advanceOrThrow(expectedTimeoutException,
-                        (e1, e2) -> expectedTimeoutException,
-                        (rs, e) -> false));
-
-        Assertions.assertEquals(actualTimeoutException, expectedTimeoutException);
-        Assertions.assertNull(actualTimeoutException.getCause(),
-                "Original timeout exception should not have a cause if transformer already returned timeout exception.");
+        assertAdvanceOrThrow(expectedTimeoutException, retryState, expectedTimeoutException,
+                (e1, e2) -> expectedTimeoutException,
+                (rs, e) -> false);
     }
 
     @Test
     void advanceOrThrowPredicateTrueAndLastAttempt() {
         RetryState retryState = RetryState.withNonRetryableState();
-        Error attemptException = new Error() {
-        };
-        assertThrows(attemptException.getClass(), () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> true));
+        Error attemptException = new Error();
+        assertAdvanceOrThrow(attemptException, retryState, attemptException);
     }
 
     @ParameterizedTest
     @MethodSource({"infiniteTimeout", "noTimeout"})
     void advanceOrThrowPredicateThrowsAfterFirstAttempt(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
-        RuntimeException predicateException = new RuntimeException() {
-        };
-        RuntimeException attemptException = new RuntimeException() {
-        };
-        assertThrows(predicateException.getClass(), () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> {
-            assertTrue(rs.isFirstAttempt());
-            assertEquals(attemptException, e);
-            throw predicateException;
-        }));
+        RuntimeException predicateException = new RuntimeException();
+        RuntimeException attemptException = new RuntimeException();
+        assertAdvanceOrThrow(predicateException, retryState, attemptException,
+                (e1, e2) -> e2,
+                (rs, e) -> {
+                    assertTrue(rs.isFirstAttempt());
+                    assertEquals(attemptException, e);
+                    throw predicateException;
+                });
     }
 
     @Test
     void advanceOrThrowPredicateThrowsTimeoutAfterFirstAttempt() {
         RetryState retryState = new RetryState(TIMEOUT_CONTEXT_EXPIRED_GLOBAL_TIMEOUT);
-        RuntimeException predicateException = new RuntimeException() {
-        };
+        RuntimeException predicateException = new RuntimeException();
         RuntimeException attemptException = new MongoOperationTimeoutException(EXPECTED_TIMEOUT_MESSAGE);
         MongoOperationTimeoutException mongoOperationTimeoutException = assertThrows(MongoOperationTimeoutException.class,
                 () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> {
@@ -346,58 +331,52 @@ final class RetryStateTest {
     @MethodSource({"infiniteTimeout", "noTimeout"})
     void advanceOrThrowPredicateThrows(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
-        RuntimeException firstAttemptException = new RuntimeException() {
-        };
+        RuntimeException firstAttemptException = new RuntimeException();
         retryState.advanceOrThrow(firstAttemptException, (e1, e2) -> e2, (rs, e) -> true);
-        RuntimeException secondAttemptException = new RuntimeException() {
-        };
-        RuntimeException predicateException = new RuntimeException() {
-        };
-        assertThrows(predicateException.getClass(), () -> retryState.advanceOrThrow(secondAttemptException, (e1, e2) -> e2, (rs, e) -> {
-            assertEquals(1, rs.attempt());
-            assertEquals(secondAttemptException, e);
-            throw predicateException;
-        }));
+        RuntimeException secondAttemptException = new RuntimeException();
+        RuntimeException predicateException = new RuntimeException();
+        assertAdvanceOrThrow(predicateException, retryState, secondAttemptException,
+                (e1, e2) -> e2,
+                (rs, e) -> {
+                    assertEquals(1, rs.attempt());
+                    assertEquals(secondAttemptException, e);
+                    throw predicateException;
+                });
     }
 
     @ParameterizedTest
     @MethodSource({"infiniteTimeout", "noTimeout", "expiredTimeout"})
     void advanceOrThrowTransformerThrowsAfterFirstAttempt(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
-        RuntimeException transformerException = new RuntimeException() {
-        };
-        assertThrows(transformerException.getClass(), () -> retryState.advanceOrThrow(new AssertionError(),
+        RuntimeException transformerException = new RuntimeException();
+        assertAdvanceOrThrow(transformerException, retryState, new AssertionError(),
                 (e1, e2) -> {
                     throw transformerException;
                 },
-                (rs, e) -> fail()));
+                (rs, e) -> fail());
     }
 
     @ParameterizedTest
-    @MethodSource({"infiniteTimeout", "noTimeout"}) //TODO mock?
+    @MethodSource({"infiniteTimeout", "noTimeout"})
     void advanceOrThrowTransformerThrows(final TimeoutContext timeoutContext) throws Throwable {
         RetryState retryState = new RetryState(timeoutContext);
-        Error firstAttemptException = new Error() {
-        };
+        Error firstAttemptException = new Error();
         retryState.advanceOrThrow(firstAttemptException, (e1, e2) -> e2, (rs, e) -> true);
-        RuntimeException transformerException = new RuntimeException() {
-        };
-        assertThrows(transformerException.getClass(), () -> retryState.advanceOrThrow(new AssertionError(),
+        RuntimeException transformerException = new RuntimeException();
+        assertAdvanceOrThrow(transformerException, retryState, new AssertionError(),
                 (e1, e2) -> {
                     throw transformerException;
                 },
-                (rs, e) -> fail()));
+                (rs, e) -> fail());
     }
 
     @ParameterizedTest
     @MethodSource({"infiniteTimeout", "noTimeout"})
     void advanceOrThrowTransformAfterFirstAttempt(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
-        RuntimeException attemptException = new RuntimeException() {
-        };
-        RuntimeException transformerResult = new RuntimeException() {
-        };
-        assertThrows(transformerResult.getClass(), () -> retryState.advanceOrThrow(attemptException,
+        RuntimeException attemptException = new RuntimeException();
+        RuntimeException transformerResult = new RuntimeException();
+        assertAdvanceOrThrow(transformerResult, retryState, attemptException,
                 (e1, e2) -> {
                     assertNull(e1);
                     assertEquals(attemptException, e2);
@@ -406,7 +385,7 @@ final class RetryStateTest {
                 (rs, e) -> {
                     assertEquals(attemptException, e);
                     return false;
-                }));
+                });
     }
 
     @Test
@@ -436,14 +415,11 @@ final class RetryStateTest {
     @MethodSource({"infiniteTimeout", "noTimeout"})
     void advanceOrThrowTransform(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
-        RuntimeException firstAttemptException = new RuntimeException() {
-        };
+        RuntimeException firstAttemptException = new RuntimeException();
         retryState.advanceOrThrow(firstAttemptException, (e1, e2) -> e2, (rs, e) -> true);
-        RuntimeException secondAttemptException = new RuntimeException() {
-        };
-        RuntimeException transformerResult = new RuntimeException() {
-        };
-        assertThrows(transformerResult.getClass(), () -> retryState.advanceOrThrow(secondAttemptException,
+        RuntimeException secondAttemptException = new RuntimeException();
+        RuntimeException transformerResult = new RuntimeException();
+        assertAdvanceOrThrow(transformerResult, retryState, secondAttemptException,
                 (e1, e2) -> {
                     assertEquals(firstAttemptException, e1);
                     assertEquals(secondAttemptException, e2);
@@ -452,7 +428,7 @@ final class RetryStateTest {
                 (rs, e) -> {
                     assertEquals(secondAttemptException, e);
                     return false;
-                }));
+                });
     }
 
     @ParameterizedTest
@@ -474,5 +450,36 @@ final class RetryStateTest {
 
     private static void advance(final RetryState retryState) {
         retryState.advanceOrThrow(new RuntimeException(), (e1, e2) -> e2, (rs, e) -> true);
+    }
+
+    private static void assertAdvanceOrThrow(
+            @Nullable final Throwable expectedException,
+            final RetryState retryState,
+            final Throwable attemptException) {
+        assertAdvanceOrThrow(expectedException, retryState, attemptException, (rs, e) -> true);
+    }
+
+    private static void assertAdvanceOrThrow(
+            @Nullable final Throwable expectedException,
+            final RetryState retryState,
+            final Throwable attemptException,
+            final BiPredicate<RetryState, Throwable> retryPredicate) {
+        assertAdvanceOrThrow(expectedException, retryState, attemptException, (e1, e2) -> e2, retryPredicate);
+    }
+
+    private static void assertAdvanceOrThrow(
+            @Nullable final Throwable expectedException,
+            final RetryState retryState,
+            final Throwable attemptException,
+            final BinaryOperator<Throwable> onAttemptFailureOperator,
+            final BiPredicate<RetryState, Throwable> retryPredicate) {
+        if (expectedException == null) {
+            assertDoesNotThrow(() -> retryState.advanceOrThrow(attemptException, onAttemptFailureOperator, retryPredicate));
+        } else {
+            assertEquals(
+                    expectedException,
+                    assertThrows(expectedException.getClass(), () ->
+                            retryState.advanceOrThrow(attemptException, onAttemptFailureOperator, retryPredicate)));
+        }
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
@@ -21,7 +21,6 @@ import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.TimeoutSettings;
 import com.mongodb.internal.async.function.LoopState.AttachmentKey;
 import com.mongodb.internal.operation.retry.AttachmentKeys;
-import com.mongodb.lang.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -93,7 +92,7 @@ final class RetryStateTest {
         assertAll(
                 () -> assertFalse(retryState.isFirstAttempt()),
                 () -> assertEquals(1, retryState.attempt()),
-                () -> assertAdvanceOrThrow(attemptException, retryState, attemptException)
+                () -> assertAdvanceOrThrowThrows(attemptException, retryState, attemptException)
         );
     }
 
@@ -104,7 +103,7 @@ final class RetryStateTest {
         assertAll(
                 () -> assertTrue(retryState.isFirstAttempt()),
                 () -> assertEquals(0, retryState.attempt()),
-                () -> assertAdvanceOrThrow(attemptException, retryState, attemptException),
+                () -> assertAdvanceOrThrowThrows(attemptException, retryState, attemptException),
                 // when there is only one attempt, it is both the first and the last one
                 () -> assertTrue(retryState.isFirstAttempt()),
                 () -> assertEquals(0, retryState.attempt())
@@ -117,7 +116,7 @@ final class RetryStateTest {
         RetryState retryState = new RetryState(timeoutContext);
         retryState.markAsLastAttempt();
         RuntimeException attemptException = new RuntimeException();
-        assertAdvanceOrThrow(attemptException, retryState, attemptException, (rs, e) -> fail());
+        assertAdvanceOrThrowThrows(attemptException, retryState, attemptException, (rs, e) -> fail());
     }
 
     @ParameterizedTest(name = "should advance with non-retryable error when marked as last attempt and : ''{0}''")
@@ -126,7 +125,7 @@ final class RetryStateTest {
         RetryState retryState = new RetryState(timeoutContext);
         retryState.markAsLastAttempt();
         Error attemptException = new Error();
-        assertAdvanceOrThrow(attemptException, retryState, attemptException, (rs, e) -> fail());
+        assertAdvanceOrThrowThrows(attemptException, retryState, attemptException, (rs, e) -> fail());
     }
 
     @ParameterizedTest
@@ -134,7 +133,7 @@ final class RetryStateTest {
     void breakAndThrowIfRetryAndFirstAttempt(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
         retryState.breakAndThrowIfRetryAnd(Assertions::fail);
-        assertAdvanceOrThrow(null, retryState, new RuntimeException());
+        assertAdvanceOrThrowDoesNotThrow(retryState, new RuntimeException());
     }
 
     @ParameterizedTest
@@ -143,7 +142,7 @@ final class RetryStateTest {
         RetryState retryState = new RetryState(timeoutContext);
         advance(retryState);
         retryState.breakAndThrowIfRetryAnd(() -> false);
-        assertAdvanceOrThrow(null, retryState, new RuntimeException());
+        assertAdvanceOrThrowDoesNotThrow(retryState, new RuntimeException());
     }
 
     @ParameterizedTest
@@ -153,7 +152,7 @@ final class RetryStateTest {
         advance(retryState);
         assertThrows(RuntimeException.class, () -> retryState.breakAndThrowIfRetryAnd(() -> true));
         RuntimeException attemptException = new RuntimeException();
-        assertAdvanceOrThrow(attemptException, retryState, attemptException);
+        assertAdvanceOrThrowThrows(attemptException, retryState, attemptException);
     }
 
     @Test
@@ -163,7 +162,7 @@ final class RetryStateTest {
         advance(retryState);
         assertThrows(RuntimeException.class, () -> retryState.breakAndThrowIfRetryAnd(() -> true));
         RuntimeException attemptException = new RuntimeException();
-        assertAdvanceOrThrow(attemptException, retryState, attemptException);
+        assertAdvanceOrThrowThrows(attemptException, retryState, attemptException);
     }
 
     @ParameterizedTest
@@ -177,7 +176,7 @@ final class RetryStateTest {
                 assertThrows(exception.getClass(), () -> retryState.breakAndThrowIfRetryAnd(() -> {
                     throw exception;
                 })));
-        assertAdvanceOrThrow(null, retryState, exception);
+        assertAdvanceOrThrowDoesNotThrow(retryState, exception);
     }
 
     @ParameterizedTest
@@ -187,7 +186,7 @@ final class RetryStateTest {
         SupplyingCallback<?> callback = new SupplyingCallback<>();
         assertFalse(retryState.breakAndCompleteIfRetryAnd(Assertions::fail, callback));
         assertFalse(callback.completed());
-        assertAdvanceOrThrow(null, retryState, new RuntimeException());
+        assertAdvanceOrThrowDoesNotThrow(retryState, new RuntimeException());
     }
 
     @ParameterizedTest
@@ -198,7 +197,7 @@ final class RetryStateTest {
         SupplyingCallback<?> callback = new SupplyingCallback<>();
         assertFalse(retryState.breakAndCompleteIfRetryAnd(() -> false, callback));
         assertFalse(callback.completed());
-        assertAdvanceOrThrow(null, retryState, new RuntimeException());
+        assertAdvanceOrThrowDoesNotThrow(retryState, new RuntimeException());
     }
 
     @ParameterizedTest
@@ -210,7 +209,7 @@ final class RetryStateTest {
         assertTrue(retryState.breakAndCompleteIfRetryAnd(() -> true, callback));
         assertThrows(RuntimeException.class, callback::get);
         RuntimeException attemptException = new RuntimeException();
-        assertAdvanceOrThrow(attemptException, retryState, attemptException);
+        assertAdvanceOrThrowThrows(attemptException, retryState, attemptException);
     }
 
     @ParameterizedTest
@@ -226,7 +225,7 @@ final class RetryStateTest {
         assertEquals(
                 exception,
                 assertThrows(exception.getClass(), callback::get));
-        assertAdvanceOrThrow(null, retryState, exception);
+        assertAdvanceOrThrowDoesNotThrow(retryState, exception);
     }
 
     @ParameterizedTest
@@ -234,7 +233,7 @@ final class RetryStateTest {
     void advanceOrThrowPredicateFalse(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
         RuntimeException attemptException = new RuntimeException();
-        assertAdvanceOrThrow(attemptException, retryState, attemptException, (rs, e) -> false);
+        assertAdvanceOrThrowThrows(attemptException, retryState, attemptException, (rs, e) -> false);
     }
 
     @ParameterizedTest
@@ -244,7 +243,7 @@ final class RetryStateTest {
         RetryState retryState = new RetryState(timeoutContext);
 
         MongoOperationTimeoutException expectedTimeoutException = TimeoutContext.createMongoTimeoutException("Server selection failed");
-        assertAdvanceOrThrow(expectedTimeoutException, retryState, expectedTimeoutException,
+        assertAdvanceOrThrowThrows(expectedTimeoutException, retryState, expectedTimeoutException,
                 (e1, e2) -> expectedTimeoutException,
                 (rs, e) -> false);
     }
@@ -284,7 +283,7 @@ final class RetryStateTest {
                 (e1, e2) -> previousAttemptException,
                 (rs, e) -> true);
 
-        assertAdvanceOrThrow(expectedTimeoutException, retryState, expectedTimeoutException,
+        assertAdvanceOrThrowThrows(expectedTimeoutException, retryState, expectedTimeoutException,
                 (e1, e2) -> expectedTimeoutException,
                 (rs, e) -> false);
     }
@@ -293,7 +292,7 @@ final class RetryStateTest {
     void advanceOrThrowPredicateTrueAndLastAttempt() {
         RetryState retryState = RetryState.withNonRetryableState();
         Error attemptException = new Error();
-        assertAdvanceOrThrow(attemptException, retryState, attemptException);
+        assertAdvanceOrThrowThrows(attemptException, retryState, attemptException);
     }
 
     @ParameterizedTest
@@ -302,7 +301,7 @@ final class RetryStateTest {
         RetryState retryState = new RetryState(timeoutContext);
         RuntimeException predicateException = new RuntimeException();
         RuntimeException attemptException = new RuntimeException();
-        assertAdvanceOrThrow(predicateException, retryState, attemptException,
+        assertAdvanceOrThrowThrows(predicateException, retryState, attemptException,
                 (e1, e2) -> e2,
                 (rs, e) -> {
                     assertTrue(rs.isFirstAttempt());
@@ -335,7 +334,7 @@ final class RetryStateTest {
         retryState.advanceOrThrow(firstAttemptException, (e1, e2) -> e2, (rs, e) -> true);
         RuntimeException secondAttemptException = new RuntimeException();
         RuntimeException predicateException = new RuntimeException();
-        assertAdvanceOrThrow(predicateException, retryState, secondAttemptException,
+        assertAdvanceOrThrowThrows(predicateException, retryState, secondAttemptException,
                 (e1, e2) -> e2,
                 (rs, e) -> {
                     assertEquals(1, rs.attempt());
@@ -349,7 +348,7 @@ final class RetryStateTest {
     void advanceOrThrowTransformerThrowsAfterFirstAttempt(final TimeoutContext timeoutContext) {
         RetryState retryState = new RetryState(timeoutContext);
         RuntimeException transformerException = new RuntimeException();
-        assertAdvanceOrThrow(transformerException, retryState, new AssertionError(),
+        assertAdvanceOrThrowThrows(transformerException, retryState, new AssertionError(),
                 (e1, e2) -> {
                     throw transformerException;
                 },
@@ -363,7 +362,7 @@ final class RetryStateTest {
         Error firstAttemptException = new Error();
         retryState.advanceOrThrow(firstAttemptException, (e1, e2) -> e2, (rs, e) -> true);
         RuntimeException transformerException = new RuntimeException();
-        assertAdvanceOrThrow(transformerException, retryState, new AssertionError(),
+        assertAdvanceOrThrowThrows(transformerException, retryState, new AssertionError(),
                 (e1, e2) -> {
                     throw transformerException;
                 },
@@ -376,7 +375,7 @@ final class RetryStateTest {
         RetryState retryState = new RetryState(timeoutContext);
         RuntimeException attemptException = new RuntimeException();
         RuntimeException transformerResult = new RuntimeException();
-        assertAdvanceOrThrow(transformerResult, retryState, attemptException,
+        assertAdvanceOrThrowThrows(transformerResult, retryState, attemptException,
                 (e1, e2) -> {
                     assertNull(e1);
                     assertEquals(attemptException, e2);
@@ -419,7 +418,7 @@ final class RetryStateTest {
         retryState.advanceOrThrow(firstAttemptException, (e1, e2) -> e2, (rs, e) -> true);
         RuntimeException secondAttemptException = new RuntimeException();
         RuntimeException transformerResult = new RuntimeException();
-        assertAdvanceOrThrow(transformerResult, retryState, secondAttemptException,
+        assertAdvanceOrThrowThrows(transformerResult, retryState, secondAttemptException,
                 (e1, e2) -> {
                     assertEquals(firstAttemptException, e1);
                     assertEquals(secondAttemptException, e2);
@@ -452,34 +451,41 @@ final class RetryStateTest {
         retryState.advanceOrThrow(new RuntimeException(), (e1, e2) -> e2, (rs, e) -> true);
     }
 
-    private static void assertAdvanceOrThrow(
-            @Nullable final Throwable expectedException,
+    private static void assertAdvanceOrThrowDoesNotThrow(
             final RetryState retryState,
             final Throwable attemptException) {
-        assertAdvanceOrThrow(expectedException, retryState, attemptException, (rs, e) -> true);
+        assertDoesNotThrow(() -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> true));
     }
 
-    private static void assertAdvanceOrThrow(
-            @Nullable final Throwable expectedException,
+    private static void assertAdvanceOrThrowThrows(
+            final Throwable expectedException,
+            final RetryState retryState,
+            final Throwable attemptException) {
+        assertAdvanceOrThrowThrows(
+                com.mongodb.assertions.Assertions.assertNotNull(expectedException),
+                retryState, attemptException, (rs, e) -> true);
+    }
+
+    private static void assertAdvanceOrThrowThrows(
+            final Throwable expectedException,
             final RetryState retryState,
             final Throwable attemptException,
             final BiPredicate<RetryState, Throwable> retryPredicate) {
-        assertAdvanceOrThrow(expectedException, retryState, attemptException, (e1, e2) -> e2, retryPredicate);
+        assertAdvanceOrThrowThrows(
+                com.mongodb.assertions.Assertions.assertNotNull(expectedException),
+                retryState, attemptException, (e1, e2) -> e2, retryPredicate);
     }
 
-    private static void assertAdvanceOrThrow(
-            @Nullable final Throwable expectedException,
+    private static void assertAdvanceOrThrowThrows(
+            final Throwable expectedException,
             final RetryState retryState,
             final Throwable attemptException,
             final BinaryOperator<Throwable> onAttemptFailureOperator,
             final BiPredicate<RetryState, Throwable> retryPredicate) {
-        if (expectedException == null) {
-            assertDoesNotThrow(() -> retryState.advanceOrThrow(attemptException, onAttemptFailureOperator, retryPredicate));
-        } else {
-            assertEquals(
-                    expectedException,
-                    assertThrows(expectedException.getClass(), () ->
-                            retryState.advanceOrThrow(attemptException, onAttemptFailureOperator, retryPredicate)));
-        }
+        com.mongodb.assertions.Assertions.assertNotNull(expectedException);
+        assertEquals(
+                expectedException,
+                assertThrows(expectedException.getClass(), () ->
+                        retryState.advanceOrThrow(attemptException, onAttemptFailureOperator, retryPredicate)));
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
@@ -253,18 +253,18 @@ final class RetryStateTest {
     void advanceThrowTimeoutExceptionWhenTransformerSwallowOriginalTimeoutException() {
         RetryState retryState = new RetryState(TIMEOUT_CONTEXT_INFINITE_GLOBAL_TIMEOUT);
         RuntimeException previousAttemptException = new RuntimeException();
-        MongoOperationTimeoutException unexpectedTimeoutException = TimeoutContext.createMongoTimeoutException("Server selection failed");
+        MongoOperationTimeoutException latestAttemptException = TimeoutContext.createMongoTimeoutException("Server selection failed");
 
         retryState.advanceOrThrow(previousAttemptException,
                 (e1, e2) -> previousAttemptException,
                 (rs, e) -> true);
 
         MongoOperationTimeoutException actualTimeoutException =
-                assertThrows(unexpectedTimeoutException.getClass(), () -> retryState.advanceOrThrow(unexpectedTimeoutException,
+                assertThrows(MongoOperationTimeoutException.class, () -> retryState.advanceOrThrow(latestAttemptException,
                         (e1, e2) -> previousAttemptException,
                         (rs, e) -> false));
 
-        assertNotEquals(unexpectedTimeoutException, actualTimeoutException);
+        assertNotEquals(latestAttemptException, actualTimeoutException);
         assertEquals(EXPECTED_TIMEOUT_MESSAGE, actualTimeoutException.getMessage());
         assertEquals(previousAttemptException, actualTimeoutException.getCause(),
                 "Retry timeout exception should have a cause if transformer returned non-timeout exception.");

--- a/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -171,7 +172,7 @@ final class RetryStateTest {
         RetryState retryState = new RetryState(timeoutContext);
         advance(retryState);
         RuntimeException exception = new RuntimeException();
-        assertEquals(
+        assertSame(
                 exception,
                 assertThrows(exception.getClass(), () -> retryState.breakAndThrowIfRetryAnd(() -> {
                     throw exception;
@@ -222,7 +223,7 @@ final class RetryStateTest {
         assertTrue(retryState.breakAndCompleteIfRetryAnd(() -> {
             throw exception;
         }, callback));
-        assertEquals(
+        assertSame(
                 exception,
                 assertThrows(exception.getClass(), callback::get));
         assertAdvanceOrThrowDoesNotThrow(retryState, exception);
@@ -266,7 +267,7 @@ final class RetryStateTest {
 
         assertNotEquals(latestAttemptException, actualTimeoutException);
         assertEquals(EXPECTED_TIMEOUT_MESSAGE, actualTimeoutException.getMessage());
-        assertEquals(previousAttemptException, actualTimeoutException.getCause(),
+        assertSame(previousAttemptException, actualTimeoutException.getCause(),
                 "Retry timeout exception should have a cause if transformer returned non-timeout exception.");
     }
 
@@ -305,7 +306,7 @@ final class RetryStateTest {
                 (e1, e2) -> e2,
                 (rs, e) -> {
                     assertTrue(rs.isFirstAttempt());
-                    assertEquals(attemptException, e);
+                    assertSame(attemptException, e);
                     throw predicateException;
                 });
     }
@@ -318,7 +319,7 @@ final class RetryStateTest {
         MongoOperationTimeoutException mongoOperationTimeoutException = assertThrows(MongoOperationTimeoutException.class,
                 () -> retryState.advanceOrThrow(attemptException, (e1, e2) -> e2, (rs, e) -> {
                     assertTrue(rs.isFirstAttempt());
-                    assertEquals(attemptException, e);
+                    assertSame(attemptException, e);
                     throw predicateException;
                 }));
 
@@ -338,7 +339,7 @@ final class RetryStateTest {
                 (e1, e2) -> e2,
                 (rs, e) -> {
                     assertEquals(1, rs.attempt());
-                    assertEquals(secondAttemptException, e);
+                    assertSame(secondAttemptException, e);
                     throw predicateException;
                 });
     }
@@ -378,11 +379,11 @@ final class RetryStateTest {
         assertAdvanceOrThrowThrows(transformerResult, retryState, attemptException,
                 (e1, e2) -> {
                     assertNull(e1);
-                    assertEquals(attemptException, e2);
+                    assertSame(attemptException, e2);
                     return transformerResult;
                 },
                 (rs, e) -> {
-                    assertEquals(attemptException, e);
+                    assertSame(attemptException, e);
                     return false;
                 });
     }
@@ -398,16 +399,16 @@ final class RetryStateTest {
                 assertThrows(MongoOperationTimeoutException.class, () -> retryState.advanceOrThrow(attemptException,
                         (e1, e2) -> {
                             assertNull(e1);
-                            assertEquals(attemptException, e2);
+                            assertSame(attemptException, e2);
                             return transformerResult;
                         },
                         (rs, e) -> {
-                            assertEquals(attemptException, e);
+                            assertSame(attemptException, e);
                             return false;
                         }));
 
         assertEquals(EXPECTED_TIMEOUT_MESSAGE, mongoOperationTimeoutException.getMessage());
-        assertEquals(transformerResult, mongoOperationTimeoutException.getCause());
+        assertSame(transformerResult, mongoOperationTimeoutException.getCause());
     }
 
     @ParameterizedTest
@@ -420,12 +421,12 @@ final class RetryStateTest {
         RuntimeException transformerResult = new RuntimeException();
         assertAdvanceOrThrowThrows(transformerResult, retryState, secondAttemptException,
                 (e1, e2) -> {
-                    assertEquals(firstAttemptException, e1);
-                    assertEquals(secondAttemptException, e2);
+                    assertSame(firstAttemptException, e1);
+                    assertSame(secondAttemptException, e2);
                     return transformerResult;
                 },
                 (rs, e) -> {
-                    assertEquals(secondAttemptException, e);
+                    assertSame(secondAttemptException, e);
                     return false;
                 });
     }
@@ -483,7 +484,7 @@ final class RetryStateTest {
             final BinaryOperator<Throwable> onAttemptFailureOperator,
             final BiPredicate<RetryState, Throwable> retryPredicate) {
         com.mongodb.assertions.Assertions.assertNotNull(expectedException);
-        assertEquals(
+        assertSame(
                 expectedException,
                 assertThrows(expectedException.getClass(), () ->
                         retryState.advanceOrThrow(attemptException, onAttemptFailureOperator, retryPredicate)));


### PR DESCRIPTION
With the backpressure spec changes, it has become painfully obvious that the logic of restricting the number of retries based on either a fixed number of retries, or a CSOT exception, is business logic, and not the internal logic of `RetryingSupplier`/`RetryState`. Given that most of the business logic lives outside of `RetryingSupplier`/`RetryState`, the part about the limit will also be moved out. This PR, just like https://github.com/mongodb/mongo-java-driver/pull/1952, does the preliminary work.

JAVA-5956, JAVA-6117, JAVA-6113, JAVA-6119, JAVA-6141