### PR TITLE
JAVA-6250 - Do not retain the connection-open handler from the channel close listener.

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/netty/NettyStream.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/netty/NettyStream.java
@@ -530,7 +530,11 @@ final class NettyStream implements Stream {
                         channelFuture.channel().close();
                     } else {
                         channel = channelFuture.channel();
-                        channel.closeFuture().addListener((ChannelFutureListener) future1 -> handleReadResponse(null, new IOException("The connection to the server was closed")));
+                        // capture only the enclosing stream in the close listener: capturing OpenChannelFutureListener.this
+                        // would pin the open handler (and everything it references) for the lifetime of the pooled channel
+                        NettyStream stream = NettyStream.this;
+                        channel.closeFuture().addListener((ChannelFutureListener) future1 ->
+                                stream.handleReadResponse(null, new IOException("The connection to the server was closed")));
                     }
                     handler.completed(null);
                 } else {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/netty/NettyStreamCloseFutureListenerTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/netty/NettyStreamCloseFutureListenerTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.connection.netty;
+
+import com.mongodb.ServerAddress;
+import com.mongodb.connection.AsyncCompletionHandler;
+import com.mongodb.connection.SocketSettings;
+import com.mongodb.connection.SslSettings;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import org.bson.ByteBuf;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.mongodb.ClusterFixture.OPERATION_CONTEXT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the listener that {@code OpenChannelFutureListener} registers on {@code channel.closeFuture()},
+ * from both angles:
+ * <ul>
+ *     <li>behavior: a read waiting on the channel must be failed when the channel closes;</li>
+ *     <li>footprint: the listener must not keep the connection-open {@link AsyncCompletionHandler}
+ *     (and everything it transitively references, e.g. the callback chain of the operation that was
+ *     waiting for the connection) strongly reachable while the channel remains open.</li>
+ * </ul>
+ */
+public class NettyStreamCloseFutureListenerTest {
+
+    private ServerSocket serverSocket;
+    private NioEventLoopGroup eventLoopGroup;
+    private NettyStream stream;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+        eventLoopGroup = new NioEventLoopGroup();
+        stream = (NettyStream) new NettyStreamFactory(
+                host -> Collections.singletonList(InetAddress.getLoopbackAddress()),
+                SocketSettings.builder().connectTimeout(10, TimeUnit.SECONDS).build(),
+                SslSettings.builder().build(),
+                eventLoopGroup, NioSocketChannel.class, PooledByteBufAllocator.DEFAULT, null)
+                .create(new ServerAddress("127.0.0.1", serverSocket.getLocalPort()));
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        stream.close();
+        eventLoopGroup.shutdownGracefully();
+        serverSocket.close();
+    }
+
+    @Test
+    @DisplayName("open handler should not remain strongly reachable from the open channel after the open completes")
+    public void shouldReleaseOpenHandlerAfterOpenCompletesWhileChannelRemainsOpen() throws Exception {
+        CountDownLatch opened = new CountDownLatch(1);
+        AsyncCompletionHandler<Void> handler = new AsyncCompletionHandler<Void>() {
+            @Override
+            public void completed(final Void result) {
+                opened.countDown();
+            }
+
+            @Override
+            public void failed(final Throwable t) {
+                opened.countDown();
+            }
+        };
+        WeakReference<AsyncCompletionHandler<Void>> canary = new WeakReference<AsyncCompletionHandler<Void>>(handler);
+
+        stream.openAsync(OPERATION_CONTEXT, handler);
+        assertTrue(opened.await(10, TimeUnit.SECONDS), "open did not complete");
+
+        handler = null;
+        for (int i = 0; i < 10 && canary.get() != null; i++) {
+            System.gc();
+            Thread.sleep(100);
+        }
+        assertNull(canary.get(),
+                "the connection-open AsyncCompletionHandler must not stay strongly reachable from the open "
+                        + "channel (closeFuture listener) after the open has completed");
+    }
+
+    @Test
+    @DisplayName("pending read should be failed when the channel is closed")
+    public void shouldFailPendingReadWhenChannelIsClosed() throws Exception {
+        AtomicReference<Socket> acceptedSocket = new AtomicReference<>();
+        Thread acceptor = new Thread(() -> {
+            try {
+                acceptedSocket.set(serverSocket.accept());
+            } catch (IOException ignored) {
+                // the assertions below fail if nothing was accepted
+            }
+        });
+        acceptor.start();
+
+        stream.open(OPERATION_CONTEXT);
+        acceptor.join(TimeUnit.SECONDS.toMillis(10));
+        assertNotNull(acceptedSocket.get(), "the server never accepted the connection");
+
+        CountDownLatch readCompleted = new CountDownLatch(1);
+        AtomicReference<Throwable> readFailure = new AtomicReference<>();
+        stream.readAsync(4, OPERATION_CONTEXT, new AsyncCompletionHandler<ByteBuf>() {
+            @Override
+            public void completed(final ByteBuf result) {
+                readCompleted.countDown();
+            }
+
+            @Override
+            public void failed(final Throwable t) {
+                readFailure.set(t);
+                readCompleted.countDown();
+            }
+        });
+
+        acceptedSocket.get().close();
+
+        assertTrue(readCompleted.await(10, TimeUnit.SECONDS), "the pending read never completed");
+        Throwable failure = readFailure.get();
+        assertNotNull(failure, "the pending read completed successfully instead of failing");
+        assertInstanceOf(IOException.class, failure);
+        assertEquals("The connection to the server was closed", failure.getMessage());
+    }
+}


### PR DESCRIPTION
### The bug

When the pool opens a connection with the Netty transport, the operation that asked for that connection stays anchored in memory for as long as the connection lives. The operation finishes normally, its caller gets its result, but its whole object graph (pool acquisition callbacks, reactive subscribers, and before 5.6.0 even the decoded result documents) cannot be garbage-collected. Pooled connections usually live forever (default `maxConnectionIdleTimeMS=0`), so the application accumulates one dead graph per connection the pool ever opened under load.

### How it happens

1. When a channel finishes opening, `OpenChannelFutureListener.operationComplete()` installs a listener on `channel.closeFuture()`. Its job: if this connection ever dies, fail the reads that are waiting on it. That listener legitimately lives as long as the channel.
2. To do its job, the listener's lambda only needs the `NettyStream` (it calls `stream.handleReadResponse(...)`). But the lambda is written inside `OpenChannelFutureListener`, which is a non-static inner class of `NettyStream`, so the compiler resolves the call as `NettyStream.this.handleReadResponse(...)` and makes the lambda capture `OpenChannelFutureListener.this`, the whole listener instance, just to reach the stream through it.
3. That instance has a `handler` field: the callback that was waiting for the connection to open. It fires once, when the open completes, and is never needed again. But since the close listener (lifetime: the channel) now references it, the handler and everything reachable from it (the operation's callback chain) survive every GC until the channel closes, which in a pool is typically never.

What the channel's close listener keeps reachable:

    before                                          after
    ──────                                          ─────
    OpenChannelFutureListener instance              NettyStream
    ├─ handler ──► waiting operation's graph        (nothing else: the stream already
    ├─ operationContext                              lives exactly as long as the
    ├─ socketAddressQueue                            channel, by design)
    └─ channelFuture

### The fix

Assign `NettyStream.this` to a local variable and use it in the lambda. The lambda then captures only the stream: same method called on the same object, same locking, no behavioral change, Java 8 compatible, nothing public touched. The one-shot open handler becomes collectable the moment the open completes.

We considered the more structural alternative: making `OpenChannelFutureListener` a `static` nested class with explicit dependencies, which would prevent this whole family of accidental captures at the type level. We kept the one-line fix instead: the class reads and writes several `NettyStream` members (`lock`, `isClosed`, `channel`, `initializeChannel`), so converting it is a much larger diff in connection-management code.

### Testing

- New `NettyStreamCloseFutureListenerTest` (driver-core unit tests against a local `ServerSocket`, no MongoDB instance required), covering the close listener from both angles. Behavior, guarding this change against regressions: a read pending on the channel must be failed with "The connection to the server was closed" when the server closes the connection (passes before and after this change). Footprint: a `WeakReference` on the connection-open handler must be cleared while the channel is still open (fails on current `main`, passes with this fix).
- `./gradlew :driver-core:test` and `./gradlew spotlessApply docs check scalaCheck` pass.
- Confirmed against real releases with the standalone two-wave reproducer attached to JAVA-6250 (two waves of 64 concurrent reads on the same client; `WeakReference` canaries on a 1 MB per-operation pipeline ballast and on the decoded documents): on 5.9.0, wave 1 pins the pipeline state of 26/64 operations and wave 2 adds 7 more (the pool keeps growing, each load episode stacks its graphs); everything survives full GCs and 95 s of idle, and is released the instant the channels close. On pre-5.6 versions the decoded documents are pinned on top (JAVA-5940 cleared that single hop in 5.6.0). With this fix applied to current `main`, the same run reports 0/64 for both canary families, in both waves, at every step.

Related: JAVA-5940 (an improvement that stopped cursors from retaining their already-delivered batch; as a side effect it removed the largest downstream consequence of this leak from 5.6.0 on, without touching the anchor itself).

JAVA-6250
