### PR TITLE
Mark micrometer OSGi imports as optional and add bundle resolution test

### DIFF
--- a/.evergreen/static-checks.sh
+++ b/.evergreen/static-checks.sh
@@ -15,4 +15,4 @@ echo "Compiling JVM drivers"
 ./gradlew -PxmlReports.enabled=true --info -x test -x integrationTest -x spotlessApply clean check scalaCheck jar testClasses docs
 
 echo "Running OSGi bundle resolution tests"
-./gradlew :testing:osgi-test:check
+./gradlew -PxmlReports.enabled=true --info :testing:osgi-test:check

--- a/.evergreen/static-checks.sh
+++ b/.evergreen/static-checks.sh
@@ -13,3 +13,6 @@ echo "Compiling JVM drivers"
 
 ./gradlew -version
 ./gradlew -PxmlReports.enabled=true --info -x test -x integrationTest -x spotlessApply clean check scalaCheck jar testClasses docs
+
+echo "Running OSGi bundle resolution tests"
+./gradlew :testing:osgi-test:check

--- a/driver-core/build.gradle.kts
+++ b/driver-core/build.gradle.kts
@@ -102,6 +102,7 @@ configureJarManifest {
                 "org.bson.codecs.record.*;resolution:=optional", // Depends on JDK version
                 "org.bson.codecs.kotlin.*;resolution:=optional",
                 "org.bson.codecs.kotlinx.*;resolution:=optional",
+                "io.micrometer.*;resolution:=optional",
                 "*" // import all that is not excluded or modified before
                 )
             .joinToString(",")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,7 +103,7 @@ micrometer-observation = { module = "io.micrometer:micrometer-observation" }
 graal-sdk = { module = "org.graalvm.sdk:graal-sdk", version.ref = "graal-sdk" }
 graal-sdk-nativeimage = { module = "org.graalvm.sdk:nativeimage", version.ref = "graal-sdk" }
 
-kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom" }
+kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
 kotlinx-coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "kotlinx-coroutines-bom" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ scala-v2-v11 = "2.11.12"
 
 # Test
 assertj = "3.24.2"
+felix-framework = "7.0.5"
 aws-lambda-core = "1.2.2"
 aws-lambda-events = "3.11.1"
 cglib = "2.2.2"
@@ -174,6 +175,7 @@ aws-lambda-core = { module = " com.amazonaws:aws-lambda-java-core", version.ref 
 aws-lambda-events = { module = " com.amazonaws:aws-lambda-java-events", version.ref = "aws-lambda-events" }
 cglib = { module = "cglib:cglib-nodep", version.ref = "cglib" }
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
+felix-framework = { module = "org.apache.felix:org.apache.felix.framework", version.ref = "felix-framework" }
 findbugs-jsr = { module = "com.google.code.findbugs:jsr305", version.ref = "findbugs-jsr" }
 groovy = { module = "org.codehaus.groovy:groovy-all", version.ref = "groovy" }
 hamcrest-all = { module = "org.hamcrest:hamcrest-all", version.ref = "hamcrest" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,6 +42,7 @@ include(":driver-kotlin-sync")
 include(":driver-scala")
 
 include(":driver-benchmarks")
+include(":testing:osgi-test")
 include(":driver-lambda")
 if (providers.gradleProperty("includeGraalvm").isPresent) {
     include(":graalvm-native-image-app")

--- a/testing/osgi-test/build.gradle.kts
+++ b/testing/osgi-test/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 plugins {
-    id("java-library")
     id("project.base")
     id("checkstyle")
     id("conventions.testing-base")
@@ -28,14 +27,39 @@ dependencies {
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.junit.jupiter.platform.launcher)
+    // AssertJ used here for infrastructure assertions (isDirectory, hasSize, containsExactly)
+    // which are significantly more readable than JUnit 5 equivalents for this test.
     testImplementation(libs.assertj)
     testImplementation(libs.felix.framework)
+
+    // These JARs are scanned by buildSystemPackagesFromClasspath() to export packages
+    // from the Felix system bundle, satisfying non-optional imports from bundles under test.
     testImplementation(libs.reactive.streams)
     testImplementation(platform(libs.project.reactor.bom))
     testImplementation(libs.project.reactor.core)
+    testImplementation(platform(libs.kotlin.bom))
+    testImplementation(libs.kotlin.stdlib.jdk8)
+    testImplementation(libs.kotlin.reflect)
+    testImplementation(platform(libs.kotlinx.coroutines.bom))
+    testImplementation(libs.kotlinx.coroutines.core)
+    testImplementation(libs.kotlinx.coroutines.reactive)
+    testImplementation(libs.findbugs.jsr)
+    testImplementation(libs.jna)
 }
 
 tasks.test {
-    dependsOn(":bson:jar", ":driver-core:jar", ":driver-sync:jar", ":driver-reactive-streams:jar")
+    dependsOn(
+        ":bson:jar",
+        ":bson-record-codec:jar",
+        ":mongodb-crypt:jar",
+        ":driver-core:jar",
+        ":bson-scala:jar",
+        ":driver-sync:jar",
+        ":driver-reactive-streams:jar",
+        ":driver-scala:jar",
+        ":driver-kotlin-sync:jar",
+        ":driver-kotlin-coroutine:jar",
+        ":driver-kotlin-extensions:jar"
+    )
     systemProperty("projectRoot", rootProject.projectDir.absolutePath)
 }

--- a/testing/osgi-test/build.gradle.kts
+++ b/testing/osgi-test/build.gradle.kts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+    id("java-library")
+    id("project.base")
+    id("checkstyle")
+    id("conventions.testing-base")
+}
+
+java {
+    toolchain { languageVersion = JavaLanguageVersion.of(17) }
+}
+
+dependencies {
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.jupiter.platform.launcher)
+    testImplementation(libs.assertj)
+    testImplementation(libs.felix.framework)
+    testImplementation(libs.reactive.streams)
+    testImplementation(platform(libs.project.reactor.bom))
+    testImplementation(libs.project.reactor.core)
+}
+
+tasks.test {
+    dependsOn(":bson:jar", ":driver-core:jar", ":driver-sync:jar", ":driver-reactive-streams:jar")
+    systemProperty("projectRoot", rootProject.projectDir.absolutePath)
+}

--- a/testing/osgi-test/src/test/java/com/mongodb/osgi/OsgiBundleResolutionTest.java
+++ b/testing/osgi-test/src/test/java/com/mongodb/osgi/OsgiBundleResolutionTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.osgi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.felix.framework.FrameworkFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.launch.Framework;
+
+class OsgiBundleResolutionTest {
+
+    private static final Path PROJECT_ROOT = Paths.get(System.getProperty("projectRoot", "../.."));
+
+    private static final String[] BUNDLE_MODULES = {
+        "bson",
+        "driver-core",
+        "driver-sync",
+        "driver-reactive-streams"
+    };
+
+    @TempDir
+    private Path cacheDir;
+
+    private Framework framework;
+
+    @BeforeEach
+    void startFramework() throws BundleException, IOException {
+
+        Map<String, String> config = new HashMap<>();
+        config.put("org.osgi.framework.storage", cacheDir.toString());
+        config.put("org.osgi.framework.storage.clean", "onFirstInit");
+        config.put("felix.log.level", "1");
+        // Export required (non-optional) third-party packages from the system bundle.
+        // In a real OSGi container these would be provided by separately installed bundles.
+        // We scan the test classpath for reactive-streams and reactor-core JARs and export
+        // their packages so versions stay in sync with the version catalog automatically.
+        String extraPackages = buildSystemPackagesFromClasspath();
+        if (!extraPackages.isEmpty()) {
+            config.put("org.osgi.framework.system.packages.extra", extraPackages);
+        }
+
+        framework = new FrameworkFactory().newFramework(config);
+        framework.start();
+    }
+
+    @AfterEach
+    void stopFramework() throws BundleException, InterruptedException {
+        if (framework != null) {
+            framework.stop();
+            framework.waitForStop(10_000);
+        }
+    }
+
+    @Test
+    void bundlesResolveWithoutOptionalDependencies() throws Exception {
+        BundleContext ctx = framework.getBundleContext();
+        List<Bundle> installed = new ArrayList<>();
+
+        for (String module : BUNDLE_MODULES) {
+            File jar = findBundleJar(module);
+            try (InputStream is = Files.newInputStream(jar.toPath())) {
+                Bundle bundle = ctx.installBundle("file:" + jar.getAbsolutePath(), is);
+                installed.add(bundle);
+            }
+        }
+
+        for (Bundle bundle : installed) {
+            try {
+                bundle.start();
+            } catch (BundleException e) {
+                fail(formatBundleFailure(bundle, e));
+            }
+        }
+    }
+
+    @Test
+    void bundlesReportCorrectSymbolicNames() throws Exception {
+        BundleContext ctx = framework.getBundleContext();
+        List<String> symbolicNames = new ArrayList<>();
+
+        for (String module : BUNDLE_MODULES) {
+            File jar = findBundleJar(module);
+            try (InputStream is = Files.newInputStream(jar.toPath())) {
+                Bundle bundle = ctx.installBundle("file:" + jar.getAbsolutePath(), is);
+                symbolicNames.add(bundle.getSymbolicName());
+            }
+        }
+
+        assertThat(symbolicNames).containsExactly(
+                "org.mongodb.bson",
+                "org.mongodb.driver-core",
+                "org.mongodb.driver-sync",
+                "org.mongodb.driver-reactivestreams");
+    }
+
+    private static String formatBundleFailure(final Bundle bundle, final BundleException e) {
+        String msg = e.getMessage();
+        StringBuilder sb = new StringBuilder();
+        sb.append("\n\n====================================================================\n");
+        sb.append("BUNDLE RESOLUTION FAILURE: ").append(bundle.getSymbolicName()).append("\n");
+        sb.append("====================================================================\n");
+
+        if (msg != null && msg.contains("missing requirement")) {
+            int pkgStart = msg.indexOf("osgi.wiring.package=");
+            if (pkgStart >= 0) {
+                String remainder = msg.substring(pkgStart + "osgi.wiring.package=".length());
+                int pkgEnd = remainder.indexOf(')');
+                String missingPackage = pkgEnd >= 0 ? remainder.substring(0, pkgEnd) : remainder;
+                sb.append("Missing required package: ").append(missingPackage).append("\n\n");
+                sb.append("FIX: Add '").append(missingPackage).append(".*;resolution:=optional' to the\n");
+                sb.append("     Import-Package list in the module's build.gradle.kts\n");
+            }
+        }
+
+        sb.append("\nFull error: ").append(msg);
+        sb.append("\n====================================================================\n");
+        return sb.toString();
+    }
+
+    private static String systemPackagesCache;
+
+    private static String buildSystemPackagesFromClasspath() {
+        if (systemPackagesCache != null) {
+            return systemPackagesCache;
+        }
+        Set<String> packages = new LinkedHashSet<>();
+        String classpath = System.getProperty("java.class.path", "");
+
+        for (String entry : classpath.split(File.pathSeparator)) {
+            File file = new File(entry);
+            String name = file.getName();
+            if (!name.startsWith("reactive-streams") && !name.startsWith("reactor-core")) {
+                continue;
+            }
+            if (!file.isFile() || !name.endsWith(".jar")) {
+                continue;
+            }
+            try (JarFile jar = new JarFile(file)) {
+                String version = jar.getManifest().getMainAttributes().getValue("Bundle-Version");
+                if (version == null) {
+                    version = "0.0.0";
+                }
+                Enumeration<JarEntry> entries = jar.entries();
+                while (entries.hasMoreElements()) {
+                    JarEntry jarEntry = entries.nextElement();
+                    String entryName = jarEntry.getName();
+                    if (entryName.endsWith(".class") && entryName.contains("/")) {
+                        String pkg = entryName.substring(0, entryName.lastIndexOf('/')).replace('/', '.');
+                        packages.add(pkg + ";version=\"" + version + "\"");
+                    }
+                }
+            } catch (IOException e) {
+                // Skip JARs that can't be read
+            }
+        }
+
+        systemPackagesCache = String.join(",", packages);
+        return systemPackagesCache;
+    }
+
+    private static File findBundleJar(final String module) {
+        Path libsDir = PROJECT_ROOT.resolve(module).resolve("build").resolve("libs");
+        assertThat(libsDir)
+                .as("Build output directory for module '%s' must exist. Run ./gradlew jar first.", module)
+                .isDirectory();
+
+        try (Stream<Path> files = Files.list(libsDir)) {
+            List<File> candidates = files
+                    .filter(p -> p.getFileName().toString().endsWith(".jar"))
+                    .filter(p -> !p.getFileName().toString().contains("-test"))
+                    .filter(p -> !p.getFileName().toString().contains("-sources"))
+                    .filter(p -> !p.getFileName().toString().contains("-javadoc"))
+                    .map(Path::toFile)
+                    .collect(Collectors.toList());
+
+            assertThat(candidates)
+                    .as("Expected exactly one main JAR in %s", libsDir)
+                    .hasSize(1);
+
+            return candidates.get(0);
+        } catch (IOException e) {
+            return fail("Failed to list JARs in " + libsDir + ": " + e.getMessage());
+        }
+    }
+}

--- a/testing/osgi-test/src/test/java/com/mongodb/osgi/OsgiBundleResolutionTest.java
+++ b/testing/osgi-test/src/test/java/com/mongodb/osgi/OsgiBundleResolutionTest.java
@@ -53,6 +53,8 @@ class OsgiBundleResolutionTest {
 
     private static final Path PROJECT_ROOT = Paths.get(System.getProperty("projectRoot", "../.."));
 
+    // Listed in dependency order (leaves last) so that the first bundle.start() failure
+    // identifies the root cause rather than a cascading downstream resolution error.
     private static final String[] BUNDLE_MODULES = {
         "bson",
         "bson-record-codec",

--- a/testing/osgi-test/src/test/java/com/mongodb/osgi/OsgiBundleResolutionTest.java
+++ b/testing/osgi-test/src/test/java/com/mongodb/osgi/OsgiBundleResolutionTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.fail;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -44,6 +46,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
+import org.osgi.framework.FrameworkEvent;
 import org.osgi.framework.launch.Framework;
 
 class OsgiBundleResolutionTest {
@@ -52,10 +55,33 @@ class OsgiBundleResolutionTest {
 
     private static final String[] BUNDLE_MODULES = {
         "bson",
+        "bson-record-codec",
+        "mongodb-crypt",
         "driver-core",
+        "bson-scala",
         "driver-sync",
-        "driver-reactive-streams"
+        "driver-reactive-streams",
+        "driver-scala",
+        "driver-kotlin-sync",
+        "driver-kotlin-coroutine",
+        "driver-kotlin-extensions"
     };
+
+    // JARs on the test classpath whose packages are exported from the Felix system bundle,
+    // satisfying non-optional imports from the bundles under test.
+    private static final String[] SYSTEM_PACKAGE_JAR_PREFIXES = {
+        "reactive-streams",
+        "reactor-core",
+        "kotlin-stdlib",
+        "kotlin-reflect",
+        "kotlinx-coroutines-core",
+        "kotlinx-coroutines-reactive",
+        "jsr305",
+        "jna"
+    };
+
+    // Eagerly computed — the classpath is fixed for the lifetime of the test JVM.
+    private static final String SYSTEM_PACKAGES = buildSystemPackagesFromClasspath();
 
     @TempDir
     private Path cacheDir;
@@ -63,19 +89,13 @@ class OsgiBundleResolutionTest {
     private Framework framework;
 
     @BeforeEach
-    void startFramework() throws BundleException, IOException {
-
+    void startFramework() throws BundleException {
         Map<String, String> config = new HashMap<>();
         config.put("org.osgi.framework.storage", cacheDir.toString());
         config.put("org.osgi.framework.storage.clean", "onFirstInit");
         config.put("felix.log.level", "1");
-        // Export required (non-optional) third-party packages from the system bundle.
-        // In a real OSGi container these would be provided by separately installed bundles.
-        // We scan the test classpath for reactive-streams and reactor-core JARs and export
-        // their packages so versions stay in sync with the version catalog automatically.
-        String extraPackages = buildSystemPackagesFromClasspath();
-        if (!extraPackages.isEmpty()) {
-            config.put("org.osgi.framework.system.packages.extra", extraPackages);
+        if (!SYSTEM_PACKAGES.isEmpty()) {
+            config.put("org.osgi.framework.system.packages.extra", SYSTEM_PACKAGES);
         }
 
         framework = new FrameworkFactory().newFramework(config);
@@ -86,27 +106,26 @@ class OsgiBundleResolutionTest {
     void stopFramework() throws BundleException, InterruptedException {
         if (framework != null) {
             framework.stop();
-            framework.waitForStop(10_000);
+            FrameworkEvent event = framework.waitForStop(10_000);
+            if (event.getType() == FrameworkEvent.WAIT_TIMEDOUT) {
+                throw new IllegalStateException("OSGi framework did not stop within 10 seconds");
+            }
         }
     }
 
     @Test
     void bundlesResolveWithoutOptionalDependencies() throws Exception {
-        BundleContext ctx = framework.getBundleContext();
-        List<Bundle> installed = new ArrayList<>();
-
-        for (String module : BUNDLE_MODULES) {
-            File jar = findBundleJar(module);
-            try (InputStream is = Files.newInputStream(jar.toPath())) {
-                Bundle bundle = ctx.installBundle("file:" + jar.getAbsolutePath(), is);
-                installed.add(bundle);
-            }
-        }
+        List<Bundle> installed = installAllBundles(framework.getBundleContext());
 
         for (Bundle bundle : installed) {
             try {
                 bundle.start();
             } catch (BundleException e) {
+                // Fail immediately on the first resolution error. Bundles are wired by
+                // Import-Package, so an unresolved bundle (e.g. driver-core missing a
+                // required import) leaves its exported packages unsatisfied for all
+                // downstream bundles. Collecting further failures would only add
+                // cascading noise — the first message identifies the root cause.
                 fail(formatBundleFailure(bundle, e));
             }
         }
@@ -114,24 +133,39 @@ class OsgiBundleResolutionTest {
 
     @Test
     void bundlesReportCorrectSymbolicNames() throws Exception {
-        BundleContext ctx = framework.getBundleContext();
-        List<String> symbolicNames = new ArrayList<>();
+        List<Bundle> installed = installAllBundles(framework.getBundleContext());
 
+        List<String> symbolicNames = installed.stream()
+                .map(Bundle::getSymbolicName)
+                .collect(Collectors.toList());
+
+        assertThat(symbolicNames).containsExactly(
+                "org.mongodb.bson",
+                "org.mongodb.bson-record-codec",
+                "com.mongodb.crypt.capi",
+                "org.mongodb.driver-core",
+                "org.mongodb.scala.mongo-scala-bson",
+                "org.mongodb.driver-sync",
+                "org.mongodb.driver-reactivestreams",
+                "org.mongodb.scala.mongo-scala-driver",
+                "org.mongodb.mongodb-driver-kotlin-sync",
+                "org.mongodb.mongodb-driver-kotlin-coroutine",
+                "org.mongodb.mongodb-driver-kotlin-extensions");
+    }
+
+    private List<Bundle> installAllBundles(final BundleContext ctx) throws Exception {
+        List<Bundle> installed = new ArrayList<>();
         for (String module : BUNDLE_MODULES) {
             File jar = findBundleJar(module);
             try (InputStream is = Files.newInputStream(jar.toPath())) {
                 Bundle bundle = ctx.installBundle("file:" + jar.getAbsolutePath(), is);
-                symbolicNames.add(bundle.getSymbolicName());
+                installed.add(bundle);
             }
         }
-
-        assertThat(symbolicNames).containsExactly(
-                "org.mongodb.bson",
-                "org.mongodb.driver-core",
-                "org.mongodb.driver-sync",
-                "org.mongodb.driver-reactivestreams");
+        return installed;
     }
 
+    // Parses Felix's error message format to extract the missing package name.
     private static String formatBundleFailure(final Bundle bundle, final BundleException e) {
         String msg = e.getMessage();
         StringBuilder sb = new StringBuilder();
@@ -156,26 +190,25 @@ class OsgiBundleResolutionTest {
         return sb.toString();
     }
 
-    private static String systemPackagesCache;
-
     private static String buildSystemPackagesFromClasspath() {
-        if (systemPackagesCache != null) {
-            return systemPackagesCache;
-        }
         Set<String> packages = new LinkedHashSet<>();
         String classpath = System.getProperty("java.class.path", "");
 
         for (String entry : classpath.split(File.pathSeparator)) {
             File file = new File(entry);
             String name = file.getName();
-            if (!name.startsWith("reactive-streams") && !name.startsWith("reactor-core")) {
+            if (!matchesAnyPrefix(name)) {
                 continue;
             }
             if (!file.isFile() || !name.endsWith(".jar")) {
                 continue;
             }
             try (JarFile jar = new JarFile(file)) {
-                String version = jar.getManifest().getMainAttributes().getValue("Bundle-Version");
+                Manifest manifest = jar.getManifest();
+                if (manifest == null) {
+                    continue;
+                }
+                String version = manifest.getMainAttributes().getValue("Bundle-Version");
                 if (version == null) {
                     version = "0.0.0";
                 }
@@ -189,12 +222,20 @@ class OsgiBundleResolutionTest {
                     }
                 }
             } catch (IOException e) {
-                // Skip JARs that can't be read
+                throw new UncheckedIOException("Failed to read classpath JAR: " + file, e);
             }
         }
 
-        systemPackagesCache = String.join(",", packages);
-        return systemPackagesCache;
+        return String.join(",", packages);
+    }
+
+    private static boolean matchesAnyPrefix(final String fileName) {
+        for (String prefix : SYSTEM_PACKAGE_JAR_PREFIXES) {
+            if (fileName.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static File findBundleJar(final String module) {

--- a/testing/osgi-test/src/test/java/com/mongodb/osgi/package-info.java
+++ b/testing/osgi-test/src/test/java/com/mongodb/osgi/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * OSGi bundle resolution regression tests using Apache Felix.
+ */
+package com.mongodb.osgi;


### PR DESCRIPTION
The micrometer-observation dependency is optional but its packages were imported as required in the OSGi metadata, causing bundle resolution failure in OSGi containers.

Adds io.micrometer.*;resolution:=optional to driver-core Import-Package.

Also adds a new testing/osgi-test module that uses Apache Felix to verify all driver bundles resolve without optional dependencies present. This runs in CI via static-checks.sh to prevent future regressions.

JAVA-6215
JAVA-5062