### PR TITLE
Guard against interface traversal type override

### DIFF
--- a/bson/src/main/org/bson/codecs/pojo/PojoBuilderHelper.java
+++ b/bson/src/main/org/bson/codecs/pojo/PojoBuilderHelper.java
@@ -199,6 +199,9 @@ final class PojoBuilderHelper {
                                                      final TypeData<S> parentClassTypeData,
                                                      final List<String> genericTypeNames,
                                                      final Type genericType) {
+        if (propertyTypeParameterMap.get(propertyMetadata.getName()) != null) {
+            return;
+        }
         TypeParameterMap typeParameterMap = getTypeParameterMap(genericTypeNames, genericType);
         propertyTypeParameterMap.put(propertyMetadata.getName(), typeParameterMap);
         propertyMetadata.typeParameterInfo(typeParameterMap, parentClassTypeData);

--- a/bson/src/test/unit/org/bson/codecs/pojo/ClassModelTest.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/ClassModelTest.java
@@ -21,6 +21,7 @@ import java.util.SortedSet;
 import org.bson.codecs.pojo.entities.CollectionNestedPojoModel;
 import org.bson.codecs.pojo.entities.ConcreteAndNestedAbstractInterfaceModel;
 import org.bson.codecs.pojo.entities.GenericHolderModel;
+import org.bson.codecs.pojo.entities.HolderConcreteMapModel;
 import org.bson.codecs.pojo.entities.InterfaceBasedModel;
 import org.bson.codecs.pojo.entities.ListGenericExtendedModel;
 import org.bson.codecs.pojo.entities.ListListGenericExtendedModel;
@@ -264,6 +265,14 @@ public final class ClassModelTest {
         assertEquals(createTypeData(Integer.class), classModel.getPropertyModel("integerField").getTypeData());
         assertEquals(createTypeData(String.class), classModel.getPropertyModel("stringField").getTypeData());
 
+    }
+
+    @Test
+    public void testHolderConcreteMap() {
+        ClassModel<?> classModel = ClassModel.builder(HolderConcreteMapModel.class).build();
+
+        assertEquals(1, classModel.getPropertyModels().size());
+        assertEquals(createTypeData(Map.class, String.class, Object.class), classModel.getPropertyModel("value").getTypeData());
     }
 
     <T> TypeData.Builder<T> createBuilder(final Class<T> clazz, final Class<?>... types) {

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/HolderAbstract.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/HolderAbstract.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+import java.util.Objects;
+
+public abstract class HolderAbstract<V> implements HolderInterface<V> {
+    private V value;
+
+    public HolderAbstract() {
+    }
+
+    public HolderAbstract(final V value) {
+        this.value = value;
+    }
+
+    @Override
+    public V getValue() {
+        return value;
+    }
+
+    @Override
+    public void setValue(final V v) {
+        this.value = v;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        HolderAbstract<?> that = (HolderAbstract<?>) o;
+
+        if (!Objects.equals(value, that.value)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return value != null ? value.hashCode() : 0;
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/HolderConcreteMapModel.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/HolderConcreteMapModel.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+import java.util.Map;
+
+public class HolderConcreteMapModel extends HolderAbstract<Map<String, Object>> {
+
+    public HolderConcreteMapModel() {
+    }
+
+    public HolderConcreteMapModel(final Map<String, Object> value) {
+        super(value);
+    }
+}

--- a/bson/src/test/unit/org/bson/codecs/pojo/entities/HolderInterface.java
+++ b/bson/src/test/unit/org/bson/codecs/pojo/entities/HolderInterface.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.codecs.pojo.entities;
+
+public interface HolderInterface<V> {
+    V getValue();
+
+    void setValue(V v);
+}


### PR DESCRIPTION
### Problem

After JAVA-3815, encoding a POJO that uses the following hierarchy shape fails:

```java
public abstract class AbstractModel<V> implements InterfaceModel<V> {
    private V value;
    public V getValue() { return value; }
    public void setValue(V v) { this.value = v; }
}

public class ConcreteModel extends AbstractModel<Map<String, Object>> {}
```

Encoding a `ConcreteModel` instance throws:

```
CodecConfigurationException: Can't find a codec for class java.lang.Object
```

The `value` property - which should resolve to `Map<String, Object>` - is being resolved to `Object` instead.

### Root cause

The underlying problem - `cachePropertyTypeData` unconditionally overwriting a property's resolution on later visits - already existed with superclass chains (JAVA-5110). Same root cause, different symptom: there, a forwarding chain like `C extends B<String>`, `B<T> extends A<T>`, `A<K>` resolves `K` to `Object` because the `TypeVariable` is never substituted. Users with that shape have been hitting it since at least 2023.

JAVA-3815 added interface scanning, which exposed the same overwrite problem for a new set of users: because `AbstractModel<V>` implements `InterfaceModel<V>`, the same property is now visited twice - first from `AbstractModel` with the correct concrete TypeData, then from `InterfaceModel` with stale TypeData. The second visit silently overwrote the first, surfacing the regression for users who had never changed their code.

Walk trace for `ConcreteModel`:

| Step | Class being added | `parentClassTypeData` passed |
|------|-------------------|------------------------------|
| 1 | `ConcreteModel` | `null` (root) |
| 2 | `AbstractModel` | `TypeData(ConcreteModel, [Map<String,Object>])` - correct |
| 3 | `InterfaceModel` (via AbstractModel's interfaces) | `TypeData(AbstractModel)` - no type params |

When the walker scans `InterfaceModel`, it finds `getValue()` again and calls `cachePropertyTypeData("value", ..., TypeData(AbstractModel))`. This overwrites the correct resolution (`Map<String,Object>`) with `TypeData(Object)`.

### Fix

Add a first-wins guard in `cachePropertyTypeData`: if a property's `TypeParameterMap` entry is already set, skip the update.

```java
private static <T, S> void cachePropertyTypeData(...) {
    if (propertyTypeParameterMap.get(propertyMetadata.getName()) != null) {
        return;
    }
    // ... existing logic
}
```

The first visit to a property comes from the most specific class in the bottom-up walk (the abstract class with the correct concrete binding). Later interface revisits carry stale TypeData and are now ignored.

### What this does not fix

This fix covers the interface-revisit overwrite case (JAVA-6065). It does not fix the class-forwarding gap (JAVA-5110), where a chain of abstract classes forward a type parameter without ever binding it concretely:

```java
class ConcreteModel extends MiddleModel<String> {}
abstract class MiddleModel<T> extends BaseModel<T> {}
abstract class BaseModel<K> { K value; }
```

In this shape, the origination TypeData itself is wrong (Object), so first-wins cannot help. That requires a separate fix.

There is other draft PR for class-forwarding issue: https://github.com/mongodb/mongo-java-driver/pull/2014

### Tests

- `HolderInterface<V>` / `HolderAbstract<V> implements HolderInterface<V>` / `HolderConcreteMapModel extends HolderAbstract<Map<String,Object>>` - new fixtures modelling the user's exact hierarchy shape.
- `ClassModelTest.testHolderConcreteMap` - asserts `value` resolves to `TypeData(Map, [String, Object])` after the fix.
