### PR TITLE
fix JAVA-5855 by Codex

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/TlsChannelStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/TlsChannelStreamFactoryFactory.java
@@ -37,6 +37,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
 import java.nio.channels.CompletionHandler;
@@ -209,32 +210,57 @@ public class TlsChannelStreamFactoryFactory implements StreamFactoryFactory {
         @Override
         public void openAsync(final OperationContext operationContext, final AsyncCompletionHandler<Void> handler) {
             isTrue("unopened", getChannel() == null);
+            SocketChannel socketChannel = null;
+            SelectorMonitor.SocketRegistration socketRegistration = null;
+            boolean registered = false;
             try {
-                SocketChannel socketChannel = SocketChannel.open();
-                socketChannel.configureBlocking(false);
-
-                socketChannel.setOption(StandardSocketOptions.TCP_NODELAY, true);
-                socketChannel.setOption(StandardSocketOptions.SO_KEEPALIVE, true);
-                if (getSettings().getReceiveBufferSize() > 0) {
-                    socketChannel.setOption(StandardSocketOptions.SO_RCVBUF, getSettings().getReceiveBufferSize());
-                }
-                if (getSettings().getSendBufferSize() > 0) {
-                    socketChannel.setOption(StandardSocketOptions.SO_SNDBUF, getSettings().getSendBufferSize());
-                }
                 //getConnectTimeoutMs MUST be called before connection attempt, as it might throw MongoOperationTimeout exception.
                 int connectTimeoutMs = operationContext.getTimeoutContext().getConnectTimeoutMs();
-                socketChannel.connect(getSocketAddresses(getServerAddress(), inetAddressResolver).get(0));
-                SelectorMonitor.SocketRegistration socketRegistration = new SelectorMonitor.SocketRegistration(
-                        socketChannel, () -> initializeTslChannel(handler, socketChannel));
+                InetSocketAddress socketAddress = getSocketAddresses(getServerAddress(), inetAddressResolver).get(0);
+                SocketChannel openedSocketChannel = SocketChannel.open();
+                socketChannel = openedSocketChannel;
+                openedSocketChannel.configureBlocking(false);
+
+                openedSocketChannel.setOption(StandardSocketOptions.TCP_NODELAY, true);
+                openedSocketChannel.setOption(StandardSocketOptions.SO_KEEPALIVE, true);
+                if (getSettings().getReceiveBufferSize() > 0) {
+                    openedSocketChannel.setOption(StandardSocketOptions.SO_RCVBUF, getSettings().getReceiveBufferSize());
+                }
+                if (getSettings().getSendBufferSize() > 0) {
+                    openedSocketChannel.setOption(StandardSocketOptions.SO_SNDBUF, getSettings().getSendBufferSize());
+                }
+                openedSocketChannel.connect(socketAddress);
+                socketRegistration = new SelectorMonitor.SocketRegistration(
+                        openedSocketChannel, () -> initializeTslChannel(handler, openedSocketChannel));
 
                 if (connectTimeoutMs > 0) {
                     scheduleTimeoutInterruption(handler, socketRegistration, connectTimeoutMs);
                 }
                 selectorMonitor.register(socketRegistration);
+                registered = true;
             } catch (IOException e) {
+                closeUnregisteredSocketChannel(socketChannel, socketRegistration, registered, e);
                 handler.failed(new MongoSocketOpenException("Exception opening socket", getServerAddress(), e));
             } catch (Throwable t) {
+                closeUnregisteredSocketChannel(socketChannel, socketRegistration, registered, t);
                 handler.failed(t);
+            }
+        }
+
+        private void closeUnregisteredSocketChannel(@Nullable final SocketChannel socketChannel,
+                                                    @Nullable final SelectorMonitor.SocketRegistration socketRegistration,
+                                                    final boolean registered, final Throwable failure) {
+            if (!registered) {
+                if (socketRegistration != null) {
+                    socketRegistration.tryCancelPendingConnection();
+                }
+                if (socketChannel != null) {
+                    try {
+                        socketChannel.close();
+                    } catch (IOException e) {
+                        failure.addSuppressed(e);
+                    }
+                }
             }
         }
 
@@ -384,4 +410,3 @@ public class TlsChannelStreamFactoryFactory implements StreamFactoryFactory {
         }
     }
 }
-

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/TlsChannelStreamFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/TlsChannelStreamFunctionalTest.java
@@ -17,18 +17,22 @@
 package com.mongodb.internal.connection;
 
 import com.mongodb.ClusterFixture;
+import com.mongodb.MongoSocketException;
 import com.mongodb.MongoSocketOpenException;
 import com.mongodb.ServerAddress;
+import com.mongodb.connection.AsyncCompletionHandler;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.SslSettings;
 import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.TimeoutSettings;
+import com.mongodb.spi.dns.InetAddressResolver;
 import org.bson.ByteBuf;
 import org.bson.ByteBufNIO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -37,11 +41,13 @@ import org.mockito.stubbing.Answer;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.nio.ByteBuffer;
 import java.nio.channels.InterruptedByTimeoutException;
 import java.nio.channels.SocketChannel;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.ClusterFixture.getPrimaryServerDescription;
@@ -52,10 +58,12 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeast;
@@ -67,6 +75,69 @@ class TlsChannelStreamFunctionalTest {
     private static final SslSettings SSL_SETTINGS = SslSettings.builder().enabled(true).build();
     private static final String UNREACHABLE_PRIVATE_IP_ADDRESS = "10.255.255.1";
     private static final int UNREACHABLE_PORT = 65333;
+
+    @Test
+    void shouldFailAsyncCompletionHandlerWithoutOpeningSocketChannelIfNameResolutionFails() {
+        //given
+        ServerAddress serverAddress = new ServerAddress();
+        MongoSocketException exception = new MongoSocketException("Temporary failure in name resolution", serverAddress);
+        InetAddressResolver inetAddressResolver = new InetAddressResolver() {
+            @Override
+            public List<InetAddress> lookupByName(final String host) {
+                throw exception;
+            }
+        };
+
+        try (StreamFactoryFactory streamFactoryFactory = new TlsChannelStreamFactoryFactory(inetAddressResolver);
+             MockedStatic<SocketChannel> socketChannelMockedStatic = Mockito.mockStatic(SocketChannel.class)) {
+            StreamFactory streamFactory = streamFactoryFactory.create(SocketSettings.builder()
+                    .connectTimeout(100, TimeUnit.MILLISECONDS)
+                    .build(), SSL_SETTINGS);
+            Stream stream = streamFactory.create(serverAddress);
+            @SuppressWarnings("unchecked")
+            AsyncCompletionHandler<Void> handler = Mockito.mock(AsyncCompletionHandler.class);
+
+            //when
+            stream.openAsync(createOperationContext(100), handler);
+
+            //then
+            verify(handler).failed(exception);
+            verify(handler, times(0)).completed(null);
+            socketChannelMockedStatic.verify(SocketChannel::open, times(0));
+        }
+    }
+
+    @Test
+    void shouldCloseSocketChannelIfConnectFailsBeforeRegistration() throws IOException {
+        //given
+        ServerAddress serverAddress = new ServerAddress();
+        IOException exception = new IOException("connect failed");
+        InetAddressResolver inetAddressResolver = host -> Collections.singletonList(InetAddress.getLoopbackAddress());
+
+        try (SocketChannel socketChannel = Mockito.spy(SocketChannel.open());
+             StreamFactoryFactory streamFactoryFactory = new TlsChannelStreamFactoryFactory(inetAddressResolver);
+             MockedStatic<SocketChannel> socketChannelMockedStatic = Mockito.mockStatic(SocketChannel.class)) {
+            socketChannelMockedStatic.when(SocketChannel::open).thenReturn(socketChannel);
+            Mockito.doThrow(exception).when(socketChannel).connect(any());
+            StreamFactory streamFactory = streamFactoryFactory.create(SocketSettings.builder()
+                    .connectTimeout(100, TimeUnit.MILLISECONDS)
+                    .build(), SSL_SETTINGS);
+            Stream stream = streamFactory.create(serverAddress);
+            @SuppressWarnings("unchecked")
+            AsyncCompletionHandler<Void> handler = Mockito.mock(AsyncCompletionHandler.class);
+            ArgumentCaptor<Throwable> failureCaptor = ArgumentCaptor.forClass(Throwable.class);
+
+            //when
+            stream.openAsync(createOperationContext(100), handler);
+
+            //then
+            verify(handler).failed(failureCaptor.capture());
+            MongoSocketOpenException actualException = assertInstanceOf(MongoSocketOpenException.class, failureCaptor.getValue());
+            assertSame(exception, actualException.getCause());
+            verify(handler, times(0)).completed(null);
+            verify(socketChannel).close();
+        }
+    }
 
     @ParameterizedTest
     @ValueSource(ints = {500, 1000, 2000})


### PR DESCRIPTION
# JAVA-5855 TLS Channel Stream Analysis

## Context

Ticket: [JAVA-5855](https://jira.mongodb.org/browse/JAVA-5855)  
Project: [mongodb/mongo-java-driver](https://github.com/mongodb/mongo-java-driver)  
Component: Reactive Streams / driver-core TLS stream handling, primarily `com.mongodb.internal.connection`

The requested fix is for a TLS channel stream bug involving failures from `getSocketAddresses`. The ticket describes a case where, when using TLSChannel, a failure from `resolver.lookupByName` is not passed to the async handler.

The engineering context matters because the Java driver has several stream implementations that should behave consistently during connection establishment. The non-TLS async stream and Netty stream both resolve addresses before opening transport resources. `TlsChannelStream` was different: it opened a `SocketChannel` before resolving the address.

The narrowest safe fix is therefore to align TLSChannel stream ordering with the other stream implementations: resolve the address before opening the socket channel, preserve the existing async failure path, and make ownership of the socket channel explicit until the selector monitor accepts it.

## User Request Context

The general ask was to help fix a public JIRA ticket for the MongoDB Java driver, beginning with analysis before implementation.

The user-provided sources of information were:

- `JAVA-5855`: <https://jira.mongodb.org/browse/JAVA-5855>
- `mongo-java-driver`: <https://github.com/mongodb/mongo-java-driver>
- the public MongoDB driver specifications: <https://github.com/mongodb/specifications/tree/master/source>

The user specifically asked to check the driver specifications for TLS-related items in auth, connection handling, and any other relevant places.

The implementation plan was driven by these constraints:

- keep the fix narrow and easy to review,
- check the nearby stream implementations instead of updating only the obvious file,
- preserve existing timeout and async handler behavior,
- add focused regression coverage,
- verify against the relevant public driver specifications,
- save the analysis as Markdown for the engineering team.

## Problem

`JAVA-5855` reports that when `TlsChannelStream` uses TLSChannel and `resolver.lookupByName` fails inside `getSocketAddresses`, the thrown exception is not passed to the async handler.

The current implementation already has a broad catch block:

```java
} catch (IOException e) {
    handler.failed(new MongoSocketOpenException("Exception opening socket", getServerAddress(), e));
} catch (Throwable t) {
    handler.failed(t);
}
```

So the literal "not passed to the handler" behavior is not obvious on current `main` or the 5.5.0 tag. However, the ordering of the code exposes a concrete resource leak:

```text
SocketChannel.open()
configure socket options
getConnectTimeoutMs()
getSocketAddresses(...).get(0)
socketChannel.connect(...)
```

If `getSocketAddresses` throws after `SocketChannel.open()`, the exception is sent to `handler.failed(t)`, but the opened channel is not registered with the stream and is not closed by the failure path.

That makes the practical bug:

```text
name resolution failure during TLS stream open can leave an opened SocketChannel behind
```

The same ownership issue also applies to failures after the channel is opened but before it is registered with the selector monitor, such as socket-option or initial `connect` failures. Until registration succeeds, `openAsync` owns the channel and is responsible for closing it on failure.

This also makes `TlsChannelStream` inconsistent with the other async stream implementations, which resolve addresses before opening transport resources.

## Likely Code Area

The affected implementation is in:

```text
driver-core/src/main/com/mongodb/internal/connection/TlsChannelStreamFactoryFactory.java
```

The relevant method is:

```java
public void openAsync(final OperationContext operationContext, final AsyncCompletionHandler<Void> handler)
```

The address resolution helper is:

```text
driver-core/src/main/com/mongodb/internal/connection/ServerAddressHelper.java
```

Specifically:

```java
public static List<InetSocketAddress> getSocketAddresses(
        final ServerAddress serverAddress,
        final InetAddressResolver resolver)
```

That helper calls the configured `InetAddressResolver` and maps resolved `InetAddress` values into `InetSocketAddress` instances. `UnknownHostException` is wrapped in `MongoSocketException`; runtime failures from a custom resolver propagate as thrown.

Related stream implementations reviewed for expected behavior:

```text
driver-core/src/main/com/mongodb/internal/connection/AsynchronousSocketChannelStream.java
driver-core/src/main/com/mongodb/internal/connection/netty/NettyStream.java
```

Both resolve names before opening their underlying channel resources.

Related test area:

```text
driver-core/src/test/functional/com/mongodb/internal/connection/TlsChannelStreamFunctionalTest.java
driver-core/src/test/functional/com/mongodb/internal/connection/AsyncSocketChannelStreamSpecification.groovy
driver-core/src/test/functional/com/mongodb/connection/netty/NettyStreamSpecification.groovy
```

The async socket-channel and Netty stream specs already had regression tests for name-resolution failure reaching the async handler. `TlsChannelStreamFunctionalTest` did not.

## Proposed Scope

Fix only the connection-establishment ordering and pre-registration cleanup in `TlsChannelStream.openAsync`.

The patch should resolve the socket address before opening a `SocketChannel`:

```text
getConnectTimeoutMs()
getSocketAddresses(...).get(0)
SocketChannel.open()
configure socket options
socketChannel.connect(resolvedAddress)
register with SelectorMonitor
```

This preserves the existing requirement that `getConnectTimeoutMs` is called before the connection attempt, while ensuring no socket channel is opened if DNS resolution fails.

The patch should also close the opened channel if any later setup step fails before registration succeeds:

```text
SocketChannel.open()
configure socket options
socketChannel.connect(resolvedAddress)
schedule timeout / register with SelectorMonitor
```

If failure occurs before the selector monitor accepts the registration, `openAsync` should cancel the pending registration action, close the channel, attach any close failure as a suppressed exception, and then report the original failure to the async handler.

The fix should avoid changing:

- public driver APIs,
- `InetAddressResolver` behavior,
- `ServerAddressHelper.getSocketAddresses`,
- TLS handshake behavior,
- selector monitor behavior,
- timeout scheduling behavior,
- connection-pool behavior,
- backpressure or retryable error labels.

This keeps the patch small and focused on the reported TLSChannel failure mode.

## Test Plan

Add focused regression coverage rather than broad connection-establishment tests.

Suggested tests:

1. A `TlsChannelStream` test with a custom `InetAddressResolver` that throws a known `MongoSocketException`.

2. An async handler assertion proving:

```java
handler.failed(exception)
```

is called.

3. A negative completion assertion proving:

```java
handler.completed(null)
```

is not called.

4. A static `SocketChannel.open()` verification proving no socket channel is opened when name resolution fails.

5. A pre-registration failure test where `SocketChannel.open()` succeeds but `connect(...)` throws, proving the channel is closed before the failure is reported.

The implemented regression tests are:

```text
driver-core/src/test/functional/com/mongodb/internal/connection/TlsChannelStreamFunctionalTest.java
```

with:

```java
shouldFailAsyncCompletionHandlerWithoutOpeningSocketChannelIfNameResolutionFails
shouldCloseSocketChannelIfConnectFailsBeforeRegistration
```

Recommended local verification:

```bash
./gradlew :driver-core:test --tests com.mongodb.internal.connection.TlsChannelStreamFunctionalTest
```

In this environment, the targeted Gradle command could not be run because no Java runtime is available. `git diff --check` passed.

## Gotchas

The ticket wording says the resolver exception is not passed to the async handler, but the current code already has `catch (Throwable)` calling `handler.failed(t)`. The safer interpretation is that the failure path is still wrong because it opens a channel before the resolver can fail, and that channel is not closed.

Do not fix this by adding another catch block around `getSocketAddresses` after `SocketChannel.open()`. That would preserve the resource-ordering problem and would require extra cleanup logic. Resolving before opening the channel is simpler and matches the other stream implementations.

Do not stop at DNS resolution ordering alone. Once `SocketChannel.open()` succeeds, `openAsync` owns that channel until `selectorMonitor.register(...)` succeeds. Any failure in that window should close the channel to avoid moving the same leak to socket configuration or initial connect failures.

Do not wrap resolver failures in `MongoSocketOpenException` unless existing behavior requires it. `ServerAddressHelper` already wraps `UnknownHostException` in `MongoSocketException`, and the existing broad catch forwards non-`IOException` failures as-is.

Do not add backpressure labels or retry labels for this path. The CMAP specification explicitly distinguishes DNS lookup failures from server-overload cases.

Be careful with timeout ordering. The existing comment says `getConnectTimeoutMs` must be called before the connection attempt because it may throw `MongoOperationTimeoutException`. The fix keeps that behavior intact.

This change does not add multi-address fallback behavior to `TlsChannelStream`. The existing TLSChannel implementation connects only to the first resolved address, and adding retry across all resolved addresses would be a larger behavior change outside the scope of `JAVA-5855`.

## PR Positioning

Recommended PR framing:

```text
JAVA-5855 Resolve TLS channel address before opening socket
```

Recommended PR summary:

```text
This change fixes the TLS channel stream connection-establishment path so address resolution happens before opening a SocketChannel. Previously, TlsChannelStream opened and configured a SocketChannel before calling getSocketAddresses. If the configured resolver failed, the exception was reported to the async handler, but the already-opened channel was not closed.

Resolving the address before opening the channel avoids the resolver-failure leak and aligns TlsChannelStream with the existing async socket-channel and Netty stream implementations. The setup path now also closes the channel if any pre-registration step fails after the channel has been opened.
```

Recommended tests section:

```text
Added regression coverage for TlsChannelStream.openAsync with a failing InetAddressResolver. The test verifies that the async handler receives the resolver exception, completion is not signaled, and SocketChannel.open is not called.

Added regression coverage for a connect failure after SocketChannel.open succeeds but before selector registration. The test verifies that the original IOException is wrapped in MongoSocketOpenException and that the opened SocketChannel is closed.
```

Recommended verification note:

```text
git diff --check
./gradlew :driver-core:test --tests com.mongodb.internal.connection.TlsChannelStreamFunctionalTest
```

## Sources Reviewed

- [JAVA-5855](https://jira.mongodb.org/browse/JAVA-5855)
- [mongodb/mongo-java-driver](https://github.com/mongodb/mongo-java-driver)
- [MongoDB driver specifications](https://github.com/mongodb/specifications/tree/master/source)
- [Connection Monitoring and Pooling specification](https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md)
- [MongoDB handshake specification](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md)
- [Client Side Operations Timeout specification](https://github.com/mongodb/specifications/blob/master/source/client-side-operations-timeout/client-side-operations-timeout.md)
- [Initial DNS Seedlist Discovery specification](https://github.com/mongodb/specifications/blob/master/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.md)
- [OCSP Support specification](https://github.com/mongodb/specifications/blob/master/source/ocsp-support/ocsp-support.md)
- Local checkout of `mongodb/mongo-java-driver`, especially `driver-core/src/main/com/mongodb/internal/connection`
