### PR TITLE
Refactor `MixedBulkWriteOperation` to simplify retry logic there

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/AsyncRunnable.java
+++ b/driver-core/src/main/com/mongodb/internal/async/AsyncRunnable.java
@@ -111,9 +111,11 @@ import java.util.function.Supplier;
  *   <li>Is every c.complete followed by a return, to end execution?</li>
  *   <li>Have all sync method calls been converted to async, where needed?</li>
  * </ol>
- *
- * <p>This class is not part of the public API and may be removed or changed
- * at any time
+ * <p>
+ * If, when writing a lambda expression, you need to have an effectively {@code final} variable
+ * whose value may be mutated, use {@link MutableValue}.
+ * <p>
+ * This class is not part of the public API and may be removed or changed at any time.
  */
 @FunctionalInterface
 public interface AsyncRunnable extends AsyncSupplier<Void>, AsyncConsumer<Void> {

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
@@ -208,7 +208,8 @@ public final class RetryState {
      * @param readOnlyRetryState Must not be mutated by this method.
      * @param onlyRuntimeExceptions See {@link #doAdvanceOrThrow(Throwable, BinaryOperator, BiPredicate, boolean)}.
      */
-    private boolean shouldRetry(final RetryState readOnlyRetryState, final Throwable attemptException, final Throwable newlyChosenException,
+    private static boolean shouldRetry(final RetryState readOnlyRetryState, final Throwable attemptException,
+            final Throwable newlyChosenException,
             final boolean onlyRuntimeExceptions, final BiPredicate<RetryState, Throwable> retryPredicate) {
         try {
             return retryPredicate.test(readOnlyRetryState, attemptException);

--- a/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
+++ b/driver-core/src/main/com/mongodb/internal/async/function/RetryState.java
@@ -297,16 +297,6 @@ public final class RetryState {
     }
 
     /**
-     * This method is similar to
-     * {@link RetryState#breakAndThrowIfRetryAnd(Supplier)} / {@link RetryState#breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)}.
-     * The difference is that it allows the current attempt to continue, yet no more attempts will happen. Also, unlike the aforementioned
-     * methods, this method has effect even if called during the {@linkplain #isFirstAttempt() first attempt}.
-     */
-    public void markAsLastAttempt() {
-        loopState.markAsLastIteration();
-    }
-
-    /**
      * Returns {@code true} iff the current attempt is the first one, i.e., no retry attempts have been made.
      *
      * @see #attempt()
@@ -319,7 +309,7 @@ public final class RetryState {
      * Returns {@code true} iff the current attempt is known to be the last one, i.e., it is known that no more attempts will be made.
      * An attempt is known to be the last one iff any of the following applies:
      * <ul>
-     *   <li>{@link #breakAndThrowIfRetryAnd(Supplier)} / {@link #breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)} / {@link #markAsLastAttempt()} was called.</li>
+     *   <li>{@link #breakAndThrowIfRetryAnd(Supplier)} / {@link #breakAndCompleteIfRetryAnd(Supplier, SingleResultCallback)} was called.</li>
      *   <li>{@code attemptException} is a {@link MongoOperationTimeoutException}.</li>
      *   <li>The number of attempts is limited, and the current attempt is the last one.</li>
      * </ul>

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
@@ -331,7 +331,7 @@ final class AsyncOperationHelper {
 
     static <R> AsyncCallbackSupplier<R> decorateReadWithRetriesAsync(final RetryState retryState, final OperationContext operationContext,
             final AsyncCallbackSupplier<R> asyncReadFunction) {
-        return new RetryingAsyncCallbackSupplier<>(retryState, onRetryableReadAttemptFailure(operationContext),
+        return new RetryingAsyncCallbackSupplier<>(retryState, onRetryableReadAttemptFailure(operationContext.getServerDeprioritization()),
                 CommandOperationHelper::loggingShouldAttemptToRetryRead, callback -> {
             logRetryCommand(retryState, operationContext);
             asyncReadFunction.get(callback);
@@ -340,7 +340,7 @@ final class AsyncOperationHelper {
 
     static <R> AsyncCallbackSupplier<R> decorateWriteWithRetriesAsync(final RetryState retryState, final OperationContext operationContext,
             final AsyncCallbackSupplier<R> asyncWriteFunction) {
-        return new RetryingAsyncCallbackSupplier<>(retryState, onRetryableWriteAttemptFailure(operationContext),
+        return new RetryingAsyncCallbackSupplier<>(retryState, onRetryableWriteAttemptFailure(operationContext.getServerDeprioritization()),
                 CommandOperationHelper::loggingShouldAttemptToRetryWriteAndAddRetryableLabel, callback -> {
             logRetryCommand(retryState, operationContext);
             asyncWriteFunction.get(callback);

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperationHelper.java
@@ -110,8 +110,7 @@ final class AsyncOperationHelper {
             final boolean wrapConnectionSourceException,
             final OperationContext operationContext,
             final SingleResultCallback<R> callback,
-            final AsyncCallbackTriFunction<AsyncConnectionSource, AsyncConnection, OperationContext, R> asyncFunction)
-            throws OperationHelper.ResourceSupplierInternalException {
+            final AsyncCallbackTriFunction<AsyncConnectionSource, AsyncConnection, OperationContext, R> asyncFunction) {
         SingleResultCallback<R> errorHandlingCallback = errorHandlingCallback(callback, OperationHelper.LOGGER);
 
         OperationContext serverSelectionOperationContext =
@@ -140,8 +139,7 @@ final class AsyncOperationHelper {
                                                                           final boolean wrapSourceConnectionException,
                                                                           final OperationContext operationContext,
                                                                           final SingleResultCallback<R> callback,
-                                                                          final AsyncCallbackFunction<T, R> function)
-            throws OperationHelper.ResourceSupplierInternalException {
+                                                                          final AsyncCallbackFunction<T, R> function) {
         SingleResultCallback<R> errorHandlingCallback = errorHandlingCallback(callback, OperationHelper.LOGGER);
         resourceSupplier.apply(operationContext, (resource, supplierException) -> {
             if (supplierException != null) {

--- a/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
@@ -322,7 +322,7 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
         } catch (MongoException mongoException) {
             resultAccumulator.onBulkWriteCommandErrorWithoutResponse(mongoException);
             if (retryWritesSetting) {
-                // Adding the `RetryableError` label here is unnecessary at this point:
+                // Adding the `RetryableWriteError` label here is unnecessary at this point:
                 // applications cannot use it for implementing retries, and it is not even part of the public driver API.
                 // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
                 addRetryableLabelOrGetWriteAttemptFailureNotToBeRetried(retryState, mongoException);
@@ -392,7 +392,7 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
                     MongoException mongoException = (MongoException) t;
                     resultAccumulator.onBulkWriteCommandErrorWithoutResponse(mongoException);
                     if (retryWritesSetting) {
-                        // Adding the `RetryableError` label here is unnecessary at this point:
+                        // Adding the `RetryableWriteError` label here is unnecessary at this point:
                         // applications cannot use it for implementing retries, and it is not even part of the public driver API.
                         // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
                         addRetryableLabelOrGetWriteAttemptFailureNotToBeRetried(retryState, mongoException);

--- a/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
@@ -129,7 +129,7 @@ import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWriteW
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncSourceAndConnection;
 import static com.mongodb.internal.operation.BulkWriteBatch.logWriteModelDoesNotSupportRetries;
 import static com.mongodb.internal.operation.CommandOperationHelper.commandWriteConcern;
-import static com.mongodb.internal.operation.CommandOperationHelper.getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel;
+import static com.mongodb.internal.operation.CommandOperationHelper.addRetryableLabelOrGetWriteAttemptFailureNotToBeRetried;
 import static com.mongodb.internal.operation.CommandOperationHelper.initialRetryState;
 import static com.mongodb.internal.operation.CommandOperationHelper.transformWriteException;
 import static com.mongodb.internal.operation.OperationHelper.isRetryableWrite;
@@ -325,7 +325,7 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
                 // Adding the `RetryableError` label here is unnecessary at this point:
                 // applications cannot use it for implementing retries, and it is not even part of the public driver API.
                 // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
-                getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(retryState, mongoException);
+                addRetryableLabelOrGetWriteAttemptFailureNotToBeRetried(retryState, mongoException);
             }
             throw mongoException;
         }
@@ -395,7 +395,7 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
                         // Adding the `RetryableError` label here is unnecessary at this point:
                         // applications cannot use it for implementing retries, and it is not even part of the public driver API.
                         // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
-                        getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(retryState, mongoException);
+                        addRetryableLabelOrGetWriteAttemptFailureNotToBeRetried(retryState, mongoException);
                     }
                     throw mongoException;
                 } else {

--- a/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
@@ -207,17 +207,19 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
             final AsyncWriteBinding binding,
             final OperationContext operationContext,
             final SingleResultCallback<ClientBulkWriteResult> callback) {
-        WriteConcern effectiveWriteConcern = validateAndGetEffectiveWriteConcern(operationContext.getSessionContext());
-        ResultAccumulator resultAccumulator = new ResultAccumulator();
-        MutableValue<MongoException> transformedTopLevelError = new MutableValue<>();
+        beginAsync().<ClientBulkWriteResult>thenSupply(c -> {
+            WriteConcern effectiveWriteConcern = validateAndGetEffectiveWriteConcern(operationContext.getSessionContext());
+            ResultAccumulator resultAccumulator = new ResultAccumulator();
+            MutableValue<MongoException> transformedTopLevelError = new MutableValue<>();
 
-        beginAsync().<Void>thenSupply(c -> {
-            executeAllBatchesAsync(effectiveWriteConcern, binding, operationContext, resultAccumulator, c);
-        }).onErrorIf(topLevelError -> topLevelError instanceof MongoException, (topLevelError, c) -> {
-            transformedTopLevelError.set(transformWriteException((MongoException) topLevelError));
-            c.complete(c);
-        }).<ClientBulkWriteResult>thenApply((ignored, c) -> {
-            c.complete(resultAccumulator.build(transformedTopLevelError.getNullable(), effectiveWriteConcern));
+            beginAsync().thenRun(executeAllBatchesCallback -> {
+                executeAllBatchesAsync(effectiveWriteConcern, binding, operationContext, resultAccumulator, executeAllBatchesCallback);
+            }).onErrorIf(topLevelError -> topLevelError instanceof MongoException, (topLevelError, onErrorCallback) -> {
+                transformedTopLevelError.set(transformWriteException((MongoException) topLevelError));
+                onErrorCallback.complete(onErrorCallback);
+            }).<ClientBulkWriteResult>thenApply((ignored, buildResultCallback) -> {
+                buildResultCallback.complete(resultAccumulator.build(transformedTopLevelError.getNullable(), effectiveWriteConcern));
+            }).finish(c);
         }).finish(callback);
     }
 
@@ -251,16 +253,18 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
             final OperationContext operationContext,
             final ResultAccumulator resultAccumulator,
             final SingleResultCallback<Void> callback) {
-        MutableValue<Integer> nextBatchStartModelIndex = new MutableValue<>(INITIAL_BATCH_MODEL_START_INDEX);
+        beginAsync().thenRun(c -> {
+            MutableValue<Integer> nextBatchStartModelIndex = new MutableValue<>(INITIAL_BATCH_MODEL_START_INDEX);
 
-        beginAsync().thenRunDoWhileLoop(iterationCallback -> {
-            beginAsync().<Integer>thenSupply(c -> {
-                executeBatchAsync(nextBatchStartModelIndex.get(), effectiveWriteConcern, binding, operationContext, resultAccumulator, c);
-            }).<Void>thenApply((nextBatchStartModelIdx, c) -> {
-                nextBatchStartModelIndex.set(nextBatchStartModelIdx);
-                c.complete(c);
-            }).finish(iterationCallback);
-        }, () -> nextBatchStartModelIndex.getNullable() != null).finish(callback);
+            beginAsync().thenRunDoWhileLoop(iterationCallback -> {
+                beginAsync().<Integer>thenSupply(executeBatchCallback -> {
+                    executeBatchAsync(nextBatchStartModelIndex.get(), effectiveWriteConcern, binding, operationContext, resultAccumulator, executeBatchCallback);
+                }).thenConsume((nextBatchStartModelIdx, setNextBatchStartModelIndexCallback) -> {
+                    nextBatchStartModelIndex.set(nextBatchStartModelIdx);
+                    setNextBatchStartModelIndexCallback.complete(setNextBatchStartModelIndexCallback);
+                }).finish(iterationCallback);
+            }, () -> nextBatchStartModelIndex.getNullable() != null).finish(c);
+        }).finish(callback);
     }
 
     /**
@@ -337,63 +341,67 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
             final OperationContext operationContext,
             final ResultAccumulator resultAccumulator,
             final SingleResultCallback<Integer> callback) {
-        List<? extends ClientNamespacedWriteModel> unexecutedModels = models.subList(batchStartModelIndex, models.size());
-        assertFalse(unexecutedModels.isEmpty());
-        SessionContext sessionContext = operationContext.getSessionContext();
-        TimeoutContext timeoutContext = operationContext.getTimeoutContext();
-        RetryState retryState = initialRetryState(retryWritesSetting, timeoutContext);
-        BatchEncoder batchEncoder = new BatchEncoder();
+        beginAsync().<Integer>thenSupply(c -> {
+            List<? extends ClientNamespacedWriteModel> unexecutedModels = models.subList(batchStartModelIndex, models.size());
+            assertFalse(unexecutedModels.isEmpty());
+            SessionContext sessionContext = operationContext.getSessionContext();
+            TimeoutContext timeoutContext = operationContext.getTimeoutContext();
+            RetryState retryState = initialRetryState(retryWritesSetting, timeoutContext);
+            BatchEncoder batchEncoder = new BatchEncoder();
 
-        AsyncCallbackSupplier<ExhaustiveClientBulkWriteCommandOkResponse> retryingBatchExecutor = decorateWriteWithRetriesAsync(
-                retryState, operationContext,
-                // Each batch re-selects a server and re-checks out a connection because this is simpler,
-                // and it is allowed by https://jira.mongodb.org/browse/DRIVERS-2502.
-                // If connection pinning is required, `binding` handles that,
-                // and `ClientSession`, `TransactionContext` are aware of that.
-                funcCallback -> withAsyncSourceAndConnection(binding::getWriteConnectionSource, true, operationContext, funcCallback,
-                        (connectionSource, connection, operationContextWithMinRtt, resultCallback) -> {
-                            ConnectionDescription connectionDescription = connection.getDescription();
-                            boolean effectiveRetryWrites = isRetryableWrite(
-                                    retryWritesSetting, effectiveWriteConcern, connectionDescription, sessionContext);
-                            retryState.breakAndThrowIfRetryAnd(() -> !effectiveRetryWrites);
-                            resultAccumulator.onNewServerAddress(connectionDescription.getServerAddress());
-                            retryState.attach(AttachmentKeys.maxWireVersion(), connectionDescription.getMaxWireVersion(), true)
-                                    .attach(AttachmentKeys.commandDescriptionSupplier(), () -> BULK_WRITE_COMMAND_NAME, false);
-                            ClientBulkWriteCommand bulkWriteCommand = createBulkWriteCommand(
-                                    retryState, effectiveRetryWrites, effectiveWriteConcern, sessionContext, unexecutedModels, batchEncoder,
-                                    () -> retryState.attach(AttachmentKeys.retryableWriteCommandFlag(), true, true));
-                            executeBulkWriteCommandAndExhaustOkResponseAsync(
-                                    retryState, connectionSource, connection, bulkWriteCommand, effectiveWriteConcern, operationContextWithMinRtt, resultCallback);
-                        })
-        );
+            AsyncCallbackSupplier<ExhaustiveClientBulkWriteCommandOkResponse> retryingBatchExecutor = decorateWriteWithRetriesAsync(
+                    retryState, operationContext,
+                    // Each batch re-selects a server and re-checks out a connection because this is simpler,
+                    // and it is allowed by https://jira.mongodb.org/browse/DRIVERS-2502.
+                    // If connection pinning is required, `binding` handles that,
+                    // and `ClientSession`, `TransactionContext` are aware of that.
+                    supplierCallback -> withAsyncSourceAndConnection(binding::getWriteConnectionSource, true, operationContext, supplierCallback,
+                            (connectionSource, connection, operationContextWithMinRtt, functionCallback) -> {
+                                beginAsync().<ExhaustiveClientBulkWriteCommandOkResponse>thenSupply(executeAndExhaustCallback -> {
+                                    ConnectionDescription connectionDescription = connection.getDescription();
+                                    boolean effectiveRetryWrites = isRetryableWrite(
+                                            retryWritesSetting, effectiveWriteConcern, connectionDescription, sessionContext);
+                                    retryState.breakAndThrowIfRetryAnd(() -> !effectiveRetryWrites);
+                                    resultAccumulator.onNewServerAddress(connectionDescription.getServerAddress());
+                                    retryState.attach(AttachmentKeys.maxWireVersion(), connectionDescription.getMaxWireVersion(), true)
+                                            .attach(AttachmentKeys.commandDescriptionSupplier(), () -> BULK_WRITE_COMMAND_NAME, false);
+                                    ClientBulkWriteCommand bulkWriteCommand = createBulkWriteCommand(
+                                            retryState, effectiveRetryWrites, effectiveWriteConcern, sessionContext, unexecutedModels, batchEncoder,
+                                            () -> retryState.attach(AttachmentKeys.retryableWriteCommandFlag(), true, true));
+                                    executeBulkWriteCommandAndExhaustOkResponseAsync(
+                                            retryState, connectionSource, connection, bulkWriteCommand, effectiveWriteConcern, operationContextWithMinRtt, executeAndExhaustCallback);
+                                }).finish(functionCallback);
+                            })
+            );
 
-        beginAsync().<ExhaustiveClientBulkWriteCommandOkResponse>thenSupply(c -> {
-            retryingBatchExecutor.get(c);
-        }).<Integer>thenApply((response, c) -> {
-            c.complete(resultAccumulator.onBulkWriteCommandOkResponseOrNoResponse(
-                    batchStartModelIndex, response, batchEncoder.intoEncodedBatchInfo()));
-        }).onErrorIf(throwable -> true, (t, c) -> {
-            if (t instanceof MongoWriteConcernWithResponseException) {
-                MongoWriteConcernWithResponseException mongoWriteConcernWithOkResponseException = (MongoWriteConcernWithResponseException) t;
-                c.complete(resultAccumulator.onBulkWriteCommandOkResponseWithWriteConcernError(
-                        batchStartModelIndex, mongoWriteConcernWithOkResponseException, batchEncoder.intoEncodedBatchInfo()));
-            } else if (t instanceof MongoCommandException) {
-                MongoCommandException bulkWriteCommandException = (MongoCommandException) t;
-                resultAccumulator.onBulkWriteCommandErrorResponse(bulkWriteCommandException);
-                c.completeExceptionally(t);
-            } else if (t instanceof MongoException) {
-                MongoException mongoException = (MongoException) t;
-                resultAccumulator.onBulkWriteCommandErrorWithoutResponse(mongoException);
-                if (retryWritesSetting) {
-                    // Adding the `RetryableError` label here is unnecessary at this point:
-                    // applications cannot use it for implementing retries, and it is not even part of the public driver API.
-                    // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
-                    getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(retryState, mongoException);
+            beginAsync().<ExhaustiveClientBulkWriteCommandOkResponse>thenSupply(executorCallback -> {
+                retryingBatchExecutor.get(executorCallback);
+            }).<Integer>thenApply((response, transformResponseCallback) -> {
+                transformResponseCallback.complete(resultAccumulator.onBulkWriteCommandOkResponseOrNoResponse(
+                        batchStartModelIndex, response, batchEncoder.intoEncodedBatchInfo()));
+            }).onErrorIf(throwable -> true, (t, onErrorCallback) -> {
+                if (t instanceof MongoWriteConcernWithResponseException) {
+                    MongoWriteConcernWithResponseException mongoWriteConcernWithOkResponseException = (MongoWriteConcernWithResponseException) t;
+                    onErrorCallback.complete(resultAccumulator.onBulkWriteCommandOkResponseWithWriteConcernError(
+                            batchStartModelIndex, mongoWriteConcernWithOkResponseException, batchEncoder.intoEncodedBatchInfo()));
+                } else if (t instanceof MongoCommandException) {
+                    MongoCommandException bulkWriteCommandException = (MongoCommandException) t;
+                    resultAccumulator.onBulkWriteCommandErrorResponse(bulkWriteCommandException);
+                    throw bulkWriteCommandException;
+                } else if (t instanceof MongoException) {
+                    MongoException mongoException = (MongoException) t;
+                    resultAccumulator.onBulkWriteCommandErrorWithoutResponse(mongoException);
+                    if (retryWritesSetting) {
+                        // Adding the `RetryableError` label here is unnecessary at this point:
+                        // applications cannot use it for implementing retries, and it is not even part of the public driver API.
+                        // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
+                        getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(retryState, mongoException);
+                    }
+                    throw mongoException;
+                } else {
+                    onErrorCallback.completeExceptionally(t);
                 }
-                c.completeExceptionally(mongoException);
-            } else {
-                c.completeExceptionally(t);
-            }
+            }).finish(c);
         }).finish(callback);
     }
 
@@ -464,8 +472,8 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
                 doWithRetriesDisabledAsync(retryState, (actionCallback) -> {
                     exhaustBulkWriteCommandOkResponseCursorAsync(connectionSource, connection, response, operationContext, actionCallback);
                 }, exhaustCallback);
-            }).<ExhaustiveClientBulkWriteCommandOkResponse>thenApply((cursorExhaustBatches, exhaustCallback) -> {
-                exhaustCallback.complete(createExhaustiveClientBulkWriteCommandOkResponse(
+            }).<ExhaustiveClientBulkWriteCommandOkResponse>thenApply((cursorExhaustBatches, transformExhaustionResultCallback) -> {
+                transformExhaustionResultCallback.complete(createExhaustiveClientBulkWriteCommandOkResponse(
                         response,
                         cursorExhaustBatches,
                         connection.getDescription()));
@@ -519,15 +527,17 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
             final RetryState retryState,
             final AsyncSupplier<R> action,
             final SingleResultCallback<R> callback) {
-        // TODO-JAVA-5956 The current implementation incorrectly uses `retryableWriteCommandFlag` to achieve the behavior needed.
-        Optional<Boolean> originalRetryableWriteCommandFlag = retryState.attachment(AttachmentKeys.retryableWriteCommandFlag());
-
         beginAsync().<R>thenSupply(c -> {
-            retryState.attach(AttachmentKeys.retryableWriteCommandFlag(), false, true);
-            action.finish(c);
-        }).thenAlwaysRunAndFinish(() -> {
-            originalRetryableWriteCommandFlag.ifPresent(value -> retryState.attach(AttachmentKeys.retryableWriteCommandFlag(), value, true));
-        }, callback);
+            // TODO-JAVA-5956 The current implementation incorrectly uses `retryableWriteCommandFlag` to achieve the behavior needed.
+            Optional<Boolean> originalRetryableWriteCommandFlag = retryState.attachment(AttachmentKeys.retryableWriteCommandFlag());
+
+            beginAsync().<R>thenSupply(actionCallback -> {
+                retryState.attach(AttachmentKeys.retryableWriteCommandFlag(), false, true);
+                action.finish(actionCallback);
+            }).thenAlwaysRunAndFinish(() -> {
+                originalRetryableWriteCommandFlag.ifPresent(value -> retryState.attach(AttachmentKeys.retryableWriteCommandFlag(), value, true));
+            }, c);
+        }).finish(callback);
     }
 
     private List<List<BsonDocument>> exhaustBulkWriteCommandOkResponseCursor(
@@ -555,21 +565,23 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
             final ClientBulkWriteCommandOkResponse response,
             final OperationContext operationContext,
             final SingleResultCallback<List<List<BsonDocument>>> callback) {
-        AsyncBatchCursor<BsonDocument> cursor = cursorDocumentToAsyncBatchCursor(
-                TimeoutMode.CURSOR_LIFETIME,
-                response.getDocument(),
-                SERVER_DEFAULT_CURSOR_BATCH_SIZE,
-                codecRegistry.get(BsonDocument.class),
-                options.getComment().orElse(null),
-                connectionSource,
-                connection,
-                operationContext);
-
         beginAsync().<List<List<BsonDocument>>>thenSupply(c -> {
-             cursor.exhaust(c);
-        }).thenAlwaysRunAndFinish(() -> {
-             cursor.close();
-        }, callback);
+            AsyncBatchCursor<BsonDocument> cursor = cursorDocumentToAsyncBatchCursor(
+                    TimeoutMode.CURSOR_LIFETIME,
+                    response.getDocument(),
+                    SERVER_DEFAULT_CURSOR_BATCH_SIZE,
+                    codecRegistry.get(BsonDocument.class),
+                    options.getComment().orElse(null),
+                    connectionSource,
+                    connection,
+                    operationContext);
+
+            beginAsync().<List<List<BsonDocument>>>thenSupply(exhaustCallback -> {
+                cursor.exhaust(exhaustCallback);
+            }).thenAlwaysRunAndFinish(() -> {
+                cursor.close();
+            }, c);
+        }).finish(callback);
     }
 
     private ClientBulkWriteCommand createBulkWriteCommand(

--- a/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
@@ -89,7 +89,6 @@ import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.internal.validator.ReplacingDocumentFieldNameValidator;
 import com.mongodb.internal.validator.UpdateFieldNameValidator;
 import com.mongodb.lang.Nullable;
-import org.bson.BsonArray;
 import org.bson.BsonBinaryWriter;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -180,12 +179,11 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
 
     @Override
     public String getCommandName() {
-        return "bulkWrite";
+        return BULK_WRITE_COMMAND_NAME;
     }
 
     @Override
     public MongoNamespace getNamespace() {
-        // The bulkWrite command is executed on the "admin" database.
         return ADMIN_DB_COMMAND_NAMESPACE;
     }
 
@@ -318,11 +316,13 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
             resultAccumulator.onBulkWriteCommandErrorResponse(bulkWriteCommandException);
             throw bulkWriteCommandException;
         } catch (MongoException mongoException) {
-            // The server does not have a chance to add "RetryableWriteError" label to `e`,
-            // and if it is the last attempt failure, `RetryingSyncSupplier` also may not have a chance
-            // to add the label. So we do that explicitly.
-            getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(retryState, mongoException);
             resultAccumulator.onBulkWriteCommandErrorWithoutResponse(mongoException);
+            if (retryWritesSetting) {
+                // Adding the `RetryableError` label here is unnecessary at this point:
+                // applications cannot use it for implementing retries, and it is not even part of the public driver API.
+                // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
+                getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(retryState, mongoException);
+            }
             throw mongoException;
         }
     }
@@ -383,11 +383,13 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
                 c.completeExceptionally(t);
             } else if (t instanceof MongoException) {
                 MongoException mongoException = (MongoException) t;
-                // The server does not have a chance to add "RetryableWriteError" label to `e`,
-                // and if it is the last attempt failure, `RetryingSyncSupplier` also may not have a chance
-                // to add the label. So we do that explicitly.
-                getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(retryState, mongoException);
                 resultAccumulator.onBulkWriteCommandErrorWithoutResponse(mongoException);
+                if (retryWritesSetting) {
+                    // Adding the `RetryableError` label here is unnecessary at this point:
+                    // applications cannot use it for implementing retries, and it is not even part of the public driver API.
+                    // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
+                    getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(retryState, mongoException);
+                }
                 c.completeExceptionally(mongoException);
             } else {
                 c.completeExceptionally(t);
@@ -471,14 +473,18 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
         }).finish(callback);
     }
 
+    /**
+     * @see #executeBulkWriteCommandAndExhaustOkResponse(RetryState, ConnectionSource, Connection, ClientBulkWriteCommand, WriteConcern, OperationContext)
+     */
     private static ExhaustiveClientBulkWriteCommandOkResponse createExhaustiveClientBulkWriteCommandOkResponse(
             final ClientBulkWriteCommandOkResponse response,
             final List<List<BsonDocument>> cursorExhaustBatches,
-            final ConnectionDescription connectionDescription) {
+            final ConnectionDescription connectionDescription) throws MongoWriteConcernWithResponseException {
         ExhaustiveClientBulkWriteCommandOkResponse exhaustiveResponse = new ExhaustiveClientBulkWriteCommandOkResponse(
                 response, cursorExhaustBatches);
 
-        // `Connection.command` does not throw `MongoWriteConcernException`, so we have to construct it ourselves
+        // Given that the response is OK, `Connection.command` does not throw an exception when the write concern is violated,
+        // so we have to construct such an exception ourselves.
         MongoWriteConcernException writeConcernException = Exceptions.createWriteConcernException(
                 response, connectionDescription.getServerAddress());
         if (writeConcernException != null) {
@@ -647,12 +653,9 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
             if (!responseDocument.containsKey(writeConcernErrorFieldName)) {
                 return null;
             }
-            BsonDocument writeConcernErrorDocument = responseDocument.getDocument(writeConcernErrorFieldName);
-            WriteConcernError writeConcernError = WriteConcernHelper.createWriteConcernError(writeConcernErrorDocument);
-            Set<String> errorLabels = responseDocument.getArray("errorLabels", new BsonArray()).stream()
-                    .map(i -> i.asString().getValue())
-                    .collect(toSet());
-            return new MongoWriteConcernException(writeConcernError, null, serverAddress, errorLabels);
+            // We do not use `MongoWriteConcernException.getWriteResult`,
+            // so we do not care what result `WriteConcernHelper.createWriteConcernException` puts there.
+            return WriteConcernHelper.createWriteConcernException(responseDocument, serverAddress);
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ClientBulkWriteOperation.java
@@ -292,7 +292,7 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
                 // and it is allowed by https://jira.mongodb.org/browse/DRIVERS-2502.
                 // If connection pinning is required, `binding` handles that,
                 // and `ClientSession`, `TransactionContext` are aware of that.
-                () -> withSourceAndConnection(binding::getWriteConnectionSource, true,
+                () -> withSourceAndConnection(binding::getWriteConnectionSource, true, operationContext,
                         (connectionSource, connection, operationContextWithMinRtt) -> {
                             ConnectionDescription connectionDescription = connection.getDescription();
                             boolean effectiveRetryWrites = isRetryableWrite(
@@ -306,7 +306,7 @@ public final class ClientBulkWriteOperation implements WriteOperation<ClientBulk
                                     () -> retryState.attach(AttachmentKeys.retryableWriteCommandFlag(), true, true));
                             return executeBulkWriteCommandAndExhaustOkResponse(
                                     retryState, connectionSource, connection, bulkWriteCommand, effectiveWriteConcern, operationContextWithMinRtt);
-                        }, operationContext)
+                        })
         );
 
         try {

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -32,6 +32,7 @@ import com.mongodb.connection.ServerDescription;
 import com.mongodb.internal.TimeoutContext;
 import com.mongodb.internal.async.function.RetryState;
 import com.mongodb.internal.connection.OperationContext;
+import com.mongodb.internal.connection.OperationContext.ServerDeprioritization;
 import com.mongodb.internal.operation.OperationHelper.ResourceSupplierInternalException;
 import com.mongodb.internal.operation.retry.AttachmentKeys;
 import com.mongodb.internal.session.SessionContext;
@@ -77,9 +78,9 @@ public final class CommandOperationHelper {
                 ConnectionDescription connectionDescription);
     }
 
-    static BinaryOperator<Throwable> onRetryableReadAttemptFailure(final OperationContext operationContext) {
+    static BinaryOperator<Throwable> onRetryableReadAttemptFailure(final ServerDeprioritization serverDeprioritization) {
         return (@Nullable Throwable previouslyChosenException, Throwable mostRecentAttemptException) -> {
-            operationContext.getServerDeprioritization().onAttemptFailure(mostRecentAttemptException);
+            serverDeprioritization.onAttemptFailure(mostRecentAttemptException);
             return chooseRetryableReadException(previouslyChosenException, mostRecentAttemptException);
         };
     }
@@ -96,9 +97,9 @@ public final class CommandOperationHelper {
         }
     }
 
-    static BinaryOperator<Throwable> onRetryableWriteAttemptFailure(final OperationContext operationContext) {
+    static BinaryOperator<Throwable> onRetryableWriteAttemptFailure(final ServerDeprioritization serverDeprioritization) {
         return (@Nullable Throwable previouslyChosenException, Throwable mostRecentAttemptException) -> {
-            operationContext.getServerDeprioritization().onAttemptFailure(mostRecentAttemptException);
+            serverDeprioritization.onAttemptFailure(mostRecentAttemptException);
             return chooseRetryableWriteException(previouslyChosenException, mostRecentAttemptException);
         };
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -177,7 +177,7 @@ public final class CommandOperationHelper {
     }
 
     static boolean loggingShouldAttemptToRetryWriteAndAddRetryableLabel(final RetryState retryState, final Throwable attemptFailure) {
-        Throwable attemptFailureNotToBeRetried = getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(retryState, attemptFailure);
+        Throwable attemptFailureNotToBeRetried = addRetryableLabelOrGetWriteAttemptFailureNotToBeRetried(retryState, attemptFailure);
         boolean decision = attemptFailureNotToBeRetried == null;
         if (!decision && retryState.attachment(AttachmentKeys.retryableWriteCommandFlag()).orElse(false)) {
             logUnableToRetryCommand(retryState, assertNotNull(attemptFailureNotToBeRetried));
@@ -186,10 +186,12 @@ public final class CommandOperationHelper {
     }
 
     /**
-     * @return {@code null} if the decision is {@code true}. Otherwise, returns the {@link Throwable} that must not be retried.
+     * Returns {@code null} if the failed attempt should be retried;
+     * in this case, also adds the {@value #RETRYABLE_WRITE_ERROR_LABEL} label if needed.
+     * Otherwise, returns a {@link Throwable} that must not be retried.
      */
     @Nullable
-    static Throwable getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(final RetryState retryState, final Throwable attemptFailure) {
+    static Throwable addRetryableLabelOrGetWriteAttemptFailureNotToBeRetried(final RetryState retryState, final Throwable attemptFailure) {
         Throwable failure = attemptFailure instanceof ResourceSupplierInternalException ? attemptFailure.getCause() : attemptFailure;
         boolean decision = false;
         MongoException exceptionRetryableRegardlessOfCommand = null;

--- a/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/FindOperation.java
@@ -301,7 +301,7 @@ public class FindOperation<T> implements ReadOperationExplainable<T> {
         OperationContext findOperationContext = getFindOperationContext(operationContext);
         RetryState retryState = initialRetryState(retryReads, findOperationContext.getTimeoutContext());
         Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, findOperationContext, () ->
-                withSourceAndConnection(binding::getReadConnectionSource, false,
+                withSourceAndConnection(binding::getReadConnectionSource, false, findOperationContext,
                         (source, connection, commandOperationContext) -> {
                             retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(commandOperationContext));
                 try {
@@ -311,7 +311,7 @@ public class FindOperation<T> implements ReadOperationExplainable<T> {
                 } catch (MongoCommandException e) {
                     throw new MongoQueryException(e.getResponse(), e.getServerAddress());
                 }
-          }, findOperationContext)
+          })
         );
         return read.get();
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListCollectionsOperation.java
@@ -177,7 +177,7 @@ public class ListCollectionsOperation<T> implements ReadOperationCursor<T> {
 
         RetryState retryState = initialRetryState(retryReads, listCollectionsOperationContext.getTimeoutContext());
         Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, listCollectionsOperationContext, () ->
-            withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection, operationContextWithMinRTT) -> {
+            withSourceAndConnection(binding::getReadConnectionSource, false, listCollectionsOperationContext, (source, connection, operationContextWithMinRTT) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(operationContextWithMinRTT));
                 try {
                     return createReadCommandAndExecute(retryState, operationContextWithMinRTT, source, databaseName,
@@ -186,7 +186,7 @@ public class ListCollectionsOperation<T> implements ReadOperationCursor<T> {
                     return rethrowIfNotNamespaceError(e,
                             createEmptySingleBatchCursor(source.getServerDescription().getAddress(), batchSize));
                 }
-            }, listCollectionsOperationContext)
+            })
         );
         return read.get();
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ListIndexesOperation.java
@@ -134,7 +134,7 @@ public class ListIndexesOperation<T> implements ReadOperationCursor<T> {
 
         RetryState retryState = initialRetryState(retryReads, listIndexesOperationContext.getTimeoutContext());
         Supplier<BatchCursor<T>> read = decorateReadWithRetries(retryState, listIndexesOperationContext, () ->
-            withSourceAndConnection(binding::getReadConnectionSource, false, (source, connection, operationContextWithMinRTT) -> {
+            withSourceAndConnection(binding::getReadConnectionSource, false, listIndexesOperationContext, (source, connection, operationContextWithMinRTT) -> {
                 retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(operationContextWithMinRTT));
                 try {
                     return createReadCommandAndExecute(retryState, operationContextWithMinRTT, source, namespace.getDatabaseName(),
@@ -143,7 +143,7 @@ public class ListIndexesOperation<T> implements ReadOperationCursor<T> {
                     return rethrowIfNotNamespaceError(e,
                             createEmptySingleBatchCursor(source.getServerDescription().getAddress(), batchSize));
                 }
-            }, listIndexesOperationContext)
+            })
         );
         return read.get();
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -147,8 +147,8 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
 
     private <R> Supplier<R> decorateWriteWithRetries(final RetryState retryState, final OperationContext operationContext,
             final Supplier<R> writeFunction) {
-        return new RetryingSyncSupplier<>(retryState, onRetryableWriteAttemptFailure(operationContext),
-                this::shouldAttemptToRetryWrite, () -> {
+        return new RetryingSyncSupplier<>(retryState, onRetryableWriteAttemptFailure(operationContext.getServerDeprioritization()),
+                MixedBulkWriteOperation::shouldAttemptToRetryWrite, () -> {
             logRetryCommand(retryState, operationContext);
             return writeFunction.get();
         });
@@ -156,14 +156,14 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
 
     private <R> AsyncCallbackSupplier<R> decorateWriteWithRetries(final RetryState retryState, final OperationContext operationContext,
             final AsyncCallbackSupplier<R> writeFunction) {
-        return new RetryingAsyncCallbackSupplier<>(retryState, onRetryableWriteAttemptFailure(operationContext),
-                this::shouldAttemptToRetryWrite, callback -> {
+        return new RetryingAsyncCallbackSupplier<>(retryState, onRetryableWriteAttemptFailure(operationContext.getServerDeprioritization()),
+                MixedBulkWriteOperation::shouldAttemptToRetryWrite, callback -> {
             logRetryCommand(retryState, operationContext);
             writeFunction.get(callback);
         });
     }
 
-    private boolean shouldAttemptToRetryWrite(final RetryState retryState, final Throwable attemptFailure) {
+    private static boolean shouldAttemptToRetryWrite(final RetryState retryState, final Throwable attemptFailure) {
         BulkWriteTracker bulkWriteTracker = retryState.attachment(AttachmentKeys.bulkWriteTracker()).orElseThrow(Assertions::fail);
         /* A retry predicate is called only if there is at least one more attempt left. Here we maintain attempt counters manually
          * and emulate the above contract by returning `false` at the very beginning of the retry predicate. */

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -407,9 +407,9 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
         return withSourceAndConnection(
                 binding::getWriteConnectionSource,
                 true,
+                operationContext,
                 (source, connection, operationContextWithMinRTT) ->
-                        new SourceAndConnection(source, connection, operationContextWithMinRTT),
-                operationContext);
+                        new SourceAndConnection(source, connection, operationContextWithMinRTT));
     }
 
     private static void selectServerAndCheckoutConnectionAsync(
@@ -575,9 +575,9 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
      * An {@link AutoCloseable} container for the arguments of
      * {@link SyncOperationHelper.ExecutionFunction#apply(ConnectionSource, Connection, OperationContext)}
      * provided by
-     * {@link SyncOperationHelper#withSourceAndConnection(Function, boolean, SyncOperationHelper.ExecutionFunction, OperationContext)}.
+     * {@link SyncOperationHelper#withSourceAndConnection(Function, boolean, OperationContext, SyncOperationHelper.ExecutionFunction)}.
      * This type allows those resources to be returned from
-     * {@link SyncOperationHelper#withSourceAndConnection(Function, boolean, SyncOperationHelper.ExecutionFunction, OperationContext)}
+     * {@link SyncOperationHelper#withSourceAndConnection(Function, boolean, OperationContext, SyncOperationHelper.ExecutionFunction)}
      * and used after method completion.
      */
     private static final class SourceAndConnection extends AbstractSourceAndConnection<ConnectionSource, Connection> {

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -19,12 +19,12 @@ package com.mongodb.internal.operation;
 import com.mongodb.MongoException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
-import com.mongodb.assertions.Assertions;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.internal.async.MutableValue;
 import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.async.function.AsyncCallbackFunction;
+import com.mongodb.internal.async.function.AsyncCallbackSupplier;
 import com.mongodb.internal.async.function.AsyncCallbackTriFunction;
 import com.mongodb.internal.async.function.RetryState;
 import com.mongodb.internal.binding.AsyncConnectionSource;
@@ -57,6 +57,9 @@ import java.util.stream.Collectors;
 import static com.mongodb.assertions.Assertions.assertFalse;
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.async.AsyncRunnable.beginAsync;
+import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWriteWithRetriesAsync;
+import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncSourceAndConnection;
 import static com.mongodb.internal.operation.CommandOperationHelper.addRetryableWriteErrorLabel;
 import static com.mongodb.internal.operation.CommandOperationHelper.getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel;
 import static com.mongodb.internal.operation.CommandOperationHelper.initialRetryState;
@@ -159,7 +162,14 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
             final AsyncWriteBinding binding,
             final OperationContext operationContext,
             final SingleResultCallback<BulkWriteResult> callback) {
-        callback.completeExceptionally(Assertions.fail("VAKOTODO implement"));
+        beginAsync().<BulkWriteResult>thenSupply(c -> {
+            WriteConcern effectiveWriteConcern = validateAndGetEffectiveWriteConcern(writeConcern, operationContext.getSessionContext());
+            beginAsync().<BulkWriteResult>thenSupply(executeAllBatchesCallback -> {
+                executeAllBatchesAsync(effectiveWriteConcern, binding, operationContext, executeAllBatchesCallback);
+            }).onErrorIf(e -> e instanceof MongoException, (e, onErrorCallback) -> {
+                throw transformWriteException((MongoException) e);
+            }).finish(c);
+        }).finish(callback);
     }
 
     private BulkWriteResult executeAllBatches(
@@ -190,7 +200,31 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
             final AsyncWriteBinding binding,
             final OperationContext operationContext,
             final SingleResultCallback<BulkWriteResult> callback) {
-        callback.completeExceptionally(Assertions.fail("VAKOTODO implement"));
+        beginAsync().<BulkWriteResult>thenSupply(c -> {
+            MutableValue<AsyncSourceAndConnection> sourceAndConnection = new MutableValue<>();
+            beginAsync().<BulkWriteResult>thenSupply(loopCallback -> {
+                MutableValue<BulkWriteBatch> nextBatch = new MutableValue<>();
+                beginAsync().thenRunDoWhileLoop(iterationCallback -> {
+                    beginAsync().<BatchWithSourceAndConnection<AsyncSourceAndConnection>>thenSupply(executeBatchCallback -> {
+                        executeBatchReusingConnectionAsync(
+                                nextBatch.getNullable(), sourceAndConnection.getNullable(), effectiveWriteConcern, binding, operationContext, executeBatchCallback);
+                    }).thenConsume((nextBatchWithSourceAndConnection, consumeExecutionResultCallback) -> {
+                        try (BatchWithSourceAndConnection<AsyncSourceAndConnection> ignoredAndAutoClosed = nextBatchWithSourceAndConnection) {
+                            nextBatch.set(nextBatchWithSourceAndConnection.getBatch());
+                            sourceAndConnection.set(nextBatchWithSourceAndConnection.intoSourceAndConnection());
+                        }
+                        consumeExecutionResultCallback.complete(consumeExecutionResultCallback);
+                    }).finish(iterationCallback);
+                }, () -> nextBatch.get().shouldProcessBatch())
+                .<BulkWriteResult>thenSupply(resultCallback -> {
+                    resultCallback.complete(nextBatch.get().getResult());
+                }).finish(loopCallback);
+            }).thenAlwaysRunAndFinish(() -> {
+                if (sourceAndConnection.getNullable() != null) {
+                    sourceAndConnection.get().close();
+                }
+            }, c);
+        }).finish(callback);
     }
 
     /**
@@ -261,7 +295,58 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
             final AsyncWriteBinding binding,
             final OperationContext operationContextForSelectServerAndCheckoutConnection,
             final SingleResultCallback<BatchWithSourceAndConnection<AsyncSourceAndConnection>> callback) {
-        callback.completeExceptionally(Assertions.fail("VAKOTODO implement"));
+        beginAsync().<BatchWithSourceAndConnection<AsyncSourceAndConnection>>thenSupply(c -> {
+            MutableValue<BulkWriteBatch> batch = new MutableValue<>(maybeBatch);
+            MutableValue<AsyncSourceAndConnection> sourceAndConnection = new MutableValue<>(maybeSourceAndConnection);
+            RetryState retryState = initialRetryState(
+                    retryWrites, operationContextForSelectServerAndCheckoutConnection.getTimeoutContext());
+            AsyncCallbackSupplier<BatchWithSourceAndConnection<AsyncSourceAndConnection>> retryingBatchExecutor = decorateWriteWithRetriesAsync(
+                    retryState,
+                    operationContextForSelectServerAndCheckoutConnection,
+                    supplierCallback -> {
+                        beginAsync().<AsyncSourceAndConnection>thenSupply(reuseOrSelectServerAndCheckoutConnectionCallback -> {
+                            reuseOrSelectServerAndCheckoutConnectionIfClosedAsync(
+                                    sourceAndConnection.getNullable(), effectiveWriteConcern, binding,
+                                    operationContextForSelectServerAndCheckoutConnection, retryState, reuseOrSelectServerAndCheckoutConnectionCallback);
+                        }).<BatchWithSourceAndConnection<AsyncSourceAndConnection>>thenApply((reusedOrNewSourceAndConnection, setSourceAndConnectionCallback) -> {
+                            beginAsync().thenRun(executeBatchCallback -> {
+                                sourceAndConnection.set(reusedOrNewSourceAndConnection);
+                                ConnectionDescription connectionDescription = reusedOrNewSourceAndConnection.getConnection().getDescription();
+                                retryState.attach(AttachmentKeys.maxWireVersion(), connectionDescription.getMaxWireVersion(), true);
+                                batch.set(batch.getNullable() != null
+                                        ? batch.get()
+                                        : createFirstBatch(connectionDescription, reusedOrNewSourceAndConnection.getOperationContext(), effectiveWriteConcern));
+                                onBatch(batch.get(), retryState);
+                                executeBatchAsync(batch.get(), reusedOrNewSourceAndConnection, effectiveWriteConcern, executeBatchCallback);
+                            }).<BatchWithSourceAndConnection<AsyncSourceAndConnection>>thenSupply(createNextBatchCallback -> {
+                                createNextBatchCallback.complete(new BatchWithSourceAndConnection<>(batch.get().getNextBatch(), reusedOrNewSourceAndConnection));
+                            }).onErrorIf(e -> true, (e, onErrorCallback) -> {
+                                reusedOrNewSourceAndConnection.close();
+                                onErrorCallback.completeExceptionally(e);
+                            }).finish(setSourceAndConnectionCallback);
+                        }).finish(supplierCallback);
+                    }
+            );
+            beginAsync().<BatchWithSourceAndConnection<AsyncSourceAndConnection>>thenSupply(executorCallback -> {
+                retryingBatchExecutor.get(executorCallback);
+            }).onErrorIf(e -> true, (e, onErrorCallback) -> {
+                if (sourceAndConnection.getNullable() != null) {
+                    sourceAndConnection.get().close();
+                }
+                if (e instanceof MongoWriteConcernWithResponseException) {
+                    batch.get().addResult((BsonDocument) ((MongoWriteConcernWithResponseException) e).getResponse());
+                    onErrorCallback.complete(new BatchWithSourceAndConnection<>(batch.get().getNextBatch(), null));
+                    return;
+                }
+                if (retryWrites && e instanceof MongoException) {
+                    // Adding the `RetryableError` label here is unnecessary at this point:
+                    // applications cannot use it for implementing retries, and it is not even part of the public driver API.
+                    // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
+                    getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(retryState, e);
+                }
+                onErrorCallback.completeExceptionally(e);
+            }).finish(c);
+        }).finish(callback);
     }
 
     private SourceAndConnection reuseOrSelectServerAndCheckoutConnectionIfClosed(
@@ -294,7 +379,26 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
             final OperationContext operationContext,
             final RetryState retryState,
             final SingleResultCallback<AsyncSourceAndConnection> callback) {
-        callback.completeExceptionally(Assertions.fail("VAKOTODO implement"));
+        beginAsync().<AsyncSourceAndConnection>thenSupply(c -> {
+            if (sourceAndConnection == null || sourceAndConnection.isClosed()) {
+                beginAsync().<AsyncSourceAndConnection>thenSupply(selectServerAndCheckoutConnectionCallback -> {
+                    selectServerAndCheckoutConnectionAsync(binding, operationContext, selectServerAndCheckoutConnectionCallback);
+                }).<AsyncSourceAndConnection>thenApply((newSourceAndConnection, onNewConnectionCallback) -> {
+                    try {
+                        onNewConnection(
+                                newSourceAndConnection.getConnection().getDescription(),
+                                newSourceAndConnection.getOperationContext().getSessionContext(),
+                                effectiveWriteConcern, retryState);
+                    } catch (Throwable e) {
+                        newSourceAndConnection.close();
+                        throw e;
+                    }
+                    onNewConnectionCallback.complete(newSourceAndConnection);
+                }).finish(c);
+            } else {
+                c.complete(sourceAndConnection);
+            }
+        }).finish(callback);
     }
 
     private static SourceAndConnection selectServerAndCheckoutConnection(
@@ -312,7 +416,15 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
             final AsyncWriteBinding binding,
             final OperationContext operationContext,
             final SingleResultCallback<AsyncSourceAndConnection> callback) {
-        callback.completeExceptionally(Assertions.fail("VAKOTODO implement"));
+        beginAsync().<AsyncSourceAndConnection>thenSupply(c -> {
+            withAsyncSourceAndConnection(
+                    binding::getWriteConnectionSource,
+                    true,
+                    operationContext,
+                    c,
+                    (source, connection, operationContextWithMinRTT, functionCallback) ->
+                            functionCallback.complete(new AsyncSourceAndConnection(source, connection, operationContextWithMinRTT)));
+        }).finish(callback);
     }
 
     private void onNewConnection(
@@ -374,7 +486,30 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
             final AsyncSourceAndConnection sourceAndConnection,
             final WriteConcern effectiveWriteConcern,
             final SingleResultCallback<Void> callback) {
-        callback.completeExceptionally(Assertions.fail("VAKOTODO implement"));
+        beginAsync().thenRun(c -> {
+            AsyncConnection connection = sourceAndConnection.getConnection();
+            OperationContext operationContext = sourceAndConnection.getOperationContext();
+            beginAsync().<BsonDocument>thenSupply(commandCallback -> {
+                connection.commandAsync(
+                        namespace.getDatabaseName(), batch.getCommand(),
+                        NoOpFieldNameValidator.INSTANCE, null,
+                        batch.getDecoder(), operationContext.withOperationName(commandName),
+                        shouldExpectResponse(batch, effectiveWriteConcern), batch.getPayload(), commandCallback);
+            }).thenConsume((result, consumeCommandResultCallback) -> {
+                if (batch.getRetryWrites()) {
+                    ConnectionDescription connectionDescription = connection.getDescription();
+                    MongoException writeConcernBasedError = ProtocolHelper.createSpecialException(
+                            result, connectionDescription.getServerAddress(), "errMsg", operationContext.getTimeoutContext());
+                    if (writeConcernBasedError != null) {
+                        addRetryableWriteErrorLabel(writeConcernBasedError, connectionDescription.getMaxWireVersion());
+                        addErrorLabelsToWriteConcern(result.getDocument("writeConcernError"), writeConcernBasedError.getErrorLabels());
+                        throw new MongoWriteConcernWithResponseException(writeConcernBasedError, result);
+                    }
+                }
+                batch.addResult(result);
+                consumeCommandResultCallback.complete(consumeCommandResultCallback);
+            }).finish(c);
+        }).finish(callback);
     }
 
     private boolean shouldExpectResponse(final BulkWriteBatch batch, final WriteConcern effectiveWriteConcern) {

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -61,7 +61,7 @@ import static com.mongodb.internal.async.AsyncRunnable.beginAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.decorateWriteWithRetriesAsync;
 import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncSourceAndConnection;
 import static com.mongodb.internal.operation.CommandOperationHelper.addRetryableWriteErrorLabel;
-import static com.mongodb.internal.operation.CommandOperationHelper.getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel;
+import static com.mongodb.internal.operation.CommandOperationHelper.addRetryableLabelOrGetWriteAttemptFailureNotToBeRetried;
 import static com.mongodb.internal.operation.CommandOperationHelper.initialRetryState;
 import static com.mongodb.internal.operation.CommandOperationHelper.transformWriteException;
 import static com.mongodb.internal.operation.CommandOperationHelper.validateAndGetEffectiveWriteConcern;
@@ -278,7 +278,7 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
                 // Adding the `RetryableError` label here is unnecessary at this point:
                 // applications cannot use it for implementing retries, and it is not even part of the public driver API.
                 // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
-                getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(retryState, e);
+                addRetryableLabelOrGetWriteAttemptFailureNotToBeRetried(retryState, e);
             }
             throw e;
         }
@@ -342,7 +342,7 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
                     // Adding the `RetryableError` label here is unnecessary at this point:
                     // applications cannot use it for implementing retries, and it is not even part of the public driver API.
                     // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
-                    getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(retryState, e);
+                    addRetryableLabelOrGetWriteAttemptFailureNotToBeRetried(retryState, e);
                 }
                 onErrorCallback.completeExceptionally(e);
             }).finish(c);

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -22,16 +22,15 @@ import com.mongodb.WriteConcern;
 import com.mongodb.assertions.Assertions;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.connection.ConnectionDescription;
-import com.mongodb.internal.TimeoutContext;
+import com.mongodb.internal.async.MutableValue;
 import com.mongodb.internal.async.SingleResultCallback;
-import com.mongodb.internal.async.function.AsyncCallbackLoop;
-import com.mongodb.internal.async.function.AsyncCallbackRunnable;
-import com.mongodb.internal.async.function.AsyncCallbackSupplier;
-import com.mongodb.internal.async.function.LoopState;
+import com.mongodb.internal.async.function.AsyncCallbackFunction;
+import com.mongodb.internal.async.function.AsyncCallbackTriFunction;
 import com.mongodb.internal.async.function.RetryState;
-import com.mongodb.internal.async.function.RetryingAsyncCallbackSupplier;
-import com.mongodb.internal.async.function.RetryingSyncSupplier;
+import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.binding.AsyncWriteBinding;
+import com.mongodb.internal.binding.ConnectionSource;
+import com.mongodb.internal.binding.ReferenceCounted;
 import com.mongodb.internal.binding.WriteBinding;
 import com.mongodb.internal.bulk.WriteRequest;
 import com.mongodb.internal.connection.AsyncConnection;
@@ -50,27 +49,22 @@ import org.bson.BsonValue;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static com.mongodb.assertions.Assertions.assertTrue;
+import static com.mongodb.assertions.Assertions.assertFalse;
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
-import static com.mongodb.internal.operation.AsyncOperationHelper.exceptionTransformingCallback;
-import static com.mongodb.internal.operation.AsyncOperationHelper.withAsyncSourceAndConnection;
 import static com.mongodb.internal.operation.CommandOperationHelper.addRetryableWriteErrorLabel;
-import static com.mongodb.internal.operation.CommandOperationHelper.logRetryCommand;
-import static com.mongodb.internal.operation.CommandOperationHelper.loggingShouldAttemptToRetryWriteAndAddRetryableLabel;
-import static com.mongodb.internal.operation.CommandOperationHelper.onRetryableWriteAttemptFailure;
+import static com.mongodb.internal.operation.CommandOperationHelper.getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel;
+import static com.mongodb.internal.operation.CommandOperationHelper.initialRetryState;
 import static com.mongodb.internal.operation.CommandOperationHelper.transformWriteException;
 import static com.mongodb.internal.operation.CommandOperationHelper.validateAndGetEffectiveWriteConcern;
-import static com.mongodb.internal.operation.OperationHelper.LOGGER;
 import static com.mongodb.internal.operation.OperationHelper.isRetryableWrite;
 import static com.mongodb.internal.operation.OperationHelper.validateWriteRequests;
-import static com.mongodb.internal.operation.OperationHelper.validateWriteRequestsAndCompleteIfInvalid;
+import static com.mongodb.internal.operation.SyncOperationHelper.decorateWriteWithRetries;
 import static com.mongodb.internal.operation.SyncOperationHelper.withSourceAndConnection;
 
 /**
@@ -145,41 +139,6 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
         return retryWrites;
     }
 
-    private <R> Supplier<R> decorateWriteWithRetries(final RetryState retryState, final OperationContext operationContext,
-            final Supplier<R> writeFunction) {
-        return new RetryingSyncSupplier<>(retryState, onRetryableWriteAttemptFailure(operationContext.getServerDeprioritization()),
-                MixedBulkWriteOperation::shouldAttemptToRetryWrite, () -> {
-            logRetryCommand(retryState, operationContext);
-            return writeFunction.get();
-        });
-    }
-
-    private <R> AsyncCallbackSupplier<R> decorateWriteWithRetries(final RetryState retryState, final OperationContext operationContext,
-            final AsyncCallbackSupplier<R> writeFunction) {
-        return new RetryingAsyncCallbackSupplier<>(retryState, onRetryableWriteAttemptFailure(operationContext.getServerDeprioritization()),
-                MixedBulkWriteOperation::shouldAttemptToRetryWrite, callback -> {
-            logRetryCommand(retryState, operationContext);
-            writeFunction.get(callback);
-        });
-    }
-
-    private static boolean shouldAttemptToRetryWrite(final RetryState retryState, final Throwable attemptFailure) {
-        BulkWriteTracker bulkWriteTracker = retryState.attachment(AttachmentKeys.bulkWriteTracker()).orElseThrow(Assertions::fail);
-        /* A retry predicate is called only if there is at least one more attempt left. Here we maintain attempt counters manually
-         * and emulate the above contract by returning `false` at the very beginning of the retry predicate. */
-        if (bulkWriteTracker.lastAttempt()) {
-            return false;
-        }
-        boolean decision = loggingShouldAttemptToRetryWriteAndAddRetryableLabel(retryState, attemptFailure);
-        if (decision) {
-            /* The attempt counter maintained by `RetryState` is updated after (in the happens-before order) testing a retry predicate,
-             * and only if the predicate completes normally. Here we maintain attempt counters manually, and we emulate the
-             * "after completion" part by updating the counter at the very end of the retry predicate. */
-            bulkWriteTracker.advance();
-        }
-        return decision;
-    }
-
     @Override
     public String getCommandName() {
         return commandName;
@@ -187,329 +146,376 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
 
     @Override
     public BulkWriteResult execute(final WriteBinding binding, final OperationContext operationContext) {
-        /* We cannot use the tracking of attempts built in the `RetryState` class because conceptually we have to maintain multiple attempt
-         * counters while executing a single bulk write operation:
-         * - a counter that limits attempts to select server and checkout a connection before we created a batch;
-         * - a counter per each batch that limits attempts to execute the specific batch.
-         * Fortunately, these counters do not exist concurrently with each other. While maintaining the counters manually,
-         * we must adhere to the contract of `RetryingSyncSupplier`. When the retry timeout is implemented, there will be no counters,
-         * and the code related to the attempt tracking in `BulkWriteTracker` will be removed. */
-        RetryState retryState = new RetryState();
-        BulkWriteTracker.attachNew(retryState, retryWrites, operationContext.getTimeoutContext());
-        Supplier<BulkWriteResult> retryingBulkWrite = decorateWriteWithRetries(retryState, operationContext, () ->
-            withSourceAndConnection(binding::getWriteConnectionSource, true, (source, connection, operationContextWithMinRTT) -> {
-                TimeoutContext timeoutContextWithMinRtt = operationContextWithMinRTT.getTimeoutContext();
-                ConnectionDescription connectionDescription = connection.getDescription();
-                // attach `maxWireVersion` ASAP because it is used to check whether we can retry
-                retryState.attach(AttachmentKeys.maxWireVersion(), connectionDescription.getMaxWireVersion(), true);
-                SessionContext sessionContext = operationContext.getSessionContext();
-                WriteConcern writeConcern = validateAndGetEffectiveWriteConcern(this.writeConcern, sessionContext);
-                if (!isRetryableWrite(retryWrites, writeConcern, connectionDescription, sessionContext)) {
-                    handleMongoWriteConcernWithResponseException(retryState, true, timeoutContextWithMinRtt);
-                }
-                validateWriteRequests(connectionDescription, bypassDocumentValidation, writeRequests, writeConcern);
-                if (!retryState.attachment(AttachmentKeys.bulkWriteTracker()).orElseThrow(Assertions::fail).batch().isPresent()) {
-                    BulkWriteTracker.attachNew(retryState, BulkWriteBatch.createBulkWriteBatch(namespace,
-                            connectionDescription, ordered, writeConcern,
-                                    bypassDocumentValidation, retryWrites, writeRequests, operationContextWithMinRTT, comment, variables),
-                            timeoutContextWithMinRtt);
-                }
-                return executeBulkWriteBatch(retryState, writeConcern, operationContextWithMinRTT, connection);
-            }, operationContext)
-        );
+        WriteConcern effectiveWriteConcern = validateAndGetEffectiveWriteConcern(writeConcern, operationContext.getSessionContext());
         try {
-            return retryingBulkWrite.get();
+            return executeAllBatches(effectiveWriteConcern, binding, operationContext);
         } catch (MongoException e) {
             throw transformWriteException(e);
         }
     }
 
-    public void executeAsync(final AsyncWriteBinding binding, final OperationContext operationContext, final SingleResultCallback<BulkWriteResult> callback) {
-        // see the comment in `execute(WriteBinding)` explaining the manual tracking of attempts
-        RetryState retryState = new RetryState();
-        BulkWriteTracker.attachNew(retryState, retryWrites, operationContext.getTimeoutContext());
-        binding.retain();
-        AsyncCallbackSupplier<BulkWriteResult> retryingBulkWrite = this.<BulkWriteResult>decorateWriteWithRetries(retryState,
-                operationContext,
-                funcCallback ->
-            withAsyncSourceAndConnection(binding::getWriteConnectionSource, true, operationContext, funcCallback,
-                    (source, connection, operationContextWithMinRtt, releasingCallback) -> {
-                TimeoutContext timeoutContextWithMinRtt = operationContextWithMinRtt.getTimeoutContext();
-                ConnectionDescription connectionDescription = connection.getDescription();
-
-                // attach `maxWireVersion` ASAP because it is used to check whether we can retry
-                retryState.attach(AttachmentKeys.maxWireVersion(), connectionDescription.getMaxWireVersion(), true);
-                SessionContext sessionContext = operationContextWithMinRtt.getSessionContext();
-                WriteConcern writeConcern = validateAndGetEffectiveWriteConcern(this.writeConcern, sessionContext);
-                        if (!isRetryableWrite(retryWrites, writeConcern, connectionDescription, sessionContext)
-                        && handleMongoWriteConcernWithResponseExceptionAsync(retryState, releasingCallback, timeoutContextWithMinRtt)) {
-                    return;
-                }
-                if (validateWriteRequestsAndCompleteIfInvalid(connectionDescription, bypassDocumentValidation, writeRequests,
-                        writeConcern, releasingCallback)) {
-                    return;
-                }
-                try {
-                    if (!retryState.attachment(AttachmentKeys.bulkWriteTracker()).orElseThrow(Assertions::fail).batch().isPresent()) {
-                        BulkWriteTracker.attachNew(retryState, BulkWriteBatch.createBulkWriteBatch(namespace,
-                                connectionDescription, ordered, writeConcern,
-                                bypassDocumentValidation, retryWrites, writeRequests, operationContextWithMinRtt, comment, variables), timeoutContextWithMinRtt);
-                    }
-                } catch (Throwable t) {
-                    releasingCallback.onResult(null, t);
-                    return;
-                }
-                executeBulkWriteBatchAsync(retryState, writeConcern, operationContextWithMinRtt, connection, releasingCallback);
-            })
-        ).whenComplete(binding::release);
-        retryingBulkWrite.get(exceptionTransformingCallback(errorHandlingCallback(callback, LOGGER)));
+    @Override
+    public void executeAsync(
+            final AsyncWriteBinding binding,
+            final OperationContext operationContext,
+            final SingleResultCallback<BulkWriteResult> callback) {
+        callback.completeExceptionally(Assertions.fail("VAKOTODO implement"));
     }
 
-    private BulkWriteResult executeBulkWriteBatch(
-            final RetryState retryState,
+    private BulkWriteResult executeAllBatches(
             final WriteConcern effectiveWriteConcern,
-            final OperationContext operationContext,
-            final Connection connection) {
-        BulkWriteTracker currentBulkWriteTracker = retryState.attachment(AttachmentKeys.bulkWriteTracker())
-                .orElseThrow(Assertions::fail);
-        BulkWriteBatch currentBatch = currentBulkWriteTracker.batch().orElseThrow(Assertions::fail);
-        int maxWireVersion = connection.getDescription().getMaxWireVersion();
-        TimeoutContext timeoutContext = operationContext.getTimeoutContext();
-
-        while (currentBatch.shouldProcessBatch()) {
-            try {
-                BsonDocument result = executeCommand(effectiveWriteConcern, operationContext, connection, currentBatch);
-                if (currentBatch.getRetryWrites() && !operationContext.getSessionContext().hasActiveTransaction()) {
-                    MongoException writeConcernBasedError = ProtocolHelper.createSpecialException(result,
-                            connection.getDescription().getServerAddress(), "errMsg", timeoutContext);
-                    if (writeConcernBasedError != null) {
-                        if (currentBulkWriteTracker.lastAttempt()) {
-                            addRetryableWriteErrorLabel(writeConcernBasedError, maxWireVersion);
-                            addErrorLabelsToWriteConcern(result.getDocument("writeConcernError"), writeConcernBasedError.getErrorLabels());
-                        } else if (loggingShouldAttemptToRetryWriteAndAddRetryableLabel(retryState, writeConcernBasedError)) {
-                            throw new MongoWriteConcernWithResponseException(writeConcernBasedError, result);
-                        }
-                    }
+            final WriteBinding binding,
+            final OperationContext operationContext) {
+        SourceAndConnection sourceAndConnection = null;
+        try {
+            BulkWriteBatch nextBatch = null;
+            do {
+                BatchWithSourceAndConnection<SourceAndConnection> nextBatchWithSourceAndConnection = executeBatchReusingConnection(
+                        nextBatch, sourceAndConnection, effectiveWriteConcern, binding, operationContext);
+                try (BatchWithSourceAndConnection<SourceAndConnection> ignoredAndAutoClosed = nextBatchWithSourceAndConnection) {
+                    nextBatch = nextBatchWithSourceAndConnection.getBatch();
+                    sourceAndConnection = nextBatchWithSourceAndConnection.intoSourceAndConnection();
                 }
-                currentBatch.addResult(result);
-                currentBulkWriteTracker = BulkWriteTracker.attachNext(retryState, currentBatch, timeoutContext);
-                currentBatch = currentBulkWriteTracker.batch().orElseThrow(Assertions::fail);
-            } catch (MongoException exception) {
-                if (!retryState.isFirstAttempt() && !(exception instanceof MongoWriteConcernWithResponseException)) {
-                    addRetryableWriteErrorLabel(exception, maxWireVersion);
-                }
-                handleMongoWriteConcernWithResponseException(retryState, false, timeoutContext);
-                throw exception;
+            } while (nextBatch.shouldProcessBatch());
+            return nextBatch.getResult();
+        } finally {
+            if (sourceAndConnection != null) {
+                sourceAndConnection.close();
             }
         }
+    }
+
+    private void executeAllBatchesAsync(
+            final WriteConcern effectiveWriteConcern,
+            final AsyncWriteBinding binding,
+            final OperationContext operationContext,
+            final SingleResultCallback<BulkWriteResult> callback) {
+        callback.completeExceptionally(Assertions.fail("VAKOTODO implement"));
+    }
+
+    /**
+     * @param maybeSourceAndConnection Is guaranteed to be {@linkplain SourceAndConnection#close() closed}
+     * if this method creates a new {@link SourceAndConnection}.
+     */
+    private BatchWithSourceAndConnection<SourceAndConnection> executeBatchReusingConnection(
+            @Nullable final BulkWriteBatch maybeBatch,
+            @Nullable final SourceAndConnection maybeSourceAndConnection,
+            final WriteConcern effectiveWriteConcern,
+            final WriteBinding binding,
+            final OperationContext operationContextForSelectServerAndCheckoutConnection) {
+        MutableValue<BulkWriteBatch> batch = new MutableValue<>(maybeBatch);
+        MutableValue<SourceAndConnection> sourceAndConnection = new MutableValue<>(maybeSourceAndConnection);
+        RetryState retryState = initialRetryState(
+                retryWrites, operationContextForSelectServerAndCheckoutConnection.getTimeoutContext());
+        Supplier<BatchWithSourceAndConnection<SourceAndConnection>> retryingBatchExecutor = decorateWriteWithRetries(
+                retryState,
+                operationContextForSelectServerAndCheckoutConnection,
+                () -> {
+                    SourceAndConnection reusedOrNewSourceAndConnection = reuseOrSelectServerAndCheckoutConnectionIfClosed(
+                            sourceAndConnection.getNullable(), effectiveWriteConcern, binding,
+                            operationContextForSelectServerAndCheckoutConnection, retryState);
+                    try {
+                        sourceAndConnection.set(reusedOrNewSourceAndConnection);
+                        ConnectionDescription connectionDescription = reusedOrNewSourceAndConnection.getConnection().getDescription();
+                        retryState.attach(AttachmentKeys.maxWireVersion(), connectionDescription.getMaxWireVersion(), true);
+                        batch.set(batch.getNullable() != null
+                                ? batch.get()
+                                : createFirstBatch(connectionDescription, reusedOrNewSourceAndConnection.getOperationContext(), effectiveWriteConcern));
+                        onBatch(batch.get(), retryState);
+                        executeBatch(batch.get(), reusedOrNewSourceAndConnection, effectiveWriteConcern);
+                        return new BatchWithSourceAndConnection<>(batch.get().getNextBatch(), reusedOrNewSourceAndConnection);
+                    } catch (Throwable e) {
+                        reusedOrNewSourceAndConnection.close();
+                        throw e;
+                    }
+                }
+        );
         try {
-            return currentBatch.getResult();
-        } catch (MongoException e) {
-            /* if we get here, some of the batches failed on the server side,
-             * so we need to mark the last attempt to avoid retrying. */
-            retryState.markAsLastAttempt();
+            return retryingBatchExecutor.get();
+        } catch (Throwable e) {
+            if (sourceAndConnection.getNullable() != null) {
+                sourceAndConnection.get().close();
+            }
+            if (e instanceof MongoWriteConcernWithResponseException) {
+                batch.get().addResult((BsonDocument) ((MongoWriteConcernWithResponseException) e).getResponse());
+                return new BatchWithSourceAndConnection<>(batch.get().getNextBatch(), null);
+            }
+            if (retryWrites && e instanceof MongoException) {
+                // Adding the `RetryableError` label here is unnecessary at this point:
+                // applications cannot use it for implementing retries, and it is not even part of the public driver API.
+                // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
+                getWriteAttemptFailureNotToBeRetriedOrAddRetryableLabel(retryState, e);
+            }
             throw e;
         }
     }
 
-    private void executeBulkWriteBatchAsync(
+    /**
+     * @param maybeSourceAndConnection Is guaranteed to be {@linkplain AsyncSourceAndConnection#close() closed}
+     * if this method creates a new {@link AsyncSourceAndConnection}.
+     */
+    private void executeBatchReusingConnectionAsync(
+            @Nullable final BulkWriteBatch maybeBatch,
+            @Nullable final AsyncSourceAndConnection maybeSourceAndConnection,
+            final WriteConcern effectiveWriteConcern,
+            final AsyncWriteBinding binding,
+            final OperationContext operationContextForSelectServerAndCheckoutConnection,
+            final SingleResultCallback<BatchWithSourceAndConnection<AsyncSourceAndConnection>> callback) {
+        callback.completeExceptionally(Assertions.fail("VAKOTODO implement"));
+    }
+
+    private SourceAndConnection reuseOrSelectServerAndCheckoutConnectionIfClosed(
+            @Nullable final SourceAndConnection sourceAndConnection,
+            final WriteConcern effectiveWriteConcern,
+            final WriteBinding binding,
+            final OperationContext operationContext,
+            final RetryState retryState) {
+        if (sourceAndConnection == null || sourceAndConnection.isClosed()) {
+            SourceAndConnection newSourceAndConnection = selectServerAndCheckoutConnection(binding, operationContext);
+            try {
+                onNewConnection(
+                        newSourceAndConnection.getConnection().getDescription(),
+                        newSourceAndConnection.getOperationContext().getSessionContext(),
+                        effectiveWriteConcern, retryState);
+            } catch (Throwable e) {
+                newSourceAndConnection.close();
+                throw e;
+            }
+            return newSourceAndConnection;
+        } else {
+            return sourceAndConnection;
+        }
+    }
+
+    private void reuseOrSelectServerAndCheckoutConnectionIfClosedAsync(
+            @Nullable final AsyncSourceAndConnection sourceAndConnection,
+            final WriteConcern effectiveWriteConcern,
+            final AsyncWriteBinding binding,
+            final OperationContext operationContext,
             final RetryState retryState,
-            final WriteConcern effectiveWriteConcern,
+            final SingleResultCallback<AsyncSourceAndConnection> callback) {
+        callback.completeExceptionally(Assertions.fail("VAKOTODO implement"));
+    }
+
+    private static SourceAndConnection selectServerAndCheckoutConnection(
+            final WriteBinding binding,
+            final OperationContext operationContext) {
+        return withSourceAndConnection(
+                binding::getWriteConnectionSource,
+                true,
+                (source, connection, operationContextWithMinRTT) ->
+                        new SourceAndConnection(source, connection, operationContextWithMinRTT),
+                operationContext);
+    }
+
+    private static void selectServerAndCheckoutConnectionAsync(
+            final AsyncWriteBinding binding,
             final OperationContext operationContext,
-            final AsyncConnection connection,
-            final SingleResultCallback<BulkWriteResult> callback) {
-        LoopState loopState = new LoopState();
-        AsyncCallbackRunnable loop = new AsyncCallbackLoop(loopState, iterationCallback -> {
-            BulkWriteTracker currentBulkWriteTracker = retryState.attachment(AttachmentKeys.bulkWriteTracker())
-                    .orElseThrow(Assertions::fail);
-            loopState.attach(AttachmentKeys.bulkWriteTracker(), currentBulkWriteTracker, true);
-            BulkWriteBatch currentBatch = currentBulkWriteTracker.batch().orElseThrow(Assertions::fail);
-            int maxWireVersion = connection.getDescription().getMaxWireVersion();
-            if (loopState.breakAndCompleteIf(() -> !currentBatch.shouldProcessBatch(), iterationCallback)) {
-                return;
-            }
-
-            TimeoutContext timeoutContext = operationContext.getTimeoutContext();
-            executeCommandAsync(effectiveWriteConcern, operationContext, connection, currentBatch, (result, t) -> {
-                if (t == null) {
-                    if (currentBatch.getRetryWrites() && !operationContext.getSessionContext().hasActiveTransaction()) {
-                        MongoException writeConcernBasedError = ProtocolHelper.createSpecialException(result,
-                                connection.getDescription().getServerAddress(), "errMsg", operationContext.getTimeoutContext());
-                        if (writeConcernBasedError != null) {
-                            if (currentBulkWriteTracker.lastAttempt()) {
-                                addRetryableWriteErrorLabel(writeConcernBasedError, maxWireVersion);
-                                addErrorLabelsToWriteConcern(result.getDocument("writeConcernError"),
-                                        writeConcernBasedError.getErrorLabels());
-                            } else if (loggingShouldAttemptToRetryWriteAndAddRetryableLabel(retryState, writeConcernBasedError)) {
-                                iterationCallback.onResult(null,
-                                        new MongoWriteConcernWithResponseException(writeConcernBasedError, result));
-                                return;
-                            }
-                        }
-                    }
-                    currentBatch.addResult(result);
-                    BulkWriteTracker.attachNext(retryState, currentBatch, timeoutContext);
-                    iterationCallback.onResult(null, null);
-                } else {
-                    if (t instanceof MongoException) {
-                        MongoException exception = (MongoException) t;
-                        if (!retryState.isFirstAttempt() && !(exception instanceof MongoWriteConcernWithResponseException)) {
-                            addRetryableWriteErrorLabel(exception, maxWireVersion);
-                        }
-                        if (handleMongoWriteConcernWithResponseExceptionAsync(retryState, null, timeoutContext)) {
-                            return;
-                        }
-                    }
-                    iterationCallback.onResult(null, t);
-                }
-            });
-        });
-        loop.run((voidResult, t) -> {
-            if (t != null) {
-                callback.onResult(null, t);
-            } else {
-                BulkWriteResult result;
-                try {
-                    result = loopState.attachment(AttachmentKeys.bulkWriteTracker())
-                            .flatMap(BulkWriteTracker::batch).orElseThrow(Assertions::fail).getResult();
-                } catch (Throwable loopResultT) {
-                    if (loopResultT instanceof MongoException) {
-                        /* if we get here, some of the batches failed on the server side,
-                         * so we need to mark the last attempt to avoid retrying. */
-                        retryState.markAsLastAttempt();
-                    }
-                    callback.onResult(null, loopResultT);
-                    return;
-                }
-                callback.onResult(result, null);
-            }
-        });
+            final SingleResultCallback<AsyncSourceAndConnection> callback) {
+        callback.completeExceptionally(Assertions.fail("VAKOTODO implement"));
     }
 
-    private void handleMongoWriteConcernWithResponseException(final RetryState retryState,
-                                                              final boolean breakAndThrowIfDifferent,
-                                                              final TimeoutContext timeoutContext) {
-        if (!retryState.isFirstAttempt()) {
-            RuntimeException prospectiveFailedResult = (RuntimeException) retryState.exception().orElse(null);
-            boolean prospectiveResultIsWriteConcernException = prospectiveFailedResult instanceof MongoWriteConcernWithResponseException;
-            retryState.breakAndThrowIfRetryAnd(() -> breakAndThrowIfDifferent && !prospectiveResultIsWriteConcernException);
-            if (prospectiveResultIsWriteConcernException) {
-                retryState.attachment(AttachmentKeys.bulkWriteTracker()).orElseThrow(Assertions::fail)
-                        .batch().ifPresent(bulkWriteBatch -> {
-                            bulkWriteBatch.addResult(
-                                    (BsonDocument) ((MongoWriteConcernWithResponseException) prospectiveFailedResult).getResponse());
-                            BulkWriteTracker.attachNext(retryState, bulkWriteBatch, timeoutContext);
-                });
-            }
-        }
-    }
-
-    private boolean handleMongoWriteConcernWithResponseExceptionAsync(final RetryState retryState,
-                                                                      @Nullable final SingleResultCallback<BulkWriteResult> callback,
-                                                                      final TimeoutContext timeoutContext) {
-        if (!retryState.isFirstAttempt()) {
-            RuntimeException prospectiveFailedResult = (RuntimeException) retryState.exception().orElse(null);
-            boolean prospectiveResultIsWriteConcernException = prospectiveFailedResult instanceof MongoWriteConcernWithResponseException;
-            if (callback != null && retryState.breakAndCompleteIfRetryAnd(() -> !prospectiveResultIsWriteConcernException, callback)) {
-                return true;
-            }
-            if (prospectiveResultIsWriteConcernException) {
-                retryState.attachment(AttachmentKeys.bulkWriteTracker()).orElseThrow(Assertions::fail)
-                        .batch().ifPresent(bulkWriteBatch -> {
-                            bulkWriteBatch.addResult(
-                                    (BsonDocument) ((MongoWriteConcernWithResponseException) prospectiveFailedResult).getResponse());
-                            BulkWriteTracker.attachNext(retryState, bulkWriteBatch, timeoutContext);
-                });
-            }
-        }
-        return false;
-    }
-
-    @Nullable
-    private BsonDocument executeCommand(
+    private void onNewConnection(
+            final ConnectionDescription connectionDescription,
+            final SessionContext sessionContext,
             final WriteConcern effectiveWriteConcern,
+            final RetryState retryState) {
+        boolean effectiveRetryWrites = isRetryableWrite(
+                retryWrites, effectiveWriteConcern, connectionDescription, sessionContext);
+        retryState.breakAndThrowIfRetryAnd(() -> !effectiveRetryWrites);
+        validateWriteRequests(connectionDescription, bypassDocumentValidation, writeRequests, effectiveWriteConcern);
+    }
+
+    private BulkWriteBatch createFirstBatch(
+            final ConnectionDescription connectionDescription,
             final OperationContext operationContext,
-            final Connection connection,
-            final BulkWriteBatch batch) {
+            final WriteConcern effectiveWriteConcern) {
+        return BulkWriteBatch.createBulkWriteBatch(
+                // This same `connectionDescription` will be used by all batches, which is likely incorrect,
+                // given that different batches may be executed via different connections.
+                // However, the code behaved this way since the introduction of retryable writes, so I am not changing it now.
+                namespace, connectionDescription, ordered, effectiveWriteConcern, bypassDocumentValidation, retryWrites,
+                writeRequests, operationContext, comment, variables);
+    }
+
+    private void onBatch(final BulkWriteBatch batch, final RetryState retryState) {
         commandName = batch.getCommand().getFirstKey();
-        return connection.command(namespace.getDatabaseName(), batch.getCommand(), NoOpFieldNameValidator.INSTANCE, null, batch.getDecoder(),
-                operationContext.withOperationName(commandName), shouldExpectResponse(batch, effectiveWriteConcern), batch.getPayload());
+        String commandDescriptionToCapture = commandName;
+        retryState.attach(AttachmentKeys.retryableWriteCommandFlag(), batch.getRetryWrites(), false)
+                .attach(AttachmentKeys.commandDescriptionSupplier(), () -> commandDescriptionToCapture, false);
     }
 
-    private void executeCommandAsync(
-            final WriteConcern effectiveWriteConcern,
-            final OperationContext operationContext,
-            final AsyncConnection connection,
+    private void executeBatch(
             final BulkWriteBatch batch,
-            final SingleResultCallback<BsonDocument> callback) {
-        commandName = batch.getCommand().getFirstKey();
-        connection.commandAsync(namespace.getDatabaseName(), batch.getCommand(), NoOpFieldNameValidator.INSTANCE, null, batch.getDecoder(),
-                operationContext.withOperationName(commandName), shouldExpectResponse(batch, effectiveWriteConcern),
-                batch.getPayload(), callback);
+            final SourceAndConnection sourceAndConnection,
+            final WriteConcern effectiveWriteConcern) {
+        Connection connection = sourceAndConnection.getConnection();
+        OperationContext operationContext = sourceAndConnection.getOperationContext();
+        BsonDocument result = connection.command(
+                namespace.getDatabaseName(), batch.getCommand(),
+                NoOpFieldNameValidator.INSTANCE, null,
+                batch.getDecoder(), operationContext.withOperationName(commandName),
+                shouldExpectResponse(batch, effectiveWriteConcern), batch.getPayload());
+        if (batch.getRetryWrites()) {
+            ConnectionDescription connectionDescription = connection.getDescription();
+            MongoException writeConcernBasedError = ProtocolHelper.createSpecialException(
+                    result, connectionDescription.getServerAddress(), "errMsg", operationContext.getTimeoutContext());
+            if (writeConcernBasedError != null) {
+                addRetryableWriteErrorLabel(writeConcernBasedError, connectionDescription.getMaxWireVersion());
+                addErrorLabelsToWriteConcern(result.getDocument("writeConcernError"), writeConcernBasedError.getErrorLabels());
+                throw new MongoWriteConcernWithResponseException(writeConcernBasedError, result);
+            }
+        }
+        batch.addResult(result);
+    }
+
+    private void executeBatchAsync(
+            final BulkWriteBatch batch,
+            final AsyncSourceAndConnection sourceAndConnection,
+            final WriteConcern effectiveWriteConcern,
+            final SingleResultCallback<Void> callback) {
+        callback.completeExceptionally(Assertions.fail("VAKOTODO implement"));
     }
 
     private boolean shouldExpectResponse(final BulkWriteBatch batch, final WriteConcern effectiveWriteConcern) {
         return effectiveWriteConcern.isAcknowledged() || (ordered && batch.hasAnotherBatch());
     }
 
-    private void addErrorLabelsToWriteConcern(final BsonDocument result, final Set<String> errorLabels) {
+    private static void addErrorLabelsToWriteConcern(final BsonDocument result, final Set<String> errorLabels) {
         if (!result.containsKey("errorLabels")) {
             result.put("errorLabels", new BsonArray(errorLabels.stream().map(BsonString::new).collect(Collectors.toList())));
         }
     }
 
-    public static final class BulkWriteTracker {
-        private int attempt;
-        private final int attempts;
-        private final boolean retryUntilTimeoutThrowsException;
-        @Nullable
+    private static final class BatchWithSourceAndConnection<SC extends AbstractSourceAndConnection<?, ?>> implements AutoCloseable {
         private final BulkWriteBatch batch;
+        @Nullable
+        private final SC sourceAndConnection;
+        private boolean consumed;
 
-        static void attachNew(final RetryState retryState, final boolean retry, final TimeoutContext timeoutContext) {
-            retryState.attach(AttachmentKeys.bulkWriteTracker(), new BulkWriteTracker(retry, null, timeoutContext), false);
-        }
-
-        static void attachNew(final RetryState retryState, final BulkWriteBatch batch, final TimeoutContext timeoutContext) {
-            attach(retryState, new BulkWriteTracker(batch.getRetryWrites(), batch, timeoutContext));
-        }
-
-        static BulkWriteTracker attachNext(final RetryState retryState, final BulkWriteBatch batch, final TimeoutContext timeoutContext) {
-            BulkWriteBatch nextBatch = batch.getNextBatch();
-            BulkWriteTracker nextTracker = new BulkWriteTracker(nextBatch.getRetryWrites(), nextBatch, timeoutContext);
-            attach(retryState, nextTracker);
-            return nextTracker;
-        }
-
-        private static void attach(final RetryState retryState, final BulkWriteTracker tracker) {
-            retryState.attach(AttachmentKeys.bulkWriteTracker(), tracker, false);
-            BulkWriteBatch batch = tracker.batch;
-            if (batch != null) {
-                retryState.attach(AttachmentKeys.retryableWriteCommandFlag(), batch.getRetryWrites(), false)
-                        .attach(AttachmentKeys.commandDescriptionSupplier(), () -> batch.getPayload().getPayloadType().toString(), false);
-            }
-        }
-
-        private BulkWriteTracker(final boolean retry, @Nullable final BulkWriteBatch batch, final TimeoutContext timeoutContext) {
-            attempt = 0;
-            attempts = retry ? RetryState.MAX_RETRIES + 1 : 1;
+        BatchWithSourceAndConnection(final BulkWriteBatch batch, @Nullable final SC sourceAndConnection) {
             this.batch = batch;
-            this.retryUntilTimeoutThrowsException = timeoutContext.hasTimeoutMS();
+            this.sourceAndConnection = sourceAndConnection;
+            consumed = false;
         }
 
-        boolean lastAttempt() {
-            if (retryUntilTimeoutThrowsException){
-                return false;
+        /**
+         * Must not be invoked if {@link #intoSourceAndConnection()} or {@link #close()} was invoked.
+         */
+        BulkWriteBatch getBatch() {
+            assertFalse(consumed);
+            return batch;
+        }
+
+        /**
+         * May be invoked at most once.
+         * Must not be invoked if {@link #close()} was invoked.
+         */
+        @Nullable
+        SC intoSourceAndConnection() {
+            assertFalse(consumed);
+            SC sourceAndConnection = this.sourceAndConnection;
+            consumed = true;
+            return sourceAndConnection;
+        }
+
+        /**
+         * {@linkplain AbstractSourceAndConnection#close() Closes} {@link AbstractSourceAndConnection}
+         * unless {@link #intoSourceAndConnection()} was invoked.
+         * <p>
+         * Idempotent.
+         */
+        @Override
+        public void close() {
+            if (!consumed) {
+                consumed = true;
+                if (sourceAndConnection != null) {
+                    sourceAndConnection.close();
+                }
             }
-            return attempt == attempts - 1;
+        }
+    }
+
+    /**
+     * An {@link AutoCloseable} container for the arguments of
+     * {@link SyncOperationHelper.ExecutionFunction#apply(ConnectionSource, Connection, OperationContext)}
+     * provided by
+     * {@link SyncOperationHelper#withSourceAndConnection(Function, boolean, SyncOperationHelper.ExecutionFunction, OperationContext)}.
+     * This type allows those resources to be returned from
+     * {@link SyncOperationHelper#withSourceAndConnection(Function, boolean, SyncOperationHelper.ExecutionFunction, OperationContext)}
+     * and used after method completion.
+     */
+    private static final class SourceAndConnection extends AbstractSourceAndConnection<ConnectionSource, Connection> {
+        SourceAndConnection(
+                final ConnectionSource connectionSource,
+                final Connection connection,
+                final OperationContext operationContext) {
+            super(connectionSource, connection, operationContext);
+        }
+    }
+
+    /**
+     * An {@link AutoCloseable} container for the arguments of {@link AsyncCallbackTriFunction}
+     * provided by
+     * {@link AsyncOperationHelper#withAsyncSourceAndConnection(AsyncCallbackFunction, boolean, OperationContext, SingleResultCallback, AsyncCallbackTriFunction)}.
+     * This type allows those resources to be produced by
+     * {@link AsyncOperationHelper#withAsyncSourceAndConnection(AsyncCallbackFunction, boolean, OperationContext, SingleResultCallback, AsyncCallbackTriFunction)}
+     * and passed to the callback of the method.
+     */
+    private static final class AsyncSourceAndConnection extends AbstractSourceAndConnection<AsyncConnectionSource, AsyncConnection> {
+        AsyncSourceAndConnection(
+                final AsyncConnectionSource connectionSource,
+                final AsyncConnection connection,
+                final OperationContext operationContext) {
+            super(connectionSource, connection, operationContext);
+        }
+    }
+
+    private abstract static class AbstractSourceAndConnection<S extends ReferenceCounted, C extends ReferenceCounted> implements AutoCloseable {
+        private final S connectionSource;
+        private final C connection;
+        private final OperationContext operationContext;
+        private boolean closed;
+
+        AbstractSourceAndConnection(
+                final S connectionSource,
+                final C connection,
+                final OperationContext operationContext) {
+            connectionSource.retain();
+            this.connectionSource = connectionSource;
+            connection.retain();
+            this.connection = connection;
+            this.operationContext = operationContext;
+            closed = false;
         }
 
-        void advance() {
-            assertTrue(!lastAttempt());
-            attempt++;
+        C getConnection() {
+            assertFalse(closed);
+            return connection;
         }
 
-        Optional<BulkWriteBatch> batch() {
-            return Optional.ofNullable(batch);
+        OperationContext getOperationContext() {
+            assertFalse(closed);
+            return operationContext;
+        }
+
+        boolean isClosed() {
+            return closed;
+        }
+
+        /**
+         * Idempotent.
+         */
+        @Override
+        public void close() {
+            if (!closed) {
+                closed = true;
+                try {
+                    connection.release();
+                } finally {
+                    connectionSource.release();
+                }
+            }
         }
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -236,18 +236,18 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
             @Nullable final SourceAndConnection maybeSourceAndConnection,
             final WriteConcern effectiveWriteConcern,
             final WriteBinding binding,
-            final OperationContext operationContextForSelectServerAndCheckoutConnection) {
+            final OperationContext operationContext) {
         MutableValue<BulkWriteBatch> batch = new MutableValue<>(maybeBatch);
         MutableValue<SourceAndConnection> sourceAndConnection = new MutableValue<>(maybeSourceAndConnection);
         RetryState retryState = initialRetryState(
-                retryWrites, operationContextForSelectServerAndCheckoutConnection.getTimeoutContext());
+                retryWrites, operationContext.getTimeoutContext());
         Supplier<BatchWithSourceAndConnection<SourceAndConnection>> retryingBatchExecutor = decorateWriteWithRetries(
                 retryState,
-                operationContextForSelectServerAndCheckoutConnection,
+                operationContext,
                 () -> {
                     SourceAndConnection reusedOrNewSourceAndConnection = reuseOrSelectServerAndCheckoutConnectionIfClosed(
                             sourceAndConnection.getNullable(), effectiveWriteConcern, binding,
-                            operationContextForSelectServerAndCheckoutConnection, retryState);
+                            operationContext, retryState);
                     try {
                         sourceAndConnection.set(reusedOrNewSourceAndConnection);
                         ConnectionDescription connectionDescription = reusedOrNewSourceAndConnection.getConnection().getDescription();
@@ -293,21 +293,21 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
             @Nullable final AsyncSourceAndConnection maybeSourceAndConnection,
             final WriteConcern effectiveWriteConcern,
             final AsyncWriteBinding binding,
-            final OperationContext operationContextForSelectServerAndCheckoutConnection,
+            final OperationContext operationContext,
             final SingleResultCallback<BatchWithSourceAndConnection<AsyncSourceAndConnection>> callback) {
         beginAsync().<BatchWithSourceAndConnection<AsyncSourceAndConnection>>thenSupply(c -> {
             MutableValue<BulkWriteBatch> batch = new MutableValue<>(maybeBatch);
             MutableValue<AsyncSourceAndConnection> sourceAndConnection = new MutableValue<>(maybeSourceAndConnection);
             RetryState retryState = initialRetryState(
-                    retryWrites, operationContextForSelectServerAndCheckoutConnection.getTimeoutContext());
+                    retryWrites, operationContext.getTimeoutContext());
             AsyncCallbackSupplier<BatchWithSourceAndConnection<AsyncSourceAndConnection>> retryingBatchExecutor = decorateWriteWithRetriesAsync(
                     retryState,
-                    operationContextForSelectServerAndCheckoutConnection,
+                    operationContext,
                     supplierCallback -> {
                         beginAsync().<AsyncSourceAndConnection>thenSupply(reuseOrSelectServerAndCheckoutConnectionCallback -> {
                             reuseOrSelectServerAndCheckoutConnectionIfClosedAsync(
                                     sourceAndConnection.getNullable(), effectiveWriteConcern, binding,
-                                    operationContextForSelectServerAndCheckoutConnection, retryState, reuseOrSelectServerAndCheckoutConnectionCallback);
+                                    operationContext, retryState, reuseOrSelectServerAndCheckoutConnectionCallback);
                         }).<BatchWithSourceAndConnection<AsyncSourceAndConnection>>thenApply((reusedOrNewSourceAndConnection, setSourceAndConnectionCallback) -> {
                             beginAsync().thenRun(executeBatchCallback -> {
                                 sourceAndConnection.set(reusedOrNewSourceAndConnection);

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -275,7 +275,7 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
                 return new BatchWithSourceAndConnection<>(batch.get().getNextBatch(), null);
             }
             if (retryWrites && e instanceof MongoException) {
-                // Adding the `RetryableError` label here is unnecessary at this point:
+                // Adding the `RetryableWriteError` label here is unnecessary at this point:
                 // applications cannot use it for implementing retries, and it is not even part of the public driver API.
                 // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
                 addRetryableLabelOrGetWriteAttemptFailureNotToBeRetried(retryState, e);
@@ -339,7 +339,7 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
                     return;
                 }
                 if (retryWrites && e instanceof MongoException) {
-                    // Adding the `RetryableError` label here is unnecessary at this point:
+                    // Adding the `RetryableWriteError` label here is unnecessary at this point:
                     // applications cannot use it for implementing retries, and it is not even part of the public driver API.
                     // Unfortunately, certain unified tests incorrectly rely on this label to verify retries, resulting in this redundant code.
                     addRetryableLabelOrGetWriteAttemptFailureNotToBeRetried(retryState, e);
@@ -443,9 +443,7 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
             final OperationContext operationContext,
             final WriteConcern effectiveWriteConcern) {
         return BulkWriteBatch.createBulkWriteBatch(
-                // This same `connectionDescription` will be used by all batches, which is likely incorrect,
-                // given that different batches may be executed via different connections.
-                // However, the code behaved this way since the introduction of retryable writes, so I am not changing it now.
+                // TODO-JAVA-6223 this same `connectionDescription` is used by all batches, which is incorrect
                 namespace, connectionDescription, ordered, effectiveWriteConcern, bypassDocumentValidation, retryWrites,
                 writeRequests, operationContext, comment, variables);
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/MixedBulkWriteOperation.java
@@ -55,6 +55,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.mongodb.assertions.Assertions.assertFalse;
+import static com.mongodb.assertions.Assertions.assertNotNull;
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.AsyncRunnable.beginAsync;
@@ -458,7 +459,7 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
     private void executeBatch(
             final BulkWriteBatch batch,
             final SourceAndConnection sourceAndConnection,
-            final WriteConcern effectiveWriteConcern) {
+            final WriteConcern effectiveWriteConcern) throws MongoWriteConcernWithResponseException {
         Connection connection = sourceAndConnection.getConnection();
         OperationContext operationContext = sourceAndConnection.getOperationContext();
         BsonDocument result = connection.command(
@@ -466,17 +467,7 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
                 NoOpFieldNameValidator.INSTANCE, null,
                 batch.getDecoder(), operationContext.withOperationName(commandName),
                 shouldExpectResponse(batch, effectiveWriteConcern), batch.getPayload());
-        if (batch.getRetryWrites()) {
-            ConnectionDescription connectionDescription = connection.getDescription();
-            MongoException writeConcernBasedError = ProtocolHelper.createSpecialException(
-                    result, connectionDescription.getServerAddress(), "errMsg", operationContext.getTimeoutContext());
-            if (writeConcernBasedError != null) {
-                addRetryableWriteErrorLabel(writeConcernBasedError, connectionDescription.getMaxWireVersion());
-                addErrorLabelsToWriteConcern(result.getDocument("writeConcernError"), writeConcernBasedError.getErrorLabels());
-                throw new MongoWriteConcernWithResponseException(writeConcernBasedError, result);
-            }
-        }
-        batch.addResult(result);
+        addResultOrThrowWriteConcernWithResponseException(batch, result, connection.getDescription(), operationContext);
     }
 
     private void executeBatchAsync(
@@ -494,17 +485,7 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
                         batch.getDecoder(), operationContext.withOperationName(commandName),
                         shouldExpectResponse(batch, effectiveWriteConcern), batch.getPayload(), commandCallback);
             }).thenConsume((result, consumeCommandResultCallback) -> {
-                if (batch.getRetryWrites()) {
-                    ConnectionDescription connectionDescription = connection.getDescription();
-                    MongoException writeConcernBasedError = ProtocolHelper.createSpecialException(
-                            result, connectionDescription.getServerAddress(), "errMsg", operationContext.getTimeoutContext());
-                    if (writeConcernBasedError != null) {
-                        addRetryableWriteErrorLabel(writeConcernBasedError, connectionDescription.getMaxWireVersion());
-                        addErrorLabelsToWriteConcern(result.getDocument("writeConcernError"), writeConcernBasedError.getErrorLabels());
-                        throw new MongoWriteConcernWithResponseException(writeConcernBasedError, result);
-                    }
-                }
-                batch.addResult(result);
+                addResultOrThrowWriteConcernWithResponseException(batch, result, connection.getDescription(), operationContext);
                 consumeCommandResultCallback.complete(consumeCommandResultCallback);
             }).finish(c);
         }).finish(callback);
@@ -512,6 +493,24 @@ public class MixedBulkWriteOperation implements WriteOperation<BulkWriteResult> 
 
     private boolean shouldExpectResponse(final BulkWriteBatch batch, final WriteConcern effectiveWriteConcern) {
         return effectiveWriteConcern.isAcknowledged() || (ordered && batch.hasAnotherBatch());
+    }
+
+    private static void addResultOrThrowWriteConcernWithResponseException(
+            final BulkWriteBatch batch,
+            @Nullable final BsonDocument result,
+            final ConnectionDescription connectionDescription,
+            final OperationContext operationContext) throws MongoWriteConcernWithResponseException {
+        if (batch.getRetryWrites()) {
+            MongoException writeConcernBasedError = ProtocolHelper.createSpecialException(
+                    result, connectionDescription.getServerAddress(), "errMsg", operationContext.getTimeoutContext());
+            if (writeConcernBasedError != null) {
+                assertNotNull(result);
+                addRetryableWriteErrorLabel(writeConcernBasedError, connectionDescription.getMaxWireVersion());
+                addErrorLabelsToWriteConcern(result.getDocument("writeConcernError"), writeConcernBasedError.getErrorLabels());
+                throw new MongoWriteConcernWithResponseException(writeConcernBasedError, result);
+            }
+        }
+        batch.addResult(result);
     }
 
     private static void addErrorLabelsToWriteConcern(final BsonDocument result, final Set<String> errorLabels) {

--- a/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/OperationHelper.java
@@ -137,18 +137,6 @@ public final class OperationHelper {
         validateWriteRequestHints(connectionDescription, requests, writeConcern);
     }
 
-    static <R> boolean validateWriteRequestsAndCompleteIfInvalid(final ConnectionDescription connectionDescription,
-            final Boolean bypassDocumentValidation, final List<? extends WriteRequest> requests, final WriteConcern writeConcern,
-            final SingleResultCallback<R> callback) {
-        try {
-            validateWriteRequests(connectionDescription, bypassDocumentValidation, requests, writeConcern);
-            return false;
-        } catch (Throwable validationT) {
-            callback.onResult(null, validationT);
-            return true;
-        }
-    }
-
     private static void checkBypassDocumentValidationIsSupported(@Nullable final Boolean bypassDocumentValidation,
             final WriteConcern writeConcern) {
         if (bypassDocumentValidation != null && !writeConcern.isAcknowledged()) {

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
@@ -117,21 +117,22 @@ final class SyncOperationHelper {
         return withSourceAndConnection(
                 binding::getWriteConnectionSource,
                 false,
+                operationContext,
                 (source, connection, operationContextWithMinRtt) ->
-                        callable.call(connection, operationContextWithMinRtt),
-                operationContext);
+                        callable.call(connection, operationContextWithMinRtt));
     }
 
     /**
      * Gets a {@link ConnectionSource} and a {@link Connection} from the {@code sourceSupplier} and executes the {@code function} with them.
      * Guarantees to {@linkplain ReferenceCounted#release() release} the source and the connection after completion of the {@code function}.
      */
-    static <R> R withSourceAndConnection(final Function<OperationContext, ConnectionSource> sourceFunction,
-                                         final boolean wrapConnectionSourceException,
-                                         final ExecutionFunction<R> function,
-                                         final OperationContext originalOperationContext) throws ResourceSupplierInternalException {
+    static <R> R withSourceAndConnection(
+            final Function<OperationContext, ConnectionSource> sourceFunction,
+            final boolean wrapConnectionSourceException,
+            final OperationContext operationContext,
+            final ExecutionFunction<R> function) throws ResourceSupplierInternalException {
         OperationContext serverSelectionOperationContext =
-                originalOperationContext.withOverride(TimeoutContext::withComputedServerSelectionTimeout);
+                operationContext.withOverride(TimeoutContext::withComputedServerSelectionTimeout);
 
         return withSuppliedResource(
                 sourceFunction,
@@ -144,7 +145,7 @@ final class SyncOperationHelper {
                         connection -> function.apply(
                                 source,
                                 connection,
-                                originalOperationContext.withMinRoundTripTime(source.getServerDescription())))
+                                operationContext.withMinRoundTripTime(source.getServerDescription())))
         );
     }
 
@@ -203,11 +204,11 @@ final class SyncOperationHelper {
         RetryState retryState = CommandOperationHelper.initialRetryState(retryReads, operationContext.getTimeoutContext());
 
         Supplier<T> read = decorateReadWithRetries(retryState, operationContext, () ->
-                withSourceAndConnection(readConnectionSourceSupplier, false, (source, connection, operationContextWithMinRtt) -> {
+                withSourceAndConnection(readConnectionSourceSupplier, false, operationContext, (source, connection, operationContextWithMinRtt) -> {
                     retryState.breakAndThrowIfRetryAnd(() -> !canRetryRead(operationContextWithMinRtt));
                     return createReadCommandAndExecute(retryState, operationContextWithMinRtt, source, database,
                                                        commandCreator, decoder, transformer, connection);
-                }, operationContext)
+                })
         );
         return read.get();
     }
@@ -216,25 +217,25 @@ final class SyncOperationHelper {
     static <T> T executeCommand(final WriteBinding binding, final OperationContext operationContext, final String database,
                                 final CommandCreator commandCreator,
             final CommandWriteTransformer<BsonDocument, T> transformer) {
-        return withSourceAndConnection(binding::getWriteConnectionSource, false, (source, connection, operationContextWithMinRtt) ->
+        return withSourceAndConnection(binding::getWriteConnectionSource, false, operationContext, (source, connection, operationContextWithMinRtt) ->
                 transformer.apply(assertNotNull(
                         connection.command(database,
                                 commandCreator.create(operationContextWithMinRtt,
                                         source.getServerDescription(),
                                         connection.getDescription()),
                                 NoOpFieldNameValidator.INSTANCE, primary(), BSON_DOCUMENT_CODEC, operationContextWithMinRtt)),
-                        connection), operationContext);
+                        connection));
     }
 
     @VisibleForTesting(otherwise = PRIVATE)
     static <D, T> T executeCommand(final WriteBinding binding, final OperationContext operationContext, final String database,
                                    final BsonDocument command,
                                    final Decoder<D> decoder, final CommandWriteTransformer<D, T> transformer) {
-        return withSourceAndConnection(binding::getWriteConnectionSource, false, (source, connection, operationContextWithMinRtt) ->
+        return withSourceAndConnection(binding::getWriteConnectionSource, false, operationContext, (source, connection, operationContextWithMinRtt) ->
                 transformer.apply(assertNotNull(
                         connection.command(database, command, NoOpFieldNameValidator.INSTANCE, primary(), decoder,
-                                operationContextWithMinRtt)), connection),
-                operationContext);
+                                operationContextWithMinRtt)), connection)
+        );
     }
 
     @Nullable
@@ -265,7 +266,7 @@ final class SyncOperationHelper {
             if (!firstAttempt && sessionContext.hasActiveTransaction()) {
                 sessionContext.clearTransactionContext();
             }
-            return withSourceAndConnection(binding::getWriteConnectionSource, true, (source, connection, operationContextWithMinRtt) -> {
+            return withSourceAndConnection(binding::getWriteConnectionSource, true, operationContext, (source, connection, operationContextWithMinRtt) -> {
                 int maxWireVersion = connection.getDescription().getMaxWireVersion();
                 try {
                     retryState.breakAndThrowIfRetryAnd(() -> !canRetryWrite(connection.getDescription()));
@@ -289,7 +290,7 @@ final class SyncOperationHelper {
                     }
                     throw e;
                 }
-            }, operationContext);
+            });
         });
         try {
             return retryingWrite.get();

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperationHelper.java
@@ -125,8 +125,6 @@ final class SyncOperationHelper {
     /**
      * Gets a {@link ConnectionSource} and a {@link Connection} from the {@code sourceSupplier} and executes the {@code function} with them.
      * Guarantees to {@linkplain ReferenceCounted#release() release} the source and the connection after completion of the {@code function}.
-     *
-     *
      */
     static <R> R withSourceAndConnection(final Function<OperationContext, ConnectionSource> sourceFunction,
                                          final boolean wrapConnectionSourceException,
@@ -323,7 +321,7 @@ final class SyncOperationHelper {
 
     static <R> Supplier<R> decorateWriteWithRetries(final RetryState retryState,
             final OperationContext operationContext, final Supplier<R> writeFunction) {
-        return new RetryingSyncSupplier<>(retryState, onRetryableWriteAttemptFailure(operationContext),
+        return new RetryingSyncSupplier<>(retryState, onRetryableWriteAttemptFailure(operationContext.getServerDeprioritization()),
                 CommandOperationHelper::loggingShouldAttemptToRetryWriteAndAddRetryableLabel, () -> {
             logRetryCommand(retryState, operationContext);
             return writeFunction.get();
@@ -332,7 +330,7 @@ final class SyncOperationHelper {
 
     static <R> Supplier<R> decorateReadWithRetries(final RetryState retryState, final OperationContext operationContext,
             final Supplier<R> readFunction) {
-        return new RetryingSyncSupplier<>(retryState, onRetryableReadAttemptFailure(operationContext),
+        return new RetryingSyncSupplier<>(retryState, onRetryableReadAttemptFailure(operationContext.getServerDeprioritization()),
                 CommandOperationHelper::loggingShouldAttemptToRetryRead, () -> {
             logRetryCommand(retryState, operationContext);
             return readFunction.get();

--- a/driver-core/src/main/com/mongodb/internal/operation/retry/AttachmentKeys.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/retry/AttachmentKeys.java
@@ -18,7 +18,6 @@ package com.mongodb.internal.operation.retry;
 import com.mongodb.MongoConnectionPoolClearedException;
 import com.mongodb.annotations.Immutable;
 import com.mongodb.internal.async.function.LoopState.AttachmentKey;
-import com.mongodb.internal.operation.MixedBulkWriteOperation.BulkWriteTracker;
 import org.bson.BsonDocument;
 
 import java.util.HashSet;
@@ -40,7 +39,6 @@ public final class AttachmentKeys {
     private static final AttachmentKey<BsonDocument> COMMAND = DefaultAttachmentKey.of("command");
     private static final AttachmentKey<Boolean> RETRYABLE_WRITE_COMMAND_FLAG = DefaultAttachmentKey.of("retryableWriteCommandFlag");
     private static final AttachmentKey<Supplier<String>> COMMAND_DESCRIPTION_SUPPLIER = DefaultAttachmentKey.of("commandDescriptionSupplier");
-    private static final AttachmentKey<BulkWriteTracker> BULK_WRITE_TRACKER = DefaultAttachmentKey.of("bulkWriteTracker");
 
     public static AttachmentKey<Integer> maxWireVersion() {
         return MAX_WIRE_VERSION;
@@ -61,10 +59,6 @@ public final class AttachmentKeys {
 
     public static AttachmentKey<Supplier<String>> commandDescriptionSupplier() {
         return COMMAND_DESCRIPTION_SUPPLIER;
-    }
-
-    public static AttachmentKey<BulkWriteTracker> bulkWriteTracker() {
-        return BULK_WRITE_TRACKER;
     }
 
     private AttachmentKeys() {

--- a/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
@@ -234,24 +234,26 @@ class OperationFunctionalSpecification extends Specification {
     void testOperation(operation, List<Integer> serverVersion, BsonDocument expectedCommand, boolean async, result = null,
                        boolean checkCommand = true, boolean checkSecondaryOk = false,
                        ReadPreference readPreference = ReadPreference.primary(), boolean retryable = false,
-                       ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false) {
+                       ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false,
+                       int expectedConnectionReleaseCountPerAttempt = 1) {
         testOperation(operation, serverVersion, ReadConcern.DEFAULT, expectedCommand, async, result, checkCommand, checkSecondaryOk,
-        readPreference, retryable, serverType, activeTransaction)
+        readPreference, retryable, serverType, activeTransaction, expectedConnectionReleaseCountPerAttempt)
     }
 
     void testOperation(operation, List<Integer> serverVersion, ReadConcern readConcern, BsonDocument expectedCommand, boolean async,
                        result = null, boolean checkCommand = true, boolean checkSecondaryOk = false,
                        ReadPreference readPreference = ReadPreference.primary(), boolean retryable = false,
-                       ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false) {
+                       ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false,
+                       int expectedConnectionReleaseCountPerAttempt = 1) {
         def test = async ? this.&testAsyncOperation : this.&testSyncOperation
         test(operation, serverVersion, readConcern, result, checkCommand, expectedCommand, checkSecondaryOk, readPreference, retryable,
-                serverType, activeTransaction)
+                serverType, activeTransaction, expectedConnectionReleaseCountPerAttempt)
     }
 
     void testOperationRetries(operation, List<Integer> serverVersion, BsonDocument expectedCommand, boolean async, result = null,
-                              Boolean activeTransaction = false) {
+                              Boolean activeTransaction = false, int expectedConnectionReleaseCountPerAttempt = 1) {
         testOperation(operation, serverVersion, expectedCommand, async, result, true, false, ReadPreference.primary(), true,
-             ServerType.REPLICA_SET_PRIMARY, activeTransaction)
+             ServerType.REPLICA_SET_PRIMARY, activeTransaction, expectedConnectionReleaseCountPerAttempt)
     }
 
     void testRetryableOperationThrowsOriginalError(operation, List<List<Integer>> serverVersions, List<ServerType> serverTypes,
@@ -278,7 +280,8 @@ class OperationFunctionalSpecification extends Specification {
     def testSyncOperation(operation, List<Integer> serverVersion, ReadConcern readConcern, result, Boolean checkCommand=true,
                           BsonDocument expectedCommand=null, Boolean checkSecondaryOk=false,
                           ReadPreference readPreference=ReadPreference.primary(), Boolean retryable = false,
-                          ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false) {
+                          ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false,
+                          int expectedConnectionReleaseCountPerAttempt = 1) {
         def operationContext = createOperationContext()
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> activeTransaction
@@ -338,9 +341,9 @@ class OperationFunctionalSpecification extends Specification {
         }
 
         if (retryable) {
-            2 * connection.release()
+            (2 * expectedConnectionReleaseCountPerAttempt) * connection.release()
         } else {
-            1 * connection.release()
+            expectedConnectionReleaseCountPerAttempt * connection.release()
         }
         if (operation instanceof ReadOperation) {
             operation.execute(readBinding, operationContext)
@@ -352,7 +355,8 @@ class OperationFunctionalSpecification extends Specification {
     def testAsyncOperation(operation = operation, List<Integer> serverVersion = serverVersion, ReadConcern readConcern, result = null,
                            Boolean checkCommand = true, BsonDocument expectedCommand = null, Boolean checkSecondaryOk = false,
                            ReadPreference readPreference = ReadPreference.primary(), Boolean retryable = false,
-                           ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false) {
+                           ServerType serverType = ServerType.STANDALONE, Boolean activeTransaction = false,
+                           int expectedConnectionReleaseCountPerAttempt = 1) {
         def operationContext = createOperationContext()
                 .withSessionContext(Stub(SessionContext) {
                     hasActiveTransaction() >> activeTransaction
@@ -417,9 +421,9 @@ class OperationFunctionalSpecification extends Specification {
         }
 
         if (retryable) {
-            2 * connection.release()
+            (2 * expectedConnectionReleaseCountPerAttempt) * connection.release()
         } else {
-            1 * connection.release()
+            expectedConnectionReleaseCountPerAttempt * connection.release()
         }
 
         if (operation instanceof ReadOperation) {

--- a/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/internal/operation/MixedBulkWriteOperationSpecification.groovy
@@ -1104,7 +1104,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
                 .append('txnNumber', new BsonInt64(0))
 
         then:
-        testOperationRetries(operation, [3, 6, 0], expectedCommand, async, cannedResult)
+        testOperationRetries(operation, [3, 6, 0], expectedCommand, async, cannedResult, false, 2)
 
         where:
         async << [true, false]
@@ -1117,16 +1117,16 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         def originalException = new MongoSocketException('Some failure', new ServerAddress())
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0], [3, 6, 0]],
-                [REPLICA_SET_PRIMARY, REPLICA_SET_PRIMARY, STANDALONE], originalException, async)
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
+                [REPLICA_SET_PRIMARY, REPLICA_SET_PRIMARY, STANDALONE], originalException, async, 4)
 
         then:
         Exception commandException = thrown()
         commandException == originalException
 
         when:
-        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0], [3, 6, 0]],
-                [REPLICA_SET_PRIMARY, REPLICA_SET_PRIMARY], originalException, async, 1)
+        testRetryableOperationThrowsOriginalError(operation, [[3, 6, 0]],
+                [REPLICA_SET_PRIMARY, REPLICA_SET_PRIMARY], originalException, async, 2)
 
         then:
         commandException = thrown()

--- a/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/async/function/RetryStateTest.java
@@ -71,12 +71,6 @@ final class RetryStateTest {
                 () -> assertFalse(retryState.isFirstAttempt()),
                 () -> assertEquals(1, retryState.attempt())
         );
-        retryState.markAsLastAttempt();
-        assertAll(
-                () -> assertFalse(retryState.isFirstAttempt()),
-                () -> assertEquals(1, retryState.attempt()),
-                () -> assertAdvanceOrThrowThrows(attemptException, retryState, attemptException)
-        );
     }
 
     @Test
@@ -91,22 +85,6 @@ final class RetryStateTest {
                 () -> assertTrue(retryState.isFirstAttempt()),
                 () -> assertEquals(0, retryState.attempt())
         );
-    }
-
-    @ParameterizedTest
-    @MethodSource({"atMostTwoRetriesAndUnlimitedRetries"})
-    void markAsLastAttemptAdvanceWithRuntimeException(final RetryState retryState) {
-        retryState.markAsLastAttempt();
-        RuntimeException attemptException = new RuntimeException();
-        assertAdvanceOrThrowThrows(attemptException, retryState, attemptException, (rs, e) -> fail());
-    }
-
-    @ParameterizedTest(name = "should advance with non-retryable error when marked as last attempt and : ''{0}''")
-    @MethodSource({"noRetries", "atMostTwoRetriesAndUnlimitedRetries"})
-    void markAsLastAttemptAdvanceWithError(final RetryState retryState) {
-        retryState.markAsLastAttempt();
-        Error attemptException = new Error();
-        assertAdvanceOrThrowThrows(attemptException, retryState, attemptException, (rs, e) -> fail());
     }
 
     @ParameterizedTest

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/MongoWriteConcernWithResponseExceptionTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/MongoWriteConcernWithResponseExceptionTest.java
@@ -16,15 +16,13 @@
 
 package com.mongodb.reactivestreams.client;
 
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
 import com.mongodb.reactivestreams.client.syncadapter.SyncMongoClient;
-import org.junit.Test;
 
-/**
- * See {@link com.mongodb.client.MongoWriteConcernWithResponseExceptionTest}.
- */
-public class MongoWriteConcernWithResponseExceptionTest {
-    @Test
-    public void doesNotLeak() throws InterruptedException {
-        com.mongodb.client.MongoWriteConcernWithResponseExceptionTest.doesNotLeak(SyncMongoClient::new);
+final class MongoWriteConcernWithResponseExceptionTest extends com.mongodb.client.MongoWriteConcernWithResponseExceptionTest {
+    @Override
+    protected MongoClient createClient(final MongoClientSettings clientSettings) {
+        return new SyncMongoClient(clientSettings);
     }
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/FailPoint.java
@@ -81,8 +81,7 @@ public final class FailPoint implements AutoCloseable {
 
         /**
          * May be invoked at most once.
-         *
-         * @see #close()
+         * Must not be invoked if {@link #close()} was invoked.
          */
         FailPoint intoFailPoint() {
             assertFalse(consumed);
@@ -93,10 +92,13 @@ public final class FailPoint implements AutoCloseable {
 
         /**
          * Invokes {@link #disableAndClose(BsonDocument, MongoClient)} unless {@link #intoFailPoint()} was invoked.
+         * <p>
+         * Idempotent.
          */
         @Override
         public void close() {
             if (!consumed) {
+                consumed = true;
                 disableAndClose(failPointDocument, client);
             }
         }

--- a/driver-sync/src/test/functional/com/mongodb/client/MongoWriteConcernWithResponseExceptionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/MongoWriteConcernWithResponseExceptionTest.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.client;
 
-import com.mongodb.Function;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoWriteConcernException;
 import com.mongodb.ServerAddress;
@@ -31,7 +30,8 @@ import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.bson.Document;
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -46,24 +46,25 @@ import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
 import static com.mongodb.internal.operation.CommandOperationHelper.NO_WRITES_PERFORMED_ERROR_LABEL;
 import static com.mongodb.internal.operation.CommandOperationHelper.RETRYABLE_WRITE_ERROR_LABEL;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Tests in this class check that the internal {@link MongoWriteConcernWithResponseException} does not leak from our API.
  */
-public final class MongoWriteConcernWithResponseExceptionTest {
+public class MongoWriteConcernWithResponseExceptionTest {
+    protected MongoClient createClient(final MongoClientSettings clientSettings) {
+        return MongoClients.create(clientSettings);
+    }
+
     /**
      * This test is similar to {@link RetryableWritesProseTest#originalErrorMustBePropagatedIfNoWritesPerformed()}.
      * The difference is in the assertions, it also verifies situations when `writeConcernError` happens on the first attempt
      * and on the last attempt.
      */
-    @Test
-    public void doesNotLeak() throws InterruptedException {
-        doesNotLeak(MongoClients::create);
-    }
-
-    public static void doesNotLeak(final Function<MongoClientSettings, MongoClient> clientCreator) throws InterruptedException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    protected void doesNotLeak(final boolean writeConcernErrorOnFirstAttempt) throws InterruptedException {
         BsonDocument writeConcernErrorFpDoc = new BsonDocument()
                 .append("configureFailPoint", new BsonString("failCommand"))
                 .append("mode", new BsonDocument()
@@ -85,13 +86,15 @@ public final class MongoWriteConcernWithResponseExceptionTest {
                         .append("errorCode", new BsonInt32(10107))
                         .append("errorLabels", new BsonArray(Stream.of(RETRYABLE_WRITE_ERROR_LABEL, NO_WRITES_PERFORMED_ERROR_LABEL)
                                 .map(BsonString::new).collect(Collectors.toList()))));
-        doesNotLeak(clientCreator, writeConcernErrorFpDoc, true, noWritesPerformedFpDoc);
-        doesNotLeak(clientCreator, noWritesPerformedFpDoc, false, writeConcernErrorFpDoc);
+        if (writeConcernErrorOnFirstAttempt) {
+            doesNotLeak(writeConcernErrorFpDoc, true, noWritesPerformedFpDoc);
+        } else {
+            doesNotLeak(noWritesPerformedFpDoc, false, writeConcernErrorFpDoc);
+        }
     }
 
     @SuppressWarnings("try")
-    private static void doesNotLeak(
-            final Function<MongoClientSettings, MongoClient> clientCreator,
+    private void doesNotLeak(
             final BsonDocument firstAttemptFpDoc,
             final boolean firstAttemptCommandSucceededEvent,
             final BsonDocument lastAttemptFpDoc) throws InterruptedException {
@@ -121,7 +124,7 @@ public final class MongoWriteConcernWithResponseExceptionTest {
                 }
             }
         };
-        try (MongoClient client = clientCreator.apply(getMongoClientSettingsBuilder()
+        try (MongoClient client = createClient(getMongoClientSettingsBuilder()
                 .retryWrites(true)
                 .addCommandListener(commandListener)
                 .applyToServerSettings(builder -> builder.heartbeatFrequency(50, TimeUnit.MILLISECONDS))

--- a/driver-sync/src/test/functional/com/mongodb/client/MongoWriteConcernWithResponseExceptionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/MongoWriteConcernWithResponseExceptionTest.java
@@ -19,12 +19,11 @@ package com.mongodb.client;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoWriteConcernException;
 import com.mongodb.ServerAddress;
-import com.mongodb.assertions.Assertions;
 import com.mongodb.event.CommandEvent;
 import com.mongodb.event.CommandFailedEvent;
-import com.mongodb.event.CommandListener;
 import com.mongodb.event.CommandSucceededEvent;
 import com.mongodb.internal.connection.MongoWriteConcernWithResponseException;
+import com.mongodb.internal.event.ConfigureFailPointCommandListener;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
@@ -33,9 +32,8 @@ import org.bson.Document;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -64,7 +62,7 @@ public class MongoWriteConcernWithResponseExceptionTest {
      */
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    protected void doesNotLeak(final boolean writeConcernErrorOnFirstAttempt) throws InterruptedException {
+    protected void doesNotLeak(final boolean writeConcernErrorOnFirstAttempt) throws Exception {
         BsonDocument writeConcernErrorFpDoc = new BsonDocument()
                 .append("configureFailPoint", new BsonString("failCommand"))
                 .append("mode", new BsonDocument()
@@ -96,39 +94,25 @@ public class MongoWriteConcernWithResponseExceptionTest {
     @SuppressWarnings("try")
     private void doesNotLeak(
             final BsonDocument firstAttemptFpDoc,
-            final boolean firstAttemptCommandSucceededEvent,
-            final BsonDocument lastAttemptFpDoc) throws InterruptedException {
+            final boolean firstAttemptSucceeds,
+            final BsonDocument lastAttemptFpDoc) throws Exception {
         assumeTrue(serverVersionAtLeast(6, 0) && isDiscoverableReplicaSet());
         ServerAddress primaryServerAddress = Fixture.getPrimary();
-        CompletableFuture<FailPoint> futureFailPointFromListener = new CompletableFuture<>();
-        CommandListener commandListener = new CommandListener() {
-            private final AtomicBoolean configureFailPoint = new AtomicBoolean(true);
-
-            @Override
-            public void commandSucceeded(final CommandSucceededEvent event) {
-                if (firstAttemptCommandSucceededEvent) {
-                    enableLastAttemptFp(event);
-                }
+        Predicate<CommandEvent> configureFailPointEventMatcher = event -> {
+            if (event.getCommandName().equals("insert")) {
+                return firstAttemptSucceeds
+                        ? event instanceof CommandSucceededEvent
+                        : event instanceof CommandFailedEvent;
             }
-
-            @Override
-            public void commandFailed(final CommandFailedEvent event) {
-                if (!firstAttemptCommandSucceededEvent) {
-                    enableLastAttemptFp(event);
-                }
-            }
-
-            private void enableLastAttemptFp(final CommandEvent event) {
-                if (event.getCommandName().equals("insert") && configureFailPoint.compareAndSet(true, false)) {
-                    Assertions.assertTrue(futureFailPointFromListener.complete(FailPoint.enable(lastAttemptFpDoc, primaryServerAddress)));
-                }
-            }
+            return false;
         };
-        try (MongoClient client = createClient(getMongoClientSettingsBuilder()
-                .retryWrites(true)
-                .addCommandListener(commandListener)
-                .applyToServerSettings(builder -> builder.heartbeatFrequency(50, TimeUnit.MILLISECONDS))
-                .build());
+        try (ConfigureFailPointCommandListener commandListener = new ConfigureFailPointCommandListener(
+                lastAttemptFpDoc, primaryServerAddress, configureFailPointEventMatcher);
+             MongoClient client = createClient(getMongoClientSettingsBuilder()
+                     .retryWrites(true)
+                     .addCommandListener(commandListener)
+                     .applyToServerSettings(builder -> builder.heartbeatFrequency(50, TimeUnit.MILLISECONDS))
+                     .build());
              FailPoint ignored = FailPoint.enable(firstAttemptFpDoc, primaryServerAddress)) {
             MongoCollection<Document> collection = client.getDatabase(getDefaultDatabaseName())
                     .getCollection("originalErrorMustBePropagatedIfNoWritesPerformed");
@@ -142,8 +126,6 @@ public class MongoWriteConcernWithResponseExceptionTest {
                     throw new AssertionError("The internal exception leaked.", e);
                 }
             });
-        } finally {
-            futureFailPointFromListener.thenAccept(FailPoint::close);
         }
     }
 }


### PR DESCRIPTION
### For reviewers

I recommend reviewing the changes commit by commit. Review the sync code changes to assess the correctness compared to the pre-PR code. Then review the async code changes to assess whether the sync code was correctly translated into the async code.

Ignore the `ServerDiscoveryAndMonitoringProseTests.testConnectionPoolBackpressure` Evergreen failures. There are unrelated and we'll [deal with them separately](https://github.com/mongodb/mongo-java-driver/pull/1918#discussion_r3351499930).

### AI usage

All the changes were handmade. AI was used only to review the changes.

JAVA-6218