### PR TITLE
Widen getSocketAddresses catch to Exceptions for custom resolver failures

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/ServerAddressHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ServerAddressHelper.java
@@ -26,7 +26,6 @@ import com.mongodb.spi.dns.InetAddressResolver;
 import com.mongodb.spi.dns.InetAddressResolverProvider;
 
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
@@ -71,7 +70,7 @@ public final class ServerAddressHelper {
             return resolver.lookupByName(serverAddress.getHost())
                     .stream()
                     .map(inetAddress -> new InetSocketAddress(inetAddress, serverAddress.getPort())).collect(Collectors.toList());
-        } catch (UnknownHostException e) {
+        } catch (Exception e) {
             throw new MongoSocketException(e.getMessage(), serverAddress, e);
         }
     }

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/TlsChannelStreamFunctionalTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/TlsChannelStreamFunctionalTest.java
@@ -17,18 +17,22 @@
 package com.mongodb.internal.connection;
 
 import com.mongodb.ClusterFixture;
+import com.mongodb.MongoSocketException;
 import com.mongodb.MongoSocketOpenException;
 import com.mongodb.ServerAddress;
+import com.mongodb.connection.AsyncCompletionHandler;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.SslSettings;
 import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.TimeoutSettings;
+import com.mongodb.spi.dns.InetAddressResolver;
 import org.bson.ByteBuf;
 import org.bson.ByteBufNIO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -67,6 +71,30 @@ class TlsChannelStreamFunctionalTest {
     private static final SslSettings SSL_SETTINGS = SslSettings.builder().enabled(true).build();
     private static final String UNREACHABLE_PRIVATE_IP_ADDRESS = "10.255.255.1";
     private static final int UNREACHABLE_PORT = 65333;
+
+    @Test
+    void shouldWrapResolverRuntimeExceptionInMongoSocketException() {
+        //given
+        InetAddressResolver inetAddressResolver = host -> { throw new RuntimeException("DNS service unavailable"); };
+
+        try (StreamFactoryFactory streamFactoryFactory = new TlsChannelStreamFactoryFactory(inetAddressResolver)) {
+            StreamFactory streamFactory = streamFactoryFactory.create(SocketSettings.builder()
+                    .connectTimeout(100, TimeUnit.MILLISECONDS)
+                    .build(), SSL_SETTINGS);
+            Stream stream = streamFactory.create(new ServerAddress());
+            @SuppressWarnings("unchecked")
+            AsyncCompletionHandler<Void> handler = Mockito.mock(AsyncCompletionHandler.class);
+
+            //when
+            stream.openAsync(createOperationContext(100), handler);
+
+            //then
+            ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
+            verify(handler).failed(captor.capture());
+            MongoSocketException actual = assertInstanceOf(MongoSocketException.class, captor.getValue());
+            assertInstanceOf(RuntimeException.class, actual.getCause());
+        }
+    }
 
     @ParameterizedTest
     @ValueSource(ints = {500, 1000, 2000})


### PR DESCRIPTION
Custom InetAddressResolver implementations may throw RuntimeException rather than UnknownHostException. Widening the catch ensures all resolver failures are consistently wrapped in MongoSocketException.

JAVA-5855