### PR TITLE
Improve the label in `withTransaction`

### DIFF
--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
@@ -275,7 +275,7 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
         MongoException lastError = null;
 
         try {
-            outer:
+            transactionAttempts:
             while (true) {
                 if (transactionAttempt > 0) {
                     backoff(transactionAttempt, withTransactionTimeout, assertNotNull(lastError), timeoutMsConfigured);
@@ -326,7 +326,7 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
                                     transactionSpan.spanFinalizing(true);
                                 }
                                 lastError = mongoException;
-                                continue outer;
+                                continue transactionAttempts;
                             }
                             throw mongoException;
                         }


### PR DESCRIPTION
Ignore the `ServerDiscoveryAndMonitoringProseTests.testConnectionPoolBackpressure` Evergreen failures. There are unrelated and we'll [deal with them separately](https://github.com/mongodb/mongo-java-driver/pull/1918#discussion_r3351499930).