### PR TITLE
JAVA-6146 Move detail out of the root AGENTS.md into references

### DIFF
--- a/.agents/references/api-design.md
+++ b/.agents/references/api-design.md
@@ -1,6 +1,6 @@
 ---
 name: api-design
-description: API stability annotations, design principles, and patterns for the MongoDB Java Driver. Use when adding or modifying public API surface — new classes, methods, interfaces, or changing method signatures.
+description: API stability annotations, nullability and thread safety conventions, design principles, and patterns for the MongoDB Java Driver. Use when adding or modifying public API surface — new classes, methods, interfaces, or changing method signatures.
 ---
 # API Design
 
@@ -28,6 +28,24 @@ description: API stability annotations, design principles, and patterns for the 
 - Public API lives in `driver-sync`, `driver-reactive-streams`, and language wrappers (`driver-kotlin-sync`, `driver-kotlin-coroutine`, `driver-scala`)
 - `driver-core` owns shared internals, query builders (`Filters`, `Updates`, `Aggregates`), and the async execution layer
 - Sync wrappers delegate to async core — never add sync-only logic that diverges from the async path
+
+## Nullability
+
+Use `com.mongodb.lang.Nullable` / `NonNull` / `NonNullApi` annotations.
+
+- Packages with `@NonNullApi` in `package-info.java` are non-null by default — only annotate
+  exceptions with `@Nullable`.
+- New packages must include `@NonNullApi`.
+- Older packages without it are nullable by default and require explicit `@NonNull` where needed.
+
+## Thread Safety
+
+Use `com.mongodb.annotations`; `@ThreadSafe`, `@NotThreadSafe`, or `@Immutable`.
+
+- All public API classes must be thread-safe unless annotated otherwise.
+- Concurrent code — particularly in async `driver-core` paths — must use locks (via
+  `Locks.withLock()`), `volatile` fields, or `java.util.concurrent` atomics; never rely on
+  external synchronization.
 
 ## Design Principles
 

--- a/.agents/references/style-reference.md
+++ b/.agents/references/style-reference.md
@@ -1,8 +1,20 @@
 ---
 name: style-reference
-description: Detailed code style rules for Java, Kotlin, Scala, and Groovy in the MongoDB Java Driver. Use when you need specific formatting rules beyond the basics in root AGENTS.md — e.g., line length, import ordering, brace style.
+description: Detailed code style rules and language level constraints for Java, Kotlin, Scala, and Groovy in the MongoDB Java Driver. Use when you need specific formatting rules beyond the basics in root AGENTS.md — e.g., line length, import ordering, brace style — or when you need to know which language features are available.
 ---
 # Style Reference
+
+## Language Level
+
+**Java 8 language constraint:** Most modules target Java 8. Do not use features from Java 9+
+(`var`, records, text blocks, sealed classes, `Stream.toList()`, switch expressions, pattern
+matching, etc.) unless the module's `build.gradle.kts` explicitly sets a higher
+`sourceCompatibility`.
+
+**Kotlin language constraint:** Kotlin modules use Kotlin 1.8 with JVM target 1.8. All Kotlin
+modules enforce `explicitApi()` — all public declarations must have explicit visibility
+modifiers and types. Do not use Kotlin language features or standard library APIs introduced
+after 1.8.
 
 ## Java Style Rules
 
@@ -40,6 +52,7 @@ description: Detailed code style rules for Java, Kotlin, Scala, and Groovy in th
 - Use `@mongodb.server.release <version>` to indicate the minimum server version required
 - Scala modules use Scaladoc — follow Scaladoc conventions (`@param`, `@return`, `@since`, `@see`)
 - Internal packages (`com.mongodb.internal.*`, `org.bson.internal.*`) are excluded from doc generation
+- Every public package must have a `package-info.java`
 - Run `./gradlew docs` to validate Javadoc/KDoc/Scaladoc builds cleanly
 
 ## Prohibited Patterns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,13 +30,10 @@ The default branch is `main` (not `master`). Always use `main` when comparing, d
 
 Gradle with Kotlin DSL. Build JDK: 17+. Source baseline: Java 8. Versions in `gradle/libs.versions.toml`.
 
-**Java 8 language constraint:** Most modules target Java 8. Do not use features from Java 9+ (`var`,
-records, text blocks, sealed classes, `Stream.toList()`, switch expressions, pattern matching, etc.)
-unless the module's `build.gradle.kts` explicitly sets a higher `sourceCompatibility`.
+- **Java 8 baseline:** no Java 9+ language features unless the module raises `sourceCompatibility`.
+- **Kotlin 1.8** with JVM target 1.8; all Kotlin modules enforce `explicitApi()`.
 
-**Kotlin language constraint:** Kotlin modules use Kotlin 1.8 with JVM target 1.8. All Kotlin modules
-enforce `explicitApi()` — all public declarations must have explicit visibility modifiers and types.
-Do not use Kotlin language features or standard library APIs introduced after 1.8.
+Details for both are in [`.agents/references/style-reference`](.agents/references/style-reference.md).
 
 ```bash
 ./gradlew check                        # Full validation (format + static checks + tests)
@@ -48,19 +45,15 @@ Do not use Kotlin language features or standard library APIs introduced after 1.
 
 `check` depends on `spotlessApply` to auto-fix formatting — run `./gradlew spotlessApply` independently when needed.
 Do not reformat outside your changes.
-See [`.agents/references/style-reference`](.agents/references/style-reference.md) for full rules.
-
-- No `System.out.println` / `System.err.println` — use SLF4J
-- No `e.printStackTrace()` — use proper error handling
-- Copyright header required: `Copyright 2008-present MongoDB, Inc.`
-- Every public package must have a `package-info.java`
+See [`.agents/references/style-reference`](.agents/references/style-reference.md) for prohibited
+patterns, required headers, and full formatting rules.
 
 ## Testing
 
 - Every code change must include tests.
   Do not reduce coverage.
-- Integration tests require a running MongoDB instance (see the test URI in Build section).
-  Do not attempt to run `integrationTest` without a configured server.
+- Integration tests require a running MongoDB instance (see the test URI in Build section) —
+  do not attempt to run `integrationTest` without a configured server.
 - See [`.agents/references/testing-guide`](.agents/references/testing-guide.md) for framework details and running specific
   tests.
 - See [`.agents/references/spec-tests`](.agents/references/spec-tests.md) for MongoDB specification test conventions.
@@ -68,17 +61,15 @@ See [`.agents/references/style-reference`](.agents/references/style-reference.md
 ## API
 
 All `com.mongodb.internal.*` / `org.bson.internal.*` is private API — never expose in public APIs.
-See [`.agents/references/api-design`](.agents/references/api-design.md) for stability annotations and design principles.
 
-**Java nullability:** Use `com.mongodb.lang.Nullable` / `NonNull` / `NonNullApi` annotations.
-Packages with `@NonNullApi` in `package-info.java` are non-null by default — only annotate exceptions
-with `@Nullable`. New packages must include `@NonNullApi`. Older packages without it are nullable by
-default and require explicit `@NonNull` where needed.
+**Nullability:** use `com.mongodb.lang` annotations; new packages must declare `@NonNullApi` in
+`package-info.java`.
 
-**Thread safety:** Use `com.mongodb.annotations`; `@ThreadSafe`, `@NotThreadSafe`, or `@Immutable`.
-All public API classes must be thread-safe unless annotated otherwise. Concurrent code — particularly
-in async `driver-core` paths — must use locks (via `Locks.withLock()`), `volatile` fields, or
-`java.util.concurrent` atomics; never rely on external synchronization.
+**Thread safety:** use `com.mongodb.annotations` (`@ThreadSafe` / `@NotThreadSafe` / `@Immutable`);
+public API classes must be thread-safe unless annotated otherwise.
+
+See [`.agents/references/api-design`](.agents/references/api-design.md) for stability annotations,
+design principles, and the full nullability and thread safety conventions.
 
 ## Do Not Modify Without Human Approval
 


### PR DESCRIPTION
An automated change to AGENTS.md to reduce the size to under 100 lines. 

No information is lost: the relocated prose is unchanged, and both reference files have updated description frontmatter so they are still discoverable for those topics. 104 -> 95 lines.