### PR TITLE
Fix reactive streams `MongoClient.getTimeout` always returning `null`

### DIFF
--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoClientImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoClientImpl.java
@@ -291,8 +291,9 @@ public final class MongoClientImpl implements MongoClient {
     }
 
     @Override
+    @Nullable
     public Long getTimeout(final TimeUnit timeUnit) {
-        return null;
+        return delegate.getTimeout(timeUnit);
     }
 
     @Override

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoClusterImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoClusterImpl.java
@@ -91,9 +91,11 @@ final class MongoClusterImpl implements MongoCluster {
     }
 
     @Override
+    @Nullable
     public Long getTimeout(final TimeUnit timeUnit) {
+        notNull("timeUnit", timeUnit);
         Long timeoutMS = mongoOperationPublisher.getTimeoutMS();
-        return timeoutMS != null ? MILLISECONDS.convert(timeoutMS, timeUnit) : null;
+        return timeoutMS == null ? null : timeUnit.convert(timeoutMS, MILLISECONDS);
     }
 
     @Override

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoClientImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoClientImpl.java
@@ -167,6 +167,7 @@ public final class MongoClientImpl implements MongoClient {
     }
 
     @Override
+    @Nullable
     public Long getTimeout(final TimeUnit timeUnit) {
         return delegate.getTimeout(timeUnit);
     }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoClusterImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoClusterImpl.java
@@ -78,6 +78,7 @@ import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.TimeoutContext.createTimeoutContext;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 final class MongoClusterImpl implements MongoCluster {
     @Nullable
@@ -163,8 +164,9 @@ final class MongoClusterImpl implements MongoCluster {
     @Override
     @Nullable
     public Long getTimeout(final TimeUnit timeUnit) {
+        notNull("timeUnit", timeUnit);
         Long timeoutMS = timeoutSettings.getTimeoutMS();
-        return timeoutMS == null ? null : timeUnit.convert(timeoutMS, TimeUnit.MILLISECONDS);
+        return timeoutMS == null ? null : timeUnit.convert(timeoutMS, MILLISECONDS);
     }
 
     @Override


### PR DESCRIPTION
This is a backport of https://github.com/mongodb/mongo-java-driver/pull/2009. The [change](https://github.com/mongodb/mongo-java-driver/commit/d84dabbfd5809c3d0a47a47b1bc5cb4282e1ddf9) was cherry-picked cleanly.

[JAVA-6246](https://jira.mongodb.org/browse/JAVA-6246)