### PR TITLE
JAVA-6224 Ensure Kotlin can encode ByteArrays correctly

### DIFF
--- a/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/ArrayCodec.kt
+++ b/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/ArrayCodec.kt
@@ -47,8 +47,17 @@ internal data class ArrayCodec<R : Any, V>(private val kClass: KClass<R>, privat
                         else -> Pair(Object::class.java as Class<Any>, emptyList())
                     }
                 }
-            val codec =
-                if (nestedTypes.isEmpty()) codecRegistry.get(valueClass) else codecRegistry.get(valueClass, nestedTypes)
+            // ByteArrays are encoded as compact BSON Binary, not as a BSON Array of Int32.
+            // Resolved directly, as a registry may order ValueCodecProvider ahead of
+            // ArrayCodecProvider.
+            val codec: Codec<Any?> =
+                if (valueClass == ByteArray::class.java) {
+                    LenientByteArrayCodec as Codec<Any?>
+                } else if (nestedTypes.isEmpty()) {
+                    codecRegistry.get(valueClass)
+                } else {
+                    codecRegistry.get(valueClass, nestedTypes)
+                }
             return ArrayCodec(kClass, codec)
         }
     }

--- a/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/ArrayCodecProvider.kt
+++ b/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/ArrayCodecProvider.kt
@@ -25,7 +25,9 @@ public class ArrayCodecProvider : CodecProvider {
     override fun <T : Any> get(clazz: Class<T>, registry: CodecRegistry): Codec<T>? = get(clazz, emptyList(), registry)
 
     override fun <T : Any> get(clazz: Class<T>, typeArguments: List<Type>, registry: CodecRegistry): Codec<T>? =
-        if (clazz.isArray) {
+        // ByteArrays must be encoded as compact BSON Binary by ByteArrayCodec.
+        // Returning null lets the registry fall through to ByteArrayCodec.
+        if (clazz.isArray && clazz != ByteArray::class.java) {
             ArrayCodec.create(clazz.kotlin, typeArguments, registry)
         } else null
 }

--- a/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/ArrayCodecProvider.kt
+++ b/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/ArrayCodecProvider.kt
@@ -24,10 +24,12 @@ import org.bson.codecs.configuration.CodecRegistry
 public class ArrayCodecProvider : CodecProvider {
     override fun <T : Any> get(clazz: Class<T>, registry: CodecRegistry): Codec<T>? = get(clazz, emptyList(), registry)
 
+    @Suppress("UNCHECKED_CAST")
     override fun <T : Any> get(clazz: Class<T>, typeArguments: List<Type>, registry: CodecRegistry): Codec<T>? =
-        // ByteArrays must be encoded as compact BSON Binary by ByteArrayCodec.
-        // Returning null lets the registry fall through to ByteArrayCodec.
-        if (clazz.isArray && clazz != ByteArray::class.java) {
+        if (clazz == ByteArray::class.java) {
+            // ByteArrays are encoded as compact BSON Binary, not as a BSON Array of Int32.
+            LenientByteArrayCodec as Codec<T>
+        } else if (clazz.isArray) {
             ArrayCodec.create(clazz.kotlin, typeArguments, registry)
         } else null
 }

--- a/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/DataClassCodec.kt
+++ b/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/DataClassCodec.kt
@@ -251,8 +251,10 @@ internal data class DataClassCodec<T : Any>(
 
         @Suppress("UNCHECKED_CAST")
         private fun CodecRegistry.getCodec(kParameter: KParameter, clazz: Class<Any>, types: List<Type>): Codec<Any> {
+            // ByteArrays use a dedicated ByteArrayCodec in the registry that encodes compact BSON
+            // Binary.
             val codec =
-                if (clazz.isArray) {
+                if (clazz.isArray && clazz != ByteArray::class.java) {
                     ArrayCodec.create(clazz.kotlin, types, this)
                 } else if (types.isEmpty()) {
                     this.get(clazz)

--- a/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/DataClassCodec.kt
+++ b/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/DataClassCodec.kt
@@ -251,10 +251,11 @@ internal data class DataClassCodec<T : Any>(
 
         @Suppress("UNCHECKED_CAST")
         private fun CodecRegistry.getCodec(kParameter: KParameter, clazz: Class<Any>, types: List<Type>): Codec<Any> {
-            // ByteArrays use a dedicated ByteArrayCodec in the registry that encodes compact BSON
-            // Binary.
+            // ByteArrays are encoded as compact BSON Binary, not as a BSON Array of Int32.
             val codec =
-                if (clazz.isArray && clazz != ByteArray::class.java) {
+                if (clazz == ByteArray::class.java) {
+                    LenientByteArrayCodec as Codec<Any>
+                } else if (clazz.isArray) {
                     ArrayCodec.create(clazz.kotlin, types, this)
                 } else if (types.isEmpty()) {
                     this.get(clazz)

--- a/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/LenientByteArrayCodec.kt
+++ b/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/LenientByteArrayCodec.kt
@@ -25,9 +25,9 @@ import org.bson.codecs.DecoderContext
 /**
  * A [ByteArrayCodec] that also decodes the legacy BSON Array representation of a `ByteArray`.
  *
- * Versions 5.2.0 - 5.9.x encoded `ByteArray` data class fields as a BSON Array of Int32, one
- * element per byte, rather than as a compact BSON Binary. This codec still decodes those documents, so data written by
- * those versions remains readable.
+ * Versions 5.2.0 - 5.9.x encoded `ByteArray` data class fields as a BSON Array of Int32, one element per byte, rather
+ * than as a compact BSON Binary. This codec still decodes those documents, so data written by those versions remains
+ * readable.
  *
  * Encoding is inherited unchanged from [ByteArrayCodec] and always produces BSON Binary. Re-saving a document therefore
  * migrates it away from the legacy representation.

--- a/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/LenientByteArrayCodec.kt
+++ b/bson-kotlin/src/main/kotlin/org/bson/codecs/kotlin/LenientByteArrayCodec.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.kotlin
+
+import java.io.ByteArrayOutputStream
+import org.bson.BsonInvalidOperationException
+import org.bson.BsonReader
+import org.bson.BsonType
+import org.bson.codecs.ByteArrayCodec
+import org.bson.codecs.DecoderContext
+
+/**
+ * A [ByteArrayCodec] that also decodes the legacy BSON Array representation of a `ByteArray`.
+ *
+ * Versions 5.2.0 - 5.9.x encoded `ByteArray` data class fields as a BSON Array of Int32, one
+ * element per byte, rather than as a compact BSON Binary. This codec still decodes those documents, so data written by
+ * those versions remains readable.
+ *
+ * Encoding is inherited unchanged from [ByteArrayCodec] and always produces BSON Binary. Re-saving a document therefore
+ * migrates it away from the legacy representation.
+ *
+ * Only values the legacy encoder could have produced are accepted: every element must be an Int32 within the signed
+ * byte range. Anything else throws [BsonInvalidOperationException] rather than silently decoding an unrelated BSON
+ * Array into bytes.
+ */
+internal object LenientByteArrayCodec : ByteArrayCodec() {
+
+    override fun decode(reader: BsonReader, decoderContext: DecoderContext): ByteArray =
+        if (reader.currentBsonType == BsonType.ARRAY) {
+            decodeLegacyArray(reader)
+        } else {
+            super.decode(reader, decoderContext)
+        }
+
+    private fun decodeLegacyArray(reader: BsonReader): ByteArray {
+        val bytes = ByteArrayOutputStream()
+        reader.readStartArray()
+        while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+            if (reader.currentBsonType != BsonType.INT32) {
+                throw invalidElement(reader.currentBsonType.toString())
+            }
+            val value = reader.readInt32()
+            if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
+                throw invalidElement(value.toString())
+            }
+            bytes.write(value)
+        }
+        reader.readEndArray()
+        return bytes.toByteArray()
+    }
+
+    private fun invalidElement(found: String) =
+        BsonInvalidOperationException(
+            "Invalid element while decoding a byte array from a BSON Array: " +
+                "expected an INT32 in the range -128..127, but found $found.")
+}

--- a/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/DataClassCodecTest.kt
+++ b/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/DataClassCodecTest.kt
@@ -45,6 +45,7 @@ import org.bson.codecs.kotlin.samples.DataClassWithBsonExtraElements
 import org.bson.codecs.kotlin.samples.DataClassWithBsonId
 import org.bson.codecs.kotlin.samples.DataClassWithBsonIgnore
 import org.bson.codecs.kotlin.samples.DataClassWithBsonProperty
+import org.bson.codecs.kotlin.samples.DataClassWithByteArray
 import org.bson.codecs.kotlin.samples.DataClassWithCollections
 import org.bson.codecs.kotlin.samples.DataClassWithDataClassMapKey
 import org.bson.codecs.kotlin.samples.DataClassWithDefaults
@@ -122,6 +123,11 @@ class DataClassCodecTest {
             | "arraySimple": ["a", "b", "c", "d"],
             | "nestedArrays":  [["e", "f"], [], ["g", "h"]],
             | "arrayOfMaps":  [{"A": ["aa"], "B": ["bb"]}, {}, {"C": ["cc", "ccc"]}],
+            | "byteArray": {"${'$'}binary": {"base64": "AQIDBA==", "subType": "00"}},
+            | "nestedByteArrays": [
+            |     {"${'$'}binary": {"base64": "AQI=", "subType": "00"}},
+            |     {"${'$'}binary": {"base64": "AwQF", "subType": "00"}}
+            | ],
             |}"""
                 .trimMargin()
 
@@ -130,7 +136,9 @@ class DataClassCodecTest {
                 arrayOf("a", "b", "c", "d"),
                 arrayOf(arrayOf("e", "f"), emptyArray(), arrayOf("g", "h")),
                 arrayOf(
-                    mapOf("A" to arrayOf("aa"), "B" to arrayOf("bb")), emptyMap(), mapOf("C" to arrayOf("cc", "ccc"))))
+                    mapOf("A" to arrayOf("aa"), "B" to arrayOf("bb")), emptyMap(), mapOf("C" to arrayOf("cc", "ccc"))),
+                byteArrayOf(1, 2, 3, 4),
+                arrayOf(byteArrayOf(1, 2), byteArrayOf(3, 4, 5)))
 
         assertRoundTrips(expected, dataClass)
     }
@@ -140,7 +148,7 @@ class DataClassCodecTest {
         val expected =
             """{
             |    "booleanArray": [true, false],
-            |    "byteArray": [1, 2],
+            |    "byteArray": {"${'$'}binary": {"base64": "AQI=", "subType": "00"}},
             |    "charArray": ["a", "b"],
             |    "doubleArray": [ 1.1, 2.2, 3.3],
             |    "floatArray": [1.0, 2.0, 3.0],
@@ -164,6 +172,55 @@ class DataClassCodecTest {
                 shortArrayOf(1, 2, 3),
                 listOf(booleanArrayOf(true, false), booleanArrayOf(false, true)),
                 mapOf(Pair("A", intArrayOf(1, 2)), Pair("B", intArrayOf()), Pair("C", intArrayOf(3, 4))))
+
+        assertRoundTrips(expected, dataClass)
+    }
+
+    @Test
+    fun testDataClassWithByteArrayEncodesAsBinary() {
+        // A ByteArray field must encode as compact BSON Binary (subType 00),
+        // via ByteArrayCodec, not as a BSON Array of Int32 (one element per byte).
+        val expected = """{"byteArray": {"${'$'}binary": {"base64": "AQIDBA==", "subType": "00"}}}"""
+        assertRoundTrips(expected, DataClassWithByteArray(byteArrayOf(1, 2, 3, 4)))
+    }
+
+    @Test
+    fun testDataClassWithByteArrayDoesNotExpandDocumentSize() {
+        // BSON Array of ints encoding expands size ~8-10x, breaking the 16MB limit.
+        // Binary encoding keeps a 1MB payload close to 1MB.
+        val oneMegabyte = ByteArray(1_000_000)
+        val codec = DataClassCodec.create(DataClassWithByteArray::class, registry())!!
+        val document = BsonDocument()
+        codec.encode(
+            BsonDocumentWriter(document), DataClassWithByteArray(oneMegabyte), EncoderContext.builder().build())
+        val encodedSize = document.toBsonDocument().getBinary("byteArray").data.size
+        assertEquals(1_000_000, encodedSize)
+    }
+
+    @Test
+    fun testDataClassWithObjectArrayEncodesAsBsonArray() {
+        // Ensure normal arrays and ByteArrays are handled correctly.
+        val expected =
+            """{
+            | "arraySimple": ["a", "b", "c", "d"],
+            | "nestedArrays": [["e", "f"], [], ["g", "h"]],
+            | "arrayOfMaps": [{"A": ["aa"], "B": ["bb"]}, {}, {"C": ["cc", "ccc"]}],
+            | "byteArray": {"${'$'}binary": {"base64": "AQIDBA==", "subType": "00"}},
+            | "nestedByteArrays": [
+            |     {"${'$'}binary": {"base64": "AQI=", "subType": "00"}},
+            |     {"${'$'}binary": {"base64": "AwQF", "subType": "00"}}
+            | ]
+            |}"""
+                .trimMargin()
+
+        val dataClass =
+            DataClassWithArrays(
+                arrayOf("a", "b", "c", "d"),
+                arrayOf(arrayOf("e", "f"), emptyArray(), arrayOf("g", "h")),
+                arrayOf(
+                    mapOf("A" to arrayOf("aa"), "B" to arrayOf("bb")), emptyMap(), mapOf("C" to arrayOf("cc", "ccc"))),
+                byteArrayOf(1, 2, 3, 4),
+                arrayOf(byteArrayOf(1, 2), byteArrayOf(3, 4, 5)))
 
         assertRoundTrips(expected, dataClass)
     }

--- a/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/DataClassCodecTest.kt
+++ b/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/DataClassCodecTest.kt
@@ -193,36 +193,8 @@ class DataClassCodecTest {
         val document = BsonDocument()
         codec.encode(
             BsonDocumentWriter(document), DataClassWithByteArray(oneMegabyte), EncoderContext.builder().build())
-        val encodedSize = document.toBsonDocument().getBinary("byteArray").data.size
+        val encodedSize = document.getBinary("byteArray").data.size
         assertEquals(1_000_000, encodedSize)
-    }
-
-    @Test
-    fun testDataClassWithObjectArrayEncodesAsBsonArray() {
-        // Ensure normal arrays and ByteArrays are handled correctly.
-        val expected =
-            """{
-            | "arraySimple": ["a", "b", "c", "d"],
-            | "nestedArrays": [["e", "f"], [], ["g", "h"]],
-            | "arrayOfMaps": [{"A": ["aa"], "B": ["bb"]}, {}, {"C": ["cc", "ccc"]}],
-            | "byteArray": {"${'$'}binary": {"base64": "AQIDBA==", "subType": "00"}},
-            | "nestedByteArrays": [
-            |     {"${'$'}binary": {"base64": "AQI=", "subType": "00"}},
-            |     {"${'$'}binary": {"base64": "AwQF", "subType": "00"}}
-            | ]
-            |}"""
-                .trimMargin()
-
-        val dataClass =
-            DataClassWithArrays(
-                arrayOf("a", "b", "c", "d"),
-                arrayOf(arrayOf("e", "f"), emptyArray(), arrayOf("g", "h")),
-                arrayOf(
-                    mapOf("A" to arrayOf("aa"), "B" to arrayOf("bb")), emptyMap(), mapOf("C" to arrayOf("cc", "ccc"))),
-                byteArrayOf(1, 2, 3, 4),
-                arrayOf(byteArrayOf(1, 2), byteArrayOf(3, 4, 5)))
-
-        assertRoundTrips(expected, dataClass)
     }
 
     @Test

--- a/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/DataClassCodecTest.kt
+++ b/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/DataClassCodecTest.kt
@@ -23,6 +23,7 @@ import org.bson.BsonDocumentWriter
 import org.bson.BsonInvalidOperationException
 import org.bson.codecs.DecoderContext
 import org.bson.codecs.EncoderContext
+import org.bson.codecs.ValueCodecProvider
 import org.bson.codecs.configuration.CodecConfigurationException
 import org.bson.codecs.configuration.CodecRegistries.fromProviders
 import org.bson.codecs.kotlin.samples.Box
@@ -62,6 +63,7 @@ import org.bson.codecs.kotlin.samples.DataClassWithMutableList
 import org.bson.codecs.kotlin.samples.DataClassWithMutableMap
 import org.bson.codecs.kotlin.samples.DataClassWithMutableSet
 import org.bson.codecs.kotlin.samples.DataClassWithNativeArrays
+import org.bson.codecs.kotlin.samples.DataClassWithNestedByteArrays
 import org.bson.codecs.kotlin.samples.DataClassWithNestedParameterized
 import org.bson.codecs.kotlin.samples.DataClassWithNestedParameterizedDataClass
 import org.bson.codecs.kotlin.samples.DataClassWithNullableGeneric
@@ -242,6 +244,22 @@ class DataClassCodecTest {
                 arrayOf(byteArrayOf(1, 2), byteArrayOf(3, 4, 5)))
 
         assertDecodesTo(data, expected)
+    }
+
+    @Test
+    fun testNestedByteArraysDecodeLegacyBsonArraysWithValueCodecProviderFirst() {
+        // MongoClientSettings.DEFAULT_CODEC_REGISTRY orders ValueCodecProvider ahead of
+        // ArrayCodecProvider, so resolving the element codec via the registry would find
+        // ByteArrayCodec
+        // rather than LenientByteArrayCodec.
+        val registry = fromProviders(ValueCodecProvider(), ArrayCodecProvider(), DataClassCodecProvider())
+        val codec = DataClassCodec.create(DataClassWithNestedByteArrays::class, registry)!!
+        val decoded =
+            codec.decode(
+                BsonDocumentReader(BsonDocument.parse("""{"nestedByteArrays": [[1, 2], [3, 4]]}""")),
+                DecoderContext.builder().build())
+
+        assertEquals(DataClassWithNestedByteArrays(arrayOf(byteArrayOf(1, 2), byteArrayOf(3, 4))), decoded)
     }
 
     @Test

--- a/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/DataClassCodecTest.kt
+++ b/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/DataClassCodecTest.kt
@@ -16,9 +16,11 @@
 package org.bson.codecs.kotlin
 
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import org.bson.BsonDocument
 import org.bson.BsonDocumentReader
 import org.bson.BsonDocumentWriter
+import org.bson.BsonInvalidOperationException
 import org.bson.codecs.DecoderContext
 import org.bson.codecs.EncoderContext
 import org.bson.codecs.configuration.CodecConfigurationException
@@ -195,6 +197,74 @@ class DataClassCodecTest {
             BsonDocumentWriter(document), DataClassWithByteArray(oneMegabyte), EncoderContext.builder().build())
         val encodedSize = document.getBinary("byteArray").data.size
         assertEquals(1_000_000, encodedSize)
+    }
+
+    @Test
+    fun testDataClassWithByteArrayDecodesLegacyBsonArray() {
+        // Versions 5.2.0 - 5.9.x encoded ByteArray as a BSON Array of Int32.
+        // Those documents must still decode.
+        assertDecodesTo(
+            BsonDocument.parse("""{"byteArray": [1, 2, 3, 4]}"""), DataClassWithByteArray(byteArrayOf(1, 2, 3, 4)))
+    }
+
+    @Test
+    fun testDataClassWithByteArrayDecodesLegacyBsonArrayWithFullByteRange() {
+        assertDecodesTo(
+            BsonDocument.parse("""{"byteArray": [-128, -1, 0, 127]}"""),
+            DataClassWithByteArray(byteArrayOf(-128, -1, 0, 127)))
+    }
+
+    @Test
+    fun testDataClassWithByteArrayDecodesEmptyLegacyBsonArray() {
+        assertDecodesTo(BsonDocument.parse("""{"byteArray": []}"""), DataClassWithByteArray(byteArrayOf()))
+    }
+
+    @Test
+    fun testDataClassWithArraysDecodesLegacyByteArrays() {
+        val data =
+            BsonDocument.parse(
+                """{
+                | "arraySimple": ["a", "b", "c", "d"],
+                | "nestedArrays":  [["e", "f"], [], ["g", "h"]],
+                | "arrayOfMaps":  [{"A": ["aa"], "B": ["bb"]}, {}, {"C": ["cc", "ccc"]}],
+                | "byteArray": [1, 2, 3, 4],
+                | "nestedByteArrays": [[1, 2], [3, 4, 5]],
+                |}"""
+                    .trimMargin())
+
+        val expected =
+            DataClassWithArrays(
+                arrayOf("a", "b", "c", "d"),
+                arrayOf(arrayOf("e", "f"), emptyArray(), arrayOf("g", "h")),
+                arrayOf(
+                    mapOf("A" to arrayOf("aa"), "B" to arrayOf("bb")), emptyMap(), mapOf("C" to arrayOf("cc", "ccc"))),
+                byteArrayOf(1, 2, 3, 4),
+                arrayOf(byteArrayOf(1, 2), byteArrayOf(3, 4, 5)))
+
+        assertDecodesTo(data, expected)
+    }
+
+    @Test
+    fun testDataClassWithByteArrayLegacyBsonArrayFailures() {
+        assertLegacyByteArrayDecodeFails("""{"byteArray": [1, 128]}""")
+        assertLegacyByteArrayDecodeFails("""{"byteArray": [1, -129]}""")
+        assertLegacyByteArrayDecodeFails("""{"byteArray": [1, 300]}""")
+        assertLegacyByteArrayDecodeFails("""{"byteArray": [1, "2"]}""")
+        assertLegacyByteArrayDecodeFails("""{"byteArray": [1, 2.0]}""")
+        assertLegacyByteArrayDecodeFails("""{"byteArray": [1, {"${'$'}numberLong": "2"}]}""")
+        assertLegacyByteArrayDecodeFails("""{"byteArray": [1, null]}""")
+    }
+
+    private fun assertLegacyByteArrayDecodeFails(json: String) {
+        val codec = DataClassCodec.create(DataClassWithByteArray::class, registry())!!
+        val exception =
+            assertThrows<CodecConfigurationException>(json) {
+                codec.decode(BsonDocumentReader(BsonDocument.parse(json)), DecoderContext.builder().build())
+            }
+        val cause = exception.cause
+        assertTrue(cause is BsonInvalidOperationException, json)
+        // Must fail on element validation, not on the absence of BSON Binary.
+        assertTrue(cause.message!!.contains("expected an INT32 in the range -128..127"), cause.message)
     }
 
     @Test

--- a/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/samples/DataClasses.kt
+++ b/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/samples/DataClasses.kt
@@ -52,7 +52,9 @@ data class DataClassWithCollections(
 data class DataClassWithArrays(
     val arraySimple: Array<String>,
     val nestedArrays: Array<Array<String>>,
-    val arrayOfMaps: Array<Map<String, Array<String>>>
+    val arrayOfMaps: Array<Map<String, Array<String>>>,
+    val byteArray: ByteArray,
+    val nestedByteArrays: Array<ByteArray>
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -70,6 +72,9 @@ data class DataClassWithArrays(
             map.keys.forEach { key -> if (!map[key].contentEquals(otherMap[key])) return false }
         }
 
+        if (!byteArray.contentEquals(other.byteArray)) return false
+        if (!nestedByteArrays.contentDeepEquals(other.nestedByteArrays)) return false
+
         return true
     }
 
@@ -77,6 +82,8 @@ data class DataClassWithArrays(
         var result = arraySimple.contentHashCode()
         result = 31 * result + nestedArrays.contentDeepHashCode()
         result = 31 * result + arrayOfMaps.contentHashCode()
+        result = 31 * result + byteArray.contentHashCode()
+        result = 31 * result + nestedByteArrays.contentDeepHashCode()
         return result
     }
 }
@@ -132,6 +139,17 @@ data class DataClassWithNativeArrays(
         result = 31 * result + mapOfArrays.hashCode()
         return result
     }
+}
+
+data class DataClassWithByteArray(val byteArray: ByteArray) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as DataClassWithByteArray
+        return byteArray.contentEquals(other.byteArray)
+    }
+
+    override fun hashCode(): Int = byteArray.contentHashCode()
 }
 
 data class DataClassWithDefaults(

--- a/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/samples/DataClasses.kt
+++ b/bson-kotlin/src/test/kotlin/org/bson/codecs/kotlin/samples/DataClasses.kt
@@ -152,6 +152,17 @@ data class DataClassWithByteArray(val byteArray: ByteArray) {
     override fun hashCode(): Int = byteArray.contentHashCode()
 }
 
+data class DataClassWithNestedByteArrays(val nestedByteArrays: Array<ByteArray>) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as DataClassWithNestedByteArrays
+        return nestedByteArrays.contentDeepEquals(other.nestedByteArrays)
+    }
+
+    override fun hashCode(): Int = nestedByteArrays.contentDeepHashCode()
+}
+
 data class DataClassWithDefaults(
     val boolean: Boolean = false,
     val string: String = "String",

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/ByteArrayAsBsonBinary.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/ByteArrayAsBsonBinary.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bson.codecs.kotlinx
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.modules.SerializersModule
+import org.bson.BsonBinary
+
+/**
+ * ByteArray KSerializer.
+ *
+ * Encodes and decodes `ByteArray` values to and from a compact `BsonBinary` (subtype
+ * [org.bson.BsonBinarySubType.BINARY]), matching the behavior of the standard `ByteArrayCodec` and the `bson-kotlin`
+ * `DataClassCodec`.
+ *
+ * This is an opt-in serializer: kotlinx.serialization's built-in `ByteArray` serializer encodes a `ByteArray` as a BSON
+ * array of int32 elements (one element per byte). To store a `ByteArray` field as `BsonBinary` instead, either annotate
+ * the field with `@Serializable(with = ByteArrayAsBsonBinary::class)`, or annotate it with `@Contextual` and register
+ * [ByteArrayAsBsonBinary.serializersModule] on the codec.
+ *
+ * @since 5.10
+ */
+@ExperimentalSerializationApi
+public object ByteArrayAsBsonBinary : KSerializer<ByteArray> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("ByteArrayAsBsonBinary", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: ByteArray) {
+        when (encoder) {
+            is BsonEncoder -> encoder.encodeBsonValue(BsonBinary(value))
+            else -> throw SerializationException("ByteArray is not supported by ${encoder::class}")
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): ByteArray {
+        return when (decoder) {
+            is BsonDecoder -> decoder.decodeBsonValue().asBinary().data
+            else -> throw SerializationException("ByteArray is not supported by ${decoder::class}")
+        }
+    }
+
+    public val serializersModule: SerializersModule = SerializersModule {
+        contextual(ByteArray::class, ByteArrayAsBsonBinary)
+    }
+}

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/ByteArrayAsBsonBinary.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/ByteArrayAsBsonBinary.kt
@@ -58,6 +58,14 @@ public object ByteArrayAsBsonBinary : KSerializer<ByteArray> {
         }
     }
 
+    /**
+     * A [SerializersModule] that registers [ByteArrayAsBsonBinary] as the contextual serializer for `ByteArray`.
+     *
+     * Register it on the codec (or combine it with an existing module) so that any `ByteArray` field annotated with
+     * `@Contextual` is encoded and decoded as a compact `BsonBinary` instead of a BSON array of int32 elements.
+     *
+     * @since 5.10
+     */
     public val serializersModule: SerializersModule = SerializersModule {
         contextual(ByteArray::class, ByteArrayAsBsonBinary)
     }

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/ByteArrayAsBsonBinary.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/ByteArrayAsBsonBinary.kt
@@ -42,10 +42,9 @@ import org.bson.BsonValue
  * [ByteArrayAsBsonBinary.serializersModule] on the codec.
  *
  * To ease migration, decoding also accepts that legacy BSON array of int32 form — as written by the built-in
- * `ByteArray` serializer, and by `bson-kotlin` 5.2.0 through 5.9.x. Encoding always produces
- * `BsonBinary`, so re-saving a document migrates it. Every element of such an array must be an int32 within the signed
- * byte range; otherwise `BsonInvalidOperationException` is thrown rather than silently decoding an unrelated BSON array
- * into bytes.
+ * `ByteArray` serializer, and by `bson-kotlin` 5.2.0 through 5.9.x. Encoding always produces `BsonBinary`, so re-saving
+ * a document migrates it. Every element of such an array must be an int32 within the signed byte range; otherwise
+ * `BsonInvalidOperationException` is thrown rather than silently decoding an unrelated BSON array into bytes.
  *
  * @since 5.10
  */

--- a/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/ByteArrayAsBsonBinary.kt
+++ b/bson-kotlinx/src/main/kotlin/org/bson/codecs/kotlinx/ByteArrayAsBsonBinary.kt
@@ -24,7 +24,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.modules.SerializersModule
+import org.bson.BsonArray
 import org.bson.BsonBinary
+import org.bson.BsonInvalidOperationException
+import org.bson.BsonValue
 
 /**
  * ByteArray KSerializer.
@@ -37,6 +40,12 @@ import org.bson.BsonBinary
  * array of int32 elements (one element per byte). To store a `ByteArray` field as `BsonBinary` instead, either annotate
  * the field with `@Serializable(with = ByteArrayAsBsonBinary::class)`, or annotate it with `@Contextual` and register
  * [ByteArrayAsBsonBinary.serializersModule] on the codec.
+ *
+ * To ease migration, decoding also accepts that legacy BSON array of int32 form — as written by the built-in
+ * `ByteArray` serializer, and by `bson-kotlin` 5.2.0 through 5.9.x. Encoding always produces
+ * `BsonBinary`, so re-saving a document migrates it. Every element of such an array must be an int32 within the signed
+ * byte range; otherwise `BsonInvalidOperationException` is thrown rather than silently decoding an unrelated BSON array
+ * into bytes.
  *
  * @since 5.10
  */
@@ -53,10 +62,35 @@ public object ByteArrayAsBsonBinary : KSerializer<ByteArray> {
 
     override fun deserialize(decoder: Decoder): ByteArray {
         return when (decoder) {
-            is BsonDecoder -> decoder.decodeBsonValue().asBinary().data
+            is BsonDecoder ->
+                when (val value = decoder.decodeBsonValue()) {
+                    // Legacy form: a BSON array of int32, one element per byte. See the class KDoc.
+                    is BsonArray -> value.toByteArray()
+                    else -> value.asBinary().data
+                }
             else -> throw SerializationException("ByteArray is not supported by ${decoder::class}")
         }
     }
+
+    private fun BsonArray.toByteArray(): ByteArray {
+        val bytes = ByteArray(size)
+        forEachIndexed { index, element ->
+            if (!element.isInt32) {
+                throw invalidElement(element)
+            }
+            val value = element.asInt32().value
+            if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
+                throw invalidElement(element)
+            }
+            bytes[index] = value.toByte()
+        }
+        return bytes
+    }
+
+    private fun invalidElement(element: BsonValue) =
+        BsonInvalidOperationException(
+            "Invalid element while decoding a byte array from a BSON Array: " +
+                "expected an INT32 in the range -128..127, but found $element.")
 
     /**
      * A [SerializersModule] that registers [ByteArrayAsBsonBinary] as the contextual serializer for `ByteArray`.

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
@@ -74,6 +74,7 @@ import org.bson.codecs.kotlinx.samples.DataClassSealedB
 import org.bson.codecs.kotlinx.samples.DataClassSealedC
 import org.bson.codecs.kotlinx.samples.DataClassSelfReferential
 import org.bson.codecs.kotlinx.samples.DataClassWithAnnotations
+import org.bson.codecs.kotlinx.samples.DataClassWithArrays
 import org.bson.codecs.kotlinx.samples.DataClassWithBooleanMapKey
 import org.bson.codecs.kotlinx.samples.DataClassWithBsonConstructor
 import org.bson.codecs.kotlinx.samples.DataClassWithBsonDiscriminator
@@ -82,6 +83,7 @@ import org.bson.codecs.kotlinx.samples.DataClassWithBsonId
 import org.bson.codecs.kotlinx.samples.DataClassWithBsonIgnore
 import org.bson.codecs.kotlinx.samples.DataClassWithBsonProperty
 import org.bson.codecs.kotlinx.samples.DataClassWithBsonRepresentation
+import org.bson.codecs.kotlinx.samples.DataClassWithByteArray
 import org.bson.codecs.kotlinx.samples.DataClassWithCamelCase
 import org.bson.codecs.kotlinx.samples.DataClassWithCollections
 import org.bson.codecs.kotlinx.samples.DataClassWithContextualDateValues
@@ -297,6 +299,50 @@ class KotlinSerializerCodecTest {
                 LocalDate.fromEpochDays(1))
 
         assertRoundTrips(expected, expectedDataClass)
+    }
+
+    @Test
+    fun testDataClassWithByteArrayEncodesAsBsonArrayByDefault() {
+        // By default kotlinx.serialization encodes a ByteArray as a BSON array of int32 elements
+        // (one per byte).
+        // This differs from bson-kotlin's DataClassCodec, which encodes ByteArray as compact BSON
+        // Binary.
+        val expected = """{"byteArray": [1, 2, 3, 4]}"""
+
+        assertRoundTrips(expected, DataClassWithByteArray(byteArrayOf(1, 2, 3, 4)))
+    }
+
+    @Test
+    fun testDataClassWithObjectArrayEncodesAsBsonArray() {
+        // Object arrays encode as BSON arrays, while ByteArray fields opted in via
+        // @Serializable(with = ByteArrayAsBsonBinary::class) encode as compact BSON Binary (subType
+        // 00),
+        // consistent with the standard ByteArrayCodec and bson-kotlin's DataClassCodec. The
+        // per-type-argument
+        // annotation on nestedByteArrays applies the serializer to each inner ByteArray element.
+        val expected =
+            """{
+            | "arraySimple": ["a", "b", "c", "d"],
+            | "nestedArrays": [["e", "f"], [], ["g", "h"]],
+            | "arrayOfMaps": [{"A": ["aa"], "B": ["bb"]}, {}, {"C": ["cc", "ccc"]}],
+            | "byteArray": {"${'$'}binary": {"base64": "AQIDBA==", "subType": "00"}},
+            | "nestedByteArrays": [
+            |     {"${'$'}binary": {"base64": "AQI=", "subType": "00"}},
+            |     {"${'$'}binary": {"base64": "AwQF", "subType": "00"}}
+            | ]
+            |}"""
+                .trimMargin()
+
+        val dataClass =
+            DataClassWithArrays(
+                arrayOf("a", "b", "c", "d"),
+                arrayOf(arrayOf("e", "f"), emptyArray(), arrayOf("g", "h")),
+                arrayOf(
+                    mapOf("A" to arrayOf("aa"), "B" to arrayOf("bb")), emptyMap(), mapOf("C" to arrayOf("cc", "ccc"))),
+                byteArrayOf(1, 2, 3, 4),
+                arrayOf(byteArrayOf(1, 2), byteArrayOf(3, 4, 5)))
+
+        assertRoundTrips(expected, dataClass)
     }
 
     @Test

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
@@ -84,8 +84,11 @@ import org.bson.codecs.kotlinx.samples.DataClassWithBsonIgnore
 import org.bson.codecs.kotlinx.samples.DataClassWithBsonProperty
 import org.bson.codecs.kotlinx.samples.DataClassWithBsonRepresentation
 import org.bson.codecs.kotlinx.samples.DataClassWithByteArray
+import org.bson.codecs.kotlinx.samples.DataClassWithByteArrayAsBsonBinary
+import org.bson.codecs.kotlinx.samples.DataClassWithByteArrayAsBsonBinaryNullable
 import org.bson.codecs.kotlinx.samples.DataClassWithCamelCase
 import org.bson.codecs.kotlinx.samples.DataClassWithCollections
+import org.bson.codecs.kotlinx.samples.DataClassWithContextualByteArray
 import org.bson.codecs.kotlinx.samples.DataClassWithContextualDateValues
 import org.bson.codecs.kotlinx.samples.DataClassWithDataClassMapKey
 import org.bson.codecs.kotlinx.samples.DataClassWithDateValues
@@ -303,23 +306,55 @@ class KotlinSerializerCodecTest {
 
     @Test
     fun testDataClassWithByteArrayEncodesAsBsonArrayByDefault() {
-        // By default kotlinx.serialization encodes a ByteArray as a BSON array of int32 elements
-        // (one per byte).
-        // This differs from bson-kotlin's DataClassCodec, which encodes ByteArray as compact BSON
-        // Binary.
+        // kotlinx.serialization's built-in ByteArray serializer encodes one int32 element per byte.
         val expected = """{"byteArray": [1, 2, 3, 4]}"""
 
         assertRoundTrips(expected, DataClassWithByteArray(byteArrayOf(1, 2, 3, 4)))
     }
 
     @Test
+    fun testDataClassWithByteArrayAsBsonBinary() {
+        val expected = """{"byteArray": {"${'$'}binary": {"base64": "AQIDBA==", "subType": "00"}}}"""
+
+        assertRoundTrips(expected, DataClassWithByteArrayAsBsonBinary(byteArrayOf(1, 2, 3, 4)))
+    }
+
+    @Test
+    fun testDataClassWithEmptyByteArrayAsBsonBinary() {
+        val expected = """{"byteArray": {"${'$'}binary": {"base64": "", "subType": "00"}}}"""
+
+        assertRoundTrips(expected, DataClassWithByteArrayAsBsonBinary(byteArrayOf()))
+    }
+
+    @Test
+    fun testDataClassWithNullableByteArrayAsBsonBinary() {
+        // Nulls are omitted by default (explicitNulls = false).
+        assertRoundTrips("{}", DataClassWithByteArrayAsBsonBinaryNullable(null))
+        assertRoundTrips(
+            """{"byteArray": {"${'$'}binary": {"base64": "AQI=", "subType": "00"}}}""",
+            DataClassWithByteArrayAsBsonBinaryNullable(byteArrayOf(1, 2)))
+    }
+
+    @Test
+    fun testDataClassWithContextualByteArrayAsBsonBinary() {
+        val expected = """{"byteArray": {"${'$'}binary": {"base64": "AQIDBA==", "subType": "00"}}}"""
+
+        assertRoundTrips(
+            expected,
+            DataClassWithContextualByteArray(byteArrayOf(1, 2, 3, 4)),
+            serializersModule = ByteArrayAsBsonBinary.serializersModule)
+    }
+
+    @Test
+    fun testByteArrayAsBsonBinaryFailsToDecodeNonBinaryValue() {
+        assertThrows<BsonInvalidOperationException> {
+            deserialize<DataClassWithByteArrayAsBsonBinary>(BsonDocument.parse("""{"byteArray": [1, 2, 3, 4]}"""))
+        }
+    }
+
+    @Test
     fun testDataClassWithObjectArrayEncodesAsBsonArray() {
-        // Object arrays encode as BSON arrays, while ByteArray fields opted in via
-        // @Serializable(with = ByteArrayAsBsonBinary::class) encode as compact BSON Binary (subType
-        // 00),
-        // consistent with the standard ByteArrayCodec and bson-kotlin's DataClassCodec. The
-        // per-type-argument
-        // annotation on nestedByteArrays applies the serializer to each inner ByteArray element.
+        // The annotation inside `Array<@Serializable(...) ByteArray>` applies per element.
         val expected =
             """{
             | "arraySimple": ["a", "b", "c", "d"],

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
@@ -349,7 +349,8 @@ class KotlinSerializerCodecTest {
     @Test
     fun testByteArrayAsBsonBinaryDecodesLegacyBsonArray() {
         // The built-in ByteArray serializer, and bson-kotlin 5.2.0 - 5.9.x,
-        // regressed abd encoded a ByteArray as a BSON Array of Int32. Those documents must still decode.
+        // regressed abd encoded a ByteArray as a BSON Array of Int32. Those documents must still
+        // decode.
         assertDecodesTo("""{"byteArray": [1, 2, 3, 4]}""", DataClassWithByteArrayAsBsonBinary(byteArrayOf(1, 2, 3, 4)))
         assertDecodesTo(
             """{"byteArray": [-128, -1, 0, 127]}""", DataClassWithByteArrayAsBsonBinary(byteArrayOf(-128, -1, 0, 127)))

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
@@ -19,6 +19,7 @@ import java.math.BigDecimal
 import java.util.Base64
 import java.util.stream.Stream
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -346,9 +347,58 @@ class KotlinSerializerCodecTest {
     }
 
     @Test
-    fun testByteArrayAsBsonBinaryFailsToDecodeNonBinaryValue() {
+    fun testByteArrayAsBsonBinaryDecodesLegacyBsonArray() {
+        // The built-in ByteArray serializer, and bson-kotlin 5.2.0 - 5.9.x,
+        // regressed abd encoded a ByteArray as a BSON Array of Int32. Those documents must still decode.
+        assertDecodesTo("""{"byteArray": [1, 2, 3, 4]}""", DataClassWithByteArrayAsBsonBinary(byteArrayOf(1, 2, 3, 4)))
+        assertDecodesTo(
+            """{"byteArray": [-128, -1, 0, 127]}""", DataClassWithByteArrayAsBsonBinary(byteArrayOf(-128, -1, 0, 127)))
+        assertDecodesTo("""{"byteArray": []}""", DataClassWithByteArrayAsBsonBinary(byteArrayOf()))
+    }
+
+    @Test
+    fun testContextualByteArrayAsBsonBinaryDecodesLegacyBsonArray() {
+        assertDecodesTo(
+            """{"byteArray": [1, 2, 3, 4]}""",
+            DataClassWithContextualByteArray(byteArrayOf(1, 2, 3, 4)),
+            serializersModule = ByteArrayAsBsonBinary.serializersModule)
+    }
+
+    @Test
+    fun testByteArrayAsBsonBinaryDecodesNestedLegacyBsonArrays() {
+        assertDecodesTo(
+            """{
+            | "arraySimple": ["a"],
+            | "nestedArrays": [["e"]],
+            | "arrayOfMaps": [{"A": ["aa"]}],
+            | "byteArray": [1, 2, 3, 4],
+            | "nestedByteArrays": [[1, 2], [3, 4, 5]]
+            |}"""
+                .trimMargin(),
+            DataClassWithArrays(
+                arrayOf("a"),
+                arrayOf(arrayOf("e")),
+                arrayOf(mapOf("A" to arrayOf("aa"))),
+                byteArrayOf(1, 2, 3, 4),
+                arrayOf(byteArrayOf(1, 2), byteArrayOf(3, 4, 5))))
+    }
+
+    @Test
+    fun testByteArrayAsBsonBinaryFailsToDecodeInvalidLegacyBsonArrayElements() {
+        listOf("[1, 128]", "[1, -129]", "[1, 300]", """[1, "2"]""", "[1, 2.0]", """[1, {"${'$'}numberLong": "2"}]""")
+            .forEach { array ->
+                val exception =
+                    assertThrows<BsonInvalidOperationException>(array) {
+                        deserialize<DataClassWithByteArrayAsBsonBinary>(BsonDocument.parse("""{"byteArray": $array}"""))
+                    }
+                assertTrue(exception.message!!.contains("expected an INT32 in the range -128..127"), exception.message)
+            }
+    }
+
+    @Test
+    fun testByteArrayAsBsonBinaryFailsToDecodeUnsupportedBsonType() {
         assertThrows<BsonInvalidOperationException> {
-            deserialize<DataClassWithByteArrayAsBsonBinary>(BsonDocument.parse("""{"byteArray": [1, 2, 3, 4]}"""))
+            deserialize<DataClassWithByteArrayAsBsonBinary>(BsonDocument.parse("""{"byteArray": "abc"}"""))
         }
     }
 

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/KotlinSerializerCodecTest.kt
@@ -349,7 +349,7 @@ class KotlinSerializerCodecTest {
     @Test
     fun testByteArrayAsBsonBinaryDecodesLegacyBsonArray() {
         // The built-in ByteArray serializer, and bson-kotlin 5.2.0 - 5.9.x,
-        // regressed abd encoded a ByteArray as a BSON Array of Int32. Those documents must still
+        // regressed and encoded a ByteArray as a BSON Array of Int32. Those documents must still
         // decode.
         assertDecodesTo("""{"byteArray": [1, 2, 3, 4]}""", DataClassWithByteArrayAsBsonBinary(byteArrayOf(1, 2, 3, 4)))
         assertDecodesTo(

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
@@ -47,6 +47,7 @@ import org.bson.BsonSymbol
 import org.bson.BsonTimestamp
 import org.bson.BsonType
 import org.bson.BsonUndefined
+import org.bson.codecs.kotlinx.ByteArrayAsBsonBinary
 import org.bson.codecs.pojo.annotations.BsonCreator
 import org.bson.codecs.pojo.annotations.BsonDiscriminator
 import org.bson.codecs.pojo.annotations.BsonExtraElements
@@ -376,3 +377,56 @@ data class DataClassWithJsonElementsNullable(
     val jsonElements: List<JsonElement?>?,
     val jsonNestedMap: Map<String, JsonElement?>?
 )
+
+@Serializable
+data class DataClassWithByteArray(val byteArray: ByteArray) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as DataClassWithByteArray
+        return byteArray.contentEquals(other.byteArray)
+    }
+
+    override fun hashCode(): Int = byteArray.contentHashCode()
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class DataClassWithArrays(
+    val arraySimple: Array<String>,
+    val nestedArrays: Array<Array<String>>,
+    val arrayOfMaps: Array<Map<String, Array<String>>>,
+    @Serializable(with = ByteArrayAsBsonBinary::class) val byteArray: ByteArray,
+    val nestedByteArrays: Array<@Serializable(with = ByteArrayAsBsonBinary::class) ByteArray>
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DataClassWithArrays
+
+        if (!arraySimple.contentEquals(other.arraySimple)) return false
+        if (!nestedArrays.contentDeepEquals(other.nestedArrays)) return false
+
+        if (arrayOfMaps.size != other.arrayOfMaps.size) return false
+        arrayOfMaps.forEachIndexed { i, map ->
+            val otherMap = other.arrayOfMaps[i]
+            if (map.keys != otherMap.keys) return false
+            map.keys.forEach { key -> if (!map[key].contentEquals(otherMap[key])) return false }
+        }
+
+        if (!byteArray.contentEquals(other.byteArray)) return false
+        if (!nestedByteArrays.contentDeepEquals(other.nestedByteArrays)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = arraySimple.contentHashCode()
+        result = 31 * result + nestedArrays.contentDeepHashCode()
+        result = 31 * result + arrayOfMaps.contentHashCode()
+        result = 31 * result + byteArray.contentHashCode()
+        result = 31 * result + nestedByteArrays.contentDeepHashCode()
+        return result
+    }
+}

--- a/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
+++ b/bson-kotlinx/src/test/kotlin/org/bson/codecs/kotlinx/samples/DataClasses.kt
@@ -392,6 +392,48 @@ data class DataClassWithByteArray(val byteArray: ByteArray) {
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
+data class DataClassWithByteArrayAsBsonBinary(
+    @Serializable(with = ByteArrayAsBsonBinary::class) val byteArray: ByteArray
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as DataClassWithByteArrayAsBsonBinary
+        return byteArray.contentEquals(other.byteArray)
+    }
+
+    override fun hashCode(): Int = byteArray.contentHashCode()
+}
+
+@Serializable
+data class DataClassWithContextualByteArray(@Contextual val byteArray: ByteArray) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as DataClassWithContextualByteArray
+        return byteArray.contentEquals(other.byteArray)
+    }
+
+    override fun hashCode(): Int = byteArray.contentHashCode()
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class DataClassWithByteArrayAsBsonBinaryNullable(
+    @Serializable(with = ByteArrayAsBsonBinary::class) val byteArray: ByteArray?
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as DataClassWithByteArrayAsBsonBinaryNullable
+        return byteArray.contentEquals(other.byteArray)
+    }
+
+    override fun hashCode(): Int = byteArray?.contentHashCode() ?: 0
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
 data class DataClassWithArrays(
     val arraySimple: Array<String>,
     val nestedArrays: Array<Array<String>>,

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -225,6 +225,12 @@
     </Match>
     <Match>
         <!-- MongoDB status: "False Positive", SpotBugs rank: 17 -->
+        <!-- Reported against inlined Kotlin stdlib lambdas, at line numbers past the end of DataClassCodec.kt -->
+        <Class name="~org\.bson\.codecs\.kotlin\.DataClassCodec(\$Companion)?"/>
+        <Bug pattern="BC_BAD_CAST_TO_ABSTRACT_COLLECTION"/>
+    </Match>
+    <Match>
+        <!-- MongoDB status: "False Positive", SpotBugs rank: 17 -->
         <Class name="com.mongodb.kotlin.client.model.PropertiesKt$path$1"/>
         <Method name="~.*invoke.*"/>
         <Bug pattern="BC_BAD_CAST_TO_ABSTRACT_COLLECTION"/>


### PR DESCRIPTION
* Fixes regression in bson-kotlin
* Adds explicit ByteArray support to bson-kotlinx

JAVA-6224